### PR TITLE
Fix Gemini tool response format by including function name

### DIFF
--- a/hindsight-api/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api/hindsight_api/engine/reflect/agent.py
@@ -436,6 +436,7 @@ async def run_reflect_agent(
                     {
                         "role": "tool",
                         "tool_call_id": done_call.id,
+                        "name": done_call.name,  # Required by Gemini
                         "content": json.dumps(
                             {
                                 "error": "You must search for information first. Use search_reflections(), search_mental_models(), or recall() before providing your final answer."
@@ -535,6 +536,7 @@ async def run_reflect_agent(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
+                        "name": tc.name,  # Required by Gemini
                         "content": json.dumps(output, default=str),
                     }
                 )


### PR DESCRIPTION
## Summary
Fixes reflect agent breaking with Gemini due to missing `name` field in tool response messages.

## Problem
When using Gemini as the LLM provider, the reflect agent fails with:
```
400 INVALID_ARGUMENT: GenerateContentRequest.contents[2].parts[0].function_response.name: Name cannot be empty.
```

## Root Cause
Gemini requires the `name` field in tool/function response messages, while OpenAI infers it from `tool_call_id`. The reflect agent was only including `tool_call_id` and `content`.

## Fix
Added `name` field to both tool result message locations in `agent.py`:
1. Normal tool execution results (line 537)
2. Guardrail error messages when done is called without evidence (line 439)

## Test plan
- [x] Tested reflect operation locally with Gemini provider