### PR TITLE
docs(openclaw): clarify memory-wiki bridge limitation

### DIFF
--- a/hindsight-docs/blog/2026-04-01-openclaw-shared-memory.md
+++ b/hindsight-docs/blog/2026-04-01-openclaw-shared-memory.md
@@ -18,6 +18,8 @@ A team of agents that can't share memory isn't really a team.
 
 Hindsight solves this with shared memory banks — a single store that every instance reads from and writes to. One agent learns something; every agent knows it. One config change.
 
+> This post is about **shared Hindsight banks across OpenClaw instances**, not OpenClaw `memory-wiki` bridge mode. Today, the `hindsight-openclaw` plugin supports shared banks via Hindsight API configuration, but it does not yet export OpenClaw `publicArtifacts` for `memory-wiki` bridge import.
+
 ---
 
 ## Why Instances Learn in Silos

--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -67,6 +67,16 @@ The plugin will automatically:
 
 Traditional memory systems give agents a `search_memory` tool - but models don't use it consistently. Auto-recall solves this by injecting memories automatically before every turn.
 
+## Compatibility note: OpenClaw `memory-wiki` bridge mode
+
+The Hindsight OpenClaw plugin currently supports OpenClaw's active memory-plugin flow: retain, recall, bank routing, and historical backfill.
+
+It does **not** currently export OpenClaw `publicArtifacts`, so OpenClaw `memory-wiki` bridge mode cannot yet import Hindsight-backed artifacts.
+
+If you enable `memory-wiki` with `vaultMode: "bridge"` while `hindsight-openclaw` is the active memory plugin, `openclaw wiki bridge import` will currently import `0` artifacts and `openclaw wiki status` may warn that the active memory plugin is not exporting any public memory artifacts yet.
+
+This is separate from Hindsight's own shared-memory setup. Shared banks via external Hindsight API work today. OpenClaw `memory-wiki` bridge import from Hindsight does not yet.
+
 ## Configuration
 
 ### Plugin Settings

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -31,6 +31,18 @@ That's it! The plugin will automatically start capturing and recalling memories.
 - **Historical backfill CLI** — import prior OpenClaw session history into Hindsight using the active plugin bank-routing config by default
 - **Retention controls** — choose which message roles to retain, toggle auto-retain on/off, and stamp retained documents with consistent tags/source metadata
 
+## Compatibility notes
+
+### OpenClaw `memory-wiki` bridge mode
+
+The Hindsight OpenClaw plugin currently supports the **active memory plugin** flow: retain, recall, bank routing, and backfill.
+
+It does **not** currently export OpenClaw `publicArtifacts`, so `memory-wiki` bridge mode cannot import Hindsight-backed artifacts yet.
+
+In practice, if you set OpenClaw `memory-wiki` to `vaultMode: "bridge"` while `hindsight-openclaw` is the active memory plugin, `openclaw wiki bridge import` will currently import `0` artifacts and `openclaw wiki status` may warn that the active memory plugin is not exporting any public memory artifacts yet.
+
+This is separate from Hindsight's own shared-bank / external-API setup. Shared Hindsight banks work today; OpenClaw `memory-wiki` bridge import from Hindsight does not yet.
+
 ## Configuration
 
 Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsight-openclaw.config`:


### PR DESCRIPTION
## Summary

Clarify that the current `hindsight-openclaw` integration supports OpenClaw's active memory-plugin flow, but does not yet export OpenClaw `publicArtifacts` for `memory-wiki` bridge mode.

Closes #963

## Changes

- add a compatibility note to the OpenClaw integration docs
- add the same note to the package README
- clarify in the shared-memory blog post that shared Hindsight banks are different from OpenClaw `memory-wiki` bridge import

## Why

Today, users can reasonably read the shared-memory docs and expect OpenClaw `memory-wiki` bridge mode to work when `hindsight-openclaw` is the active memory plugin.

In practice, `openclaw wiki bridge import` currently imports `0` artifacts and OpenClaw warns that the active memory plugin is not exporting any public memory artifacts yet.

This PR does not add artifact export support. It just documents the current limitation clearly so users do not confuse:

- shared Hindsight banks via external API
- OpenClaw `memory-wiki` bridge import
