### PR TITLE
fix: make PyTorch device detection more robust

### DIFF
--- a/hindsight-api/hindsight_api/engine/embeddings.py
+++ b/hindsight-api/hindsight_api/engine/embeddings.py
@@ -135,11 +135,17 @@ class LocalSTEmbeddings(Embeddings):
         import torch
 
         # Check for GPU (CUDA) or Apple Silicon (MPS)
-        has_gpu = torch.cuda.is_available() or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
-
-        if has_gpu:
-            device = None  # Let sentence-transformers auto-detect GPU/MPS
-        else:
+        # Wrap in try-except to gracefully handle any device detection issues
+        # (e.g., in CI environments or when PyTorch is built without GPU support)
+        device = "cpu"  # Default to CPU
+        try:
+            has_gpu = torch.cuda.is_available() or (
+                hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+            )
+            if has_gpu:
+                device = None  # Let sentence-transformers auto-detect GPU/MPS
+        except Exception as e:
+            logger.warning(f"Failed to detect GPU/MPS, falling back to CPU: {e}")
             device = "cpu"
 
         self._model = SentenceTransformer(
@@ -181,13 +187,17 @@ class LocalSTEmbeddings(Embeddings):
         gc.collect()
 
         # If using CUDA/MPS, clear the cache
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            try:
-                torch.mps.empty_cache()
-            except AttributeError:
-                pass  # Method might not exist in all PyTorch versions
+        # Wrap in try-except to handle any device detection issues
+        try:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                try:
+                    torch.mps.empty_cache()
+                except AttributeError:
+                    pass  # Method might not exist in all PyTorch versions
+        except Exception:
+            pass  # Ignore any cache clearing errors
 
         # Reinitialize the model (inline version of initialize() but synchronous)
         try:
@@ -199,11 +209,16 @@ class LocalSTEmbeddings(Embeddings):
             )
 
         # Determine device based on hardware availability
-        has_gpu = torch.cuda.is_available() or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
-
-        if has_gpu:
-            device = None  # Let sentence-transformers auto-detect GPU/MPS
-        else:
+        # Wrap in try-except to gracefully handle any device detection issues
+        device = "cpu"  # Default to CPU
+        try:
+            has_gpu = torch.cuda.is_available() or (
+                hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+            )
+            if has_gpu:
+                device = None  # Let sentence-transformers auto-detect GPU/MPS
+        except Exception as e:
+            logger.warning(f"Failed to detect GPU/MPS during reinit, falling back to CPU: {e}")
             device = "cpu"
 
         self._model = SentenceTransformer(


### PR DESCRIPTION
## Problem

CI tests have been failing intermittently when starting the API server, specifically during the initialization of the embedding and reranking models. The issue occurs because PyTorch device detection code can behave unexpectedly in certain environments (especially CI runners without proper GPU/MPS support).

## Root Cause

The device detection code was calling `torch.cuda.is_available()` and `torch.backends.mps.is_available()` without defensive error handling. While the code checked for attribute existence with `hasattr()`, these methods could still:
- Throw unexpected exceptions in certain environments
- Behave unpredictably in CI environments with CPU-only PyTorch builds
- Fail in systems with partial or misconfigured PyTorch installations

## Solution

This PR wraps all PyTorch device detection code in try-except blocks that gracefully fall back to CPU mode if ANY errors occur during device detection. This makes the code defensive while still taking advantage of hardware acceleration when available.

### Changes

Modified device detection in:
- `hindsight-api/hindsight_api/engine/embeddings.py`
  - `LocalSTEmbeddings.initialize()` method
  - `LocalSTEmbeddings._reinitialize_model_sync()` method
- `hindsight-api/hindsight_api/engine/cross_encoder.py`
  - `LocalSTCrossEncoder.initialize()` method
  - `LocalSTCrossEncoder._reinitialize_model_sync()` method

All device detection now:
1. Defaults to `device = "cpu"`
2. Attempts to detect GPU/MPS in a try-except block
3. Falls back to CPU with a warning if detection fails
4. Works reliably in all environments

## Testing

The CI workflow will validate this fix automatically. **This fix does NOT require any FORCE_CPU environment variables** - it makes the code work correctly in all environments by default.

## Benefits

- ✅ Works in CI environments without configuration
- ✅ Works with CPU-only PyTorch builds
- ✅ Still uses GPU/MPS when available
- ✅ Defensive against unexpected PyTorch configurations
- ✅ Provides clear warning logs when fallback occurs