### PR TITLE
feat: add DELETE endpoint for individual memory units

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1374,8 +1374,18 @@ class DeleteResponse(BaseModel):
 class DeleteMemoryUnitResponse(BaseModel):
     """Response model for deleting a single memory unit."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "success": True,
+                "memory_id": "abc123",
+                "message": "Memory unit and all its links deleted successfully",
+            }
+        }
+    )
+
     success: bool
-    unit_id: str | None = None
+    memory_id: str | None = None
     message: str | None = None
 
 
@@ -2437,13 +2447,27 @@ def _register_routes(app: FastAPI):
     ):
         """Delete a single memory unit by ID."""
         try:
+            import uuid as _uuid
+
+            try:
+                _uuid.UUID(memory_id)
+            except ValueError:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid memory_id format: '{memory_id}' is not a valid UUID"
+                )
+
             result = await app.state.memory.delete_memory_unit(
                 unit_id=memory_id,
+                bank_id=bank_id,
                 request_context=request_context,
             )
             if not result.get("success"):
-                raise HTTPException(status_code=404, detail=result.get("message", "Memory unit not found"))
-            return DeleteMemoryUnitResponse(**result)
+                raise HTTPException(status_code=404, detail=f"Memory unit '{memory_id}' not found in bank '{bank_id}'")
+            return DeleteMemoryUnitResponse(
+                success=result["success"],
+                memory_id=result.get("memory_id"),
+                message=result.get("message"),
+            )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -291,6 +291,7 @@ class MemoryEngineInterface(ABC):
         self,
         unit_id: str,
         *,
+        bank_id: str,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """
@@ -298,6 +299,7 @@ class MemoryEngineInterface(ABC):
 
         Args:
             unit_id: The memory unit ID.
+            bank_id: The bank that owns the memory unit (enforced in query).
             request_context: Request context for authentication.
 
         Returns:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3730,6 +3730,7 @@ class MemoryEngine(MemoryEngineInterface):
         self,
         unit_id: str,
         *,
+        bank_id: str,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """
@@ -3745,39 +3746,47 @@ class MemoryEngine(MemoryEngineInterface):
 
         Args:
             unit_id: UUID of the memory unit to delete
+            bank_id: The bank that owns the memory unit (enforced in query).
             request_context: Request context for authentication.
 
         Returns:
             Dictionary with deletion result
         """
         await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext
+
+            ctx = BankWriteContext(bank_id=bank_id, operation="delete_memory_unit", request_context=request_context)
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         pool = await self._get_pool()
         invalidated_obs = 0
         bank_id_for_consolidation: str | None = None
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
-                # Get bank_id and fact_type before deletion
+                # Get fact_type before deletion (scoped to bank)
                 row = await conn.fetchrow(
-                    f"SELECT bank_id, fact_type FROM {fq_table('memory_units')} WHERE id = $1",
+                    f"SELECT fact_type FROM {fq_table('memory_units')} WHERE id = $1 AND bank_id = $2",
                     unit_id,
+                    bank_id,
                 )
-                bank_id = row["bank_id"] if row else None
                 fact_type = row["fact_type"] if row else None
 
                 # Invalidate observations before deletion (only for source memory types)
-                if bank_id and fact_type in ("experience", "world"):
+                if fact_type in ("experience", "world"):
                     invalidated_obs = await self._delete_stale_observations_for_memories(conn, bank_id, [unit_id])
                     if invalidated_obs > 0:
                         bank_id_for_consolidation = bank_id
 
-                # Delete the memory unit (cascades to links and associations)
+                # Delete the memory unit (scoped to bank, cascades to links and associations)
                 deleted = await conn.fetchval(
-                    f"DELETE FROM {fq_table('memory_units')} WHERE id = $1 RETURNING id", unit_id
+                    f"DELETE FROM {fq_table('memory_units')} WHERE id = $1 AND bank_id = $2 RETURNING id",
+                    unit_id,
+                    bank_id,
                 )
 
                 result = {
                     "success": deleted is not None,
-                    "unit_id": str(deleted) if deleted else None,
+                    "memory_id": str(deleted) if deleted else None,
                     "message": "Memory unit and all its links deleted successfully"
                     if deleted
                     else "Memory unit not found",

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -2033,7 +2033,7 @@ def _register_delete_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
             Args:
                 memory_id: The ID of the memory to delete
-                bank_id: Optional bank (accepted for consistency, not used in deletion).
+                bank_id: Optional bank to scope the deletion to.
             """
             try:
                 target_bank = bank_id or config.bank_id_resolver()
@@ -2042,6 +2042,7 @@ def _register_delete_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
                 result = await memory.delete_memory_unit(
                     unit_id=memory_id,
+                    bank_id=target_bank,
                     request_context=_get_request_context(config),
                 )
                 return json.dumps({"status": "deleted", "memory_id": memory_id, **result}, default=str)
@@ -2073,6 +2074,7 @@ def _register_delete_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
                 result = await memory.delete_memory_unit(
                     unit_id=memory_id,
+                    bank_id=target_bank,
                     request_context=_get_request_context(config),
                 )
                 return {"status": "deleted", "memory_id": memory_id, **result}

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1262,7 +1262,7 @@ async def test_delete_individual_memory_unit(api_client):
     assert response.status_code == 200
     result = response.json()
     assert result["success"] is True
-    assert result["unit_id"] == memory_id
+    assert result["memory_id"] == memory_id
     assert result["message"] is not None
 
     # 4. Verify the memory is gone
@@ -1278,3 +1278,37 @@ async def test_delete_individual_memory_unit(api_client):
     # 6. Deleting again should return 404
     response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/memories/{memory_id}")
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_unit_cross_bank_isolation(api_client):
+    """Deleting a memory via a different bank's path should return 404 (not delete it)."""
+    bank_a = f"delete_bank_a_{datetime.now().timestamp()}"
+    bank_b = f"delete_bank_b_{datetime.now().timestamp()}"
+
+    # Create a memory in bank A
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_a}/memories",
+        json={"items": [{"content": "Memory in bank A.", "context": "isolation test"}]},
+    )
+    assert response.status_code == 200
+
+    # Get the memory ID from bank A
+    response = await api_client.get(f"/v1/default/banks/{bank_a}/memories/list", params={"limit": 10})
+    assert response.status_code == 200
+    memory_id = response.json()["items"][0]["id"]
+
+    # Try to delete it via bank B's path — should fail with 404
+    response = await api_client.delete(f"/v1/default/banks/{bank_b}/memories/{memory_id}")
+    assert response.status_code == 404, "Cross-bank deletion should be rejected"
+
+    # Verify memory still exists in bank A
+    response = await api_client.get(f"/v1/default/banks/{bank_a}/memories/{memory_id}")
+    assert response.status_code == 200, "Memory should still exist in its original bank"
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_unit_invalid_uuid(api_client):
+    """Deleting with a non-UUID memory_id should return 400, not 500."""
+    response = await api_client.delete(f"/v1/default/banks/test/memories/not-a-uuid")
+    assert response.status_code == 400

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -95,7 +95,7 @@ class TestDeleteMemoryUnitObservationCleanup:
             m2 = await _insert_memory(conn, bank_id, "Alice goes hiking every weekend.")
             obs_id = await _insert_observation(conn, bank_id, "Alice enjoys hiking regularly.", [m1, m2])
 
-        await memory.delete_memory_unit(str(m1), request_context=request_context)
+        await memory.delete_memory_unit(str(m1), bank_id=bank_id, request_context=request_context)
 
         async with pool.acquire() as conn:
             obs_ids = await _get_observation_ids(conn, bank_id)
@@ -122,7 +122,7 @@ class TestDeleteMemoryUnitObservationCleanup:
 
         # Patch out consolidation so it doesn't re-set consolidated_at before we can check it
         with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
-            await memory.delete_memory_unit(str(m1), request_context=request_context)
+            await memory.delete_memory_unit(str(m1), bank_id=bank_id, request_context=request_context)
 
         async with pool.acquire() as conn:
             # m2 should have consolidated_at reset to NULL
@@ -146,7 +146,7 @@ class TestDeleteMemoryUnitObservationCleanup:
             unrelated = await _insert_memory(conn, bank_id, "Bob likes cycling.")
             obs_id = await _insert_observation(conn, bank_id, "Alice enjoys hiking regularly.", [m1, m2])
 
-        await memory.delete_memory_unit(str(unrelated), request_context=request_context)
+        await memory.delete_memory_unit(str(unrelated), bank_id=bank_id, request_context=request_context)
 
         async with pool.acquire() as conn:
             obs_ids = await _get_observation_ids(conn, bank_id)
@@ -170,7 +170,7 @@ class TestDeleteMemoryUnitObservationCleanup:
             m1 = await _insert_memory(conn, bank_id, "Alice loves hiking.")
             obs_id = await _insert_observation(conn, bank_id, "Alice enjoys hiking.", [m1])
 
-        await memory.delete_memory_unit(str(m1), request_context=request_context)
+        await memory.delete_memory_unit(str(m1), bank_id=bank_id, request_context=request_context)
 
         async with pool.acquire() as conn:
             obs_ids = await _get_observation_ids(conn, bank_id)
@@ -192,7 +192,7 @@ class TestDeleteMemoryUnitObservationCleanup:
             obs_id = await _insert_observation(conn, bank_id, "Alice enjoys hiking.", [m1])
 
         # Delete the observation directly (not the source memory)
-        await memory.delete_memory_unit(str(obs_id), request_context=request_context)
+        await memory.delete_memory_unit(str(obs_id), bank_id=bank_id, request_context=request_context)
 
         async with pool.acquire() as conn:
             # Source memory should still be consolidated (not reset)


### PR DESCRIPTION
Closes #791.

## Summary

Add `DELETE /v1/default/banks/{bank_id}/memories/{memory_id}` — exposes the existing `MemoryEngine.delete_memory_unit()` method as an HTTP route.

The engine method already handled CASCADE deletion, observation invalidation, and re-consolidation. This PR adds the HTTP route and fixes two gaps in the engine method:

1. **Bank isolation**: `delete_memory_unit()` previously accepted only `unit_id` without bank scoping — a caller could delete a memory from any bank by knowing its UUID. Now filters with `AND bank_id = $2` and passes `bank_id` from the URL path.
2. **Write authorization**: Added `validate_bank_write()` call, matching every other destructive method in the engine.

Also: response model with OpenAPI example, UUID validation (400 not 500), cross-bank isolation test, updated all callers (MCP tools, existing engine tests).

**Note**: Checked-in OpenAPI spec and generated clients will need regeneration via `./scripts/generate-openapi.sh` after merge.

## Test plan

- [x] Existing engine tests (`test_observation_invalidation.py`) — updated to pass `bank_id`
- [x] HTTP integration: create → delete → verify gone → 404 on re-delete
- [x] Cross-bank isolation: delete via wrong bank returns 404
- [x] Invalid UUID returns 400
- [ ] Verify audit log records the deletion
- [ ] Regenerate OpenAPI spec after merge