### PR TITLE
fix: coerce JSON-string tags to list in MemoryItem and MCP tools

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -424,6 +424,27 @@ class MemoryItem(BaseModel):
         default=None,
         description="Optional tags for visibility scoping. Memories with tags can be filtered during recall.",
     )
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def coerce_tags(cls, v):
+        """Coerce JSON-string tags to list.
+
+        MCP tool bridges sometimes serialize JSON arrays as strings during
+        transport, e.g. '["a", "b"]' instead of ["a", "b"]. This validator
+        parses such strings back into lists so the retain call succeeds.
+        A plain non-JSON string is wrapped in a single-element list.
+        """
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+            return [v]
+        return v
+
     observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = Field(
         default=None,
         title="ObservationScopes",

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -115,6 +115,19 @@ def build_content_dict(
     Returns:
         Tuple of (content_dict, error_message). error_message is None if successful.
     """
+    # Coerce tags from JSON string to list if needed.
+    # MCP tool bridges sometimes serialize JSON arrays as strings during
+    # transport, e.g. '["a", "b"]' instead of ["a", "b"].
+    if isinstance(tags, str):
+        try:
+            parsed = json.loads(tags)
+            if isinstance(parsed, list):
+                tags = parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if isinstance(tags, str):
+            tags = [tags]
+
     content_dict: dict[str, Any] = {"content": content, "context": context}
 
     if timestamp:


### PR DESCRIPTION
### Problem

MCP tool bridges (including Claude Code and other MCP hosts) sometimes serialize JSON arrays as strings during transport. For example, a tags value of `["project", "urgent"]` arrives as the literal string `'["project", "urgent"]'` instead of a native JSON array.

When this happens, Pydantic rejects the input with a validation error:

```
Input should be a valid list [type=list_type, input_value='["project", "urgent"]', input_type=str]
```

This causes `retain` operations to fail when tags are provided through MCP bridges that exhibit this serialization behavior.

### Fix

Add defensive coercion at two layers:

1. **HTTP API (`http.py`)** — A Pydantic `field_validator` on `MemoryItem.tags` with `mode="before"` that detects string input, attempts `json.loads`, and returns the parsed list. Falls back to wrapping a plain string in a single-element list.

2. **MCP tools (`mcp_tools.py`)** — The same coercion logic at the top of `build_content_dict`, which receives tags before they reach the Pydantic model.

### Behavior

| Input | Result | Changed? |
|-------|--------|----------|
| `["a", "b"]` (native list) | `["a", "b"]` | No |
| `'["a", "b"]'` (JSON string) | `["a", "b"]` | **Fixed** |
| `"single-tag"` (plain string) | `["single-tag"]` | **Fixed** |
| `None` | `None` | No |

Correctly-formatted input is passed through unchanged. The fix is purely defensive.

### Affected paths

- `POST /memories` (HTTP API via `MemoryItem` model)
- `retain` MCP tool (via `build_content_dict` in `mcp_tools.py`)