### PR TITLE
Fix GCS auth for Workload Identity Federation credentials

### DIFF
--- a/hindsight-api/hindsight_api/engine/storage/gcs.py
+++ b/hindsight-api/hindsight_api/engine/storage/gcs.py
@@ -63,11 +63,12 @@ class GCSFileStorage(FileStorage):
                     f"Failed to create google.auth credential provider, falling back to obstore defaults: {e}"
                 )
 
-        # obstore's GCSStore eagerly parses GOOGLE_APPLICATION_CREDENTIALS even
-        # when credential_provider is supplied, and it can't handle all credential
-        # types (e.g. external_account from Workload Identity Federation).
-        # Temporarily hide the env var so GCSStore doesn't attempt to parse it;
-        # google.auth (used by credential_provider) has already loaded credentials.
+        # Workaround for https://github.com/developmentseed/obstore/issues/605
+        # obstore's Rust layer doesn't support external_account credentials (Workload
+        # Identity Federation) and eagerly parses GOOGLE_APPLICATION_CREDENTIALS even
+        # when credential_provider is given. Per the obstore maintainer's guidance,
+        # remove env vars so the Rust code doesn't try to authenticate itself.
+        # google.auth (used by credential_provider above) has already loaded credentials.
         gac = os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
         try:
             self._store = GCSStore(bucket, **kwargs)


### PR DESCRIPTION
## Summary

obstore's Rust layer doesn't support `external_account` credential files used by GCP Workload Identity Federation. It eagerly parses `GOOGLE_APPLICATION_CREDENTIALS` even when a `credential_provider` callback is supplied, and crashes on unrecognized credential types.

- obstore issue: https://github.com/developmentseed/obstore/issues/605
- Upstream Rust issue: https://github.com/apache/arrow-rs-object-store/issues/258

Per the [obstore maintainer's guidance](https://github.com/developmentseed/obstore/issues/605#issuecomment-2616048553), the fix is:

1. Use `google.auth.default()` via `credential_provider` for authentication (handles all credential types)
2. Remove `GOOGLE_APPLICATION_CREDENTIALS` from the environment during `GCSStore` construction so the Rust code doesn't try to authenticate itself

The env var is restored immediately after construction.

## Changes

- `gcs.py`: Add `_make_google_auth_credential_provider()` using `google.auth` for broad credential type support
- `gcs.py`: Temporarily hide `GOOGLE_APPLICATION_CREDENTIALS` during `GCSStore()` construction per maintainer guidance