### PR TITLE
fix: reduce temporal ordering offset from 10s to 10ms

### DIFF
--- a/hindsight-api/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api/hindsight_api/engine/retain/fact_extraction.py
@@ -1274,8 +1274,8 @@ from .types import ExtractedFact as ExtractedFactType
 
 logger = logging.getLogger(__name__)
 
-# Each fact gets 10 seconds offset to preserve ordering within a document
-SECONDS_PER_FACT = 10
+# Each fact gets 10ms offset to preserve ordering within a document
+SECONDS_PER_FACT = 0.01
 
 
 async def extract_facts_from_contents_batch_api(


### PR DESCRIPTION
## Summary

- Reduces `SECONDS_PER_FACT` from 10 to 0.01 (10ms) in `_add_temporal_offsets`
- The 10-second offset caused significant timestamp drift for large ingestions — 600 facts would shift the last fact ~100 minutes from its actual event time
- This broke timeline views and made `occurred_start`/`mentioned_at` unreliable for temporal queries

## Context

When ingesting timestamped multimodal content (audio transcripts + vision frames), each item carries a precise `timestamp` that flows through to `mentioned_at` and influences `occurred_start`. The 10s-per-fact ordering offset was dwarfing the actual temporal signal, making the timeline view unusable.

With 10ms, fact ordering is preserved while max drift stays under 8 seconds even for 800+ fact batches.

## Test plan

- [x] Built locally, ingested 774 memories (602 audio + 172 vision) from a 49-minute session
- [x] Verified timeline view shows facts at correct timestamps (no multi-minute drift)
- [x] Pre-commit hooks pass (ruff check, ruff format, ty check)