### PR TITLE
cli: add linux-arm64 binary to release and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,10 @@ jobs:
             target: aarch64-apple-darwin
             artifact_name: hindsight
             asset_name: hindsight-darwin-arm64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact_name: hindsight
+            asset_name: hindsight-linux-arm64
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -686,6 +686,30 @@ jobs:
         echo "=== API Server Logs ==="
         cat /tmp/api-server.log || echo "No API server log found"
 
+  build-rust-cli-arm64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: aarch64-unknown-linux-gnu
+
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          hindsight-cli/target
+        key: linux-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build CLI
+      working-directory: hindsight-cli
+      run: cargo build --release --target aarch64-unknown-linux-gnu
+
   test-rust-client:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

- Adds `hindsight-linux-arm64` binary to the release matrix using the native `ubuntu-24.04-arm` GitHub-hosted runner — no cross-compilation or special tooling needed
- Adds a `build-rust-cli-arm64` job to the CI workflow so compilation is verified on every PR

## Approach

Uses GitHub's native ARM runner (`ubuntu-24.04-arm`) instead of cross-compilation tools like `cross` or `cargo-zigbuild`. This keeps the build steps identical across all targets.

## Test plan

- [ ] Verify `build-rust-cli-arm64` job passes in CI on this PR
- [ ] Verify `release-rust-cli` matrix includes `hindsight-linux-arm64` artifact on next release tag

Closes #483