### PR TITLE
Control Plane Timeline: Switch to descending date and fallback to mentioned_at for non events

### DIFF
--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -715,7 +715,7 @@ function TimelineView({ data, filteredRows }: { data: any; filteredRows: any[] }
   const [currentIndex, setCurrentIndex] = useState(0);
   const timelineRef = useRef<HTMLDivElement>(null);
 
-  // Filter and sort items that have dates (occurred_start for facts, mentioned_at as fallback because occurred_start is not present on experiences and opinions)
+  // Filter and sort items that have dates (occurred_start is only present for events, mentioned_at as fallback - opinions don't tend to be events)
   const { sortedItems, itemsWithoutDates } = useMemo(() => {
     if (!filteredRows || filteredRows.length === 0)
       return { sortedItems: [], itemsWithoutDates: [] };


### PR DESCRIPTION
Addresses #55

**Introduce effective_date**
Instead of using just occurred_start for display/ordering I've introduced an effective_date property to object in the withDates array: This will be occurred_start if present but otherwise will fallback to mentioned_at (or null if not set).

**Sort order**
It now sorts by effective_date in _descending_ order, which seems to be consistent with the query on the api:

https://github.com/vectorize-io/hindsight/blob/6d820ef91bbf27f890754a71e758d99600b56b90/hindsight-api/hindsight_api/engine/memory_engine.py#L2082-L2091

**Testing**
I've tested this manually with a memory bank of mine, verifying that opinions which previously were hidden now show and are ordered correctly.