### PR TITLE
Fix Iris parser httpx read timeout

### DIFF
--- a/hindsight-api/hindsight_api/engine/parsers/iris.py
+++ b/hindsight-api/hindsight_api/engine/parsers/iris.py
@@ -62,7 +62,7 @@ class IrisParser(FileParser):
         """
         content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, read=120.0)) as client:
             # Step 1: Request a presigned upload URL
             init_resp = await client.post(
                 f"{_IRIS_BASE_URL}/org/{self._org_id}/files",


### PR DESCRIPTION
## Summary
- The `httpx.AsyncClient` in `IrisParser.convert()` was created without a timeout, defaulting to 5s reads
- This caused `httpx.ReadTimeout` when uploading PDFs to presigned URLs or waiting for Iris API responses
- Set explicit timeouts: 30s default, 120s for reads

## Test plan
- [ ] Upload a PDF using Iris extraction and verify it completes without timeout
- [ ] Upload a large PDF (multi-page) to confirm the 120s read timeout is sufficient