### PR TITLE
Fix async batch retain incorrectly marked as internal

### DIFF
--- a/hindsight-api/hindsight_api/models.py
+++ b/hindsight-api/hindsight_api/models.py
@@ -20,7 +20,8 @@ class RequestContext:
     api_key: str | None = None
     api_key_id: str | None = None  # UUID of the API key used for authentication
     tenant_id: str | None = None  # Tenant identifier (set by extension after auth)
-    internal: bool = False  # True for background/internal operations (not user-visible)
+    internal: bool = False  # True for background/internal operations (skips extension auth)
+    user_initiated: bool = False  # True for async operations that originated from a user request
 
 
 from pgvector.sqlalchemy import Vector


### PR DESCRIPTION
## Summary
- User-initiated async retains (`async=true`) were incorrectly marked `internal=True` in `_handle_batch_retain`, causing operation validator extensions to treat them as system sub-operations instead of user-initiated operations

## Changes
- Set `internal=False` in `_handle_batch_retain()` since these are user-initiated operations processed asynchronously, not system-triggered sub-operations like consolidation

## Test plan
- [x] Pre-commit hooks pass
- [ ] E2E test in hindsight-deployment PR [#148](https://github.com/vectorize-io/hindsight-deployment/pull/148) verifies the fix