### PR TITLE
fix(hindsight-embed): respect HINDSIGHT_API_DATABASE_URL if already set

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_client.py
+++ b/hindsight-embed/hindsight_embed/daemon_client.py
@@ -76,7 +76,10 @@ def _start_daemon(config: dict) -> bool:
         env["HINDSIGHT_API_LLM_MODEL"] = config["llm_model"]
 
     # Use single shared pg0 database for all banks (banks are isolated within the database)
-    env["HINDSIGHT_API_DATABASE_URL"] = "pg0://hindsight-embed"
+    # Allow override via HINDSIGHT_API_DATABASE_URL for external PostgreSQL
+    # (e.g. when running as root where embedded pg0 cannot use initdb)
+    if "HINDSIGHT_API_DATABASE_URL" not in env:
+        env["HINDSIGHT_API_DATABASE_URL"] = "pg0://hindsight-embed"
     env["HINDSIGHT_API_LOG_LEVEL"] = "info"
 
     # Get idle timeout from environment or use default


### PR DESCRIPTION
## Summary

One-line fix: check if `HINDSIGHT_API_DATABASE_URL` is already set before defaulting to `pg0://hindsight-embed`.

## Problem

`daemon_client.py` unconditionally overwrites `HINDSIGHT_API_DATABASE_URL`, preventing users from using an external PostgreSQL instance. This breaks on VPS deployments running as root, where pg0 embedded PostgreSQL fails with `initdb: cannot be run as root`.

## Change

```python
# Before:
env["HINDSIGHT_API_DATABASE_URL"] = "pg0://hindsight-embed"

# After:
if "HINDSIGHT_API_DATABASE_URL" not in env:
    env["HINDSIGHT_API_DATABASE_URL"] = "pg0://hindsight-embed"
```

## Impact

- **Default behavior unchanged**: Users without the env var set still get pg0 embedded PostgreSQL
- **New capability**: Users can set `HINDSIGHT_API_DATABASE_URL=postgresql://...` to use external PostgreSQL
- **Fixes root user deployments**: VPS/server users running as root can now use hindsight-embed with system PostgreSQL

## Testing

Tested on Hetzner VPS (Ubuntu 24.04) running OpenClaw as root:
- ✅ External PostgreSQL 16 with pgvector extension
- ✅ Memory retain and recall working correctly
- ✅ Gemini 2.5 Flash as LLM provider
- ✅ OpenClaw hindsight-openclaw plugin integration

Fixes #261