### PR TITLE
fix(ci): force CPU mode for embeddings and reranker in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,8 @@ jobs:
       HINDSIGHT_API_URL: http://localhost:8888
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -376,6 +378,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Prefer CPU-only PyTorch in CI (but keep PyPI for everything else)
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -452,6 +456,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Prefer CPU-only PyTorch in CI (but keep PyPI for everything else)
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -533,6 +539,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Prefer CPU-only PyTorch in CI (but keep PyPI for everything else)
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -612,6 +620,8 @@ jobs:
       HINDSIGHT_API_URL: http://localhost:8888
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -773,6 +783,8 @@ jobs:
       HINDSIGHT_API_URL: http://localhost:8888
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4
@@ -883,6 +895,8 @@ jobs:
       HINDSIGHT_API_LLM_MODEL: openai/gpt-oss-20b
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UV_INDEX: pytorch=https://download.pytorch.org/whl/cpu
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU: "1"
+      HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU: "1"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The CI tests have been failing intermittently when starting the API server. The issue occurs because PyTorch tries to detect and use hardware accelerators (GPU/MPS) in CI environments where they're not properly available, causing initialization failures.

## Solution

This PR adds `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` and `HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU` environment variables (set to "1") to all CI jobs that start the API server.

These environment variables were introduced in PR #218 but were only automatically enabled for daemon mode. CI tests run the API server directly (not in daemon mode), so they need these variables explicitly set.

## Changes

Updated `.github/workflows/test.yml` to add the FORCE_CPU environment variables to the following jobs:
- test-rust-cli
- test-python-client
- test-typescript-client
- test-rust-client
- test-integration
- test-doc-examples
- test-upgrade

## Testing

The CI workflow will validate this fix automatically. The forced CPU mode should prevent any GPU/MPS detection issues in CI runners.