### PR TITLE
fix(api): correct consolidation endpoint stats reporting

### DIFF
--- a/hindsight-api/hindsight_api/api/http.py
+++ b/hindsight-api/hindsight_api/api/http.py
@@ -3209,9 +3209,9 @@ def _register_routes(app: FastAPI):
         """Trigger consolidation for a bank."""
         try:
             result = await app.state.memory.run_consolidation(bank_id, request_context=request_context)
-            processed = result.get("processed", 0)
-            created = result.get("created", 0)
-            updated = result.get("updated", 0)
+            processed = result.get("memories_processed", 0)
+            created = result.get("mental_models_created", 0)
+            updated = result.get("mental_models_updated", 0)
             return ConsolidationResponse(
                 status="completed",
                 processed=processed,

--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -2641,9 +2641,9 @@ class MemoryEngine(MemoryEngineInterface):
         )
 
         return {
-            "processed": result.get("processed", 0),
-            "created": result.get("created", 0),
-            "updated": result.get("updated", 0),
+            "memories_processed": result.get("memories_processed", 0),
+            "mental_models_created": result.get("mental_models_created", 0),
+            "mental_models_updated": result.get("mental_models_updated", 0),
             "skipped": result.get("skipped", 0),
         }
 


### PR DESCRIPTION
## Summary
- Fix consolidation endpoint returning 0 for all stats (processed, created, updated)
- The result dictionary keys didn't match between the consolidator (`memories_processed`, `mental_models_created`, `mental_models_updated`) and the API layers (`processed`, `created`, `updated`)

## Test plan
- [x] Create fresh bank with no mental models
- [x] Retain memories, verify `pending_consolidation` count
- [x] Call `/consolidate`, verify `processed` and `created` match actual counts
- [x] Add related memory, verify `updated` count increments correctly
- [x] Verify `total_mental_models` in stats matches consolidation results