### PR TITLE
blog: add cover image to NemoClaw memory post

### DIFF
--- a/hindsight-docs/blog/2026-03-19-nemoclaw-memory.md
+++ b/hindsight-docs/blog/2026-03-19-nemoclaw-memory.md
@@ -8,6 +8,8 @@ image: /img/blog/2026-03-19/nemoclaw-memory.png
 hide_table_of_contents: true
 ---
 
+![Give NemoClaw the Best Agent Memory Available In One Command](/img/blog/2026-03-19/nemoclaw-memory.png)
+
 ## TL;DR
 
 - [NemoClaw](https://nemoclaw.ai) sandboxes isolate AI agents — controlled filesystem, processes, and network. That isolation makes persistent memory harder.


### PR DESCRIPTION
Adds inline cover photo to the NemoClaw persistent memory blog post, following the same pattern used in most other blog posts.