### PR TITLE
fix: serialize Alembic upgrades in-process

### DIFF
--- a/hindsight-api/hindsight_api/migrations.py
+++ b/hindsight-api/hindsight_api/migrations.py
@@ -18,6 +18,7 @@ No alembic.ini required - all configuration is done programmatically.
 import hashlib
 import logging
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -32,6 +33,13 @@ logger = logging.getLogger(__name__)
 
 # Advisory lock ID for migrations (arbitrary unique number)
 MIGRATION_LOCK_ID = 123456789
+
+# Alembic's command.upgrade() is NOT thread-safe: it uses module-level global
+# proxies (context._proxy, script) that get overwritten when two threads call
+# upgrade() concurrently.  This causes migrations to target the wrong schema
+# and crash with "relation already exists" or KeyError: 'script'.
+# Serialize all Alembic invocations with a process-level lock.
+_alembic_lock = threading.Lock()
 
 
 def _detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
@@ -144,9 +152,12 @@ def _run_migrations_internal(database_url: str, script_location: str, schema: st
     if schema:
         alembic_cfg.set_main_option("target_schema", schema)
 
-    # Run migrations
+    # Run migrations under a process-level lock.  Alembic uses module-level
+    # global proxies that are not thread-safe, so concurrent command.upgrade()
+    # calls from different threads corrupt each other's context.
     try:
-        command.upgrade(alembic_cfg, "head")
+        with _alembic_lock:
+            command.upgrade(alembic_cfg, "head")
     except ResolutionError as e:
         # This happens during rolling deployments when a newer version of the code
         # has already run migrations, and this older replica doesn't have the new

--- a/hindsight-api/tests/test_migrations_thread_safety.py
+++ b/hindsight-api/tests/test_migrations_thread_safety.py
@@ -1,0 +1,48 @@
+import threading
+import time
+
+from hindsight_api import migrations
+
+
+def test_run_migrations_internal_serializes_alembic_upgrade(monkeypatch):
+    max_concurrent_upgrades = 0
+    active_upgrades = 0
+    active_lock = threading.Lock()
+    start_barrier = threading.Barrier(2)
+
+    def fake_upgrade(_cfg, _revision):
+        nonlocal max_concurrent_upgrades, active_upgrades
+        with active_lock:
+            active_upgrades += 1
+            max_concurrent_upgrades = max(max_concurrent_upgrades, active_upgrades)
+        time.sleep(0.05)
+        with active_lock:
+            active_upgrades -= 1
+
+    monkeypatch.setattr(migrations.command, "upgrade", fake_upgrade)
+
+    errors = []
+
+    def run_in_thread(schema):
+        try:
+            start_barrier.wait()
+            migrations._run_migrations_internal(
+                "postgresql://user:pass@localhost/db",
+                "/tmp/alembic",
+                schema=schema,
+            )
+        except Exception as exc:  # pragma: no cover - diagnostic path
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run_in_thread, args=("tenant_alpha",)),
+        threading.Thread(target=run_in_thread, args=("tenant_beta",)),
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert max_concurrent_upgrades == 1


### PR DESCRIPTION
## Summary
- serialize `alembic.command.upgrade()` with a process-local lock
- keep PostgreSQL advisory locks for cross-process coordination
- add a regression test that proves two threads cannot overlap inside `command.upgrade()`

## Problem
`run_migrations()` can be invoked concurrently inside a single Python process when multiple schema provisioning flows run at the same time.

The current migration code already uses PostgreSQL advisory locks, but those locks are schema-specific. That means two different schemas can still run migrations concurrently in the same process.

That is safe at the database coordination layer, but it is not safe inside Alembic itself. `alembic.command.upgrade()` relies on module-level global state such as `context._proxy` and `script`. When two threads enter `command.upgrade()` at the same time, they can overwrite each other's migration context.

The resulting failures are confusing and non-deterministic, but typically look like:
- duplicate DDL during initial schema creation, such as `DuplicateTable`
- follow-on Alembic teardown errors such as `KeyError: 'script'`

## Fix
Wrap `command.upgrade()` in a process-level `threading.Lock()` so only one thread per process can execute Alembic upgrade logic at a time.

This preserves the existing advisory-lock behavior for distributed coordination while removing the unsafe same-process concurrency path.

## Testing
- `uv run pytest tests/test_migrations_thread_safety.py -q`