### PR TITLE
feat(openclaw): add autoRecall toggle and excludeProviders schema

### DIFF
--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -63,6 +63,16 @@
       "bankIdPrefix": {
         "type": "string",
         "description": "Optional prefix for bank IDs (e.g., 'prod' results in 'prod-slack-U123'). Useful for separating environments."
+      },
+      "autoRecall": {
+        "type": "boolean",
+        "description": "Automatically recall memories on every prompt and inject them as context. Set to false when agent has its own recall tool.",
+        "default": true
+      },
+      "excludeProviders": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Message providers to exclude from recall and retain (e.g. ['telegram', 'discord'])"
       }
     },
     "additionalProperties": false
@@ -119,6 +129,14 @@
     "bankIdPrefix": {
       "label": "Bank ID Prefix",
       "placeholder": "e.g., prod, staging (optional)"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "placeholder": "true (inject memories on every prompt)"
+    },
+    "excludeProviders": {
+      "label": "Excluded Providers",
+      "placeholder": "e.g. telegram, discord"
     }
   }
 }

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -440,6 +440,7 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     dynamicBankId: config.dynamicBankId !== false,
     bankIdPrefix: config.bankIdPrefix,
     excludeProviders: Array.isArray(config.excludeProviders) ? config.excludeProviders : [],
+    autoRecall: config.autoRecall !== false, // Default: true (on) — backward compatible
   };
 }
 
@@ -723,6 +724,12 @@ export default function (api: MoltbotPluginAPI) {
         // Check if this provider is excluded
         if (ctx?.messageProvider && pluginConfig.excludeProviders?.includes(ctx.messageProvider)) {
           console.log(`[Hindsight] Skipping recall for excluded provider: ${ctx.messageProvider}`);
+          return;
+        }
+
+        // Skip auto-recall when disabled (agent has its own recall tool)
+        if (!pluginConfig.autoRecall) {
+          console.log('[Hindsight] Auto-recall disabled via config, skipping');
           return;
         }
 

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -43,6 +43,7 @@ export interface PluginConfig {
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
+  autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary
- Add `autoRecall` config option (default: `true`) to allow disabling automatic memory recall injection. Set to `false` when the host agent has its own dedicated recall tool.
- Add `excludeProviders` to `openclaw.plugin.json` configSchema + uiHints (already implemented in code but missing from schema).

## Changes
- `types.ts`: Add `autoRecall?: boolean` to `PluginConfig`
- `index.ts`: Parse `autoRecall` in `getPluginConfig()` (default true), add early return guard in `before_agent_start`
- `openclaw.plugin.json`: Add `autoRecall` and `excludeProviders` to configSchema properties and uiHints

## Test plan
- [x] All existing openclaw tests pass
- [x] Lint clean
- [ ] Default behavior unchanged (autoRecall defaults to true)
- [ ] Setting autoRecall: false skips recall injection
- [ ] excludeProviders appears in UI/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)