### PR TITLE
fix: sanitize null bytes from text fields before PostgreSQL insertion

### DIFF
--- a/hindsight-api/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api/hindsight_api/engine/retain/fact_storage.py
@@ -8,16 +8,10 @@ import json
 import logging
 
 from ..memory_engine import fq_table
+from .fact_extraction import _sanitize_text
 from .types import ProcessedFact
 
 logger = logging.getLogger(__name__)
-
-
-def _sanitize_text(text: str | None) -> str | None:
-    """Remove null bytes that break PostgreSQL UTF-8 encoding."""
-    if text is None:
-        return None
-    return text.replace("\x00", "")
 
 
 async def insert_facts_batch(


### PR DESCRIPTION
## Summary
- Adds `_sanitize_text()` helper that strips null bytes (`\x00`) from text fields before PostgreSQL insertion
- Prevents `invalid byte sequence for encoding UTF8: 0x00` errors during batch retain

## Problem
Documents with embedded null bytes (common in OCR, PDF extraction, copy-paste from binary sources) cause PostgreSQL to reject the insert. This is a data integrity issue that silently breaks the retain pipeline.

## Solution
Strip null bytes from `fact_text` and `context` fields before insertion. Null bytes carry no semantic meaning in text and can be safely removed.

## Test plan
- [x] Lint passes
- [ ] Tested with documents containing null bytes

🤖 Generated with [Claude Code](https://claude.ai/code)