### PR TITLE
fix(mcp): coerce string-encoded metadata, types, and tags in tool calls

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -172,6 +172,23 @@ class RecallRequest(BaseModel):
         "Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.",
     )
 
+    @field_validator("types", "tags", mode="before")
+    @classmethod
+    def coerce_string_to_list(cls, v: Any) -> Any:
+        """Coerce JSON-string arrays to list.
+
+        MCP tool bridges sometimes serialize JSON arrays as strings during
+        transport, e.g. '["world"]' instead of ["world"]. Parse them back.
+        """
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return v
+
     @field_validator("query")
     @classmethod
     def validate_query_not_empty(cls, v: str) -> str:
@@ -446,6 +463,23 @@ class MemoryItem(BaseModel):
             except (json.JSONDecodeError, TypeError):
                 pass
             return [v]
+        return v
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def coerce_metadata(cls, v: Any) -> Any:
+        """Coerce JSON-string metadata to dict.
+
+        MCP tool bridges sometimes serialize JSON objects as strings during
+        transport, e.g. '{"key": "value"}' instead of {"key": "value"}.
+        """
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, dict):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
         return v
 
     observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = Field(

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -167,6 +167,15 @@ def build_content_dict(
         if isinstance(tags, str):
             tags = [tags]
 
+    # Coerce metadata from JSON string to dict if needed.
+    if isinstance(metadata, str):
+        try:
+            parsed = json.loads(metadata)
+            if isinstance(parsed, dict):
+                metadata = parsed
+        except (json.JSONDecodeError, TypeError):
+            metadata = None
+
     content_dict: dict[str, Any] = {"content": content, "context": context}
 
     if timestamp:
@@ -665,6 +674,18 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
                 budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
                 budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
+                # Coerce JSON-string arrays to list (MCP bridges sometimes serialize them as strings)
+                if isinstance(types, str):
+                    try:
+                        types = json.loads(types)
+                    except (json.JSONDecodeError, TypeError):
+                        types = None
+                if isinstance(tags, str):
+                    try:
+                        parsed = json.loads(tags)
+                        tags = parsed if isinstance(parsed, list) else [tags]
+                    except (json.JSONDecodeError, TypeError):
+                        tags = [tags]
                 fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)
 
                 recall_kwargs: dict[str, Any] = {
@@ -722,6 +743,18 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
                 budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
                 budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
+                # Coerce JSON-string arrays to list (MCP bridges sometimes serialize them as strings)
+                if isinstance(types, str):
+                    try:
+                        types = json.loads(types)
+                    except (json.JSONDecodeError, TypeError):
+                        types = None
+                if isinstance(tags, str):
+                    try:
+                        parsed = json.loads(tags)
+                        tags = parsed if isinstance(parsed, list) else [tags]
+                    except (json.JSONDecodeError, TypeError):
+                        tags = [tags]
                 fact_types = types if types is not None else list(VALID_RECALL_FACT_TYPES)
 
                 recall_kwargs: dict[str, Any] = {


### PR DESCRIPTION
Fixes #849

## Problem
MCP tool bridges (Claude Code, Cursor, and others) sometimes serialize JSON arrays and objects as strings during transport. This causes Pydantic validation failures on `retain` and `recall` calls:

```
Error: 1 validation error for call[retain]
tags
  Input should be a valid list [type=list_type, input_value='["tag1", "tag2"]', input_type=str]

Error: 1 validation error for call[recall]
types
  Input should be a valid list [type=list_type, input_value='["world"]', input_type=str]

Error: 1 validation error for call[retain]
metadata
  Input should be a valid dictionary [type=dict_type, input_value='{"key": "value"}', input_type=str]
```

The agent retries with the same broken format, wasting tokens and silently failing to store memories.

## Solution
Add defensive coercion at two layers — mirroring the pattern already used for `MemoryItem.tags` (added in #682):

**HTTP API (`http.py`)**:
- `RecallRequest`: `field_validator` on `types` and `tags` (`mode="before"`) that parses JSON-string arrays back into lists
- `MemoryItem`: `field_validator` on `metadata` (`mode="before"`) that parses JSON-string objects back into dicts

**MCP tools (`mcp_tools.py`)**:
- `build_content_dict`: coerce `metadata` from JSON string to dict, matching the existing `tags` coercion in the same function
- Both `recall()` variants (with and without `bank_id` param): coerce `types` and `tags` from JSON strings before passing to the memory engine

All coercions are backward-compatible — correctly-typed native arrays/objects pass through unchanged.

## Testing
The existing coercion pattern for `tags` in `MemoryItem` (from #682) already has test coverage. The new validators follow the identical logic and can be validated by sending a JSON-string value to the affected fields.