### PR TITLE
fix(gemini): thought_signature read from wrong object and type in gemini 3.1+ tool calls

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -7,6 +7,7 @@ This provider supports both:
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -472,9 +473,10 @@ class GeminiLLM(LLMInterface):
                         fn_args = parse_llm_json(fn_args_str)
                         thought_signature = tc.get("thought_signature")
                         fc_kwargs: dict[str, Any] = {"name": fn_name, "args": fn_args}
+                        part_kwargs: dict[str, Any] = {"function_call": genai_types.FunctionCall(**fc_kwargs)}
                         if thought_signature:
-                            fc_kwargs["thought_signature"] = thought_signature
-                        parts.append(genai_types.Part(function_call=genai_types.FunctionCall(**fc_kwargs)))
+                            part_kwargs["thought_signature"] = base64.b64decode(thought_signature)
+                        parts.append(genai_types.Part(**part_kwargs))
                     gemini_contents.append(genai_types.Content(role="model", parts=parts))
                 else:
                     gemini_contents.append(genai_types.Content(role="model", parts=[genai_types.Part(text=content)]))
@@ -547,7 +549,10 @@ class GeminiLLM(LLMInterface):
                                 content = part.text
                             if hasattr(part, "function_call") and part.function_call:
                                 fc = part.function_call
-                                thought_signature = getattr(fc, "thought_signature", None)
+                                _raw_ts = getattr(part, "thought_signature", None)
+                                thought_signature = (
+                                    base64.b64encode(_raw_ts).decode("ascii") if isinstance(_raw_ts, bytes) else _raw_ts
+                                )
                                 tool_calls.append(
                                     LLMToolCall(
                                         id=f"gemini_{len(tool_calls)}",


### PR DESCRIPTION
## Summary

  The reflect agent failed with `400 INVALID_ARGUMENT`: Function call is missing a thought_signature with `gemini-3.1-flash-lite-preview` model during iteration 2+ of tool-calling loops.

  Root causes in `gemini_llm.py`:
  - Wrong object: `thought_signature` was read from `FunctionCall` but Gemini returns it on `Part`
  - Wrong type: SDK returns `thought_signature` as `bytes`, but `LLMToolCall` stores `str`
  - Wrong reconstruction: history rebuild passed `thought_signature` to `FunctionCall()` (which rejects it) instead of
  setting it on `Part`

  Fix reads `thought_signature` from `Part`, `base64.b64encode`→`str` for storage, and `base64.b64decode` →`bytes` when
  reconstructing `Part` for subsequent turns.
## Bug Reproduction

  1. Start Hindsight with `gemini-3.1-flash-lite-preview`
  2. Create any bank with data, then:
  3. `client.reflect(bank_id="my-bank", query="anything")`
    → Works on first iteration (no history to reconstruct)
    → Fails on iteration 2 with `thought_signature` error
  Adding mental models makes it 100% reproducible since reflect always calls search_mental_models tool.

##  Test plan
  - [x] Extraction: thought_signature captured from Part and stored as base64 str
  - [x] History reconstruction: tool call history with thought_signature doesn't crash
  - [x] End-to-end: 2-iteration tool call round trip (extract → reconstruct → respond)
  - [x] test_llm_provider_api_methods[gemini-gemini-3.1-flash-lite-preview] passes
  - [x] test_llm_provider_memory_operations[gemini-gemini-3.1-flash-lite-preview] passes
  - [x] Tested across different google-genai versions 1.53.0, 1.59.0, 1.67.0, 1.68.0 — all pass