### PR TITLE
feat(openclaw): add external Hindsight API support

### DIFF
--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -46,6 +46,15 @@
         "type": "number",
         "description": "Port for the openclaw profile daemon (default: 9077)",
         "default": 9077
+      },
+      "hindsightApiUrl": {
+        "type": "string",
+        "description": "External Hindsight API URL (e.g. 'https://mcp.hindsight.devcraft.team'). When set, skips local daemon and connects directly to this API.",
+        "format": "uri"
+      },
+      "hindsightApiToken": {
+        "type": "string",
+        "description": "API token for external Hindsight API authentication. Required if the external API has authentication enabled."
       }
     },
     "additionalProperties": false
@@ -86,6 +95,14 @@
     "apiPort": {
       "label": "API Port",
       "placeholder": "9077 (default)"
+    },
+    "hindsightApiUrl": {
+      "label": "External Hindsight API URL",
+      "placeholder": "e.g. https://mcp.hindsight.devcraft.team (leave empty for local daemon)"
+    },
+    "hindsightApiToken": {
+      "label": "External API Token",
+      "placeholder": "API token if external API requires authentication"
     }
   }
 }

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -37,6 +37,8 @@ export interface PluginConfig {
   llmModel?: string; // LLM model override (e.g. 'gpt-4o-mini', 'claude-3-5-haiku-20241022')
   llmApiKeyEnv?: string; // Env var name holding the API key (e.g. 'MY_CUSTOM_KEY')
   apiPort?: number; // Port for openclaw profile daemon (default: 9077)
+  hindsightApiUrl?: string; // External Hindsight API URL (skips local daemon when set)
+  hindsightApiToken?: string; // API token for external Hindsight API authentication
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary

Add support for connecting to an external Hindsight API instead of starting a local daemon.

## Use cases

- **Shared memory** across multiple OpenClaw instances
- **Centralized deployment** (e.g., Hindsight on GKE)
- **Reduced resource usage** (no local daemon per instance)
- **Multi-tenant setups** where a central Hindsight serves multiple bots

## Configuration

```bash
# Via environment variable (highest priority)
export HINDSIGHT_EMBED_API_URL=https://hindsight.example.com
export HINDSIGHT_EMBED_API_TOKEN=optional-auth-token  # if API requires auth

# Or via plugin config
{
  "hindsightApiUrl": "https://hindsight.example.com",
  "hindsightApiToken": "optional-auth-token"
}
```

## How it works

When `hindsightApiUrl` is configured:
1. Skip local daemon startup entirely
2. Health check external API on startup
3. Pass API URL/token to CLI commands via env vars
4. All memory operations go to external API

When not configured, falls back to local daemon mode (existing behavior).

## Test plan

- [x] TypeScript build succeeds
- [ ] Manual test with external API deployment