### PR TITLE
fix: update Docusaurus config for custom domain

### DIFF
--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -16,8 +16,8 @@ const config: Config = {
     mermaid: true,
   },
 
-  url: 'https://vectorize-io.github.io',
-  baseUrl: '/hindsight/',
+  url: 'https://hindsight.vectorize.io',
+  baseUrl: '/',
 
   organizationName: 'vectorize-io',
   projectName: 'hindsight',


### PR DESCRIPTION
Update url and baseUrl for hindsight.vectorize.io custom domain. With custom domains, GitHub Pages serves from root path instead of project subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)