### PR TITLE
test(reflect): regression test for internal billing in sub-recalls

### DIFF
--- a/hindsight-api-slim/tests/test_reflect_internal_billing.py
+++ b/hindsight-api-slim/tests/test_reflect_internal_billing.py
@@ -1,0 +1,80 @@
+"""Regression test for #972: reflect sub-recalls must be marked internal.
+
+When reflect calls search_observations or recall, the sub-recalls must use
+``request_context.internal=True`` to avoid double-billing.  The reflect caller
+is already billed for the overall operation; sub-recalls are implementation
+details that should not generate additional billing events.
+"""
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hindsight_api.engine.reflect.tools import tool_recall, tool_search_observations
+from hindsight_api.engine.response_models import RecallResult
+
+
+@dataclass
+class _FakeRequestContext:
+    """Dataclass stand-in matching the fields used by ``dataclasses.replace``."""
+
+    api_key: str | None = None
+    api_key_id: str | None = None
+    tenant_id: str | None = None
+    internal: bool = False
+    mcp_authenticated: bool = False
+    user_initiated: bool = False
+    allowed_bank_ids: list[str] | None = None
+
+
+def _mock_engine():
+    engine = MagicMock()
+    engine.recall_async = AsyncMock(
+        return_value=RecallResult(results=[], source_facts={})
+    )
+    return engine
+
+
+class TestReflectInternalBilling:
+    """Verify that reflect sub-recalls are marked internal (#972)."""
+
+    @pytest.mark.asyncio
+    async def test_search_observations_marks_recall_internal(self):
+        engine = _mock_engine()
+        ctx = _FakeRequestContext(api_key="k", internal=False)
+
+        await tool_search_observations(engine, "bank-1", "query", ctx)
+
+        engine.recall_async.assert_called_once()
+        passed_ctx = engine.recall_async.call_args.kwargs["request_context"]
+        assert passed_ctx.internal is True, "sub-recall must be internal"
+
+    @pytest.mark.asyncio
+    async def test_search_observations_preserves_original_context(self):
+        engine = _mock_engine()
+        ctx = _FakeRequestContext(api_key="k", internal=False)
+
+        await tool_search_observations(engine, "bank-1", "query", ctx)
+
+        assert ctx.internal is False, "original context must not be mutated"
+
+    @pytest.mark.asyncio
+    async def test_recall_marks_recall_internal(self):
+        engine = _mock_engine()
+        ctx = _FakeRequestContext(api_key="k", internal=False)
+
+        await tool_recall(engine, "bank-1", "query", ctx)
+
+        engine.recall_async.assert_called_once()
+        passed_ctx = engine.recall_async.call_args.kwargs["request_context"]
+        assert passed_ctx.internal is True, "sub-recall must be internal"
+
+    @pytest.mark.asyncio
+    async def test_recall_preserves_original_context(self):
+        engine = _mock_engine()
+        ctx = _FakeRequestContext(api_key="k", internal=False)
+
+        await tool_recall(engine, "bank-1", "query", ctx)
+
+        assert ctx.internal is False, "original context must not be mutated"


### PR DESCRIPTION
## Summary

PR #972 fixed a double-billing bug where reflect's internal `recall_async` calls were billed as user-facing operations. The fix correctly uses `dataclasses.replace(request_context, internal=True)`, but no regression test was added.

This PR adds 4 focused tests to prevent accidental revert:

1. `test_search_observations_marks_recall_internal` — verifies `internal=True` is passed
2. `test_search_observations_preserves_original_context` — verifies `replace()` is used (not mutation)
3. `test_recall_marks_recall_internal` — same check for `tool_recall`
4. `test_recall_preserves_original_context` — same non-mutation check

**Why this matters**: If someone refactors the reflect tools and removes the `internal=True` flag, customers would be silently double-billed. The billing impact is invisible to tests that don't explicitly assert on the `request_context.internal` field.

Fixes #988

## Test plan

- [ ] `pytest hindsight-api-slim/tests/test_reflect_internal_billing.py -v` — all 4 tests pass