### PR TITLE
fix(openclaw): improve shell argument escaping

### DIFF
--- a/hindsight-integrations/openclaw/src/client.test.ts
+++ b/hindsight-integrations/openclaw/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { HindsightClient } from './client.js';
+import { HindsightClient, escapeShellArg } from './client.js';
 
 describe('HindsightClient', () => {
   it('should create instance with provider and API key', () => {
@@ -19,5 +19,86 @@ describe('HindsightClient', () => {
     // This test validates the client is instantiated correctly
     // Actual CLI calls would require mocking
     expect(client).toBeDefined();
+  });
+});
+
+describe('escapeShellArg', () => {
+  it('should return unchanged string when no special characters', () => {
+    expect(escapeShellArg('hello world')).toBe('hello world');
+    expect(escapeShellArg('simple text 123')).toBe('simple text 123');
+  });
+
+  it('should escape single quotes', () => {
+    expect(escapeShellArg("it's")).toBe("it'\\''s");
+    expect(escapeShellArg("don't")).toBe("don'\\''t");
+    expect(escapeShellArg("'quoted'")).toBe("'\\''quoted'\\''");
+  });
+
+  it('should preserve dollar signs (protected by single quotes)', () => {
+    // These are NOT escaped - single quotes protect them
+    expect(escapeShellArg('$HOME')).toBe('$HOME');
+    expect(escapeShellArg('cost is $100')).toBe('cost is $100');
+  });
+
+  it('should preserve backticks (protected by single quotes)', () => {
+    expect(escapeShellArg('`ls`')).toBe('`ls`');
+    expect(escapeShellArg('run `command`')).toBe('run `command`');
+  });
+
+  it('should preserve exclamation marks (protected by single quotes)', () => {
+    expect(escapeShellArg('hello!')).toBe('hello!');
+    expect(escapeShellArg('wow! amazing!')).toBe('wow! amazing!');
+  });
+
+  it('should preserve glob patterns (protected by single quotes)', () => {
+    expect(escapeShellArg('*.txt')).toBe('*.txt');
+    expect(escapeShellArg('file?.log')).toBe('file?.log');
+    expect(escapeShellArg('[abc]')).toBe('[abc]');
+  });
+
+  it('should preserve parentheses and braces (protected by single quotes)', () => {
+    expect(escapeShellArg('(subshell)')).toBe('(subshell)');
+    expect(escapeShellArg('{a,b,c}')).toBe('{a,b,c}');
+  });
+
+  it('should preserve redirection and control operators (protected by single quotes)', () => {
+    expect(escapeShellArg('a > b')).toBe('a > b');
+    expect(escapeShellArg('cmd | grep')).toBe('cmd | grep');
+    expect(escapeShellArg('a && b')).toBe('a && b');
+    expect(escapeShellArg('a; b')).toBe('a; b');
+  });
+
+  it('should preserve backslashes (protected by single quotes)', () => {
+    expect(escapeShellArg('path\\to\\file')).toBe('path\\to\\file');
+  });
+
+  it('should preserve double quotes (protected by single quotes)', () => {
+    expect(escapeShellArg('"quoted"')).toBe('"quoted"');
+  });
+
+  it('should preserve hash (protected by single quotes)', () => {
+    expect(escapeShellArg('# comment')).toBe('# comment');
+  });
+
+  it('should preserve tilde (protected by single quotes)', () => {
+    expect(escapeShellArg('~user')).toBe('~user');
+  });
+
+  it('should preserve newlines (protected by single quotes)', () => {
+    expect(escapeShellArg('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('should handle complex mixed content', () => {
+    expect(escapeShellArg("It's $100! Run `ls`")).toBe("It'\\''s $100! Run `ls`");
+    expect(escapeShellArg("user's file*.txt")).toBe("user'\\''s file*.txt");
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeShellArg('')).toBe('');
+  });
+
+  it('should handle multiple consecutive single quotes', () => {
+    expect(escapeShellArg("''")).toBe("'\\'''\\''");
+    expect(escapeShellArg("'''")).toBe("'\\'''\\'''\\''");
   });
 });


### PR DESCRIPTION
## Summary

Improve shell argument escaping in openclaw plugin to handle all shell-special characters using POSIX single-quote method.

## Problem

Current code only escapes single quotes inline with `.replace(/'/g, "'\\''")`, but:
- Document ID in `retain()` was not escaped at all
- The escaping logic is duplicated in multiple places
- No centralized, well-documented escaping function

## Solution

- Add exported `escapeShellArg()` function using POSIX single-quote escaping
- Replace all inline escaping with the shared function
- Escape document ID in `retain()`
- Add comprehensive tests (17 test cases) covering:
  - Single quotes
  - Dollar signs (`$`)
  - Backticks (`` ` ``)
  - Exclamation marks (`!`)
  - Glob patterns (`*`, `?`, `[]`)
  - Redirection and control operators (`>`, `|`, `&&`, `;`)
  - Backslashes, double quotes, hash, tilde, newlines

The POSIX single-quote method handles ALL shell metacharacters by wrapping in single quotes (which protect everything except single quotes themselves) and escaping any embedded single quotes with `'\''` sequence.

## Test plan

- [x] All 19 unit tests pass
- [x] TypeScript build succeeds