### PR TITLE
feat(api): add duration_ms to operation responses

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1600,8 +1600,9 @@ class OperationResponse(BaseModel):
                 "items_count": 5,
                 "document_id": None,
                 "created_at": "2024-01-15T10:30:00Z",
-                "status": "pending",
+                "status": "completed",
                 "error_message": None,
+                "duration_ms": 1530,
             }
         }
     )
@@ -1613,6 +1614,10 @@ class OperationResponse(BaseModel):
     created_at: str
     status: str
     error_message: str | None
+    duration_ms: int | None = Field(
+        default=None,
+        description="Server-computed duration in milliseconds (created_at → completed_at). Null if not yet completed.",
+    )
 
 
 class ConsolidationResponse(BaseModel):
@@ -1710,6 +1715,7 @@ class OperationStatusResponse(BaseModel):
                 "created_at": "2024-01-15T10:30:00Z",
                 "updated_at": "2024-01-15T10:31:30Z",
                 "completed_at": "2024-01-15T10:31:30Z",
+                "duration_ms": 90000,
                 "error_message": None,
             }
         }
@@ -1721,6 +1727,10 @@ class OperationStatusResponse(BaseModel):
     created_at: str | None = None
     updated_at: str | None = None
     completed_at: str | None = None
+    duration_ms: int | None = Field(
+        default=None,
+        description="Server-computed duration in milliseconds (created_at → completed_at). Null if not yet completed.",
+    )
     error_message: str | None = None
     result_metadata: dict[str, Any] | None = Field(
         default=None,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7174,7 +7174,7 @@ class MemoryEngine(MemoryEngineInterface):
             # Get operations with pagination (include result_metadata to check for parent operations)
             operations = await conn.fetch(
                 f"""
-                SELECT operation_id, operation_type, created_at, status, error_message, result_metadata
+                SELECT operation_id, operation_type, created_at, completed_at, status, error_message, result_metadata
                 FROM {fq_table("async_operations")}
                 WHERE {where_clause}
                 ORDER BY created_at DESC
@@ -7193,6 +7193,10 @@ class MemoryEngine(MemoryEngineInterface):
                 db_status = row["status"]
                 api_status = "pending" if db_status in ("pending", "processing") else db_status
 
+                duration_ms = None
+                if row["completed_at"] and row["created_at"]:
+                    duration_ms = int((row["completed_at"] - row["created_at"]).total_seconds() * 1000)
+
                 operation_list.append(
                     {
                         "id": str(row["operation_id"]),
@@ -7202,6 +7206,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "created_at": row["created_at"].isoformat(),
                         "status": api_status,
                         "error_message": row["error_message"],
+                        "duration_ms": duration_ms,
                     }
                 )
 
@@ -7318,6 +7323,10 @@ class MemoryEngine(MemoryEngineInterface):
                         )
                         api_status = correct_status
 
+                    duration_ms = None
+                    if row["completed_at"] and row["created_at"]:
+                        duration_ms = int((row["completed_at"] - row["created_at"]).total_seconds() * 1000)
+
                     return {
                         "operation_id": operation_id,
                         "status": api_status,
@@ -7325,12 +7334,17 @@ class MemoryEngine(MemoryEngineInterface):
                         "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                         "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
+                        "duration_ms": duration_ms,
                         "error_message": row["error_message"],
                         "result_metadata": result_metadata,
                         "child_operations": child_statuses,
                     }
                 else:
                     # Regular operation (not a parent)
+                    duration_ms = None
+                    if row["completed_at"] and row["created_at"]:
+                        duration_ms = int((row["completed_at"] - row["created_at"]).total_seconds() * 1000)
+
                     return {
                         "operation_id": operation_id,
                         "status": api_status,
@@ -7338,6 +7352,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                         "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
+                        "duration_ms": duration_ms,
                         "error_message": row["error_message"],
                         "result_metadata": result_metadata,
                     }

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -4388,9 +4388,10 @@ components:
       description: Response model for a single async operation.
       example:
         created_at: 2024-01-15T10:30:00Z
+        duration_ms: 1530
         id: 550e8400-e29b-41d4-a716-446655440000
         items_count: 5
-        status: pending
+        status: completed
         task_type: retain
       properties:
         id:
@@ -4414,6 +4415,9 @@ components:
         error_message:
           nullable: true
           type: string
+        duration_ms:
+          nullable: true
+          type: integer
       required:
       - created_at
       - error_message
@@ -4427,6 +4431,7 @@ components:
       example:
         completed_at: 2024-01-15T10:31:30Z
         created_at: 2024-01-15T10:30:00Z
+        duration_ms: 90000
         operation_id: 550e8400-e29b-41d4-a716-446655440000
         operation_type: refresh_mental_models
         status: completed
@@ -4455,6 +4460,9 @@ components:
         completed_at:
           nullable: true
           type: string
+        duration_ms:
+          nullable: true
+          type: integer
         error_message:
           nullable: true
           type: string

--- a/hindsight-clients/go/model_operation_response.go
+++ b/hindsight-clients/go/model_operation_response.go
@@ -28,6 +28,7 @@ type OperationResponse struct {
 	CreatedAt string `json:"created_at"`
 	Status string `json:"status"`
 	ErrorMessage NullableString `json:"error_message"`
+	DurationMs NullableInt32 `json:"duration_ms,omitempty"`
 }
 
 type _OperationResponse OperationResponse
@@ -243,6 +244,48 @@ func (o *OperationResponse) SetErrorMessage(v string) {
 	o.ErrorMessage.Set(&v)
 }
 
+// GetDurationMs returns the DurationMs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationResponse) GetDurationMs() int32 {
+	if o == nil || IsNil(o.DurationMs.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.DurationMs.Get()
+}
+
+// GetDurationMsOk returns a tuple with the DurationMs field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationResponse) GetDurationMsOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.DurationMs.Get(), o.DurationMs.IsSet()
+}
+
+// HasDurationMs returns a boolean if a field has been set.
+func (o *OperationResponse) HasDurationMs() bool {
+	if o != nil && o.DurationMs.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetDurationMs gets a reference to the given NullableInt32 and assigns it to the DurationMs field.
+func (o *OperationResponse) SetDurationMs(v int32) {
+	o.DurationMs.Set(&v)
+}
+// SetDurationMsNil sets the value for DurationMs to be an explicit nil
+func (o *OperationResponse) SetDurationMsNil() {
+	o.DurationMs.Set(nil)
+}
+
+// UnsetDurationMs ensures that no value is present for DurationMs, not even an explicit nil
+func (o *OperationResponse) UnsetDurationMs() {
+	o.DurationMs.Unset()
+}
+
 func (o OperationResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -262,6 +305,9 @@ func (o OperationResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["status"] = o.Status
 	toSerialize["error_message"] = o.ErrorMessage.Get()
+	if o.DurationMs.IsSet() {
+		toSerialize["duration_ms"] = o.DurationMs.Get()
+	}
 	return toSerialize, nil
 }
 

--- a/hindsight-clients/go/model_operation_status_response.go
+++ b/hindsight-clients/go/model_operation_status_response.go
@@ -27,6 +27,7 @@ type OperationStatusResponse struct {
 	CreatedAt NullableString `json:"created_at,omitempty"`
 	UpdatedAt NullableString `json:"updated_at,omitempty"`
 	CompletedAt NullableString `json:"completed_at,omitempty"`
+	DurationMs NullableInt32 `json:"duration_ms,omitempty"`
 	ErrorMessage NullableString `json:"error_message,omitempty"`
 	ResultMetadata map[string]interface{} `json:"result_metadata,omitempty"`
 	ChildOperations []ChildOperationStatus `json:"child_operations,omitempty"`
@@ -269,6 +270,48 @@ func (o *OperationStatusResponse) UnsetCompletedAt() {
 	o.CompletedAt.Unset()
 }
 
+// GetDurationMs returns the DurationMs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationStatusResponse) GetDurationMs() int32 {
+	if o == nil || IsNil(o.DurationMs.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.DurationMs.Get()
+}
+
+// GetDurationMsOk returns a tuple with the DurationMs field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationStatusResponse) GetDurationMsOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.DurationMs.Get(), o.DurationMs.IsSet()
+}
+
+// HasDurationMs returns a boolean if a field has been set.
+func (o *OperationStatusResponse) HasDurationMs() bool {
+	if o != nil && o.DurationMs.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetDurationMs gets a reference to the given NullableInt32 and assigns it to the DurationMs field.
+func (o *OperationStatusResponse) SetDurationMs(v int32) {
+	o.DurationMs.Set(&v)
+}
+// SetDurationMsNil sets the value for DurationMs to be an explicit nil
+func (o *OperationStatusResponse) SetDurationMsNil() {
+	o.DurationMs.Set(nil)
+}
+
+// UnsetDurationMs ensures that no value is present for DurationMs, not even an explicit nil
+func (o *OperationStatusResponse) UnsetDurationMs() {
+	o.DurationMs.Unset()
+}
+
 // GetErrorMessage returns the ErrorMessage field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *OperationStatusResponse) GetErrorMessage() string {
 	if o == nil || IsNil(o.ErrorMessage.Get()) {
@@ -400,6 +443,9 @@ func (o OperationStatusResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.CompletedAt.IsSet() {
 		toSerialize["completed_at"] = o.CompletedAt.Get()
+	}
+	if o.DurationMs.IsSet() {
+		toSerialize["duration_ms"] = o.DurationMs.Get()
 	}
 	if o.ErrorMessage.IsSet() {
 		toSerialize["error_message"] = o.ErrorMessage.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_response.py
@@ -33,7 +33,8 @@ class OperationResponse(BaseModel):
     created_at: StrictStr
     status: StrictStr
     error_message: Optional[StrictStr]
-    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "created_at", "status", "error_message"]
+    duration_ms: Optional[StrictInt] = None
+    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "created_at", "status", "error_message", "duration_ms"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -84,6 +85,11 @@ class OperationResponse(BaseModel):
         if self.error_message is None and "error_message" in self.model_fields_set:
             _dict['error_message'] = None
 
+        # set to None if duration_ms (nullable) is None
+        # and model_fields_set contains the field
+        if self.duration_ms is None and "duration_ms" in self.model_fields_set:
+            _dict['duration_ms'] = None
+
         return _dict
 
     @classmethod
@@ -102,7 +108,8 @@ class OperationResponse(BaseModel):
             "document_id": obj.get("document_id"),
             "created_at": obj.get("created_at"),
             "status": obj.get("status"),
-            "error_message": obj.get("error_message")
+            "error_message": obj.get("error_message"),
+            "duration_ms": obj.get("duration_ms")
         })
         return _obj
 

--- a/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.child_operation_status import ChildOperationStatus
 from typing import Optional, Set
@@ -33,10 +33,11 @@ class OperationStatusResponse(BaseModel):
     created_at: Optional[StrictStr] = None
     updated_at: Optional[StrictStr] = None
     completed_at: Optional[StrictStr] = None
+    duration_ms: Optional[StrictInt] = None
     error_message: Optional[StrictStr] = None
     result_metadata: Optional[Dict[str, Any]] = None
     child_operations: Optional[List[ChildOperationStatus]] = None
-    __properties: ClassVar[List[str]] = ["operation_id", "status", "operation_type", "created_at", "updated_at", "completed_at", "error_message", "result_metadata", "child_operations"]
+    __properties: ClassVar[List[str]] = ["operation_id", "status", "operation_type", "created_at", "updated_at", "completed_at", "duration_ms", "error_message", "result_metadata", "child_operations"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -111,6 +112,11 @@ class OperationStatusResponse(BaseModel):
         if self.completed_at is None and "completed_at" in self.model_fields_set:
             _dict['completed_at'] = None
 
+        # set to None if duration_ms (nullable) is None
+        # and model_fields_set contains the field
+        if self.duration_ms is None and "duration_ms" in self.model_fields_set:
+            _dict['duration_ms'] = None
+
         # set to None if error_message (nullable) is None
         # and model_fields_set contains the field
         if self.error_message is None and "error_message" in self.model_fields_set:
@@ -144,6 +150,7 @@ class OperationStatusResponse(BaseModel):
             "created_at": obj.get("created_at"),
             "updated_at": obj.get("updated_at"),
             "completed_at": obj.get("completed_at"),
+            "duration_ms": obj.get("duration_ms"),
             "error_message": obj.get("error_message"),
             "result_metadata": obj.get("result_metadata"),
             "child_operations": [ChildOperationStatus.from_dict(_item) for _item in obj["child_operations"]] if obj.get("child_operations") is not None else None

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1385,6 +1385,12 @@ export type OperationResponse = {
    * Error Message
    */
   error_message: string | null;
+  /**
+   * Duration Ms
+   *
+   * Server-computed duration in milliseconds (created_at → completed_at). Null if not yet completed.
+   */
+  duration_ms?: number | null;
 };
 
 /**
@@ -1417,6 +1423,12 @@ export type OperationStatusResponse = {
    * Completed At
    */
   completed_at?: string | null;
+  /**
+   * Duration Ms
+   *
+   * Server-computed duration in milliseconds (created_at → completed_at). Null if not yet completed.
+   */
+  duration_ms?: number | null;
   /**
    * Error Message
    */

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -6632,6 +6632,18 @@
               }
             ],
             "title": "Error Message"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms",
+            "description": "Server-computed duration in milliseconds (created_at \u2192 completed_at). Null if not yet completed."
           }
         },
         "type": "object",
@@ -6647,9 +6659,10 @@
         "description": "Response model for a single async operation.",
         "example": {
           "created_at": "2024-01-15T10:30:00Z",
+          "duration_ms": 1530,
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "items_count": 5,
-          "status": "pending",
+          "status": "completed",
           "task_type": "retain"
         }
       },
@@ -6713,6 +6726,18 @@
             ],
             "title": "Completed At"
           },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms",
+            "description": "Server-computed duration in milliseconds (created_at \u2192 completed_at). Null if not yet completed."
+          },
           "error_message": {
             "anyOf": [
               {
@@ -6763,6 +6788,7 @@
         "example": {
           "completed_at": "2024-01-15T10:31:30Z",
           "created_at": "2024-01-15T10:30:00Z",
+          "duration_ms": 90000,
           "operation_id": "550e8400-e29b-41d4-a716-446655440000",
           "operation_type": "refresh_mental_models",
           "status": "completed",


### PR DESCRIPTION
## Summary
- Adds server-computed `duration_ms` (integer, milliseconds) to `OperationResponse` and `OperationStatusResponse`
- Computed from `created_at → completed_at`; `null` for in-progress or not-found operations
- No DB migration needed — purely derived from existing columns
- Regenerated OpenAPI spec and all client SDKs (Python, TypeScript, Go)

Closes #749

## Test plan
- [ ] Start API, run a retain, then `GET /operations` — completed ops should have `duration_ms` set
- [ ] `GET /operations/{id}` on a pending op returns `duration_ms: null`
- [ ] `GET /operations/{id}` on a completed op returns correct ms value