### PR TITLE
fix(retain): guard against None event_date in fact extraction debug log

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1055,7 +1055,7 @@ async def _extract_facts_from_chunk(
                     f"LLM response missing 'facts' field or returned empty list. "
                     f"Response: {extraction_response_json}. "
                     f"Input: "
-                    f"date: {event_date.isoformat()}, "
+                    f"date: {event_date.isoformat() if event_date is not None else 'unset'}, "
                     f"context: {context if context else 'none'}, "
                     f"text: {chunk}"
                 )


### PR DESCRIPTION
Fixes #892

## Problem

When retaining a memory with `timestamp: "unset"`, `event_date` is set to `None`. If the LLM returns an empty facts list for that content, the debug log statement in `_extract_facts_from_chunk` calls `event_date.isoformat()` without a `None` check:

```python
logger.debug(
    f"LLM response missing 'facts' field or returned empty list. "
    f"Response: {extraction_response_json}. "
    f"Input: "
    f"date: {event_date.isoformat()}, "  # <-- raises AttributeError when event_date is None
    ...
)
```

This raises `AttributeError: 'NoneType' object has no attribute 'isoformat'`, which propagates up and causes a 500 error.

## Solution

Use a conditional expression to safely format `event_date`:

```python
f"date: {event_date.isoformat() if event_date is not None else 'unset'}, "
```

## Testing

- Verified that retaining with `timestamp: "unset"` no longer raises AttributeError when the LLM returns empty facts
- One-line change with no behavioral impact on normal paths where `event_date` is set