### PR TITLE
fix(embed): skip profile .env overwrite when config has no HINDSIGHT_API_* keys

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -419,6 +419,8 @@ class DaemonEmbedManager(EmbedManager):
         """
         try:
             api_config = {k: v for k, v in config.items() if k.startswith("HINDSIGHT_API_")}
+            if not api_config:
+                return
             self._profile_manager.create_profile(profile, port, api_config)
         except Exception as e:
             logger.debug(f"Failed to register profile '{profile}' in metadata: {e}")


### PR DESCRIPTION
Fixes #894

## Problem

Every CLI command that calls `ensure_daemon_running` overwrites the profile `.env` file with an empty config, causing intermittent `"LLM API key is required"` errors.

In `daemon_embed_manager.py`, `_register_profile()` filters the config dict for keys starting with `HINDSIGHT_API_`, but the config passed from `cli.py`'s `get_config()` uses short keys (`llm_api_key`, `llm_provider`, etc.). None match the prefix, so `api_config` is always `{}`. `create_profile()` then writes an empty `.env` file, overwriting any existing profile configuration.

## Solution

Add an early return guard in `_register_profile()`: if `api_config` is empty after filtering, return without calling `create_profile()`. This preserves the existing profile `.env` contents when the config dict contains no `HINDSIGHT_API_*` keys.

```python
api_config = {k: v for k, v in config.items() if k.startswith("HINDSIGHT_API_")}
if not api_config:
    return
self._profile_manager.create_profile(profile, port, api_config)
```

## Testing

- Manually verified that `_register_profile` with a short-key config dict no longer calls `create_profile`
- Existing profile `.env` contents are preserved across CLI commands