### PR TITLE
ci: add ad-hoc release workflow for @vectorize-io/hindsight-all

### DIFF
--- a/.github/workflows/release-hindsight-all-npm.yml
+++ b/.github/workflows/release-hindsight-all-npm.yml
@@ -1,0 +1,90 @@
+name: Release @vectorize-io/hindsight-all (manual)
+
+# Ad-hoc publisher for @vectorize-io/hindsight-all. Decoupled from the main
+# Hindsight `v*` tag pipeline so we can cut a fresh version without cutting a
+# full Hindsight release.
+#
+# Trigger: GitHub Actions UI → "Release @vectorize-io/hindsight-all (manual)"
+# → "Run workflow" → enter the version (e.g. 0.1.0). Or from the command
+# line: `gh workflow run release-hindsight-all-npm.yml -f version=0.1.0`.
+#
+# The workflow overrides hindsight-all-npm/package.json at build time via
+# `npm version --no-git-tag-version`, so the committed version (which
+# scripts/release.sh keeps in sync with the main Hindsight version) is not
+# disturbed. npm lets us publish any version number as long as it has not
+# been published before.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (semver, e.g. 0.1.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (build + npm pack, skip publish)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: main
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+
+    - name: Install root workspace dependencies
+      run: npm ci
+
+    - name: Set package version (build-time only, not committed)
+      working-directory: ./hindsight-all-npm
+      run: npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
+
+    - name: Build
+      run: npm run build --workspace=hindsight-all-npm
+
+    - name: Run unit tests
+      run: npm test --workspace=hindsight-all-npm
+
+    - name: Publish to npm
+      if: ${{ !inputs.dry_run }}
+      working-directory: ./hindsight-all-npm
+      run: |
+        set +e
+        OUTPUT=$(npm publish --access public 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          if echo "$OUTPUT" | grep -q "cannot publish over"; then
+            echo "Package version ${{ inputs.version }} already published, skipping..."
+            exit 0
+          fi
+          exit $EXIT_CODE
+        fi
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Pack (dry run)
+      if: ${{ inputs.dry_run }}
+      working-directory: ./hindsight-all-npm
+      run: npm pack
+
+    - name: Upload tarball artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: hindsight-all-npm-${{ inputs.version }}
+        path: hindsight-all-npm/*.tgz
+        if-no-files-found: warn
+        retention-days: 14


### PR DESCRIPTION
## Summary

Adds a standalone workflow that publishes a specific version of \`@vectorize-io/hindsight-all\` on demand, decoupled from the main Hindsight \`v*\` tag pipeline. Needed so we can cut an initial 0.1.0 (and any subsequent patch) without waiting for a full Hindsight release.

## How it works

- **Trigger**: \`workflow_dispatch\` from the Actions UI (or \`gh workflow run\`), with a required \`version\` input and an optional \`dry_run\` toggle.
- **Version handling**: overrides \`hindsight-all-npm/package.json\` at build time via \`npm version --no-git-tag-version\`. The committed version (which \`scripts/release.sh\` keeps in sync with the main Hindsight version) is not disturbed, so there's no split-brain with the main release pipeline.
- **Credentials**: uses the existing \`NPM_TOKEN\` secret via the \`npm\` environment, same as \`release.yml\`.
- **Safety**: standard "cannot publish over" guard so re-runs on the same version number are no-ops.

## Next step after merge

Trigger manually to publish 0.1.0:

\`\`\`bash
gh workflow run release-hindsight-all-npm.yml -f version=0.1.0 --ref main
\`\`\`

Or from the GitHub Actions UI: **Release @vectorize-io/hindsight-all (manual)** → **Run workflow** → enter \`0.1.0\`.

## Version drift note

After 0.1.0 ships, the committed \`package.json\` still reads \`0.5.0\` (matching main Hindsight). On the next \`v*\` tag release, \`scripts/release.sh\` will bump to e.g. \`0.5.1\` and the existing \`release-hindsight-all-npm\` job in \`release.yml\` will publish \`0.5.1\`. So the npm version history will be \`0.1.0 → 0.5.1\`. That's fine semver-wise — npm allows non-monotonic publishes as long as each version is unique — but it's a version jump. If we want to fully decouple this package from the main Hindsight version long-term, that's a separate follow-up (stop bumping it in \`scripts/release.sh\`, remove the job from \`release.yml\`).

## Test plan

- [ ] CI lint + shellcheck on the new workflow passes
- [ ] Manually trigger with \`dry_run=true\` first to validate the build + pack steps produce a tarball, without publishing
- [ ] Then trigger with \`version=0.1.0\` \`dry_run=false\` to publish
- [ ] Verify \`npm view @vectorize-io/hindsight-all@0.1.0\` shows the new version