### PR TITLE
fix: add DOM.Iterable lib to resolve URLSearchParams type errors

### DIFF
--- a/hindsight-clients/typescript/tsconfig.json
+++ b/hindsight-clients/typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./",


### PR DESCRIPTION
## Summary
- Adds `DOM.Iterable` to the TypeScript `lib` config in the TypeScript client
- Fixes build errors where `URLSearchParams.entries()` was not recognized

## Test plan
- [x] Verified `npm run build` succeeds in `hindsight-clients/typescript`