### PR TITLE
fix: update author name to Michael Bourkas

### DIFF
--- a/hindsight-docs/blog/authors.yml
+++ b/hindsight-docs/blog/authors.yml
@@ -33,7 +33,7 @@ fabioscarsi:
   image_url: https://github.com/fabioscarsi.png
 
 404sand808s:
-  name: Mike Bourkas
+  name: Michael Bourkas
   title: Guest Author
   url: https://github.com/404sand808s
   image_url: https://github.com/404sand808s.png


### PR DESCRIPTION
Corrects the display name for guest author 404sand808s from Mike to Michael Bourkas.