### PR TITLE
feat(hermes): add on_pre_compress hook to preserve context before compression

### DIFF
--- a/hindsight-integrations/hermes/hindsight_hermes/tools.py
+++ b/hindsight-integrations/hermes/hindsight_hermes/tools.py
@@ -427,8 +427,58 @@ def register(ctx: Any) -> None:
         except Exception as exc:
             logger.warning("Hindsight post_llm_call retain failed: %s", exc)
 
+    def _on_pre_compress(
+        *,
+        messages: list[dict[str, Any]] | None = None,
+        session_id: str = "",
+        **kwargs: Any,
+    ) -> str:
+        """Extract insights before context compression discards turns.
+
+        When Hermes compresses the context window to save tokens, the
+        original messages are summarised and the full text is lost.  This
+        hook fires just before that happens, giving us a chance to persist
+        the about-to-be-discarded turns into the Hindsight knowledge graph
+        so they remain searchable via recall/reflect.
+
+        The retain call runs in a background thread so it never blocks the
+        compression pipeline.
+        """
+        if not messages or not bank_id:
+            return ""
+        parts: list[str] = []
+        for msg in messages[-10:]:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if isinstance(content, str) and content.strip() and role in ("user", "assistant"):
+                parts.append(f"{role}: {content[:500]}")
+        if not parts:
+            return ""
+        combined = "\n".join(parts)
+
+        import threading
+
+        def _flush() -> None:
+            try:
+                _ensure_bank_sync(bank_id)
+                resolved_client.retain(
+                    bank_id=bank_id,
+                    content=f"[Pre-compression context]\n{combined}",
+                )
+                logger.info(
+                    "Hindsight pre-compression flush: %d messages retained",
+                    len(parts),
+                )
+            except Exception as exc:
+                logger.warning("Hindsight pre-compression flush failed: %s", exc)
+
+        t = threading.Thread(target=_flush, daemon=True, name="hindsight-precompress")
+        t.start()
+        return ""
+
     ctx.register_hook("pre_llm_call", _on_pre_llm_call)
     ctx.register_hook("post_llm_call", _on_post_llm_call)
+    ctx.register_hook("on_pre_compress", _on_pre_compress)
 
 
 def memory_instructions(


### PR DESCRIPTION
## Summary

- Adds an `on_pre_compress` lifecycle hook to the Hermes integration that fires before context window compression
- Captures the last 10 user/assistant messages and persists them to the Hindsight knowledge graph via `retain()`
- Runs the retain call in a background thread so it never blocks the compression pipeline

## Motivation

When Hermes compresses its context window to save tokens, the original messages are summarized and the full text is discarded. This means potentially valuable context is lost forever. By hooking into the compression lifecycle, we can preserve those messages in Hindsight's knowledge graph where they remain searchable via `recall()` and `reflect()`.

This was inspired by ByteRover's `on_pre_compress` implementation, adapted to use Hindsight's sync `retain()` API.

## Details

- Messages are truncated to 500 chars each to keep the retain payload reasonable
- Tagged with `[Pre-compression context]` prefix for easy identification
- Requires hermes-agent >= 0.7.0 which supports the `on_pre_compress` hook
- On older hermes-agent versions, the hook is simply never called (safe to register)

## Test plan

- [x] Tested locally with Hermes v0.7.0 and Hindsight in local/embedded mode
- [x] Verified pre-compression messages appear in knowledge graph after context compression
- [x] Confirmed background thread does not block the compression pipeline