### PR TITLE
fix(opencode-plugin): correct session.messages API params and response shape

### DIFF
--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -58,7 +58,12 @@ interface SystemTransformOutput {
 
 type OpencodeClient = {
     session: {
-        messages: (opts: { path: { id: string } }) => Promise<{ data?: Array<{ role: string; parts?: Array<{ type: string; text?: string }> }> }>;
+        messages: (params: { sessionID: string }) => Promise<{
+            data?: Array<{
+                info: { role: string };
+                parts: Array<{ type: string; text?: string }>;
+            }>;
+        }>;
     };
 };
 
@@ -118,23 +123,24 @@ export function createHooks(
     async function getSessionMessages(sessionId: string): Promise<Message[]> {
         try {
             const response = await opencodeClient.session.messages({
-                path: { id: sessionId },
+                sessionID: sessionId,
             });
             const rawMessages = response.data || [];
             const messages: Message[] = [];
             for (const msg of rawMessages) {
-                const role = msg.role;
+                const role = msg.info.role;
                 if (role !== 'user' && role !== 'assistant') continue;
-                const textParts = (msg.parts || [])
-                    .filter((p: { type: string; text?: string }) => p.type === 'text' && p.text)
-                    .map((p: { type: string; text?: string }) => p.text!);
+                const textParts = msg.parts
+                    .filter((p) => p.type === 'text' && p.text)
+                    .map((p) => p.text!);
                 if (textParts.length) {
                     messages.push({ role, content: textParts.join('\n') });
                 }
             }
+            console.error(`[Hindsight] getSessionMessages: raw=${rawMessages.length}, parsed=${messages.length}`);
             return messages;
         } catch (e) {
-            debugLog(config, 'Failed to get session messages:', e);
+            console.error('[Hindsight] Failed to get session messages:', e);
             return [];
         }
     }
@@ -177,14 +183,20 @@ export function createHooks(
 
     /** Auto-retain conversation transcript */
     async function handleSessionIdle(sessionId: string): Promise<void> {
-        if (!config.autoRetain) return;
+        console.error(`[Hindsight] handleSessionIdle called for session ${sessionId}`);
+        if (!config.autoRetain) {
+            console.error('[Hindsight] handleSessionIdle: autoRetain is false, skipping');
+            return;
+        }
 
         const messages = await getSessionMessages(sessionId);
+        console.error(`[Hindsight] handleSessionIdle: got ${messages.length} messages`);
         if (!messages.length) return;
 
         // Count user turns
         const userTurns = messages.filter((m) => m.role === 'user').length;
         const lastRetained = state.lastRetainedTurn.get(sessionId) || 0;
+        console.error(`[Hindsight] handleSessionIdle: userTurns=${userTurns}, lastRetained=${lastRetained}, retainEveryNTurns=${config.retainEveryNTurns}`);
 
         // Only retain if enough new turns since last retain
         if (userTurns - lastRetained < config.retainEveryNTurns) return;
@@ -192,18 +204,20 @@ export function createHooks(
         try {
             await retainSession(sessionId, messages);
             state.lastRetainedTurn.set(sessionId, userTurns);
-            debugLog(config, `Auto-retained ${messages.length} messages for session ${sessionId}`);
+            console.error(`[Hindsight] Auto-retained ${messages.length} messages for session ${sessionId}`);
         } catch (e) {
-            debugLog(config, 'Auto-retain failed:', e);
+            console.error('[Hindsight] Auto-retain failed:', e);
         }
     }
 
     const event = async (input: EventInput): Promise<void> => {
         try {
             const { event: evt } = input;
+            console.error(`[Hindsight] event hook fired: type=${evt.type}`);
 
             if (evt.type === 'session.idle') {
                 const sessionId = (evt.properties as { sessionID?: string }).sessionID;
+                console.error(`[Hindsight] session.idle event: sessionId=${sessionId}`);
                 if (sessionId) {
                     await handleSessionIdle(sessionId);
                 }


### PR DESCRIPTION
## Summary

- Fix `getSessionMessages()` calling `opencodeClient.session.messages()` with wrong params — `{ path: { id } }` instead of `{ sessionID }` — causing the API to return empty results
- Fix response parsing — SDK returns `{ info: { role }, parts }` but code was reading `msg.role` (flat) instead of `msg.info.role` (nested)
- Add `console.error` logging along the idle→retain path so failures are visible in opencode logs without `config.debug`

## Root cause

`getSessionMessages()` had two bugs that compounded to always return `[]`:

1. **Wrong API params**: Passed `{ path: { id: sessionId } }` to the OpenCode v2 SDK's `session.messages()`, which expects `{ sessionID: string }`. The SDK silently ignored the unknown params and the request returned no data.
2. **Wrong response shape**: The SDK returns `Array<{ info: { role }, parts: Part[] }>` but the code accessed `msg.role` directly (undefined) instead of `msg.info.role`.

With 0 messages, `handleSessionIdle` bailed at `if (!messages.length) return` every time — auto-retain never fired.

## Testing

- Built and deployed locally with `npm run build` in `hindsight-integrations/opencode/`
- Verified deployed code contains `sessionID:` param and `msg.info.role`
- Restart opencode and check `~/opencode-debug.log` for `getSessionMessages: raw=N, parsed=M` with non-zero counts, followed by `Auto-retained N messages`