### PR TITLE
doc: improve Node.js client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ npm install @vectorize-io/hindsight-client
 ```javascript
 const { HindsightClient } = require('@vectorize-io/hindsight-client');
 
-const client = new HindsightClient({ baseUrl: 'http://localhost:8888' });
+const example = async () => {
+  const client = new HindsightClient({ baseUrl: 'http://localhost:8888' });
 
-await client.retain('my-bank', 'Alice loves hiking in Yosemite');
-await client.recall('my-bank', 'What does Alice like?');
+  await client.retain('my-bank', 'Alice loves hiking in Yosemite');
+
+  const results = await client.recall('my-bank', 'What does Alice like?');
+  console.log(results);
+}
+
+example();
 ```
 
 ---


### PR DESCRIPTION
Fix doc to increase the developer experience...

- if the code is intended to be a CommonJS by using `require` then you have to wrap `await` calls in an async function
- calling `client.recall` with using the results