### PR TITLE
Fix trailing commas in openclaw plugin manifest

### DIFF
--- a/hindsight-integrations/claude-code/tests/test_manifest.py
+++ b/hindsight-integrations/claude-code/tests/test_manifest.py
@@ -1,0 +1,14 @@
+"""Validate that JSON manifests are strict-valid JSON (no trailing commas, etc.)."""
+
+import json
+from pathlib import Path
+
+INTEGRATION_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_hooks_json_is_valid():
+    path = INTEGRATION_ROOT / "hooks" / "hooks.json"
+    raw = path.read_text()
+    parsed = json.loads(raw)
+    assert "hooks" in parsed
+    assert isinstance(parsed["hooks"], dict)

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -215,7 +215,7 @@
         "type": "number",
         "description": "Interval in ms to batch retain/recall log summaries. 0 = log every event individually. Default: 300000 (5 min).",
         "default": 300000
-      },
+      }
     },
     "additionalProperties": false
   },
@@ -349,6 +349,6 @@
     "logSummaryIntervalMs": {
       "label": "Log Summary Interval (ms)",
       "placeholder": "300000"
-    },
+    }
   }
 }

--- a/hindsight-integrations/openclaw/src/manifest.test.ts
+++ b/hindsight-integrations/openclaw/src/manifest.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const manifestPath = resolve(__dirname, '..', 'openclaw.plugin.json');
+
+describe('openclaw.plugin.json', () => {
+  it('is valid JSON', () => {
+    const raw = readFileSync(manifestPath, 'utf-8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it('has required top-level fields', () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.id).toBe('hindsight-openclaw');
+    expect(manifest.name).toBeTypeOf('string');
+    expect(manifest.configSchema).toBeDefined();
+    expect(manifest.configSchema.properties).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes two trailing commas in `openclaw.plugin.json` that caused OpenClaw's strict JSON parser to reject the manifest during `openclaw plugins install` (line 219 and 353)
- Adds JSON manifest validation tests for openclaw (vitest) and claude-code (pytest) integrations so CI catches invalid JSON before release

Fixes #771

## Test plan
- [x] `python3 -m json.tool openclaw.plugin.json` validates cleanly
- [x] `npx vitest run src/manifest.test.ts` passes (openclaw)
- [x] `python -m pytest tests/test_manifest.py` passes (claude-code)
- [ ] CI passes for `build-openclaw-integration` and `test-claude-code-integration` jobs