### PR TITLE
fix(worker): classify IntegrityConstraintViolationError as non-retryable

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1140,6 +1140,16 @@ class MemoryEngine(MemoryEngineInterface):
                     logger.error(f"Not retrying task {task_type} (non-retryable), marking as failed")
                     if operation_id:
                         await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                elif isinstance(e, asyncpg.IntegrityConstraintViolationError):
+                    # Non-retryable: constraint violations are deterministic and won't
+                    # succeed on retry (e.g. UniqueViolationError on pk_chunks when
+                    # re-submitting a retain with an existing document_id, see #977).
+                    logger.error(
+                        f"Not retrying task {task_type} (deterministic constraint violation: "
+                        f"{type(e).__name__}), marking as failed"
+                    )
+                    if operation_id:
+                        await self._mark_operation_failed(operation_id, str(e), error_traceback)
                 else:
                     if task_type == "consolidation" and operation_id:
                         # Fire failure webhook (non-transactional — operation not yet marked failed;


### PR DESCRIPTION
## Summary

Constraint violations (`UniqueViolationError`, `ForeignKeyViolationError`, `CheckViolationError`, `NotNullViolationError`, `ExclusionViolationError`) are deterministic — retrying will never resolve them. Currently these exceptions fall through to the generic retry path in `execute_task`, wasting worker capacity with up to 3 retries at 60-second intervals before the task is finally marked as failed.

This PR adds an `isinstance` check for `asyncpg.IntegrityConstraintViolationError` (the parent class of all constraint violation exceptions) before the retry logic. Matching exceptions are marked as failed immediately via `_mark_operation_failed`, following the same pattern as the existing `file_convert_retain` non-retryable path.

## Motivation

Reported as the secondary issue in #977: when `retain` is called with an existing `document_id`, the worker hits `UniqueViolationError` on `pk_chunks` and retries ~3 times over ~3 minutes before giving up. Each retry is wasted work that also blocks the worker slot.

The primary issue in #977 (upsert semantics for `document_id`) is a separate design discussion. This PR addresses only the retry classification.

## Changes

- `hindsight-api-slim/hindsight_api/engine/memory_engine.py`: Add `elif isinstance(e, asyncpg.IntegrityConstraintViolationError)` branch in `execute_task`'s exception handler, between the existing `file_convert_retain` check and the generic retry path (+8 lines)

## Test plan

- [ ] Existing `test_executor_exception_marks_failed_immediately` continues to pass (same pattern)
- [ ] Existing `test_executor_exception_triggers_retry` continues to pass (non-constraint errors still retry)
- [ ] Manual: trigger a `UniqueViolationError` via duplicate `document_id` retain — task should fail immediately instead of retrying 3 times

Fixes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)