### PR TITLE
fixed cast error

### DIFF
--- a/hindsight-api/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api/hindsight_api/engine/reflect/agent.py
@@ -871,21 +871,21 @@ async def _execute_tool(
         query = args.get("query")
         if not query:
             return {"error": "search_mental_models requires a query parameter"}
-        max_results = args.get("max_results") or 5
+        max_results = int(args.get("max_results") or 5)
         return await search_mental_models_fn(query, max_results)
 
     elif tool_name == "search_observations":
         query = args.get("query")
         if not query:
             return {"error": "search_observations requires a query parameter"}
-        max_tokens = max(args.get("max_tokens") or 5000, 1000)  # Default 5000, min 1000
+        max_tokens = max(int(args.get("max_tokens") or 5000), 1000)  # Default 5000, min 1000
         return await search_observations_fn(query, max_tokens)
 
     elif tool_name == "recall":
         query = args.get("query")
         if not query:
             return {"error": "recall requires a query parameter"}
-        max_tokens = max(args.get("max_tokens") or 2048, 1000)  # Default 2048, min 1000
+        max_tokens = max(int(args.get("max_tokens") or 2048), 1000)  # Default 2048, min 1000
         return await recall_fn(query, max_tokens)
 
     elif tool_name == "expand":
@@ -904,18 +904,18 @@ def _summarize_input(tool_name: str, args: dict[str, Any]) -> str:
     if tool_name == "search_mental_models":
         query = args.get("query", "")
         query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
-        max_results = args.get("max_results") or 5
+        max_results = int(args.get("max_results") or 5)
         return f"(query={query_preview}, max_results={max_results})"
     elif tool_name == "search_observations":
         query = args.get("query", "")
         query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
-        max_tokens = max(args.get("max_tokens") or 5000, 1000)
+        max_tokens = max(int(args.get("max_tokens") or 5000), 1000)
         return f"(query={query_preview}, max_tokens={max_tokens})"
     elif tool_name == "recall":
         query = args.get("query", "")
         query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
         # Show actual value used (default 2048, min 1000)
-        max_tokens = max(args.get("max_tokens") or 2048, 1000)
+        max_tokens = max(int(args.get("max_tokens") or 2048), 1000)
         return f"(query={query_preview}, max_tokens={max_tokens})"
     elif tool_name == "expand":
         memory_ids = args.get("memory_ids", [])


### PR DESCRIPTION
A casting error happened when running with ollama on reflect.

```log
2026-02-04 16:13:01 2026-02-04 21:13:01,571 - ERROR - hindsight_api.mcp_tools - Error reflecting: '>' not supported between instances of 'int' and 'str'
2026-02-04 16:13:01 Traceback (most recent call last):
2026-02-04 16:13:01   File "/app/api/hindsight_api/mcp_tools.py", line 386, in reflect
2026-02-04 16:13:01     reflect_result = await memory.reflect_async(
2026-02-04 16:13:01                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-04 16:13:01   File "/app/api/hindsight_api/engine/memory_engine.py", line 3707, in reflect_async
2026-02-04 16:13:01     agent_result = await run_reflect_agent(
2026-02-04 16:13:01                    ^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-04 16:13:01   File "/app/api/hindsight_api/engine/reflect/agent.py", line 718, in run_reflect_agent
2026-02-04 16:13:01     input_summary = _summarize_input(tc.name, tc.arguments)
2026-02-04 16:13:01                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-04 16:13:01   File "/app/api/hindsight_api/engine/reflect/agent.py", line 912, in _summarize_input
2026-02-04 16:13:01     max_tokens = max(args.get("max_tokens") or 5000, 1000)
2026-02-04 16:13:01                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-04 16:13:01 TypeError: '>' not supported between instances of 'int' and 'str'
2026-02-04 16:13:01 2026-02-04 21:13:01,573 - INFO - mcp.server.streamable_http - Terminating session: None
2026-02-04 16:13:03 2026-02-04 21:13:03,033 - INFO - mcp.server.lowlevel.server - Processing request of type CallToolRequest
2026-02-04 16:13:03 2026-02-04 21:13:03,033 - INFO - hindsight_api.engine.memory_engine - [RECAL
```