### PR TITLE
feat(openclaw): retain last n+2 turns every n turns (default n=10)

### DIFF
--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -20,6 +20,7 @@ const banksWithMissionSet = new Set<string>();
 // In-flight recall deduplication: concurrent recalls for the same bank reuse one promise
 import type { RecallResponse } from './types.js';
 const inflightRecalls = new Map<string, Promise<RecallResponse>>();
+const turnCountBySession = new Map<string, number>();
 const RECALL_TIMEOUT_MS = 10_000;
 
 // Cooldown + guard to prevent concurrent reinit attempts
@@ -857,8 +858,29 @@ User message: ${prompt}
           return;
         }
 
+        // --- Chunked retention: only retain every Nth turn ---
+        const retainEveryN = pluginConfig.retainEveryNTurns ?? 10;
+        let messagesToRetain = event.messages;
+
+        if (retainEveryN > 1) {
+          const sessionTrackingKey = `${bankId}:${effectiveCtx?.sessionKey || currentSessionKey || 'session'}`;
+          const turnCount = (turnCountBySession.get(sessionTrackingKey) || 0) + 1;
+          turnCountBySession.set(sessionTrackingKey, turnCount);
+
+          if (turnCount % retainEveryN !== 0) {
+            const nextRetain = Math.ceil(turnCount / retainEveryN) * retainEveryN;
+            console.log(`[Hindsight Hook] Skipping retain (turn ${turnCount}, next at ${nextRetain})`);
+            return;
+          }
+
+          // Sliding window: N turns of new content + 2-turn overlap for context continuity
+          const windowSize = retainEveryN * 2 + 4;
+          messagesToRetain = event.messages.slice(-windowSize);
+          console.log(`[Hindsight Hook] Chunked retain at turn ${turnCount} \u2014 last ${messagesToRetain.length} msgs`);
+        }
+
         // Format messages into a transcript
-        const transcript = event.messages
+        const transcript = messagesToRetain
           .map((msg: any) => {
             const role = msg.role || 'unknown';
             let content = '';
@@ -895,14 +917,14 @@ User message: ${prompt}
           document_id: documentId,
           metadata: {
             retained_at: new Date().toISOString(),
-            message_count: String(event.messages.length),
+            message_count: String(messagesToRetain.length),
             channel_type: effectiveCtx?.messageProvider,
             channel_id: effectiveCtx?.channelId,
             sender_id: effectiveCtx?.senderId,
           },
         });
 
-        console.log(`[Hindsight] Retained ${event.messages.length} messages to bank ${bankId} for session ${documentId}`);
+        console.log(`[Hindsight] Retained ${messagesToRetain.length} messages to bank ${bankId} for session ${documentId}`);
       } catch (error) {
         console.error('[Hindsight] Error retaining messages:', error);
       }

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -44,6 +44,7 @@ export interface PluginConfig {
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.
+  retainEveryNTurns?: number; // Retain every Nth turn instead of every turn (default: 10). Reduces O(n²) storage growth for long sessions.
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## What

Adds chunked retention to the openclaw plugin: instead of sending the full message history to Hindsight on every turn, it retains the last n+2 turns every n turns (default n=10).

Closes #451

## Why

The current `agent_end` hook sends the **entire** `event.messages` array on every turn. Since messages accumulate within a session, a 50-turn conversation sends 2,550 cumulative messages across 50 API calls — while only ~100 are unique. This creates O(n²) storage growth and causes Hindsight to extract the same facts repeatedly.

## How

- Every `agent_end` event increments a per-session turn counter
- Only every 10th turn triggers a retain call (configurable via `retainEveryNTurns`)
- On retain turns, a sliding window of the last 24 messages is sent (12 turns = 10 new + 2 overlap for context continuity)
- At the first retain (turn 10), there are only ~20 messages, so all are included
- Turn counting is per-session (keyed by `bankId:sessionKey`), so multi-channel setups track independently
- Default is 10 — current behavior (retain every turn) requires explicitly setting `retainEveryNTurns: 1`

## Impact (default n=10)

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Retain API calls (50-turn session) | 50 | 5 | 90% |
| Messages sent to API | 2,550 | ~120 | 95% |
| Unique content preserved | 100% | 100% | — |

## Changes

- `src/types.ts`: Added `retainEveryNTurns?: number` to `PluginConfig`
- `src/index.ts`: Added turn tracking Map and chunked retention logic in `agent_end` handler

## Testing

Tested in production for ~2 weeks on openclaw v2026.2.25-2026.2.27 with Hindsight in external API mode. Verified via gateway logs showing correct skip/retain pattern and Hindsight dashboard showing controlled document sizes.
