### PR TITLE
feat: track retrieval frequency on memory units

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/f6a7b8c9d0e1_add_access_count_to_memory_units.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/f6a7b8c9d0e1_add_access_count_to_memory_units.py
@@ -1,0 +1,46 @@
+"""Add access_count column to memory_units for retrieval frequency tracking
+
+Tracks how many times a memory unit has been retrieved via user-facing recall
+operations.  System/maintenance operations (reflect, consolidation) do NOT
+increment the counter.
+
+Revision ID: f6a7b8c9d0e1
+Revises: c2d3e4f5g6h7, c5d6e7f8a9b0, a2b3c4d5e6f8
+Create Date: 2026-03-31
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: str | Sequence[str] | None = ("c2d3e4f5g6h7", "c5d6e7f8a9b0", "a2b3c4d5e6f8")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def upgrade() -> None:
+    schema = _get_schema_prefix()
+
+    # Add access_count column (default 0, NOT NULL)
+    op.execute(
+        f"ALTER TABLE {schema}memory_units "
+        f"ADD COLUMN IF NOT EXISTS access_count INTEGER NOT NULL DEFAULT 0"
+    )
+
+    # Index for sorting/filtering by retrieval frequency
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_memory_units_access_count "
+        f"ON {schema}memory_units (access_count DESC)"
+    )
+
+
+def downgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_access_count")
+    op.execute(f"ALTER TABLE {schema}memory_units DROP COLUMN IF EXISTS access_count")

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -225,6 +225,7 @@ class RecallResult(BaseModel):
     source_fact_ids: list[str] | None = (
         None  # IDs of source facts (observation type only, when source_facts is enabled)
     )
+    access_count: int | None = None  # Number of user-facing recall retrievals
 
 
 class EntityObservationResponse(BaseModel):
@@ -2548,6 +2549,7 @@ def _register_routes(app: FastAPI):
                     chunk_id=fact.chunk_id,
                     tags=fact.tags,
                     source_fact_ids=fact.source_fact_ids,
+                    access_count=fact.access_count,
                 )
 
             recall_results = [_fact_to_result(fact) for fact in core_result.results]

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2635,6 +2635,26 @@ class MemoryEngine(MemoryEngineInterface):
                 except Exception as e:
                     logger.warning(f"Post-recall hook error (non-fatal): {e}")
 
+            # Increment access_count for user-facing recall results (not internal operations).
+            # Internal operations (reflect, consolidation) pass _quiet=True to suppress logging
+            # and should not inflate retrieval frequency metrics.
+            if not _quiet and result is not None and result.results:
+                memory_ids = [uuid.UUID(fact.id) for fact in result.results]
+                try:
+                    pool = await self._get_pool()
+                    async with acquire_with_retry(pool) as conn:
+                        await conn.execute(
+                            f"""
+                            UPDATE {fq_table("memory_units")}
+                            SET access_count = access_count + 1
+                            WHERE id = ANY($1::uuid[])
+                            """,
+                            memory_ids,
+                        )
+                except Exception as e:
+                    # Non-fatal: log and continue — recall results are still valid
+                    logger.warning(f"Failed to increment access_count: {e}")
+
             return result
         finally:
             recall_span_context.__exit__(None, None, None)
@@ -3354,6 +3374,25 @@ class MemoryEngine(MemoryEngineInterface):
                                 {"entity_id": str(row["entity_id"]), "canonical_name": row["canonical_name"]}
                             )
 
+            # Fetch access_count for final results (single batch query)
+            access_count_map: dict[str, int] = {}
+            if top_scored:
+                unit_ids_for_access = [uuid.UUID(sr.id) for sr in top_scored]
+                try:
+                    async with acquire_with_retry(pool) as ac_conn:
+                        ac_rows = await ac_conn.fetch(
+                            f"""
+                            SELECT id, access_count
+                            FROM {fq_table("memory_units")}
+                            WHERE id = ANY($1::uuid[])
+                            """,
+                            unit_ids_for_access,
+                        )
+                        for r in ac_rows:
+                            access_count_map[str(r["id"])] = r["access_count"]
+                except Exception:
+                    pass  # Non-fatal: access_count will be None in response
+
             # Convert results to MemoryFact objects
             memory_facts = []
             for result_dict in top_results_dicts:
@@ -3378,6 +3417,7 @@ class MemoryEngine(MemoryEngineInterface):
                         chunk_id=result_dict.get("chunk_id"),
                         tags=result_dict.get("tags"),
                         source_fact_ids=source_fact_ids_by_obs.get(result_id) if include_source_facts else None,
+                        access_count=access_count_map.get(result_id),
                     )
                 )
 
@@ -4553,7 +4593,7 @@ class MemoryEngine(MemoryEngineInterface):
 
             units = await conn.fetch(
                 f"""
-                SELECT id, text, event_date, context, fact_type, mentioned_at, occurred_start, occurred_end, chunk_id, proof_count, tags
+                SELECT id, text, event_date, context, fact_type, mentioned_at, occurred_start, occurred_end, chunk_id, proof_count, tags, access_count
                 FROM {fq_table("memory_units")}
                 {where_clause}
                 ORDER BY mentioned_at DESC NULLS LAST, created_at DESC
@@ -4607,6 +4647,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "chunk_id": row["chunk_id"] if row["chunk_id"] else None,
                         "proof_count": row["proof_count"] if row["proof_count"] is not None else 1,
                         "tags": list(row["tags"]) if row["tags"] else [],
+                        "access_count": row["access_count"],
                     }
                 )
 
@@ -4642,7 +4683,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, text, context, event_date, occurred_start, occurred_end,
                        mentioned_at, fact_type, document_id, chunk_id, tags, source_memory_ids,
-                       observation_scopes
+                       observation_scopes, access_count
                 FROM {fq_table("memory_units")}
                 WHERE id = $1 AND bank_id = $2
                 """,
@@ -4692,6 +4733,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "chunk_id": str(row["chunk_id"]) if row["chunk_id"] else None,
                 "tags": row["tags"] if row["tags"] else [],
                 "observation_scopes": row["observation_scopes"] if row["observation_scopes"] else None,
+                "access_count": row["access_count"],
             }
 
             # For observations, include source_memory_ids

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -180,6 +180,10 @@ class MemoryFact(BaseModel):
         None,
         description="IDs of source facts this observation was derived from (observation type only, when source_facts is enabled)",
     )
+    access_count: int | None = Field(
+        None,
+        description="Number of times this memory has been retrieved via user-facing recall operations",
+    )
 
 
 class ChunkInfo(BaseModel):

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -104,6 +104,7 @@ class MemoryUnit(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
+    access_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
     # Relationships
     document = relationship("Document", back_populates="memory_units")
     unit_entities = relationship("UnitEntity", back_populates="memory_unit", cascade="all, delete-orphan")
@@ -169,6 +170,7 @@ class MemoryUnit(Base):
             postgresql_using="hnsw",
             postgresql_ops={"embedding": "vector_cosine_ops"},
         ),
+        Index("idx_memory_units_access_count", "access_count", postgresql_ops={"access_count": "DESC"}),
     )
 
 

--- a/hindsight-api-slim/tests/test_access_count.py
+++ b/hindsight-api-slim/tests/test_access_count.py
@@ -1,0 +1,165 @@
+"""
+Tests for retrieval frequency tracking (access_count) feature.
+
+Tests the response model, migration structure, and API response format
+for the access_count field on memory units.
+"""
+
+import importlib
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+
+class TestAccessCountResponseModels:
+    """Test access_count is properly defined in response models."""
+
+    def test_memory_fact_has_access_count_field(self):
+        """MemoryFact core model should have access_count field."""
+        from hindsight_api.engine.response_models import MemoryFact
+
+        # Create a MemoryFact with access_count
+        fact = MemoryFact(
+            id="test-id",
+            text="some memory",
+            fact_type="world",
+            access_count=5,
+        )
+        assert fact.access_count == 5
+
+    def test_memory_fact_access_count_defaults_to_none(self):
+        """access_count should default to None when not provided."""
+        from hindsight_api.engine.response_models import MemoryFact
+
+        fact = MemoryFact(
+            id="test-id",
+            text="some memory",
+            fact_type="world",
+        )
+        assert fact.access_count is None
+
+    def test_memory_fact_access_count_in_json_schema(self):
+        """access_count should appear in the JSON schema."""
+        from hindsight_api.engine.response_models import MemoryFact
+
+        schema = MemoryFact.model_json_schema()
+        assert "access_count" in schema["properties"]
+        prop = schema["properties"]["access_count"]
+        assert "integer" in str(prop.get("anyOf", prop.get("type", "")))
+
+    def test_memory_fact_serialization_includes_access_count(self):
+        """access_count should be included in model_dump output."""
+        from hindsight_api.engine.response_models import MemoryFact
+
+        fact = MemoryFact(
+            id="test-id",
+            text="some memory",
+            fact_type="world",
+            access_count=42,
+        )
+        dumped = fact.model_dump()
+        assert dumped["access_count"] == 42
+
+    def test_memory_fact_serialization_includes_null_access_count(self):
+        """access_count=None should still be present in serialized output."""
+        from hindsight_api.engine.response_models import MemoryFact
+
+        fact = MemoryFact(
+            id="test-id",
+            text="some memory",
+            fact_type="world",
+        )
+        dumped = fact.model_dump()
+        assert "access_count" in dumped
+        assert dumped["access_count"] is None
+
+
+class TestAccessCountAPIModel:
+    """Test access_count in the HTTP API response model."""
+
+    def test_api_recall_result_has_access_count(self):
+        """HTTP API RecallResult should have access_count field."""
+        from hindsight_api.api.http import RecallResult
+
+        result = RecallResult(
+            id="test-id",
+            text="some memory",
+            type="world",
+            access_count=10,
+        )
+        assert result.access_count == 10
+
+    def test_api_recall_result_access_count_defaults_to_none(self):
+        """HTTP API RecallResult access_count should default to None."""
+        from hindsight_api.api.http import RecallResult
+
+        result = RecallResult(
+            id="test-id",
+            text="some memory",
+            type="world",
+        )
+        assert result.access_count is None
+
+
+class TestAccessCountMigration:
+    """Test the migration file structure."""
+
+    def test_migration_file_exists(self):
+        """Migration file for access_count should exist."""
+        migration_dir = (
+            Path(__file__).parent.parent
+            / "hindsight_api"
+            / "alembic"
+            / "versions"
+        )
+        migration_file = migration_dir / "f6a7b8c9d0e1_add_access_count_to_memory_units.py"
+        assert migration_file.exists(), f"Migration file not found: {migration_file}"
+
+    def test_migration_has_correct_revision(self):
+        """Migration should have the expected revision ID."""
+        from hindsight_api.alembic.versions.f6a7b8c9d0e1_add_access_count_to_memory_units import (
+            revision,
+            down_revision,
+        )
+
+        assert revision == "f6a7b8c9d0e1"
+        # Should depend on existing heads (merge migration)
+        assert isinstance(down_revision, (tuple, list))
+
+    def test_migration_has_upgrade_and_downgrade(self):
+        """Migration should have both upgrade() and downgrade() functions."""
+        from hindsight_api.alembic.versions import (
+            f6a7b8c9d0e1_add_access_count_to_memory_units as migration,
+        )
+
+        assert hasattr(migration, "upgrade")
+        assert hasattr(migration, "downgrade")
+        assert callable(migration.upgrade)
+        assert callable(migration.downgrade)
+
+
+class TestAccessCountORMModel:
+    """Test access_count in the SQLAlchemy ORM model."""
+
+    def test_memory_unit_model_has_access_count(self):
+        """MemoryUnit ORM model should have access_count column."""
+        from hindsight_api.models import MemoryUnit
+
+        # Check the column exists in the model
+        assert hasattr(MemoryUnit, "access_count")
+
+    def test_memory_unit_access_count_column_properties(self):
+        """access_count column should have correct properties."""
+        from hindsight_api.models import MemoryUnit
+
+        col = MemoryUnit.__table__.columns["access_count"]
+        assert not col.nullable
+        assert str(col.server_default.arg) in ("0", "'0'")
+
+    def test_memory_unit_has_access_count_index(self):
+        """MemoryUnit should have an index on access_count."""
+        from hindsight_api.models import MemoryUnit
+
+        index_names = [idx.name for idx in MemoryUnit.__table__.indexes]
+        assert "idx_memory_units_access_count" in index_names


### PR DESCRIPTION
## Summary

Adds retrieval frequency tracking to memory units by re-introducing the `access_count` column with actual increment logic.

Closes #793

## Changes

### Migration (`f6a7b8c9d0e1`)
- Adds `access_count INTEGER NOT NULL DEFAULT 0` to `memory_units`
- Creates `idx_memory_units_access_count` (DESC) for efficient sorting/filtering
- Merge migration depending on all three current heads

### ORM Model
- Adds `access_count` field to `MemoryUnit` with `server_default='0'`
- Adds corresponding index definition in `__table_args__`

### Increment Logic
- After successful `recall_async()`, batch-increments `access_count` for all returned memory IDs in a single UPDATE
- **Only user-facing recalls** trigger increment — internal operations (reflect tool calls, consolidation) pass `_quiet=True` and are excluded
- Increment is fire-and-forget: failures are logged but don't affect the recall response

### API Exposure
- `access_count` exposed in:
  - `MemoryFact` (core response model)
  - `RecallResult` (HTTP API)
  - `list_memory_units` response
  - `get_memory_unit` response
  - MCP tools (via `model_dump()` serialization)
- Returns `null` if the fetch fails (graceful degradation)

### What increments vs. what doesn't

| Caller | Increments? | Why |
|---|---|---|
| POST /recall (user API) | ✅ | User-facing retrieval |
| MCP recall tool (user) | ✅ | User-facing retrieval |
| Reflect tool `recall_fn` | ❌ | Internal (`_quiet=True`) |
| Reflect tool `search_observations` | ❌ | Internal (`_quiet=True`) |
| Consolidation recall | ❌ | Internal (`_quiet=True`) |

### Tests
- 13 unit tests covering response models, API model, migration structure, and ORM model properties
- Existing SQL schema safety test passes (all new SQL uses `fq_table()`)

## Design Notes

- The `access_count` in recall results reflects the count **before** the current retrieval's increment (read happens before write in the pipeline)
- The `_quiet` flag was chosen as the signal for internal operations because it's already consistently used by all internal callers (reflect, consolidation). This avoids adding a new parameter to `recall_async()`

---

> [!NOTE]
> This PR was authored with AI assistance (Kagura/Claude).