### PR TITLE
blog: add cover image to Agent Memory Benchmark post

### DIFF
--- a/hindsight-docs/blog/2026-03-23-agent-memory-benchmark.mdx
+++ b/hindsight-docs/blog/2026-03-23-agent-memory-benchmark.mdx
@@ -3,9 +3,11 @@ title: "Agent Memory Benchmark: A Manifesto"
 authors: [hindsight]
 date: 2026-03-23
 tags: [benchmark, memory, agents, evaluation, longmemeval, locomo, open-source]
-image: /img/blog/agent-memory-benchmark.png
+image: /img/blog/amb/landing.png
 hide_table_of_contents: true
 ---
+
+![Agent Memory Benchmark: A Manifesto](/img/blog/amb/landing.png)
 
 import ImageCarousel from '@site/src/components/ImageCarousel';
 


### PR DESCRIPTION
Adds inline cover photo to the Agent Memory Benchmark blog post. Also updates the `image` frontmatter to use `amb/landing.png` (the referenced `agent-memory-benchmark.png` file did not exist).