### PR TITLE
chore: add dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency updates for GitHub Actions
- Configured with a weekly schedule

## Test plan
- No code changes; Dependabot will automatically open PRs for outdated actions once merged