### PR TITLE
fix: cap uvicorn graceful shutdown at 5s and enable force-kill on double Ctrl+C

### DIFF
--- a/hindsight-api/hindsight_api/main.py
+++ b/hindsight-api/hindsight_api/main.py
@@ -389,6 +389,7 @@ def main():
         "ws": "wsproto",  # Use wsproto instead of websockets to avoid deprecation warnings
         "loop": loop_impl,  # Explicitly set event loop implementation
         "timeout_keep_alive": 30,  # Exceed aiohttp's 15s client timeout so the client always closes first
+        "timeout_graceful_shutdown": 5,  # Cap graceful shutdown at 5s; also enables force-kill on second Ctrl+C
     }
 
     # Add optional parameters if provided


### PR DESCRIPTION
## Summary
- Adds `timeout_graceful_shutdown=5` to uvicorn config, capping shutdown at 5 seconds instead of waiting indefinitely
- Enables force-kill on second Ctrl+C (uvicorn only installs this handler when `timeout_graceful_shutdown` is set)

## Root cause
`timeout_keep_alive=30` (kept intentionally to outlast aiohttp's 15s client timeout) caused uvicorn to wait up to 30s draining connections on shutdown. Without `timeout_graceful_shutdown`, uvicorn also never installed the second-SIGINT force-kill handler.

## Test plan
- [ ] Start API server and press Ctrl+C — should stop within 5 seconds
- [ ] Start API server and press Ctrl+C twice — second press should force-kill immediately