### PR TITLE
fix: search_mental_models uuid type mismatch

### DIFF
--- a/hindsight-api/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api/hindsight_api/engine/reflect/tools.py
@@ -69,7 +69,7 @@ async def tool_search_mental_models(
         next_param += 1
 
     if exclude_ids:
-        filters += f" AND id != ALL(${next_param}::uuid[])"
+        filters += f" AND id != ALL(${next_param}::text[])"
         params.append(exclude_ids)
         next_param += 1
 


### PR DESCRIPTION
## Summary
- The `mental_models.id` column was changed from UUID to TEXT in migration `u6p7q8r9s0t1`, but `search_mental_models` in the reflect agent still cast the `exclude_ids` parameter as `::uuid[]`
- Every `search_mental_models` call fails with `operator does not exist: text <> uuid`, causing the reflect agent to waste all 5 agentic iterations on retries
- Mental models that depend on cross-referencing other models (e.g. "Employee Locations") produce degraded content like "I don't have information"

**Fix:** Change `::uuid[]` to `::text[]` in `tools.py:72` to match the current column type.

## Test plan
- [x] Verified with end-to-end test: retain → consolidation → mental model auto-refresh pipeline
- [x] Before fix: "Employee Locations" model returned "I don't have information"
- [x] After fix: correctly returns "Laura Martinez | Floor 3 | Back side (the Cafe)"
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)