### PR TITLE
fix(codex): serialize hindsight daemon startup

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2421,6 +2421,7 @@ def create_app(
                 tenant_extension=memory._tenant_extension,
                 max_slots=config.worker_max_slots,
                 consolidation_max_slots=config.worker_consolidation_max_slots,
+                stale_processing_timeout_seconds=config.worker_stale_processing_timeout_seconds,
             )
             poller_task = asyncio.create_task(poller.run())
             logging.info(f"Worker poller started (worker_id={worker_id})")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -374,6 +374,7 @@ ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
 ENV_WORKER_CONSOLIDATION_MAX_SLOTS = "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS"
+ENV_WORKER_STALE_PROCESSING_TIMEOUT_SECONDS = "HINDSIGHT_API_WORKER_STALE_PROCESSING_TIMEOUT_SECONDS"
 ENV_RETAIN_MAX_CONCURRENT = "HINDSIGHT_API_RETAIN_MAX_CONCURRENT"
 
 # Reflect agent settings
@@ -572,6 +573,7 @@ DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_WORKER_CONSOLIDATION_MAX_SLOTS = 2  # Max concurrent consolidation tasks per worker
+DEFAULT_WORKER_STALE_PROCESSING_TIMEOUT_SECONDS = 180  # Warn when processing rows stop heartbeating for 3 minutes
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
 
 # Reflect agent settings
@@ -940,6 +942,7 @@ class HindsightConfig:
     worker_http_port: int
     worker_max_slots: int
     worker_consolidation_max_slots: int
+    worker_stale_processing_timeout_seconds: int
     retain_max_concurrent: int
 
     # Reflect agent settings
@@ -1493,6 +1496,12 @@ class HindsightConfig:
             worker_max_slots=int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS))),
             worker_consolidation_max_slots=int(
                 os.getenv(ENV_WORKER_CONSOLIDATION_MAX_SLOTS, str(DEFAULT_WORKER_CONSOLIDATION_MAX_SLOTS))
+            ),
+            worker_stale_processing_timeout_seconds=int(
+                os.getenv(
+                    ENV_WORKER_STALE_PROCESSING_TIMEOUT_SECONDS,
+                    str(DEFAULT_WORKER_STALE_PROCESSING_TIMEOUT_SECONDS),
+                )
             ),
             retain_max_concurrent=int(os.getenv(ENV_RETAIN_MAX_CONCURRENT, str(DEFAULT_RETAIN_MAX_CONCURRENT))),
             # Reflect agent settings

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, field_validator
 from ...config import get_config
 from ..llm_wrapper import sanitize_llm_output
 from ..memory_engine import fq_table
+from ..operation_metadata import ConsolidationMetadata
 from ..retain import embedding_utils
 from .prompts import build_batch_consolidation_prompt
 
@@ -221,9 +222,30 @@ async def run_consolidation_job(
     max_memories_per_batch = config.consolidation_batch_size
     llm_batch_size = max(1, config.consolidation_llm_batch_size)
 
+    async def heartbeat(
+        phase: str,
+        progress_message: str,
+        *,
+        memories_processed: int = 0,
+        total_memories: int | None = None,
+        llm_batch_index: int = 0,
+    ) -> None:
+        if not operation_id:
+            return
+        metadata = ConsolidationMetadata(
+            phase=phase,
+            progress_message=progress_message,
+            memories_processed=memories_processed,
+            total_memories=total_memories,
+            llm_batch_index=llm_batch_index,
+            last_heartbeat_at=datetime.now(timezone.utc).isoformat(),
+        ).to_dict()
+        await memory_engine._merge_operation_result_metadata(operation_id, metadata)
+
     # Check if consolidation is enabled
     if not config.enable_observations:
         logger.debug(f"Consolidation disabled for bank {bank_id}")
+        await heartbeat("completed", "Consolidation disabled", total_memories=0)
         return {"status": "disabled", "bank_id": bank_id}
 
     pool = memory_engine._pool
@@ -242,6 +264,7 @@ async def run_consolidation_job(
 
         if not bank_row:
             logger.warning(f"Bank {bank_id} not found for consolidation")
+            await heartbeat("completed", "Bank not found for consolidation", total_memories=0)
             return {"status": "bank_not_found", "bank_id": bank_id}
 
         perf.record_timing("fetch_bank", time.time() - t0)
@@ -261,10 +284,12 @@ async def run_consolidation_job(
 
     if total_count == 0:
         logger.debug(f"No new memories to consolidate for bank {bank_id}")
+        await heartbeat("completed", "No new memories to consolidate", total_memories=0)
         return {"status": "no_new_memories", "bank_id": bank_id, "memories_processed": 0}
 
     logger.info(f"[CONSOLIDATION] bank={bank_id} total_unconsolidated={total_count}")
     perf.log(f"[1] Found {total_count} pending memories to consolidate")
+    await heartbeat("running", f"Found {total_count} memories to consolidate", total_memories=total_count)
 
     # Process each memory with individual commits for crash recovery
     stats: dict[str, int] = {
@@ -322,6 +347,13 @@ async def run_consolidation_job(
         for llm_batch in llm_batches:
             llm_batch_num += 1
             llm_batch_start = time.time()
+            await heartbeat(
+                "running",
+                f"Processing consolidation batch {llm_batch_num}",
+                memories_processed=stats["memories_processed"],
+                total_memories=total_count,
+                llm_batch_index=llm_batch_num,
+            )
 
             # Snapshot perf and stats before this LLM batch
             snap_timings = perf.timings.copy()
@@ -523,6 +555,13 @@ async def run_consolidation_job(
                 + f" | input_tokens=~{input_tokens}"
                 f" | avg={llm_batch_time / len(llm_batch):.3f}s/memory"
             )
+            await heartbeat(
+                "running",
+                f"Processed {stats['memories_processed']} of {total_count} memories",
+                memories_processed=stats["memories_processed"],
+                total_memories=total_count,
+                llm_batch_index=llm_batch_num,
+            )
 
     # Build summary
     perf.log(
@@ -564,6 +603,13 @@ async def run_consolidation_job(
     stats["mental_models_refreshed"] = mental_models_refreshed
 
     perf.flush()
+    await heartbeat(
+        "completed",
+        f"Completed consolidation: processed {stats['memories_processed']} memories",
+        memories_processed=stats["memories_processed"],
+        total_memories=total_count,
+        llm_batch_index=llm_batch_num,
+    )
 
     return {"status": "completed", "bank_id": bank_id, **stats}
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1249,22 +1249,43 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> None:
         """Persist last HTTP attempt info into async_operations.result_metadata."""
         try:
-            pool = await self._get_pool()
-            meta = json.dumps(
+            await self._merge_operation_result_metadata(
+                operation_id,
                 {
                     "last_status_code": status_code,
                     "last_response_body": (response_body or "")[:2048],
                     "last_attempt_at": datetime.now(UTC).isoformat(),
-                }
+                },
             )
-            async with acquire_with_retry(pool) as conn:
-                await conn.execute(
-                    f"UPDATE {fq_table('async_operations')} SET result_metadata = $2::jsonb, updated_at = now() WHERE operation_id = $1",
-                    uuid.UUID(operation_id),
-                    meta,
-                )
         except Exception as meta_err:
             logger.debug(f"Failed to update webhook delivery metadata: {meta_err}")
+
+    async def _merge_operation_result_metadata(
+        self,
+        operation_id: str | uuid.UUID,
+        metadata: dict[str, Any],
+        *,
+        touch_updated_at: bool = True,
+    ) -> None:
+        """Merge fields into async_operations.result_metadata for an operation."""
+        pool = await self._get_pool()
+        operation_uuid = operation_id if isinstance(operation_id, uuid.UUID) else uuid.UUID(str(operation_id))
+        metadata_json = json.dumps(metadata, default=_json_default)
+        if touch_updated_at:
+            sql = f"""
+                UPDATE {fq_table('async_operations')}
+                SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb,
+                    updated_at = now()
+                WHERE operation_id = $1
+            """
+        else:
+            sql = f"""
+                UPDATE {fq_table('async_operations')}
+                SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb
+                WHERE operation_id = $1
+            """
+        async with acquire_with_retry(pool) as conn:
+            await conn.execute(sql, operation_uuid, metadata_json)
 
     async def _handle_webhook_delivery(self, task_dict: dict[str, Any]) -> None:
         """Deliver a webhook event via HTTP.
@@ -8071,6 +8092,11 @@ class MemoryEngine(MemoryEngineInterface):
             operation_type="consolidation",
             task_type="consolidation",
             task_payload=task_payload,
+            result_metadata=ConsolidationMetadata(
+                phase="queued",
+                progress_message="Queued for consolidation",
+                memories_processed=0,
+            ).to_dict(),
             dedupe_by_bank=True,
         )
 

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -52,7 +52,13 @@ class RetainMetadata:
 class ConsolidationMetadata:
     """Metadata for consolidation operations."""
 
-    # Currently empty, but structure for future fields
+    phase: str
+    progress_message: str | None = None
+    memories_processed: int = 0
+    total_memories: int | None = None
+    llm_batch_index: int = 0
+    last_heartbeat_at: str | None = None
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for JSON serialization."""
         return asdict(self)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -69,6 +69,69 @@ def _sanitize_text(text: str | None) -> str | None:
     return sanitize_llm_output(text)
 
 
+_SIMPLE_DECLARATIVE_FACT_RE = re.compile(
+    r"^\s*(?P<subject>(?:I|We|You|[A-Z][\w'’-]*(?:\s+[A-Z][\w'’-]*)*))\s+"
+    r"(?P<verb>love|loves|like|likes|hate|hates|dislike|dislikes|prefer|prefers|value|values|"
+    r"is|are|was|were|originated|originates)\s+"
+    r"(?P<object>.+?)\s*[.!?]*\s*$",
+    re.IGNORECASE,
+)
+_FALLBACK_SUBJECT_BLOCKLIST = {"this", "that", "it", "there", "here", "hi", "hello", "thanks", "thank"}
+_FALLBACK_TEXT_BLOCKLIST_PREFIXES = (
+    "hi ",
+    "hello ",
+    "thanks",
+    "thank you",
+    "how are you",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "let me ",
+    "one moment",
+    "sounds good",
+    "got it",
+)
+
+
+def _fallback_simple_preference_fact(chunk: str) -> "Fact | None":
+    """
+    Recover an obvious one-line fact when the LLM returns an empty facts list.
+
+    Some providers occasionally drop short statements like "Alex hates pizza."
+    or "Pizza originated in Naples." even though they are useful durable facts.
+    Keep the fallback narrow so greetings/process chatter still stay empty.
+    """
+    chunk = chunk.strip()
+    chunk_lower = chunk.lower()
+    if "\n" in chunk or len(chunk) > 200:
+        return None
+    if any(chunk_lower.startswith(prefix) for prefix in _FALLBACK_TEXT_BLOCKLIST_PREFIXES):
+        return None
+
+    match = _SIMPLE_DECLARATIVE_FACT_RE.match(chunk)
+    if not match:
+        return None
+
+    subject = match.group("subject").strip()
+    verb = match.group("verb").lower()
+    obj = match.group("object").strip().rstrip(".!?")
+    if not obj:
+        return None
+
+    subject_lower = subject.lower()
+    if subject_lower in _FALLBACK_SUBJECT_BLOCKLIST:
+        return None
+    if subject_lower in {"i", "we"}:
+        fact_type = "experience"
+        entities = [Entity(text="user")]
+    else:
+        fact_type = "world"
+        entities = [Entity(text=subject)] if subject_lower not in {"you"} else None
+
+    fact = f"{subject} {verb} {obj}"
+    return Fact(fact=fact, fact_type=fact_type, entities=entities)
+
+
 class Entity(BaseModel):
     """An entity extracted from text."""
 
@@ -1056,6 +1119,12 @@ async def _extract_facts_from_chunk(
             raw_facts = extraction_response_json.get("facts", [])
 
             if not raw_facts:
+                fallback_fact = _fallback_simple_preference_fact(chunk)
+                if fallback_fact is not None:
+                    logger.info(
+                        "LLM returned 0 facts for an obvious preference statement; applying simple fallback extraction"
+                    )
+                    return [fallback_fact], usage
                 logger.debug(
                     f"LLM response missing 'facts' field or returned empty list. "
                     f"Response: {extraction_response_json}. "

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -165,6 +165,7 @@ def main():
     print(f"  Max retries: {args.max_retries}")
     print(f"  Max slots: {config.worker_max_slots}")
     print(f"  Consolidation max slots: {config.worker_consolidation_max_slots}")
+    print(f"  Stale processing timeout: {config.worker_stale_processing_timeout_seconds}s")
     print(f"  HTTP server: {args.http_host}:{args.http_port}")
     print()
 
@@ -223,6 +224,7 @@ def main():
             tenant_extension=tenant_extension,
             max_slots=config.worker_max_slots,
             consolidation_max_slots=config.worker_consolidation_max_slots,
+            stale_processing_timeout_seconds=config.worker_stale_processing_timeout_seconds,
         )
 
         # Create the HTTP app for metrics/health

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -12,6 +12,7 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import RetryTaskAt
@@ -25,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 # Progress logging interval in seconds
 PROGRESS_LOG_INTERVAL = 30
+WATCHDOG_SCAN_INTERVAL = 15
+WATCHDOG_LOG_INTERVAL = 60
 
 
 def fq_table(table: str, schema: str | None = None) -> str:
@@ -63,6 +66,7 @@ class WorkerPoller:
         tenant_extension: "TenantExtension | None" = None,
         max_slots: int = 10,
         consolidation_max_slots: int = 2,
+        stale_processing_timeout_seconds: int = 180,
     ):
         """
         Initialize the worker poller.
@@ -77,6 +81,7 @@ class WorkerPoller:
                             DefaultTenantExtension with the configured schema.
             max_slots: Maximum concurrent tasks per worker
             consolidation_max_slots: Maximum concurrent consolidation tasks per worker
+            stale_processing_timeout_seconds: Warn when processing rows stop heartbeating for this long
         """
         self._pool = pool
         self._worker_id = worker_id
@@ -93,16 +98,19 @@ class WorkerPoller:
         self._tenant_extension = tenant_extension
         self._max_slots = max_slots
         self._consolidation_max_slots = consolidation_max_slots
+        self._stale_processing_timeout_seconds = stale_processing_timeout_seconds
         self._shutdown = asyncio.Event()
         self._current_tasks: set[asyncio.Task] = set()
         self._in_flight_count = 0
         self._in_flight_lock = asyncio.Lock()
         self._last_progress_log = 0.0
+        self._last_watchdog_scan = 0.0
         self._tasks_completed_since_log = 0
         # Track active tasks locally: operation_id -> (op_type, bank_id, schema, asyncio.Task)
         self._active_tasks: dict[str, tuple[str, str, str | None, asyncio.Task]] = {}
         # Track in-flight tasks by operation type
         self._in_flight_by_type: dict[str, int] = {}
+        self._watchdog_last_warned_at: dict[tuple[str | None, str], float] = {}
 
     async def _get_schemas(self) -> list[str | None]:
         """Get list of schemas to poll. Returns [None] for default schema (no prefix)."""
@@ -641,6 +649,7 @@ class WorkerPoller:
                     for task in tasks:
                         await self.execute_task(task)
 
+                    await self._run_stale_processing_watchdog()
                     # Continue immediately to claim more tasks (if slots available)
                     continue
 
@@ -656,6 +665,7 @@ class WorkerPoller:
 
                 # Log progress stats periodically
                 await self._log_progress_if_due()
+                await self._run_stale_processing_watchdog()
 
             except asyncio.CancelledError:
                 logger.info(f"Worker {self._worker_id} polling loop cancelled")
@@ -778,6 +788,85 @@ class WorkerPoller:
 
         except Exception as e:
             logger.debug(f"Failed to log progress stats: {e}")
+
+    async def _run_stale_processing_watchdog(self) -> int:
+        """Annotate processing operations that have stopped heartbeating."""
+        now = time.time()
+        if now - self._last_watchdog_scan < WATCHDOG_SCAN_INTERVAL:
+            return 0
+        self._last_watchdog_scan = now
+
+        annotated = 0
+        schemas = await self._get_schemas()
+        async with self._in_flight_lock:
+            active_operation_ids = set(self._active_tasks.keys())
+
+        for schema in schemas:
+            table = fq_table("async_operations", schema)
+            try:
+                rows = await self._pool.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, bank_id, worker_id, updated_at
+                    FROM {table}
+                    WHERE status = 'processing'
+                      AND updated_at < NOW() - ($1 * interval '1 second')
+                    ORDER BY updated_at ASC
+                    """,
+                    self._stale_processing_timeout_seconds,
+                )
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else "default"
+                logger.debug(f"Worker {self._worker_id} failed stale watchdog scan for schema {schema_display}: {e}")
+                continue
+
+            observed_at = datetime.now(timezone.utc)
+            for row in rows:
+                operation_id = str(row["operation_id"])
+                cache_key = (schema, operation_id)
+                last_warned_at = self._watchdog_last_warned_at.get(cache_key, 0.0)
+                if now - last_warned_at < WATCHDOG_LOG_INTERVAL:
+                    continue
+
+                assigned_worker_id = row["worker_id"]
+                if assigned_worker_id == self._worker_id and operation_id in active_operation_ids:
+                    reason = "local_task_running_without_heartbeat"
+                elif assigned_worker_id == self._worker_id:
+                    reason = "assigned_to_this_worker_but_not_active"
+                else:
+                    reason = "other_worker_no_heartbeat"
+
+                stale_for_seconds = max(0, int((observed_at - row["updated_at"]).total_seconds()))
+                watchdog_metadata = {
+                    "watchdog": {
+                        "status": "stale",
+                        "reason": reason,
+                        "worker_id": assigned_worker_id,
+                        "observed_by_worker": self._worker_id,
+                        "stale_for_seconds": stale_for_seconds,
+                        "last_warned_at": observed_at.isoformat(),
+                    }
+                }
+
+                await self._pool.execute(
+                    f"""
+                    UPDATE {table}
+                    SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb
+                    WHERE operation_id = $1
+                    """,
+                    row["operation_id"],
+                    json.dumps(watchdog_metadata),
+                )
+
+                schema_display = schema if schema else "default"
+                logger.warning(
+                    f"[WORKER_WATCHDOG] worker={self._worker_id} schema={schema_display} "
+                    f"operation_id={operation_id} bank_id={row['bank_id']} operation_type={row['operation_type']} "
+                    f"assigned_worker={assigned_worker_id} reason={reason} stale_for={stale_for_seconds}s"
+                )
+                self._watchdog_last_warned_at[cache_key] = now
+                annotated += 1
+
+        return annotated
 
     @property
     def worker_id(self) -> str:

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -4,6 +4,7 @@ These tests exercise the real consolidation implementation with actual database 
 Note: Consolidation runs automatically after retain via SyncTaskBackend in tests.
 """
 
+import json
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -36,6 +37,98 @@ def enable_observations():
     config.enable_observations = True
     yield
     config.enable_observations = original_value
+
+
+@pytest.mark.asyncio
+async def test_submit_async_consolidation_seeds_queued_metadata(memory_no_llm_verify: MemoryEngine, request_context):
+    """Queued consolidation operations should expose initial progress metadata immediately."""
+    bank_id = f"test-consolidation-queued-{uuid.uuid4().hex[:8]}"
+    await memory_no_llm_verify.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    with patch.object(memory_no_llm_verify._task_backend, "submit_task", new=AsyncMock()) as mock_submit:
+        result = await memory_no_llm_verify.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+
+    mock_submit.assert_awaited_once()
+
+    async with memory_no_llm_verify._pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT status, result_metadata
+            FROM async_operations
+            WHERE operation_id = $1
+            """,
+            uuid.UUID(result["operation_id"]),
+        )
+
+    assert row is not None
+    assert row["status"] == "pending"
+    metadata = row["result_metadata"]
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+
+    assert metadata["phase"] == "queued"
+    assert metadata["progress_message"] == "Queued for consolidation"
+    assert metadata["memories_processed"] == 0
+
+    await memory_no_llm_verify.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_run_consolidation_job_persists_progress_metadata(
+    memory_no_llm_verify: MemoryEngine, request_context
+):
+    """Consolidation updates operation metadata with progress and final heartbeat details."""
+    bank_id = f"test-consolidation-progress-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+    await memory_no_llm_verify.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    async with memory_no_llm_verify._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, result_metadata)
+            VALUES ($1, $2, 'consolidation', 'processing', '{}'::jsonb)
+            """,
+            operation_id,
+            bank_id,
+        )
+        await _insert_memories_with_tags(
+            conn,
+            bank_id,
+            ["Alice loves long mountain hikes."],
+            tags=["scope:test"],
+        )
+
+    result = await run_consolidation_job(
+        memory_engine=memory_no_llm_verify,
+        bank_id=bank_id,
+        request_context=request_context,
+        operation_id=str(operation_id),
+    )
+
+    async with memory_no_llm_verify._pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT result_metadata
+            FROM async_operations
+            WHERE operation_id = $1
+            """,
+            operation_id,
+        )
+
+    assert row is not None
+    metadata = row["result_metadata"]
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+
+    assert result["memories_processed"] >= 1
+    assert metadata["phase"] == "completed"
+    assert metadata["memories_processed"] == result["memories_processed"]
+    assert metadata["total_memories"] >= result["memories_processed"]
+    assert metadata["progress_message"]
+    assert metadata["last_heartbeat_at"]
+    datetime.fromisoformat(metadata["last_heartbeat_at"])
+
+    await memory_no_llm_verify.delete_bank(bank_id, request_context=request_context)
 
 
 class TestConsolidationIntegration:

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -175,6 +175,66 @@ async def test_none_event_date_with_empty_facts_no_crash():
 
 
 @pytest.mark.asyncio
+async def test_empty_facts_falls_back_for_simple_preference_statement():
+    """An empty LLM response should still preserve obvious one-line preferences."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=1)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, usage = await _extract_facts_from_chunk(
+            chunk="Alex hates pizza.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2024, 11, 13, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert facts[0].fact == "Alex hates pizza"
+    assert facts[0].fact_type == "world"
+    assert facts[0].entities is not None
+    assert facts[0].entities[0].text == "Alex"
+
+
+@pytest.mark.asyncio
+async def test_empty_facts_falls_back_for_simple_declarative_statement():
+    """An empty LLM response should still preserve obvious one-line world facts."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=1)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, usage = await _extract_facts_from_chunk(
+            chunk="Pizza is a popular Italian food.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2024, 11, 13, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert facts[0].fact == "Pizza is a popular Italian food"
+    assert facts[0].fact_type == "world"
+    assert facts[0].entities is not None
+    assert facts[0].entities[0].text == "Pizza"
+
+
+@pytest.mark.asyncio
 async def test_none_event_date_with_valid_facts_no_crash():
     """
     When event_date is None but the LLM returns valid facts,

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -702,6 +702,102 @@ class TestWorkerRecovery:
         assert recovered_count == 0
 
 
+class TestWorkerWatchdog:
+    """Tests for stale processing watchdog annotations."""
+
+    @pytest.mark.asyncio
+    async def test_watchdog_marks_other_worker_task_stale_without_touching_updated_at(self, pool, clean_operations):
+        """Stale tasks on another worker get annotated, but remain stale in updated_at."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        operation_id = uuid.uuid4()
+        await _ensure_bank(pool, bank_id)
+
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, worker_id, result_metadata, updated_at)
+            VALUES
+                ($1, $2, 'consolidation', 'processing', $3::jsonb, 'other-worker', '{}'::jsonb, now() - interval '10 minutes')
+            """,
+            operation_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(operation_id)}),
+        )
+
+        before = await pool.fetchrow(
+            "SELECT updated_at FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="watchdog-worker",
+            executor=lambda x: None,
+            stale_processing_timeout_seconds=60,
+        )
+
+        assert await poller._run_stale_processing_watchdog() == 1
+
+        after = await pool.fetchrow(
+            "SELECT updated_at, result_metadata FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+
+        assert after["updated_at"] == before["updated_at"]
+        metadata = after["result_metadata"] or {}
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        watchdog = metadata["watchdog"]
+        assert watchdog["reason"] == "other_worker_no_heartbeat"
+        assert watchdog["worker_id"] == "other-worker"
+        assert watchdog["stale_for_seconds"] >= 600
+
+    @pytest.mark.asyncio
+    async def test_watchdog_marks_orphaned_self_assigned_task(self, pool, clean_operations):
+        """Tasks assigned to this worker but missing from the local active map get a distinct reason."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        operation_id = uuid.uuid4()
+        worker_id = "watchdog-worker"
+        await _ensure_bank(pool, bank_id)
+
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, worker_id, result_metadata, updated_at)
+            VALUES
+                ($1, $2, 'test', 'processing', $3::jsonb, $4, '{}'::jsonb, now() - interval '10 minutes')
+            """,
+            operation_id,
+            bank_id,
+            json.dumps({"type": "test_task", "bank_id": bank_id, "operation_id": str(operation_id)}),
+            worker_id,
+        )
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id=worker_id,
+            executor=lambda x: None,
+            stale_processing_timeout_seconds=60,
+        )
+
+        assert await poller._run_stale_processing_watchdog() == 1
+
+        row = await pool.fetchrow(
+            "SELECT result_metadata FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+        metadata = row["result_metadata"] or {}
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        watchdog = metadata["watchdog"]
+        assert watchdog["reason"] == "assigned_to_this_worker_but_not_active"
+        assert watchdog["worker_id"] == worker_id
+
+
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""
 

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -513,24 +513,27 @@ def do_daemon(args, config: dict, logger):
         console = Console()
 
         if daemon_client.is_daemon_running(profile):
-            # Build title with profile and port
-            if profile:
-                already_running_title = (
-                    f"[bold yellow]Daemon Already Running[/bold yellow] [dim]({profile} @ :{port})[/dim]"
-                )
+            if getattr(args, "replace", False):
+                logger.info(f"Healthy daemon already running for profile '{profile or 'default'}'; replacing on request")
             else:
-                already_running_title = f"[bold yellow]Daemon Already Running[/bold yellow] [dim](:{port})[/dim]"
+            # Build title with profile and port
+                if profile:
+                    already_running_title = (
+                        f"[bold yellow]Daemon Already Running[/bold yellow] [dim]({profile} @ :{port})[/dim]"
+                    )
+                else:
+                    already_running_title = f"[bold yellow]Daemon Already Running[/bold yellow] [dim](:{port})[/dim]"
 
-            console.print(
-                Panel(
-                    Text("Daemon is already running", style="yellow"),
-                    title=already_running_title,
-                    border_style="yellow",
+                console.print(
+                    Panel(
+                        Text("Daemon is already running", style="yellow"),
+                        title=already_running_title,
+                        border_style="yellow",
+                    )
                 )
-            )
-            return 0
+                return 0
 
-        if daemon_client.ensure_daemon_running(config, profile):
+        if daemon_client.ensure_daemon_running(config, profile, replace_existing=getattr(args, "replace", False)):
             # Start UI if --ui flag was passed
             if getattr(args, "ui", False):
                 from .daemon_embed_manager import DaemonEmbedManager
@@ -1411,6 +1414,11 @@ def main():
             subparsers = parser.add_subparsers(dest="daemon_command")
             start_parser = subparsers.add_parser("start", help="Start the daemon")
             start_parser.add_argument("--ui", action="store_true", help="Also start the web UI after daemon is ready")
+            start_parser.add_argument(
+                "--replace",
+                action="store_true",
+                help="Replace an already healthy daemon on this profile port",
+            )
             subparsers.add_parser("stop", help="Stop the daemon")
             subparsers.add_parser("status", help="Check daemon status")
             logs_parser = subparsers.add_parser("logs", help="View daemon logs")
@@ -1502,7 +1510,7 @@ Profile management:
     profile delete NAME                                     Delete a profile
 
 Daemon management:
-    daemon start           Start the background daemon
+    daemon start [--replace]  Start the background daemon
     daemon stop            Stop the daemon
     daemon status          Check daemon status
     daemon logs [-f] [-n]  View daemon logs

--- a/hindsight-embed/hindsight_embed/daemon_client.py
+++ b/hindsight-embed/hindsight_embed/daemon_client.py
@@ -56,7 +56,12 @@ def get_daemon_url(profile: str | None = None) -> str:
     return _manager.get_url(profile)
 
 
-def ensure_daemon_running(config: dict, profile: str | None = None, extra_args: list[str] | None = None) -> bool:
+def ensure_daemon_running(
+    config: dict,
+    profile: str | None = None,
+    extra_args: list[str] | None = None,
+    replace_existing: bool = False,
+) -> bool:
     """
     Ensure daemon is running, starting it if needed.
 
@@ -65,6 +70,7 @@ def ensure_daemon_running(config: dict, profile: str | None = None, extra_args: 
                 like "llm_api_key" and env var format like "HINDSIGHT_API_LLM_API_KEY").
         profile: Profile name (None = resolve from priority).
         extra_args: Extra CLI arguments to pass to hindsight-api (e.g. ["--offline"]).
+        replace_existing: Whether to replace an already healthy daemon on the profile port.
 
     Returns:
         True if daemon is running.
@@ -72,7 +78,12 @@ def ensure_daemon_running(config: dict, profile: str | None = None, extra_args: 
     if profile is None:
         profile = resolve_active_profile()
 
-    return _manager.ensure_running(config, profile, extra_args=extra_args)
+    return _manager.ensure_running(
+        config,
+        profile,
+        extra_args=extra_args,
+        replace_existing=replace_existing,
+    )
 
 
 def stop_daemon(profile: str | None = None) -> bool:

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -159,11 +159,12 @@ class DaemonEmbedManager(EmbedManager):
             return True  # Already gone
         return False
 
-    def _clear_port(self, port: int) -> bool:
+    def _clear_port(self, port: int, replace_existing: bool = False) -> bool:
         """
         Ensure the port is free before starting a daemon.
 
-        If the port is occupied by a hindsight daemon, stop it gracefully.
+        If the port is occupied by a healthy hindsight daemon, reuse it by default.
+        If replace_existing is True, stop the existing daemon first.
         If occupied by something else, return False.
 
         Returns:
@@ -183,7 +184,11 @@ class DaemonEmbedManager(EmbedManager):
             logger.warning(f"Port {port} is in use by another process")
             return False
 
-        # It's a hindsight daemon — find its PID and stop it
+        if not replace_existing:
+            logger.info(f"Reusing existing healthy daemon on port {port}")
+            return True
+
+        # It's a hindsight daemon and replacement was requested — find its PID and stop it
         pid = self._find_pid_on_port(port)
         if pid is None:
             logger.warning(f"Port {port} has a hindsight daemon but could not find its PID")
@@ -197,17 +202,28 @@ class DaemonEmbedManager(EmbedManager):
         logger.warning(f"Old daemon (PID {pid}) did not stop in time")
         return False
 
-    def _start_daemon(self, config: dict, profile: str, extra_args: list[str] | None = None) -> bool:
+    def _start_daemon(
+        self,
+        config: dict,
+        profile: str,
+        extra_args: list[str] | None = None,
+        replace_existing: bool = False,
+    ) -> bool:
         """Start the daemon in background."""
         paths = self._profile_manager.resolve_profile_paths(profile)
         profile_label = f"profile '{profile}'" if profile else "default profile"
         daemon_log = paths.log
         port = paths.port
 
-        # Ensure port is free before starting (handles stale daemons from version upgrades)
-        if not self._clear_port(port):
+        # Ensure port is free before starting. Healthy daemons are reused by default.
+        if not self._clear_port(port, replace_existing=replace_existing):
             logger.error(f"Cannot start daemon: port {port} is in use by a non-hindsight process")
             return False
+        if not replace_existing and self.is_running(profile):
+            logger.info(f"Using already-running daemon for {profile_label} on port {port}")
+            if profile:
+                self._register_profile(profile, port, config)
+            return True
 
         # Load profile's .env file and merge with provided config
         # This fixes issue #305 where profile env vars were ignored
@@ -613,7 +629,13 @@ class DaemonEmbedManager(EmbedManager):
 
         return not self.is_ui_running(profile, ui_port)
 
-    def ensure_running(self, config: dict, profile: str, extra_args: list[str] | None = None) -> bool:
+    def ensure_running(
+        self,
+        config: dict,
+        profile: str,
+        extra_args: list[str] | None = None,
+        replace_existing: bool = False,
+    ) -> bool:
         """
         Ensure daemon is running, starting it if needed.
 
@@ -621,17 +643,23 @@ class DaemonEmbedManager(EmbedManager):
             config: Environment configuration dict (HINDSIGHT_API_* vars)
             profile: Profile name for isolation
             extra_args: Extra CLI arguments to pass to hindsight-api (e.g. ["--offline"])
+            replace_existing: Whether to replace an already healthy daemon on the profile port.
 
         Returns:
             True if daemon is running (started or already running), False on failure
         """
-        if self.is_running(profile):
+        if self.is_running(profile) and not replace_existing:
             logger.debug(f"Daemon already running for profile '{profile}'")
             if profile:
                 paths = self._profile_manager.resolve_profile_paths(profile)
                 self._register_profile(profile, paths.port, config)
             return True
-        return self._start_daemon(config, profile, extra_args=extra_args)
+        return self._start_daemon(
+            config,
+            profile,
+            extra_args=extra_args,
+            replace_existing=replace_existing,
+        )
 
     def stop(self, profile: str) -> bool:
         """

--- a/hindsight-embed/hindsight_embed/embed_manager.py
+++ b/hindsight-embed/hindsight_embed/embed_manager.py
@@ -13,13 +13,21 @@ class EmbedManager(ABC):
     """Abstract interface for managing Hindsight embedded servers and profiles."""
 
     @abstractmethod
-    def ensure_running(self, config: dict, profile: str) -> bool:
+    def ensure_running(
+        self,
+        config: dict,
+        profile: str,
+        extra_args: list[str] | None = None,
+        replace_existing: bool = False,
+    ) -> bool:
         """
         Ensure daemon is running for the given profile with config.
 
         Args:
             config: Environment configuration dict (HINDSIGHT_API_* vars)
             profile: Profile name for isolation
+            extra_args: Extra CLI arguments to pass to hindsight-api.
+            replace_existing: Whether to replace an already healthy daemon on the profile port.
 
         Returns:
             True if daemon is running (started or already running), False on failure

--- a/hindsight-embed/tests/test_daemon_client.py
+++ b/hindsight-embed/tests/test_daemon_client.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -10,6 +11,7 @@ import pytest
 
 from hindsight_embed import daemon_client
 from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
 
 @pytest.fixture
 def config():
@@ -190,8 +192,27 @@ class TestClearPort:
         with patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=False):
             assert manager._clear_port(9555) is True
 
-    def test_port_occupied_by_hindsight_stops_it(self):
-        """Port occupied by a hindsight daemon — kills it and returns True."""
+    def test_port_occupied_by_hindsight_reuses_it_by_default(self):
+        """Port occupied by a healthy hindsight daemon is reused by default."""
+        manager = DaemonEmbedManager()
+        with (
+            patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
+            patch("httpx.Client") as mock_httpx_cls,
+            patch.object(DaemonEmbedManager, "_find_pid_on_port") as mock_find_pid,
+            patch.object(DaemonEmbedManager, "_kill_process") as mock_kill,
+        ):
+            mock_client = MagicMock()
+            mock_client.__enter__ = Mock(return_value=mock_client)
+            mock_client.__exit__ = Mock(return_value=False)
+            mock_client.get.return_value = Mock(status_code=200)
+            mock_httpx_cls.return_value = mock_client
+
+            assert manager._clear_port(9555) is True
+            mock_find_pid.assert_not_called()
+            mock_kill.assert_not_called()
+
+    def test_port_occupied_by_hindsight_replace_existing_stops_it(self):
+        """Explicit replace kills the healthy daemon already serving the port."""
         manager = DaemonEmbedManager()
         with (
             patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
@@ -205,7 +226,7 @@ class TestClearPort:
             mock_client.get.return_value = Mock(status_code=200)
             mock_httpx_cls.return_value = mock_client
 
-            assert manager._clear_port(9555) is True
+            assert manager._clear_port(9555, replace_existing=True) is True
 
     def test_port_occupied_by_non_hindsight_returns_false(self):
         """Port occupied by non-hindsight process — returns False."""
@@ -251,7 +272,7 @@ class TestClearPort:
             mock_client.get.return_value = Mock(status_code=200)
             mock_httpx_cls.return_value = mock_client
 
-            assert manager._clear_port(9555) is False
+            assert manager._clear_port(9555, replace_existing=True) is False
 
     def test_kill_fails_returns_false(self):
         """Hindsight daemon found but won't die — returns False."""
@@ -268,5 +289,41 @@ class TestClearPort:
             mock_client.get.return_value = Mock(status_code=200)
             mock_httpx_cls.return_value = mock_client
 
-            assert manager._clear_port(9555) is False
+            assert manager._clear_port(9555, replace_existing=True) is False
 
+
+class TestEnsureDaemonRunning:
+    """Tests for daemon_client.ensure_daemon_running."""
+
+    def test_forwards_replace_existing_to_manager(self, config):
+        """Wrapper passes replace_existing through to the singleton manager."""
+        with patch.object(daemon_client, "_manager") as mock_manager:
+            mock_manager.ensure_running.return_value = True
+
+            assert daemon_client.ensure_daemon_running(config, "test-profile", replace_existing=True) is True
+
+            mock_manager.ensure_running.assert_called_once_with(
+                config,
+                "test-profile",
+                extra_args=None,
+                replace_existing=True,
+            )
+
+
+class TestDaemonCommand:
+    """Tests for explicit daemon command behaviors."""
+
+    def test_do_daemon_start_replace_restarts_even_if_healthy(self, config):
+        """`daemon start --replace` must bypass the early already-running return."""
+        from hindsight_embed.cli import do_daemon
+
+        args = Namespace(profile="test-profile", daemon_command="start", ui=False, replace=True)
+        mock_paths = Mock(log=Path("/tmp/hindsight-daemon.log"), port=9555)
+
+        with (
+            patch("hindsight_embed.profile_manager.ProfileManager.resolve_profile_paths", return_value=mock_paths),
+            patch.object(daemon_client, "is_daemon_running", return_value=True),
+            patch.object(daemon_client, "ensure_daemon_running", return_value=True) as mock_ensure,
+        ):
+            assert do_daemon(args, config, Mock()) == 0
+            mock_ensure.assert_called_once_with(config, "test-profile", replace_existing=True)

--- a/hindsight-integrations/codex/scripts/lib/daemon.py
+++ b/hindsight-integrations/codex/scripts/lib/daemon.py
@@ -8,17 +8,22 @@ Manages three connection modes:
 Daemon state is tracked via files in ~/.hindsight/codex/state/.
 """
 
+import json
 import os
 import platform
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 
 from .llm import detect_llm_config, get_llm_env_vars
-from .state import read_state, write_state
+from .state import _state_file, fcntl, write_state
 
 DAEMON_STATE_FILE = "daemon.json"
+DAEMON_START_LOCK_FILE = "daemon-start.lock"
+DAEMON_START_LOCK_TIMEOUT_SECONDS = 30.0
 PROFILE_NAME = "codex"
 
 
@@ -33,7 +38,9 @@ def _get_embed_command(config: dict) -> list:
     return ["uvx", package]
 
 
-def _run_embed(config: dict, args: list, env: dict = None, timeout: int = 10) -> subprocess.CompletedProcess:
+def _run_embed(
+    config: dict, args: list, env: dict = None, timeout: int = 10
+) -> subprocess.CompletedProcess:
     """Run a hindsight-embed command and return the result."""
     cmd = _get_embed_command(config) + args
     run_env = dict(os.environ)
@@ -55,7 +62,9 @@ def _is_embed_available(config: dict) -> bool:
     embed_path = config.get("embedPackagePath")
     if embed_path:
         return os.path.isdir(embed_path)
-    return shutil.which("uvx") is not None or shutil.which("hindsight-embed") is not None
+    return (
+        shutil.which("uvx") is not None or shutil.which("hindsight-embed") is not None
+    )
 
 
 def _check_health(base_url: str, timeout: int = 2) -> bool:
@@ -67,6 +76,38 @@ def _check_health(base_url: str, timeout: int = 2) -> bool:
             return resp.status == 200
     except Exception:
         return False
+
+
+@contextmanager
+def _daemon_start_lock(timeout_seconds: float = DAEMON_START_LOCK_TIMEOUT_SECONDS):
+    """Serialize daemon startup attempts across hook processes."""
+    if fcntl is None:
+        yield
+        return
+
+    lock_path = _state_file(DAEMON_START_LOCK_FILE)
+    deadline = time.time() + timeout_seconds
+    lock_fd = open(lock_path, "w")
+    acquired = False
+
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError:
+                if time.time() >= deadline:
+                    raise RuntimeError(
+                        "Timed out waiting for another Hindsight daemon start to finish"
+                    )
+                time.sleep(0.1)
+
+        yield
+    finally:
+        if acquired:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        lock_fd.close()
 
 
 def get_api_url(config: dict, debug_fn=None, allow_daemon_start: bool = False) -> str:
@@ -119,100 +160,126 @@ def get_api_url(config: dict, debug_fn=None, allow_daemon_start: bool = False) -
 
 def _ensure_daemon_running(config: dict, port: int, debug_fn=None):
     """Start the hindsight-embed daemon if not already running."""
-    if not _is_embed_available(config):
-        raise RuntimeError(
-            "hindsight-embed not found (uvx not on PATH). "
-            "Install with: pip install hindsight-embed, or set hindsightApiUrl."
-        )
-
     base_url = f"http://127.0.0.1:{port}"
 
-    try:
-        llm_config = detect_llm_config(config)
-    except RuntimeError as e:
-        raise RuntimeError(f"Cannot start daemon: {e}") from e
-
-    llm_env = get_llm_env_vars(llm_config)
-
-    daemon_env = dict(llm_env)
-    idle_timeout = config.get("daemonIdleTimeout", 300)
-    daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
-
-    if platform.system() == "Darwin":
-        daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
-        daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
-
-    # Step 1: Configure profile
-    if debug_fn:
-        debug_fn(f'Configuring "{PROFILE_NAME}" profile...')
-
-    profile_args = [
-        "profile",
-        "create",
-        PROFILE_NAME,
-        "--merge",
-        "--port",
-        str(port),
-    ]
-    for env_name, env_val in daemon_env.items():
-        if env_val:
-            profile_args.extend(["--env", f"{env_name}={env_val}"])
-
-    try:
-        result = _run_embed(config, profile_args, daemon_env, timeout=10)
-        if result.returncode != 0:
-            if debug_fn:
-                debug_fn(f"Profile create stderr: {result.stderr.strip()}")
-            raise RuntimeError(f"Profile create failed (exit {result.returncode}): {result.stderr}")
-        if debug_fn:
-            debug_fn("Profile configured")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("Profile create timed out")
-    except FileNotFoundError:
-        raise RuntimeError(
-            "hindsight-embed not found. Install with: pip install hindsight-embed "
-            "or set hindsightApiUrl for external API mode."
-        )
-
-    # Step 2: Start daemon
-    if debug_fn:
-        debug_fn("Starting daemon...")
-
-    try:
-        result = _run_embed(
-            config,
-            ["daemon", "--profile", PROFILE_NAME, "start"],
-            daemon_env,
-            timeout=30,
-        )
-        if debug_fn:
-            debug_fn(f"Daemon start exit={result.returncode} stdout={result.stdout.strip()}")
-        if result.returncode != 0 and "already running" not in result.stderr.lower():
-            raise RuntimeError(f"Daemon start failed (exit {result.returncode}): {result.stderr}")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("Daemon start timed out")
-
-    # Step 3: Wait for ready
-    if debug_fn:
-        debug_fn("Waiting for daemon to be ready...")
-
-    for attempt in range(30):
+    with _daemon_start_lock():
         if _check_health(base_url):
             if debug_fn:
-                debug_fn(f"Daemon ready after {attempt + 1} attempts")
-            write_state(
-                DAEMON_STATE_FILE,
-                {
-                    "port": port,
-                    "started_by_plugin": True,
-                    "started_at": time.time(),
-                    "pid": os.getpid(),
-                },
-            )
+                debug_fn(
+                    f"Daemon became healthy on port {port} while waiting for startup lock"
+                )
             return
-        time.sleep(1)
+
+        if not _is_embed_available(config):
+            raise RuntimeError(
+                "hindsight-embed not found (uvx not on PATH). "
+                "Install with: pip install hindsight-embed, or set hindsightApiUrl."
+            )
+
+        try:
+            llm_config = detect_llm_config(config)
+        except RuntimeError as e:
+            raise RuntimeError(f"Cannot start daemon: {e}") from e
+
+        llm_env = get_llm_env_vars(llm_config)
+
+        daemon_env = dict(llm_env)
+        idle_timeout = config.get("daemonIdleTimeout", 300)
+        daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
+
+        if platform.system() == "Darwin":
+            daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
+            daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
+
+        # Step 1: Configure profile
+        if debug_fn:
+            debug_fn(f'Configuring "{PROFILE_NAME}" profile...')
+
+        profile_args = [
+            "profile",
+            "create",
+            PROFILE_NAME,
+            "--merge",
+            "--port",
+            str(port),
+        ]
+        for env_name, env_val in daemon_env.items():
+            if env_val:
+                profile_args.extend(["--env", f"{env_name}={env_val}"])
+
+        try:
+            result = _run_embed(config, profile_args, daemon_env, timeout=10)
+            if result.returncode != 0:
+                if debug_fn:
+                    debug_fn(f"Profile create stderr: {result.stderr.strip()}")
+                raise RuntimeError(
+                    f"Profile create failed (exit {result.returncode}): {result.stderr}"
+                )
+            if debug_fn:
+                debug_fn("Profile configured")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Profile create timed out")
+        except FileNotFoundError:
+            raise RuntimeError(
+                "hindsight-embed not found. Install with: pip install hindsight-embed "
+                "or set hindsightApiUrl for external API mode."
+            )
+
+        # Step 2: Start daemon
+        if debug_fn:
+            debug_fn("Starting daemon...")
+
+        try:
+            result = _run_embed(
+                config,
+                ["daemon", "--profile", PROFILE_NAME, "start"],
+                daemon_env,
+                timeout=30,
+            )
+            if debug_fn:
+                debug_fn(
+                    f"Daemon start exit={result.returncode} stdout={result.stdout.strip()}"
+                )
+            if (
+                result.returncode != 0
+                and "already running" not in result.stderr.lower()
+            ):
+                raise RuntimeError(
+                    f"Daemon start failed (exit {result.returncode}): {result.stderr}"
+                )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Daemon start timed out")
+
+        # Step 3: Wait for ready
+        if debug_fn:
+            debug_fn("Waiting for daemon to be ready...")
+
+        for attempt in range(30):
+            if _check_health(base_url):
+                if debug_fn:
+                    debug_fn(f"Daemon ready after {attempt + 1} attempts")
+                write_state(
+                    DAEMON_STATE_FILE,
+                    {
+                        "port": port,
+                        "started_by_plugin": True,
+                        "started_at": time.time(),
+                        "pid": os.getpid(),
+                    },
+                )
+                return
+            time.sleep(1)
 
     raise RuntimeError("Daemon failed to become ready within 30 seconds")
+
+
+def _background_start_daemon(config: dict, port: int):
+    """Background helper entrypoint for session warmup."""
+    try:
+        _ensure_daemon_running(config, port)
+    except Exception:
+        # SessionStart warmup is opportunistic. Retain can still retry in foreground.
+        return
 
 
 def prestart_daemon_background(config: dict, debug_fn=None):
@@ -235,40 +302,18 @@ def prestart_daemon_background(config: dict, debug_fn=None):
             debug_fn("hindsight-embed not available, skipping pre-start")
         return
 
-    try:
-        llm_config = detect_llm_config(config)
-    except RuntimeError as e:
-        if debug_fn:
-            debug_fn(f"No LLM configured, skipping daemon pre-start: {e}")
-        return
+    helper_code = (
+        "import json, sys;"
+        f"sys.path.insert(0, {os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))!r});"
+        "from lib.daemon import _background_start_daemon;"
+        f"_background_start_daemon(json.loads({json.dumps(json.dumps(config))}), {int(port)})"
+    )
 
-    llm_env = get_llm_env_vars(llm_config)
-    daemon_env = dict(os.environ)
-    daemon_env.update(llm_env)
-    idle_timeout = config.get("daemonIdleTimeout", 300)
-    daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
-    if platform.system() == "Darwin":
-        daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
-        daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
-
-    embed_cmd = _get_embed_command(config)
-
-    profile_args = ["profile", "create", PROFILE_NAME, "--merge", "--port", str(port)]
-    for env_name, env_val in llm_env.items():
-        if env_val:
-            profile_args.extend(["--env", f"{env_name}={env_val}"])
-
-    import shlex
-    profile_str = shlex.join(embed_cmd + profile_args)
-    daemon_str = shlex.join(embed_cmd + ["daemon", "--profile", PROFILE_NAME, "start"])
-
-    import subprocess as _sp
-    _sp.Popen(
-        f"{profile_str} && {daemon_str}",
-        shell=True,
-        env=daemon_env,
-        stdout=_sp.DEVNULL,
-        stderr=_sp.DEVNULL,
+    subprocess.Popen(
+        [sys.executable, "-c", helper_code],
+        env=dict(os.environ),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
     if debug_fn:

--- a/hindsight-integrations/codex/tests/test_daemon.py
+++ b/hindsight-integrations/codex/tests/test_daemon.py
@@ -1,0 +1,71 @@
+"""Tests for lib/daemon.py startup coordination."""
+
+import threading
+import time
+
+import pytest
+
+from lib import daemon, state
+
+
+@pytest.mark.skipif(
+    state.fcntl is None, reason="startup lock coordination uses fcntl on Unix"
+)
+def test_get_api_url_waits_for_inflight_daemon_start(monkeypatch, tmp_path):
+    """A second hook should wait for the first daemon start instead of racing it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config = {
+        "apiPort": 9077,
+        "llmProvider": "openai-codex",
+        "llmModel": "gpt-5.2-codex",
+    }
+
+    health_state = {"ready": False}
+    lock_path = state._state_file("daemon-start.lock")
+    lock_ready = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_startup_lock():
+        with open(lock_path, "w") as lock_fd:
+            state.fcntl.flock(lock_fd, state.fcntl.LOCK_EX)
+            lock_ready.set()
+            release_lock.wait(timeout=2)
+            state.fcntl.flock(lock_fd, state.fcntl.LOCK_UN)
+
+    holder = threading.Thread(target=hold_startup_lock, daemon=True)
+    holder.start()
+    assert lock_ready.wait(timeout=1), "test setup failed to acquire daemon lock"
+
+    def check_health(_base_url, timeout=2):
+        return health_state["ready"]
+
+    monkeypatch.setattr(daemon, "_check_health", check_health)
+    monkeypatch.setattr(daemon, "_is_embed_available", lambda _config: True)
+    monkeypatch.setattr(
+        daemon,
+        "detect_llm_config",
+        lambda _config: (_ for _ in ()).throw(AssertionError("should not detect llm")),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "_run_embed",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("should not start second daemon")
+        ),
+    )
+    monkeypatch.setattr(daemon, "write_state", lambda *args, **kwargs: None)
+
+    def mark_ready():
+        time.sleep(0.1)
+        health_state["ready"] = True
+        release_lock.set()
+
+    releaser = threading.Thread(target=mark_ready, daemon=True)
+    releaser.start()
+
+    api_url = daemon.get_api_url(config, allow_daemon_start=True)
+
+    holder.join(timeout=1)
+    releaser.join(timeout=1)
+    assert api_url == "http://127.0.0.1:9077"


### PR DESCRIPTION
## Summary
- serialize Codex-side daemon startup so concurrent hooks cannot start a second `hindsight-embed` daemon
- route SessionStart warmup through the same locked startup path used by foreground retain/recall flows
- add a regression test covering the in-flight startup race

## Root cause
A duplicate local daemon start on April 11, 2026 caused a bind conflict on port `9077`. The losing process then ran shutdown cleanup and stopped the shared embedded Postgres instance, leaving the first worker stuck polling the database with connection-refused errors.

## Verification
- `uv run pytest hindsight-integrations/codex/tests/test_hooks.py hindsight-integrations/codex/tests/test_content.py hindsight-integrations/codex/tests/test_daemon.py -q`
- `uv run ruff check hindsight-integrations/codex/scripts/lib/daemon.py hindsight-integrations/codex/tests/test_daemon.py`

Both passed locally (`72 passed`, Ruff clean).