### PR TITLE
fix(recall): reject empty queries with 400 and fix SQL parameter gap

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -172,10 +172,9 @@ class RecallRequest(BaseModel):
     @field_validator("query")
     @classmethod
     def validate_query_not_empty(cls, v: str) -> str:
-        import re
+        from ..engine.search.retrieval import tokenize_query
 
-        tokens = re.sub(r"[^\w\s]", " ", v.lower()).split()
-        if not tokens:
+        if not tokenize_query(v):
             raise ValueError("query must contain at least one word character after normalization")
         return v
 

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -10,6 +10,7 @@ Implements:
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Optional
@@ -24,6 +25,15 @@ from .tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags
 from .types import MPFPTimings, RetrievalResult
 
 logger = logging.getLogger(__name__)
+
+
+def tokenize_query(query_text: str) -> list[str]:
+    """Normalize query text and split into BM25 tokens.
+
+    Strips punctuation, lowercases, and splits on whitespace.
+    Returns an empty list when the query contains no word characters.
+    """
+    return re.sub(r"[^\w\s]", " ", query_text.lower()).split()
 
 
 @dataclass
@@ -129,12 +139,9 @@ async def retrieve_semantic_bm25_combined(
     Returns:
         Dict mapping fact_type -> (semantic_results, bm25_results)
     """
-    import re
-
     result_dict: dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]] = {ft: ([], []) for ft in fact_types}
 
-    sanitized_text = re.sub(r"[^\w\s]", " ", query_text.lower())
-    tokens = [token for token in sanitized_text.split() if token]
+    tokens = tokenize_query(query_text)
 
     # Over-fetch for HNSW approximation; semantic results trimmed to limit in Python.
     hnsw_fetch = max(limit * 5, 100)


### PR DESCRIPTION
## Summary

- **SQL parameter gap fix**: When `query` text has no word characters (only punctuation/symbols), BM25 arms are skipped but the old code still placed `limit` at `$3` in the params list. If `tags` or `tag_groups` were set, their params (`$4+`) were referenced in the SQL while `$3` was a gap — causing PostgreSQL to raise `IndeterminateDatatypeError: could not determine data type of parameter $3`. Fixed by only appending `limit` to params when tokens are present, and shifting `tags_param_idx` from 4 to 3 in the no-tokens path.

- **400 validation**: Added a `@field_validator` on `RecallRequest.query` that rejects queries with no word characters after normalization (same regex used by BM25 tokenization) before they reach the database.

## Root cause

The consolidation worker calls `recall_async` internally with `query=m["text"]` and `tags=m.get("tags")`. If a retained fact's text contained only punctuation and the fact had tags, the retrieval query had a `$3` gap → crash.

## Test plan

- [ ] All existing recall tests pass (42 passed)
- [ ] `POST /recall` with `{"query": "???", "tags": ["x"]}` → 422 with validation error
- [ ] `POST /recall` with `{"query": "", "tags": ["x"]}` → 422 with validation error  
- [ ] `POST /recall` with `{"query": "nicol"}` → works normally