### PR TITLE
feat: propagate bank_id as user field in LLM calls

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -25,6 +25,7 @@ from ..metrics import get_metrics_collector
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
 from .db_budget import budgeted_operation
+from .providers.openai_compatible_llm import llm_user
 from .operation_metadata import (
     BatchRetainChildMetadata,
     BatchRetainParentMetadata,
@@ -933,6 +934,11 @@ class MemoryEngine(MemoryEngineInterface):
         if schema:
             _current_schema.set(schema)
 
+        # Set llm_user so LLM calls include it for upstream proxy attribution
+        bank_id = task_dict.get("bank_id")
+        if bank_id:
+            llm_user.set(bank_id)
+
         # Check if operation was cancelled (only for tasks with operation_id)
         if operation_id:
             try:
@@ -1739,6 +1745,9 @@ class MemoryEngine(MemoryEngineInterface):
             )
             # Returns: [["unit-id-1"], ["unit-id-2"]]
         """
+        # Set llm_user so LLM calls include it for upstream proxy attribution
+        llm_user.set(bank_id)
+
         start_time = time.time()
 
         if not contents:
@@ -4234,6 +4243,9 @@ class MemoryEngine(MemoryEngineInterface):
                 - based_on: Empty dict (agent retrieves facts dynamically)
                 - structured_output: None (not yet supported for agentic reflect)
         """
+        # Set llm_user so LLM calls include it for upstream proxy attribution
+        llm_user.set(bank_id)
+
         # Use cached LLM config
         if self._reflect_llm_config is None:
             raise ValueError("Memory LLM API key not set. Set HINDSIGHT_API_LLM_API_KEY environment variable.")

--- a/hindsight-api/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -16,6 +16,7 @@ Features:
 """
 
 import asyncio
+import contextvars
 import io
 import json
 import logging
@@ -33,6 +34,11 @@ from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult,
 from hindsight_api.metrics import get_metrics_collector
 
 logger = logging.getLogger(__name__)
+
+# Context variable for upstream proxy attribution — injected as the "user" field
+# in OpenAI API requests. Set this before making LLM calls to enable per-caller
+# cost tracking when running behind a proxy.
+llm_user: contextvars.ContextVar[str | None] = contextvars.ContextVar("llm_user", default=None)
 
 # Seed applied to every Groq request for deterministic behavior
 DEFAULT_LLM_SEED = 4242
@@ -215,6 +221,11 @@ class OpenAICompatibleLLM(LLMInterface):
             "model": self.model,
             "messages": messages,
         }
+
+        # Inject llm_user as "user" for upstream proxy attribution
+        _llm_user = llm_user.get()
+        if _llm_user:
+            call_params["user"] = _llm_user
 
         # Check if model supports reasoning parameter
         is_reasoning_model = self._supports_reasoning_model()
@@ -529,6 +540,11 @@ class OpenAICompatibleLLM(LLMInterface):
             "tools": tools,
             "tool_choice": tool_choice,
         }
+
+        # Inject llm_user as "user" for upstream proxy attribution
+        _llm_user = llm_user.get()
+        if _llm_user:
+            call_params["user"] = _llm_user
 
         if max_completion_tokens is not None:
             call_params["max_completion_tokens"] = max_completion_tokens


### PR DESCRIPTION
## Problem

When Hindsight is deployed behind an LLM proxy (e.g. for cost tracking or rate limiting), the proxy has no way to know which memory bank triggered each LLM call. This makes it impossible to attribute LLM costs to specific banks/tenants.

## Solution

Add an `llm_user` context variable (`contextvars.ContextVar`) that propagates into the OpenAI-compatible LLM provider as the standard `user` field in API requests.

### Changes (2 files)

**`engine/providers/openai_compatible_llm.py`**
- Define `llm_user` context variable
- Inject as `user` field in both `call()` and `call_with_tools()` when set

**`engine/memory_engine.py`**
- Set `llm_user` in `retain_batch_async()` — covers extraction LLM calls
- Set `llm_user` in `reflect_async()` — covers reflection LLM calls
- Set `llm_user` in `execute_task()` — covers all background worker tasks (consolidation, mental model refresh, etc.)

### How it works

```
HTTP request (retain/reflect)    → MemoryEngine method sets llm_user from bank_id
Background task (consolidation)  → execute_task() sets llm_user from task dict
                                   ↓
                          OpenAICompatibleLLM reads llm_user
                                   ↓
                          Injects as "user" field in API request
                                   ↓
                          Proxy reads "user" → attributes cost
```

### Why contextvars?

`bank_id` is available at the entry points but would need to be threaded through many intermediate functions (`_extract_facts_from_chunk`, `_consolidate_batch`, `run_reflect_agent`, etc.) to reach the LLM provider. `contextvars` provides clean propagation without touching any function signatures, and is async-safe — concurrent requests for different banks don't interfere.

### No behavior change when not using a proxy

The `user` field is simply ignored by providers when no proxy is involved. The feature is zero-cost when not used — `llm_user` defaults to `None` and no field is injected.