### PR TITLE
Fix Iris parser httpx read timeout

### DIFF
--- a/hindsight-api/hindsight_api/engine/parsers/iris.py
+++ b/hindsight-api/hindsight_api/engine/parsers/iris.py
@@ -62,7 +62,7 @@ class IrisParser(FileParser):
         """
         content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
             # Step 1: Request a presigned upload URL
             init_resp = await client.post(
                 f"{_IRIS_BASE_URL}/org/{self._org_id}/files",


### PR DESCRIPTION
## Summary

- Set explicit 30-second timeout on `httpx.AsyncClient` in the Iris parser

The default httpx read timeout is 5 seconds. The Vectorize API can take longer than that to respond (e.g. ~3-4 seconds observed for simple requests), leaving very little margin. Bumping to 30 seconds gives adequate headroom.

The 300-second polling deadline for the overall extraction job is unchanged — this only affects individual HTTP request timeouts.