### PR TITLE
fix: refresh bank list when dropdown is opened

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -367,7 +367,13 @@ function BankSelectorInner() {
         <div className="h-8 w-px bg-border" />
 
         {/* Memory Bank Selector */}
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover
+          open={open}
+          onOpenChange={(isOpen) => {
+            setOpen(isOpen);
+            if (isOpen) loadBanks();
+          }}
+        >
           <PopoverTrigger asChild>
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
- Refresh the bank list each time the dropdown is opened, so newly created banks appear without requiring a page reload
- Calls `loadBanks()` in the `onOpenChange` handler of the bank selector `Popover`

## Test plan
- [x] Open control plane, create a new bank in a separate tab/API call
- [x] Click the bank dropdown — new bank appears without page refresh