### PR TITLE
fix(mental-models): surface warning when tag filtering empties fact pool

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -996,10 +996,33 @@ class MemoryEngine(MemoryEngineInterface):
                     )
             based_on_serialized[fact_type] = serialized_facts
 
-        reflect_response = {
+        # Detect empty fact pool caused by tag filtering and surface a clear warning.
+        # Without this, users see "I don't have information" with no hint that tags are
+        # the cause (reported in https://github.com/vectorize-io/hindsight/issues/945).
+        has_tag_filtering = bool(tag_filtering.tags or tag_filtering.tag_groups)
+        non_directive_facts = sum(
+            len(facts) for fact_type, facts in based_on_serialized.items() if fact_type != "directives"
+        )
+        tag_filter_warning: str | None = None
+        if has_tag_filtering and non_directive_facts == 0:
+            active_tags = tag_filtering.tags or [str(tg) for tg in (tag_filtering.tag_groups or [])]
+            tag_filter_warning = (
+                f"No memories matched the tags {active_tags!r} configured on this mental model. "
+                f"The model content could not be generated. "
+                f"Remove the tags from the model or backfill memory tags to allow facts to be retrieved."
+            )
+            logger.warning(
+                f"[REFRESH_MENTAL_MODEL_TASK] Tag filtering produced empty fact pool for "
+                f"mental_model_id={mental_model_id}, bank_id={bank_id}, tags={active_tags!r}"
+            )
+            generated_content = f"[Tag filter warning: {tag_filter_warning}]"
+
+        reflect_response: dict[str, Any] = {
             "text": reflect_result.text,
             "based_on": based_on_serialized,
         }
+        if tag_filter_warning is not None:
+            reflect_response["tag_filter_warning"] = tag_filter_warning
 
         # Update the mental model with the generated content and reflect_response
         await self.update_mental_model(

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1023,6 +1023,65 @@ class TestMentalModelRefreshTagSecurity:
         # Cleanup
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_refresh_with_tags_emits_warning_when_no_facts_match(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Test that refreshing a mental model whose tags match no memories surfaces a clear warning.
+
+        Regression test for https://github.com/vectorize-io/hindsight/issues/945.
+        Previously, tag filtering that produced an empty fact pool resulted in a generic
+        "I don't have information" message with no indication that tags were the cause.
+        """
+        bank_id = f"test-refresh-tag-warning-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        # Retain memories tagged with "user:alice" only
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {"content": "Alice works on the frontend React project.", "tags": ["user:alice"]},
+            ],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+
+        # Create a mental model tagged with "user:bob" — no memories share this tag
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Bob's Summary",
+            source_query="What is known about Bob?",
+            content="Initial content",
+            tags=["user:bob"],
+            request_context=request_context,
+        )
+
+        # Refresh the model — tag filter will produce an empty fact pool
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+
+        updated = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+
+        # The content should contain a tag filter warning, not a generic "no information" message
+        assert updated["content"] is not None
+        assert "user:bob" in updated["content"] or "tag" in updated["content"].lower(), (
+            f"Expected tag filter warning in content, got: {updated['content']}"
+        )
+
+        # The reflect_response should carry the structured warning field
+        reflect_response = updated.get("reflect_response") or {}
+        assert "tag_filter_warning" in reflect_response, (
+            f"Expected 'tag_filter_warning' in reflect_response, got keys: {list(reflect_response.keys())}"
+        )
+        assert "user:bob" in reflect_response["tag_filter_warning"], (
+            f"Warning should mention the active tags: {reflect_response['tag_filter_warning']}"
+        )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 class TestMentalModelTriggerTagsConfig:
     """Test trigger-level tags_match and tag_groups configuration for mental model refresh."""


### PR DESCRIPTION
Fixes #945

## Problem

When a mental model has tags configured (e.g. `["user:bob"]`) and those tags do not match any memories in the bank, the refresh operation calls `reflect_async` which finds zero matching facts. The LLM then returns a generic *"I don't have information about this"* response — indistinguishable from a bad `source_query` or a genuinely empty bank.

Users were spending hours debugging what looked like a platform bug before discovering that the culprit was their own tag configuration (see issue for a detailed first-person account).

## Solution

In `_handle_refresh_mental_model`, after the reflect completes and `based_on_serialized` is built, check whether:
1. Tag filtering was active (the model has `tags` or `tag_groups` set), **and**
2. No non-directive facts appear in `based_on` (directives don't require tag matches).

When both conditions are true:
- Replace `generated_content` with a human-readable `[Tag filter warning: ...]` message that explicitly names the active tags and tells the user what to do.
- Add a `tag_filter_warning` field to the stored `reflect_response` dict so API consumers can detect the condition programmatically without parsing the content string.
- Emit a `WARNING`-level server log entry for operator visibility.

## Testing

- Added `test_refresh_with_tags_emits_warning_when_no_facts_match` to `TestMentalModelRefreshTagSecurity`. The test retains memories tagged `user:alice`, creates a mental model tagged `user:bob` (no overlap), refreshes it, and asserts that:
  - The resulting `content` mentions the active tags or the word "tag".
  - The `reflect_response` dict contains the `tag_filter_warning` key.
  - The warning text references `user:bob`.