### PR TITLE
Replace waitlist links with direct signup URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Hindsight Banner](./hindsight-docs/static/img/hindsight-github-banner.png)
 
-[Documentation](https://hindsight.vectorize.io) • [Paper](https://arxiv.org/abs/2512.12818) • [Cookbook](https://hindsight.vectorize.io/cookbook) • [Hindsight Cloud](https://vectorize.io/hindsight/cloud)
+[Documentation](https://hindsight.vectorize.io) • [Paper](https://arxiv.org/abs/2512.12818) • [Cookbook](https://hindsight.vectorize.io/cookbook) • [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)
 
 [![CI](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml/badge.svg)](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml)
 [![Slack Community](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg)

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -3,7 +3,7 @@
 Hindsight can be deployed in several ways depending on your infrastructure and requirements.
 
 :::tip Don't want to manage infrastructure?
-**[Hindsight Cloud](https://vectorize.io/hindsight/cloud)** is a fully managed service that handles all infrastructure, scaling, and maintenance. We're onboarding design partners now — [request early access](https://vectorize.io/hindsight/cloud).
+**[Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** is a fully managed service that handles all infrastructure, scaling, and maintenance — [sign up here](https://ui.hindsight.vectorize.io/signup).
 :::
 
 ## Prerequisites

--- a/hindsight-docs/docs/sdks/integrations/skills.md
+++ b/hindsight-docs/docs/sdks/integrations/skills.md
@@ -161,11 +161,11 @@ uvx hindsight-embed configure
 
 ## Cloud Mode Setup
 
-Cloud mode connects to [Hindsight Cloud](https://vectorize.io/hindsight/cloud), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
+Cloud mode connects to [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
 
 ### Prerequisites
 
-1. A Hindsight Cloud account ([request access](https://vectorize.io/hindsight/cloud))
+1. A Hindsight Cloud account ([sign up](https://ui.hindsight.vectorize.io/signup))
 2. An API key from your team admin
 3. A bank ID for your project (e.g., `team-acme-frontend`)
 

--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -226,7 +226,7 @@ const config: Config = {
           className: 'navbar-item-changelog',
         },
         {
-          href: 'https://vectorize.io/hindsight/cloud',
+          href: 'https://ui.hindsight.vectorize.io/signup',
           position: 'right',
           label: 'Hindsight Cloud',
           className: 'navbar-item-cloud',
@@ -285,7 +285,7 @@ const config: Config = {
             },
             {
               label: 'Hindsight Cloud',
-              href: 'https://vectorize.io/hindsight/cloud',
+              href: 'https://ui.hindsight.vectorize.io/signup',
             },
           ],
         },

--- a/hindsight-docs/versioned_docs/version-0.3/developer/installation.md
+++ b/hindsight-docs/versioned_docs/version-0.3/developer/installation.md
@@ -3,7 +3,7 @@
 Hindsight can be deployed in several ways depending on your infrastructure and requirements.
 
 :::tip Don't want to manage infrastructure?
-**[Hindsight Cloud](https://vectorize.io/hindsight/cloud)** is a fully managed service that handles all infrastructure, scaling, and maintenance. We're onboarding design partners now — [request early access](https://vectorize.io/hindsight/cloud).
+**[Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** is a fully managed service that handles all infrastructure, scaling, and maintenance — [sign up here](https://ui.hindsight.vectorize.io/signup).
 :::
 
 ## Prerequisites

--- a/hindsight-docs/versioned_docs/version-0.3/sdks/integrations/skills.md
+++ b/hindsight-docs/versioned_docs/version-0.3/sdks/integrations/skills.md
@@ -161,11 +161,11 @@ uvx hindsight-embed configure
 
 ## Cloud Mode Setup
 
-Cloud mode connects to [Hindsight Cloud](https://vectorize.io/hindsight/cloud), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
+Cloud mode connects to [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
 
 ### Prerequisites
 
-1. A Hindsight Cloud account ([request access](https://vectorize.io/hindsight/cloud))
+1. A Hindsight Cloud account ([sign up](https://ui.hindsight.vectorize.io/signup))
 2. An API key from your team admin
 3. A bank ID for your project (e.g., `team-acme-frontend`)
 

--- a/hindsight-docs/versioned_docs/version-0.4/developer/installation.md
+++ b/hindsight-docs/versioned_docs/version-0.4/developer/installation.md
@@ -3,7 +3,7 @@
 Hindsight can be deployed in several ways depending on your infrastructure and requirements.
 
 :::tip Don't want to manage infrastructure?
-**[Hindsight Cloud](https://vectorize.io/hindsight/cloud)** is a fully managed service that handles all infrastructure, scaling, and maintenance. We're onboarding design partners now — [request early access](https://vectorize.io/hindsight/cloud).
+**[Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** is a fully managed service that handles all infrastructure, scaling, and maintenance — [sign up here](https://ui.hindsight.vectorize.io/signup).
 :::
 
 ## Prerequisites

--- a/hindsight-docs/versioned_docs/version-0.4/sdks/integrations/skills.md
+++ b/hindsight-docs/versioned_docs/version-0.4/sdks/integrations/skills.md
@@ -161,11 +161,11 @@ uvx hindsight-embed configure
 
 ## Cloud Mode Setup
 
-Cloud mode connects to [Hindsight Cloud](https://vectorize.io/hindsight/cloud), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
+Cloud mode connects to [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
 
 ### Prerequisites
 
-1. A Hindsight Cloud account ([request access](https://vectorize.io/hindsight/cloud))
+1. A Hindsight Cloud account ([sign up](https://ui.hindsight.vectorize.io/signup))
 2. An API key from your team admin
 3. A bank ID for your project (e.g., `team-acme-frontend`)
 

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -3,7 +3,7 @@
 Hindsight can be deployed in several ways depending on your infrastructure and requirements.
 
 :::tip Don't want to manage infrastructure?
-**[Hindsight Cloud](https://vectorize.io/hindsight/cloud)** is a fully managed service that handles all infrastructure, scaling, and maintenance. We're onboarding design partners now — [request early access](https://vectorize.io/hindsight/cloud).
+**[Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** is a fully managed service that handles all infrastructure, scaling, and maintenance — [sign up here](https://ui.hindsight.vectorize.io/signup).
 :::
 
 ## Prerequisites

--- a/skills/hindsight-docs/references/sdks/integrations/skills.md
+++ b/skills/hindsight-docs/references/sdks/integrations/skills.md
@@ -161,11 +161,11 @@ uvx hindsight-embed configure
 
 ## Cloud Mode Setup
 
-Cloud mode connects to [Hindsight Cloud](https://vectorize.io/hindsight/cloud), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
+Cloud mode connects to [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup), allowing teams to share memories about a codebase. When one team member learns something, everyone benefits.
 
 ### Prerequisites
 
-1. A Hindsight Cloud account ([request access](https://vectorize.io/hindsight/cloud))
+1. A Hindsight Cloud account ([sign up](https://ui.hindsight.vectorize.io/signup))
 2. An API key from your team admin
 3. A bank ID for your project (e.g., `team-acme-frontend`)
 


### PR DESCRIPTION
## Summary
- Replace all `vectorize.io/hindsight/cloud` waitlist links with `ui.hindsight.vectorize.io/signup`
- Update "request early access" / "request access" language to "sign up" across README, docs, versioned docs, and skill references
- Waitlist is no longer needed — Hindsight Cloud is now open for direct signup

## Test plan
- [ ] Verify all links in README render correctly and point to signup page
- [ ] Verify docs site navbar and footer links point to signup page
- [ ] Verify installation.md tip box links work across all doc versions
- [ ] Verify Cloud Mode Setup links in skills.md work across all doc versions