### PR TITLE
fix(recall): preserve RRF ranking when reranker is a passthrough

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -60,6 +60,32 @@ def apply_combined_scoring(
     if now.tzinfo is None:
         now = now.replace(tzinfo=UTC)
 
+    # When the configured cross-encoder is a passthrough (e.g.
+    # RRFPassthroughCrossEncoder used by slim deployments), every
+    # cross_encoder_score_normalized is identical and provides no relevance
+    # signal. In that case the multiplicative recency / temporal / proof_count
+    # boosts below become the *only* ranking signal — making the final order a
+    # pure recency sort regardless of how relevant a candidate actually is.
+    #
+    # Detect that case and seed cross_encoder_score_normalized from the RRF
+    # rank instead, so the boosts modulate a meaningful base score rather than
+    # replacing it. This is a no-op for real cross-encoders, which produce
+    # diverse scores.
+    if scored_results:
+        ce_scores = {sr.cross_encoder_score_normalized for sr in scored_results}
+        if len(ce_scores) <= 1:
+            n = len(scored_results)
+            sorted_by_rrf = sorted(
+                scored_results,
+                key=lambda s: getattr(getattr(s, "candidate", None), "rrf_score", 0.0),
+                reverse=True,
+            )
+            denom = max(1, n - 1)
+            for new_rank, sr in enumerate(sorted_by_rrf):
+                # Map rank → [0.1, 1.0] so the recency boost can still nudge
+                # ordering between adjacent candidates without overpowering RRF.
+                sr.cross_encoder_score_normalized = 1.0 - (0.9 * new_rank / denom)
+
     for sr in scored_results:
         # Recency: linear decay over 365 days → [0.1, 1.0]; neutral 0.5 if no date.
         sr.recency = 0.5


### PR DESCRIPTION
## Summary

When `reranker_provider=rrf` (the slim deployment default,
`RRFPassthroughCrossEncoder`), `apply_combined_scoring` silently turns the
final ranking into a pure newest-first sort. The upstream RRF rank — which
fuses semantic, BM25 and graph signals — is discarded entirely, so any
fact with an old ``occurred_start`` is guaranteed to lose to a recent fact
in the candidate set, no matter how relevant it is.

## Root cause

`hindsight_api/engine/search/reranking.py` — `apply_combined_scoring()`:

1. The passthrough cross-encoder returns ``[0.5, 0.5, …]`` for every
   query/document pair (`engine/cross_encoder.py`,
   `RRFPassthroughCrossEncoder.predict`).
2. After sigmoid normalisation in ``CrossEncoderReranker.rerank``, every
   candidate ends up with the same ``cross_encoder_score_normalized``
   (~0.6225).
3. ``apply_combined_scoring`` then sets ``rrf_normalized = 0.0`` (line 87)
   and computes::

       combined_score = ce_norm * recency_boost * temporal_boost * proof_count_boost

   With ``ce_norm`` constant across all candidates and the temporal /
   proof_count boosts collapsing to 1.0 for non-temporal world-fact
   queries, ``combined_score`` is a pure function of ``recency_boost``.
   The relative ordering becomes ``occurred_start`` desc — newest wins.

## Reproduction

In a bank that contains ``world`` facts spanning a wide date range
(e.g. historical records mixed with recent observations), pick a
``world`` fact whose ``occurred_start`` is several years in the past
and a query that semantically matches that fact. With ``trace=true``::

    semantic   (world): 1000 items | target rank 1
    bm25       (world): 1000 items | target rank 1
    graph      (world):  346 items | target visited
    RRF merged       :  1673 items | target rank 1
    Reranked         :   300 items | target rank 80
    Final            :    77 items | target dropped (outside max_tokens)

Every retrieval arm — semantic, BM25, graph — and the RRF fusion put the
target at rank 1. The reranker pushes it to 80 and the token-budget
filter drops it.

This reproduces consistently across query phrasings (long, short, with
or without entity names) and across budget levels (low/mid/high). It
also reproduces against a clean bank populated only with the
``hindsight-all-slim`` defaults — no custom configuration required.

## Fix

Detect the degenerate-CE case in ``apply_combined_scoring`` and seed
``cross_encoder_score_normalized`` from the RRF rank before the boosts
are applied. The boosts then modulate a meaningful base instead of
replacing it.

```python
ce_scores = {sr.cross_encoder_score_normalized for sr in scored_results}
if len(ce_scores) <= 1:
    n = len(scored_results)
    sorted_by_rrf = sorted(
        scored_results,
        key=lambda s: getattr(getattr(s, \"candidate\", None), \"rrf_score\", 0.0),
        reverse=True,
    )
    denom = max(1, n - 1)
    for new_rank, sr in enumerate(sorted_by_rrf):
        sr.cross_encoder_score_normalized = 1.0 - (0.9 * new_rank / denom)
```

The mapping ``rank → [0.1, 1.0]`` keeps the recency / temporal /
proof_count boosts able to break ties between adjacent RRF candidates,
without letting them dominate the ranking.

## What this does NOT change

- Real cross-encoders (``local``, ``flashrank``, ``cohere``, ``litellm``,
  …) produce diverse scores, so the ``len(set(...)) <= 1`` guard never
  triggers and the existing scoring path is unchanged.
- No schema migration, no embedding change, no API change.
- ``rrf_normalized`` stays at 0.0 in the trace for backward compatibility.

## After fix

Same database, same queries, same Hindsight build with the patch
applied: the target fact lands in the top 10 of the final response for
every tested phrasing of the query.

## Test plan

- [ ] Run a recall query against a bank where the most relevant
      ``world`` fact has an old ``occurred_start`` and the bank also
      contains many recent observations / world facts. Confirm that
      with ``reranker_provider=rrf`` the relevant fact is in the
      response (was previously dropped).
- [ ] Run the same query against a deployment with a real cross-encoder
      (``local``, ``flashrank``) and confirm the result set is
      unchanged from main.
- [ ] Existing reranking unit tests still pass.

Happy to add a regression test for the passthrough case if you'd like
me to extend this PR — let me know which test file you'd prefer it
under (didn't want to guess at the project's test conventions).

Would appreciate a review when you get a chance — flagging
@vectorize-io maintainers since this affects the default slim
deployment behavior.