### PR TITLE
fix(billing): mark reflect's internal recall calls as internal

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -9,6 +9,7 @@ Implements hierarchical retrieval:
 
 import logging
 import uuid
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -162,13 +163,18 @@ async def tool_search_observations(
     if include_source_facts and source_facts_max_tokens > 0:
         recall_kwargs["max_source_facts_tokens"] = source_facts_max_tokens
 
+    # Use an internal request context so this recall is not billed as a
+    # user-facing operation. The reflect caller is already billed for the
+    # overall reflect operation; double-billing the sub-recalls would
+    # overcharge the customer.
+    internal_ctx = replace(request_context, internal=True)
     result = await memory_engine.recall_async(
         bank_id=bank_id,
         query=query,
         fact_type=["observation"],
         max_tokens=max_tokens,
         enable_trace=False,
-        request_context=request_context,
+        request_context=internal_ctx,
         tags=tags,
         tags_match=tags_match,
         tag_groups=tag_groups,
@@ -233,13 +239,14 @@ async def tool_recall(
     # Only world/experience are valid for raw recall (observation is handled by search_observations)
     recall_fact_type = [ft for ft in (fact_types or ["experience", "world"]) if ft in ("world", "experience")]
     include_chunks = True
+    internal_ctx = replace(request_context, internal=True)
     result = await memory_engine.recall_async(
         bank_id=bank_id,
         query=query,
         fact_type=recall_fact_type,
         max_tokens=max_tokens,
         enable_trace=False,
-        request_context=request_context,
+        request_context=internal_ctx,
         tags=tags,
         tags_match=tags_match,
         tag_groups=tag_groups,


### PR DESCRIPTION
## Summary

Reflect's tool functions (`tool_search_observations`, `tool_recall`) pass the caller's `request_context` directly to `recall_async` without setting `internal=True`. This causes the metering extension to record and bill these sub-recalls as standalone user-facing recall operations, double-charging for work that is already part of the reflect operation.

## Fix

Wrap `request_context` with `dataclasses.replace(request_context, internal=True)` at both call sites. This matches the pattern consolidation already uses for its internal sub-operations.

With the `internal` flag set, the metering extension:
- Records usage as `internal_recall` (tracked for analytics, not billed)
- Skips credit deduction

## Test plan

- [ ] CI passes
- [ ] After deploy: verify metering logs show `op=internal_recall_complete` for reflect's sub-recalls, not `op=recall_complete`