### PR TITLE
fix: multi-tenant schema context for worker task execution

### DIFF
--- a/hindsight-api/hindsight_api/api/http.py
+++ b/hindsight-api/hindsight_api/api/http.py
@@ -1389,6 +1389,7 @@ def create_app(
                 poll_interval_ms=config.worker_poll_interval_ms,
                 batch_size=config.worker_batch_size,
                 max_retries=config.worker_max_retries,
+                tenant_extension=getattr(memory, "_tenant_extension", None),
             )
             poller_task = asyncio.create_task(poller.run())
             logging.info(f"Worker poller started (worker_id={worker_id})")

--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -433,7 +433,10 @@ class MemoryEngine(MemoryEngineInterface):
         # Initialize task backend
         # If no custom backend provided, use BrokerTaskBackend which stores tasks in PostgreSQL
         # The pool_getter lambda will return the pool once it's initialized
-        self._task_backend = task_backend or BrokerTaskBackend(pool_getter=lambda: self._pool)
+        self._task_backend = task_backend or BrokerTaskBackend(
+            pool_getter=lambda: self._pool,
+            schema_getter=get_current_schema,
+        )
 
         # Backpressure mechanism: limit concurrent searches to prevent overwhelming the database
         # Configurable via HINDSIGHT_API_RECALL_MAX_CONCURRENT (default: 50)
@@ -497,6 +500,13 @@ class MemoryEngine(MemoryEngineInterface):
         if request_context is None:
             raise AuthenticationError("RequestContext is required when tenant extension is configured")
 
+        # For internal/background operations (e.g., worker tasks), skip extension authentication
+        # if the schema has already been set by execute_task via the _schema field.
+        if request_context.internal:
+            current = _current_schema.get()
+            if current and current != "public":
+                return current
+
         # Let AuthenticationError propagate - HTTP layer will convert to 401
         tenant_context = await self._tenant_extension.authenticate(request_context)
 
@@ -523,10 +533,10 @@ class MemoryEngine(MemoryEngineInterface):
             f"[BATCH_RETAIN_TASK] Starting background batch retain for bank_id={bank_id}, {len(contents)} items"
         )
 
-        # Use internal request context for background tasks
+        # Use internal request context for background tasks (skips tenant auth when schema is pre-set)
         from hindsight_api.models import RequestContext
 
-        internal_context = RequestContext()
+        internal_context = RequestContext(internal=True)
         await self.retain_batch_async(bank_id=bank_id, contents=contents, request_context=internal_context)
 
         logger.info(f"[BATCH_RETAIN_TASK] Completed background batch retain for bank_id={bank_id}")
@@ -552,7 +562,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         from .consolidation import run_consolidation_job
 
-        internal_context = RequestContext()
+        internal_context = RequestContext(internal=True)
         result = await run_consolidation_job(
             memory_engine=self,
             bank_id=bank_id,
@@ -587,7 +597,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         from hindsight_api.models import RequestContext
 
-        internal_context = RequestContext()
+        internal_context = RequestContext(internal=True)
 
         # Run reflect to generate content
         reflect_result = await self.reflect_async(
@@ -653,7 +663,7 @@ class MemoryEngine(MemoryEngineInterface):
 
         from hindsight_api.models import RequestContext
 
-        internal_context = RequestContext()
+        internal_context = RequestContext(internal=True)
 
         # Get the current reflection to get source_query
         reflection = await self.get_reflection(bank_id, reflection_id, request_context=internal_context)
@@ -718,6 +728,11 @@ class MemoryEngine(MemoryEngineInterface):
         operation_id = task_dict.get("operation_id")
         retry_count = task_dict.get("retry_count", 0)
         max_retries = 3
+
+        # Set schema context for multi-tenant task execution
+        schema = task_dict.pop("_schema", None)
+        if schema:
+            _current_schema.set(schema)
 
         # Check if operation was cancelled (only for tasks with operation_id)
         if operation_id:

--- a/hindsight-api/hindsight_api/worker/poller.py
+++ b/hindsight-api/hindsight_api/worker/poller.py
@@ -261,6 +261,9 @@ class WorkerPoller:
         try:
             schema_info = f", schema={task.schema}" if task.schema else ""
             logger.debug(f"Executing task {task.operation_id} (type={task_type}, bank={bank_id}{schema_info})")
+            # Pass schema to executor so it can set the correct context
+            if task.schema:
+                task.task_dict["_schema"] = task.schema
             await self._executor(task.task_dict)
             await self._mark_completed(task.operation_id, task.schema)
             logger.debug(f"Task {task.operation_id} completed successfully")


### PR DESCRIPTION
## Summary
- Background tasks (async retain, consolidation, reflections) fail silently in multi-tenant deployments.
- **Root cause:** The worker executes tasks without setting the tenant schema context, causing two cascading failures:
  1. The cancellation check in `execute_task` queries `public.async_operations` instead of the tenant's schema, finds no row, and **skips the task as "cancelled"** — even though it wasn't.
  2. Even if that were bypassed, `_authenticate_tenant` would throw `AuthenticationError` because background tasks have no API key/token.
- **Observed symptom:** Every async operation logs `Skipping cancelled operation: <id>` immediately after being picked up.

## Changes
- **poller.py**: Pass `task.schema` into `task_dict["_schema"]` so the executor receives it
- **memory_engine.py** (`execute_task`): Pop `_schema` from task dict and set `_current_schema` **before** the cancellation check
- **memory_engine.py** (`_authenticate_tenant`): Skip tenant extension auth for `internal=True` requests when schema is already set
- **memory_engine.py** (task handlers): Use `RequestContext(internal=True)` for all 4 background task handlers
- **task_backend.py**: Add `schema_getter` for dynamic schema resolution in `submit_task` and `wait_for_result`
- **http.py**: Pass `tenant_extension` to `WorkerPoller` in `create_app`

## Test plan
- [ ] Deploy to dev with multi-tenant config
- [ ] Trigger async retain — verify task completes instead of logging "Skipping cancelled operation"
- [ ] Trigger consolidation — verify it runs in the correct tenant schema
- [ ] Trigger reflection creation — verify background generation completes
- [ ] Verify single-tenant (no extension) deployments are unaffected