### PR TITLE
fix(openclaw): remove unused imports, retry health check, suppress unhandled rejection

### DIFF
--- a/hindsight-integrations/openclaw/src/embed-manager.ts
+++ b/hindsight-integrations/openclaw/src/embed-manager.ts
@@ -1,8 +1,6 @@
 import { spawn, ChildProcess } from 'child_process';
-import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { execSync } from 'child_process';
 
 export class HindsightEmbedManager {
   private process: ChildProcess | null = null;


### PR DESCRIPTION
## Summary
- Remove unused `fs` and `execSync` imports from `embed-manager.ts`
- Remove unused `join` import from `index.ts`
- Add retry logic to external API health check (3 attempts, 2s delay) — container DNS may not be ready on first boot
- Use ES2022 `{ cause: error }` for better error chain preservation
- Add `.catch(() => {})` to `initPromise` to suppress Node.js unhandled rejection warnings (error is properly handled later in `service.start()`)

## Test plan
- [ ] No behavior changes for happy path — import removal and error handling cleanup only
- [ ] Health check retries 3x before failing, handles slow DNS resolution on container startup
- [ ] `initPromise` errors still logged and handled in `service.start()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)