### PR TITLE
Fix MCP usage metering: propagate tenant_id through context vars

### DIFF
--- a/hindsight-api/hindsight_api/mcp_tools.py
+++ b/hindsight-api/hindsight_api/mcp_tools.py
@@ -35,6 +35,12 @@ class MCPToolsConfig:
     # How to resolve API key for tenant auth (optional)
     api_key_resolver: Callable[[], str | None] | None = None
 
+    # How to resolve tenant_id for usage metering (set by MCP middleware after auth)
+    tenant_id_resolver: Callable[[], str | None] | None = None
+
+    # How to resolve api_key_id for usage metering (set by MCP middleware after auth)
+    api_key_id_resolver: Callable[[], str | None] | None = None
+
     # Whether to include bank_id as a parameter on tools (for multi-bank support)
     include_bank_id_param: bool = False
 
@@ -50,13 +56,15 @@ class MCPToolsConfig:
 
 
 def _get_request_context(config: MCPToolsConfig) -> RequestContext:
-    """Create RequestContext with API key from resolver if available.
+    """Create RequestContext with auth details from resolvers.
 
-    This enables tenant auth to work with MCP tools by propagating
-    the Bearer token from the MCP middleware to the memory engine.
+    This enables tenant auth and usage metering to work with MCP tools by propagating
+    the authentication results from the MCP middleware to the memory engine.
     """
     api_key = config.api_key_resolver() if config.api_key_resolver else None
-    return RequestContext(api_key=api_key)
+    tenant_id = config.tenant_id_resolver() if config.tenant_id_resolver else None
+    api_key_id = config.api_key_id_resolver() if config.api_key_id_resolver else None
+    return RequestContext(api_key=api_key, tenant_id=tenant_id, api_key_id=api_key_id)
 
 
 def parse_timestamp(timestamp: str) -> datetime | None:


### PR DESCRIPTION
## Summary

- MCP middleware was discarding `tenant_id` and `api_key_id` after authentication — `authenticate_mcp()` set them on a throwaway `RequestContext`, so tools created a fresh one without them
- `UsageMeteringValidator` saw `tenant_id="unknown"` for all MCP operations and skipped billing entirely
- Propagate `tenant_id` and `api_key_id` via `ContextVar` (same pattern as existing `bank_id` and `api_key`) so the `RequestContext` passed to the memory engine carries the full auth context

## Test plan

- [x] `test_tenant_id_context_variable` — verifies new context vars set/get/reset correctly
- [x] `test_mcp_tools_propagate_tenant_id_and_api_key_id` — proves `tenant_id` and `api_key_id` flow from context vars through `MCPToolsConfig` resolvers into the `RequestContext` passed to the memory engine
- [x] All 13 tests in `test_mcp_routing.py` pass
- [ ] E2E: `mcp-usage-metering.spec.ts` verifies `total_tokens > 0` for MCP retain/recall on the org's usage records (in hindsight-cloud-ui)
- [ ] E2E: downstream `UsageMeteringValidator` tests with real `RequestContext` (in hindsight-cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)