### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,14 +27,14 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - run: npm ci --workspace=hindsight-docs
       - run: uv run generate-llms-full
       - run: npm run build --workspace=hindsight-docs
         env:
           UMAMI_URL: https://analytics.hindsight.vectorize.io
           UMAMI_WEBSITE_ID: ${{ secrets.UMAMI_WEBSITE_ID }}
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: hindsight-docs/build
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -466,13 +466,13 @@ jobs:
         swap-storage: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -484,7 +484,7 @@ jobs:
 
     - name: Extract metadata for release tags
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}
         flavor: |
@@ -500,7 +500,7 @@ jobs:
     # # Step 1: Build for local testing (single platform, no push)
     # # This creates an identical image to what will be released, just for one platform
     # - name: Build image for testing
-    #   uses: docker/build-push-action@v6
+    #   uses: docker/build-push-action@v7
     #   with:
     #     context: .
     #     file: docker/standalone/Dockerfile
@@ -519,7 +519,7 @@ jobs:
 
     # Build multi-platform and push to release tags
     - name: Build and push release images
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: docker/standalone/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -238,7 +238,7 @@ jobs:
         retention-days: 1
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -372,10 +372,10 @@ jobs:
         swap-storage: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build ${{ matrix.name }} image (${{ matrix.variant }})
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: docker/standalone/Dockerfile
@@ -433,7 +433,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -496,7 +496,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -599,7 +599,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -731,7 +731,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -838,7 +838,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -943,7 +943,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1050,7 +1050,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1135,7 +1135,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1164,7 +1164,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1193,7 +1193,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1234,7 +1234,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1288,7 +1288,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1365,7 +1365,7 @@ jobs:
         cp target/release/hindsight /usr/local/bin/hindsight
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1483,7 +1483,7 @@ jobs:
       run: git fetch --tags
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         prune-cache: false
@@ -1546,7 +1546,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -1620,7 +1620,7 @@ jobs:
         fetch-depth: 0  # Fetch full git history to access base branch
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Diff](https://github.com/actions/upload-pages-artifact/compare/v3...v4) | deploy-docs.yml |
| `astral-sh/setup-uv` | [`v4`](https://github.com/astral-sh/setup-uv/releases/tag/v4), [`v5`](https://github.com/astral-sh/setup-uv/releases/tag/v5) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Diff](https://github.com/astral-sh/setup-uv/compare/v4...v7) | deploy-docs.yml, release.yml, test.yml |
| `docker/build-push-action` | [`v6`](https://github.com/docker/build-push-action/releases/tag/v6) | [`v7`](https://github.com/docker/build-push-action/releases/tag/v7) | [Diff](https://github.com/docker/build-push-action/compare/v6...v7) | release.yml, test.yml |
| `docker/login-action` | [`v3`](https://github.com/docker/login-action/releases/tag/v3) | [`v4`](https://github.com/docker/login-action/releases/tag/v4) | [Diff](https://github.com/docker/login-action/compare/v3...v4) | release.yml |
| `docker/metadata-action` | [`v5`](https://github.com/docker/metadata-action/releases/tag/v5) | [`v6`](https://github.com/docker/metadata-action/releases/tag/v6) | [Diff](https://github.com/docker/metadata-action/compare/v5...v6) | release.yml |
| `docker/setup-buildx-action` | [`v3`](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-buildx-action/releases/tag/v4) | [Diff](https://github.com/docker/setup-buildx-action/compare/v3...v4) | release.yml, test.yml |
| `docker/setup-qemu-action` | [`v3`](https://github.com/docker/setup-qemu-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-qemu-action/releases/tag/v4) | [Diff](https://github.com/docker/setup-qemu-action/compare/v3...v4) | release.yml |

## Release Notes

<details>
<summary>Release notes for astral-sh/setup-uv</summary>

### [v7.5.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.5.0)

# No more rate-limits

This release addresses a long-standing source of timeouts and rate-limit failures in setup-uv.

 Previously, the action resolved version identifiers like 0.5.x by iterating over available uv releases via the GitHub API to find the best match. In contrast, latest and exact versions such as 0.5.0 skipped version resolution entirely and downloaded uv directly.

The `manifest-file` input was an earlier attempt to improve this. It allows providing an url to a file that li

*...truncated*

### [v7.4.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.4.0)

## Changes

Thank you @luhenry for adding support for riscv64 arch

## 🚀 Enhancements

- Add riscv64 architecture support to platform detection @luhenry (#791)

## 🧰 Maintenance

- Delete .github/workflows/dependabot-build.yml @eifinger (#789)
- Harden Dependabot build workflow @eifinger (#788)
- Fix: check PR author instead of event sender for Dependabot detection @eifinger-bot (#787)
- chore: update known checksums for 0.10.9 @[github-actions[bot]](https://github.com/apps/github-a

*...truncated*

### [v7.3.1](https://github.com/astral-sh/setup-uv/releases/tag/v7.3.1)

## Changes

This release adds support for running in containers like `debian:testing` or `debian:unstable`

## 🐛 Bug fixes

- fix: fall back to VERSION_CODENAME when VERSION_ID is not available @eifinger-bot (#774)

## 🧰 Maintenance

- chore: update known checksums for 0.10.6 @[github-actions[bot]](https://github.com/apps/github-actions) (#771)
- chore: update known checksums for 0.10.5 @[github-actions[bot]](https://github.com/apps/github-actions) (#770)
- chore: update known checks

*...truncated*

### [v7.3.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.3.0)

## Changes

This release contains a few bug fixes and a new feature for the activate-environment functionality.

## 🐛 Bug fixes

- fix: warn instead of error when no python to cache @eifinger (#762)
- fix: use --clear to create venv @eifinger (#761)

## 🚀 Enhancements

- feat: add venv-path input for activate-environment @eifinger (#746)

## 🧰 Maintenance

- chore: update known checksums for 0.10.0 @[github-actions[bot]](https://github.com/apps/github-actions) (#759)
- refactor: 

*...truncated*

### [v7.2.1](https://github.com/astral-sh/setup-uv/releases/tag/v7.2.1)

## Changes

## 🧰 Maintenance

- chore: update known checksums for 0.9.28 @[github-actions[bot]](https://github.com/apps/github-actions) (#744)
- chore: update known checksums for 0.9.27 @[github-actions[bot]](https://github.com/apps/github-actions) (#742)
- chore: update known checksums for 0.9.26 @[github-actions[bot]](https://github.com/apps/github-actions) (#734)
- chore: update known checksums for 0.9.25 @[github-actions[bot]](https://github.com/apps/github-actions) (#733)
- chore: u

*...truncated*

</details>

<details>
<summary>Release notes for actions/upload-pages-artifact</summary>

### [v4.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)

## What's Changed
* Potentially breaking change: hidden files (specifically dotfiles) will not be included in the artifact by @tsusdere in https://github.com/actions/upload-pages-artifact/pull/102
   If you need to include dotfiles in your artifact: instead of using this action, create your own artifact according to these requirements https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#artifact-validation
* Pin `actions/upload-artifact` to SHA by @heavymachinery in https://git

*...truncated*

### [v3.0.1](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1)

# Changelog

- Group tar's output to prevent it from messing up action logs @SilverRainZ (#94)
- Update README.md @uiolee (#88)
- Bump the non-breaking-changes group with 1 update @dependabot (#92)
- Update Dependabot config to group non-breaking changes @JamesMGreene (#91)
- Bump actions/checkout from 3 to 4 @dependabot (#76)

See details of [all code changes](https://github.com/actions/upload-pages-artifact/compare/v3.0.0...v3.0.1) since previous release.

</details>

<details>
<summary>Release notes for docker/setup-qemu-action</summary>

### [v4.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/setup-qemu-action/pull/245
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/setup-qemu-action/pull/241
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/setup-qemu-action/pull/244
* Bump @docker/actions-toolkit from 0.67.0 to 0.77.0 in https://github.com/docker

*...truncated*

### [v3.7.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.7.0)

* Bump @docker/actions-toolkit from 0.56.0 to 0.67.0 in https://github.com/docker/setup-qemu-action/pull/217 https://github.com/docker/setup-qemu-action/pull/230
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/setup-qemu-action/pull/220
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/setup-qemu-action/pull/218
* Bump tmp from 0.2.3 to 0.2.4 in https://github.com/docker/setup-qemu-action/pull/221
* Bump undici from 5.28.4 to 5.29.0 in https://github

*...truncated*

### [v3.6.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0)

* Display binfmt version by @crazy-max in https://github.com/docker/setup-qemu-action/pull/202

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.5.0...v3.6.0

### [v3.5.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.5.0)

* Bump @docker/actions-toolkit from 0.54.0 to 0.56.0 in https://github.com/docker/setup-qemu-action/pull/205

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.4.0...v3.5.0

### [v3.4.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.4.0)

* Bump @docker/actions-toolkit from 0.49.0 to 0.54.0 in https://github.com/docker/setup-qemu-action/pull/193 https://github.com/docker/setup-qemu-action/pull/197

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.3.0...v3.4.0

</details>

<details>
<summary>Release notes for docker/setup-buildx-action</summary>

### [v4.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/setup-buildx-action/pull/483
* Remove deprecated inputs/outputs by @crazy-max in https://github.com/docker/setup-buildx-action/pull/464
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/setup-buildx-action/pull/481
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/dock

*...truncated*

### [v3.12.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0)

* Deprecate `install` input by @crazy-max in https://github.com/docker/setup-buildx-action/pull/455
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/setup-buildx-action/pull/434
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/setup-buildx-action/pull/436
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/setup-buildx-action/pull/432
* Bump undici from 5.28.4 to 5.29.0 in https://github.com/docker/setup-buildx-action/pu

*...truncated*

### [v3.11.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1)

* Fix `keep-state` not being respected by @crazy-max in https://github.com/docker/setup-buildx-action/pull/429

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.11.0...v3.11.1

### [v3.11.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.0)

* Keep BuildKit state support by @crazy-max in https://github.com/docker/setup-buildx-action/pull/427
* Remove aliases created when installing by default by @hashhar in https://github.com/docker/setup-buildx-action/pull/139
* Bump @docker/actions-toolkit from 0.56.0 to 0.62.1 in https://github.com/docker/setup-buildx-action/pull/422 https://github.com/docker/setup-buildx-action/pull/425

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.10.0...v3.11.0

### [v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)

* Bump @docker/actions-toolkit from 0.54.0 to 0.56.0 in https://github.com/docker/setup-buildx-action/pull/408

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.9.0...v3.10.0

</details>

<details>
<summary>Release notes for docker/login-action</summary>

### [v4.0.0](https://github.com/docker/login-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/login-action/pull/929
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/login-action/pull/927
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/login-action/pull/919
* Bump @aws-sdk/client-ecr from 3.890.0 to 3.1000.0 in https://github.com/docker/login-action/pu

*...truncated*

### [v3.7.0](https://github.com/docker/login-action/releases/tag/v3.7.0)

* Add `scope` input to set scopes for the authentication token by @crazy-max in https://github.com/docker/login-action/pull/912
* Add support for AWS European Sovereign Cloud ECR by @dphi in https://github.com/docker/login-action/pull/914
* Ensure passwords are redacted with `registry-auth` input by @crazy-max in https://github.com/docker/login-action/pull/911
* build(deps): bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/login-action/pull/915

**Full Changelog**: https://g

*...truncated*

### [v3.6.0](https://github.com/docker/login-action/releases/tag/v3.6.0)

* Add `registry-auth` input for raw authentication to registries by @crazy-max in https://github.com/docker/login-action/pull/887
* Bump @aws-sdk/client-ecr to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @aws-sdk/client-ecr-public to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/logi

*...truncated*

### [v3.5.0](https://github.com/docker/login-action/releases/tag/v3.5.0)

* Support dual-stack endpoints for AWS ECR by @Spacefish @crazy-max in https://github.com/docker/login-action/pull/874 https://github.com/docker/login-action/pull/876
* Bump @aws-sdk/client-ecr to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @aws-sdk/client-ecr-public to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @docker/actions-toolkit from 0.57.0 to 0.6

*...truncated*

### [v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)

* Bump @actions/core from 1.10.1 to 1.11.1 in https://github.com/docker/login-action/pull/791
* Bump @aws-sdk/client-ecr to 3.766.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @aws-sdk/client-ecr-public to 3.758.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @docker/actions-toolkit from 0.35.0 to 0.57.0 in https://github.com/docker/login-action/pull/801 https://github.com

*...truncated*

</details>

<details>
<summary>Release notes for docker/metadata-action</summary>

### [v6.0.0](https://github.com/docker/metadata-action/releases/tag/v6.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/metadata-action/pull/605
* List inputs now preserve `#` inside values while still supporting full-line `#` comments by @crazy-max in https://github.com/docker/metadata-action/pull/607
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/metadata-action/pull/602
* Bump lodash from 4.17.

*...truncated*

### [v5.10.0](https://github.com/docker/metadata-action/releases/tag/v5.10.0)

* Bump @docker/actions-toolkit from 0.66.0 to 0.68.0 in https://github.com/docker/metadata-action/pull/559 https://github.com/docker/metadata-action/pull/569
* Bump js-yaml from 3.14.1 to 3.14.2 in https://github.com/docker/metadata-action/pull/564

**Full Changelog**: https://github.com/docker/metadata-action/compare/v5.9.0...v5.10.0

### [v5.9.0](https://github.com/docker/metadata-action/releases/tag/v5.9.0)

* Add `tag-names` output to return tag names without image base name by @crazy-max in https://github.com/docker/metadata-action/pull/553
* Bump @babel/runtime-corejs3 from 7.14.7 to 7.28.2 in https://github.com/docker/metadata-action/pull/539
* Bump @docker/actions-toolkit from 0.62.1 to 0.66.0 in https://github.com/docker/metadata-action/pull/555
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/metadata-action/pull/540
* Bump csv-parse from 5.6.0 to 6.1.0 in https:/

*...truncated*

### [v5.8.0](https://github.com/docker/metadata-action/releases/tag/v5.8.0)

* New `is_not_default_branch` global expression by @crazy-max in https://github.com/docker/metadata-action/pull/535
* Allow to match part of the git tag or value for semver/pep440 types by @crazy-max in https://github.com/docker/metadata-action/pull/536 https://github.com/docker/metadata-action/pull/537
* Bump @actions/github from 6.0.0 to 6.0.1 in https://github.com/docker/metadata-action/pull/523
* Bump @docker/actions-toolkit from 0.56.0 to 0.62.1 in https://github.com/docker/metadata-acti

*...truncated*

### [v5.7.0](https://github.com/docker/metadata-action/releases/tag/v5.7.0)

* Global expressions support for labels and annotations by @crazy-max in https://github.com/docker/metadata-action/pull/489
* Support disabling outputs as environment variables by @omus in https://github.com/docker/metadata-action/pull/497
* Bump @docker/actions-toolkit from 0.44.0 to 0.56.0 in https://github.com/docker/metadata-action/pull/507 https://github.com/docker/metadata-action/pull/509
* Bump csv-parse from 5.5.6 to 5.6.0 in https://github.com/docker/metadata-action/pull/482
* Bump 

*...truncated*

</details>

<details>
<summary>Release notes for docker/build-push-action</summary>

### [v7.0.0](https://github.com/docker/build-push-action/releases/tag/v7.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/build-push-action/pull/1470
* Remove deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs by @crazy-max in https://github.com/docker/build-push-action/pull/1473
* Remove legacy export-build tool support for build summary by @crazy-max in https://github.com/docker/build-push-action/pull/1474


*...truncated*

### [v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2)

* Preserve port in `GIT_AUTH_TOKEN` host by @crazy-max in https://github.com/docker/build-push-action/pull/1458

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.1...v6.19.2

### [v6.19.1](https://github.com/docker/build-push-action/releases/tag/v6.19.1)

* Derive `GIT_AUTH_TOKEN` host from GitHub server URL by @crazy-max in https://github.com/docker/build-push-action/pull/1456

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.0...v6.19.1

### [v6.19.0](https://github.com/docker/build-push-action/releases/tag/v6.19.0)

* Scope default git auth token to `github.com` by @crazy-max in https://github.com/docker/build-push-action/pull/1451
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/build-push-action/pull/1396
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/build-push-action/pull/1391
* Bump js-yaml from 3.14.1 to 3.14.2 in https://github.com/docker/build-push-action/pull/1429
* Bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/build-push-action/pul

*...truncated*

### [v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)

* Bump @docker/actions-toolkit from 0.61.0 to 0.62.1 in https://github.com/docker/build-push-action/pull/1381

> [!NOTE]
> [Build summary](https://docs.docker.com/build/ci/github-actions/build-summary/) is now supported with [Docker Build Cloud](https://docs.docker.com/build-cloud/).

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.17.0...v6.18.0

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.

## Validation Warnings

The following issues were detected by [actionlint](https://github.com/rhysd/actionlint):

- `release.yml: .github/workflows/release.yml:483:7: shellcheck reported issue in this script: SC2086:info:1:45: Double quote to prevent globbing and word splitting [shellcheck]`
- `release.yml: |`
- `release.yml: 483 |       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT`
- `test.yml: .github/workflows/test.yml:208:7: shellcheck reported issue in this script: SC2086:info:3:61: Double quote to prevent globbing and word splitting [shellcheck]`
- `test.yml: |`
- `test.yml: 208 |       run: |`
