### PR TITLE
fix(embed): make fcntl import conditional for Windows compatibility

### DIFF
--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -4,11 +4,13 @@ Handles creation, deletion, and management of configuration profiles.
 Each profile has its own config, daemon lock, log file, and port.
 """
 
-import fcntl
 import hashlib
 import json
 import os
 import sys
+
+if sys.platform != "win32":
+    import fcntl
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -470,8 +472,9 @@ class ProfileManager:
         temp_file = metadata_file.with_suffix(".json.tmp")
 
         with open(temp_file, "w") as f:
-            # Acquire exclusive lock
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            # Acquire exclusive lock (Unix only — Windows uses atomic rename for safety)
+            if sys.platform != "win32":
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             try:
                 json.dump(
                     {"version": metadata.version, "profiles": metadata.profiles},
@@ -481,7 +484,8 @@ class ProfileManager:
                 f.flush()
                 os.fsync(f.fileno())
             finally:
-                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                if sys.platform != "win32":
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
         # Atomic rename
         temp_file.rename(metadata_file)


### PR DESCRIPTION
Fixes #865

## Problem
`hindsight-embed` crashes immediately on Windows 11 at import time because `profile_manager.py` unconditionally imports `fcntl`, which is a Unix-only stdlib module. This blocks all Windows users from using `hindsight-embed` (and the OpenClaw plugin that depends on it).

## Solution
Guard the `import fcntl` with `if sys.platform != "win32":` and wrap both `fcntl.flock()` calls in the same check. The fix follows the same pattern used in `#694` for the Claude Code integration.

On Windows, the file locking step is skipped — the atomic `rename()` that follows already provides sufficient crash-safety for the single-process metadata writes in `_save_metadata()`.

## Testing
- The conditional import prevents `ModuleNotFoundError` on Windows at startup.
- On Unix/macOS the behavior is unchanged: `fcntl.flock()` is still called for exclusive locking during metadata writes.
- No new tests added (locking behaviour is OS-specific and not currently unit-tested).