### PR TITLE
fix(ag2): code cleanup and CI/release integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
       integrations-crewai: ${{ steps.filter.outputs.integrations-crewai }}
       integrations-litellm: ${{ steps.filter.outputs.integrations-litellm }}
       integrations-pydantic-ai: ${{ steps.filter.outputs.integrations-pydantic-ai }}
+      integrations-ag2: ${{ steps.filter.outputs.integrations-ag2 }}
       integrations-hermes: ${{ steps.filter.outputs.integrations-hermes }}
       dev: ${{ steps.filter.outputs.dev }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -94,6 +95,8 @@ jobs:
             - 'hindsight-integrations/litellm/**'
           integrations-pydantic-ai:
             - 'hindsight-integrations/pydantic-ai/**'
+          integrations-ag2:
+            - 'hindsight-integrations/ag2/**'
           integrations-hermes:
             - 'hindsight-integrations/hermes/**'
           dev:
@@ -1486,6 +1489,40 @@ jobs:
       run: |
         echo "=== API Server Logs ==="
         cat /tmp/api-server.log || echo "No API server log found"
+
+  test-ag2-integration:
+    needs: [detect-changes]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.integrations-ag2 == 'true' ||
+      needs.detect-changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        prune-cache: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: ".python-version"
+
+    - name: Build ag2 integration
+      working-directory: ./hindsight-integrations/ag2
+      run: uv build
+
+    - name: Install dependencies
+      working-directory: ./hindsight-integrations/ag2
+      run: uv sync --frozen
+
+    - name: Run tests
+      working-directory: ./hindsight-integrations/ag2
+      run: uv run pytest tests -v
 
   test-crewai-integration:
     needs: [detect-changes]

--- a/hindsight-integrations/ag2/hindsight_ag2/errors.py
+++ b/hindsight-integrations/ag2/hindsight_ag2/errors.py
@@ -3,5 +3,3 @@
 
 class HindsightError(Exception):
     """Exception raised when a Hindsight memory operation fails."""
-
-    pass

--- a/hindsight-integrations/ag2/hindsight_ag2/tools.py
+++ b/hindsight-integrations/ag2/hindsight_ag2/tools.py
@@ -7,6 +7,7 @@ functions with ``Annotated`` type hints, compatible with AG2's
 """
 
 import logging
+from collections.abc import Callable
 from typing import Annotated, Any, Optional
 
 from hindsight_client import Hindsight
@@ -44,7 +45,7 @@ def create_hindsight_tools(
     include_retain: bool = True,
     include_recall: bool = True,
     include_reflect: bool = True,
-) -> list:
+) -> list[Callable]:
     """Create Hindsight memory tools for AG2 agents.
 
     Returns a list of plain Python functions compatible with AG2's
@@ -110,7 +111,7 @@ def create_hindsight_tools(
         else (config.max_tokens if config else 4096)
     )
 
-    tools: list = []
+    tools: list[Callable] = []
 
     if include_retain:
 
@@ -137,7 +138,7 @@ def create_hindsight_tools(
                 resolved_client.retain(**retain_kwargs)
                 return "Memory stored successfully."
             except Exception as e:
-                logger.error(f"Retain failed: {e}")
+                logger.error("Retain failed: %s", e)
                 raise HindsightError(f"Retain failed: {e}") from e
 
         tools.append(hindsight_retain)
@@ -177,7 +178,7 @@ def create_hindsight_tools(
                     lines.append(f"{i}. {result.text}")
                 return "\n".join(lines)
             except Exception as e:
-                logger.error(f"Recall failed: {e}")
+                logger.error("Recall failed: %s", e)
                 raise HindsightError(f"Recall failed: {e}") from e
 
         tools.append(hindsight_recall)
@@ -221,7 +222,7 @@ def create_hindsight_tools(
                 response = resolved_client.reflect(**reflect_kwargs)
                 return response.text or "No relevant memories found."
             except Exception as e:
-                logger.error(f"Reflect failed: {e}")
+                logger.error("Reflect failed: %s", e)
                 raise HindsightError(f"Reflect failed: {e}") from e
 
         tools.append(hindsight_reflect)
@@ -235,7 +236,7 @@ def register_hindsight_tools(
     *,
     bank_id: str,
     **kwargs,
-) -> list:
+) -> list[Callable]:
     """Convenience: create tools AND register them on AG2 agents.
 
     Creates Hindsight memory tools and registers them on the given AG2

--- a/scripts/release-integration.sh
+++ b/scripts/release-integration.sh
@@ -13,7 +13,7 @@ print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-VALID_INTEGRATIONS=("litellm" "pydantic-ai" "crewai" "ai-sdk" "chat" "openclaw" "langgraph" "nemoclaw" "strands" "claude-code")
+VALID_INTEGRATIONS=("litellm" "pydantic-ai" "crewai" "ag2" "ai-sdk" "chat" "openclaw" "langgraph" "nemoclaw" "strands" "claude-code")
 
 usage() {
     print_error "Usage: $0 <integration> <version>"


### PR DESCRIPTION
## Summary
- Remove unnecessary `pass` in `HindsightError` class
- Add `list[Callable]` return type annotations to `create_hindsight_tools()` and `register_hindsight_tools()`
- Use lazy `logger.error("...: %s", e)` formatting instead of f-strings
- Add `test-ag2-integration` CI job in `test.yml` (path-filtered, matching crewai/litellm pattern)
- Add `ag2` to `release-integration.sh` valid integrations list

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 40 unit tests pass (`uv run pytest tests -v`)
- [x] Pre-commit hooks pass
- [ ] CI `test-ag2-integration` job runs on this PR