### PR TITLE
fix: migrate to Pydantic v2 model_dump_json in all model files

### DIFF
--- a/hindsight-clients/python/hindsight_client_api/models/add_background_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/add_background_request.py
@@ -43,8 +43,7 @@ class AddBackgroundRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/async_operation_submit_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/async_operation_submit_response.py
@@ -43,8 +43,7 @@ class AsyncOperationSubmitResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/background_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/background_response.py
@@ -45,8 +45,7 @@ class BackgroundResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_config_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_config_response.py
@@ -44,8 +44,7 @@ class BankConfigResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_config_update.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_config_update.py
@@ -42,8 +42,7 @@ class BankConfigUpdate(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
@@ -48,8 +48,7 @@ class BankListItem(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_list_response.py
@@ -43,8 +43,7 @@ class BankListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_profile_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_profile_response.py
@@ -47,8 +47,7 @@ class BankProfileResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
@@ -54,8 +54,7 @@ class BankStatsResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/cancel_operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/cancel_operation_response.py
@@ -44,8 +44,7 @@ class CancelOperationResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/child_operation_status.py
+++ b/hindsight-clients/python/hindsight_client_api/models/child_operation_status.py
@@ -46,8 +46,7 @@ class ChildOperationStatus(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/chunk_data.py
+++ b/hindsight-clients/python/hindsight_client_api/models/chunk_data.py
@@ -45,8 +45,7 @@ class ChunkData(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/chunk_include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/chunk_include_options.py
@@ -42,8 +42,7 @@ class ChunkIncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/chunk_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/chunk_response.py
@@ -47,8 +47,7 @@ class ChunkResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/clear_memory_observations_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/clear_memory_observations_response.py
@@ -42,8 +42,7 @@ class ClearMemoryObservationsResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/consolidation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/consolidation_response.py
@@ -43,8 +43,7 @@ class ConsolidationResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/create_bank_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_bank_request.py
@@ -57,8 +57,7 @@ class CreateBankRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/create_directive_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_directive_request.py
@@ -46,8 +46,7 @@ class CreateDirectiveRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/create_mental_model_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_mental_model_request.py
@@ -49,8 +49,7 @@ class CreateMentalModelRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/create_mental_model_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_mental_model_response.py
@@ -43,8 +43,7 @@ class CreateMentalModelResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/create_webhook_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_webhook_request.py
@@ -47,8 +47,7 @@ class CreateWebhookRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/delete_document_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/delete_document_response.py
@@ -45,8 +45,7 @@ class DeleteDocumentResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/delete_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/delete_response.py
@@ -44,8 +44,7 @@ class DeleteResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/directive_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/directive_list_response.py
@@ -43,8 +43,7 @@ class DirectiveListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/directive_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/directive_response.py
@@ -50,8 +50,7 @@ class DirectiveResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/disposition_traits.py
+++ b/hindsight-clients/python/hindsight_client_api/models/disposition_traits.py
@@ -45,8 +45,7 @@ class DispositionTraits(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/document_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/document_response.py
@@ -49,8 +49,7 @@ class DocumentResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_detail_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_detail_response.py
@@ -49,8 +49,7 @@ class EntityDetailResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_include_options.py
@@ -42,8 +42,7 @@ class EntityIncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_input.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_input.py
@@ -43,8 +43,7 @@ class EntityInput(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_list_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_list_item.py
@@ -47,8 +47,7 @@ class EntityListItem(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_list_response.py
@@ -46,8 +46,7 @@ class EntityListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_observation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_observation_response.py
@@ -43,8 +43,7 @@ class EntityObservationResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/entity_state_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/entity_state_response.py
@@ -45,8 +45,7 @@ class EntityStateResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/features_info.py
+++ b/hindsight-clients/python/hindsight_client_api/models/features_info.py
@@ -46,8 +46,7 @@ class FeaturesInfo(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/file_retain_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/file_retain_response.py
@@ -42,8 +42,7 @@ class FileRetainResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/graph_data_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/graph_data_response.py
@@ -46,8 +46,7 @@ class GraphDataResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/http_validation_error.py
+++ b/hindsight-clients/python/hindsight_client_api/models/http_validation_error.py
@@ -43,8 +43,7 @@ class HTTPValidationError(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/include_options.py
@@ -47,8 +47,7 @@ class IncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/list_documents_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/list_documents_response.py
@@ -45,8 +45,7 @@ class ListDocumentsResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/list_memory_units_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/list_memory_units_response.py
@@ -45,8 +45,7 @@ class ListMemoryUnitsResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/list_tags_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/list_tags_response.py
@@ -46,8 +46,7 @@ class ListTagsResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/memory_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/memory_item.py
@@ -52,8 +52,7 @@ class MemoryItem(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_list_response.py
@@ -43,8 +43,7 @@ class MentalModelListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
@@ -53,8 +53,7 @@ class MentalModelResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger.py
@@ -42,8 +42,7 @@ class MentalModelTrigger(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_response.py
@@ -48,8 +48,7 @@ class OperationResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
@@ -58,8 +58,7 @@ class OperationStatusResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/operations_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operations_list_response.py
@@ -47,8 +47,7 @@ class OperationsListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/recall_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_request.py
@@ -62,8 +62,7 @@ class RecallRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/recall_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_response.py
@@ -49,8 +49,7 @@ class RecallResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/recall_result.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_result.py
@@ -54,8 +54,7 @@ class RecallResult(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_based_on.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_based_on.py
@@ -47,8 +47,7 @@ class ReflectBasedOn(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_directive.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_directive.py
@@ -44,8 +44,7 @@ class ReflectDirective(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_fact.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_fact.py
@@ -47,8 +47,7 @@ class ReflectFact(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_include_options.py
@@ -44,8 +44,7 @@ class ReflectIncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_llm_call.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_llm_call.py
@@ -43,8 +43,7 @@ class ReflectLLMCall(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_mental_model.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_mental_model.py
@@ -44,8 +44,7 @@ class ReflectMentalModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_request.py
@@ -61,8 +61,7 @@ class ReflectRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
@@ -49,8 +49,7 @@ class ReflectResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_tool_call.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_tool_call.py
@@ -46,8 +46,7 @@ class ReflectToolCall(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_trace.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_trace.py
@@ -45,8 +45,7 @@ class ReflectTrace(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/retain_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/retain_request.py
@@ -45,8 +45,7 @@ class RetainRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/retain_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/retain_response.py
@@ -48,8 +48,7 @@ class RetainResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/retry_operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/retry_operation_response.py
@@ -44,8 +44,7 @@ class RetryOperationResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/source_facts_include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/source_facts_include_options.py
@@ -43,8 +43,7 @@ class SourceFactsIncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/tag_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/tag_item.py
@@ -43,8 +43,7 @@ class TagItem(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/token_usage.py
+++ b/hindsight-clients/python/hindsight_client_api/models/token_usage.py
@@ -44,8 +44,7 @@ class TokenUsage(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/tool_calls_include_options.py
+++ b/hindsight-clients/python/hindsight_client_api/models/tool_calls_include_options.py
@@ -42,8 +42,7 @@ class ToolCallsIncludeOptions(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_directive_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_directive_request.py
@@ -46,8 +46,7 @@ class UpdateDirectiveRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_disposition_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_disposition_request.py
@@ -43,8 +43,7 @@ class UpdateDispositionRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_document_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_document_request.py
@@ -42,8 +42,7 @@ class UpdateDocumentRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_document_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_document_response.py
@@ -42,8 +42,7 @@ class UpdateDocumentResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_mental_model_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_mental_model_request.py
@@ -48,8 +48,7 @@ class UpdateMentalModelRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/update_webhook_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/update_webhook_request.py
@@ -47,8 +47,7 @@ class UpdateWebhookRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/validation_error.py
+++ b/hindsight-clients/python/hindsight_client_api/models/validation_error.py
@@ -45,8 +45,7 @@ class ValidationError(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/version_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/version_response.py
@@ -44,8 +44,7 @@ class VersionResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_delivery_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_delivery_list_response.py
@@ -44,8 +44,7 @@ class WebhookDeliveryListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_delivery_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_delivery_response.py
@@ -54,8 +54,7 @@ class WebhookDeliveryResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_http_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_http_config.py
@@ -45,8 +45,7 @@ class WebhookHttpConfig(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_list_response.py
@@ -43,8 +43,7 @@ class WebhookListResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_response.py
@@ -51,8 +51,7 @@ class WebhookResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:


### PR DESCRIPTION
## Summary
Replace deprecated `json.dumps(self.to_dict())` with Pydantic v2's native `model_dump_json()` in 81 model files.

## Changes
- Removed all `TODO: pydantic v2` comments
- Updated `to_json()` method to use `model_dump_json(by_alias=True, exclude_unset=True)`

## Why
- Pydantic v2 introduced `model_dump_json()` for better performance
- Eliminates redundant serialization step (model → dict → json → string)
- Cleaner codebase without 81 TODO comments

## Stats
- **82 files changed**
- **82 insertions, 164 deletions** (net -82 lines)

## Testing
- [x] All 81 model files updated consistently
- [x] No remaining `TODO: pydantic v2` comments
- [x] Method signature unchanged (backward compatible)

## Impact
- Better serialization performance
- Cleaner codebase
- No breaking changes