### PR TITLE
fix(control-plane): handle undefined response.data in graph route

### DIFF
--- a/hindsight-control-plane/src/app/api/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/graph/route.ts
@@ -24,6 +24,14 @@ export async function GET(request: NextRequest) {
       },
     });
 
+    if (response.error || !response.data) {
+      console.error("Graph API error:", response.error);
+      return NextResponse.json(
+        { error: response.error || "Failed to fetch graph data" },
+        { status: 500 },
+      );
+    }
+
     return NextResponse.json(response.data, { status: 200 });
   } catch (error) {
     console.error("Error fetching graph data:", error);


### PR DESCRIPTION
## Summary
- Add defensive check for undefined `response.data` before JSON serialization in graph route

## Problem
When the backend graph API returns an error, the SDK sets `response.data` to undefined. Calling `NextResponse.json(undefined)` throws `Value is not JSON serializable`, crashing the control plane.

## Solution
Check for error or missing data before serializing, return proper error response with 500 status.

## Test plan
- [x] Verified with backend returning error response
- [x] Control plane no longer crashes on graph API errors

🤖 Generated with [Claude Code](https://claude.ai/code)