### PR TITLE
fix(reflect): disable source facts in search_observations to prevent context overflow

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -136,7 +136,7 @@ async def tool_search_observations(
     pending_consolidation: int = 0,
 ) -> dict[str, Any]:
     """
-    Search consolidated observations using recall with include_source_facts.
+    Search consolidated observations using recall.
 
     Observations are auto-generated from memories. Returns freshness info
     so the agent knows if it should also verify with recall().
@@ -165,8 +165,7 @@ async def tool_search_observations(
         tags=tags,
         tags_match=tags_match,
         tag_groups=tag_groups,
-        include_source_facts=True,
-        max_source_facts_tokens=-1,  # No token limit — include all source facts
+        include_source_facts=False,
         _connection_budget=1,
         _quiet=True,
     )


### PR DESCRIPTION
## Summary

The reflect agent's `search_observations` hardcodes `include_source_facts=True` with `max_source_facts_tokens=-1` (unlimited). For banks with many observations backed by thousands of facts, a single tool call produces 300K+ tokens, exceeding the default 100K context budget. This forces early synthesis with an empty "Retrieved Data" section, causing reflect to return "No information available" despite the data existing.

Fixes #668.

## Root Cause

`search_observations()` in `hindsight-api-slim/hindsight_api/engine/reflect/tools.py` unconditionally includes all source facts with no token limit. The consolidation path already has configurable limits (PR #509, v0.4.17), but the reflect path was not updated.

## Fix

Set `include_source_facts=False` in the reflect agent's `search_observations`. The reflect agent synthesizes from observations, not raw backing facts — source facts are unnecessary overhead here.

This reduces payload from ~310K tokens to ~6K tokens for the reporter's bank (230 observations, ~2,400 facts).

## Changes

`hindsight-api-slim/hindsight_api/engine/reflect/tools.py`: 1 file, +2/-3 lines

## Alternative Considered

Adding per-bank config (`reflect_source_facts_max_tokens`) to mirror the consolidation path. Opted for the simpler fix since reflect does not use source facts in its synthesis prompt.