### PR TITLE
fix: allow claude-agent-sdk installation on Linux/Docker

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "orjson>=3.11.6", # Unbounded recursion DoS fix
     "tornado>=6.5.5", # DoS multipart/incomplete cookie validation fix
     "aiohttp>=3.13.3", # Multiple DoS vulnerabilities
-    "claude-agent-sdk>=0.1.27; sys_platform == 'darwin'",
+    "claude-agent-sdk>=0.1.27",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Fixes #640 — claude-code provider broken in Docker because claude-agent-sdk is excluded on Linux
- Removed the `sys_platform == 'darwin'` platform constraint from `hindsight-api-slim/pyproject.toml`

## Changes
- Changed `"claude-agent-sdk>=0.1.27; sys_platform == 'darwin'"` to `"claude-agent-sdk>=0.1.27"` so the package installs on all platforms

## Test plan
- [ ] Verify `pip install` resolves claude-agent-sdk on Linux
- [ ] Verify claude-code provider initializes in Docker without `RuntimeError`
- [ ] Verify no regression on macOS