### PR TITLE
feat(openclaw): support bankId for static banks

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -96,7 +96,8 @@ Optional settings in `~/.openclaw/openclaw.json`:
 - `embedVersion` - hindsight-embed version (default: `"latest"`)
 - `bankMission` - Agent identity/purpose stored on the memory bank. Helps the memory engine understand context for better fact extraction during retain. Set once per bank on first use — not a recall prompt.
 - `dynamicBankId` - Enable per-context memory banks (default: `true`)
-- `bankIdPrefix` - Optional prefix for bank IDs (e.g. `"prod"` → `"prod-slack-C123"`)
+- `bankId` - Static bank ID used when `dynamicBankId` is `false`. Can also be set with `HINDSIGHT_BANK_ID`.
+- `bankIdPrefix` - Optional prefix for bank IDs (e.g. `"prod"` → `"prod-slack-C123"` or `"prod-shared-bank"`)
 - `dynamicBankGranularity` - Fields used to derive bank ID: `agent`, `channel`, `user`, `provider` (default: `["agent", "channel", "user"]`)
 - `excludeProviders` - Message providers to skip for recall/retain (e.g. `["slack"]`, `["telegram"]`, `["discord"]`)
 - `autoRecall` - Auto-inject memories before each turn (default: `true`). Set to `false` when the agent has its own recall tool.
@@ -144,7 +145,7 @@ Available isolation fields:
 - `user` - The user interacting with the agent
 - `provider` - The message provider (e.g. Slack, Discord)
 
-Use `bankIdPrefix` to namespace bank IDs across environments (e.g. `"prod"`, `"staging"`). Set `dynamicBankId` to `false` to use a single shared bank for all conversations.
+Use `bankIdPrefix` to namespace bank IDs across environments (e.g. `"prod"`, `"staging"`). Set `dynamicBankId` to `false` to use a single shared bank for all conversations. In static mode, the plugin uses `bankId`, then `HINDSIGHT_BANK_ID`, then the default `openclaw` bank name.
 
 ### Retention Controls
 

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -46,7 +46,7 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `llmModel` | provider default | LLM model override used with `llmProvider` |
 | `llmApiKeyEnv` | provider standard env var | Custom env var name for the provider API key |
 | `dynamicBankId` | `true` | Enable per-context memory banks |
-| `staticBankId` | — | Exact bank ID to use for all memories. Overrides `dynamicBankId` and `bankIdPrefix` when set. |
+| `bankId` | — | Static bank ID used when `dynamicBankId` is `false`. Can also be set with `HINDSIGHT_BANK_ID`. |
 | `bankIdPrefix` | — | Prefix for bank IDs (e.g. `"prod"`) |
 | `dynamicBankGranularity` | `["agent", "channel", "user"]` | Fields used to derive bank ID. Options: `agent`, `channel`, `user`, `provider` |
 | `excludeProviders` | `[]` | Message providers to skip for recall/retain (e.g. `slack`, `telegram`, `discord`) |

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -68,9 +68,9 @@
         "description": "Enable per-user memory banks. When true, memories are isolated by user per channel (e.g., slack-U123, telegram-456789). When false, all users share a single 'openclaw' bank.",
         "default": true
       },
-      "staticBankId": {
+      "bankId": {
         "type": "string",
-        "description": "Exact bank ID to use for all memories. Overrides dynamicBankId and bankIdPrefix when set."
+        "description": "Static bank ID used when dynamicBankId is false. Can also be provided via HINDSIGHT_BANK_ID."
       },
       "bankIdPrefix": {
         "type": "string",
@@ -285,6 +285,10 @@
     "dynamicBankId": {
       "label": "Dynamic Bank IDs",
       "placeholder": "true (isolate memories per channel)"
+    },
+    "bankId": {
+      "label": "Static Bank ID",
+      "placeholder": "e.g. openclaw, shared-bank (used when dynamicBankId is false)"
     },
     "bankIdPrefix": {
       "label": "Bank ID Prefix",

--- a/hindsight-integrations/openclaw/src/derive-bank-id.test.ts
+++ b/hindsight-integrations/openclaw/src/derive-bank-id.test.ts
@@ -91,15 +91,15 @@ describe('deriveBankId', () => {
     expect(bankId).toBe('openclaw');
   });
 
-  it('should return staticBankId exactly when configured', () => {
+  it('should return configured bankId when dynamicBankId is false', () => {
     const config: PluginConfig = {
-      dynamicBankId: true,
-      staticBankId: 'shared-bank',
-      bankIdPrefix: 'ignored',
+      dynamicBankId: false,
+      bankId: 'shared-bank',
+      bankIdPrefix: 'prod',
       dynamicBankGranularity: ['provider', 'user'],
     };
     const bankId = deriveBankId(ctx, config);
-    expect(bankId).toBe('shared-bank');
+    expect(bankId).toBe('prod-shared-bank');
   });
 
   it('should encode segments to prevent separator collisions', () => {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -268,26 +268,27 @@ const __dirname = dirname(__filename);
 // Default bank name (fallback when channel context not available)
 const DEFAULT_BANK_NAME = 'openclaw';
 
-function getConfiguredStaticBankId(pluginConfig: PluginConfig): string | undefined {
-  if (typeof pluginConfig.staticBankId !== 'string') {
+function getConfiguredBankId(pluginConfig: PluginConfig): string | undefined {
+  if (typeof pluginConfig.bankId !== 'string') {
     return undefined;
   }
 
-  const trimmed = pluginConfig.staticBankId.trim();
+  const trimmed = pluginConfig.bankId.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function usesStaticBank(pluginConfig: PluginConfig): boolean {
-  return !!getConfiguredStaticBankId(pluginConfig) || pluginConfig.dynamicBankId === false;
+  return pluginConfig.dynamicBankId === false;
 }
 
-function getDefaultStaticBankId(pluginConfig: PluginConfig): string {
-  const configuredStaticBankId = getConfiguredStaticBankId(pluginConfig);
-  if (configuredStaticBankId) {
-    return configuredStaticBankId;
-  }
-
+function getDefaultBankId(pluginConfig: PluginConfig): string {
   return pluginConfig.bankIdPrefix ? `${pluginConfig.bankIdPrefix}-${DEFAULT_BANK_NAME}` : DEFAULT_BANK_NAME;
+}
+
+function getStaticBankId(pluginConfig: PluginConfig): string {
+  const configuredBankId = getConfiguredBankId(pluginConfig);
+  const baseBankId = configuredBankId || DEFAULT_BANK_NAME;
+  return pluginConfig.bankIdPrefix ? `${pluginConfig.bankIdPrefix}-${baseBankId}` : baseBankId;
 }
 
 /**
@@ -536,18 +537,13 @@ function parseSessionKey(sessionKey: string): { agentId?: string; provider?: str
 }
 
 export function deriveBankId(ctx: PluginHookAgentContext | undefined, pluginConfig: PluginConfig): string {
-  const configuredStaticBankId = getConfiguredStaticBankId(pluginConfig);
-  if (configuredStaticBankId) {
-    return configuredStaticBankId;
-  }
-
   if (pluginConfig.dynamicBankId === false) {
-    return getDefaultStaticBankId(pluginConfig);
+    return getStaticBankId(pluginConfig);
   }
 
   // When no context is available, fall back to the static default bank.
   if (!ctx) {
-    return getDefaultStaticBankId(pluginConfig);
+    return getDefaultBankId(pluginConfig);
   }
 
   const fields = pluginConfig.dynamicBankGranularity?.length ? pluginConfig.dynamicBankGranularity : ['agent', 'channel', 'user'];
@@ -795,6 +791,9 @@ async function checkExternalApiHealth(apiUrl: string, apiToken?: string | null):
 function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
   const config = api.config.plugins?.entries?.['hindsight-openclaw']?.config || {};
   const defaultMission = 'You are an AI assistant helping users across multiple communication channels (Telegram, Slack, Discord, etc.). Remember user preferences, instructions, and important context from conversations to provide personalized assistance.';
+  const envBankId = typeof process.env.HINDSIGHT_BANK_ID === 'string' && process.env.HINDSIGHT_BANK_ID.trim().length > 0
+    ? process.env.HINDSIGHT_BANK_ID.trim()
+    : undefined;
 
   return {
     bankMission: config.bankMission || defaultMission,
@@ -810,7 +809,7 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     apiPort: config.apiPort || 9077,
     // Dynamic bank ID options (default: enabled)
     dynamicBankId: config.dynamicBankId !== false,
-    staticBankId: typeof config.staticBankId === 'string' && config.staticBankId.trim().length > 0 ? config.staticBankId.trim() : undefined,
+    bankId: envBankId || (typeof config.bankId === 'string' && config.bankId.trim().length > 0 ? config.bankId.trim() : undefined),
     bankIdPrefix: config.bankIdPrefix,
     excludeProviders: Array.isArray(config.excludeProviders) ? config.excludeProviders : [],
     autoRecall: config.autoRecall !== false, // Default: true (on) — backward compatible
@@ -884,13 +883,12 @@ export default function (api: MoltbotPluginAPI) {
         }
 
         // Log bank ID mode
-        if (getConfiguredStaticBankId(pluginConfig)) {
-          debug(`[Hindsight] Static bank override configured - using bank: ${getDefaultStaticBankId(pluginConfig)}`);
-        } else if (pluginConfig.dynamicBankId) {
+        if (pluginConfig.dynamicBankId) {
           const prefixInfo = pluginConfig.bankIdPrefix ? ` (prefix: ${pluginConfig.bankIdPrefix})` : '';
           debug(`[Hindsight] ✓ Dynamic bank IDs enabled${prefixInfo} - each channel gets isolated memory`);
         } else {
-          debug(`[Hindsight] Dynamic bank IDs disabled - using static bank: ${getDefaultStaticBankId(pluginConfig)}`);
+          const sourceInfo = getConfiguredBankId(pluginConfig) ? 'configured' : 'default';
+          debug(`[Hindsight] Dynamic bank IDs disabled - using ${sourceInfo} static bank: ${getStaticBankId(pluginConfig)}`);
         }
 
         // Detect external API mode

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -62,7 +62,7 @@ export interface PluginConfig {
   hindsightApiUrl?: string; // External Hindsight API URL (skips local daemon when set)
   hindsightApiToken?: string; // API token for external Hindsight API authentication
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
-  staticBankId?: string; // Exact bank ID to use for all memories. Overrides dynamicBankId and bankIdPrefix when set.
+  bankId?: string; // Static bank ID used when dynamicBankId is false. Can also be set via HINDSIGHT_BANK_ID.
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.


### PR DESCRIPTION
## Summary

- add `bankId` as the static bank config for OpenClaw when `dynamicBankId` is `false`
- honor `HINDSIGHT_BANK_ID` during OpenClaw config loading
- keep the existing OpenClaw default of `dynamicBankId: true`
- update the OpenClaw plugin schema, tests, README, and docs page to reflect static bank configuration

Static mode still falls back to the default `openclaw` bank name when no `bankId` is set.

## Test plan

- [x] `npm test` in `hindsight-integrations/openclaw` (67/67 passing)
- [x] `npm run build` in `hindsight-integrations/openclaw`
