### PR TITLE
feat: add cross-bank querying — multi-bank recall and reflect

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/cross_bank_models.py
+++ b/hindsight-api-slim/hindsight_api/api/cross_bank_models.py
@@ -1,0 +1,357 @@
+"""
+Cross-bank operation models for Hindsight memory system.
+
+These models define the structure of data returned by cross-bank operations
+(recall and reflect across multiple memory banks).
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Type aliases for cross-bank operations
+TagsMatch = Literal["any", "all", "any_strict", "all_strict"]
+
+
+class BankInfo(BaseModel):
+    """
+    Information about a memory bank participating in cross-bank operations.
+
+    Contains the bank's identity and configuration relevant to
+    cross-bank query processing.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bank_id": "personal-notes",
+                "name": "Personal Notes",
+                "disposition": {"skepticism": 3, "literalism": 2, "empathy": 4},
+                "background": "Personal journaling and notes",
+                "tags": ["personal", "journal"],
+            }
+        }
+    )
+
+    bank_id: str = Field(description="Unique identifier for the bank")
+    name: str | None = Field(default=None, description="Human-readable name for the bank")
+    disposition: dict[str, int] = Field(
+        default_factory=lambda: {"skepticism": 3, "literalism": 3, "empathy": 3},
+        description="Bank disposition traits (skepticism, literalism, empathy 1-5)",
+    )
+    background: str | None = Field(default=None, description="Bank background context")
+    tags: list[str] = Field(default_factory=list, description="Tags for bank categorization")
+
+
+class CrossBankFact(BaseModel):
+    """
+    A memory fact with bank attribution for cross-bank operations.
+
+    Extends the base MemoryFact with bank identification to track
+    which bank each fact originated from during cross-bank queries.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "123e4567-e89b-12d3-a456-426614174000",
+                "text": "Alice works at Google on the AI team",
+                "fact_type": "world",
+                "bank_id": "work-notes",
+                "bank_name": "Work Notes",
+                "context": "work info",
+                "confidence": 0.95,
+                "occurred_start": "2024-01-15T10:30:00Z",
+                "entities": ["Alice", "Google"],
+            }
+        }
+    )
+
+    id: str = Field(description="Unique identifier for the memory fact")
+    text: str = Field(description="The actual text content of the memory")
+    fact_type: str = Field(description="Type of fact: 'world', 'experience', or 'observation'")
+    bank_id: str = Field(description="ID of the bank this fact belongs to")
+    bank_name: str | None = Field(default=None, description="Human-readable name of the bank")
+    context: str | None = Field(default=None, description="Additional context for the memory")
+    confidence: float | None = Field(default=None, description="Confidence score (0-1)")
+    occurred_start: datetime | None = Field(default=None, description="When the fact occurred")
+    entities: list[str] = Field(default_factory=list, description="Entities mentioned in this fact")
+    tags: list[str] = Field(default_factory=list, description="Tags associated with this fact")
+
+
+class MentalModelReference(BaseModel):
+    """
+    Reference to a mental model used during cross-bank reflection.
+
+    Tracks which mental models from which banks contributed to
+    the reflection response.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "team-dynamics-model",
+                "name": "Team Dynamics",
+                "bank_id": "work-notes",
+                "excerpt": "The team has strong collaboration patterns...",
+            }
+        }
+    )
+
+    id: str = Field(description="Unique identifier for the mental model")
+    name: str = Field(description="Human-readable name of the mental model")
+    bank_id: str = Field(description="ID of the bank this mental model belongs to")
+    excerpt: str = Field(description="Relevant portion of the mental model content")
+
+
+class ReasoningStepModel(BaseModel):
+    """
+    A single step in a multi-step reasoning chain.
+
+    Used when cross-bank reflect operates with MID/HIGH budget
+    and decomposes complex queries into sub-questions.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "step_number": 1,
+                "question": "What are the team dynamics?",
+                "relevant_banks": ["work-notes", "personal-notes"],
+                "conclusion": "The team has strong collaboration...",
+                "confidence": 0.85,
+                "evidence_count": 5,
+                "budget_used": 100,
+            }
+        }
+    )
+
+    step_number: int = Field(description="Step number in the reasoning chain (1-based)")
+    question: str = Field(description="The sub-question being answered")
+    relevant_banks: list[str] = Field(description="Bank IDs consulted for this step")
+    conclusion: str = Field(description="The conclusion drawn for this step")
+    confidence: float = Field(description="Confidence in the conclusion (0-1)")
+    evidence_count: int = Field(description="Number of facts supporting this conclusion")
+    budget_used: int = Field(description="Budget tokens consumed for this step")
+
+
+class CrossBankRecallResult(BaseModel):
+    """
+    Result from a cross-bank recall operation.
+
+    Contains fused results from multiple banks with attribution
+    and statistics about the cross-bank query.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "results": [
+                    {
+                        "id": "fact-123",
+                        "text": "Alice works at Google",
+                        "fact_type": "world",
+                        "bank_id": "work-notes",
+                        "bank_name": "Work Notes",
+                    }
+                ],
+                "bank_stats": {"work-notes": 5, "personal-notes": 3},
+                "total_results": 8,
+                "fusion_metadata": {
+                    "strategy": "reciprocal_rank_fusion",
+                    "dedup_count": 2,
+                },
+            }
+        }
+    )
+
+    results: list[CrossBankFact] = Field(
+        default_factory=list,
+        description="Fused and ranked facts from all queried banks",
+    )
+    bank_stats: dict[str, int] = Field(
+        default_factory=dict,
+        description="Number of facts contributed by each bank (bank_id -> count)",
+    )
+    total_results: int = Field(default=0, description="Total number of results returned")
+    fusion_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Metadata about the fusion process (strategy, dedup counts, etc.)",
+    )
+
+
+class CrossBankReflectResult(BaseModel):
+    """
+    Result from a cross-bank reflect operation.
+
+    Contains the synthesized response along with supporting facts,
+    mental models used, and attribution to source banks.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "text": "Based on my knowledge from your work and personal notes...",
+                "based_on": [
+                    {
+                        "id": "fact-123",
+                        "text": "Alice works at Google",
+                        "fact_type": "world",
+                        "bank_id": "work-notes",
+                    }
+                ],
+                "mental_models_used": [
+                    {
+                        "id": "team-dynamics",
+                        "name": "Team Dynamics",
+                        "bank_id": "work-notes",
+                        "excerpt": "...",
+                    }
+                ],
+                "bank_dispositions": {
+                    "work-notes": {"skepticism": 3, "literalism": 3, "empathy": 3}
+                },
+                "structured_output": None,
+                "reasoning_chain": None,
+                "new_opinions": [],
+            }
+        }
+    )
+
+    text: str = Field(description="The synthesized response text")
+    based_on: list[CrossBankFact] = Field(
+        default_factory=list,
+        description="Facts used to formulate the response",
+    )
+    mental_models_used: list[MentalModelReference] = Field(
+        default_factory=list,
+        description="Mental models consulted during reflection",
+    )
+    bank_dispositions: dict[str, dict[str, int]] = Field(
+        default_factory=dict,
+        description="Disposition traits per bank (bank_id -> disposition dict)",
+    )
+    structured_output: dict[str, Any] | None = Field(
+        default=None,
+        description="Structured output if response_schema was provided",
+    )
+    reasoning_chain: list[ReasoningStepModel] | None = Field(
+        default=None,
+        description="Reasoning steps if multi-step was used (MID/HIGH budget)",
+    )
+    new_opinions: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="New opinions extracted during reflection",
+    )
+
+
+class CrossBankRecallRequest(BaseModel):
+    """
+    Request model for cross-bank recall endpoint.
+
+    Allows querying multiple memory banks simultaneously with fused ranking.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "query": "What projects is Alice working on?",
+                "bank_ids": ["work-notes", "personal-notes"],
+                "bank_tags": None,
+                "max_results": 20,
+                "budget": "mid",
+                "tags": None,
+                "tags_match": "any",
+            }
+        }
+    )
+
+    query: str = Field(description="The search query to execute across banks")
+    bank_ids: list[str] | None = Field(
+        default=None,
+        description="Specific bank IDs to query. If None, queries all accessible banks.",
+    )
+    bank_tags: list[str] | None = Field(
+        default=None,
+        description="Filter banks by tags. Only banks with these tags will be queried.",
+    )
+    max_results: int = Field(
+        default=20,
+        description="Maximum total results to return after fusion",
+    )
+    budget: str = Field(
+        default="mid",
+        description="Budget level: 'low' (100 tokens), 'mid' (300 tokens), or 'high' (1000 tokens)",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Filter memories by tags within each bank",
+    )
+    tags_match: TagsMatch = Field(
+        default="any",
+        description="How to match tags: 'any' (OR), 'all' (AND), 'any_strict', 'all_strict'",
+    )
+
+
+class CrossBankReflectRequest(BaseModel):
+    """
+    Request model for cross-bank reflect endpoint.
+
+    Allows disposition-aware reflection across multiple memory banks.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "query": "What do you think about our team's progress?",
+                "bank_ids": ["work-notes", "personal-notes"],
+                "bank_tags": None,
+                "budget": "mid",
+                "context": None,
+                "include_mental_models": True,
+                "include_reasoning_chain": False,
+                "response_schema": None,
+                "tags": None,
+                "tags_match": "any",
+            }
+        }
+    )
+
+    query: str = Field(description="The question to reflect on across banks")
+    bank_ids: list[str] | None = Field(
+        default=None,
+        description="Specific bank IDs to query. If None, queries all accessible banks.",
+    )
+    bank_tags: list[str] | None = Field(
+        default=None,
+        description="Filter banks by tags. Only banks with these tags will be queried.",
+    )
+    budget: str = Field(
+        default="low",
+        description="Budget level: 'low' (100 tokens), 'mid' (300 tokens), or 'high' (1000 tokens)",
+    )
+    context: str | None = Field(
+        default=None,
+        description="Additional context for the reflection",
+    )
+    include_mental_models: bool = Field(
+        default=True,
+        description="Whether to consult mental models during reflection",
+    )
+    include_reasoning_chain: bool = Field(
+        default=False,
+        description="Whether to decompose complex queries into reasoning steps",
+    )
+    response_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional JSON Schema for structured output",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Filter memories by tags within each bank",
+    )
+    tags_match: TagsMatch = Field(
+        default="any",
+        description="How to match tags: 'any' (OR), 'all' (AND), 'any_strict', 'all_strict'",
+    )

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -70,6 +70,12 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
     return Field(default_factory=default_factory, json_schema_extra=json_extra, **kwargs)
 
 
+from hindsight_api.api.cross_bank_models import (
+    CrossBankRecallRequest,
+    CrossBankRecallResult,
+    CrossBankReflectRequest,
+    CrossBankReflectResult,
+)
 from hindsight_api.config import get_config
 from hindsight_api.engine.memory_engine import Budget, _current_schema, _get_tiktoken_encoding, fq_table
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MemoryFact, TokenUsage
@@ -1842,7 +1848,13 @@ def create_app(
         import asyncio
         import socket
 
-        from hindsight_api.config import get_config
+        from hindsight_api.api.cross_bank_models import (
+    CrossBankRecallRequest,
+    CrossBankRecallResult,
+    CrossBankReflectRequest,
+    CrossBankReflectResult,
+)
+from hindsight_api.config import get_config
         from hindsight_api.worker import WorkerPoller
 
         config = get_config()
@@ -1950,7 +1962,13 @@ def create_app(
         logging.info("Memory system closed")
 
     from hindsight_api import __version__
-    from hindsight_api.config import get_config
+    from hindsight_api.api.cross_bank_models import (
+    CrossBankRecallRequest,
+    CrossBankRecallResult,
+    CrossBankReflectRequest,
+    CrossBankReflectResult,
+)
+from hindsight_api.config import get_config
 
     config = get_config()
 
@@ -2563,6 +2581,153 @@ def _register_routes(app: FastAPI):
 
             error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
             logger.error(f"Error in /v1/default/banks/{bank_id}/reflect: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    # ═══════════════════════════════════════════════════════════════════════
+    # Cross-Bank Operations
+    # ═══════════════════════════════════════════════════════════════════════
+
+    @app.post(
+        "/v1/default/cross-bank/recall",
+        response_model=CrossBankRecallResult,
+        summary="Cross-bank recall",
+        description="Recall memories from multiple banks with fused ranking.\n\n"
+        "This endpoint queries multiple memory banks in parallel and fuses results "
+        "using Reciprocal Rank Fusion (RRF). Results are deduplicated and ranked "
+        "by combined relevance across all specified banks.\n\n"
+        "Specify banks by ID using bank_ids, or by tag using bank_tags. "
+        "If neither is provided, all accessible banks will be queried.",
+        operation_id="cross_bank_recall",
+        tags=["Cross-Bank"],
+    )
+    async def api_cross_bank_recall(
+        request: CrossBankRecallRequest,
+        request_context: RequestContext = Depends(get_request_context),
+    ):
+        """Run cross-bank recall with fused ranking."""
+        import time
+
+        handler_start = time.time()
+        metrics = get_metrics_collector()
+
+        # Validate query length
+        encoding = _get_tiktoken_encoding()
+        query_tokens = len(encoding.encode(request.query))
+        if query_tokens > MAX_QUERY_TOKENS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Query too long: {query_tokens} tokens exceeds maximum of {MAX_QUERY_TOKENS}.",
+            )
+
+        try:
+            # Parse budget from string
+            budget = Budget(request.budget.lower())
+
+            with metrics.record_operation(
+                "cross_bank_recall",
+                bank_id="multi",
+                source="api",
+                budget=budget.value,
+            ):
+                result = await app.state.memory._cross_bank_orchestrator.cross_bank_recall(
+                    query=request.query,
+                    bank_ids=request.bank_ids,
+                    bank_tags=request.bank_tags,
+                    max_results=request.max_results,
+                    budget=budget,
+                    request_context=request_context,
+                )
+
+            handler_duration = time.time() - handler_start
+            if handler_duration > 1.0:
+                logging.info(
+                    f"[CROSS_BANK_RECALL] handler_total={handler_duration:.3f}s "
+                    f"banks={len(result.bank_stats)} results={result.total_results}"
+                )
+
+            return result
+
+        except ValueError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid budget value: {request.budget}. Use 'low', 'mid', or 'high'.",
+            )
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in /v1/default/cross-bank/recall: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post(
+        "/v1/default/cross-bank/reflect",
+        response_model=CrossBankReflectResult,
+        summary="Cross-bank reflect",
+        description="Reflect across multiple banks with disposition-aware synthesis.\n\n"
+        "This endpoint gathers evidence from multiple memory banks, fuses findings "
+        "using Reciprocal Rank Fusion, and synthesizes a response that considers "
+        "each bank's disposition traits (skepticism, literalism, empathy).\n\n"
+        "The response reflects the combined knowledge and perspectives from all "
+        "specified banks, weighted by their contribution to the answer.\n\n"
+        "Specify banks by ID using bank_ids, or by tag using bank_tags. "
+        "If neither is provided, all accessible banks will be queried.",
+        operation_id="cross_bank_reflect",
+        tags=["Cross-Bank"],
+    )
+    async def api_cross_bank_reflect(
+        request: CrossBankReflectRequest,
+        request_context: RequestContext = Depends(get_request_context),
+    ):
+        """Run cross-bank reflect with disposition-aware synthesis."""
+        metrics = get_metrics_collector()
+
+        try:
+            # Parse budget from string
+            budget = Budget(request.budget.lower())
+
+            # Handle deprecated context field
+            query = request.query
+            if request.context:
+                query = f"{request.query}\n\nAdditional context: {request.context}"
+
+            with metrics.record_operation(
+                "cross_bank_reflect",
+                bank_id="multi",
+                source="api",
+                budget=budget.value,
+            ):
+                result = await app.state.memory._cross_bank_orchestrator.cross_bank_reflect(
+                    query=query,
+                    bank_ids=request.bank_ids,
+                    bank_tags=request.bank_tags,
+                    budget=budget,
+                    context=None,  # Already merged into query
+                    include_mental_models=request.include_mental_models,
+                    include_reasoning_chain=request.include_reasoning_chain,
+                    response_schema=request.response_schema,
+                    request_context=request_context,
+                )
+
+            return result
+
+        except ValueError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=str(e),
+            )
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in /v1/default/cross-bank/reflect: {error_detail}")
             raise HTTPException(status_code=500, detail=str(e))
 
     @app.get(
@@ -4479,7 +4644,13 @@ def _register_routes(app: FastAPI):
                 )
             else:
                 # Check if batch API is enabled - if so, require async mode
-                from hindsight_api.config import get_config
+                from hindsight_api.api.cross_bank_models import (
+    CrossBankRecallRequest,
+    CrossBankRecallResult,
+    CrossBankReflectRequest,
+    CrossBankReflectResult,
+)
+from hindsight_api.config import get_config
 
                 config = get_config()
                 if config.retain_batch_enabled:
@@ -4574,7 +4745,13 @@ def _register_routes(app: FastAPI):
         request_context: RequestContext = Depends(get_request_context),
     ):
         """Upload and convert files to memories."""
-        from hindsight_api.config import get_config
+        from hindsight_api.api.cross_bank_models import (
+    CrossBankRecallRequest,
+    CrossBankRecallResult,
+    CrossBankReflectRequest,
+    CrossBankReflectResult,
+)
+from hindsight_api.config import get_config
 
         config = get_config()
 

--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -47,6 +47,8 @@ _ALL_TOOLS: frozenset[str] = frozenset(
         "update_bank",
         "delete_bank",
         "clear_memories",
+        "cross_bank_recall",
+        "cross_bank_reflect",
     }
 )
 

--- a/hindsight-api-slim/hindsight_api/engine/cross_bank.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_bank.py
@@ -1,0 +1,1352 @@
+"""
+Cross-bank orchestration for Hindsight memory system.
+
+This module provides the CrossBankOrchestrator which coordinates queries
+across multiple memory banks, handling bank selection, budget allocation,
+and result fusion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hindsight_api.api.cross_bank_models import (
+        BankInfo,
+        CrossBankFact,
+        CrossBankRecallResult,
+        CrossBankReflectResult,
+    )
+    from hindsight_api.config_resolver import ConfigResolver
+    from hindsight_api.engine.interface import MemoryEngineInterface
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.memory_engine import Budget
+    from hindsight_api.extensions.operation_validator import (
+        CrossBankRecallContext,
+        CrossBankReflectContext,
+    )
+    from hindsight_api.extensions.operation_validator import (
+        CrossBankRecallResult as CrossBankRecallResultContext,
+    )
+    from hindsight_api.extensions.operation_validator import (
+        CrossBankReflectResult as CrossBankReflectResultContext,
+    )
+    from hindsight_api.models import RequestContext
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Budget Allocation
+# =============================================================================
+
+
+class BudgetStrategy(str, Enum):
+    """Strategies for allocating budget across banks."""
+
+    EQUAL = "equal"  # Split budget equally across all banks
+    PROPORTIONAL = "proportional"  # Allocate based on bank memory counts
+    QUERY_RELEVANT = "query_relevant"  # Allocate based on estimated query relevance
+
+
+@dataclass
+class BudgetAllocation:
+    """Result of budget allocation across banks."""
+
+    per_bank: dict[str, int]  # bank_id -> token budget
+    total_used: int
+    strategy: BudgetStrategy
+    synthesis_reserve: int = 0  # Tokens reserved for final synthesis (multi-step)
+
+
+class BudgetAllocator:
+    """
+    Allocates query budget across multiple banks.
+
+    Supports different allocation strategies to optimize
+    cross-bank query performance.
+    """
+
+    SYNTHESIS_RESERVE_RATIO = 0.30  # Reserve 30% for synthesis in multi-step
+
+    # Budget token values (matching MemoryEngine)
+    BUDGET_VALUES = {
+        "low": 100,
+        "mid": 300,
+        "high": 1000,
+    }
+    MIN_BUDGET_PER_BANK = 100  # Minimum budget per bank (LOW budget value)
+
+    @staticmethod
+    def equal_split(
+        budget_value: int,
+        bank_ids: list[str],
+        ensure_minimum: bool = True,
+    ) -> BudgetAllocation:
+        """
+        Split budget equally across all banks.
+
+        Args:
+            budget_value: Total budget tokens to allocate.
+            bank_ids: List of bank IDs to allocate budget for.
+            ensure_minimum: If True, ensure no bank gets less than MIN_BUDGET_PER_BANK.
+
+        Returns:
+            BudgetAllocation with equal per-bank amounts.
+
+        Raises:
+            ValueError: If budget is too low to provide minimum to each bank.
+        """
+        if not bank_ids:
+            return BudgetAllocation(per_bank={}, total_used=0, strategy=BudgetStrategy.EQUAL)
+
+        per_bank_raw = int(budget_value / len(bank_ids))
+
+        # Ensure minimum budget per bank — auto-raise to minimum if too low
+        if ensure_minimum and per_bank_raw < BudgetAllocator.MIN_BUDGET_PER_BANK:
+            per_bank_raw = BudgetAllocator.MIN_BUDGET_PER_BANK
+
+        allocation = {bank_id: per_bank_raw for bank_id in bank_ids}
+        total_used = per_bank_raw * len(bank_ids)
+
+        return BudgetAllocation(
+            per_bank=allocation,
+            total_used=total_used,
+            strategy=BudgetStrategy.EQUAL,
+        )
+
+    @staticmethod
+    def proportional(
+        budget_value: int,
+        bank_sizes: dict[str, int],
+    ) -> BudgetAllocation:
+        """
+        Allocate budget proportional to bank memory counts.
+
+        Banks with more memories get larger budget allocations.
+
+        Args:
+            budget_value: Total budget tokens to allocate.
+            bank_sizes: Dict mapping bank_id to memory count.
+
+        Returns:
+            BudgetAllocation weighted by bank sizes.
+        """
+        if not bank_sizes:
+            return BudgetAllocation(per_bank={}, total_used=0, strategy=BudgetStrategy.PROPORTIONAL)
+
+        total_memories = sum(bank_sizes.values())
+        if total_memories == 0:
+            return BudgetAllocator.equal_split(budget_value, list(bank_sizes.keys()))
+
+        allocation = {}
+        total_used = 0
+        for bank_id, size in bank_sizes.items():
+            bank_budget = int(budget_value * (size / total_memories))
+            allocation[bank_id] = bank_budget
+            total_used += bank_budget
+
+        return BudgetAllocation(
+            per_bank=allocation,
+            total_used=total_used,
+            strategy=BudgetStrategy.PROPORTIONAL,
+        )
+
+    @staticmethod
+    def query_relevant(
+        budget_value: int,
+        bank_relevance: dict[str, float],
+    ) -> BudgetAllocation:
+        """
+        Allocate budget based on estimated query relevance per bank.
+
+        Uses a lightweight pre-query (e.g., BM25) to estimate
+        which banks are most relevant to the query.
+
+        Args:
+            budget_value: Total budget tokens to allocate.
+            bank_relevance: Dict mapping bank_id to relevance score (0-1).
+
+        Returns:
+            BudgetAllocation weighted by relevance scores.
+        """
+        if not bank_relevance:
+            return BudgetAllocation(per_bank={}, total_used=0, strategy=BudgetStrategy.QUERY_RELEVANT)
+
+        total_relevance = sum(bank_relevance.values())
+        if total_relevance == 0:
+            return BudgetAllocator.equal_split(budget_value, list(bank_relevance.keys()))
+
+        allocation = {}
+        total_used = 0
+        for bank_id, relevance in bank_relevance.items():
+            bank_budget = int(budget_value * (relevance / total_relevance))
+            allocation[bank_id] = bank_budget
+            total_used += bank_budget
+
+        return BudgetAllocation(
+            per_bank=allocation,
+            total_used=total_used,
+            strategy=BudgetStrategy.QUERY_RELEVANT,
+        )
+
+    @staticmethod
+    def allocate_for_multistep(
+        total_budget: int,
+        bank_ids: list[str],
+        n_steps: int,
+    ) -> tuple[BudgetAllocation, int]:
+        """
+        Allocate budget for multi-step reasoning.
+
+        Reserves a portion for final synthesis and splits
+        the remainder across steps and banks.
+
+        Args:
+            total_budget: Total budget tokens.
+            bank_ids: List of bank IDs.
+            n_steps: Number of reasoning steps.
+
+        Returns:
+            Tuple of (per_step_allocation, synthesis_budget).
+        """
+        synthesis_budget = int(total_budget * BudgetAllocator.SYNTHESIS_RESERVE_RATIO)
+        remaining = total_budget - synthesis_budget
+
+        per_step_per_bank = int(remaining / (n_steps * len(bank_ids))) if bank_ids and n_steps > 0 else 0
+        allocation = {bank_id: per_step_per_bank for bank_id in bank_ids}
+
+        return BudgetAllocation(
+            per_bank=allocation,
+            total_used=per_step_per_bank * len(bank_ids),
+            strategy=BudgetStrategy.EQUAL,
+            synthesis_reserve=synthesis_budget,
+        ), synthesis_budget
+
+
+# =============================================================================
+# Bank Selection
+# =============================================================================
+
+
+class BankSelector:
+    """
+    Resolves which banks participate in a cross-bank query.
+
+    Supports selection by explicit IDs, tags, or automatic
+    discovery of accessible banks.
+    """
+
+    def __init__(self, engine: "MemoryEngineInterface"):
+        """
+        Initialize the bank selector.
+
+        Args:
+            engine: Memory engine instance for bank queries.
+        """
+        self._engine = engine
+
+    async def resolve(
+        self,
+        bank_ids: list[str] | None = None,
+        bank_tags: list[str] | None = None,
+        request_context: "RequestContext | None" = None,
+    ) -> list["BankInfo"]:
+        """
+        Resolve the list of banks to query.
+
+        Selection priority:
+        1. If bank_ids provided: validate access and return those banks
+        2. If bank_tags provided: filter banks by tags
+        3. Otherwise: return all accessible banks
+
+        Args:
+            bank_ids: Explicit list of bank IDs to query.
+            bank_tags: Filter banks by these tags.
+            request_context: Request context for authorization.
+
+        Returns:
+            List of BankInfo for participating banks.
+        """
+        # Create default context if not provided
+        from hindsight_api.models import RequestContext
+
+        ctx = request_context or RequestContext()
+
+        if bank_ids:
+            return await self._validate_and_load(bank_ids, ctx)
+        if bank_tags:
+            return await self._filter_by_tags(bank_tags, ctx)
+        return await self._all_accessible(ctx)
+
+    async def _validate_and_load(
+        self,
+        bank_ids: list[str],
+        request_context: "RequestContext",
+    ) -> list["BankInfo"]:
+        """Validate access to specified banks and load their info."""
+        from hindsight_api.api.cross_bank_models import BankInfo
+
+        # Check if access is restricted by allowed_bank_ids
+        allowed = request_context.allowed_bank_ids
+        if allowed is not None:
+            # Filter to only allowed banks
+            invalid = set(bank_ids) - set(allowed)
+            if invalid:
+                logger.warning(f"Access denied to banks: {invalid}")
+            bank_ids = [bid for bid in bank_ids if bid in allowed]
+
+        result = []
+        for bank_id in bank_ids:
+            try:
+                profile = await self._engine.get_bank_profile(bank_id, request_context=request_context)
+                result.append(
+                    BankInfo(
+                        bank_id=bank_id,
+                        name=profile.get("name"),
+                        disposition=profile.get("disposition", {"skepticism": 3, "literalism": 3, "empathy": 3}),
+                        background=profile.get("mission"),
+                        tags=[],  # Tags not stored in bank profile currently
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"Failed to load bank {bank_id}: {e}")
+
+        return result
+
+    async def _filter_by_tags(
+        self,
+        tags: list[str],
+        request_context: "RequestContext",
+    ) -> list["BankInfo"]:
+        """Find banks matching any of the specified tags."""
+        from hindsight_api.api.cross_bank_models import BankInfo
+
+        # Get all banks and filter by tags
+        all_banks = await self._engine.list_banks(request_context=request_context)
+
+        result = []
+        for bank_data in all_banks:
+            bank_tags = bank_data.get("tags", [])
+            # Check if any of the requested tags match
+            if any(tag in bank_tags for tag in tags):
+                result.append(
+                    BankInfo(
+                        bank_id=bank_data["bank_id"],
+                        name=bank_data.get("name"),
+                        disposition=bank_data.get("disposition", {"skepticism": 3, "literalism": 3, "empathy": 3}),
+                        background=bank_data.get("mission"),
+                        tags=bank_tags,
+                    )
+                )
+
+        return result
+
+    async def _all_accessible(
+        self,
+        request_context: "RequestContext",
+    ) -> list["BankInfo"]:
+        """Get all banks accessible to the request context."""
+        from hindsight_api.api.cross_bank_models import BankInfo
+
+        all_banks = await self._engine.list_banks(request_context=request_context)
+
+        # Check if access is restricted
+        allowed = request_context.allowed_bank_ids
+
+        result = []
+        for bank_data in all_banks:
+            bank_id = bank_data["bank_id"]
+
+            # Skip if not in allowed list (when restricted)
+            if allowed is not None and bank_id not in allowed:
+                continue
+
+            result.append(
+                BankInfo(
+                    bank_id=bank_id,
+                    name=bank_data.get("name"),
+                    disposition=bank_data.get("disposition", {"skepticism": 3, "literalism": 3, "empathy": 3}),
+                    background=bank_data.get("mission"),
+                    tags=bank_data.get("tags", []),
+                )
+            )
+
+        return result
+
+
+# =============================================================================
+# Disposition Reconciliation
+# =============================================================================
+
+
+@dataclass
+class ReconciledDisposition:
+    """Result of reconciling dispositions across banks."""
+
+    skepticism: int
+    literalism: int
+    empathy: int
+    reconciliation_method: str
+    bank_weights: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, int]:
+        """Convert to disposition dict format."""
+        return {
+            "skepticism": self.skepticism,
+            "literalism": self.literalism,
+            "empathy": self.empathy,
+        }
+
+
+def reconcile_dispositions(
+    bank_results: dict[str, list["CrossBankFact"]],
+    bank_dispositions: dict[str, dict[str, int]],
+) -> ReconciledDisposition:
+    """
+    Reconcile conflicting dispositions using relevance-weighted averaging.
+
+    Weight each bank's disposition by how many relevant facts it contributed.
+
+    Args:
+        bank_results: Dict mapping bank_id to list of facts returned.
+        bank_dispositions: Dict mapping bank_id to disposition traits.
+
+    Returns:
+        ReconciledDisposition with weighted average traits.
+    """
+    if not bank_results or not bank_dispositions:
+        return ReconciledDisposition(
+            skepticism=3,
+            literalism=3,
+            empathy=3,
+            reconciliation_method="default",
+        )
+
+    total_facts = sum(len(facts) for facts in bank_results.values())
+    if total_facts == 0:
+        return ReconciledDisposition(
+            skepticism=3,
+            literalism=3,
+            empathy=3,
+            reconciliation_method="no_facts",
+        )
+
+    weighted_skepticism = 0.0
+    weighted_literalism = 0.0
+    weighted_empathy = 0.0
+    bank_weights = {}
+
+    for bank_id, facts in bank_results.items():
+        if bank_id not in bank_dispositions:
+            continue
+
+        weight = len(facts) / total_facts
+        bank_weights[bank_id] = weight
+
+        disposition = bank_dispositions[bank_id]
+        weighted_skepticism += disposition.get("skepticism", 3) * weight
+        weighted_literalism += disposition.get("literalism", 3) * weight
+        weighted_empathy += disposition.get("empathy", 3) * weight
+
+    # Clamp values to valid 1-5 range
+    skepticism_clamped = max(1, min(5, round(weighted_skepticism)))
+    literalism_clamped = max(1, min(5, round(weighted_literalism)))
+    empathy_clamped = max(1, min(5, round(weighted_empathy)))
+
+    return ReconciledDisposition(
+        skepticism=skepticism_clamped,
+        literalism=literalism_clamped,
+        empathy=empathy_clamped,
+        reconciliation_method="relevance_weighted",
+        bank_weights=bank_weights,
+    )
+
+
+# =============================================================================
+# Cross-Bank Orchestrator
+# =============================================================================
+
+
+class CrossBankOrchestrator:
+    """
+    Orchestrates queries across multiple Hindsight banks.
+
+    Coordinates parallel bank queries, result fusion, and
+    multi-step reasoning for complex queries.
+    """
+
+    def __init__(
+        self,
+        engine: "MemoryEngineInterface",
+        config_resolver: "ConfigResolver | None" = None,
+    ):
+        """
+        Initialize the cross-bank orchestrator.
+
+        Args:
+            engine: Memory engine for executing per-bank queries.
+            config_resolver: Optional config resolver for hierarchical config.
+        """
+        self._engine = engine
+        self._config_resolver = config_resolver
+        self._bank_selector = BankSelector(engine)
+
+    async def cross_bank_recall(
+        self,
+        query: str,
+        bank_ids: list[str] | None = None,
+        bank_tags: list[str] | None = None,
+        max_results: int = 20,
+        budget: "Budget | None" = None,
+        request_context: "RequestContext | None" = None,
+    ) -> "CrossBankRecallResult":
+        """
+        Recall facts from multiple banks with fused ranking.
+
+        Args:
+            query: The search query.
+            bank_ids: Specific banks to query (None = all accessible).
+            bank_tags: Filter banks by tags.
+            max_results: Maximum total results to return.
+            budget: Budget level for the query.
+            request_context: Request context for authorization.
+
+        Returns:
+            CrossBankRecallResult with fused and ranked facts.
+        """
+        from hindsight_api.api.cross_bank_models import CrossBankRecallResult
+        from hindsight_api.extensions.operation_validator import (
+            CrossBankRecallContext,
+        )
+        from hindsight_api.extensions.operation_validator import (
+            CrossBankRecallResult as CrossBankRecallResultContext,
+        )
+        from hindsight_api.models import RequestContext
+
+        # Create default context if not provided
+        ctx = request_context or RequestContext()
+
+        # Run pre-operation validation hook
+        if hasattr(self._engine, '_operation_validator') and self._engine._operation_validator:
+            validation_ctx = CrossBankRecallContext(
+                bank_ids=bank_ids,
+                query=query,
+                request_context=ctx,
+                budget=budget,
+                bank_tags=bank_tags,
+                max_results=max_results,
+            )
+            result = await self._engine._operation_validator.validate_cross_bank_recall(validation_ctx)
+            if not result.allowed:
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(
+                    result.reason or "Cross-bank recall not allowed",
+                    result.status_code,
+                )
+
+        # Resolve banks to query
+        banks = await self._bank_selector.resolve(
+            bank_ids=bank_ids,
+            bank_tags=bank_tags,
+            request_context=ctx,
+        )
+
+        if not banks:
+            return CrossBankRecallResult(
+                results=[],
+                bank_stats={},
+                total_results=0,
+                fusion_metadata={"strategy": "none", "reason": "no_banks"},
+            )
+
+        # Determine budget value
+        budget_value = self._get_budget_value(budget)
+
+        # Allocate budget across banks
+        bank_id_list = [b.bank_id for b in banks]
+        try:
+            allocation = BudgetAllocator.equal_split(budget_value, bank_id_list)
+        except ValueError as e:
+            # Budget too low - use minimum per bank
+            logger.warning(f"Budget allocation failed: {e}. Using minimum per bank.")
+            allocation = BudgetAllocation(
+                per_bank={bid: BudgetAllocator.MIN_BUDGET_PER_BANK for bid in bank_id_list},
+                total_used=len(bank_id_list) * BudgetAllocator.MIN_BUDGET_PER_BANK,
+                strategy=BudgetStrategy.EQUAL,
+            )
+
+        # Execute parallel recall
+        bank_results = await self._parallel_recall(query, banks, allocation, ctx)
+
+        # Fuse results with RRF
+        fused = await self._fuse_results(bank_results, max_results)
+
+        # Compute bank stats
+        bank_stats = {bank_id: len(facts) for bank_id, facts in bank_results.items()}
+
+        # Build result
+        result = CrossBankRecallResult(
+            results=fused,
+            bank_stats=bank_stats,
+            total_results=len(fused),
+            fusion_metadata={
+                "strategy": "reciprocal_rank_fusion",
+                "k": 60,
+                "banks_queried": len(banks),
+                "banks_succeeded": len([b for b in bank_results.values() if b]),
+            },
+        )
+
+        # Run post-operation completion hook
+        if hasattr(self._engine, '_operation_validator') and self._engine._operation_validator:
+            completion_result = CrossBankRecallResultContext(
+                bank_ids=bank_id_list,
+                query=query,
+                request_context=ctx,
+                budget=budget,
+                bank_tags=bank_tags,
+                max_results=max_results,
+                results_per_bank=bank_stats,
+                total_results=len(fused),
+                fusion_metadata=result.fusion_metadata,
+                success=True,
+                error=None,
+            )
+            await self._engine._operation_validator.on_cross_bank_recall_complete(completion_result)
+
+        return result
+
+    async def cross_bank_reflect(
+        self,
+        query: str,
+        bank_ids: list[str] | None = None,
+        bank_tags: list[str] | None = None,
+        budget: "Budget | None" = None,
+        context: str | None = None,
+        include_mental_models: bool = True,
+        include_reasoning_chain: bool = False,
+        response_schema: dict | None = None,
+        request_context: "RequestContext | None" = None,
+    ) -> "CrossBankReflectResult":
+        """
+        Reflect across multiple banks with disposition-aware synthesis.
+
+        This method:
+        1. Gathers evidence (facts + mental models) from multiple banks
+        2. Fuses facts using Reciprocal Rank Fusion
+        3. Reconciles bank dispositions weighted by fact count
+        4. Makes a single LLM synthesis call with disposition-aware prompt
+        5. Optionally extracts structured output if response_schema provided
+
+        Args:
+            query: The question to reflect on.
+            bank_ids: Specific banks to query (None = all accessible).
+            bank_tags: Filter banks by tags.
+            budget: Budget level for the query.
+            context: Additional context for the reflection.
+            include_mental_models: Whether to consult mental models.
+            include_reasoning_chain: Whether to decompose complex queries.
+            response_schema: Optional JSON Schema for structured output.
+            request_context: Request context for authorization.
+
+        Returns:
+            CrossBankReflectResult with synthesized response.
+        """
+        from hindsight_api.api.cross_bank_models import (
+            CrossBankFact,
+            CrossBankReflectResult,
+            MentalModelReference,
+        )
+        from hindsight_api.engine.memory_engine import Budget
+        from hindsight_api.extensions.operation_validator import (
+            CrossBankReflectContext,
+        )
+        from hindsight_api.extensions.operation_validator import (
+            CrossBankReflectResult as CrossBankReflectResultContext,
+        )
+        from hindsight_api.models import RequestContext
+
+        # Create default context if not provided
+        ctx = request_context or RequestContext()
+
+        # Run pre-operation validation hook
+        if hasattr(self._engine, '_operation_validator') and self._engine._operation_validator:
+            validation_ctx = CrossBankReflectContext(
+                bank_ids=bank_ids,
+                query=query,
+                request_context=ctx,
+                budget=budget,
+                bank_tags=bank_tags,
+                context=context,
+                include_mental_models=include_mental_models,
+                include_reasoning_chain=include_reasoning_chain,
+                response_schema=response_schema,
+            )
+            result = await self._engine._operation_validator.validate_cross_bank_reflect(validation_ctx)
+            if not result.allowed:
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(
+                    result.reason or "Cross-bank reflect not allowed",
+                    result.status_code,
+                )
+
+        # Resolve banks to query
+        banks = await self._bank_selector.resolve(
+            bank_ids=bank_ids,
+            bank_tags=bank_tags,
+            request_context=ctx,
+        )
+
+        if not banks:
+            return CrossBankReflectResult(
+                text="No accessible banks found for cross-bank reflection.",
+                based_on=[],
+                mental_models_used=[],
+                bank_dispositions={},
+                structured_output=None,
+                reasoning_chain=None,
+                new_opinions=[],
+            )
+
+        bank_id_list = [b.bank_id for b in banks]
+
+        # Calculate budget allocation
+        budget_value = self._get_budget_value(budget)
+        budget_allocation = BudgetAllocator.equal_split(budget_value, bank_id_list)
+
+        # Gather evidence from all banks
+        evidence = await self._gather_evidence(
+            query=query,
+            banks=banks,
+            budget_allocation=budget_allocation,
+            include_mental_models=include_mental_models,
+            request_context=ctx,
+        )
+
+        # Extract fused facts
+        fused_facts = evidence["fused_facts"]
+
+        # Extract bank dispositions
+        bank_dispositions = {bank.bank_id: bank.disposition for bank in banks}
+
+        # Reconcile dispositions weighted by fact count
+        reconciled = reconcile_dispositions(evidence["bank_results"], bank_dispositions)
+
+        # Build synthesis prompt with disposition context
+        synthesis_prompt = self._build_synthesis_prompt(
+            query=query,
+            fused_facts=fused_facts,
+            mental_models=evidence.get("mental_models", []),
+            reconciled_disposition=reconciled,
+            context=context,
+        )
+
+        # Make single LLM synthesis call
+        llm_provider = self._get_llm_provider()
+        if llm_provider is None:
+            return CrossBankReflectResult(
+                text="LLM provider not configured. Set HINDSIGHT_API_LLM_API_KEY environment variable.",
+                based_on=fused_facts,
+                mental_models_used=evidence.get("mental_model_refs", []),
+                bank_dispositions=bank_dispositions,
+                structured_output=None,
+                reasoning_chain=None,
+                new_opinions=[],
+            )
+
+        # Get resolved config for the first bank (or use default)
+        resolved_config = None
+        if self._config_resolver and banks:
+            resolved_config = await self._config_resolver.resolve_full_config(banks[0].bank_id, ctx)
+
+        # Apply config to LLM provider if available
+        if resolved_config:
+            llm_provider = llm_provider.with_config(resolved_config)
+
+        # Make the synthesis call
+        try:
+            response, _ = await llm_provider.call(
+                messages=[
+                    {"role": "system", "content": self._get_cross_bank_system_prompt(reconciled)},
+                    {"role": "user", "content": synthesis_prompt},
+                ],
+                max_completion_tokens=4096,
+                scope="cross_bank_reflect",
+                return_usage=True,
+            )
+
+            synthesized_text = response.strip() if isinstance(response, str) else str(response)
+
+        except Exception as e:
+            logger.error(f"Cross-bank reflect LLM call failed: {e}")
+
+            # Run post-operation completion hook (failure case)
+            if hasattr(self._engine, '_operation_validator') and self._engine._operation_validator:
+                completion_result = CrossBankReflectResultContext(
+                    bank_ids=bank_id_list,
+                    query=query,
+                    request_context=ctx,
+                    budget=budget,
+                    bank_tags=bank_tags,
+                    context=context,
+                    include_mental_models=include_mental_models,
+                    include_reasoning_chain=include_reasoning_chain,
+                    response_schema=response_schema,
+                    facts_per_bank={},
+                    mental_models_per_bank={},
+                    reasoning_steps=0,
+                    output_tokens=0,
+                    structured_output=None,
+                    success=False,
+                    error=str(e),
+                )
+                await self._engine._operation_validator.on_cross_bank_reflect_complete(completion_result)
+
+            return CrossBankReflectResult(
+                text=f"Failed to synthesize response: {e}",
+                based_on=fused_facts,
+                mental_models_used=evidence.get("mental_model_refs", []),
+                bank_dispositions=bank_dispositions,
+                structured_output=None,
+                reasoning_chain=None,
+                new_opinions=[],
+            )
+
+        # Generate structured output if schema provided
+        structured_output = None
+        if response_schema and synthesized_text:
+            structured_output = await self._generate_structured_output(
+                answer=synthesized_text,
+                response_schema=response_schema,
+                llm_provider=llm_provider,
+            )
+
+        # Compute facts per bank for the completion hook
+        facts_per_bank = {}
+        for bank_id, facts in evidence.get("bank_results", {}).items():
+            facts_per_bank[bank_id] = len(facts)
+
+        mental_models_per_bank = {}
+        if evidence.get("mental_models"):
+            for mm in evidence["mental_models"]:
+                bank_id = mm.get("bank_id")
+                if bank_id:
+                    mental_models_per_bank[bank_id] = mental_models_per_bank.get(bank_id, 0) + 1
+
+        result = CrossBankReflectResult(
+            text=synthesized_text,
+            based_on=fused_facts,
+            mental_models_used=evidence.get("mental_model_refs", []),
+            bank_dispositions=bank_dispositions,
+            structured_output=structured_output,
+            reasoning_chain=None,  # Multi-step reasoning not implemented in this sprint
+            new_opinions=[],
+        )
+
+        # Run post-operation completion hook (success case)
+        if hasattr(self._engine, '_operation_validator') and self._engine._operation_validator:
+            completion_result = CrossBankReflectResultContext(
+                bank_ids=bank_id_list,
+                query=query,
+                request_context=ctx,
+                budget=budget,
+                bank_tags=bank_tags,
+                context=context,
+                include_mental_models=include_mental_models,
+                include_reasoning_chain=include_reasoning_chain,
+                response_schema=response_schema,
+                facts_per_bank=facts_per_bank,
+                mental_models_per_bank=mental_models_per_bank,
+                reasoning_steps=0,
+                output_tokens=0,
+                structured_output=structured_output,
+                success=True,
+                error=None,
+            )
+            await self._engine._operation_validator.on_cross_bank_reflect_complete(completion_result)
+
+        return result
+
+    async def _parallel_recall(
+        self,
+        query: str,
+        banks: list["BankInfo"],
+        budget_allocation: BudgetAllocation,
+        request_context: "RequestContext",
+    ) -> dict[str, list["CrossBankFact"]]:
+        """Execute recall in parallel across specified banks."""
+        from hindsight_api.api.cross_bank_models import CrossBankFact
+
+        async def recall_single_bank(bank: "BankInfo") -> tuple[str, list["CrossBankFact"]]:
+            """Recall from a single bank, handling failures gracefully."""
+            try:
+                bank_budget = budget_allocation.per_bank.get(bank.bank_id, BudgetAllocator.MIN_BUDGET_PER_BANK)
+                # Convert token budget to Budget enum-like value
+                budget = self._tokens_to_budget(bank_budget)
+
+                result = await self._engine.recall_async(
+                    bank_id=bank.bank_id,
+                    query=query,
+                    budget=budget,
+                    request_context=request_context,
+                )
+
+                # Convert MemoryFact to CrossBankFact
+                facts = []
+                for fact in result.results:
+                    facts.append(
+                        CrossBankFact(
+                            id=fact.id,
+                            text=fact.text,
+                            fact_type=fact.fact_type,
+                            bank_id=bank.bank_id,
+                            bank_name=bank.name,
+                            context=fact.context,
+                            confidence=None,  # MemoryFact doesn't have confidence
+                            occurred_start=self._parse_datetime(fact.occurred_start),
+                            entities=fact.entities or [],
+                            tags=fact.tags or [],
+                        )
+                    )
+
+                return (bank.bank_id, facts)
+
+            except Exception as e:
+                logger.error(f"Recall failed for bank {bank.bank_id}: {e}")
+                return (bank.bank_id, [])
+
+        # Execute all recalls in parallel with asyncio.gather
+        tasks = [recall_single_bank(bank) for bank in banks]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Process results, handling any exceptions
+        bank_results = {}
+        for i, result in enumerate(results):
+            bank_id = banks[i].bank_id
+            if isinstance(result, Exception):
+                logger.error(f"Recall task failed for bank {bank_id}: {result}")
+                bank_results[bank_id] = []
+            elif isinstance(result, tuple):
+                bank_id_result, facts = result
+                bank_results[bank_id_result] = facts
+            else:
+                logger.warning(f"Unexpected result type for bank {bank_id}: {type(result)}")
+                bank_results[bank_id] = []
+
+        return bank_results
+
+    async def _fuse_results(
+        self,
+        bank_results: dict[str, list["CrossBankFact"]],
+        max_results: int,
+    ) -> list["CrossBankFact"]:
+        """Fuse and rank results from multiple banks using RRF."""
+        # RRF constant
+        K = 60
+
+        # Build a map of unique facts by entity ID for deduplication
+        # Facts are deduplicated by their ID (which should be unique across banks)
+        all_facts: dict[str, "CrossBankFact"] = {}
+        fact_ranks: dict[str, list[int]] = {}  # fact_id -> list of ranks from each bank
+
+        for _, facts in bank_results.items():
+            for rank, fact in enumerate(facts, start=1):
+                fact_id = fact.id
+
+                # Store the fact (may be overwritten but that's okay)
+                if fact_id not in all_facts:
+                    all_facts[fact_id] = fact
+                    fact_ranks[fact_id] = []
+
+                # Record the rank from this bank
+                fact_ranks[fact_id].append(rank)
+
+        # Compute RRF scores
+        rrf_scores: list[tuple[str, float]] = []
+        for fact_id, ranks in fact_ranks.items():
+            # RRF score = sum over ranks: 1 / (k + rank)
+            score = sum(1.0 / (K + rank) for rank in ranks)
+            rrf_scores.append((fact_id, score))
+
+        # Sort by RRF score descending
+        rrf_scores.sort(key=lambda x: x[1], reverse=True)
+
+        # Take top max_results
+        top_fact_ids = [fact_id for fact_id, _ in rrf_scores[:max_results]]
+
+        # Return the fused facts
+        return [all_facts[fact_id] for fact_id in top_fact_ids]
+
+    def _get_budget_value(self, budget: "Budget | None") -> int:
+        """Convert Budget enum to token value."""
+        from hindsight_api.engine.memory_engine import Budget
+
+        if budget is None:
+            return BudgetAllocator.BUDGET_VALUES["mid"]
+
+        # Handle Budget enum
+        if isinstance(budget, Budget):
+            return BudgetAllocator.BUDGET_VALUES.get(budget.value, BudgetAllocator.BUDGET_VALUES["mid"])
+
+        # Handle string budget values
+        if isinstance(budget, str):
+            budget_str = budget.lower()
+            return BudgetAllocator.BUDGET_VALUES.get(budget_str, BudgetAllocator.BUDGET_VALUES["mid"])
+
+        # Budget is already an int
+        return int(budget) if isinstance(budget, int) else BudgetAllocator.BUDGET_VALUES["mid"]
+
+    def _tokens_to_budget(self, tokens: int) -> "Budget":
+        """Convert token count to Budget enum."""
+        from hindsight_api.engine.memory_engine import Budget
+
+        if tokens <= BudgetAllocator.BUDGET_VALUES["low"]:
+            return Budget.LOW
+        elif tokens <= BudgetAllocator.BUDGET_VALUES["mid"]:
+            return Budget.MID
+        return Budget.HIGH
+
+    def _parse_datetime(self, dt_str: str | None) -> datetime | None:
+        """Parse ISO datetime string to datetime object."""
+        if dt_str is None:
+            return None
+
+        try:
+            # Handle ISO format with or without timezone
+            if dt_str.endswith("Z"):
+                dt_str = dt_str[:-1] + "+00:00"
+            return datetime.fromisoformat(dt_str)
+        except (ValueError, TypeError):
+            return None
+
+    async def _gather_evidence(
+        self,
+        query: str,
+        banks: list["BankInfo"],
+        budget_allocation: BudgetAllocation,
+        include_mental_models: bool,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """
+        Gather evidence (facts + mental models) from multiple banks.
+
+        This method:
+        1. Performs parallel recall across all banks
+        2. Optionally searches mental models in each bank
+        3. Fuses all facts using Reciprocal Rank Fusion
+
+        Args:
+            query: The search query.
+            banks: List of BankInfo for banks to query.
+            budget_allocation: Budget allocation per bank.
+            include_mental_models: Whether to include mental models.
+            request_context: Request context for authorization.
+
+        Returns:
+            Dict containing:
+                - bank_results: Dict mapping bank_id to list of CrossBankFact
+                - fused_facts: List of fused and ranked CrossBankFact
+                - mental_models: List of mental model dicts (if include_mental_models)
+                - mental_model_refs: List of MentalModelReference objects
+        """
+        from hindsight_api.api.cross_bank_models import CrossBankFact, MentalModelReference
+
+        # Step 1: Parallel recall across all banks
+        bank_results = await self._parallel_recall(
+            query=query,
+            banks=banks,
+            budget_allocation=budget_allocation,
+            request_context=request_context,
+        )
+
+        # Step 2: Fuse results using RRF
+        max_facts = 50  # Maximum facts to include in synthesis
+        fused_facts = await self._fuse_results(bank_results, max_facts)
+
+        # Step 3: Optionally gather mental models
+        mental_models = []
+        mental_model_refs = []
+
+        if include_mental_models and banks:
+            mental_model_results = await self._search_mental_models_parallel(
+                query=query,
+                banks=banks,
+                max_results_per_bank=3,
+                _request_context=request_context,
+            )
+
+            for bank_id, models in mental_model_results.items():
+                for model in models:
+                    mental_models.append(model)
+                    mental_model_refs.append(
+                        MentalModelReference(
+                            id=model["id"],
+                            name=model["name"],
+                            bank_id=bank_id,
+                            excerpt=model["content"][:200] + "..." if len(model["content"]) > 200 else model["content"],
+                        )
+                    )
+
+        return {
+            "bank_results": bank_results,
+            "fused_facts": fused_facts,
+            "mental_models": mental_models,
+            "mental_model_refs": mental_model_refs,
+        }
+
+    async def _search_mental_models_parallel(
+        self,
+        query: str,
+        banks: list["BankInfo"],
+        max_results_per_bank: int,
+        _request_context: "RequestContext",
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Search mental models in parallel across banks."""
+        from hindsight_api.engine.retain import embedding_utils
+
+        # Generate embedding for the query
+        try:
+            embeddings = await embedding_utils.generate_embeddings_batch(
+                self._engine.embeddings,
+                [query],
+            )
+            query_embedding = embeddings[0]
+        except Exception as e:
+            logger.error(f"Failed to generate embedding for mental model search: {e}")
+            return {}
+
+        async def search_single_bank(bank: "BankInfo") -> tuple[str, list[dict[str, Any]]]:
+            """Search mental models in a single bank."""
+            try:
+                pool = await self._engine._get_pool()
+                async with pool.acquire() as conn:
+                    from hindsight_api.engine.reflect.tools import tool_search_mental_models
+
+                    result = await tool_search_mental_models(
+                        conn,
+                        bank.bank_id,
+                        query,
+                        query_embedding,
+                        max_results=max_results_per_bank,
+                    )
+
+                    return (bank.bank_id, result.get("mental_models", []))
+            except Exception as e:
+                logger.error(f"Mental model search failed for bank {bank.bank_id}: {e}")
+                return (bank.bank_id, [])
+
+        # Execute all searches in parallel
+        tasks = [search_single_bank(bank) for bank in banks]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Process results
+        mental_model_results = {}
+        for i, result in enumerate(results):
+            bank_id = banks[i].bank_id
+            if isinstance(result, Exception):
+                logger.error(f"Mental model search task failed for bank {bank_id}: {result}")
+                mental_model_results[bank_id] = []
+            elif isinstance(result, tuple):
+                bank_id_result, models = result
+                mental_model_results[bank_id_result] = models
+            else:
+                logger.warning(f"Unexpected result type for bank {bank_id}: {type(result)}")
+                mental_model_results[bank_id] = []
+
+        return mental_model_results
+
+    def _get_llm_provider(self) -> "LLMProvider | None":
+        """Get the LLM provider from the engine."""
+        return getattr(self._engine, "_reflect_llm_config", None)
+
+    def _get_cross_bank_system_prompt(self, reconciled_disposition: ReconciledDisposition) -> str:
+        """Build system prompt with disposition traits for cross-bank synthesis."""
+        skepticism = reconciled_disposition.skepticism
+        literalism = reconciled_disposition.literalism
+        empathy = reconciled_disposition.empathy
+
+        # Build disposition-aware guidance
+        guidance_parts = []
+
+        # Skepticism guidance (1-5 scale)
+        if skepticism >= 4:
+            guidance_parts.append(
+                "Be critical and skeptical. Question assumptions, look for contradictions, "
+                "and explicitly note when evidence is weak or conflicting."
+            )
+        elif skepticism >= 3:
+            guidance_parts.append(
+                "Maintain healthy skepticism. Verify claims against available evidence "
+                "and note any uncertainties."
+            )
+        else:
+            guidance_parts.append(
+                "Be accepting and open. Present information positively and focus on "
+                "constructive synthesis rather than criticism."
+            )
+
+        # Literalism guidance (1-5 scale)
+        if literalism >= 4:
+            guidance_parts.append(
+                "Be literal and precise. Quote facts directly, avoid metaphors or figurative "
+                "language, and stick to what is explicitly stated."
+            )
+        elif literalism >= 3:
+            guidance_parts.append(
+                "Balance precision with clarity. Present facts accurately while making "
+                "reasonable interpretations."
+            )
+        else:
+            guidance_parts.append(
+                "Be interpretive and contextual. Draw connections and inferences, "
+                "and explain the broader meaning behind the facts."
+            )
+
+        # Empathy guidance (1-5 scale)
+        if empathy >= 4:
+            guidance_parts.append(
+                "Be empathetic and understanding. Consider emotional contexts, "
+                "acknowledge feelings, and present information with warmth."
+            )
+        elif empathy >= 3:
+            guidance_parts.append(
+                "Balance objectivity with understanding. Acknowledge different "
+                "perspectives while presenting factual information."
+            )
+        else:
+            guidance_parts.append(
+                "Be objective and factual. Focus on the facts without emotional "
+                "framing, presenting information in a straightforward manner."
+            )
+
+        guidance = "\n\n".join(guidance_parts)
+
+        return f"""CRITICAL: You MUST ONLY use information from the provided memories and mental models. NEVER make up names, people, events, or entities.
+
+You are a thoughtful assistant synthesizing answers from memories retrieved across multiple memory banks.
+
+Your approach:
+- Reason over the retrieved memories to answer the question
+- Make reasonable inferences when the exact answer isn't explicitly stated
+- Connect related memories to form a complete picture
+- Be helpful - if you have related information, use it to give the best possible answer
+- ONLY use information from the provided context - no external knowledge or guessing
+- Attribute information to the appropriate source bank when relevant
+
+DISPOSITION GUIDANCE (reconciled across banks):
+{guidance}
+
+Only say "I don't have information" if the retrieved data is truly unrelated to the question.
+
+FORMATTING: Use proper markdown formatting in your answer:
+- Headers (##, ###) for sections
+- Lists (bullet or numbered) for enumerations
+- Bold/italic for emphasis
+- Tables with proper syntax (ensure blank line before and after)
+- Code blocks where appropriate
+- CRITICAL: Always add blank lines before and after block elements (tables, code blocks, lists)
+- Proper spacing between sections
+
+CRITICAL: Output ONLY the final synthesized answer. Do NOT include:
+- Meta-commentary about what you're doing ("I'll search...", "Let me analyze...")
+- Explanations of your reasoning process
+- Descriptions of your approach
+Just provide the direct answer with proper markdown formatting.
+
+CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, offer to search again, suggest alternatives, or end with anything like "Would you like me to..." or "Let me know if...". The user cannot reply. Your answer must be complete and self-contained."""
+
+    def _build_synthesis_prompt(
+        self,
+        query: str,
+        fused_facts: list["CrossBankFact"],
+        mental_models: list[dict[str, Any]],
+        reconciled_disposition: ReconciledDisposition,
+        context: str | None,
+    ) -> str:
+        """Build the synthesis prompt with facts and mental models."""
+        sections = []
+
+        # Add context if provided
+        if context:
+            sections.append(f"## Context\n{context}")
+
+        # Add mental models if available
+        if mental_models:
+            sections.append("## Mental Models")
+            for model in mental_models[:5]:  # Limit to top 5
+                sections.append(f"### {model['name']} (from {model.get('bank_id', 'unknown')})")
+                sections.append(model["content"])
+            sections.append("")
+
+        # Add fused facts
+        if fused_facts:
+            sections.append("## Retrieved Memories")
+            for i, fact in enumerate(fused_facts[:30], 1):  # Limit to 30 facts
+                bank_info = f" (from {fact.bank_name or fact.bank_id})" if fact.bank_name or fact.bank_id else ""
+                sections.append(f"{i}. {fact.text}{bank_info}")
+            sections.append("")
+
+        # Add the query
+        sections.append("## Question")
+        sections.append(query)
+
+        # Add disposition note
+        sections.append("")
+        sections.append(
+            f"Note: Synthesize this response with the following disposition traits: "
+            f"Skepticism={reconciled_disposition.skepticism}/5, "
+            f"Literalism={reconciled_disposition.literalism}/5, "
+            f"Empathy={reconciled_disposition.empathy}/5"
+        )
+
+        return "\n".join(sections)
+
+    async def _generate_structured_output(
+        self,
+        answer: str,
+        response_schema: dict,
+        llm_provider: "LLMProvider",
+    ) -> dict[str, Any] | None:
+        """Generate structured output from an answer using the provided JSON schema."""
+        import json
+
+        try:
+            # Create prompt for structured extraction
+            schema_str = json.dumps(response_schema, indent=2)
+            extraction_prompt = f"""Given the following answer, extract structured data according to the JSON schema provided.
+
+ANSWER:
+{answer}
+
+JSON SCHEMA:
+{schema_str}
+
+Output ONLY valid JSON matching the schema. No markdown, no explanation, just the JSON object."""
+
+            response = await llm_provider.call(
+                messages=[
+                    {"role": "system", "content": "You extract structured data from text. Output only valid JSON."},
+                    {"role": "user", "content": extraction_prompt},
+                ],
+                scope="cross_bank_structured_output",
+                skip_validation=True,
+            )
+
+            # Parse the JSON response
+            result = json.loads(response.strip())
+            return result
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse structured output JSON: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to generate structured output: {e}")
+            return None

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -480,6 +480,9 @@ class MemoryEngine(MemoryEngineInterface):
         # Store operation validator extension (optional)
         self._operation_validator = operation_validator
 
+        # Cross-bank orchestrator (initialized in initialize())
+        self._cross_bank_orchestrator = None
+
         # Store tenant extension (always set, use default if none provided)
         if tenant_extension is None:
             from ..extensions.builtin.tenant import DefaultTenantExtension
@@ -491,6 +494,11 @@ class MemoryEngine(MemoryEngineInterface):
     def tenant_extension(self) -> "TenantExtension | None":
         """The configured tenant extension, if any."""
         return self._tenant_extension
+
+    @property
+    def cross_bank_orchestrator(self) -> "CrossBankOrchestrator | None":
+        """The cross-bank orchestrator for multi-bank operations."""
+        return self._cross_bank_orchestrator
 
     async def _validate_operation(self, validation_coro) -> None:
         """
@@ -1693,6 +1701,15 @@ class MemoryEngine(MemoryEngineInterface):
 
         self._config_resolver = ConfigResolver(pool=self._pool, tenant_extension=self._tenant_extension)
         logger.debug("Config resolver initialized for hierarchical configuration")
+
+        # Initialize cross-bank orchestrator for multi-bank operations
+        from .cross_bank import CrossBankOrchestrator
+
+        self._cross_bank_orchestrator = CrossBankOrchestrator(
+            engine=self,
+            config_resolver=self._config_resolver,
+        )
+        logger.debug("Cross-bank orchestrator initialized")
 
         # Initialize file storage
         from .storage import create_file_storage

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -170,6 +170,9 @@ def register_mcp_tools(
         "update_bank",
         "delete_bank",
         "clear_memories",
+        "cross_bank_recall",
+        "cross_bank_reflect",
+        "create_documents",
     }
 
     if "retain" in tools_to_register:
@@ -264,6 +267,16 @@ def register_mcp_tools(
 
     if "clear_memories" in tools_to_register:
         _register_clear_memories(mcp, memory, config)
+
+    # Cross-bank tools (multi-bank only)
+    if "cross_bank_recall" in tools_to_register:
+        _register_cross_bank_recall(mcp, memory, config)
+
+    if "cross_bank_reflect" in tools_to_register:
+        _register_cross_bank_reflect(mcp, memory, config)
+
+    if "create_documents" in tools_to_register:
+        _register_create_documents(mcp, memory, config)
 
     _apply_bank_tool_filtering(mcp, memory, config)
 
@@ -2725,3 +2738,254 @@ def _register_clear_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
             except Exception as e:
                 logger.error(f"Error clearing memories: {e}", exc_info=True)
                 return {"error": str(e)}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Cross-Bank Tools (multi-bank only)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _register_cross_bank_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
+    """Register the cross_bank_recall tool (multi-bank only)."""
+
+    # Cross-bank tools only make sense in multi-bank mode
+    @mcp.tool()
+    async def cross_bank_recall(
+        query: str,
+        bank_ids: list[str] | None = None,
+        bank_tags: list[str] | None = None,
+        max_results: int = 20,
+        budget: str = "mid",
+        tags: list[str] | None = None,
+        tags_match: str = "any",
+    ) -> str:
+        """
+        Recall memories from multiple banks simultaneously with fused ranking.
+
+        Use this tool when you need to search across multiple memory banks at once.
+        Results are merged using Reciprocal Rank Fusion and deduplicated.
+
+        WHEN TO USE:
+        - Searching across work and personal notes together
+        - Finding connections between different knowledge domains
+        - Getting a comprehensive view from all banks
+
+        Args:
+            query: The search query to execute across banks
+            bank_ids: Optional list of specific bank IDs to query. If None, queries all accessible banks.
+            bank_tags: Optional tags to filter which banks to query (e.g., ['work', 'project'])
+            max_results: Maximum total results to return (default: 20)
+            budget: Search budget - 'low' (100), 'mid' (300), or 'high' (1000). Default: 'mid'
+            tags: Optional tags to filter memories within each bank
+            tags_match: How to match tags - 'any' (OR) or 'all' (AND). Default: 'any'
+        """
+        try:
+            budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
+            budget_enum = budget_map.get(budget.lower(), Budget.MID)
+
+            result = await memory._cross_bank_orchestrator.cross_bank_recall(
+                query=query,
+                bank_ids=bank_ids,
+                bank_tags=bank_tags,
+                max_results=max_results,
+                budget=budget_enum,
+                request_context=_get_request_context(config),
+            )
+
+            # Return as JSON string for MCP
+            return result.model_dump_json()
+
+        except OperationValidationError as e:
+            logger.warning(f"Cross-bank recall rejected: {e}")
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            logger.error(f"Error in cross-bank recall: {e}", exc_info=True)
+            return json.dumps({"error": str(e)})
+
+
+def _register_cross_bank_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
+    """Register the cross_bank_reflect tool (multi-bank only)."""
+
+    @mcp.tool()
+    async def cross_bank_reflect(
+        query: str,
+        bank_ids: list[str] | None = None,
+        bank_tags: list[str] | None = None,
+        budget: str = "low",
+        context: str | None = None,
+        include_mental_models: bool = True,
+        response_schema: dict | None = None,
+        tags: list[str] | None = None,
+        tags_match: str = "any",
+    ) -> str:
+        """
+        Reflect across multiple banks with disposition-aware synthesis.
+
+        This tool gathers evidence from multiple memory banks, fuses findings,
+        and synthesizes a response that considers each bank's personality traits.
+
+        WHEN TO USE:
+        - Getting perspectives from different knowledge domains
+        - Synthesizing insights across work and personal contexts
+        - Comprehensive analysis using all available knowledge
+
+        Args:
+            query: The question to reflect on across banks
+            bank_ids: Optional list of specific bank IDs to query. If None, queries all accessible banks.
+            bank_tags: Optional tags to filter which banks to query
+            budget: Search budget - 'low' (100), 'mid' (300), or 'high' (1000). Default: 'low'
+            context: Optional additional context for the reflection
+            include_mental_models: Whether to consult mental models (default: True)
+            response_schema: Optional JSON schema for structured output
+            tags: Optional tags to filter memories within each bank
+            tags_match: How to match tags - 'any' (OR) or 'all' (AND). Default: 'any'
+        """
+        try:
+            budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
+            budget_enum = budget_map.get(budget.lower(), Budget.LOW)
+
+            # Handle context similar to regular reflect
+            full_query = query
+            if context:
+                full_query = f"{query}\n\nAdditional context: {context}"
+
+            result = await memory._cross_bank_orchestrator.cross_bank_reflect(
+                query=full_query,
+                bank_ids=bank_ids,
+                bank_tags=bank_tags,
+                budget=budget_enum,
+                context=None,  # Already merged into query
+                include_mental_models=include_mental_models,
+                response_schema=response_schema,
+                request_context=_get_request_context(config),
+            )
+
+            # Return as JSON string for MCP
+            return result.model_dump_json()
+
+        except OperationValidationError as e:
+            logger.warning(f"Cross-bank reflect rejected: {e}")
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            logger.error(f"Error in cross-bank reflect: {e}", exc_info=True)
+            return json.dumps({"error": str(e)})
+
+
+def _register_create_documents(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
+    """Register the create_documents tool."""
+
+    if config.include_bank_id_param:
+
+        @mcp.tool()
+        async def create_documents(
+            contents: list[dict],
+            document_name: str | None = None,
+            tags: list[str] | None = None,
+            bank_id: str | None = None,
+        ) -> dict:
+            """
+            Retain one or multiple text documents as a named document group.
+
+            Use this tool when you have text content (not files) that you want to store
+            as memories. Each content item gets fact extraction and knowledge graph building.
+
+            WHEN TO USE:
+            - Storing meeting notes, research notes, or journal entries
+            - Creating multiple related documents at once
+            - Batch retaining text content with automatic document grouping
+
+            Args:
+                contents: List of content items, each with:
+                    - content (str): The document text
+                    - context (str): Category (e.g., 'meeting-notes', 'research', 'journal')
+                    - tags (list, optional): Tags for this content item
+                    - metadata (dict, optional): Key-value metadata
+                    - document_id (str, optional): Custom document ID
+                document_name: Human-readable name for the document group (optional)
+                tags: Tags applied to all documents in this batch
+                bank_id: Target bank (defaults to session bank)
+            """
+            try:
+                target_bank = bank_id or config.bank_id_resolver()
+                if target_bank is None:
+                    return {"status": "error", "message": "No bank_id configured"}
+
+                request_context = _get_request_context(config)
+
+                result = await memory.submit_async_retain(
+                    bank_id=target_bank,
+                    contents=contents,
+                    document_tags=tags,
+                    request_context=request_context,
+                )
+
+                return {
+                    "status": "accepted",
+                    "message": "Document batch submitted for processing",
+                    "operation_id": result.get("operation_id"),
+                    "documents_submitted": len(contents),
+                }
+
+            except OperationValidationError as e:
+                logger.warning(f"Create documents rejected: {e}")
+                return {"status": "error", "message": str(e)}
+            except Exception as e:
+                logger.error(f"Error creating documents: {e}", exc_info=True)
+                return {"status": "error", "message": str(e)}
+
+    else:
+
+        @mcp.tool()
+        async def create_documents(
+            contents: list[dict],
+            document_name: str | None = None,
+            tags: list[str] | None = None,
+        ) -> dict:
+            """
+            Retain one or multiple text documents as a named document group.
+
+            Use this tool when you have text content (not files) that you want to store
+            as memories. Each content item gets fact extraction and knowledge graph building.
+
+            WHEN TO USE:
+            - Storing meeting notes, research notes, or journal entries
+            - Creating multiple related documents at once
+            - Batch retaining text content with automatic document grouping
+
+            Args:
+                contents: List of content items, each with:
+                    - content (str): The document text
+                    - context (str): Category (e.g., 'meeting-notes', 'research', 'journal')
+                    - tags (list, optional): Tags for this content item
+                    - metadata (dict, optional): Key-value metadata
+                    - document_id (str, optional): Custom document ID
+                document_name: Human-readable name for the document group (optional)
+                tags: Tags applied to all documents in this batch
+            """
+            try:
+                target_bank = config.bank_id_resolver()
+                if target_bank is None:
+                    return {"status": "error", "message": "No bank_id configured"}
+
+                request_context = _get_request_context(config)
+
+                result = await memory.submit_async_retain(
+                    bank_id=target_bank,
+                    contents=contents,
+                    document_tags=tags,
+                    request_context=request_context,
+                )
+
+                return {
+                    "status": "accepted",
+                    "message": "Document batch submitted for processing",
+                    "operation_id": result.get("operation_id"),
+                    "documents_submitted": len(contents),
+                }
+
+            except OperationValidationError as e:
+                logger.warning(f"Create documents rejected: {e}")
+                return {"status": "error", "message": str(e)}
+            except Exception as e:
+                logger.error(f"Error creating documents: {e}", exc_info=True)
+                return {"status": "error", "message": str(e)}

--- a/hindsight-api-slim/tests/test_cross_bank.py
+++ b/hindsight-api-slim/tests/test_cross_bank.py
@@ -1,0 +1,1093 @@
+"""
+Tests for cross-bank orchestration functionality.
+
+Tests the core components: BudgetAllocator, BankSelector, RRF fusion,
+and CrossBankOrchestrator.cross_bank_recall().
+"""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
+
+from hindsight_api.engine.cross_bank import (
+    BudgetAllocator,
+    BudgetAllocation,
+    BudgetStrategy,
+    BankSelector,
+    CrossBankOrchestrator,
+    reconcile_dispositions,
+    ReconciledDisposition,
+)
+from hindsight_api.api.cross_bank_models import (
+    BankInfo,
+    CrossBankFact,
+    CrossBankRecallResult,
+)
+from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.models import RequestContext
+
+
+# =============================================================================
+# BudgetAllocator Tests
+# =============================================================================
+
+
+class TestBudgetAllocator:
+    """Tests for BudgetAllocator static methods."""
+
+    def test_equal_split_basic(self):
+        """Test basic equal split across banks."""
+        allocation = BudgetAllocator.equal_split(
+            budget_value=300,
+            bank_ids=["bank-a", "bank-b", "bank-c"],
+        )
+
+        assert allocation.strategy == BudgetStrategy.EQUAL
+        assert allocation.per_bank == {"bank-a": 100, "bank-b": 100, "bank-c": 100}
+        assert allocation.total_used == 300
+
+    def test_equal_split_with_minimum(self):
+        """Test equal split respects minimum per bank."""
+        # Should fail: 150 budget for 2 banks = 75 each, below minimum 100
+        with pytest.raises(ValueError) as exc_info:
+            BudgetAllocator.equal_split(
+                budget_value=150,
+                bank_ids=["bank-a", "bank-b"],
+                ensure_minimum=True,
+            )
+
+        assert "too low" in str(exc_info.value)
+
+    def test_equal_split_no_banks(self):
+        """Test equal split with empty bank list."""
+        allocation = BudgetAllocator.equal_split(
+            budget_value=300,
+            bank_ids=[],
+        )
+
+        assert allocation.per_bank == {}
+        assert allocation.total_used == 0
+
+    def test_equal_split_without_minimum_check(self):
+        """Test equal split can bypass minimum check."""
+        allocation = BudgetAllocator.equal_split(
+            budget_value=150,
+            bank_ids=["bank-a", "bank-b"],
+            ensure_minimum=False,
+        )
+
+        assert allocation.per_bank == {"bank-a": 75, "bank-b": 75}
+
+    def test_proportional_allocation(self):
+        """Test proportional allocation based on bank sizes."""
+        allocation = BudgetAllocator.proportional(
+            budget_value=300,
+            bank_sizes={"bank-a": 100, "bank-b": 200},
+        )
+
+        assert allocation.strategy == BudgetStrategy.PROPORTIONAL
+        # bank-a has 1/3 of memories, bank-b has 2/3
+        assert allocation.per_bank["bank-a"] == 100
+        assert allocation.per_bank["bank-b"] == 200
+
+    def test_proportional_empty(self):
+        """Test proportional allocation with empty sizes."""
+        allocation = BudgetAllocator.proportional(
+            budget_value=300,
+            bank_sizes={},
+        )
+
+        assert allocation.per_bank == {}
+
+    def test_query_relevant_allocation(self):
+        """Test allocation based on query relevance scores."""
+        allocation = BudgetAllocator.query_relevant(
+            budget_value=300,
+            bank_relevance={"bank-a": 0.3, "bank-b": 0.7},
+        )
+
+        assert allocation.strategy == BudgetStrategy.QUERY_RELEVANT
+        # bank-a has 30% relevance, bank-b has 70%
+        assert allocation.per_bank["bank-a"] == 90
+        assert allocation.per_bank["bank-b"] == 210
+
+    def test_allocate_for_multistep(self):
+        """Test multi-step budget allocation with synthesis reserve."""
+        allocation, synthesis = BudgetAllocator.allocate_for_multistep(
+            total_budget=1000,
+            bank_ids=["bank-a", "bank-b"],
+            n_steps=2,
+        )
+
+        # 30% reserved for synthesis = 300
+        assert synthesis == 300
+        # Remaining 700 split across 2 steps x 2 banks = 175 per bank per step
+        assert allocation.synthesis_reserve == 300
+
+
+# =============================================================================
+# BankSelector Tests
+# =============================================================================
+
+
+class TestBankSelector:
+    """Tests for BankSelector.resolve() method."""
+
+    @pytest.fixture
+    def mock_engine(self):
+        """Create a mock engine for testing."""
+        engine = MagicMock()
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+                "tags": ["personal", "journal"],
+            },
+            {
+                "bank_id": "bank-b",
+                "name": "Bank B",
+                "disposition": {"skepticism": 5, "literalism": 2, "empathy": 4},
+                "mission": "Test bank B",
+                "tags": ["work"],
+            },
+        ])
+        engine.get_bank_profile = AsyncMock(side_effect=lambda bank_id, **kwargs: {
+            "bank_id": bank_id,
+            "name": f"Bank {bank_id[-1].upper()}",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": f"Test bank {bank_id}",
+        })
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_explicit_ids(self, mock_engine):
+        """Test resolving banks with explicit IDs."""
+        selector = BankSelector(mock_engine)
+
+        banks = await selector.resolve(bank_ids=["bank-a"])
+
+        assert len(banks) == 1
+        assert banks[0].bank_id == "bank-a"
+        mock_engine.get_bank_profile.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_tags(self, mock_engine):
+        """Test resolving banks filtered by tags."""
+        selector = BankSelector(mock_engine)
+
+        banks = await selector.resolve(bank_tags=["personal"])
+
+        assert len(banks) == 1
+        assert banks[0].bank_id == "bank-a"
+        assert "personal" in banks[0].tags
+
+    @pytest.mark.asyncio
+    async def test_resolve_all_accessible(self, mock_engine):
+        """Test resolving all accessible banks."""
+        selector = BankSelector(mock_engine)
+
+        banks = await selector.resolve()
+
+        assert len(banks) == 2
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_restricted_context(self, mock_engine):
+        """Test resolving banks with access restrictions."""
+        selector = BankSelector(mock_engine)
+
+        # Create context with restricted bank access
+        ctx = RequestContext(allowed_bank_ids=["bank-a"])
+
+        banks = await selector.resolve(bank_ids=["bank-a", "bank-b"], request_context=ctx)
+
+        # Should only return bank-a since bank-b is not in allowed list
+        assert len(banks) == 1
+        assert banks[0].bank_id == "bank-a"
+
+
+# =============================================================================
+# RRF Fusion Tests
+# =============================================================================
+
+
+class TestRRFFusion:
+    """Tests for Reciprocal Rank Fusion in _fuse_results."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        """Create an orchestrator with a mock engine."""
+        engine = MagicMock()
+        return CrossBankOrchestrator(engine)
+
+    @pytest.mark.asyncio
+    async def test_fuse_results_basic(self, orchestrator):
+        """Test basic RRF fusion of results from two banks."""
+        bank_results = {
+            "bank-a": [
+                CrossBankFact(id="fact-1", text="Fact 1", fact_type="world", bank_id="bank-a"),
+                CrossBankFact(id="fact-2", text="Fact 2", fact_type="world", bank_id="bank-a"),
+            ],
+            "bank-b": [
+                CrossBankFact(id="fact-2", text="Fact 2", fact_type="world", bank_id="bank-b"),  # Duplicate
+                CrossBankFact(id="fact-3", text="Fact 3", fact_type="world", bank_id="bank-b"),
+            ],
+        }
+
+        fused = await orchestrator._fuse_results(bank_results, max_results=10)
+
+        # Should deduplicate fact-2
+        assert len(fused) == 3
+
+        # fact-2 should rank highest because it appears in both banks
+        fact_ids = [f.id for f in fused]
+        assert fact_ids[0] == "fact-2"  # Highest RRF score
+
+    @pytest.mark.asyncio
+    async def test_fuse_results_respects_max_results(self, orchestrator):
+        """Test that fusion respects max_results limit."""
+        bank_results = {
+            "bank-a": [
+                CrossBankFact(id=f"fact-{i}", text=f"Fact {i}", fact_type="world", bank_id="bank-a")
+                for i in range(10)
+            ],
+        }
+
+        fused = await orchestrator._fuse_results(bank_results, max_results=5)
+
+        assert len(fused) == 5
+
+    @pytest.mark.asyncio
+    async def test_fuse_results_empty_input(self, orchestrator):
+        """Test fusion with empty input."""
+        fused = await orchestrator._fuse_results({}, max_results=10)
+
+        assert fused == []
+
+
+# =============================================================================
+# Disposition Reconciliation Tests
+# =============================================================================
+
+
+class TestDispositionReconciliation:
+    """Tests for disposition reconciliation across banks."""
+
+    def test_reconcile_basic(self):
+        """Test basic disposition reconciliation."""
+        bank_results = {
+            "bank-a": [
+                CrossBankFact(id="f1", text="Fact 1", fact_type="world", bank_id="bank-a"),
+                CrossBankFact(id="f2", text="Fact 2", fact_type="world", bank_id="bank-a"),
+            ],
+            "bank-b": [
+                CrossBankFact(id="f3", text="Fact 3", fact_type="world", bank_id="bank-b"),
+            ],
+        }
+        bank_dispositions = {
+            "bank-a": {"skepticism": 5, "literalism": 2, "empathy": 3},
+            "bank-b": {"skepticism": 1, "literalism": 4, "empathy": 5},
+        }
+
+        result = reconcile_dispositions(bank_results, bank_dispositions)
+
+        assert result.reconciliation_method == "relevance_weighted"
+        # bank-a contributed 2/3 of facts, bank-b contributed 1/3
+        # skepticism = 5 * 2/3 + 1 * 1/3 = 3.67 ≈ 4
+        assert result.skepticism == 4
+        assert result.bank_weights["bank-a"] == 2/3
+        assert result.bank_weights["bank-b"] == 1/3
+
+    def test_reconcile_empty_results(self):
+        """Test reconciliation with empty results."""
+        result = reconcile_dispositions({}, {})
+
+        assert result.reconciliation_method == "default"
+        assert result.skepticism == 3
+        assert result.literalism == 3
+        assert result.empathy == 3
+
+
+# =============================================================================
+# Cross-Bank Recall Integration Tests
+# =============================================================================
+
+
+class TestCrossBankRecall:
+    """Integration tests for CrossBankOrchestrator.cross_bank_recall()."""
+
+    @pytest.fixture
+    def mock_engine(self):
+        """Create a mock engine with recall capability."""
+        engine = MagicMock()
+
+        # Mock list_banks
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+                "tags": ["personal"],
+            },
+            {
+                "bank_id": "bank-b",
+                "name": "Bank B",
+                "disposition": {"skepticism": 4, "literalism": 2, "empathy": 5},
+                "mission": "Test bank B",
+                "tags": ["work"],
+            },
+        ])
+
+        # Mock get_bank_profile
+        engine.get_bank_profile = AsyncMock(side_effect=lambda bank_id, **kwargs: {
+            "bank_id": bank_id,
+            "name": f"Bank {bank_id[-1].upper()}",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": f"Test bank {bank_id}",
+        })
+
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_recall_basic(self, mock_engine):
+        """Test basic cross-bank recall flow."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        # Mock recall_async to return some facts
+        mock_engine.recall_async = AsyncMock(side_effect=lambda bank_id, query, **kwargs: RecallResult(
+            results=[
+                MemoryFact(
+                    id=f"{bank_id}-fact-1",
+                    text=f"Fact from {bank_id}",
+                    fact_type="world",
+                    entities=["Alice"],
+                ),
+            ]
+        ))
+
+        orchestrator = CrossBankOrchestrator(mock_engine)
+
+        result = await orchestrator.cross_bank_recall(
+            query="What does Alice do?",
+            bank_ids=["bank-a", "bank-b"],
+            budget=Budget.MID,
+        )
+
+        assert isinstance(result, CrossBankRecallResult)
+        assert len(result.results) == 2
+        assert result.total_results == 2
+        assert "bank-a" in result.bank_stats
+        assert "bank-b" in result.bank_stats
+        assert result.fusion_metadata["strategy"] == "reciprocal_rank_fusion"
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_recall_with_failures(self, mock_engine):
+        """Test cross-bank recall handles bank failures gracefully."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        call_count = 0
+
+        async def mock_recall(bank_id, query, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if bank_id == "bank-b":
+                raise Exception("Simulated failure for bank-b")
+            return RecallResult(
+                results=[
+                    MemoryFact(
+                        id="fact-1",
+                        text="Fact from bank-a",
+                        fact_type="world",
+                    ),
+                ]
+            )
+
+        mock_engine.recall_async = AsyncMock(side_effect=mock_recall)
+
+        orchestrator = CrossBankOrchestrator(mock_engine)
+
+        result = await orchestrator.cross_bank_recall(
+            query="Test query",
+            bank_ids=["bank-a", "bank-b"],
+            budget=Budget.LOW,
+        )
+
+        # Should still return results from successful bank
+        assert len(result.results) == 1
+        assert result.results[0].bank_id == "bank-a"
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_recall_no_banks(self, mock_engine):
+        """Test cross-bank recall with no accessible banks."""
+        mock_engine.list_banks = AsyncMock(return_value=[])
+
+        orchestrator = CrossBankOrchestrator(mock_engine)
+
+        result = await orchestrator.cross_bank_recall(
+            query="Test query",
+        )
+
+        assert result.results == []
+        assert result.total_results == 0
+        assert result.fusion_metadata["reason"] == "no_banks"
+
+
+# =============================================================================
+# Budget Conversion Tests
+# =============================================================================
+
+
+class TestBudgetConversion:
+    """Tests for budget conversion utilities."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        """Create an orchestrator with a mock engine."""
+        engine = MagicMock()
+        return CrossBankOrchestrator(engine)
+
+    def test_tokens_to_budget(self, orchestrator):
+        """Test token count to Budget enum conversion."""
+        assert orchestrator._tokens_to_budget(50) == Budget.LOW
+        assert orchestrator._tokens_to_budget(100) == Budget.LOW
+        assert orchestrator._tokens_to_budget(150) == Budget.MID
+        assert orchestrator._tokens_to_budget(300) == Budget.MID
+        assert orchestrator._tokens_to_budget(500) == Budget.HIGH
+        assert orchestrator._tokens_to_budget(1000) == Budget.HIGH
+
+    def test_get_budget_value(self, orchestrator):
+        """Test Budget enum to token value conversion."""
+        assert orchestrator._get_budget_value(None) == 300  # Default to MID
+        assert orchestrator._get_budget_value(Budget.LOW) == 100
+        assert orchestrator._get_budget_value(Budget.MID) == 300
+        assert orchestrator._get_budget_value(Budget.HIGH) == 1000
+        assert orchestrator._get_budget_value("low") == 100
+        assert orchestrator._get_budget_value("HIGH") == 1000  # Case insensitive
+
+
+# =============================================================================
+# Cross-Bank Reflect Integration Tests
+# =============================================================================
+
+
+class TestCrossBankReflect:
+    """Integration tests for CrossBankOrchestrator.cross_bank_reflect()."""
+
+    @pytest.fixture
+    def mock_engine_for_reflect(self):
+        """Create a mock engine with reflect capability."""
+        engine = MagicMock()
+
+        # Mock list_banks
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+                "tags": ["personal"],
+            },
+            {
+                "bank_id": "bank-b",
+                "name": "Bank B",
+                "disposition": {"skepticism": 5, "literalism": 2, "empathy": 4},
+                "mission": "Test bank B",
+                "tags": ["work"],
+            },
+        ])
+
+        # Mock get_bank_profile
+        engine.get_bank_profile = AsyncMock(side_effect=lambda bank_id, **kwargs: {
+            "bank_id": bank_id,
+            "name": f"Bank {bank_id[-1].upper()}",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3} if bank_id == "bank-a" else {"skepticism": 5, "literalism": 2, "empathy": 4},
+            "mission": f"Test bank {bank_id}",
+        })
+
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_reflect_basic(self, mock_engine_for_reflect):
+        """Test basic cross-bank reflect flow."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+        from hindsight_api.api.cross_bank_models import CrossBankReflectResult
+
+        # Mock recall_async for evidence gathering
+        mock_engine_for_reflect.recall_async = AsyncMock(side_effect=lambda bank_id, query, **kwargs: RecallResult(
+            results=[
+                MemoryFact(
+                    id=f"{bank_id}-fact-1",
+                    text=f"Fact from {bank_id}",
+                    fact_type="world",
+                    entities=["Alice"],
+                ),
+            ]
+        ))
+
+        # Mock LLM provider
+        mock_llm = MagicMock()
+        mock_llm.generate = AsyncMock(return_value="Synthesized reflection response")
+        mock_engine_for_reflect._llm_provider = mock_llm
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="What does Alice do?",
+            bank_ids=["bank-a", "bank-b"],
+            budget=Budget.MID,
+        )
+
+        assert isinstance(result, CrossBankReflectResult)
+        assert "Synthesized reflection response" in result.text or len(result.based_on) >= 0
+        assert "bank-a" in result.bank_dispositions
+        assert "bank-b" in result.bank_dispositions
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_reflect_with_mental_models(self, mock_engine_for_reflect):
+        """Test cross-bank reflect includes mental models."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+        from hindsight_api.api.cross_bank_models import CrossBankReflectResult
+
+        # Mock recall_async
+        mock_engine_for_reflect.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        # Mock get_mental_models
+        mock_engine_for_reflect.get_mental_models = AsyncMock(return_value=[
+            {"id": "mm-1", "name": "User Prefs", "content": "Prefers Python"}
+        ])
+
+        # Mock LLM provider
+        mock_llm = MagicMock()
+        mock_llm.generate = AsyncMock(return_value="Reflection with mental models")
+        mock_engine_for_reflect._llm_provider = mock_llm
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="What are user preferences?",
+            bank_ids=["bank-a"],
+            include_mental_models=True,
+            budget=Budget.LOW,
+        )
+
+        assert isinstance(result, CrossBankReflectResult)
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_reflect_no_banks(self, mock_engine_for_reflect):
+        """Test cross-bank reflect with no accessible banks."""
+        mock_engine_for_reflect.list_banks = AsyncMock(return_value=[])
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test query",
+        )
+
+        assert "No accessible banks" in result.text
+        assert result.based_on == []
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_reflect_llm_failure(self, mock_engine_for_reflect):
+        """Test cross-bank reflect handles LLM failures gracefully."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        # Mock recall_async
+        mock_engine_for_reflect.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        # Mock LLM provider that fails
+        mock_llm = MagicMock()
+        mock_llm.generate = AsyncMock(side_effect=Exception("LLM API error"))
+        mock_engine_for_reflect._llm_provider = mock_llm
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test query",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Should return an error message in the text
+        assert "LLM" in result.text or "error" in result.text.lower() or len(result.text) > 0
+
+    @pytest.mark.asyncio
+    async def test_cross_bank_reflect_disposition_reconciliation(self, mock_engine_for_reflect):
+        """Test that dispositions are reconciled correctly."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        # Mock recall_async - bank-a returns 2 facts, bank-b returns 1 fact
+        async def mock_recall(bank_id, query, **kwargs):
+            if bank_id == "bank-a":
+                return RecallResult(results=[
+                    MemoryFact(id="f1", text="Fact 1", fact_type="world"),
+                    MemoryFact(id="f2", text="Fact 2", fact_type="world"),
+                ])
+            else:
+                return RecallResult(results=[
+                    MemoryFact(id="f3", text="Fact 3", fact_type="world"),
+                ])
+
+        mock_engine_for_reflect.recall_async = AsyncMock(side_effect=mock_recall)
+
+        # Mock LLM provider
+        mock_llm = MagicMock()
+        mock_llm.generate = AsyncMock(return_value="Synthesized")
+        mock_engine_for_reflect._llm_provider = mock_llm
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test query",
+            bank_ids=["bank-a", "bank-b"],
+            budget=Budget.MID,
+        )
+
+        # Verify dispositions are present
+        assert "bank-a" in result.bank_dispositions
+        assert "bank-b" in result.bank_dispositions
+        # bank-a disposition should have skepticism=3, bank-b should have skepticism=5
+        assert result.bank_dispositions["bank-a"]["skepticism"] == 3
+        assert result.bank_dispositions["bank-b"]["skepticism"] == 5
+
+
+# =============================================================================
+# Evidence Gathering Tests
+# =============================================================================
+
+
+class TestEvidenceGathering:
+    """Tests for _gather_evidence method."""
+
+    @pytest.fixture
+    def mock_engine_for_evidence(self):
+        """Create a mock engine for evidence gathering tests."""
+        engine = MagicMock()
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+            },
+        ])
+        engine.get_bank_profile = AsyncMock(return_value={
+            "bank_id": "bank-a",
+            "name": "Bank A",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": "Test bank A",
+        })
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_gather_evidence_basic(self, mock_engine_for_evidence):
+        """Test basic evidence gathering."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+        from hindsight_api.api.cross_bank_models import BankInfo
+
+        # Mock recall_async
+        mock_engine_for_evidence.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_evidence)
+
+        banks = [BankInfo(
+            bank_id="bank-a",
+            name="Bank A",
+            disposition={"skepticism": 3, "literalism": 3, "empathy": 3},
+            mission="Test bank A",
+        )]
+
+        evidence = await orchestrator._gather_evidence(
+            query="Test query",
+            banks=banks,
+            budget_allocation=BudgetAllocation(per_bank={"bank-a": 100}, total_used=100),
+            include_mental_models=False,
+            request_context=RequestContext(),
+        )
+
+        assert "fused_facts" in evidence
+        assert "bank_results" in evidence
+        assert len(evidence["fused_facts"]) >= 0
+
+    @pytest.mark.asyncio
+    async def test_gather_evidence_with_mental_models(self, mock_engine_for_evidence):
+        """Test evidence gathering includes mental models when requested."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+        from hindsight_api.api.cross_bank_models import BankInfo
+
+        # Mock recall_async
+        mock_engine_for_evidence.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        # Mock get_mental_models
+        mock_engine_for_evidence.get_mental_models = AsyncMock(return_value=[
+            {"id": "mm-1", "name": "Test Model", "content": "Test content"}
+        ])
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_evidence)
+
+        banks = [BankInfo(
+            bank_id="bank-a",
+            name="Bank A",
+            disposition={"skepticism": 3, "literalism": 3, "empathy": 3},
+            mission="Test bank A",
+        )]
+
+        evidence = await orchestrator._gather_evidence(
+            query="Test query",
+            banks=banks,
+            budget_allocation=BudgetAllocation(per_bank={"bank-a": 100}, total_used=100),
+            include_mental_models=True,
+            request_context=RequestContext(),
+        )
+
+        assert "mental_models" in evidence
+        assert len(evidence["mental_models"]) == 1
+        assert evidence["mental_models"][0]["name"] == "Test Model"
+
+
+# =============================================================================
+# Extension Hook Tests
+# =============================================================================
+
+
+class TestCrossBankRecallHooks:
+    """Tests for extension hooks in cross_bank_recall."""
+
+    @pytest.fixture
+    def mock_engine_with_validator(self):
+        """Create a mock engine with operation validator."""
+        engine = MagicMock()
+
+        # Mock list_banks
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+                "tags": ["personal"],
+            },
+        ])
+
+        # Mock get_bank_profile
+        engine.get_bank_profile = AsyncMock(return_value={
+            "bank_id": "bank-a",
+            "name": "Bank A",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": "Test bank A",
+        })
+
+        # Mock recall_async
+        engine.recall_async = AsyncMock(return_value=MagicMock(
+            results=[],
+            model_dump=lambda: {"results": []}
+        ))
+
+        # Mock operation validator
+        engine._operation_validator = MagicMock()
+        engine._operation_validator.validate_cross_bank_recall = AsyncMock(
+            return_value=MagicMock(allowed=True, reason=None, status_code=None)
+        )
+        engine._operation_validator.notify_cross_bank_recall_complete = AsyncMock()
+
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_pre_validation_hook_allowed(self, mock_engine_with_validator):
+        """Test that pre-validation hook is called and allows operation."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        mock_engine_with_validator.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        orchestrator = CrossBankOrchestrator(mock_engine_with_validator)
+
+        result = await orchestrator.cross_bank_recall(
+            query="Test query",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Verify pre-validation hook was called
+        mock_engine_with_validator._operation_validator.validate_cross_bank_recall.assert_called_once()
+        call_kwargs = mock_engine_with_validator._operation_validator.validate_cross_bank_recall.call_args.kwargs
+        validation_ctx = call_kwargs["context"]
+        assert validation_ctx.query == "Test query"
+        assert validation_ctx.bank_ids == ["bank-a"]
+
+    @pytest.mark.asyncio
+    async def test_pre_validation_hook_denied(self, mock_engine_with_validator):
+        """Test that pre-validation hook can deny operation."""
+        from hindsight_api.extensions import OperationValidationError
+
+        # Configure validator to deny
+        mock_engine_with_validator._operation_validator.validate_cross_bank_recall = AsyncMock(
+            return_value=MagicMock(allowed=False, reason="Rate limit exceeded", status_code=429)
+        )
+
+        orchestrator = CrossBankOrchestrator(mock_engine_with_validator)
+
+        with pytest.raises(OperationValidationError) as exc_info:
+            await orchestrator.cross_bank_recall(
+                query="Test query",
+                bank_ids=["bank-a"],
+                budget=Budget.LOW,
+            )
+
+        assert "Rate limit exceeded" in str(exc_info.value)
+        assert exc_info.value.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_post_completion_hook_success(self, mock_engine_with_validator):
+        """Test that post-completion hook is called after success."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        mock_engine_with_validator.recall_async = AsyncMock(return_value=RecallResult(
+            results=[
+                MemoryFact(id="fact-1", text="Test fact", fact_type="world"),
+            ]
+        ))
+
+        orchestrator = CrossBankOrchestrator(mock_engine_with_validator)
+
+        result = await orchestrator.cross_bank_recall(
+            query="Test query",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Verify post-completion hook was called
+        mock_engine_with_validator._operation_validator.notify_cross_bank_recall_complete.assert_called_once()
+        call_kwargs = mock_engine_with_validator._operation_validator.notify_cross_bank_recall_complete.call_args.kwargs
+        completion_ctx = call_kwargs["context"]
+        assert completion_ctx.success is True
+        assert completion_ctx.total_results >= 0
+
+    @pytest.mark.asyncio
+    async def test_hook_context_includes_budget(self, mock_engine_with_validator):
+        """Test that hook context includes budget parameter."""
+        from hindsight_api.engine.response_models import RecallResult, MemoryFact
+
+        mock_engine_with_validator.recall_async = AsyncMock(return_value=RecallResult(results=[]))
+
+        orchestrator = CrossBankOrchestrator(mock_engine_with_validator)
+
+        result = await orchestrator.cross_bank_recall(
+            query="Test query",
+            bank_ids=["bank-a"],
+            budget=Budget.HIGH,
+        )
+
+        call_kwargs = mock_engine_with_validator._operation_validator.validate_cross_bank_recall.call_args.kwargs
+        validation_ctx = call_kwargs["context"]
+        assert validation_ctx.budget == Budget.HIGH
+
+
+class TestCrossBankReflectHooks:
+    """Tests for extension hooks in cross_bank_reflect."""
+
+    @pytest.fixture
+    def mock_engine_for_reflect_hooks(self):
+        """Create a mock engine for reflect hook tests."""
+        engine = MagicMock()
+
+        # Mock list_banks
+        engine.list_banks = AsyncMock(return_value=[
+            {
+                "bank_id": "bank-a",
+                "name": "Bank A",
+                "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+                "mission": "Test bank A",
+                "tags": ["personal"],
+            },
+        ])
+
+        # Mock get_bank_profile
+        engine.get_bank_profile = AsyncMock(return_value={
+            "bank_id": "bank-a",
+            "name": "Bank A",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": "Test bank A",
+        })
+
+        # Mock recall_async for evidence gathering
+        engine.recall_async = AsyncMock(return_value=MagicMock(
+            results=[],
+            model_dump=lambda: {"results": []}
+        ))
+
+        # Mock LLM provider
+        mock_llm = MagicMock()
+        mock_llm.generate = AsyncMock(return_value="Synthesized reflection")
+        engine._llm_provider = mock_llm
+
+        # Mock operation validator
+        engine._operation_validator = MagicMock()
+        engine._operation_validator.validate_cross_bank_reflect = AsyncMock(
+            return_value=MagicMock(allowed=True, reason=None, status_code=None)
+        )
+        engine._operation_validator.notify_cross_bank_reflect_complete = AsyncMock()
+
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_pre_validation_hook_allowed(self, mock_engine_for_reflect_hooks):
+        """Test that pre-validation hook is called and allows reflect operation."""
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect_hooks)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test question",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Verify pre-validation hook was called
+        mock_engine_for_reflect_hooks._operation_validator.validate_cross_bank_reflect.assert_called_once()
+        call_kwargs = mock_engine_for_reflect_hooks._operation_validator.validate_cross_bank_reflect.call_args.kwargs
+        validation_ctx = call_kwargs["context"]
+        assert validation_ctx.query == "Test question"
+        assert validation_ctx.bank_ids == ["bank-a"]
+
+    @pytest.mark.asyncio
+    async def test_pre_validation_hook_denied(self, mock_engine_for_reflect_hooks):
+        """Test that pre-validation hook can deny reflect operation."""
+        from hindsight_api.extensions import OperationValidationError
+
+        # Configure validator to deny
+        mock_engine_for_reflect_hooks._operation_validator.validate_cross_bank_reflect = AsyncMock(
+            return_value=MagicMock(allowed=False, reason="Reflect not allowed for this user", status_code=403)
+        )
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect_hooks)
+
+        with pytest.raises(OperationValidationError) as exc_info:
+            await orchestrator.cross_bank_reflect(
+                query="Test question",
+                bank_ids=["bank-a"],
+                budget=Budget.LOW,
+            )
+
+        assert "Reflect not allowed" in str(exc_info.value)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_post_completion_hook_success(self, mock_engine_for_reflect_hooks):
+        """Test that post-completion hook is called after successful reflect."""
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect_hooks)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test question",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Verify post-completion hook was called
+        mock_engine_for_reflect_hooks._operation_validator.notify_cross_bank_reflect_complete.assert_called_once()
+        call_kwargs = mock_engine_for_reflect_hooks._operation_validator.notify_cross_bank_reflect_complete.call_args.kwargs
+        completion_ctx = call_kwargs["context"]
+        assert completion_ctx.success is True
+
+    @pytest.mark.asyncio
+    async def test_post_completion_hook_on_llm_failure(self, mock_engine_for_reflect_hooks):
+        """Test that post-completion hook is called even when LLM fails."""
+        # Configure LLM to fail
+        mock_engine_for_reflect_hooks._llm_provider.generate = AsyncMock(
+            side_effect=Exception("LLM API error")
+        )
+
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect_hooks)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test question",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+        )
+
+        # Verify post-completion hook was still called
+        mock_engine_for_reflect_hooks._operation_validator.notify_cross_bank_reflect_complete.assert_called_once()
+        call_kwargs = mock_engine_for_reflect_hooks._operation_validator.notify_cross_bank_reflect_complete.call_args.kwargs
+        completion_ctx = call_kwargs["context"]
+        assert completion_ctx.success is False
+
+    @pytest.mark.asyncio
+    async def test_hook_context_includes_include_mental_models(self, mock_engine_for_reflect_hooks):
+        """Test that hook context includes include_mental_models parameter."""
+        orchestrator = CrossBankOrchestrator(mock_engine_for_reflect_hooks)
+
+        result = await orchestrator.cross_bank_reflect(
+            query="Test question",
+            bank_ids=["bank-a"],
+            budget=Budget.LOW,
+            include_mental_models=False,
+        )
+
+        call_kwargs = mock_engine_for_reflect_hooks._operation_validator.validate_cross_bank_reflect.call_args.kwargs
+        validation_ctx = call_kwargs["context"]
+        assert validation_ctx.include_mental_models is False
+
+
+class TestHookContextData:
+    """Tests for hook context data structures."""
+
+    def test_cross_bank_recall_context_fields(self):
+        """Test CrossBankRecallContext has expected fields."""
+        from hindsight_api.extensions.operation_validator import CrossBankRecallContext
+
+        ctx = CrossBankRecallContext(
+            bank_ids=["bank-a", "bank-b"],
+            query="Test query",
+            request_context=RequestContext(),
+            budget=Budget.MID,
+            bank_tags=["personal"],
+            max_results=20,
+        )
+
+        assert ctx.bank_ids == ["bank-a", "bank-b"]
+        assert ctx.query == "Test query"
+        assert ctx.budget == Budget.MID
+        assert ctx.bank_tags == ["personal"]
+        assert ctx.max_results == 20
+
+    def test_cross_bank_reflect_context_fields(self):
+        """Test CrossBankReflectContext has expected fields."""
+        from hindsight_api.extensions.operation_validator import CrossBankReflectContext
+
+        ctx = CrossBankReflectContext(
+            bank_ids=["bank-a"],
+            query="Test question",
+            request_context=RequestContext(),
+            budget=Budget.LOW,
+            bank_tags=["work"],
+            context="Additional context",
+            include_mental_models=True,
+            include_reasoning_chain=False,
+            response_schema=None,
+        )
+
+        assert ctx.bank_ids == ["bank-a"]
+        assert ctx.query == "Test question"
+        assert ctx.budget == Budget.LOW
+        assert ctx.context == "Additional context"
+        assert ctx.include_mental_models is True
+        assert ctx.include_reasoning_chain is False

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1357,3 +1357,346 @@ class TestBankToolFiltering:
         # Filter bypassed — config resolver was never consulted, all tools visible
         assert "recall" in visible
         mock_memory_with_resolver._config_resolver.get_bank_config.assert_not_called()
+        assert "recall" in visible
+        mock_memory_with_resolver._config_resolver.get_bank_config.assert_not_called()
+
+
+# =============================================================================
+# Cross-Bank MCP Tool Tests
+# =============================================================================
+
+
+@pytest.fixture
+def mock_memory_for_cross_bank():
+    """Create a mock MemoryEngine with cross-bank capabilities."""
+    memory = MagicMock()
+    memory.list_banks = AsyncMock(return_value=[
+        {
+            "bank_id": "bank-a",
+            "name": "Bank A",
+            "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+            "mission": "Test bank A",
+            "tags": ["personal"],
+        },
+        {
+            "bank_id": "bank-b",
+            "name": "Bank B",
+            "disposition": {"skepticism": 5, "literalism": 2, "empathy": 4},
+            "mission": "Test bank B",
+            "tags": ["work"],
+        },
+    ])
+    memory.get_bank_profile = AsyncMock(side_effect=lambda bank_id, **kwargs: {
+        "bank_id": bank_id,
+        "name": f"Bank {bank_id[-1].upper()}",
+        "disposition": {"skepticism": 3, "literalism": 3, "empathy": 3},
+        "mission": f"Test bank {bank_id}",
+    })
+    # Mock cross_bank_orchestrator
+    memory._cross_bank_orchestrator = MagicMock()
+    memory._cross_bank_orchestrator.cross_bank_recall = AsyncMock(
+        return_value=MagicMock(
+            results=[],
+            bank_stats={},
+            total_results=0,
+            fusion_metadata={"strategy": "reciprocal_rank_fusion"},
+            model_dump=lambda: {"results": [], "bank_stats": {}, "total_results": 0},
+        )
+    )
+    memory._cross_bank_orchestrator.cross_bank_reflect = AsyncMock(
+        return_value=MagicMock(
+            text="Test reflection",
+            based_on=[],
+            mental_models_used=[],
+            bank_dispositions={},
+            structured_output=None,
+            reasoning_chain=None,
+            new_opinions=[],
+            model_dump=lambda: {"text": "Test reflection", "based_on": []},
+        )
+    )
+    # Mock create_documents
+    memory.create_documents = AsyncMock(return_value=[
+        {"document_id": "doc-1", "status": "created", "memory_count": 5}
+    ])
+    return memory
+
+
+@pytest.mark.asyncio
+class TestCrossBankRecallMCPTool:
+    """Tests for cross_bank_recall MCP tool."""
+
+    async def test_cross_bank_recall_registered_multi_bank_only(self, mock_memory_for_cross_bank):
+        """cross_bank_recall should only be registered in multi-bank mode."""
+        from fastmcp import FastMCP
+
+        # Multi-bank mode (include_bank_id_param=True)
+        mcp_multi = FastMCP("test", stateless_http=True)
+        config_multi = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp_multi, mock_memory_for_cross_bank, config_multi)
+        assert "cross_bank_recall" in mcp_multi._tool_manager._tools
+
+        # Single-bank mode (include_bank_id_param=False)
+        mcp_single = FastMCP("test", stateless_http=True)
+        config_single = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=False,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp_single, mock_memory_for_cross_bank, config_single)
+        # Tool should not be registered in single-bank mode
+        assert "cross_bank_recall" not in mcp_single._tool_manager._tools
+
+    async def test_cross_bank_recall_basic(self, mock_memory_for_cross_bank):
+        """Test basic cross_bank_recall tool invocation."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_recall"].fn(
+            query="What does Alice do?",
+        )
+
+        # Verify orchestrator was called
+        mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_recall.assert_called_once()
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_recall.call_args.kwargs
+        assert call_kwargs["query"] == "What does Alice do?"
+
+    async def test_cross_bank_recall_with_bank_ids(self, mock_memory_for_cross_bank):
+        """Test cross_bank_recall with explicit bank_ids."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_recall"].fn(
+            query="Test query",
+            bank_ids=["bank-a", "bank-b"],
+        )
+
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_recall.call_args.kwargs
+        assert call_kwargs["bank_ids"] == ["bank-a", "bank-b"]
+
+    async def test_cross_bank_recall_with_bank_tags(self, mock_memory_for_cross_bank):
+        """Test cross_bank_recall with bank_tags filter."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_recall"].fn(
+            query="Test query",
+            bank_tags=["work"],
+        )
+
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_recall.call_args.kwargs
+        assert call_kwargs["bank_tags"] == ["work"]
+
+    async def test_cross_bank_recall_budget_parameter(self, mock_memory_for_cross_bank):
+        """Test cross_bank_recall passes budget parameter correctly."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_recall"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_recall"].fn(
+            query="Test query",
+            budget="high",
+        )
+
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_recall.call_args.kwargs
+        assert call_kwargs["budget"] == "high"
+
+
+@pytest.mark.asyncio
+class TestCrossBankReflectMCPTool:
+    """Tests for cross_bank_reflect MCP tool."""
+
+    async def test_cross_bank_reflect_registered_multi_bank_only(self, mock_memory_for_cross_bank):
+        """cross_bank_reflect should only be registered in multi-bank mode."""
+        from fastmcp import FastMCP
+
+        # Multi-bank mode
+        mcp_multi = FastMCP("test", stateless_http=True)
+        config_multi = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_reflect"},
+        )
+        register_mcp_tools(mcp_multi, mock_memory_for_cross_bank, config_multi)
+        assert "cross_bank_reflect" in mcp_multi._tool_manager._tools
+
+        # Single-bank mode
+        mcp_single = FastMCP("test", stateless_http=True)
+        config_single = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=False,
+            tools={"cross_bank_reflect"},
+        )
+        register_mcp_tools(mcp_single, mock_memory_for_cross_bank, config_single)
+        assert "cross_bank_reflect" not in mcp_single._tool_manager._tools
+
+    async def test_cross_bank_reflect_basic(self, mock_memory_for_cross_bank):
+        """Test basic cross_bank_reflect tool invocation."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_reflect"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_reflect"].fn(
+            query="What are user preferences?",
+        )
+
+        mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_reflect.assert_called_once()
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_reflect.call_args.kwargs
+        assert call_kwargs["query"] == "What are user preferences?"
+
+    async def test_cross_bank_reflect_with_context(self, mock_memory_for_cross_bank):
+        """Test cross_bank_reflect passes context parameter."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_reflect"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_reflect"].fn(
+            query="Test question",
+            context="Additional context for reflection",
+        )
+
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_reflect.call_args.kwargs
+        assert call_kwargs["context"] == "Additional context for reflection"
+
+    async def test_cross_bank_reflect_include_mental_models(self, mock_memory_for_cross_bank):
+        """Test cross_bank_reflect include_mental_models parameter."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"cross_bank_reflect"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["cross_bank_reflect"].fn(
+            query="Test question",
+            include_mental_models=False,
+        )
+
+        call_kwargs = mock_memory_for_cross_bank._cross_bank_orchestrator.cross_bank_reflect.call_args.kwargs
+        assert call_kwargs["include_mental_models"] is False
+
+
+@pytest.mark.asyncio
+class TestCreateDocumentsMCPTool:
+    """Tests for create_documents MCP tool."""
+
+    async def test_create_documents_registered(self, mock_memory_for_cross_bank):
+        """create_documents should be registered in multi-bank mode."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"create_documents"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+        assert "create_documents" in mcp._tool_manager._tools
+
+    async def test_create_documents_basic(self, mock_memory_for_cross_bank):
+        """Test basic create_documents tool invocation."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"create_documents"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["create_documents"].fn(
+            documents=[{"content": "Test document 1", "context": "test"}],
+        )
+
+        mock_memory_for_cross_bank.create_documents.assert_called_once()
+        call_kwargs = mock_memory_for_cross_bank.create_documents.call_args.kwargs
+        assert len(call_kwargs["documents"]) == 1
+
+    async def test_create_documents_multiple(self, mock_memory_for_cross_bank):
+        """Test create_documents with multiple documents."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"create_documents"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["create_documents"].fn(
+            documents=[
+                {"content": "Document 1", "context": "test"},
+                {"content": "Document 2", "context": "test"},
+            ],
+        )
+
+        call_kwargs = mock_memory_for_cross_bank.create_documents.call_args.kwargs
+        assert len(call_kwargs["documents"]) == 2
+
+    async def test_create_documents_with_bank_id(self, mock_memory_for_cross_bank):
+        """Test create_documents with explicit bank_id."""
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test", stateless_http=True)
+        config = MCPToolsConfig(
+            bank_id_resolver=lambda: "test-bank",
+            include_bank_id_param=True,
+            tools={"create_documents"},
+        )
+        register_mcp_tools(mcp, mock_memory_for_cross_bank, config)
+
+        result = await mcp._tool_manager._tools["create_documents"].fn(
+            documents=[{"content": "Test", "context": "test"}],
+            bank_id="custom-bank",
+        )
+
+        call_kwargs = mock_memory_for_cross_bank.create_documents.call_args.kwargs
+        assert call_kwargs["bank_id"] == "custom-bank"


### PR DESCRIPTION
## Summary

- **CrossBankOrchestrator** for querying across multiple memory banks in parallel
- **BudgetAllocator** with equal/proportional/custom strategies for distributing query budget
- **Reciprocal Rank Fusion** (k=60) for merging and deduplicating results across banks
- **Disposition reconciliation** for multi-bank reflect (weighted average of bank traits)
- HTTP endpoints: `POST /v1/{tenant}/cross-bank/recall` and `/v1/{tenant}/cross-bank/reflect`
- MCP tools: `cross_bank_recall`, `cross_bank_reflect`
- Comprehensive unit tests (1400+ lines)

## Motivation

Currently each bank is an isolated memory store with no way to query across banks. Many use cases (multi-agent systems, federated knowledge) need to search and reason across multiple banks simultaneously while respecting per-bank dispositions and access controls.

## New files
- `hindsight-api-slim/hindsight_api/engine/cross_bank.py` — Orchestrator, allocator, fusion
- `hindsight-api-slim/hindsight_api/api/cross_bank_models.py` — Pydantic request/response models
- `hindsight-api-slim/tests/test_cross_bank.py` — Unit tests
- `hindsight-api-slim/tests/test_mcp_tools.py` — MCP tool tests

## Modified files
- `api/http.py` — Two new cross-bank endpoints
- `api/mcp.py` — Register cross-bank tools
- `engine/memory_engine.py` — CrossBankOrchestrator property + initialization
- `mcp_tools.py` — Cross-bank tool implementations

## Test plan
- [ ] Unit tests pass: `uv run pytest tests/test_cross_bank.py tests/test_mcp_tools.py -v`
- [ ] Cross-bank recall returns fused results from multiple banks
- [ ] Cross-bank reflect produces disposition-reconciled answers
- [ ] Budget allocation respects per-bank minimums
- [ ] No impact on existing single-bank operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)