### PR TITLE
Add pre-operation validation hooks for mental model create/refresh

### DIFF
--- a/hindsight-api/hindsight_api/extensions/__init__.py
+++ b/hindsight-api/hindsight_api/extensions/__init__.py
@@ -27,6 +27,7 @@ from hindsight_api.extensions.operation_validator import (
     # Mental Model operations
     MentalModelGetContext,
     MentalModelGetResult,
+    MentalModelRefreshContext,
     MentalModelRefreshResult,
     # Core operations
     OperationValidationError,
@@ -72,6 +73,7 @@ __all__ = [
     # Operation Validator - Mental Model
     "MentalModelGetContext",
     "MentalModelGetResult",
+    "MentalModelRefreshContext",
     "MentalModelRefreshResult",
     # Tenant/Auth
     "ApiKeyTenantExtension",

--- a/hindsight-api/hindsight_api/extensions/operation_validator.py
+++ b/hindsight-api/hindsight_api/extensions/operation_validator.py
@@ -211,6 +211,15 @@ class MentalModelGetContext:
 
 
 @dataclass
+class MentalModelRefreshContext:
+    """Context for a mental model refresh/create operation validation (pre-operation)."""
+
+    bank_id: str
+    mental_model_id: str | None  # None for create (not yet assigned)
+    request_context: "RequestContext"
+
+
+@dataclass
 class MentalModelGetResult:
     """Result context for post-mental-model-GET hook."""
 
@@ -459,6 +468,23 @@ class OperationValidatorExtension(Extension, ABC):
             ctx: Context containing:
                 - bank_id: Bank identifier
                 - mental_model_id: Mental model identifier
+                - request_context: Request context with auth info
+
+        Returns:
+            ValidationResult indicating whether the operation is allowed.
+        """
+        return ValidationResult.accept()
+
+    async def validate_mental_model_refresh(self, ctx: MentalModelRefreshContext) -> ValidationResult:
+        """
+        Validate a mental model refresh/create operation before execution.
+
+        Override to implement custom validation logic for mental model refresh.
+
+        Args:
+            ctx: Context containing:
+                - bank_id: Bank identifier
+                - mental_model_id: Mental model identifier (None for create)
                 - request_context: Request context with auth info
 
         Returns:


### PR DESCRIPTION
## Summary

- Adds `MentalModelRefreshContext` dataclass for pre-operation validation context
- Adds `validate_mental_model_refresh` method to `OperationValidatorExtension`
- Wires up pre-operation validation in both create and refresh mental model HTTP routes
- Extensions can now reject mental model operations before async LLM work is queued

## Changes

| File | Change |
|------|--------|
| `hindsight-api/hindsight_api/extensions/operation_validator.py` | Add `MentalModelRefreshContext` and `validate_mental_model_refresh` hook |
| `hindsight-api/hindsight_api/extensions/__init__.py` | Export `MentalModelRefreshContext` |
| `hindsight-api/hindsight_api/api/http.py` | Wire up pre-operation validation in create/refresh endpoints |

## Test plan

- [ ] Verify create mental model route calls `validate_mental_model_refresh` before creating
- [ ] Verify refresh mental model route calls `validate_mental_model_refresh` before refreshing
- [ ] Verify rejected operations return correct status code and reason
- [ ] Verify operations proceed normally when no validator is configured