### PR TITLE
fix(llm): send max_completion_tokens for reasoning models and Azure OpenAI

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -196,15 +196,28 @@ class OpenAICompatibleLLM(LLMInterface):
     def _max_tokens_param_name(self) -> str:
         """Return the correct parameter name for limiting response tokens.
 
-        Native OpenAI and Groq accept 'max_completion_tokens'. Mistral and other
-        OpenAI-compatible endpoints that haven't adopted the newer parameter name
-        require 'max_tokens'. Using a custom base_url with the openai provider
-        signals a third-party compatible API, so fall back to 'max_tokens'.
+        Native OpenAI, Azure OpenAI, Groq, and llamacpp accept 'max_completion_tokens'.
+        Mistral and other OpenAI-compatible endpoints that haven't adopted the newer
+        parameter name require 'max_tokens', so when the openai provider is configured
+        with a non-Azure custom base_url we fall back to the widely-supported
+        'max_tokens'.
+
+        Reasoning models (GPT-5, o1, o3) only accept 'max_completion_tokens' and reject
+        'max_tokens' outright, so they always use the new parameter name regardless of
+        base_url.
         """
+        # Reasoning models (GPT-5, o1, o3, ...) only accept max_completion_tokens.
+        # Azure OpenAI + GPT-5 is the canonical example: issue #978.
+        if self._supports_reasoning_model():
+            return "max_completion_tokens"
         # Native OpenAI (no custom base URL), Groq, and llamacpp use max_completion_tokens
         if self.provider in ("groq", "llamacpp"):
             return "max_completion_tokens"
         if self.provider == "openai" and not self.base_url:
+            return "max_completion_tokens"
+        # Azure OpenAI is fully OpenAI-API-compatible — detect it by hostname so users
+        # can keep provider=openai + an Azure base_url (the documented setup).
+        if self.provider == "openai" and self.base_url and ".openai.azure.com" in self.base_url:
             return "max_completion_tokens"
         # openai with custom base_url, ollama, lmstudio, minimax, volcano —
         # use the widely-supported max_tokens

--- a/hindsight-api-slim/tests/test_openai_max_tokens_param.py
+++ b/hindsight-api-slim/tests/test_openai_max_tokens_param.py
@@ -1,0 +1,72 @@
+"""
+Tests for OpenAICompatibleLLM._max_tokens_param_name.
+
+Regression coverage for issue #978: Azure OpenAI + GPT-5 models were failing with
+"'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."
+because PR #858 started sending 'max_tokens' whenever the openai provider had a
+custom base_url. Reasoning models only accept 'max_completion_tokens', and Azure
+OpenAI is fully OpenAI-API-compatible, so both cases must keep using the new
+parameter name.
+"""
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+def _make(provider: str, model: str, base_url: str = "") -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider=provider,
+        api_key="test-key",
+        base_url=base_url,
+        model=model,
+    )
+
+
+class TestMaxTokensParamName:
+    def test_native_openai_uses_max_completion_tokens(self):
+        llm = _make("openai", "gpt-4o-mini")
+        assert llm._max_tokens_param_name() == "max_completion_tokens"
+
+    def test_openai_custom_base_url_falls_back_to_max_tokens(self):
+        """Mistral/Together-style OpenAI-compatible endpoints need max_tokens (PR #858)."""
+        llm = _make("openai", "mistral-large-latest", base_url="https://api.mistral.ai/v1")
+        assert llm._max_tokens_param_name() == "max_tokens"
+
+    def test_azure_openai_uses_max_completion_tokens(self):
+        """Regression for #978: Azure is fully OpenAI-API-compatible, not a third-party clone."""
+        llm = _make(
+            "openai",
+            "gpt-4o-mini",
+            base_url="https://my-resource.openai.azure.com/openai/v1/",
+        )
+        assert llm._max_tokens_param_name() == "max_completion_tokens"
+
+    def test_reasoning_model_always_uses_max_completion_tokens(self):
+        """Regression for #978: GPT-5/o1/o3 reject max_tokens outright, base_url must not matter."""
+        # Azure + GPT-5 (exact reporter setup)
+        azure_gpt5 = _make(
+            "openai",
+            "gpt-5.4-nano",
+            base_url="https://my-resource.openai.azure.com/openai/v1/",
+        )
+        assert azure_gpt5._max_tokens_param_name() == "max_completion_tokens"
+
+        # Even a Mistral-style custom base_url must not downgrade a reasoning model
+        for model in ("gpt-5", "gpt-5-mini", "o1-mini", "o3", "deepseek-r1"):
+            llm = _make("openai", model, base_url="https://some-proxy.example.com/v1")
+            assert llm._max_tokens_param_name() == "max_completion_tokens", model
+
+    def test_groq_uses_max_completion_tokens(self):
+        llm = _make("groq", "openai/gpt-oss-120b", base_url="https://api.groq.com/openai/v1")
+        assert llm._max_tokens_param_name() == "max_completion_tokens"
+
+    def test_llamacpp_uses_max_completion_tokens(self):
+        llm = _make("llamacpp", "some-model", base_url="http://localhost:8080/v1")
+        assert llm._max_tokens_param_name() == "max_completion_tokens"
+
+    def test_ollama_uses_max_tokens(self):
+        llm = _make("ollama", "gemma3:12b", base_url="http://localhost:11434/v1")
+        assert llm._max_tokens_param_name() == "max_tokens"
+
+    def test_lmstudio_uses_max_tokens(self):
+        llm = _make("lmstudio", "openai/gpt-oss-20b", base_url="http://localhost:1234/v1")
+        assert llm._max_tokens_param_name() == "max_tokens"


### PR DESCRIPTION
## Summary

Fixes #978 — a regression introduced by #858. When the `openai` provider is configured with a custom `base_url`, PR #858 started sending `max_tokens` instead of `max_completion_tokens` so Mistral/Together-style endpoints would work. That swept in two setups that **must** keep using `max_completion_tokens`:

1. **Reasoning models** (GPT-5, o1, o3, DeepSeek) — they reject `max_tokens` with HTTP 400: `"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."`
2. **Azure OpenAI** — fully OpenAI-API-compatible, it only has a custom `base_url` because of Azure's hostname structure (`*.openai.azure.com`).

The combination — Azure OpenAI + GPT-5 — is the exact config in #978 and fails connection verification on startup.

## Changes

`_max_tokens_param_name()` in `openai_compatible_llm.py` now:

- Returns `max_completion_tokens` for reasoning models regardless of `base_url`.
- Detects Azure OpenAI endpoints by `.openai.azure.com` in the hostname and treats them as native OpenAI.
- Preserves the Mistral/Together fallback from #858 for non-reasoning models on non-Azure custom base URLs.

## Test plan

- [x] New unit tests in `tests/test_openai_max_tokens_param.py` covering:
  - Native OpenAI → `max_completion_tokens`
  - `openai` + Mistral base_url → `max_tokens` (preserves #858)
  - `openai` + Azure base_url → `max_completion_tokens` (fixes #978)
  - Reasoning model + any custom base_url → `max_completion_tokens` (fixes #978; matches reporter's `gpt-5.4-nano` on Azure)
  - Groq, llamacpp → `max_completion_tokens`
  - ollama, lmstudio → `max_tokens`
- [x] Existing `test_lmstudio_tool_choice.py` still passes (no behavior change for lmstudio).
- [x] `./scripts/hooks/lint.sh` passes.