### PR TITLE
fix(migration): use IF EXISTS when dropping chunk FK constraint

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/f6g7h8i9j0k1_chunk_fk_cascade_delete.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f6g7h8i9j0k1_chunk_fk_cascade_delete.py
@@ -31,8 +31,21 @@ def upgrade() -> None:
     # Use raw SQL with IF EXISTS so this is safe on schemas where the FK was
     # already dropped or never existed under this name.
     op.execute(f"ALTER TABLE {schema_prefix}memory_units DROP CONSTRAINT IF EXISTS memory_units_chunk_fkey")
-    op.create_foreign_key(
-        "memory_units_chunk_fkey", "memory_units", "chunks", ["chunk_id"], ["chunk_id"], ondelete="CASCADE"
+    # Use a DO block so the ADD is also idempotent: if the FK already exists (e.g.
+    # the schema was provisioned after the base migration already added it) the
+    # duplicate_object exception is swallowed rather than failing the migration.
+    op.execute(
+        f"""
+        DO $$ BEGIN
+            ALTER TABLE {schema_prefix}memory_units
+                ADD CONSTRAINT memory_units_chunk_fkey
+                FOREIGN KEY (chunk_id)
+                REFERENCES {schema_prefix}chunks (chunk_id)
+                ON DELETE CASCADE;
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
     )
 
 


### PR DESCRIPTION
## Summary

- The `f6g7h8i9j0k1` migration unconditionally drops `memory_units_chunk_fkey`, but depending on the migration history of a schema the constraint may not exist, causing new user signups to fail with a database error on first load
- Use raw SQL `DROP CONSTRAINT IF EXISTS` so the drop is safe regardless of schema state
- Retry succeeds because on the second attempt the constraint has been created by earlier migrations

## Impact

Currently hitting every new user signup in production — the error is visible on first page load after signup, and clears on retry.

## Test plan

- [ ] Verify new tenant schema provisioning succeeds without error
- [ ] Confirm existing schemas with the constraint upgrade cleanly