### PR TITLE
fix: chunk FK cascade so doc deletion doesn't leave orphan memory units

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/f6g7h8i9j0k1_chunk_fk_cascade_delete.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f6g7h8i9j0k1_chunk_fk_cascade_delete.py
@@ -1,0 +1,38 @@
+"""chunk_fk_cascade_delete
+
+Revision ID: f6g7h8i9j0k1
+Revises: e5f6g7h8i9j0
+Create Date: 2026-03-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6g7h8i9j0k1"
+down_revision: str | Sequence[str] | None = "e5f6g7h8i9j0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Change memory_units.chunk_id FK from SET NULL to CASCADE.
+
+    When a document is deleted the CASCADE reaches chunks first; with SET NULL
+    the memory_units rows survived with chunk_id = NULL, leaving ghost records.
+    Switching to CASCADE ensures they are removed together with their chunk.
+    """
+    op.drop_constraint("memory_units_chunk_fkey", "memory_units", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_units_chunk_fkey", "memory_units", "chunks", ["chunk_id"], ["chunk_id"], ondelete="CASCADE"
+    )
+
+
+def downgrade() -> None:
+    """Revert to SET NULL behaviour."""
+    op.drop_constraint("memory_units_chunk_fkey", "memory_units", type_="foreignkey")
+    op.create_foreign_key(
+        "memory_units_chunk_fkey", "memory_units", "chunks", ["chunk_id"], ["chunk_id"], ondelete="SET NULL"
+    )


### PR DESCRIPTION
## Summary

- Change the `memory_units.chunk_id` foreign key from `ON DELETE SET NULL` to `ON DELETE CASCADE` via a new Alembic migration.
- When a document is deleted, the cascade now flows `documents → chunks → memory_units`, removing chunk-linked memory units instead of nulling out their `chunk_id` and leaving them as ghost records.
- The observation-layer cleanup (`_delete_stale_observations_for_memories`) already handles derived observation nodes, so this completes the fix for both layers described in #572.

Closes #572

## Test plan

- [ ] Run the new migration against a test database and verify `\d memory_units` shows `ON DELETE CASCADE` for the `memory_units_chunk_fkey` constraint
- [ ] Delete a document via the dashboard or `DELETE /documents/{id}` API and confirm no memory_units with `chunk_id IS NULL AND document_id IS NULL` are left behind
- [ ] Verify the graph API returns no orphaned observation nodes after document deletion
- [ ] Run the downgrade migration and confirm it restores `ON DELETE SET NULL`