### PR TITLE
feat: add support for volcano LLM providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # LLM Configuration (Required)
-# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax
+# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, volcano
 HINDSIGHT_API_LLM_PROVIDER=openai
 HINDSIGHT_API_LLM_API_KEY=your-api-key-here
 HINDSIGHT_API_LLM_MODEL=gpt-4o-mini

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -368,6 +368,7 @@ PROVIDER_DEFAULT_MODELS = {
     "none": "none",
     "litellm": "gpt-4o-mini",
     "bedrock": "us.amazon.nova-2-lite-v1:0",
+    "volcano": "doubao-pro-32k",
 }
 DEFAULT_LLM_MODEL = "gpt-4o-mini"  # Fallback if provider not in table
 DEFAULT_LLM_MAX_CONCURRENT = 32

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -261,7 +261,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
         )
 
-    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax"):
+    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "volcano"):
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,
@@ -334,6 +334,7 @@ class LLMProvider:
             "minimax",
             "litellm",
             "bedrock",
+            "volcano",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -98,7 +98,7 @@ class OpenAICompatibleLLM(LLMInterface):
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
         # Validate provider
-        valid_providers = ["openai", "groq", "ollama", "lmstudio", "minimax"]
+        valid_providers = ["openai", "groq", "ollama", "lmstudio", "minimax", "volcano"]
         if self.provider not in valid_providers:
             raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
 
@@ -316,8 +316,8 @@ class OpenAICompatibleLLM(LLMInterface):
                         first_msg = call_params["messages"][0]
                         if isinstance(first_msg, dict) and isinstance(first_msg.get("content"), str):
                             first_msg["content"] = schema_msg + "\n\n" + first_msg["content"]
-                if self.provider not in ("lmstudio", "ollama"):
-                    # LM Studio and Ollama don't support json_object response format reliably
+                if self.provider not in ("lmstudio", "ollama", "volcano"):
+                    # LM Studio, Ollama and Volcano don't support json_object response format reliably
                     call_params["response_format"] = {"type": "json_object"}
 
         last_exception = None


### PR DESCRIPTION
- Add 'volcano' as valid LLM provider (aliases for Volcano Engine)
- Set default model to 'doubao-pro-32k' for provider
- Add them to OpenAICompatibleLLM provider list
- Exclude from json_object response format support