### PR TITLE
Fix incorrect MCP tool parameters in docs

### DIFF
--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -147,7 +147,6 @@ Search memories to provide personalized responses.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | string | Yes | Natural language search query |
-| `max_results` | integer | No | Maximum results to return (default: 10) |
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 
 **Example:**
@@ -204,6 +203,7 @@ Create a mental model — a living document that stays current with your memorie
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Human-readable name for the mental model |
 | `source_query` | string | Yes | The query used to generate and refresh the model |
+| `mental_model_id` | string | No | Custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided |
 | `tags` | list[string] | No | Tags for organizing and filtering models |
 | `max_tokens` | integer | No | Maximum tokens for model content (default: 2048) |
 
@@ -290,6 +290,8 @@ Create a new memory bank or retrieve an existing one.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `bank_id` | string | Yes | The ID for the new bank |
+| `name` | string | No | Human-friendly name for the bank |
+| `mission` | string | No | Mission describing who the agent is and what they're trying to accomplish |
 
 ---
 

--- a/hindsight-docs/docs/sdks/integrations/local-mcp.md
+++ b/hindsight-docs/docs/sdks/integrations/local-mcp.md
@@ -132,7 +132,6 @@ Search memories to provide personalized responses.
 |-----------|------|----------|-------------|
 | `query` | string | Yes | Natural language search query |
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
-| `budget` | string | No | Search depth: `low`, `mid`, or `high` (default: `low`) |
 
 **Example:**
 ```json
@@ -140,8 +139,7 @@ Search memories to provide personalized responses.
   "name": "recall",
   "arguments": {
     "query": "What are the user's color preferences?",
-    "max_tokens": 2048,
-    "budget": "mid"
+    "max_tokens": 2048
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Remove phantom `max_results` param from recall docs (only has `query` + `max_tokens`)
- Remove `budget` param from local-mcp recall docs (only reflect has budget, recall uses HIGH internally)
- Add missing `name` and `mission` optional params to create_bank docs
- Add missing `mental_model_id` optional param to create_mental_model docs

Found by auditing docs against actual tool schemas from the running server.

## Test plan

- [ ] Verify `mcp-server.md` recall params match `mcp_tools.py` recall signature
- [ ] Verify `local-mcp.md` recall params match local MCP recall (no budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)