### PR TITLE
Fix stats endpoint missing tenant authentication

### DIFF
--- a/hindsight-api/hindsight_api/api/http.py
+++ b/hindsight-api/hindsight_api/api/http.py
@@ -1321,9 +1321,14 @@ def _register_routes(app: FastAPI):
         operation_id="get_agent_stats",
         tags=["Banks"],
     )
-    async def api_stats(bank_id: str):
+    async def api_stats(
+        bank_id: str,
+        request_context: RequestContext = Depends(get_request_context),
+    ):
         """Get statistics about memory nodes and links for a memory bank."""
         try:
+            # Authenticate and set tenant schema
+            await app.state.memory._authenticate_tenant(request_context)
             pool = await app.state.memory._get_pool()
             async with acquire_with_retry(pool) as conn:
                 # Get node counts by fact_type


### PR DESCRIPTION
## Summary
- Fixed the `/v1/default/banks/{bank_id}/stats` endpoint which was missing tenant authentication
- Stats were returning zeros for multi-tenant deployments because queries were running against the `public` schema instead of the tenant's schema

## Changes
- Added `request_context: RequestContext = Depends(get_request_context)` parameter to `api_stats()`
- Added `await app.state.memory._authenticate_tenant(request_context)` call before querying

## Root Cause
The stats endpoint was the only endpoint doing raw SQL queries with `fq_table()` without first calling `_authenticate_tenant()` to set the schema context. All other endpoints call memory engine methods which handle authentication internally.

## Test plan
- [x] Verified stats now return correct counts in multi-tenant deployment
- [x] Confirmed numbers match the actual memory counts shown in the Data view