### PR TITLE
feat: temporal-aware batching in consolidation

### DIFF
--- a/hindsight-api/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api/hindsight_api/engine/consolidation/consolidator.py
@@ -216,9 +216,16 @@ async def run_consolidation_job(
             tag_key = tuple(sorted(m.get("tags") or []))
             tag_groups.setdefault(tag_key, []).append(dict(m))
 
-        # Flatten into LLM batches respecting both tag groups and llm_batch_size
+        # Flatten into LLM batches respecting both tag groups and llm_batch_size.
+        # Sort each tag group by temporal fields so co-occurring facts land in the
+        # same LLM batch, enabling cross-modal observation merging.
         llm_batches: list[list[dict[str, Any]]] = []
         for group in tag_groups.values():
+            group.sort(
+                key=lambda m: (
+                    m.get("occurred_start") or m.get("mentioned_at") or datetime.min.replace(tzinfo=timezone.utc),
+                )
+            )
             for i in range(0, len(group), llm_batch_size):
                 llm_batches.append(group[i : i + llm_batch_size])
 


### PR DESCRIPTION
## Summary

Sort each tag group by `occurred_start` (falling back to `mentioned_at`) before chunking into LLM batches during consolidation. This ensures temporally co-occurring facts land in the same batch, giving the consolidation LLM the opportunity to merge related facts into richer observations.

## Change

**`consolidator.py`** — Added a temporal sort to each tag group before slicing into LLM batches. The sort key falls back through `occurred_start` → `mentioned_at` → `datetime.min`. No behavior change for facts with identical timestamps (sort is stable).

## Test plan

- [x] Ruff lint and format pass
- [x] Pre-commit hooks pass
- [x] Existing test suite: all failures are pre-existing DB migration issues on main
- [x] Manual validation with multimodal ingest + consolidation