### PR TITLE
fix: use CONCURRENTLY only for non-empty schemas to prevent deadlock

### DIFF
--- a/hindsight-api/hindsight_api/alembic/versions/b3c4d5e6f7g8_add_temporal_date_indexes.py
+++ b/hindsight-api/hindsight_api/alembic/versions/b3c4d5e6f7g8_add_temporal_date_indexes.py
@@ -13,14 +13,16 @@ These three partial indexes give the planner bitmap-index scan options for the
 three most common date predicates, dramatically reducing the row set before any
 embedding computation is required.
 
-All indexes are created CONCURRENTLY so the migration does not block writes on
-memory_units during production deployments. CONCURRENTLY requires running outside
-a transaction block; see migrations.py for how this is handled safely.
+Uses CONCURRENTLY for schemas with existing data (avoids blocking writes during
+production deployments on large tables). Uses regular CREATE INDEX for empty
+schemas (new tenant provisioning) because CONCURRENTLY waits for ALL open
+transactions database-wide, which deadlocks against the worker's polling loop.
 """
 
 from collections.abc import Sequence
 
 from alembic import context, op
+from sqlalchemy import text
 
 revision: str = "b3c4d5e6f7g8"
 down_revision: str | Sequence[str] | None = "c1a2b3d4e5f6"
@@ -33,28 +35,47 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
+def _table_has_data(table: str) -> bool:
+    """Check if a table has any rows (used to decide CONCURRENTLY vs regular)."""
+    conn = op.get_bind()
+    result = conn.execute(text(f"SELECT EXISTS (SELECT 1 FROM {table} LIMIT 1)"))
+    return result.scalar()
+
+
+def _create_index(schema: str, definition: str) -> None:
+    """Create an index, using CONCURRENTLY only when the table has data."""
+    # Extract table name from "ON {schema}table_name(...)"
+    table_part = definition.split(" ON ")[1].split("(")[0].strip()
+    if _table_has_data(table_part):
+        op.execute("COMMIT")
+        op.execute(f"CREATE INDEX CONCURRENTLY {definition}")
+    else:
+        op.execute(f"CREATE INDEX {definition}")
+
+
 def upgrade() -> None:
     schema = _get_schema_prefix()
+
     # Partial index on occurred_start (covers "occurred_start BETWEEN $4 AND $5")
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_units_bank_occurred_start "
+    _create_index(
+        schema,
+        f"IF NOT EXISTS idx_memory_units_bank_occurred_start "
         f"ON {schema}memory_units(bank_id, fact_type, occurred_start) "
-        f"WHERE occurred_start IS NOT NULL"
+        f"WHERE occurred_start IS NOT NULL",
     )
     # Partial index on occurred_end (covers "occurred_end BETWEEN $4 AND $5")
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_units_bank_occurred_end "
+    _create_index(
+        schema,
+        f"IF NOT EXISTS idx_memory_units_bank_occurred_end "
         f"ON {schema}memory_units(bank_id, fact_type, occurred_end) "
-        f"WHERE occurred_end IS NOT NULL"
+        f"WHERE occurred_end IS NOT NULL",
     )
     # Partial index on mentioned_at (covers "mentioned_at BETWEEN $4 AND $5")
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_units_bank_mentioned_at "
+    _create_index(
+        schema,
+        f"IF NOT EXISTS idx_memory_units_bank_mentioned_at "
         f"ON {schema}memory_units(bank_id, fact_type, mentioned_at) "
-        f"WHERE mentioned_at IS NOT NULL"
+        f"WHERE mentioned_at IS NOT NULL",
     )
 
 

--- a/hindsight-api/hindsight_api/alembic/versions/c1a2b3d4e5f6_enable_pg_trgm_and_entities_trgm_index.py
+++ b/hindsight-api/hindsight_api/alembic/versions/c1a2b3d4e5f6_enable_pg_trgm_and_entities_trgm_index.py
@@ -4,14 +4,16 @@ Revision ID: c1a2b3d4e5f6
 Revises: b4c5d6e7f8a9
 Create Date: 2026-03-02
 
-Index is created CONCURRENTLY so the migration does not block writes on entities
-during production deployments. CONCURRENTLY requires running outside a transaction
-block; see migrations.py for how this is handled safely.
+Uses CONCURRENTLY for schemas with existing data (avoids blocking writes during
+production deployments on large tables). Uses regular CREATE INDEX for empty
+schemas (new tenant provisioning) because CONCURRENTLY waits for ALL open
+transactions database-wide, which deadlocks against the worker's polling loop.
 """
 
 from collections.abc import Sequence
 
 from alembic import context, op
+from sqlalchemy import text
 
 revision: str = "c1a2b3d4e5f6"
 down_revision: str | Sequence[str] | None = "b4c5d6e7f8a9"
@@ -24,19 +26,36 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
+def _table_has_data(table: str) -> bool:
+    """Check if a table has any rows (used to decide CONCURRENTLY vs regular)."""
+    conn = op.get_bind()
+    result = conn.execute(text(f"SELECT EXISTS (SELECT 1 FROM {table} LIMIT 1)"))
+    return result.scalar()
+
+
 def upgrade() -> None:
     # pg_trgm ships with every standard PostgreSQL installation as a contrib module.
     # It enables fast similarity lookups via GIN indexes, used for entity name matching.
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
 
     schema = _get_schema_prefix()
+
     # GIN index on canonical_name enables sub-millisecond trigram similarity queries
     # (% operator, similarity()) instead of full-table scans across all bank entities.
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS entities_canonical_name_trgm_idx "
-        f"ON {schema}entities USING GIN (canonical_name gin_trgm_ops)"
-    )
+    if _table_has_data(f"{schema}entities"):
+        # Existing schema with data: use CONCURRENTLY to avoid blocking writes.
+        # Requires running outside a transaction block.
+        op.execute("COMMIT")
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS entities_canonical_name_trgm_idx "
+            f"ON {schema}entities USING GIN (canonical_name gin_trgm_ops)"
+        )
+    else:
+        # New/empty schema: use regular CREATE INDEX (instant, no deadlock risk).
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS entities_canonical_name_trgm_idx "
+            f"ON {schema}entities USING GIN (canonical_name gin_trgm_ops)"
+        )
 
 
 def downgrade() -> None:

--- a/hindsight-api/hindsight_api/alembic/versions/d2e3f4a5b6c7_add_memory_links_expansion_indexes.py
+++ b/hindsight-api/hindsight_api/alembic/versions/d2e3f4a5b6c7_add_memory_links_expansion_indexes.py
@@ -20,10 +20,10 @@ memory_links table:
    scan), eliminating the heap reads entirely.
    Partial index (WHERE link_type = 'entity') keeps index size ~40 % smaller.
 
-Both indexes are created with CONCURRENTLY so the migration does not block
-concurrent reads or writes on memory_links.  CONCURRENTLY requires running
-outside a transaction block, so the migration emits an explicit COMMIT before
-each statement and uses IF NOT EXISTS for idempotency.
+Uses CONCURRENTLY for schemas with existing data (avoids blocking writes during
+production deployments on large tables). Uses regular CREATE INDEX for empty
+schemas (new tenant provisioning) because CONCURRENTLY waits for ALL open
+transactions database-wide, which deadlocks against the worker's polling loop.
 
 Revision ID: d2e3f4a5b6c7
 Revises: b3c4d5e6f7g8
@@ -33,6 +33,7 @@ Create Date: 2026-03-02
 from collections.abc import Sequence
 
 from alembic import context, op
+from sqlalchemy import text
 
 revision: str = "d2e3f4a5b6c7"
 down_revision: str | Sequence[str] | None = "b3c4d5e6f7g8"
@@ -45,33 +46,46 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
+def _table_has_data(table: str) -> bool:
+    """Check if a table has any rows (used to decide CONCURRENTLY vs regular)."""
+    conn = op.get_bind()
+    result = conn.execute(text(f"SELECT EXISTS (SELECT 1 FROM {table} LIMIT 1)"))
+    return result.scalar()
+
+
+def _create_index(schema: str, definition: str) -> None:
+    """Create an index, using CONCURRENTLY only when the table has data."""
+    # Extract table name from "ON {schema}table_name(...)"
+    table_part = definition.split(" ON ")[1].split("(")[0].strip()
+    if _table_has_data(table_part):
+        op.execute("COMMIT")
+        op.execute(f"CREATE INDEX CONCURRENTLY {definition}")
+    else:
+        op.execute(f"CREATE INDEX {definition}")
+
+
 def upgrade() -> None:
     schema = _get_schema_prefix()
-
-    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
-    # Commit the current Alembic transaction, then issue each CONCURRENTLY
-    # statement in its own implicit autocommit transaction.
-    # IF NOT EXISTS makes each statement idempotent if the migration is retried.
 
     # Index for the semantic *incoming* direction in link_expansion_retrieval.py.
     # Replaces the BitmapAnd of idx_memory_links_to_unit ∩ idx_memory_links_link_type
     # with a single composite index scan.
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_to_type_weight "
-        f"ON {schema}memory_links(to_unit_id, link_type, weight DESC)"
+    _create_index(
+        schema,
+        f"IF NOT EXISTS idx_memory_links_to_type_weight "
+        f"ON {schema}memory_links(to_unit_id, link_type, weight DESC)",
     )
 
     # Covering index for entity co-occurrence expansion.
     # Enables an index-only scan: entity_id and to_unit_id are read from the
     # index leaf pages instead of the heap, eliminating ~2 500 random heap-page
     # reads per expansion query.
-    op.execute("COMMIT")
-    op.execute(
-        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_entity_covering "
+    _create_index(
+        schema,
+        f"IF NOT EXISTS idx_memory_links_entity_covering "
         f"ON {schema}memory_links(from_unit_id) "
         f"INCLUDE (to_unit_id, entity_id) "
-        f"WHERE link_type = 'entity'"
+        f"WHERE link_type = 'entity'",
     )
 
 


### PR DESCRIPTION
## Summary

- Fixes a deadlock where `CREATE INDEX CONCURRENTLY` in migration files hangs the server when provisioning new tenant schemas while the worker is running
- `CONCURRENTLY` waits for ALL open transactions database-wide. The worker's polling loop always has a transaction open, so `CONCURRENTLY` waits forever
- This happens in both dev (worker in-process) and production (worker in separate pod) — same database, same problem

## Fix

Migrations now check whether the target table has data before choosing the index creation strategy:

- **Empty tables** (new tenant provisioning): regular `CREATE INDEX` — instant, no deadlock risk
- **Tables with data** (existing schemas during rolling deployments): `CREATE INDEX CONCURRENTLY` — avoids blocking writes on large tables

## Test plan

- [x] Full integration test suite passes (87/87, no deadlocks, 28s)
- [x] Verified against the previously deadlocking scenario (new tenant creation while worker is active)
- [x] Pre-existing test failures unchanged (api key format, auto-recharge, mailpit)