### PR TITLE
fix: clamp out-of-range content_index in _map_results_to_contents

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1522,7 +1522,12 @@ def _map_results_to_contents(
     """Map created unit IDs back to original content items."""
     facts_by_content: dict[int, list[int]] = {i: [] for i in range(len(contents))}
     for i, fact in enumerate(extracted_facts):
-        facts_by_content[fact.content_index].append(i)
+        # Normalize content_index: some LLM providers return 1-indexed values.
+        # Clamp to valid range to prevent KeyError.
+        idx = fact.content_index
+        if idx < 0 or idx >= len(contents):
+            idx = min(max(idx, 0), len(contents) - 1) if len(contents) > 0 else 0
+        facts_by_content[idx].append(i)
 
     result_unit_ids = []
     unit_idx = 0


### PR DESCRIPTION
## Summary

Fixes #873.

Some LLM providers (e.g. Anthropic's Claude Haiku) return 1-indexed `content_index` values in extracted facts. When only one content item is provided (index 0), `_map_results_to_contents` raises `KeyError: 1` because the dict only has key 0.

## Change

Clamp `content_index` to the valid `[0, len(contents)-1]` range in `_map_results_to_contents()` instead of using it directly as a dict key. This makes the function resilient to LLMs returning out-of-range indices.

1 file changed: `hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py`

## Test plan

- Retain with single item using Anthropic provider should no longer crash
- Retain with multiple items should work as before (indices already in range)