### PR TITLE
fix: inject Accept header in MCP middleware to prevent 406 errors

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -381,6 +381,15 @@ class MCPMiddleware:
             # Clear root_path since we're passing directly to the app
             new_scope["root_path"] = ""
 
+            # Ensure Accept header includes required MIME types for MCP SDK.
+            # Some clients (e.g., Claude Code) don't send Accept, causing
+            # the SDK to reject with 406 Not Acceptable.
+            accept_header = self._get_header(new_scope, "accept")
+            if not accept_header or "text/event-stream" not in accept_header:
+                headers = [(k, v) for k, v in new_scope.get("headers", []) if k.lower() != b"accept"]
+                headers.append((b"accept", b"application/json, text/event-stream"))
+                new_scope["headers"] = headers
+
             # Wrap send to rewrite the SSE endpoint URL to include bank_id if using path-based routing.
             # Only rewrite SSE (text/event-stream) responses to avoid corrupting tool results
             # that might contain the literal string "data: /messages".


### PR DESCRIPTION
## Summary
- Some MCP clients (e.g., Claude Code) don't send an `Accept` header, causing the MCP SDK to reject requests with `406 Not Acceptable`
- The `MCPMiddleware` now injects `Accept: application/json, text/event-stream` when the header is missing or doesn't include `text/event-stream`
- This ensures all MCP clients can connect without requiring client-side configuration changes

## Test plan
- [ ] Verify MCP connection works with Claude Code (which omits Accept header)
- [ ] Verify MCP connection still works with clients that send proper Accept headers
- [ ] Confirm no regression in SSE streaming responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)