### PR TITLE
feat(docker): preload tiktoken encoding during build

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -185,6 +185,7 @@ print('Downloading embedding model...'); \
 SentenceTransformer('BAAI/bge-small-en-v1.5'); \
 print('Downloading cross-encoder model...'); \
 CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2'); \
+print('Downloading tiktoken encoding...'); import tiktoken; tiktoken.get_encoding('cl100k_base'); \
 print('Models cached successfully')" && break; \
       if [ $i -lt $MAX_RETRIES ]; then \
         echo "Attempt $i failed, retrying in ${RETRY_DELAY}s..."; \
@@ -310,6 +311,7 @@ print('Downloading embedding model...'); \
 SentenceTransformer('BAAI/bge-small-en-v1.5'); \
 print('Downloading cross-encoder model...'); \
 CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2'); \
+print('Downloading tiktoken encoding...'); import tiktoken; tiktoken.get_encoding('cl100k_base'); \
 print('Models cached successfully')" && break; \
       if [ $i -lt $MAX_RETRIES ]; then \
         echo "Attempt $i failed, retrying in ${RETRY_DELAY}s..."; \


### PR DESCRIPTION
## Summary
Pre-download `cl100k_base` tiktoken encoding during Docker build to avoid runtime download delays.

## Why
Tiktoken is used by OpenAI models for tokenization. Without preloading, the first API call that uses tiktoken triggers a download, adding latency to the initial request.

## Changes
- Added tiktoken preload to both `api-only` and `standalone` stages
- Downloads `cl100k_base` encoding (most commonly used)

## Test plan
- [x] Built image locally
- [x] Verified tiktoken encoding is cached in image

🤖 Generated with [Claude Code](https://claude.ai/code)