### PR TITLE
Fix Docker build: copy uv.lock to prevent dependency drift

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -41,19 +41,21 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv
 
-# Copy dependency files and README (required by pyproject.toml)
+# Copy dependency files, lockfile, and README (required by pyproject.toml)
 COPY hindsight-api-slim/pyproject.toml ./api/
 COPY hindsight-api-slim/README.md ./api/
+COPY uv.lock ./api/
 
 WORKDIR /app/api
 
 # Sync dependencies using appropriate extras based on INCLUDE_LOCAL_MODELS
+# Uses --frozen to install exact versions from uv.lock (prevents unexpected upgrades)
 # local-ml: torch, sentence-transformers, transformers, einops, flashrank, mlx (optional)
 # embedded-db: pg0-embedded (always included for embedded PostgreSQL support)
 RUN if [ "$INCLUDE_LOCAL_MODELS" = "true" ]; then \
-        uv sync --extra local-ml --extra embedded-db; \
+        uv sync --frozen --no-install-project --extra local-ml --extra embedded-db; \
     else \
-        uv sync --extra embedded-db; \
+        uv sync --frozen --no-install-project --extra embedded-db; \
     fi
 
 # Copy source code (alembic migrations are inside hindsight_api/)


### PR DESCRIPTION
## Summary
- Copy `uv.lock` into the Docker build stage so `uv sync` uses locked dependency versions
- Use `--frozen --no-install-project` to enforce exact versions from the lockfile
- Fixes CI breakage caused by `claude-agent-sdk==0.1.49` being published with only macOS ARM wheels (no Linux x86_64)

## Context
The standalone Dockerfile only copied `pyproject.toml` but not `uv.lock`, so `uv sync` resolved dependencies fresh on every build. When `claude-agent-sdk>=0.1.27` resolved to `0.1.49` (which lacks Linux wheels), all Docker builds on Linux x86_64 started failing.

## Test plan
- [x] Local Docker build succeeds with `--target api-only`
- [x] Verified installed `claude-agent-sdk` version is `0.1.31` (locked) not `0.1.49`
- [ ] CI Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)