### PR TITLE
Load .env file automatically on startup

### DIFF
--- a/hindsight-api/hindsight_api/config.py
+++ b/hindsight-api/hindsight_api/config.py
@@ -8,6 +8,11 @@ import logging
 import os
 from dataclasses import dataclass
 
+from dotenv import find_dotenv, load_dotenv
+
+# Load .env file, searching current and parent directories (overrides existing env vars)
+load_dotenv(find_dotenv(usecwd=True), override=True)
+
 logger = logging.getLogger(__name__)
 
 # Environment variable names


### PR DESCRIPTION
## Summary
- Add automatic `.env` file loading using python-dotenv on startup
- Searches current working directory and parent directories for `.env` file
- Uses `override=True` so `.env` values take precedence over shell environment

## Motivation
When running `uv run hindsight-api` from a project directory, users expect the `.env` file to be loaded automatically without needing to manually source it (`set -a; source .env; set +a`).

## Test plan
- [ ] Run `uv run hindsight-api` from a directory with a `.env` file containing `HINDSIGHT_API_LOG_LEVEL=info`
- [ ] Verify log level is respected without manually exporting the variable
- [ ] Verify existing tests pass