### PR TITLE
feat(openclaw): add excludeProviders config

### DIFF
--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -270,6 +270,7 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     // Dynamic bank ID options (default: enabled)
     dynamicBankId: config.dynamicBankId !== false,
     bankIdPrefix: config.bankIdPrefix,
+    excludeProviders: Array.isArray(config.excludeProviders) ? config.excludeProviders : [],
   };
 }
 
@@ -549,6 +550,12 @@ export default function (api: MoltbotPluginAPI) {
         }
         currentAgentContext = ctx;
 
+        // Check if this provider is excluded
+        if (ctx?.messageProvider && pluginConfig.excludeProviders?.includes(ctx.messageProvider)) {
+          console.log(`[Hindsight] Skipping recall for excluded provider: ${ctx.messageProvider}`);
+          return;
+        }
+
         // Derive bank ID from context
         const bankId = deriveBankId(ctx, pluginConfig);
         console.log(`[Hindsight] before_agent_start - bank: ${bankId}, channel: ${ctx?.messageProvider}/${ctx?.channelId}`);
@@ -646,6 +653,12 @@ User message: ${prompt}
       try {
         // Use context from this hook, or fall back to context captured in before_agent_start
         const effectiveCtx = ctx || currentAgentContext;
+
+        // Check if this provider is excluded
+        if (effectiveCtx?.messageProvider && pluginConfig.excludeProviders?.includes(effectiveCtx.messageProvider)) {
+          console.log(`[Hindsight] Skipping retain for excluded provider: ${effectiveCtx.messageProvider}`);
+          return;
+        }
 
         // Derive bank ID from context
         const bankId = deriveBankId(effectiveCtx, pluginConfig);

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -42,6 +42,7 @@ export interface PluginConfig {
   hindsightApiToken?: string; // API token for external Hindsight API authentication
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
+  excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary
- Adds `excludeProviders?: string[]` to the OpenClaw `PluginConfig` type
- When a message provider (e.g. `telegram`, `discord`) is in the exclude list, both auto-recall and auto-retain are skipped for that provider
- Logs `[Hindsight] Skipping recall/retain for excluded provider: {provider}` when skipping

## Usage
```json
{
  "plugins": {
    "entries": {
      "hindsight-openclaw": {
        "enabled": true,
        "config": {
          "excludeProviders": ["telegram", "discord"]
        }
      }
    }
  }
}
```

## Test plan
- [x] TypeScript compiles without errors
- [x] All 19 existing tests pass (`vitest run`)
- [x] Python lint passes (`ruff check` + `ruff format --check`)
- [ ] Manual: configure `excludeProviders` with a provider name and verify recall/retain are skipped
- [ ] Manual: verify providers NOT in the list still work normally

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)