### PR TITLE
fix: run migrations on tenant schemas at startup and harden worker poller

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -883,6 +883,23 @@ class MemoryEngine(MemoryEngineInterface):
             logger.info("Running database migrations...")
             run_migrations(self.db_url)
 
+            # Migrate all existing tenant schemas (if multi-tenant)
+            if self._tenant_extension is not None:
+                try:
+                    tenants = await self._tenant_extension.list_tenants()
+                    if tenants:
+                        logger.info(f"Running migrations on {len(tenants)} tenant schemas...")
+                        for tenant in tenants:
+                            schema = tenant.schema
+                            if schema and schema != "public":
+                                try:
+                                    run_migrations(self.db_url, schema=schema)
+                                except Exception as e:
+                                    logger.warning(f"Failed to migrate tenant schema {schema}: {e}")
+                        logger.info("Tenant schema migrations completed")
+                except Exception as e:
+                    logger.warning(f"Failed to run tenant schema migrations: {e}")
+
             # Ensure embedding column dimension matches the model's dimension
             # This is done after migrations and after embeddings.initialize()
             ensure_embedding_dimension(self.db_url, self.embeddings.dimension)


### PR DESCRIPTION
## Summary

- Run database migrations on all existing tenant schemas at startup (not just the `public` schema)
- Harden the worker poller so one broken tenant schema doesn't crash the entire polling loop

## Problem

When new migrations are deployed, only the `public` schema gets migrated at startup. Existing tenant schemas are left behind on their old migration version. This caused the worker poller to crash silently when it tried to query columns (e.g. `worker_id`, `task_payload`) that didn't exist in tenant schemas.

The crash was completely silent because `poller.run()` is started via `asyncio.create_task()` and the exception in `recover_own_tasks()` (called before any try/except block) killed the coroutine with no logging.

## Changes

**`memory_engine.py`** — After running public schema migrations, iterate all tenants from the tenant extension and run migrations on each schema. Wrapped in try/except per-schema so one failure doesn't block others.

**`worker/poller.py`** — Defense-in-depth:
- `recover_own_tasks()`: try/except per-schema so a broken schema doesn't prevent the polling loop from starting
- `_claim_batch_for_schema()`: try/except wrapper so a broken schema doesn't prevent claiming tasks from other schemas

## Test plan

- [x] Verified fix on hindsight-dev: ran migrations on 15 tenant schemas, restarted pods, worker poller successfully entered polling loop and processed tasks
- [x] Verified fix on hindsight-prod: ran migrations on 3 tenant schemas preemptively
- [ ] Run unit tests