### PR TITLE
fix(openclaw): remove format:uri to fix ajv warning

### DIFF
--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -49,8 +49,7 @@
       },
       "hindsightApiUrl": {
         "type": "string",
-        "description": "External Hindsight API URL (e.g. 'https://mcp.hindsight.devcraft.team'). When set, skips local daemon and connects directly to this API.",
-        "format": "uri"
+        "description": "External Hindsight API URL (e.g. 'https://mcp.hindsight.devcraft.team'). When set, skips local daemon and connects directly to this API."
       },
       "hindsightApiToken": {
         "type": "string",


### PR DESCRIPTION
## Problem

When OpenClaw starts with the hindsight-openclaw plugin, this warning appears multiple times:

```
unknown format "uri" ignored in schema at path "#/properties/hindsightApiUrl"
```

This occurs because the plugin's JSON schema uses `format: "uri"` but OpenClaw's Ajv validator doesn't have ajv-formats loaded.

## Solution

Remove the `format: "uri"` from the `hindsightApiUrl` schema property.

The URI validation isn't critical for this field since:
1. Invalid URLs will fail at connection time with a clear error
2. The description already shows the expected format with an example
3. This is a configuration field that users intentionally set

## Changes

- Removed `"format": "uri"` from `hindsightApiUrl` in `openclaw.plugin.json`

## Testing

The warning should no longer appear when OpenClaw loads the plugin.