### PR TITLE
fix: use mental model text field in reflect based_on response

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -3722,12 +3722,12 @@ class MemoryEngine(MemoryEngineInterface):
                             continue  # Skip models not actually used by the agent
                         seen_model_ids.add(model_id)
                         # Add to based_on as MemoryFact with type "mental-models"
-                        model_name = model.get("name", "")
-                        model_summary = model.get("summary") or model.get("description", "")
+                        # Use "text" if available (search_mental_models), else build from name/summary (get_mental_model)
+                        model_text = model.get("text") or f"{model.get('name', '')}: {model.get('summary') or model.get('description', '')}"
                         based_on["mental-models"].append(
                             MemoryFact(
                                 id=model_id,
-                                text=f"{model_name}: {model_summary}",
+                                text=model_text,
                                 fact_type="mental-models",
                                 context=f"{model.get('type', 'concept')} ({model.get('subtype', 'structural')})",
                                 occurred_start=None,
@@ -3744,12 +3744,12 @@ class MemoryEngine(MemoryEngineInterface):
                             continue  # Skip models not actually used by the agent
                         seen_model_ids.add(model_id)
                         # Add to based_on as MemoryFact with type "mental-models"
-                        model_name = model.get("name", "")
-                        model_summary = model.get("summary") or model.get("description", "")
+                        # Use "text" if available (search_mental_models), else build from name/summary (get_mental_model)
+                        model_text = model.get("text") or f"{model.get('name', '')}: {model.get('summary') or model.get('description', '')}"
                         based_on["mental-models"].append(
                             MemoryFact(
                                 id=model_id,
-                                text=f"{model_name}: {model_summary}",
+                                text=model_text,
                                 fact_type="mental-models",
                                 context=f"{model.get('type', 'concept')} ({model.get('subtype', 'structural')})",
                                 occurred_start=None,


### PR DESCRIPTION
## Summary
- Auto-consolidated mental models have a `text` field but no `name` or `summary`. The old code always constructed text as `f"{name}: {summary}"` which produced `": "` for these models.
- Now uses the `text` field when available, falling back to name/summary construction for backwards compatibility with older model formats.
- Fixes both `get_mental_model` and `search_mental_models` code paths in the reflect response builder.

## Test plan
- [ ] Run reflect with a bank that has auto-consolidated mental models
- [ ] Verify the `based_on.mental-models` entries have correct text (not `": "`)
- [ ] Verify backwards compatibility with older mental models that have name/summary fields