### PR TITLE
fix: add readme field to integration pyproject.toml files for PyPI

### DIFF
--- a/hindsight-integrations/agno/pyproject.toml
+++ b/hindsight-integrations/agno/pyproject.toml
@@ -2,6 +2,7 @@
 name = "hindsight-agno"
 version = "0.4.19"
 description = "Agno integration for Hindsight - persistent memory tools for AI agents"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [

--- a/hindsight-integrations/hermes/pyproject.toml
+++ b/hindsight-integrations/hermes/pyproject.toml
@@ -2,6 +2,7 @@
 name = "hindsight-hermes"
 version = "0.4.19"
 description = "Hermes agent integration for Hindsight - persistent memory tools for AI agents"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [

--- a/hindsight-integrations/langgraph/pyproject.toml
+++ b/hindsight-integrations/langgraph/pyproject.toml
@@ -2,6 +2,7 @@
 name = "hindsight-langgraph"
 version = "0.1.1"
 description = "LangGraph integration for Hindsight - persistent memory tools, nodes, and store for AI agents"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [

--- a/hindsight-integrations/pydantic-ai/pyproject.toml
+++ b/hindsight-integrations/pydantic-ai/pyproject.toml
@@ -2,6 +2,7 @@
 name = "hindsight-pydantic-ai"
 version = "0.4.19"
 description = "Pydantic AI integration for Hindsight - persistent memory tools for AI agents"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [


### PR DESCRIPTION
## Summary
- Add missing `readme = "README.md"` to `pyproject.toml` for 4 integrations: **langgraph**, **agno**, **hermes**, **pydantic-ai**
- Without this, Hatchling doesn't include the README in the package, so PyPI shows no description
- The other integrations (crewai, litellm) already had the field

## Test plan
- [ ] Verify the next release of each package shows its README on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)