### PR TITLE
feat: add configurable base URL for ZeroEntropy reranker

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -226,6 +226,7 @@ ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
 # ZeroEntropy configuration (reranker only)
 ENV_RERANKER_ZEROENTROPY_API_KEY = "HINDSIGHT_API_RERANKER_ZEROENTROPY_API_KEY"
 ENV_RERANKER_ZEROENTROPY_MODEL = "HINDSIGHT_API_RERANKER_ZEROENTROPY_MODEL"
+ENV_RERANKER_ZEROENTROPY_BASE_URL = "HINDSIGHT_API_RERANKER_ZEROENTROPY_BASE_URL"
 
 ENV_VECTOR_EXTENSION = "HINDSIGHT_API_VECTOR_EXTENSION"
 ENV_TEXT_SEARCH_EXTENSION = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION"
@@ -720,6 +721,7 @@ class HindsightConfig:
     reranker_litellm_sdk_api_base: str | None
     reranker_zeroentropy_api_key: str | None
     reranker_zeroentropy_model: str
+    reranker_zeroentropy_base_url: str | None
 
     # Server
     host: str
@@ -865,6 +867,7 @@ class HindsightConfig:
         "embeddings_tei_base_url",
         "reranker_tei_base_url",
         "reranker_cohere_base_url",
+        "reranker_zeroentropy_base_url",
         # Service Account Keys
         "llm_vertexai_service_account_key",
         # File storage credentials
@@ -1188,6 +1191,7 @@ class HindsightConfig:
             # ZeroEntropy reranker
             reranker_zeroentropy_api_key=os.getenv(ENV_RERANKER_ZEROENTROPY_API_KEY),
             reranker_zeroentropy_model=os.getenv(ENV_RERANKER_ZEROENTROPY_MODEL, DEFAULT_RERANKER_ZEROENTROPY_MODEL),
+            reranker_zeroentropy_base_url=os.getenv(ENV_RERANKER_ZEROENTROPY_BASE_URL) or None,
             # Server
             host=os.getenv(ENV_HOST, DEFAULT_HOST),
             port=int(os.getenv(ENV_PORT, DEFAULT_PORT)),

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -629,12 +629,14 @@ class ZeroEntropyCrossEncoder(CrossEncoderModel):
     See: https://docs.zeroentropy.dev/models
     """
 
-    RERANK_URL = "https://api.zeroentropy.dev/v1/models/rerank"
+    DEFAULT_BASE_URL = "https://api.zeroentropy.dev"
+    RERANK_PATH = "/v1/models/rerank"
 
     def __init__(
         self,
         api_key: str,
         model: str = DEFAULT_RERANKER_ZEROENTROPY_MODEL,
+        base_url: str | None = None,
         timeout: float = 60.0,
     ):
         """
@@ -643,10 +645,13 @@ class ZeroEntropyCrossEncoder(CrossEncoderModel):
         Args:
             api_key: ZeroEntropy API key
             model: ZeroEntropy rerank model name (default: zerank-2)
+            base_url: Custom base URL for ZeroEntropy-compatible API (e.g., mock server or proxy)
             timeout: Request timeout in seconds (default: 60.0)
         """
         self.api_key = api_key
         self.model = model
+        self.base_url = base_url.rstrip("/") if base_url else self.DEFAULT_BASE_URL
+        self.rerank_url = f"{self.base_url}{self.RERANK_PATH}"
         self.timeout = timeout
         self._async_client: httpx.AsyncClient | None = None
 


### PR DESCRIPTION
## Problem

The ZeroEntropy reranker provider has a hardcoded API URL (`https://api.zeroentropy.dev/v1/models/rerank`). This prevents pointing the reranker at a mock server or proxy for testing, which other providers (Cohere, TEI, OpenAI) support via `BASE_URL` configuration.

## Fix

Add `HINDSIGHT_API_RERANKER_ZEROENTROPY_BASE_URL` environment variable, following the existing pattern from the Cohere reranker provider. When set, the ZeroEntropy reranker constructs the URL as `{base_url}/v1/models/rerank` instead of the hardcoded default.

This enables:
- Mock/proxy testing with tools like llmock
- Self-hosted ZeroEntropy deployments
- Consistent configuration pattern across all reranker providers

## Changes

- `config.py`: Add `ENV_RERANKER_ZEROENTROPY_BASE_URL` constant and read it in the reranker factory
- `cross_encoder.py`: Accept optional `base_url` in `ZeroEntropyCrossEncoder.__init__`, construct rerank URL from it