### PR TITLE
blog: What's New in Hindsight 0.4.22

### DIFF
--- a/hindsight-docs/blog/2026-03-31-version-0-4-22.md
+++ b/hindsight-docs/blog/2026-03-31-version-0-4-22.md
@@ -1,0 +1,60 @@
+---
+title: "What's new in Hindsight 0.4.22"
+description: New features and improvements in Hindsight 0.4.22
+authors: [nicoloboschi]
+date: 2026-03-31
+hide_table_of_contents: true
+---
+
+Hindsight 0.4.22 is primarily a bugfix release, with fixes across providers, integrations, and the recall pipeline. It also adds mental model trigger tag filtering and exposes document metadata through the API and Control Plane.
+
+<!-- truncate -->
+
+- [**Mental Model Tag Filtering**](#mental-model-tag-filtering): Control how memories are filtered during mental model refresh with `tags_match` and `tag_groups`.
+- [**Document Metadata API**](#document-metadata-api): Retained document metadata is now exposed in list/get endpoints and the Control Plane UI.
+
+## Mental Model Tag Filtering
+
+When refreshing a mental model with tags, Hindsight previously hardcoded `all_strict` tag matching, which silently excluded all untagged memories from the refresh. Mental model triggers now support `tags_match` and `tag_groups` fields, giving you explicit control over how memories are filtered during refresh.
+
+For example, you can use `any` matching to include untagged memories alongside tagged ones, or define tag groups for complex filtering logic. The Control Plane UI adds corresponding dropdowns and inputs for these new fields.
+
+Existing mental models without these fields keep the previous `all_strict` behavior — no migration required.
+
+## Document Metadata API
+
+The `retain` endpoint has always accepted a `metadata` dict, but that data was never surfaced back through the API. This release properly exposes `document_metadata` in both the list and get document endpoints, and displays it in the Control Plane documents table and detail panel.
+
+This is useful for any workflow that tags documents at ingest time — for example, by source system, user, or session ID.
+
+## Other Updates
+
+**Improvements**
+- Custom LLM parameters via `HINDSIGHT_API_LLM_EXTRA_BODY` — pass arbitrary JSON to `extra_body` on every OpenAI-compatible API call, useful for vLLM and custom model servers. *(Contributed by @emirhan-gazi.)*
+- Codex integration now retains structured tool calls (`function_call`, `local_shell_call`, `web_search_call`, etc.) as JSON content blocks, enabled by default.
+- API responses now include an `X-Ignored-Params` header to warn when unknown request parameters were silently ignored.
+- LiteLLM embeddings support optional output dimensions via `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS`. *(Contributed by @bullbo.)*
+- ZeroEntropy reranker now supports a configurable base URL for self-hosted deployments. *(Contributed by @iskhakovt.)*
+- Experience fact classification now correctly categorizes first-person agent actions (code changes, debugging, discoveries) as `experience` facts instead of `world` facts, improving recall precision for coding agents and agentic workflows.
+- LLM provider initialization refactored to use centralized `from_env()` pattern with proper config constants.
+- 13 previously undocumented config fields are now documented (Gemini safety settings, retain batch tokens, webhook settings, audit log settings, and more).
+
+**Bug Fixes**
+- Cohere reranker on Azure AI Foundry endpoints no longer hits 404 errors from double-path URLs — uses httpx directly when a custom `base_url` is configured. *(Contributed by @kagura-agent.)*
+- Claude Code LLM provider no longer suffers from MCP tool deferral when too many built-in tools are loaded — built-in tools are now disabled so MCP tools load eagerly. *(Contributed by @mkremnev.)*
+- Recall endpoint no longer drops metadata from response.
+- Codex integration merges new settings on upgrade instead of overwriting existing configuration.
+- LlamaIndex integration fixes for `document_id` handling, memory API, and ReAct trace formatting.
+- OpenClaw defers heavy initialization to `service.start()` to avoid CLI slowdown.
+- Gemini `thought_signature` is now read from the correct object for 3.1+ tool calls.
+
+## Feedback and Community
+
+Hindsight 0.4.22 is a drop-in replacement for 0.4.x with no breaking changes.
+
+Share your feedback:
+
+- [GitHub Discussions](https://github.com/vectorize-io/hindsight/discussions)
+- [GitHub Issues](https://github.com/vectorize-io/hindsight/issues)
+
+For detailed changes, see the [full changelog](/changelog).

--- a/hindsight-docs/src/pages/changelog/index.md
+++ b/hindsight-docs/src/pages/changelog/index.md
@@ -6,6 +6,33 @@ import PageHero from '@site/src/components/PageHero';
 
 <PageHero title="Changelog" subtitle="User-facing changes only. Internal maintenance and infrastructure updates are omitted." />
 
+## [0.4.22](https://github.com/vectorize-io/hindsight/releases/tag/v0.4.22)
+
+**Features**
+
+- API now supports passing custom LLM request parameters via the HINDSIGHT_API_LLM_EXTRA_BODY configuration. ([`ecaa1ad1`](https://github.com/vectorize-io/hindsight/commit/ecaa1ad1))
+- Document metadata is now exposed through the API and control plane. ([`627ec5d5`](https://github.com/vectorize-io/hindsight/commit/627ec5d5))
+- Added a /code-review skill for automated code quality checks against project standards. ([`bdb33c58`](https://github.com/vectorize-io/hindsight/commit/bdb33c58))
+- ZeroEntropy reranker now supports a configurable base URL. ([`a915584e`](https://github.com/vectorize-io/hindsight/commit/a915584e))
+- Codex can now retain structured tool calls from rollout files. ([`3461398b`](https://github.com/vectorize-io/hindsight/commit/3461398b))
+
+**Improvements**
+
+- Embeddings via the LiteLLM SDK can now optionally specify output dimensions. ([`f841bcb9`](https://github.com/vectorize-io/hindsight/commit/f841bcb9))
+- API responses now include an X-Ignored-Params header to warn when unknown request parameters were ignored. ([`cef42d81`](https://github.com/vectorize-io/hindsight/commit/cef42d81))
+- OpenClaw CLI startup is faster by deferring heavy initialization until the service starts. ([`41025c3b`](https://github.com/vectorize-io/hindsight/commit/41025c3b))
+
+**Bug Fixes**
+
+- Mental model triggers now support the full config schema, including tag matching and tag group filters. ([`2c32ffad`](https://github.com/vectorize-io/hindsight/commit/2c32ffad))
+- Cohere reranking via Azure endpoints now works reliably (avoids 404 errors). ([`84985ee9`](https://github.com/vectorize-io/hindsight/commit/84985ee9))
+- Claude Code provider no longer defers to built-in tools, preventing MCP tool handling issues. ([`fa82efc8`](https://github.com/vectorize-io/hindsight/commit/fa82efc8))
+- Recall endpoint now returns metadata correctly instead of dropping it from the response. ([`4768bf39`](https://github.com/vectorize-io/hindsight/commit/4768bf39))
+- Gemini 3.1+ tool calls now read thought signatures correctly. ([`1b5c262a`](https://github.com/vectorize-io/hindsight/commit/1b5c262a))
+- First-person agent memories are now correctly classified as "experience" facts. ([`00961156`](https://github.com/vectorize-io/hindsight/commit/00961156))
+- Codex upgrades now preserve and merge new settings instead of skipping them. ([`b104bad0`](https://github.com/vectorize-io/hindsight/commit/b104bad0))
+- LlamaIndex integration fixes improve document ID handling, memory API behavior, and ReAct tracing. ([`d93dfea8`](https://github.com/vectorize-io/hindsight/commit/d93dfea8))
+
 ## [0.4.21](https://github.com/vectorize-io/hindsight/releases/tag/v0.4.21)
 
 **Features**


### PR DESCRIPTION
## Summary
- Add 0.4.22 release blog post with mental model tag filtering and document metadata API highlights
- Generate changelog entry for 0.4.22

## Test plan
- [ ] Docs build passes