### PR TITLE
fix(docs): use tools=[] in BaseMemory example

### DIFF
--- a/hindsight-docs/docs/sdks/integrations/llamaindex.md
+++ b/hindsight-docs/docs/sdks/integrations/llamaindex.md
@@ -37,7 +37,7 @@ async def main():
         mission="Track user preferences and project context",
     )
 
-    agent = ReActAgent(tools=tools, llm=OpenAI(model="gpt-4o"), memory=memory)
+    agent = ReActAgent(tools=[], llm=OpenAI(model="gpt-4o"), memory=memory)
     response = await agent.run("Remember that I prefer dark mode")
     print(response)
 


### PR DESCRIPTION
## Summary

- Fix undefined `tools` variable in the LlamaIndex docs BaseMemory example
- The automatic memory pattern doesn't need tools — `HindsightMemory` handles retain/recall transparently, so `tools=[]` is correct

## Test plan

- [x] Verify the code snippet is valid Python with `tools=[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)