### PR TITLE
fix(control-plane): observations count always showing 0

### DIFF
--- a/hindsight-control-plane/src/components/bank-profile-view.tsx
+++ b/hindsight-control-plane/src/components/bank-profile-view.tsx
@@ -100,7 +100,7 @@ interface BankStats {
   // Consolidation stats
   last_consolidated_at: string | null;
   pending_consolidation: number;
-  total_mental_models: number;
+  total_observations: number;
 }
 
 interface Operation {
@@ -607,8 +607,8 @@ export function BankProfileView({ hideReflectFields = false }: { hideReflectFiel
                   This will delete all consolidated knowledge. Observations will be regenerated the
                   next time consolidation runs.
                 </p>
-                {stats && stats.total_mental_models > 0 && (
-                  <p>This will delete {stats.total_mental_models} observations.</p>
+                {stats && stats.total_observations > 0 && (
+                  <p>This will delete {stats.total_observations} observations.</p>
                 )}
               </div>
             </AlertDialogDescription>

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -26,7 +26,7 @@ interface BankStats {
   failed_operations: number;
   last_consolidated_at: string | null;
   pending_consolidation: number;
-  total_mental_models: number;
+  total_observations: number;
 }
 
 export function BankStatsView() {
@@ -183,7 +183,7 @@ export function BankStatsView() {
               observationsEnabled ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground"
             }`}
           >
-            {observationsEnabled ? stats.total_mental_models || 0 : "—"}
+            {observationsEnabled ? stats.total_observations || 0 : "—"}
           </p>
         </div>
         <div className="bg-cyan-500/10 border border-cyan-500/20 rounded-xl p-4 text-center">


### PR DESCRIPTION
## Summary
- The **Observations** card in the Control Plane was always displaying `0`, even when the DB had thousands of observations
- Root cause: the `BankStats` TypeScript interface declared `total_mental_models` but the API's `BankStatsResponse` returns `total_observations` — so the field was always `undefined`, falling back to `|| 0`
- Fixed by renaming the field to `total_observations` in both `bank-stats-view.tsx` and `bank-profile-view.tsx`

## Test plan
- [ ] Open the Control Plane for a bank with existing observations
- [ ] Verify the Observations count card shows the correct number instead of 0
- [ ] Verify the delete confirmation dialog shows the correct observations count