### PR TITLE
fix: pass encoding_format="float" in LiteLLM SDK embedding calls

### DIFF
--- a/hindsight-api/hindsight_api/engine/embeddings.py
+++ b/hindsight-api/hindsight_api/engine/embeddings.py
@@ -794,6 +794,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 "model": self.model,
                 "input": ["test"],
                 "api_key": self.api_key,
+                "encoding_format": "float",
             }
             if self.api_base:
                 embed_kwargs["api_base"] = self.api_base
@@ -840,6 +841,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
                     "model": self.model,
                     "input": batch,
                     "api_key": self.api_key,
+                    "encoding_format": "float",
                 }
                 if self.api_base:
                     embed_kwargs["api_base"] = self.api_base

--- a/hindsight-api/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api/tests/test_litellm_sdk_embeddings.py
@@ -85,6 +85,7 @@ class TestLiteLLMSDKEmbeddings:
                 model="cohere/embed-english-v3.0",
                 input=["test"],
                 api_key="test_key",
+                encoding_format="float",
             )
 
     async def test_initialization_missing_package(self):
@@ -137,6 +138,7 @@ class TestLiteLLMSDKEmbeddings:
             model="cohere/embed-english-v3.0",
             input=["Hello world"],
             api_key="test_key",
+            encoding_format="float",
         )
 
     async def test_encode_multiple_texts(self, embeddings, mock_litellm):


### PR DESCRIPTION
## Summary

- Explicitly pass `encoding_format="float"` in all `litellm.embedding()` / `litellm.aembedding()` calls in `LiteLLMSDKEmbeddings`
- DeepInfra (and other OpenAI-compatible providers) reject requests when `encoding_format` is `null`/`None`
- LiteLLM defaults `encoding_format` to `None` to prevent the OpenAI SDK from using `"base64"`, but this `None` value causes 400 errors on providers that validate the field

## Problem

When using DeepInfra embedding models (e.g., `Qwen/Qwen3-Embedding-8B`, `BAAI/bge-small-en-v1.5`) via the `litellm-sdk` provider, requests fail with:

```
BadRequestError: Error code: 400 - 'encoding_format' only support with [float, base64]
```

This happens because:
1. LiteLLM explicitly sets `encoding_format=None` when not specified ([source](https://deepwiki.com/BerriAI/litellm)) to override OpenAI SDK's default of `"base64"`
2. DeepInfra's API validates the field and rejects `null` — it only accepts `"float"` or `"base64"`

This is a known issue across the ecosystem: [microsoft/graphrag#2194](https://github.com/microsoft/graphrag/issues/2194), [BerriAI/litellm#12110](https://github.com/BerriAI/litellm/issues/12110), [RooCodeInc/Roo-Code#7199](https://github.com/RooCodeInc/Roo-Code/issues/7199).

## Fix

Pass `encoding_format="float"` explicitly. This is always safe because `LiteLLMSDKEmbeddings.encode()` returns `list[list[float]]` — float is the only compatible format.

## Test plan

- [x] Unit tests updated to verify `encoding_format="float"` is passed
- [ ] Run `cd hindsight-api && uv run pytest tests/test_litellm_sdk_embeddings.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)