### PR TITLE
fix: catch ValueError instead of bare except in date parsing

### DIFF
--- a/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
+++ b/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
@@ -96,7 +96,7 @@ class LoComoDataset(BenchmarkDataset):
         try:
             dt = datetime.strptime(date_string, "%I:%M %p on %d %B, %Y")
             return dt.replace(tzinfo=timezone.utc)
-        except:
+        except ValueError:
             raise
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except ValueError:` in `locomo_benchmark.py` date parsing.

## Why

`datetime.strptime()` raises `ValueError` on format mismatch. Bare `except:` also catches `KeyboardInterrupt` and `SystemExit`, which masks real errors and prevents clean process termination.

## Changes

- `hindsight-dev/benchmarks/locomo/locomo_benchmark.py`: `except:` → `except ValueError:`