### PR TITLE
fix(hindsight-api): add script entry points so uvx hindsight-api works directly

### DIFF
--- a/hindsight-api/pyproject.toml
+++ b/hindsight-api/pyproject.toml
@@ -15,5 +15,11 @@ dependencies = [
 [tool.uv.sources]
 hindsight-api-slim = { workspace = true }
 
+[project.scripts]
+hindsight-api = "hindsight_api.main:main"
+hindsight-worker = "hindsight_api.worker.main:main"
+hindsight-local-mcp = "hindsight_api.mcp_local:main"
+hindsight-admin = "hindsight_api.admin.cli:main"
+
 [tool.setuptools]
 packages = []


### PR DESCRIPTION
## Summary
- `hindsight-api` meta-package was missing `[project.scripts]`, causing `uvx hindsight-api@{version}` to fail with exit code 28 in `hindsight-embed`'s daemon launcher
- Added the same script entry points as `hindsight-api-slim` so uvx can resolve the `hindsight-api` executable directly

## Test plan
- [ ] Run embedded Python client (`HindsightEmbedded`) and verify daemon starts without the exit code 28 / uvx warning
- [ ] Verify `uvx hindsight-api@<version>` works after publishing the fixed package