### PR TITLE
fix(openclaw): warn log and tests for CLI mode waitForReady no-op

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -425,3 +425,23 @@ describe('truncateRecallQuery', () => {
     expect(truncated.length).toBeLessThanOrEqual(180);
   });
 });
+
+// ---------------------------------------------------------------------------
+// waitForReady — CLI mode no-op (initPromise is null before service.start())
+// ---------------------------------------------------------------------------
+
+describe('waitForReady (CLI mode)', () => {
+  it('returns without error when initPromise is null (service.start not called)', async () => {
+    // The module sets up global.__hindsightClient on import.
+    // In test context, service.start() is never called so initPromise remains null.
+    const hindsight = (global as any).__hindsightClient;
+    expect(hindsight).toBeDefined();
+    // Should resolve without throwing
+    await expect(hindsight.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it('getClient returns null when service.start not called', () => {
+    const hindsight = (global as any).__hindsightClient;
+    expect(hindsight.getClient()).toBeNull();
+  });
+});

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -134,7 +134,7 @@ if (typeof global !== 'undefined') {
       // If initPromise is null, it means service.start() hasn't been called yet
       // (CLI mode, not gateway mode). Hooks should gracefully no-op.
       if (!initPromise) {
-        debug('[Hindsight] waitForReady called but initPromise is null (gateway not started)');
+        log.warn('waitForReady called before service.start() — hooks will no-op (expected in CLI mode)');
         return;
       }
       try {


### PR DESCRIPTION
## Summary

Follow-up to #764. Two improvements from the review:

- **Upgrade `waitForReady` log to `log.warn`** when `initPromise` is null — makes it visible if this path is hit unexpectedly in gateway mode, rather than being silently swallowed at debug level
- **Add tests for CLI mode no-op path** — verifies `waitForReady()` resolves without error and `getClient()` returns null when `service.start()` hasn't been called

## Test plan

- [x] All 66 tests pass (`npx vitest run src`)
- [x] Lint passes (`./scripts/hooks/lint.sh`)