### PR TITLE
feat(docker): add Claude CLI for claude-code LLM provider

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -269,9 +269,12 @@ RUN apt-get update && apt-get install -y \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir uv
+    && pip install --no-cache-dir uv \
+    && npm install -g @anthropic-ai/claude-code
 
-RUN useradd -m -s /bin/bash hindsight
+RUN useradd -m -s /bin/bash hindsight \
+    && mkdir -p /home/hindsight/.claude \
+    && chown hindsight:hindsight /home/hindsight/.claude
 
 # Copy API with virtual environment from builder
 COPY --from=api-builder /app/api /app/api


### PR DESCRIPTION
## Summary
- Add Claude CLI (`@anthropic-ai/claude-code`) to Docker image for `claude-code` LLM provider support
- Create `/home/hindsight/.claude/` directory for credentials mount
- Enable using Claude Pro/Max subscriptions via Agent SDK authentication in Docker containers

## Changes
- `docker/standalone/Dockerfile`: Install Claude CLI globally and create user directory

## Test plan
- [x] Docker image builds successfully (verified via CI/CD)
- [x] Claude CLI accessible in container (`claude --version` returns `2.1.31`)
- [x] Memory operations work with `claude-code` LLM provider (tested retain/recall on VM deployment)

## Usage
Mount credentials file to container:
```yaml
volumes:
  - ~/.claude/.credentials.json:/home/hindsight/.claude/.credentials.json:ro
environment:
  HINDSIGHT_API_LLM_PROVIDER: claude-code
  HINDSIGHT_API_LLM_MODEL: claude-sonnet-4-20250514
  CLAUDE_CODE_OAUTH_TOKEN: <your-oauth-token>  # Optional: pass token via env var
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)