### PR TITLE
docs(hermes): update integration docs for plugin overhaul (hermes-agent#5094)

### DIFF
--- a/hindsight-docs/docs-integrations/hermes.md
+++ b/hindsight-docs/docs-integrations/hermes.md
@@ -63,7 +63,7 @@ The plugin registers via Hermes's `hermes_agent.plugins` entry point system:
 
 ### 1. Cloud (recommended for production)
 
-Connect to Hindsight Cloud. Get an API key at [ui.hindsight.vectorize.io](https://ui.hindsight.vectorize.io).
+Connect to Hindsight Cloud at `https://api.hindsight.vectorize.io`. Get an API key at [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect).
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Replace `uv pip install hindsight-hermes` quick start with `hermes memory setup` wizard and `hermes config set` manual alternative
- Update config path from `~/.hindsight/hermes.json` (camelCase) to `~/.hermes/hindsight/config.json` (flat snake_case keys)
- Add `memory_mode` (`hybrid`/`context`/`tools`) and `prefetch_method` (`recall`/`reflect`) config options
- Add LLM provider config section for local mode — all 7 providers with per-provider model defaults
- Add `HINDSIGHT_MODE`, `HINDSIGHT_LLM_API_KEY`, `HINDSIGHT_API_URL` env vars to table
- Document local daemon auto-start behavior and log paths
- Fix URL: `app.hindsight.vectorize.io` → `ui.hindsight.vectorize.io`
- Note tools only registered in `hybrid` and `tools` memory modes

Tracks: NousResearch/hermes-agent#5094