### PR TITLE
fix(codex): don't crash on startup when quota is exhausted (429)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -140,6 +140,10 @@ class CodexLLM(LLMInterface):
             )
             logger.info(f"Codex LLM verified: {self.model}")
         except Exception as e:
+            # 429 means quota exhausted, not a configuration error — warn but allow startup
+            if "429" in str(e) or "usage_limit_reached" in str(e):
+                logger.warning(f"Codex LLM quota exhausted for {self.model}, continuing startup: {e}")
+                return
             raise RuntimeError(f"Codex LLM connection verification failed for {self.model}: {e}") from e
 
     async def call(


### PR DESCRIPTION
## Problem

When the Codex usage limit is reached, `verify_connection()` receives a 429 response and raises a `RuntimeError`, which causes the entire server to refuse to start:

```
RuntimeError: Codex LLM connection verification failed for gpt-5.4: ...429 Too Many Requests
ERROR: Application startup failed. Exiting.
```

A quota limit is not a configuration error — the credentials are valid, the model is correct, there's just no budget left until the quota resets. The server should start normally and serve retain/recall requests; it just can't make LLM calls until the quota resets.

## Fix

Catch 429 / `usage_limit_reached` responses in `verify_connection()` and log a warning instead of raising, allowing startup to proceed.

## Tested

Verified locally: server starts and serves requests with quota exhausted. Retain/recall works; LLM-dependent operations (fact extraction, consolidation) fail gracefully per their own retry/error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)