### PR TITLE
feat(openclaw): merge inline retain tags with defaults

### DIFF
--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -91,7 +91,7 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `dynamicBankId` | `true` | Enable per-context memory banks |
 | `bankId` | — | Static bank ID used when `dynamicBankId` is `false`. |
 | `bankIdPrefix` | — | Prefix for bank IDs (e.g. `"prod"`) |
-| `retainTags` | `[]` | Tags applied to every retained document, useful for cross-agent/source labeling (e.g. `source_system:openclaw`, `agent:agentname`) |
+| `retainTags` | `[]` | Tags applied to every retained document, useful for cross-agent/source labeling (e.g. `source_system:openclaw`, `agent:agentname`). Auto-retain also merges inline per-message tags from `<retain_tags>...</retain_tags>` or `<hindsight_retain_tags>...</hindsight_retain_tags>` blocks in user messages. |
 | `retainSource` | `"openclaw"` | `source` value written into retained document metadata |
 | `dynamicBankGranularity` | `["agent", "channel", "user"]` | Fields used to derive bank ID. Options: `agent`, `channel`, `user`, `provider` |
 | `excludeProviders` | `["heartbeat"]` | Message providers to skip for recall/retain (e.g. `heartbeat`, `slack`, `telegram`, `discord`) |

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -93,6 +93,8 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `bankIdPrefix` | — | Prefix for bank IDs (e.g. `"prod"`) |
 | `retainTags` | `[]` | Tags applied to every retained document, useful for cross-agent/source labeling (e.g. `source_system:openclaw`, `agent:agentname`) |
 | `retainSource` | `"openclaw"` | `source` value written into retained document metadata |
+| `retainUserPrefix` | `"User"` | Reserved for future transcript-label parity work. Current retained transcripts still use structured role markers. |
+| `retainAssistantPrefix` | `"Assistant"` | Reserved for future transcript-label parity work. Current retained transcripts still use structured role markers. |
 | `dynamicBankGranularity` | `["agent", "channel", "user"]` | Fields used to derive bank ID. Options: `agent`, `channel`, `user`, `provider` |
 | `excludeProviders` | `["heartbeat"]` | Message providers to skip for recall/retain (e.g. `heartbeat`, `slack`, `telegram`, `discord`) |
 | `autoRecall` | `true` | Auto-inject memories before each turn. Set to `false` when the agent has its own recall tool. |

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -93,8 +93,6 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `bankIdPrefix` | — | Prefix for bank IDs (e.g. `"prod"`) |
 | `retainTags` | `[]` | Tags applied to every retained document, useful for cross-agent/source labeling (e.g. `source_system:openclaw`, `agent:agentname`) |
 | `retainSource` | `"openclaw"` | `source` value written into retained document metadata |
-| `retainUserPrefix` | `"User"` | Reserved for future transcript-label parity work. Current retained transcripts still use structured role markers. |
-| `retainAssistantPrefix` | `"Assistant"` | Reserved for future transcript-label parity work. Current retained transcripts still use structured role markers. |
 | `dynamicBankGranularity` | `["agent", "channel", "user"]` | Fields used to derive bank ID. Options: `agent`, `channel`, `user`, `provider` |
 | `excludeProviders` | `["heartbeat"]` | Message providers to skip for recall/retain (e.g. `heartbeat`, `slack`, `telegram`, `discord`) |
 | `autoRecall` | `true` | Auto-inject memories before each turn. Set to `false` when the agent has its own recall tool. |

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -100,16 +100,6 @@
         "description": "Source value written into retained document metadata. Defaults to 'openclaw'.",
         "default": "openclaw"
       },
-      "retainUserPrefix": {
-        "type": "string",
-        "description": "Reserved for future transcript-label parity work. Currently retained transcripts continue using structured role markers.",
-        "default": "User"
-      },
-      "retainAssistantPrefix": {
-        "type": "string",
-        "description": "Reserved for future transcript-label parity work. Currently retained transcripts continue using structured role markers.",
-        "default": "Assistant"
-      },
       "autoRecall": {
         "type": "boolean",
         "description": "Automatically recall memories on every prompt and inject them as context. Set to false when agent has its own recall tool.",

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -100,6 +100,16 @@
         "description": "Source value written into retained document metadata. Defaults to 'openclaw'.",
         "default": "openclaw"
       },
+      "retainUserPrefix": {
+        "type": "string",
+        "description": "Reserved for future transcript-label parity work. Currently retained transcripts continue using structured role markers.",
+        "default": "User"
+      },
+      "retainAssistantPrefix": {
+        "type": "string",
+        "description": "Reserved for future transcript-label parity work. Currently retained transcripts continue using structured role markers.",
+        "default": "Assistant"
+      },
       "autoRecall": {
         "type": "boolean",
         "description": "Automatically recall memories on every prompt and inject them as context. Set to false when agent has its own recall tool.",

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -17,6 +17,8 @@ import {
   isEphemeralOperationalText,
   deriveBankId,
   normalizeRetainTags,
+  extractInlineRetainTags,
+  stripInlineRetainTags,
 } from './index.js';
 import type { PluginConfig, MemoryResult } from './types.js';
 
@@ -284,6 +286,21 @@ describe('normalizeRetainTags', () => {
   });
 });
 
+describe('inline retain tag helpers', () => {
+  it('extracts retain tags from inline directives', () => {
+    expect(extractInlineRetainTags('hello <retain_tags> client:acme, type:decision, client:acme </retain_tags> world')).toEqual([
+      'client:acme',
+      'type:decision',
+    ]);
+  });
+
+  it('supports hindsight_retain_tags alias and strips directives from content', () => {
+    const input = 'Keep this.\n<hindsight_retain_tags>scope:user</hindsight_retain_tags>\nNot the directive.';
+    expect(extractInlineRetainTags(input)).toEqual(['scope:user']);
+    expect(stripInlineRetainTags(input)).toBe('Keep this.\n\nNot the directive.');
+  });
+});
+
 describe('buildRetainRequest', () => {
   it('adds configured source metadata and retain tags', () => {
     const request = buildRetainRequest('hello world', 2, {
@@ -345,6 +362,21 @@ describe('buildRetainRequest', () => {
       sender_id: 'user:456',
       window_turns: '2',
     });
+  });
+
+  it('merges configured retain tags with inline per-message tags', () => {
+    const request = buildRetainRequest('hello world', 1, {}, {
+      retainTags: ['source_system:openclaw', 'agent:main'],
+    }, 1700000000000, {
+      turnIndex: 1,
+      tags: ['client:acme', 'agent:main'],
+    });
+
+    expect(request.tags).toEqual([
+      'source_system:openclaw',
+      'agent:main',
+      'client:acme',
+    ]);
   });
 
   it('defaults source metadata to openclaw when unset', () => {
@@ -430,6 +462,19 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).not.toContain('<hindsight_memories>');
     expect(result?.transcript).not.toContain('User prefers dark mode');
     expect(result?.transcript).toContain('Here is how to enable dark mode.');
+  });
+
+  it('strips inline retain-tag directives from retained content', () => {
+    const messages = [
+      { role: 'user', content: 'Remember this.\n<retain_tags>client:acme, type:decision</retain_tags>\nActual content.' },
+      { role: 'assistant', content: 'Got it.' }
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    expect(result).not.toBeNull();
+    expect(result?.transcript).toContain('Remember this.');
+    expect(result?.transcript).toContain('Actual content.');
+    expect(result?.transcript).not.toContain('<retain_tags>');
+    expect(result?.transcript).not.toContain('client:acme');
   });
 
   it('strips memory tags from user message when prependContext is prepended to it', () => {

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -295,6 +295,19 @@ describe('buildRetainRequest', () => {
     });
   });
 
+  it('merges configured retain tags with per-call tags', () => {
+    const request = buildRetainRequest('hello world', 1, {
+      sessionKey: 'agent:main:discord:channel:123',
+    }, {
+      retainTags: ['source_system:openclaw', 'agent:main'],
+    }, 1700000000000, {
+      turnIndex: 1,
+      tags: ['agent:main', 'kind:manual'],
+    });
+
+    expect(request.tags).toEqual(['source_system:openclaw', 'agent:main', 'kind:manual']);
+  });
+
   it('defaults source metadata to openclaw when unset', () => {
     const request = buildRetainRequest('hello world', 1, {}, {}, 1700000000000, { turnIndex: 1 });
     expect(request.metadata?.source).toBe('openclaw');
@@ -323,6 +336,8 @@ describe('prepareRetentionTranscript', () => {
   const baseConfig: PluginConfig = {
     dynamicBankId: true,
     retainRoles: ['user', 'assistant'],
+    retainUserPrefix: 'User',
+    retainAssistantPrefix: 'Assistant',
   };
 
   it('returns null if no user message found (turn boundary)', () => {
@@ -346,6 +361,17 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).toContain('New user');
     expect(result?.transcript).toContain('New assistant');
     expect(result?.transcript).not.toContain('Old user');
+  });
+
+  it('uses configured prefixes for user and assistant turns', () => {
+    const config: PluginConfig = { ...baseConfig, retainUserPrefix: 'Operator', retainAssistantPrefix: 'Aldous' };
+    const messages = [
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'General Kenobi' }
+    ];
+    const result = prepareRetentionTranscript(messages, config);
+    expect(result?.transcript).toContain('Operator: Hello there');
+    expect(result?.transcript).toContain('Aldous: General Kenobi');
   });
 
   it('filters out excluded roles', () => {

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -363,15 +363,15 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).not.toContain('Old user');
   });
 
-  it('uses configured prefixes for user and assistant turns', () => {
+  it('retains structured role markers even when prefixes are configured', () => {
     const config: PluginConfig = { ...baseConfig, retainUserPrefix: 'Operator', retainAssistantPrefix: 'Aldous' };
     const messages = [
       { role: 'user', content: 'Hello there' },
       { role: 'assistant', content: 'General Kenobi' }
     ];
     const result = prepareRetentionTranscript(messages, config);
-    expect(result?.transcript).toContain('Operator: Hello there');
-    expect(result?.transcript).toContain('Aldous: General Kenobi');
+    expect(result?.transcript).toContain('[role: user]\nHello there\n[user:end]');
+    expect(result?.transcript).toContain('[role: assistant]\nGeneral Kenobi\n[assistant:end]');
   });
 
   it('filters out excluded roles', () => {

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -336,8 +336,6 @@ describe('prepareRetentionTranscript', () => {
   const baseConfig: PluginConfig = {
     dynamicBankId: true,
     retainRoles: ['user', 'assistant'],
-    retainUserPrefix: 'User',
-    retainAssistantPrefix: 'Assistant',
   };
 
   it('returns null if no user message found (turn boundary)', () => {
@@ -361,17 +359,6 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).toContain('New user');
     expect(result?.transcript).toContain('New assistant');
     expect(result?.transcript).not.toContain('Old user');
-  });
-
-  it('retains structured role markers even when prefixes are configured', () => {
-    const config: PluginConfig = { ...baseConfig, retainUserPrefix: 'Operator', retainAssistantPrefix: 'Aldous' };
-    const messages = [
-      { role: 'user', content: 'Hello there' },
-      { role: 'assistant', content: 'General Kenobi' }
-    ];
-    const result = prepareRetentionTranscript(messages, config);
-    expect(result?.transcript).toContain('[role: user]\nHello there\n[user:end]');
-    expect(result?.transcript).toContain('[role: assistant]\nGeneral Kenobi\n[assistant:end]');
   });
 
   it('filters out excluded roles', () => {

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -4,6 +4,8 @@ import {
   extractRecallQuery,
   formatMemories,
   prepareRetentionTranscript,
+  countUserTurns,
+  getRetentionTurnIndex,
   sliceLastTurnsByUserBoundary,
   composeRecallQuery,
   truncateRecallQuery,
@@ -14,6 +16,7 @@ import {
   getIdentitySkipReason,
   isEphemeralOperationalText,
   deriveBankId,
+  normalizeRetainTags,
 } from './index.js';
 import type { PluginConfig, MemoryResult } from './types.js';
 
@@ -229,8 +232,57 @@ describe('formatMemories', () => {
 });
 
 // ---------------------------------------------------------------------------
-// prepareRetentionTranscript
+// retention helpers
 // ---------------------------------------------------------------------------
+
+describe('countUserTurns', () => {
+  it('counts user messages across a resumed conversation history', () => {
+    expect(countUserTurns([
+      { role: 'user', content: 'turn 1' },
+      { role: 'assistant', content: 'reply 1' },
+      { role: 'system', content: 'meta' },
+      { role: 'user', content: 'turn 2' },
+      { role: 'assistant', content: 'reply 2' },
+      { role: 'user', content: 'turn 3' },
+    ])).toBe(3);
+  });
+});
+
+describe('getRetentionTurnIndex', () => {
+  it('uses the full conversation turn count for per-turn retention', () => {
+    expect(getRetentionTurnIndex(7, 1)).toBe(7);
+  });
+
+  it('derives a stable window sequence for chunked retention', () => {
+    expect(getRetentionTurnIndex(6, 3)).toBe(2);
+  });
+
+  it('returns null when a chunk boundary has not been reached', () => {
+    expect(getRetentionTurnIndex(5, 3)).toBeNull();
+  });
+});
+
+describe('normalizeRetainTags', () => {
+  it('trims, deduplicates, and preserves order for string arrays', () => {
+    expect(normalizeRetainTags([' source_system:openclaw ', 'agent:main', 'agent:main', ''])).toEqual([
+      'source_system:openclaw',
+      'agent:main',
+    ]);
+  });
+
+  it('drops non-string values instead of stringifying them', () => {
+    expect(normalizeRetainTags(['agent:main', { a: 1 } as unknown as string, 42 as unknown as string, null as unknown as string])).toEqual([
+      'agent:main',
+    ]);
+  });
+
+  it('accepts comma-separated strings', () => {
+    expect(normalizeRetainTags(' source_system:openclaw, agent:main , agent:main ')).toEqual([
+      'source_system:openclaw',
+      'agent:main',
+    ]);
+  });
+});
 
 describe('buildRetainRequest', () => {
   it('adds configured source metadata and retain tags', () => {
@@ -293,19 +345,6 @@ describe('buildRetainRequest', () => {
       sender_id: 'user:456',
       window_turns: '2',
     });
-  });
-
-  it('merges configured retain tags with per-call tags', () => {
-    const request = buildRetainRequest('hello world', 1, {
-      sessionKey: 'agent:main:discord:channel:123',
-    }, {
-      retainTags: ['source_system:openclaw', 'agent:main'],
-    }, 1700000000000, {
-      turnIndex: 1,
-      tags: ['agent:main', 'kind:manual'],
-    });
-
-    expect(request.tags).toEqual(['source_system:openclaw', 'agent:main', 'kind:manual']);
   });
 
   it('defaults source metadata to openclaw when unset', () => {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -371,6 +371,40 @@ export function stripMemoryTags(content: string): string {
 }
 
 /**
+ * Extract per-message retain tag overrides from inline user content.
+ *
+ * Supported forms:
+ * - <retain_tags>tag:a, tag:b</retain_tags>
+ * - <hindsight_retain_tags>tag:a, tag:b</hindsight_retain_tags>
+ */
+export function extractInlineRetainTags(content: string): string[] {
+  if (!content) return [];
+
+  const tags: string[] = [];
+  const blockRe = /<(?:hindsight_)?retain_tags>([\s\S]*?)<\/(?:hindsight_)?retain_tags>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = blockRe.exec(content)) !== null) {
+    const normalized = normalizeRetainTags(match[1]);
+    for (const tag of normalized) {
+      if (!tags.includes(tag)) {
+        tags.push(tag);
+      }
+    }
+  }
+
+  return tags;
+}
+
+/**
+ * Remove inline retain tag directives from message content before storing it.
+ */
+export function stripInlineRetainTags(content: string): string {
+  if (!content) return content;
+  return content.replace(/<(?:hindsight_)?retain_tags>[\s\S]*?<\/(?:hindsight_)?retain_tags>/gi, '');
+}
+
+/**
  * Extract sender_id from OpenClaw's injected inbound metadata blocks.
  * Checks both "Conversation info (untrusted metadata)" and "Sender (untrusted metadata)" blocks.
  * Returns the first sender_id / id string found, or undefined if none.
@@ -1781,6 +1815,25 @@ ${memoriesFormatted}
           debug(`[Hindsight Hook] Turn ${turnCount}: chunked retain firing (window: ${windowTurns} turns, ${messagesToRetain.length} messages)`);
         }
 
+        const inlineRetainTags = normalizeRetainTags(
+          messagesToRetain.flatMap((msg: any) => {
+            if (msg?.role !== 'user') {
+              return [];
+            }
+
+            const content = typeof msg?.content === 'string'
+              ? msg.content
+              : Array.isArray(msg?.content)
+                ? msg.content
+                    .filter((block: any) => block?.type === 'text' && typeof block?.text === 'string')
+                    .map((block: any) => block.text)
+                    .join('\n')
+                : '';
+
+            return extractInlineRetainTags(content);
+          }),
+        );
+
         const retention = prepareRetentionTranscript(messagesToRetain, pluginConfig, retainFullWindow);
         if (!retention) {
           debug('[Hindsight Hook] No messages to retain (filtered/short/no-user)');
@@ -1820,6 +1873,7 @@ ${memoriesFormatted}
           {
             retentionScope: retainFullWindow ? 'window' : 'turn',
             windowTurns: retainFullWindow ? (pluginConfig.retainEveryNTurns ?? 1) + (pluginConfig.retainOverlapTurns ?? 0) : undefined,
+            tags: inlineRetainTags,
           },
         );
 
@@ -1895,7 +1949,7 @@ export function buildRetainRequest(
   effectiveCtx: PluginHookAgentContext | undefined,
   pluginConfig: PluginConfig,
   now = Date.now(),
-  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number },
+  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number; tags?: string[] },
 ): RetainRequest {
   const resolvedCtx = resolveSessionIdentity(effectiveCtx);
   const parsedSession = resolvedCtx?.sessionKey ? parseSessionKey(resolvedCtx.sessionKey) : {};
@@ -1908,6 +1962,10 @@ export function buildRetainRequest(
   const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const channelType = effectiveCtx?.messageProvider;
   const threadId = extractThreadId(channelId);
+  const mergedTags = normalizeRetainTags([
+    ...(pluginConfig.retainTags ?? []),
+    ...(options?.tags ?? []),
+  ]);
 
   return {
     content: transcript,
@@ -1927,7 +1985,7 @@ export function buildRetainRequest(
       sender_id: resolvedCtx?.senderId,
       ...(options?.windowTurns !== undefined ? { window_turns: String(options.windowTurns) } : {}),
     },
-    tags: pluginConfig.retainTags && pluginConfig.retainTags.length > 0 ? pluginConfig.retainTags : undefined,
+    tags: mergedTags.length > 0 ? mergedTags : undefined,
   };
 }
 
@@ -1993,6 +2051,7 @@ export function prepareRetentionTranscript(
     }
 
     content = stripMemoryTags(content);
+    content = stripInlineRetainTags(content);
     content = stripMetadataEnvelopes(content);
 
     if (content.trim()) {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1013,19 +1013,20 @@ async function checkExternalApiHealth(apiUrl: string, apiToken?: string | null):
   }
 }
 
-function normalizeRetainTags(value: unknown): string[] {
+export function normalizeRetainTags(value: unknown): string[] {
   if (value == null) return [];
 
   const rawItems = Array.isArray(value)
     ? value
     : typeof value === 'string'
       ? value.split(',')
-      : [value];
+      : [];
 
   const seen = new Set<string>();
   const normalized: string[] = [];
   for (const item of rawItems) {
-    const tag = String(item ?? '').trim();
+    if (typeof item !== 'string') continue;
+    const tag = item.trim();
     if (!tag || seen.has(tag)) continue;
     seen.add(tag);
     normalized.push(tag);
@@ -1894,7 +1895,7 @@ export function buildRetainRequest(
   effectiveCtx: PluginHookAgentContext | undefined,
   pluginConfig: PluginConfig,
   now = Date.now(),
-  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number; tags?: string[] },
+  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number },
 ): RetainRequest {
   const resolvedCtx = resolveSessionIdentity(effectiveCtx);
   const parsedSession = resolvedCtx?.sessionKey ? parseSessionKey(resolvedCtx.sessionKey) : {};
@@ -1907,8 +1908,6 @@ export function buildRetainRequest(
   const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const channelType = effectiveCtx?.messageProvider;
   const threadId = extractThreadId(channelId);
-
-  const mergedTags = normalizeRetainTags([...(pluginConfig.retainTags || []), ...((options?.tags || []).filter(Boolean))]);
 
   return {
     content: transcript,
@@ -1928,7 +1927,7 @@ export function buildRetainRequest(
       sender_id: resolvedCtx?.senderId,
       ...(options?.windowTurns !== undefined ? { window_turns: String(options.windowTurns) } : {}),
     },
-    tags: mergedTags.length > 0 ? mergedTags : undefined,
+    tags: pluginConfig.retainTags && pluginConfig.retainTags.length > 0 ? pluginConfig.retainTags : undefined,
   };
 }
 
@@ -2116,6 +2115,30 @@ function buildToolResultBlock(msg: any): any | null {
   const block: any = { type: 'tool_result', content: text };
   if (toolUseId) block.tool_use_id = toolUseId;
   return block;
+}
+
+export function countUserTurns(messages: any[]): number {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return 0;
+  }
+
+  return messages.reduce((count: number, message: any) => count + (message?.role === 'user' ? 1 : 0), 0);
+}
+
+export function getRetentionTurnIndex(conversationTurnCount: number, retainEveryN: number): number | null {
+  if (conversationTurnCount <= 0 || retainEveryN <= 0) {
+    return null;
+  }
+
+  if (retainEveryN === 1) {
+    return conversationTurnCount;
+  }
+
+  if (conversationTurnCount % retainEveryN !== 0) {
+    return null;
+  }
+
+  return Math.floor(conversationTurnCount / retainEveryN);
 }
 
 export function sliceLastTurnsByUserBoundary(messages: any[], turns: number): any[] {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1056,8 +1056,6 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     bankIdPrefix: config.bankIdPrefix,
     retainTags: normalizeRetainTags(config.retainTags),
     retainSource: typeof config.retainSource === 'string' && config.retainSource.trim().length > 0 ? config.retainSource.trim() : undefined,
-    retainUserPrefix: typeof config.retainUserPrefix === 'string' && config.retainUserPrefix.trim().length > 0 ? config.retainUserPrefix.trim() : 'User',
-    retainAssistantPrefix: typeof config.retainAssistantPrefix === 'string' && config.retainAssistantPrefix.trim().length > 0 ? config.retainAssistantPrefix.trim() : 'Assistant',
     excludeProviders: Array.isArray(config.excludeProviders)
       ? Array.from(new Set(['heartbeat', ...config.excludeProviders.filter((provider): provider is string => typeof provider === 'string')]))
       : ['heartbeat'],

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1013,6 +1013,26 @@ async function checkExternalApiHealth(apiUrl: string, apiToken?: string | null):
   }
 }
 
+function normalizeRetainTags(value: unknown): string[] {
+  if (value == null) return [];
+
+  const rawItems = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : [value];
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const item of rawItems) {
+    const tag = String(item ?? '').trim();
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    normalized.push(tag);
+  }
+  return normalized;
+}
+
 function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
   const config = api.config.plugins?.entries?.['hindsight-openclaw']?.config || {};
   const defaultMission = 'You are an AI assistant helping users across multiple communication channels (Telegram, Slack, Discord, etc.). Remember user preferences, instructions, and important context from conversations to provide personalized assistance.';
@@ -1034,8 +1054,10 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     dynamicBankId: config.dynamicBankId !== false,
     bankId: typeof config.bankId === 'string' && config.bankId.trim().length > 0 ? config.bankId.trim() : undefined,
     bankIdPrefix: config.bankIdPrefix,
-    retainTags: Array.isArray(config.retainTags) ? config.retainTags.filter((tag): tag is string => typeof tag === 'string') : undefined,
+    retainTags: normalizeRetainTags(config.retainTags),
     retainSource: typeof config.retainSource === 'string' && config.retainSource.trim().length > 0 ? config.retainSource.trim() : undefined,
+    retainUserPrefix: typeof config.retainUserPrefix === 'string' && config.retainUserPrefix.trim().length > 0 ? config.retainUserPrefix.trim() : 'User',
+    retainAssistantPrefix: typeof config.retainAssistantPrefix === 'string' && config.retainAssistantPrefix.trim().length > 0 ? config.retainAssistantPrefix.trim() : 'Assistant',
     excludeProviders: Array.isArray(config.excludeProviders)
       ? Array.from(new Set(['heartbeat', ...config.excludeProviders.filter((provider): provider is string => typeof provider === 'string')]))
       : ['heartbeat'],
@@ -1874,7 +1896,7 @@ export function buildRetainRequest(
   effectiveCtx: PluginHookAgentContext | undefined,
   pluginConfig: PluginConfig,
   now = Date.now(),
-  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number },
+  options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number; tags?: string[] },
 ): RetainRequest {
   const resolvedCtx = resolveSessionIdentity(effectiveCtx);
   const parsedSession = resolvedCtx?.sessionKey ? parseSessionKey(resolvedCtx.sessionKey) : {};
@@ -1887,6 +1909,8 @@ export function buildRetainRequest(
   const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const channelType = effectiveCtx?.messageProvider;
   const threadId = extractThreadId(channelId);
+
+  const mergedTags = normalizeRetainTags([...(pluginConfig.retainTags || []), ...((options?.tags || []).filter(Boolean))]);
 
   return {
     content: transcript,
@@ -1906,7 +1930,7 @@ export function buildRetainRequest(
       sender_id: resolvedCtx?.senderId,
       ...(options?.windowTurns !== undefined ? { window_turns: String(options.windowTurns) } : {}),
     },
-    tags: pluginConfig.retainTags && pluginConfig.retainTags.length > 0 ? pluginConfig.retainTags : undefined,
+    tags: mergedTags.length > 0 ? mergedTags : undefined,
   };
 }
 

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -67,8 +67,6 @@ export interface PluginConfig {
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
   retainTags?: string[]; // Default tags applied to retained documents; merged with per-call tags when provided
   retainSource?: string; // Source written into retained document metadata (default: 'openclaw')
-  retainUserPrefix?: string; // Label used before user turns in retained transcripts (default: 'User')
-  retainAssistantPrefix?: string; // Label used before assistant turns in retained transcripts (default: 'Assistant')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.
   dynamicBankGranularity?: Array<'agent' | 'provider' | 'channel' | 'user'>; // Fields for bank ID derivation. Default: ['agent', 'channel', 'user']

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -65,7 +65,7 @@ export interface PluginConfig {
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
   bankId?: string; // Static bank ID used when dynamicBankId is false.
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
-  retainTags?: string[]; // Tags applied to all retained documents after trimming and deduplication (e.g. ['source_system:openclaw', 'agent:agentname'])
+  retainTags?: string[]; // Tags applied to all retained documents after trimming and deduplication; auto-retain merges these with inline per-message retain-tag directives (e.g. ['source_system:openclaw', 'agent:agentname'])
   retainSource?: string; // Source written into retained document metadata (default: 'openclaw')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -65,8 +65,10 @@ export interface PluginConfig {
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
   bankId?: string; // Static bank ID used when dynamicBankId is false.
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
-  retainTags?: string[]; // Tags applied to all retained documents (e.g. ['source_system:openclaw', 'agent:agentname'])
+  retainTags?: string[]; // Default tags applied to retained documents; merged with per-call tags when provided
   retainSource?: string; // Source written into retained document metadata (default: 'openclaw')
+  retainUserPrefix?: string; // Label used before user turns in retained transcripts (default: 'User')
+  retainAssistantPrefix?: string; // Label used before assistant turns in retained transcripts (default: 'Assistant')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.
   dynamicBankGranularity?: Array<'agent' | 'provider' | 'channel' | 'user'>; // Fields for bank ID derivation. Default: ['agent', 'channel', 'user']

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -65,7 +65,7 @@ export interface PluginConfig {
   dynamicBankId?: boolean; // Enable per-channel memory banks (default: true)
   bankId?: string; // Static bank ID used when dynamicBankId is false.
   bankIdPrefix?: string; // Prefix for bank IDs (e.g. 'prod' -> 'prod-slack-C123')
-  retainTags?: string[]; // Default tags applied to retained documents; merged with per-call tags when provided
+  retainTags?: string[]; // Tags applied to all retained documents after trimming and deduplication (e.g. ['source_system:openclaw', 'agent:agentname'])
   retainSource?: string; // Source written into retained document metadata (default: 'openclaw')
   excludeProviders?: string[]; // Message providers to exclude from recall/retain (e.g. ['telegram', 'discord'])
   autoRecall?: boolean; // Auto-recall memories on every prompt (default: true). Set to false when agent has its own recall tool.


### PR DESCRIPTION
## Summary
- merge configured `retainTags` with inline per-message retain tags from user content
- keep retain-tag normalization strict so non-string config values are dropped
- preserve the existing structured transcript format while stripping tag directives from stored content

## Why
There are two useful retain-tag layers here:
- stable defaults from config, such as `source_system:openclaw`
- context-specific tags attached at retain time, such as `client:acme` or `type:decision`

OpenClaw should support both. Default tags provide consistent source labeling, while per-message tags let retained memories capture immediate context at the moment they are stored.

For OpenClaw, the clean runtime caller is a per-message override: user messages can include an inline retain-tag directive, and auto-retain merges those tags with configured defaults when building the retain request.

## What changed
- keep `normalizeRetainTags(...)` strict: trim, deduplicate, preserve order, and reject non-string values
- add inline retain-tag parsing for user messages via:
  - `<retain_tags>...</retain_tags>`
  - `<hindsight_retain_tags>...</hindsight_retain_tags>`
- merge configured `retainTags` first, then inline per-message tags
- strip inline retain-tag directives back out before transcript storage so they do not pollute retained content
- leave the existing `[role: ...] ... [role:end]` transcript structure intact
- add tests for inline tag extraction, merged tag behavior, and directive stripping

## Why this shape
This addresses the review concern about the old `options.tags` path having no runtime caller.

The caller is now real and production-facing: user messages can provide per-message retain tags, and the auto-retain hook threads those through to `buildRetainRequest(...)`.

## Testing
- `npm test -- src/index.test.ts` in `hindsight-integrations/openclaw`

## Follow-up
- filed #1033 for the separate backfill symlink-path issue mentioned in review
