### PR TITLE
fix(retain): inject retain_mission into verbose extraction mode

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -616,7 +616,7 @@ VERBOSE_FACT_EXTRACTION_PROMPT = """Extract facts from text into structured form
 
 LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL output in that EXACT same language. You are STRICTLY FORBIDDEN from translating or switching to any other language. Every single word of your output must be in the same language as the input. Do NOT output in a different language under any circumstance.
 
-══════════════════════════════════════════════════════════════════════════
+{retain_mission_section}══════════════════════════════════════════════════════════════════════════
 FACT FORMAT - ALL FIVE DIMENSIONS REQUIRED - MAXIMUM VERBOSITY
 ══════════════════════════════════════════════════════════════════════════
 
@@ -827,7 +827,9 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
                 custom_instructions=config.retain_custom_instructions,
             )
     elif extraction_mode == "verbose":
-        prompt = VERBOSE_FACT_EXTRACTION_PROMPT
+        prompt = VERBOSE_FACT_EXTRACTION_PROMPT.format(
+            retain_mission_section=retain_mission_section,
+        )
     elif extraction_mode == "verbatim":
         prompt = VERBATIM_FACT_EXTRACTION_PROMPT.format(
             retain_mission_section=retain_mission_section,

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -2612,11 +2612,11 @@ def test_retain_mission_injected_into_prompt():
     assert spec in prompt
     assert "FOCUS" in prompt
 
-    # retain_mission is present regardless of extraction mode (verbose has its own template, no spec injection)
+    # retain_mission is injected into verbose mode as well
     config.retain_extraction_mode = "verbose"
     prompt_verbose, _ = _build_extraction_prompt_and_schema(config)
-    # verbose uses its own template - spec not injected there
-    assert spec not in prompt_verbose
+    assert spec in prompt_verbose
+    assert "FOCUS" in prompt_verbose
 
 
 def test_retain_mission_absent_when_not_set():


### PR DESCRIPTION
## Summary

Closes #745

- Added `{retain_mission_section}` placeholder to `VERBOSE_FACT_EXTRACTION_PROMPT` template
- Changed verbose mode branch in `_build_extraction_prompt_and_schema()` to call `.format()` with `retain_mission_section`, matching concise/verbatim/custom modes
- Updated test to assert verbose mode now includes the mission

## Test plan

- [x] `test_retain_mission_injected_into_prompt` updated and passing — verifies mission appears in verbose prompt
- [x] `test_retain_mission_absent_when_not_set` still passing — verifies no FOCUS section when mission is unset
- [x] Lint passes