### PR TITLE
chore: add /integrate skill for building framework integrations

### DIFF
--- a/.claude/skills/integrate/SKILL.md
+++ b/.claude/skills/integrate/SKILL.md
@@ -118,14 +118,6 @@ Write a blog post draft following the established pattern (see `hindsight-docs/b
 - Shows the problem → solution → working code
 - Save as a draft for review
 
-## Phase 4: Upstream (post-launch)
-
-After the integration is released and working:
-
-1. **Get into their docs** — open an issue or PR on the $ARGUMENTS repo proposing Hindsight as an official memory provider. Include a link to our integration and docs.
-2. **Propose official integration** — offer to move the integration code into their repo if they prefer to own it. Create a PR following their contribution guidelines.
-3. **If accepted upstream** — write a follow-up blog post about the official partnership and update our docs to point to the upstream package.
-
 ## Key references
 
 - Hindsight Python client: `hindsight-clients/python/`


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`/integrate [framework-name]`) that guides building new Hindsight integrations end-to-end
- Covers research, implementation (with features checklist), docs/marketing, and upstream contribution

## Test plan
- [ ] Invoke `/integrate autogen` (or similar) and verify the workflow is coherent
- [ ] Confirm skill appears in `/` menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)