### PR TITLE
fix(typescript-client): Add error handling to all API methods

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -79,6 +79,16 @@ export class HindsightClient {
     }
 
     /**
+     * Validates the API response and throws an error if the request failed.
+     */
+    private validateResponse<T>(response: { data?: T; error?: unknown }, operation: string): T {
+        if (!response.data) {
+            throw new Error(`${operation} failed: ${JSON.stringify(response.error || 'Unknown error')}`);
+        }
+        return response.data;
+    }
+
+    /**
      * Retain a single memory for a bank.
      */
     async retain(
@@ -126,7 +136,7 @@ export class HindsightClient {
             body: { items: [item], async: options?.async },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'retain');
     }
 
     /**
@@ -160,7 +170,7 @@ export class HindsightClient {
             },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'retainBatch');
     }
 
     /**
@@ -198,11 +208,7 @@ export class HindsightClient {
             },
         });
 
-        if (!response.data) {
-            throw new Error(`API returned no data: ${JSON.stringify(response.error || 'Unknown error')}`);
-        }
-
-        return response.data;
+        return this.validateResponse(response, 'recall');
     }
 
     /**
@@ -223,7 +229,7 @@ export class HindsightClient {
             },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'reflect');
     }
 
     /**
@@ -244,7 +250,7 @@ export class HindsightClient {
             },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'listMemories');
     }
 
     /**
@@ -264,7 +270,7 @@ export class HindsightClient {
             },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'createBank');
     }
 
     /**
@@ -276,7 +282,7 @@ export class HindsightClient {
             path: { bank_id: bankId },
         });
 
-        return response.data!;
+        return this.validateResponse(response, 'getBankProfile');
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a `validateResponse` helper method that checks for API errors
- Applies error checking to all API methods that previously returned `response.data!` without validation
- Now all methods throw descriptive errors when API calls fail instead of silently returning undefined

## Problem

Most methods in the TypeScript client were returning `response.data!` without checking if the response was successful. When the API was unreachable or returned an error, these methods would silently return `undefined` instead of throwing an error.

This was discovered when running load tests against a non-existent server - the tests showed 100% success rate because `retain` and `reflect` never threw errors.

## Changes

Methods updated:
- `retain` 
- `retainBatch`
- `recall` (already had error checking, now uses the shared helper)
- `reflect`
- `listMemories`
- `createBank`
- `getBankProfile`

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] TypeScript compiles without errors (`npm run build`)