### PR TITLE
feat(openclaw): add llmProvider/llmModel plugin config options

### DIFF
--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -24,6 +24,19 @@
         "type": "string",
         "description": "hindsight-embed version to use (e.g. 'latest', '0.4.2', or empty for latest)",
         "default": "latest"
+      },
+      "llmProvider": {
+        "type": "string",
+        "description": "LLM provider for Hindsight memory (e.g. 'openai', 'anthropic', 'gemini', 'groq', 'ollama'). Takes priority over auto-detection but not over HINDSIGHT_API_LLM_PROVIDER env var.",
+        "enum": ["openai", "anthropic", "gemini", "groq", "ollama"]
+      },
+      "llmModel": {
+        "type": "string",
+        "description": "LLM model to use (e.g. 'gpt-4o-mini', 'claude-3-5-haiku-20241022'). Used with llmProvider."
+      },
+      "llmApiKeyEnv": {
+        "type": "string",
+        "description": "Name of the env var holding the API key (e.g. 'MY_CUSTOM_KEY'). If not set, uses the standard env var for the chosen provider."
       }
     },
     "additionalProperties": false
@@ -44,6 +57,18 @@
     "embedVersion": {
       "label": "Hindsight Embed Version",
       "placeholder": "latest (or pin to specific version like 0.4.2)"
+    },
+    "llmProvider": {
+      "label": "LLM Provider",
+      "placeholder": "e.g. openai, anthropic, gemini, groq"
+    },
+    "llmModel": {
+      "label": "LLM Model",
+      "placeholder": "e.g. gpt-4o-mini, claude-3-5-haiku-20241022"
+    },
+    "llmApiKeyEnv": {
+      "label": "API Key Env Var",
+      "placeholder": "e.g. MY_CUSTOM_API_KEY (optional)"
     }
   }
 }

--- a/hindsight-integrations/openclaw/package-lock.json
+++ b/hindsight-integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-openclaw",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-openclaw",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -32,6 +32,9 @@ export interface PluginConfig {
   embedPort?: number;
   daemonIdleTimeout?: number; // Seconds before daemon shuts down (0 = never)
   embedVersion?: string; // hindsight-embed version (default: "latest")
+  llmProvider?: string; // LLM provider override (e.g. 'openai', 'anthropic', 'gemini', 'groq', 'ollama')
+  llmModel?: string; // LLM model override (e.g. 'gpt-4o-mini', 'claude-3-5-haiku-20241022')
+  llmApiKeyEnv?: string; // Env var name holding the API key (e.g. 'MY_CUSTOM_KEY')
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary

Adds `llmProvider`, `llmModel`, and `llmApiKeyEnv` config options to the hindsight-openclaw plugin, allowing users to explicitly choose which LLM Hindsight uses directly in their openclaw.json config.

## Problem

Currently, the plugin auto-detects the LLM by iterating through environment variables in a fixed order (OpenAI > Anthropic > Gemini > Groq). Users who want a specific provider (e.g., Groq for its free tier) must set `HINDSIGHT_API_LLM_PROVIDER` env vars, which is not discoverable and bypasses the plugin config system entirely.

## Solution

New plugin config options with a clear priority chain:

1. **`HINDSIGHT_API_LLM_PROVIDER` env var** (highest, existing behavior)
2. **Plugin config `llmProvider`/`llmModel`** (NEW)
3. **Auto-detect from env vars** (lowest, existing behavior)

### Example config:
```json
"hindsight-openclaw": {
  "config": {
    "llmProvider": "groq",
    "llmModel": "openai/gpt-oss-20b",
    "embedVersion": "0.4.7"
  }
}
```

### Optional: `llmApiKeyEnv`
For users with custom env var names (e.g., `MY_GROQ_KEY` instead of `GROQ_API_KEY`).

## Changes

- **`src/types.ts`** — Added `llmProvider?`, `llmModel?`, `llmApiKeyEnv?` to PluginConfig
- **`src/index.ts`** — `detectLLMConfig()` now checks plugin config between env override and auto-detect; updated error messages to mention all three options
- **`openclaw.plugin.json`** — Added config schema properties with enum validation and UI hints

## Backward Compatible

No config = same auto-detect behavior as before. Existing env var overrides continue to work at highest priority.