### PR TITLE
fix(codex): merge new settings on upgrade instead of skipping

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -704,7 +704,7 @@ class ZeroEntropyCrossEncoder(CrossEncoderModel):
             indices = [idx for idx, _ in indexed_texts]
 
             response = await self._async_client.post(
-                self.RERANK_URL,
+                self.rerank_url,
                 json={
                     "model": self.model,
                     "query": query,

--- a/hindsight-docs/static/get-codex
+++ b/hindsight-docs/static/get-codex
@@ -210,13 +210,43 @@ chmod +x "${SCRIPTS_DIR}/retain.py"
 
 print_success "Scripts installed to ${SCRIPTS_DIR}"
 
-# Step 4: Download default settings (don't overwrite existing)
+# Step 4: Download default settings (don't overwrite existing, but update version)
 SETTINGS_DST="${INSTALL_DIR}/settings.json"
 if [ ! -f "${SETTINGS_DST}" ]; then
     download_file "${GITHUB_RAW}/settings.json" "${SETTINGS_DST}"
     print_success "Default settings written to ${SETTINGS_DST}"
 else
-    print_info "Keeping existing settings at ${SETTINGS_DST}"
+    # Merge version and any new keys from upstream into existing settings
+    SETTINGS_TMP="${INSTALL_DIR}/settings.json.new"
+    download_file "${GITHUB_RAW}/settings.json" "${SETTINGS_TMP}"
+    if command -v python3 &> /dev/null; then
+        python3 -c "
+import json, sys
+with open('${SETTINGS_DST}') as f:
+    existing = json.load(f)
+with open('${SETTINGS_TMP}') as f:
+    upstream = json.load(f)
+# Add new keys from upstream (don't overwrite user customizations)
+for key, value in upstream.items():
+    if key not in existing:
+        existing[key] = value
+# Always update version
+existing['version'] = upstream.get('version', existing.get('version', ''))
+with open('${SETTINGS_DST}', 'w') as f:
+    json.dump(existing, f, indent=2)
+    f.write('\n')
+" 2>/dev/null && {
+            rm -f "${SETTINGS_TMP}"
+            NEW_VER=$(python3 -c "import json; print(json.load(open('${SETTINGS_DST}'))['version'])" 2>/dev/null)
+            print_success "Settings updated (v${NEW_VER}), user customizations preserved"
+        } || {
+            rm -f "${SETTINGS_TMP}"
+            print_info "Keeping existing settings at ${SETTINGS_DST}"
+        }
+    else
+        rm -f "${SETTINGS_TMP}"
+        print_info "Keeping existing settings at ${SETTINGS_DST}"
+    fi
 fi
 
 # Step 5: Configure connection


### PR DESCRIPTION
## Summary

- The codex installer skipped `settings.json` entirely if it already existed, leaving `version` and new config keys (like `retainToolCalls`) stale on upgrades
- Now merges upstream settings into existing: updates `version`, adds new keys, preserves user customizations
- Also fixes pre-existing typo `RERANK_URL` → `rerank_url` in ZeroEntropy cross-encoder

## Test plan
- [x] Verified merge logic preserves user customizations while updating version and adding new keys
- [ ] Manual test: install codex, modify settings, reinstall — verify version bumped and customizations preserved