### PR TITLE
fix(tests): use random port for pg0 to avoid port conflicts

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -17,7 +17,7 @@ from hindsight_api.pg0 import EmbeddedPostgres
 
 # Default pg0 instance configuration for tests
 DEFAULT_PG0_INSTANCE_NAME = "hindsight-test"
-DEFAULT_PG0_PORT = 5556
+DEFAULT_PG0_PORT = None
 
 
 # Load environment variables from .env at the start of test session


### PR DESCRIPTION
## Summary
- Use `port=None` for pg0 in tests so it auto-assigns a free port instead of hardcoding 5556
- Avoids test failures when port 5556 is already in use by another process or stale pg0 instance

## Test plan
- [x] Verified pg0 starts and auto-assigns port correctly
- [x] Verified 44 tests pass with 4 xdist parallel workers sharing the auto-assigned port
- [ ] CI passes