### PR TITLE
fix(auth): skip tenant auth for all internal background tasks

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -504,12 +504,11 @@ class MemoryEngine(MemoryEngineInterface):
         if request_context is None:
             raise AuthenticationError("RequestContext is required when tenant extension is configured")
 
-        # For internal/background operations (e.g., worker tasks), skip extension authentication
-        # if the schema has already been set by execute_task via the _schema field.
+        # For internal/background operations (e.g., worker tasks), skip extension authentication.
+        # The task was already authenticated at submission time, and execute_task sets _current_schema
+        # from the task's _schema field. For public schema tasks, _current_schema keeps its default "public".
         if request_context.internal:
-            current = _current_schema.get()
-            if current and current != "public":
-                return current
+            return _current_schema.get()
 
         # Let AuthenticationError propagate - HTTP layer will convert to 401
         tenant_context = await self._tenant_extension.authenticate(request_context)


### PR DESCRIPTION
## Summary
- Remove public-schema guard from internal request authentication bypass

## Problem
Internal background tasks (consolidation, async retain via worker) fail with `AuthenticationError` when using tenant extension on public schema. The worker doesn't have an API key, and the previous code only skipped auth for non-public schemas.

The original logic was:
```python
if request_context.internal:
    current = _current_schema.get()
    if current and current != "public":
        return current
```

This breaks async HTTP retain (`async_processing=True`) because:
1. Task is submitted and queued (authenticated at submission time)
2. Worker picks up task, sets internal context
3. Worker tries to execute but has no API key
4. Auth fails because schema is "public" (default)

## Solution
Since tasks were already authenticated at submission time, skip tenant auth for ALL internal requests:
```python
if request_context.internal:
    return _current_schema.get()
```

## Test plan
- [x] Async document upload works with tenant extension enabled
- [x] Consolidation tasks complete successfully
- [x] Tenant isolation still enforced for external requests

🤖 Generated with [Claude Code](https://claude.ai/code)