### PR TITLE
fix(go-client): use monorepo-compatible module path

### DIFF
--- a/hindsight-clients/go/README.md
+++ b/hindsight-clients/go/README.md
@@ -22,7 +22,7 @@ go get golang.org/x/net/context
 Put the package under your project folder and add the following in import:
 
 ```go
-import hindsight "github.com/vectorize-io/hindsight-client-go"
+import hindsight "github.com/vectorize-io/hindsight/hindsight-clients/go"
 ```
 
 To use a proxy, set the environment variable `HTTP_PROXY`:

--- a/hindsight-clients/go/go.mod
+++ b/hindsight-clients/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/vectorize-io/hindsight-client-go
+module github.com/vectorize-io/hindsight/hindsight-clients/go
 
 go 1.18
 

--- a/hindsight-clients/go/openapi-generator-config.yaml
+++ b/hindsight-clients/go/openapi-generator-config.yaml
@@ -3,8 +3,8 @@ outputDir: ./
 inputSpec: ../../hindsight-docs/static/openapi.json
 packageName: hindsight
 gitUserId: vectorize-io
-gitRepoId: hindsight-client-go
-isGoSubmodule: false
+gitRepoId: hindsight/hindsight-clients/go
+isGoSubmodule: true
 enumClassPrefix: true
 structPrefix: true
 generateInterfaces: true

--- a/hindsight-clients/go/test/api_banks_test.go
+++ b/hindsight-clients/go/test/api_banks_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_BanksAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_directives_test.go
+++ b/hindsight-clients/go/test/api_directives_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_DirectivesAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_documents_test.go
+++ b/hindsight-clients/go/test/api_documents_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_DocumentsAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_entities_test.go
+++ b/hindsight-clients/go/test/api_entities_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_EntitiesAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_memory_test.go
+++ b/hindsight-clients/go/test/api_memory_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_MemoryAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_mental_models_test.go
+++ b/hindsight-clients/go/test/api_mental_models_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_MentalModelsAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_monitoring_test.go
+++ b/hindsight-clients/go/test/api_monitoring_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_MonitoringAPIService(t *testing.T) {

--- a/hindsight-clients/go/test/api_operations_test.go
+++ b/hindsight-clients/go/test/api_operations_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/vectorize-io/hindsight-client-go"
+	openapiclient "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func Test_hindsight_OperationsAPIService(t *testing.T) {

--- a/hindsight-docs/docs/sdks/go.md
+++ b/hindsight-docs/docs/sdks/go.md
@@ -12,7 +12,7 @@ import quickstartGo from '!!raw-loader!@site/examples/api/quickstart.go';
 ## Installation
 
 ```bash
-go get github.com/vectorize-io/hindsight-client-go
+go get github.com/vectorize-io/hindsight/hindsight-clients/go
 ```
 
 Requires Go 1.23+.

--- a/hindsight-docs/examples/api/quickstart.go
+++ b/hindsight-docs/examples/api/quickstart.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	hindsight "github.com/vectorize-io/hindsight-client-go"
+	hindsight "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func main() {

--- a/hindsight-docs/versioned_docs/version-0.4/sdks/go.md
+++ b/hindsight-docs/versioned_docs/version-0.4/sdks/go.md
@@ -9,7 +9,7 @@ Official Go client for the Hindsight API, built on [ogen](https://github.com/oge
 ## Installation
 
 ```bash
-go get github.com/vectorize-io/hindsight-client-go
+go get github.com/vectorize-io/hindsight/hindsight-clients/go
 ```
 
 Requires Go 1.25+.
@@ -24,7 +24,7 @@ import (
     "fmt"
     "log"
 
-    hindsight "github.com/vectorize-io/hindsight-client-go"
+    hindsight "github.com/vectorize-io/hindsight/hindsight-clients/go"
 )
 
 func main() {
@@ -53,7 +53,7 @@ func main() {
 ## Client Initialization
 
 ```go
-import hindsight "github.com/vectorize-io/hindsight-client-go"
+import hindsight "github.com/vectorize-io/hindsight/hindsight-clients/go"
 
 // Default client
 client, err := hindsight.New("http://localhost:8888")
@@ -231,7 +231,7 @@ resp, _ := client.Reflect(ctx, "my-bank", "Summarize project X",
 For operations not covered by the high-level wrapper (documents, entities, mental models, directives, operations), access the generated ogen client directly:
 
 ```go
-import "github.com/vectorize-io/hindsight-client-go/internal/ogenapi"
+import "github.com/vectorize-io/hindsight/hindsight-clients/go/internal/ogenapi"
 
 ogen := client.OgenClient()
 

--- a/scripts/generate-clients.sh
+++ b/scripts/generate-clients.sh
@@ -381,7 +381,7 @@ else
         -o . \
         --package-name hindsight \
         --git-user-id vectorize-io \
-        --git-repo-id hindsight-client-go \
+        --git-repo-id hindsight/hindsight-clients/go \
         --global-property apiDocs=false,apiTests=false,modelDocs=false,modelTests=false
 
     # Remove OpenAPI Generator boilerplate files


### PR DESCRIPTION
## Summary

- Update Go module path from `github.com/vectorize-io/hindsight-client-go` to `github.com/vectorize-io/hindsight/hindsight-clients/go` to match the actual monorepo location
- Enable `isGoSubmodule: true` in OpenAPI generator config
- Update all import references across tests (8 files), docs (3 files), README, and the client generation script

This allows consumers to use standard `go get` imports once a directory-prefixed tag (e.g., `hindsight-clients/go/v0.4.11`) is created, instead of requiring fragile `replace` directives.

## Test plan

- [x] `go build ./...` passes in `hindsight-clients/go/`
- [x] No remaining references to `hindsight-client-go` in the repository
- [ ] After merge, create tag `hindsight-clients/go/v0.4.11` to enable `go get`

🤖 Generated with [Claude Code](https://claude.com/claude-code)