### PR TITLE
fix(storage): use dynamic schema_getter in PostgreSQLFileStorage for multi-tenant

### DIFF
--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -1366,7 +1366,7 @@ class MemoryEngine(MemoryEngineInterface):
         self._file_storage = create_file_storage(
             storage_type=config.file_storage_type,
             pool_getter=lambda: self._pool,
-            schema=get_current_schema() if get_current_schema() != config.database_schema else None,
+            schema_getter=get_current_schema,
         )
         logger.debug(f"File storage initialized ({config.file_storage_type})")
 

--- a/hindsight-api/hindsight_api/engine/storage/__init__.py
+++ b/hindsight-api/hindsight_api/engine/storage/__init__.py
@@ -12,6 +12,7 @@ def create_file_storage(
     storage_type: str,
     pool_getter: Callable | None = None,
     schema: str | None = None,
+    schema_getter: Callable | None = None,
     **kwargs,
 ) -> FileStorage:
     """
@@ -20,7 +21,8 @@ def create_file_storage(
     Args:
         storage_type: "native" (PostgreSQL BYTEA) or "s3" (S3-compatible object storage)
         pool_getter: Database pool getter (required for native)
-        schema: Database schema (for native multi-tenant)
+        schema: Static database schema (for native single-tenant)
+        schema_getter: Callable returning current schema at query time (for native multi-tenant)
         **kwargs: Additional args passed to storage backend
 
     Returns:
@@ -32,7 +34,7 @@ def create_file_storage(
     if storage_type == "native":
         if not pool_getter:
             raise ValueError("pool_getter required for native (PostgreSQL) storage")
-        return PostgreSQLFileStorage(pool_getter=pool_getter, schema=schema)
+        return PostgreSQLFileStorage(pool_getter=pool_getter, schema=schema, schema_getter=schema_getter)
     elif storage_type == "s3":
         from ...config import get_config
         from .s3 import S3FileStorage


### PR DESCRIPTION
## Summary

- `PostgreSQLFileStorage` was initialized once at startup with a static `schema` value from `get_current_schema()`. Since the context variable has no tenant set at init time, it always resolved to the default schema (`public`), causing **"relation file_storage does not exist"** errors for multi-tenant requests.
- Replace static `schema` with `schema_getter` callable — the same pattern already used by `BrokerTaskBackend` since #208.
- The `_schema` attribute becomes a `@property` that resolves dynamically per-request via `contextvars`, so each tenant hits the correct schema.

## Details

This is the same class of bug fixed in:
- `83f44c4b` — "fix: multi-tenant schema context for worker task execution (#208)" (`BrokerTaskBackend`)
- `b180b3ad` — "Fix bank config API for multi-tenant schema isolation (#417)" (`ConfigResolver`)

Backward compatible: the static `schema` parameter is preserved as a fallback for single-tenant deployments and tests.

## Test plan

- [x] All existing `test_file_retain.py` and `test_file_storage_s3.py` tests pass (16/16)
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] Manual verification: file retain on a tenant schema no longer returns 500