### PR TITLE
fix(client): handle async context in sync bridge to prevent event loop deadlock

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -30,7 +30,26 @@ from hindsight_client_api.models.retain_response import RetainResponse
 
 
 def _run_async(coro):
-    """Run an async coroutine synchronously."""
+    """Run an async coroutine synchronously.
+
+    Handles both sync and async calling contexts:
+    - Sync context: uses the current (or new) event loop directly
+    - Async context: runs the coroutine in a separate thread to avoid
+      'event loop already running' deadlocks (fixes #677)
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        # We're inside an async context (e.g., Discord/Telegram gateway).
+        # Run in a new thread with its own event loop to avoid deadlock.
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result()
+
+    # Sync context: safe to use run_until_complete
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:


### PR DESCRIPTION
## Summary

Fixes #677 — `_run_async()` crashes with `RuntimeError: This event loop is already running` when called from async contexts (Discord/Telegram gateway mode).

## Root Cause

`_run_async()` uses `loop.run_until_complete()` unconditionally. This is fine in sync contexts (CLI mode), but fails when an event loop is already running (gateway mode with asyncio-based frameworks like discord.py).

## Fix

Detect if an event loop is already running via `asyncio.get_running_loop()`. If so, run the coroutine in a separate thread with its own event loop using `ThreadPoolExecutor`. This avoids the nested event loop deadlock while keeping full backward compatibility for sync callers.

```python
# Async context detected → run in separate thread
if loop is not None and loop.is_running():
    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
        return pool.submit(asyncio.run, coro).result()
```

## Testing

- Existing reflect response parsing tests still pass (5/5)
- Integration tests require a running Hindsight server (not affected by this change)
- The fix addresses the exact error path described in #677