### PR TITLE
fix(docker): honor HINDSIGHT_CP_HOSTNAME for control-plane startup

### DIFF
--- a/docker/standalone/start-all.sh
+++ b/docker/standalone/start-all.sh
@@ -111,6 +111,7 @@ fi
 if [ "$ENABLE_CP" = "true" ]; then
     echo "🎛️  Starting Control Plane..."
     cd /app/control-plane
+    export HOSTNAME="${HINDSIGHT_CP_HOSTNAME:-0.0.0.0}"
     PORT="${HINDSIGHT_CP_PORT:-9999}" node server.js &
     CP_PID=$!
     PIDS+=($CP_PID)


### PR DESCRIPTION
## Summary
- bridge `HINDSIGHT_CP_HOSTNAME` into `HOSTNAME` before the control plane starts `node server.js`
- keep the fix scoped to the shared Docker/Kubernetes startup path used by the control-plane image
- preserve the existing `HINDSIGHT_CP_PORT` behavior while making the hostname override work as intended in Kubernetes

## Issue
Fixes #591

When the control plane runs in Kubernetes, the chart sets `HINDSIGHT_CP_HOSTNAME=0.0.0.0`, but `docker/standalone/start-all.sh` starts `node server.js` without exporting `HOSTNAME` first.

In that situation, Next.js falls back to the container's existing `HOSTNAME`, and in Kubernetes that value is the pod hostname. The control plane then binds to the pod hostname/IP instead of `0.0.0.0`, which breaks the expected port-forward workflow. Manually setting `HOSTNAME=0.0.0.0` in the pod works around the issue.

## Why this change
The repo already uses this same hostname bridge in `scripts/dev/start-control-plane.sh`. Reusing that behavior in `start-all.sh` keeps the Docker and Kubernetes runtime path aligned with the documented control-plane configuration.

## Verification
- `bash -n docker/standalone/start-all.sh`
- sourced the startup script with a stubbed `node` command and verified it launches with `HOSTNAME=0.0.0.0` even when Kubernetes-style `HOSTNAME=pod-123` is present