### PR TITLE
fix: JSON serialization and logging exception propagation in claude_code_llm

### DIFF
--- a/hindsight-api/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api/hindsight_api/engine/providers/claude_code_llm.py
@@ -238,21 +238,24 @@ class ClaudeCodeLLM(LLMInterface):
                 )
 
                 # Record trace span
-                from hindsight_api.tracing import get_span_recorder
+                try:
+                    from hindsight_api.tracing import get_span_recorder
 
-                span_recorder = get_span_recorder()
-                span_recorder.record_llm_call(
-                    provider=self.provider,
-                    model=self.model,
-                    scope=scope,
-                    messages=messages,
-                    response_content=result if isinstance(result, str) else json.dumps(result),
-                    input_tokens=estimated_input,
-                    output_tokens=estimated_output,
-                    duration=duration,
-                    finish_reason=None,
-                    error=None,
-                )
+                    span_recorder = get_span_recorder()
+                    span_recorder.record_llm_call(
+                        provider=self.provider,
+                        model=self.model,
+                        scope=scope,
+                        messages=messages,
+                        response_content=result if isinstance(result, str) else result.model_dump_json(),
+                        input_tokens=estimated_input,
+                        output_tokens=estimated_output,
+                        duration=duration,
+                        finish_reason=None,
+                        error=None,
+                    )
+                except Exception:
+                    pass  # logging failure must never affect the operation
 
                 # Log slow calls
                 if duration > 10.0:

--- a/hindsight-api/tests/test_llm_provider.py
+++ b/hindsight-api/tests/test_llm_provider.py
@@ -332,8 +332,8 @@ async def test_llm_provider_consolidation(memory_no_llm_verify, request_context,
     test_bank_id = f"llm_test_consolidation_{provider}_{model}_{datetime.now().timestamp()}"
 
     # Enable observations for this bank
-    from hindsight_api.config import get_config
-    config = get_config()
+    from hindsight_api.config import _get_raw_config
+    config = _get_raw_config()
     original_value = config.enable_observations
     config.enable_observations = True
 


### PR DESCRIPTION
## Summary

Fixes two bugs reported in issues #458 and #459 that caused every consolidation task to retry 11 times, generating thousands of wasted LLM API calls.

- **#458**: Replace `json.dumps(result)` with `result.model_dump_json()` — Pydantic models are not JSON-serializable by default, causing a `TypeError` on every consolidation attempt
- **#459**: Wrap the `record_llm_call` tracing block in `try/except Exception: pass` — logging failures are non-critical and must never propagate to the retry handler
- **Test fix**: Update `test_llm_provider.py` to use `_get_raw_config()` for the bank-configurable `enable_observations` field (same pattern as `test_consolidation.py`)

## Test plan

- [x] `test_llm_provider_consolidation[claude-code-claude-sonnet-4-20250514]` passes locally
- [x] Linting passes (ruff)