### PR TITLE
Add Hindsight Cloud links to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Hindsight Banner](./hindsight-docs/static/img/banner.svg)
 
-[Documentation](https://vectorize-io.github.io/hindsight) • [Paper](https://arxiv.org/abs/2512.12818) • [Cookbook](https://hindsight.vectorize.io/cookbook)
+[Documentation](https://hindsight.vectorize.io) • [Paper](https://arxiv.org/abs/2512.12818) • [Cookbook](https://hindsight.vectorize.io/cookbook) • [Hindsight Cloud](https://vectorize.io/hindsight/cloud)
 
 [![CI](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml/badge.svg)](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml)
 [![Slack Community](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/hindsight-space/shared_invite/zt-3klo21kua-VUCC_zHP5rIcXFB1_5yw6A)

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -1,6 +1,10 @@
 # Installation
 
-Hindsight can be deployed in three ways depending on your infrastructure and requirements.
+Hindsight can be deployed in several ways depending on your infrastructure and requirements.
+
+:::tip Don't want to manage infrastructure?
+**[Hindsight Cloud](https://vectorize.io/hindsight/cloud)** is a fully managed service that handles all infrastructure, scaling, and maintenance. We're onboarding design partners now — [request early access](https://vectorize.io/hindsight/cloud).
+:::
 
 ## Prerequisites
 

--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -175,6 +175,12 @@ const config: Config = {
           className: 'navbar-item-changelog',
         },
         {
+          href: 'https://vectorize.io/hindsight/cloud',
+          position: 'right',
+          label: 'Hindsight Cloud',
+          className: 'navbar-item-cloud',
+        },
+        {
           href: 'https://github.com/vectorize-io/hindsight',
           position: 'right',
           className: 'header-github-link',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "hindsight-clients/typescript": {
       "name": "@vectorize-io/hindsight-client",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "license": "MIT",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.88.0",
@@ -25,7 +25,7 @@
       }
     },
     "hindsight-control-plane": {
-      "version": "0.1.5",
+      "version": "0.1.8",
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Summary
- Add Hindsight Cloud link to README header (alongside Documentation, Paper, Cookbook)
- Add Hindsight Cloud navbar item in docs site
- Add callout tip in installation docs for those who don't want to self-host

## Links
All links point to: https://vectorize.io/hindsight/cloud