### PR TITLE
fix: truncate long bank names in selector dropdown

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -375,7 +375,7 @@ function BankSelectorInner() {
               aria-expanded={open}
               className="w-[250px] justify-between font-bold border-2 border-primary hover:bg-accent"
             >
-              {currentBank || "Select a memory bank..."}
+              <span className="truncate">{currentBank || "Select a memory bank..."}</span>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>


### PR DESCRIPTION
## Summary
- Wrap the bank selector button label in a `truncate` span so long bank names ellipsize instead of overflowing the fixed-width button

## Test plan
- [x] Select a bank with a very long name — text truncates with ellipsis, chevron icon stays visible
- [x] Short bank names display normally with no visual change