### PR TITLE
docs(hermes): update integration page for memory provider architecture

### DIFF
--- a/hindsight-docs/docs/sdks/integrations/hermes.md
+++ b/hindsight-docs/docs/sdks/integrations/hermes.md
@@ -8,10 +8,6 @@ description: "Add long-term memory to Hermes Agent with Hindsight. Automatically
 
 Persistent long-term memory for [Hermes Agent](https://github.com/NousResearch/hermes-agent) using [Hindsight](https://vectorize.io/hindsight). Automatically recalls relevant context before every LLM call and retains conversations for future sessions — plus explicit retain/recall/reflect tools.
 
-:::note
-This page reflects the memory provider architecture introduced in [hermes-agent PR #4154](https://github.com/NousResearch/hermes-agent/pull/4154). If you're on an older version, see [Legacy Setup](#legacy-setup) below.
-:::
-
 ## Quick Start
 
 ```bash
@@ -167,28 +163,3 @@ curl http://localhost:9077/health
 
 **Recall returning no memories**: Memories need at least one retain cycle. Try storing a fact first, then asking about it in a new session.
 
----
-
-## Legacy Setup
-
-For hermes-agent versions before [PR #4154](https://github.com/NousResearch/hermes-agent/pull/4154), install and configure the plugin manually:
-
-```bash
-# 1. Install the plugin into Hermes's Python environment
-uv pip install hindsight-hermes --python $HOME/.hermes/hermes-agent/venv/bin/python
-
-# 2. Configure
-mkdir -p ~/.hindsight
-cat > ~/.hindsight/hermes.json << 'EOF'
-{
-  "hindsightApiUrl": "http://localhost:9077",
-  "bankId": "hermes"
-}
-EOF
-
-# 3. Disable Hermes's built-in memory tool to avoid conflicts
-hermes tools disable memory
-
-# 4. Start Hermes
-hermes
-```


### PR DESCRIPTION
## Context

[hermes-agent PR #4154](https://github.com/NousResearch/hermes-agent/pull/4154) introduces a pluggable memory provider architecture with a new CLI (`hermes memory setup`, `hermes memory status`, `hermes memory off`). This replaces the manual plugin install flow that our integration page currently documents.

## Changes

- **Quick Start**: Now leads with `hermes memory setup` wizard instead of manual `uv pip install`
- **New Memory CLI section**: Documents `hermes memory setup`, `hermes memory status`, `hermes memory off`
- **Removed**: "Disabling Hermes's Built-in Memory" section (the setup wizard handles this automatically)
- **Updated note**: References PR #4154 instead of PR #2823
- **Legacy Setup section**: Preserves the old manual install instructions for users on older hermes-agent versions
- **Config table**: Added `recallContextTurns`, `recallTopK`, `recallTypes` fields that were missing

## When to merge

Hold until hermes-agent PR #4154 is merged and released.