### PR TITLE
docs: add best practice for filtering recall by memory shape

### DIFF
--- a/hindsight-docs/src/pages/best-practices.mdx
+++ b/hindsight-docs/src/pages/best-practices.mdx
@@ -12,7 +12,7 @@ import PageHero from '@site/src/components/PageHero';
 - [Core Concepts](#core-concepts) — Memory banks, taxonomy, memory types
 - [Bank Configuration](#bank-configuration) — Missions, dispositions, entity labels
 - [Retaining Data](#retaining-data) — Content format, context, document_id, [tags](#tags-naming-conventions), observation scopes
-- [Recalling Memories](#recalling-memories) — Budget, tag filtering, include options, query_timestamp
+- [Recalling Memories](#recalling-memories) — Budget, tag filtering, entity label filtering, include options, query_timestamp
 - [Reflecting](#reflecting) — Recall vs reflect, response_schema, auditing
 - [Mental Models](#mental-models) — When to create, tag strategy, refresh
 - [Anti-patterns](#anti-patterns)
@@ -399,6 +399,50 @@ recall(
 | *(not set)* | All types |
 | `["observation"]` | Consolidated patterns only — faster for high-level questions |
 | `["world", "experience"]` | Raw facts only — for ground-truth or citation-sensitive queries |
+
+---
+
+### Filtering by Memory Shape with Entity Labels
+
+When a single bank contains semantically similar memories that serve different purposes (e.g., concise operating rules vs. detailed troubleshooting procedures), ranking alone cannot reliably distinguish them — two memories about "entrypoints" will score similarly regardless of whether one is a one-line rule and the other is a multi-step runbook.
+
+Use [entity labels](/developer/api/memory-banks#entity-labels) with `tag: true` to classify facts at retain time and hard-filter at recall time.
+
+**1. Define a label group on the bank:**
+
+```json
+{
+  "entity_labels": [
+    {
+      "key": "memory_type",
+      "description": "The type of knowledge: 'rule' for concise operating rules and canonical guidance, 'procedure' for step-by-step technical instructions and troubleshooting notes",
+      "type": "value",
+      "optional": false,
+      "tag": true,
+      "values": [
+        { "value": "rule",      "description": "Concise operating rule or canonical guidance" },
+        { "value": "procedure", "description": "Step-by-step technical instruction or troubleshooting note" }
+      ]
+    }
+  ]
+}
+```
+
+**2. Retain normally** — the LLM classifies each fact automatically and writes `memory_type:rule` or `memory_type:procedure` as a tag.
+
+**3. Filter at recall time:**
+
+```python
+# Only rules — procedures are excluded at the database level, not post-filtered
+result = client.recall(
+    bank_id="my-bank",
+    query="which entrypoint should I use?",
+    tags=["memory_type:rule"],
+    tags_match="any_strict"
+)
+```
+
+This is a hard SQL WHERE clause applied across all four retrieval strategies. The unwanted memories never enter the ranking pipeline.
 
 ---
 

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -21,6 +21,7 @@ import PageHero from '@site/src/components/PageHero';
 - [When should I use mental models?](#when-should-i-use-mental-models)
 - [Latency expectations](#whats-the-typical-latency-for-recall-operations)
 - [Tags, metadata, and entity labels](#does-hindsight-support-metadata-filtering)
+- [Controlling which memory types are recalled](#how-do-i-control-which-types-of-memories-are-recalled)
 - [Recommended format for conversations](#what-is-the-recommended-format-for-retaining-conversations)
 
 ---
@@ -245,6 +246,20 @@ Document metadata (the `metadata` key-value pairs on a retain item) serves a dif
 - **Returned with every recalled memory** as-is, so your application can link memories back to source systems (e.g. a URL, thread ID, or ticket number) without extra lookups.
 
 Metadata is not a filter — use tags when you need recall to be scoped to a subset of documents.
+
+---
+
+### How do I control which types of memories are recalled?
+
+If your bank mixes different shapes of memory (e.g., concise rules and detailed procedures) and recall surfaces the wrong shape for a given query, use **entity labels** with `tag: true` to classify facts during retain and hard-filter them during recall.
+
+1. Define a label group on the bank with `tag: true` and a controlled vocabulary (e.g., `rule` vs `procedure`)
+2. Retain normally — the LLM classifies each extracted fact automatically
+3. Pass `tags=["memory_type:rule"]` and `tags_match="any_strict"` at recall time to deterministically include only matching memories
+
+This is a SQL-level filter applied before ranking, not a scoring signal — the excluded memories never enter the retrieval pipeline. This is more reliable than adjusting ranking weights, which only nudge continuous scores and cannot guarantee ordering.
+
+See [Best Practices — Filtering by Memory Shape](/best-practices#filtering-by-memory-shape-with-entity-labels) for a full walkthrough, or [Entity Labels](/developer/api/memory-banks#entity-labels) for the configuration reference.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new "Filtering by Memory Shape with Entity Labels" section to **Best Practices** showing how to use entity labels with `tag: true` to deterministically filter recall results when a bank contains different memory shapes (e.g., concise rules vs. detailed procedures)
- Adds a new FAQ entry "How do I control which types of memories are recalled?" linking to the best practice

Closes #856

## Context

Ranking weights and retrieval profiles can't reliably distinguish semantically similar memories that serve different purposes. The existing entity labels + tag filtering mechanism already solves this with hard SQL-level filtering, but the docs didn't make this pattern discoverable.

## Test plan

- [ ] Verify best-practices page renders correctly with the new section
- [ ] Verify FAQ page renders correctly with the new entry
- [ ] Verify internal links resolve correctly