### PR TITLE
Fix: POST files/retain uses authentication headers

### DIFF
--- a/hindsight-control-plane/src/app/api/files/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/files/retain/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL } from "@/lib/hindsight-client";
+import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -25,6 +25,7 @@ export async function POST(request: NextRequest) {
     // Forward the form data to the dataplane
     const response = await fetch(url, {
       method: "POST",
+      headers: getDataplaneHeaders(),
       body: formData,
       // Don't set Content-Type - let fetch handle multipart boundary
     });


### PR DESCRIPTION
This pull request updates the API route for retaining files to ensure proper headers are included when forwarding requests to the dataplane service. Previously requests were unauthenticated and thus rejected by the dataplane service (401).

Integration with dataplane service:

* Updated the import in `route.ts` to include `getDataplaneHeaders` from `@/lib/hindsight-client`, and added these headers to the forwarded POST request to the dataplane. [[1]](diffhunk://#diff-cc1e1c9f6a64f079b62b9388e2e50291a2c3f53e2483a4ca78e8bc29786c60c6L2-R2) [[2]](diffhunk://#diff-cc1e1c9f6a64f079b62b9388e2e50291a2c3f53e2483a4ca78e8bc29786c60c6R28)