### PR TITLE
fix: remove bank_id from OTel metric attributes to prevent unbounded memory growth

### DIFF
--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -332,7 +332,6 @@ class MetricsCollector(MetricsCollectorBase):
         start_time = time.time()
         attributes = {
             "operation": operation,
-            "bank_id": bank_id,
             "source": source,
             "tenant": _get_tenant(),
         }

--- a/hindsight-api-slim/tests/test_metrics.py
+++ b/hindsight-api-slim/tests/test_metrics.py
@@ -95,7 +95,7 @@ class TestMetricsCollector:
         # Second arg is attributes dict
         attributes = call_args[0][1]
         assert attributes["operation"] == "recall"
-        assert attributes["bank_id"] == "test_bank"
+        assert "bank_id" not in attributes
         assert attributes["source"] == "api"
         assert attributes["success"] == "true"
 


### PR DESCRIPTION
Fixes #850

## Problem

`MetricsCollector.record_operation()` includes `bank_id` as an attribute in OpenTelemetry histogram and counter recordings. Since `bank_id` is a per-user value (e.g., `user-123`), every unique user creates a permanent, never-evicted time series in the OTel SDK's in-memory aggregation buffers, causing unbounded memory growth proportional to `unique_users × operations × budgets × statuses`.

After 15 days of normal usage with ~50 users, this was observed to cause ~3 GB physical memory footprint due to millions of never-freed allocations in `MALLOC_SMALL`.

## Solution

Remove `bank_id` from metric attributes in `record_operation()`. The `bank_id` parameter is kept in the method signature for API compatibility, but is no longer added to the OTel attributes dict. `bank_id` belongs in tracing spans (which are exported and evicted), not in metrics (which accumulate in process for the lifetime of the SDK).

Updated the test assertion to verify `bank_id` is NOT present in the attributes.

## Testing

- Updated `test_metrics.py` to assert `"bank_id" not in attributes`
- Existing tests continue to pass as the fix is minimal (one line removed)