### PR TITLE
fix: use correct schema name in webhook outbox callback

### DIFF
--- a/hindsight-api/hindsight_api/api/http.py
+++ b/hindsight-api/hindsight_api/api/http.py
@@ -72,7 +72,7 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
 
 from hindsight_api.config import get_config
 from hindsight_api.engine.db_utils import acquire_with_retry
-from hindsight_api.engine.memory_engine import Budget, _get_tiktoken_encoding, fq_table
+from hindsight_api.engine.memory_engine import Budget, _current_schema, _get_tiktoken_encoding, fq_table
 from hindsight_api.engine.reflect.observations import Observation
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MemoryFact, TokenUsage
 from hindsight_api.engine.search.tags import TagsMatch
@@ -4280,7 +4280,7 @@ def _register_routes(app: FastAPI):
                             bank_id=bank_id,
                             contents=contents,
                             operation_id=None,
-                            schema=request_context.tenant_id,
+                            schema=_current_schema.get(),
                         ),
                     )
 

--- a/hindsight-api/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api/hindsight_api/engine/memory_engine.py
@@ -594,7 +594,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id,
                 contents=contents,
                 operation_id=operation_id,
-                schema=context.tenant_id,
+                schema=_current_schema.get(),
             ),
         )
 

--- a/hindsight-api/hindsight_api/webhooks/manager.py
+++ b/hindsight-api/hindsight_api/webhooks/manager.py
@@ -235,4 +235,8 @@ class WebhookManager:
             )
 
         except Exception as e:
-            logger.error(f"Failed to queue webhook deliveries (in-transaction) for event {event.event}: {e}")
+            logger.error(
+                f"Failed to queue webhook deliveries (in-transaction) for event {event.event}: {e}. "
+                "CRITICAL: The enclosing database transaction is now aborted and will roll back all changes."
+            )
+            raise


### PR DESCRIPTION
## Summary

- Fix silent data loss in multi-tenant retain: the webhook outbox callback was using `context.tenant_id` (raw UUID) instead of the PostgreSQL schema name (`tenant_<uuid>`), causing a relation-not-found error that silently aborted the entire retain transaction
- Affects both async worker path (`memory_engine.py`) and sync HTTP path (`http.py`) — both now use `_current_schema.get()`
- Changed `fire_event_with_conn` to re-raise exceptions instead of swallowing them, since errors inside a caller's transaction poison it irreversibly and the previous behavior masked the root cause

## Test plan

- [x] Reproduced locally: async retain via E2E test showed 0 memories persisted
- [x] Verified fix: E2E test `banks.spec.ts:465` ("should add document with async processing and verify memories appear") now passes
- [x] Lints pass