### PR TITLE
Update MCP OAuth blog post date to March 30

### DIFF
--- a/hindsight-docs/blog/2026-03-30-mcp-oauth-native.md
+++ b/hindsight-docs/blog/2026-03-30-mcp-oauth-native.md
@@ -1,7 +1,7 @@
 ---
 title: "What's New in Hindsight Cloud: Native OAuth for MCP Clients"
 authors: [hindsight]
-date: 2026-03-27T12:00
+date: 2026-03-30T12:00
 tags: [hindsight-cloud, release, mcp, oauth, claude-code, cursor, windsurf]
 description: "Hindsight Cloud now supports native OAuth 2.1 for MCP clients. Connect Claude Code, Cursor, Windsurf, and ChatGPT directly with no API keys required."
 image: /img/blog/hindsight-cloud-mcp-oauth.png


### PR DESCRIPTION
## Summary
- Renames `2026-03-27-mcp-oauth-native.md` → `2026-03-30-mcp-oauth-native.md`
- Updates `date:` frontmatter from `2026-03-27T12:00` to `2026-03-30T12:00`

Depends on #731 merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)