### PR TITLE
docs: update documentation URL to custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ with HindsightServer(llm_provider="openai", llm_model="gpt-4o-mini", llm_api_key
 
 ## Documentation
 
-Full documentation: [vectorize-io.github.io/hindsight](https://vectorize-io.github.io/hindsight)
+Full documentation: [hindsight.vectorize.io](https://hindsight.vectorize.io)
 
 ## Contributing
 


### PR DESCRIPTION
Update docs link from vectorize-io.github.io/hindsight to hindsight.vectorize.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)