### PR TITLE
fix(retain): make chunk insert idempotent and stop retrying integrity errors

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1140,6 +1140,26 @@ class MemoryEngine(MemoryEngineInterface):
                     logger.error(f"Not retrying task {task_type} (non-retryable), marking as failed")
                     if operation_id:
                         await self._mark_operation_failed(operation_id, str(e), error_traceback)
+                elif isinstance(e, asyncpg.exceptions.IntegrityConstraintViolationError):
+                    # Non-retryable: deterministic Postgres integrity violations
+                    # (UniqueViolationError, ForeignKeyViolationError, CheckViolationError,
+                    # NotNullViolationError, ExclusionViolationError) will never succeed on
+                    # retry — the offending row state is already committed. Retrying just
+                    # burns worker capacity. See vectorize-io/hindsight#980.
+                    logger.error(
+                        f"Not retrying task {task_type} (integrity violation, deterministic): {type(e).__name__}"
+                    )
+                    if task_type == "consolidation" and operation_id:
+                        await self._fire_consolidation_webhook(
+                            bank_id=task_dict.get("bank_id", ""),
+                            operation_id=operation_id,
+                            status="failed",
+                            result=None,
+                            error_message=str(e),
+                            schema=schema,
+                        )
+                    if operation_id:
+                        await self._mark_operation_failed(operation_id, str(e), error_traceback)
                 else:
                     if task_type == "consolidation" and operation_id:
                         # Fire failure webhook (non-transactional — operation not yet marked failed;

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -100,11 +100,20 @@ async def store_chunks_batch(conn, bank_id: str, document_id: str, chunks: list[
         content_hashes.append(compute_chunk_hash(chunk.chunk_text))
         chunk_id_map[chunk.chunk_index] = chunk_id
 
-    # Batch insert all chunks
+    # Batch upsert all chunks. ON CONFLICT makes this idempotent: re-submitting
+    # a retain under the same document_id (the pattern in vectorize-io/hindsight#977)
+    # may produce chunk_ids that already exist when upstream cascade-delete or
+    # delta-retain paths don't run (or race with a concurrent task). Overwriting
+    # is the correct behavior per the document_id grouping semantics — the caller
+    # intends this chunk to hold the latest content at that (document_id, index).
     await conn.execute(
         f"""
         INSERT INTO {fq_table("chunks")} (chunk_id, document_id, bank_id, chunk_text, chunk_index, content_hash)
         SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::integer[], $6::text[])
+        ON CONFLICT (chunk_id) DO UPDATE SET
+            chunk_text = EXCLUDED.chunk_text,
+            chunk_index = EXCLUDED.chunk_index,
+            content_hash = EXCLUDED.content_hash
         """,
         chunk_ids,
         [document_id] * len(chunk_texts),

--- a/hindsight-api-slim/tests/test_chunk_storage_upsert.py
+++ b/hindsight-api-slim/tests/test_chunk_storage_upsert.py
@@ -1,0 +1,149 @@
+"""
+Regression tests for chunk_storage.store_chunks_batch idempotency.
+
+Covers vectorize-io/hindsight#977: re-submitting a retain under the same
+document_id must not fail with ``UniqueViolationError`` on ``pk_chunks``.
+The upstream retain paths (cascade delete on first batch, delta retain)
+should usually prevent a chunk_id collision, but any bug in those paths
+used to surface as a raw Postgres constraint violation. ``store_chunks_batch``
+is now idempotent: inserting the same ``chunk_id`` twice overwrites the
+existing row rather than raising.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.retain import chunk_storage
+from hindsight_api.engine.retain.types import ChunkMetadata
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+async def _seed_bank_and_document(conn, bank_id: str, document_id: str) -> None:
+    """Insert the minimum rows required for the chunks FK to pass."""
+    await conn.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+    await conn.execute(
+        """
+        INSERT INTO documents (id, bank_id, original_text, content_hash)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (id, bank_id) DO NOTHING
+        """,
+        document_id,
+        bank_id,
+        "seed",
+        "seed-hash",
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_chunks_batch_is_idempotent_for_same_chunk_id(memory):
+    """
+    Regression for #977.
+
+    Directly exercises the chunk insert path: inserting a ChunkMetadata with
+    a chunk_index that already exists (i.e., the same chunk_id) must not
+    raise. The new content should overwrite the old one.
+    """
+    bank_id = f"test_chunk_upsert_{_ts()}"
+    document_id = "doc-upsert-regression"
+
+    pool = await memory._get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await _seed_bank_and_document(conn, bank_id, document_id)
+
+            # First insert — fresh chunks at indices 0, 1, 2.
+            v1 = [
+                ChunkMetadata(chunk_text="alpha", fact_count=1, content_index=0, chunk_index=0),
+                ChunkMetadata(chunk_text="beta", fact_count=1, content_index=0, chunk_index=1),
+                ChunkMetadata(chunk_text="gamma", fact_count=1, content_index=0, chunk_index=2),
+            ]
+            v1_map = await chunk_storage.store_chunks_batch(conn, bank_id, document_id, v1)
+            assert set(v1_map.keys()) == {0, 1, 2}
+
+            # Second insert — overlapping chunk_index (1 and 2) with new text,
+            # plus a fresh chunk at index 3. Before the fix this raised
+            # asyncpg.exceptions.UniqueViolationError on pk_chunks; after the
+            # fix the conflicting rows are overwritten and the new one is
+            # inserted.
+            v2 = [
+                ChunkMetadata(chunk_text="beta-updated", fact_count=1, content_index=0, chunk_index=1),
+                ChunkMetadata(chunk_text="gamma-updated", fact_count=1, content_index=0, chunk_index=2),
+                ChunkMetadata(chunk_text="delta", fact_count=1, content_index=0, chunk_index=3),
+            ]
+            v2_map = await chunk_storage.store_chunks_batch(conn, bank_id, document_id, v2)
+            assert set(v2_map.keys()) == {1, 2, 3}
+
+            # Verify the stored state matches the upserted content.
+            rows = await conn.fetch(
+                """
+                SELECT chunk_index, chunk_text, content_hash
+                FROM chunks
+                WHERE document_id = $1 AND bank_id = $2
+                ORDER BY chunk_index
+                """,
+                document_id,
+                bank_id,
+            )
+            by_index = {row["chunk_index"]: row for row in rows}
+
+            assert set(by_index.keys()) == {0, 1, 2, 3}, (
+                "Expected four chunks total after upsert (0 untouched, 1-2 overwritten, 3 new)"
+            )
+            assert by_index[0]["chunk_text"] == "alpha", "Untouched chunk must be preserved"
+            assert by_index[1]["chunk_text"] == "beta-updated", "Conflicting chunk must be overwritten"
+            assert by_index[2]["chunk_text"] == "gamma-updated", "Conflicting chunk must be overwritten"
+            assert by_index[3]["chunk_text"] == "delta", "New chunk must be inserted"
+
+            # content_hash should reflect the new text, not the original.
+            assert by_index[1]["content_hash"] == chunk_storage.compute_chunk_hash("beta-updated")
+            assert by_index[2]["content_hash"] == chunk_storage.compute_chunk_hash("gamma-updated")
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM chunks WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM documents WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_store_chunks_batch_second_call_with_identical_payload(memory):
+    """
+    The exact #977 shape: ``store_chunks_batch`` called twice with the same
+    chunks must succeed both times (the second call is a no-op in terms of
+    stored content, but must not raise).
+    """
+    bank_id = f"test_chunk_upsert_identical_{_ts()}"
+    document_id = "doc-upsert-identical"
+
+    pool = await memory._get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await _seed_bank_and_document(conn, bank_id, document_id)
+
+            chunks = [
+                ChunkMetadata(chunk_text=f"chunk-{i}", fact_count=1, content_index=0, chunk_index=i)
+                for i in range(5)
+            ]
+
+            await chunk_storage.store_chunks_batch(conn, bank_id, document_id, chunks)
+            # Second call with identical chunks — must not raise.
+            await chunk_storage.store_chunks_batch(conn, bank_id, document_id, chunks)
+
+            count = await conn.fetchval(
+                "SELECT COUNT(*) FROM chunks WHERE document_id = $1 AND bank_id = $2",
+                document_id,
+                bank_id,
+            )
+            assert count == 5, "Second identical insert should not duplicate rows"
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM chunks WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM documents WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)

--- a/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
+++ b/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
@@ -1,0 +1,184 @@
+"""
+Regression tests for vectorize-io/hindsight#980.
+
+Deterministic Postgres integrity-constraint violations (UniqueViolationError,
+ForeignKeyViolationError, CheckViolationError, NotNullViolationError,
+ExclusionViolationError) must NOT be retried by the worker — they will never
+succeed on retry, and retrying just burns worker capacity for ~3 minutes
+(3 retries × 60s) before finally giving up.
+
+These tests verify that ``MemoryEngine.execute_task`` classifies
+``asyncpg.exceptions.IntegrityConstraintViolationError`` as non-retryable
+and marks the operation as failed on the first occurrence.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import asyncpg
+import pytest
+
+from hindsight_api.worker.exceptions import RetryTaskAt
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    """Upsert a minimal bank row so FK on async_operations passes."""
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _create_pending_operation(pool, bank_id: str, operation_id: uuid.UUID) -> None:
+    """Insert a pending batch_retain operation row for the test."""
+    payload = json.dumps(
+        {
+            "type": "batch_retain",
+            "operation_id": str(operation_id),
+            "bank_id": bank_id,
+            "contents": [{"content": "test", "document_id": "doc-1"}],
+        }
+    )
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'retain', 'pending', $3::jsonb)
+        """,
+        operation_id,
+        bank_id,
+        payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unique_violation_marks_failed_without_retry(memory):
+    """
+    UniqueViolationError must mark the operation as failed immediately, not
+    raise RetryTaskAt. This is the primary symptom from #977: re-submitting
+    retain caused PK collisions that the poller retried ~3 times before
+    giving up. With #980's fix, the first collision fails the task.
+    """
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    # Synthesize a real asyncpg UniqueViolationError the way the server would
+    # raise it (matches the error observed in the bug report's logs).
+    unique_violation = asyncpg.exceptions.UniqueViolationError(
+        'duplicate key value violates unique constraint "pk_chunks"'
+    )
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+    }
+
+    # Force _handle_batch_retain to raise the integrity error, isolating the
+    # execute_task exception-classification path.
+    with patch.object(memory, "_handle_batch_retain", side_effect=unique_violation):
+        # Must not raise RetryTaskAt — the whole point of the fix.
+        try:
+            await memory.execute_task(task_dict)
+        except RetryTaskAt as exc:
+            pytest.fail(
+                f"IntegrityConstraintViolationError must not be retried, but execute_task raised {exc!r}"
+            )
+
+    # The operation must be marked 'failed' (not left pending / retrying).
+    row = await pool.fetchrow(
+        "SELECT status, error_message FROM async_operations WHERE operation_id = $1",
+        operation_id,
+    )
+    assert row is not None, "Operation row disappeared"
+    assert row["status"] == "failed", (
+        f"Expected status='failed' after integrity violation, got {row['status']!r}"
+    )
+    assert row["error_message"] is not None
+    assert "pk_chunks" in row["error_message"]
+
+    # Cleanup
+    await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", operation_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_foreign_key_violation_also_not_retried(memory):
+    """
+    All subclasses of IntegrityConstraintViolationError are non-retryable —
+    verify ForeignKeyViolationError is classified the same way as
+    UniqueViolationError.
+    """
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    fk_violation = asyncpg.exceptions.ForeignKeyViolationError(
+        "insert or update on table \"memory_units\" violates foreign key constraint \"fk_bank\""
+    )
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+    }
+
+    with patch.object(memory, "_handle_batch_retain", side_effect=fk_violation):
+        try:
+            await memory.execute_task(task_dict)
+        except RetryTaskAt as exc:
+            pytest.fail(
+                f"ForeignKeyViolationError must not be retried, but execute_task raised {exc!r}"
+            )
+
+    row = await pool.fetchrow(
+        "SELECT status FROM async_operations WHERE operation_id = $1",
+        operation_id,
+    )
+    assert row["status"] == "failed"
+
+    await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", operation_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_non_integrity_error_still_retried(memory):
+    """
+    Sanity check: non-integrity errors (network errors, timeouts, value errors)
+    should STILL use the existing retry path — i.e., raise RetryTaskAt when
+    ``_retry_count < 3``. Only integrity violations are the new non-retryable
+    class.
+    """
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+        # _retry_count = 0 (first attempt), so the existing retry path should fire.
+    }
+
+    transient_error = RuntimeError("transient connection blip")
+
+    with patch.object(memory, "_handle_batch_retain", side_effect=transient_error):
+        with pytest.raises(RetryTaskAt):
+            await memory.execute_task(task_dict)
+
+    await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", operation_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)


### PR DESCRIPTION
## Summary

Two related fixes for retain re-submission failures, captured as vectorize-io/hindsight#977 and vectorize-io/hindsight#980.

- **#977 — duplicate chunk_id on re-submission.** `store_chunks_batch` now uses `ON CONFLICT (chunk_id) DO UPDATE`, making chunk inserts idempotent. Re-submitting retain under the same `document_id` (the documented grouping semantics) used to surface a raw `UniqueViolationError` on `pk_chunks` whenever any upstream cleanup path — `handle_document_tracking`'s cascade delete on `is_first_batch=True`, the delta-retain chunk diff, or a concurrent `batch_retain` task — didn't run before the insert. Overwriting is the correct behavior: the caller intends this chunk to hold the latest content at `(document_id, index)`.
- **#980 — worker retries deterministic errors.** `MemoryEngine.execute_task` now classifies `asyncpg.exceptions.IntegrityConstraintViolationError` (base class of `UniqueViolation`, `ForeignKeyViolation`, `CheckViolation`, `NotNullViolation`, `ExclusionViolation`) as non-retryable and marks the operation failed on the first occurrence. Previously the poller retried these ~3 times over ~3 minutes, burning worker capacity on an error class that can never succeed on retry.

Both fixes are small and targeted; no API or schema changes.

## Test plan

- [x] **#977 regression** — `tests/test_chunk_storage_upsert.py` (2 tests). Exercises `store_chunks_batch` directly: inserting overlapping `chunk_index` twice must not raise, conflicting rows must be overwritten with the new text/hash, non-conflicting rows must be preserved. Both tests reproduce the bug against the unpatched code (`asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "pk_chunks"`) and pass after the fix.
- [x] **#980 regression** — `tests/test_integrity_violation_not_retried.py` (3 tests). Patches `_handle_batch_retain` to raise `UniqueViolationError` and `ForeignKeyViolationError`; asserts `execute_task` does NOT raise `RetryTaskAt` and the operation row is marked `failed` with the error message. Third test confirms non-integrity errors (e.g., `RuntimeError`) still use the existing retry path. Verified that the `UniqueViolationError` test fails against the unpatched `execute_task` before re-applying the fix.
- [x] `./scripts/hooks/lint.sh` — all lints passed.
- [x] `uv run ty check` on all changed files — all checks passed.
- [x] `tests/test_delta_retain.py` + `tests/test_document_tracking.py` + `tests/test_async_batch_retain.py` + `tests/test_batch_chunking.py` + `tests/test_chunking.py` — 44 passed, 0 failures related to these changes.
- [x] `tests/test_worker.py` — 30 passed, 0 failures related to these changes.

## Notes

- I could not pin down a single exact reproducer for the upstream bug that makes cascade-delete / delta-retain emit a duplicate `chunk_id` — the code paths have several defensive layers that should handle re-submission correctly. With the upsert in place the class of bug is no longer load-bearing, so I chose to make the insert robust rather than chase the specific trigger. One narrow suspect worth a follow-up: `_build_delta_contents` → `delta_chunk_map` remap at `orchestrator.py:1356` uses `cm.chunk_index` as the lookup key, which only matches when each delta_content produces exactly one sub-chunk during fact extraction. Happy to file a separate issue if reviewers want that cleaned up.