### PR TITLE
fix: include tags, created_at, proof_count in graph table_rows

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -2826,7 +2826,7 @@ class MemoryEngine(MemoryEngineInterface):
             param_count += 1
             units = await conn.fetch(
                 f"""
-                SELECT id, text, event_date, context, occurred_start, occurred_end, mentioned_at, document_id, chunk_id, fact_type
+                SELECT id, text, event_date, context, occurred_start, occurred_end, mentioned_at, document_id, chunk_id, fact_type, tags, created_at, proof_count
                 FROM {fq_table("memory_units")}
                 {where_clause}
                 ORDER BY mentioned_at DESC NULLS LAST, event_date DESC
@@ -2967,6 +2967,9 @@ class MemoryEngine(MemoryEngineInterface):
                     "document_id": row["document_id"],
                     "chunk_id": row["chunk_id"] if row["chunk_id"] else None,
                     "fact_type": row["fact_type"],
+                    "tags": list(row["tags"]) if row["tags"] else [],
+                    "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                    "proof_count": row["proof_count"] if row["proof_count"] else None,
                 }
             )
 


### PR DESCRIPTION
## Summary
- The graph endpoint's `table_rows` response was missing three fields that the control plane UI expects:
  - `tags`: memory unit tags (shown in Tags column for all fact types)
  - `created_at`: creation timestamp (shown in Created column for mental models)
  - `proof_count`: source memory count (shown in Sources column for mental models)
- All three columns exist on the `memory_units` table but were not being selected in the SQL query or included in the response dict.
- Without this fix, the Tags column shows `-`, Created shows `-`, and Sources always shows `1` (due to `|| 1` fallback in the UI).

## Test plan
- [ ] Load the Graph/Table view for a bank with tagged memories
- [ ] Verify Tags column shows actual tags instead of `-`
- [ ] Switch to mental models view and verify Sources shows real proof_count
- [ ] Verify Created column shows actual dates for mental models