### PR TITLE
fix(worker): reclaim stale tasks from dead workers

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -776,17 +776,13 @@ async def compute_semantic_links_ann(
         await conn.execute("SET LOCAL hnsw.ef_search = 60")
 
         t_setup = time_mod.time()
-        await conn.execute(
-            "CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP"
-        )
+        await conn.execute("CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP")
 
         records = [
             (uid, emb if isinstance(emb, str) else str(emb), ft)
             for uid, emb, ft in zip(unit_ids, embeddings, fact_types)
         ]
-        await conn.copy_records_to_table(
-            "_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"]
-        )
+        await conn.copy_records_to_table("_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"])
         logger.debug(f"[ANN] Temp table setup: {time_mod.time() - t_setup:.3f}s ({len(records)} seeds)")
 
         # Run one ANN query per fact_type so each uses the right HNSW index.

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -531,7 +531,6 @@ class WorkerPoller:
             logger.info(f"Worker {self._worker_id} recovered {total_count} stale tasks from previous run")
         return total_count
 
-
     async def reclaim_stale_tasks(self) -> int:
         """
         Reclaim tasks stuck in 'processing' from dead workers.
@@ -576,8 +575,7 @@ class WorkerPoller:
             except Exception as e:
                 schema_display = f'"{schema}"' if schema else str(schema)
                 logger.warning(
-                    f"Worker {self._worker_id} failed to reclaim stale tasks "
-                    f"for schema {schema_display}: {e}"
+                    f"Worker {self._worker_id} failed to reclaim stale tasks for schema {schema_display}: {e}"
                 )
 
         if total_reclaimed > 0:

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 # Progress logging interval in seconds
 PROGRESS_LOG_INTERVAL = 30
 
+# Interval between stale-claim reclamation checks (seconds)
+RECLAIM_CHECK_INTERVAL = 60
+
 
 def fq_table(table: str, schema: str | None = None) -> str:
     """Get fully-qualified table name with optional schema prefix."""
@@ -63,6 +66,7 @@ class WorkerPoller:
         tenant_extension: "TenantExtension | None" = None,
         max_slots: int = 10,
         consolidation_max_slots: int = 2,
+        stale_claim_timeout_minutes: int = 15,
     ):
         """
         Initialize the worker poller.
@@ -77,6 +81,8 @@ class WorkerPoller:
                             DefaultTenantExtension with the configured schema.
             max_slots: Maximum concurrent tasks per worker
             consolidation_max_slots: Maximum concurrent consolidation tasks per worker
+            stale_claim_timeout_minutes: Minutes after which processing tasks from other
+                workers are considered stale and reclaimed (0 to disable)
         """
         self._pool = pool
         self._worker_id = worker_id
@@ -93,6 +99,8 @@ class WorkerPoller:
         self._tenant_extension = tenant_extension
         self._max_slots = max_slots
         self._consolidation_max_slots = consolidation_max_slots
+        self._stale_claim_timeout_minutes = stale_claim_timeout_minutes
+        self._last_reclaim_check = 0.0
         self._shutdown = asyncio.Event()
         self._current_tasks: set[asyncio.Task] = set()
         self._in_flight_count = 0
@@ -523,6 +531,70 @@ class WorkerPoller:
             logger.info(f"Worker {self._worker_id} recovered {total_count} stale tasks from previous run")
         return total_count
 
+
+    async def reclaim_stale_tasks(self) -> int:
+        """
+        Reclaim tasks stuck in 'processing' from dead workers.
+
+        When a worker dies without graceful shutdown (e.g. container OOM-killed,
+        node failure), its claimed tasks remain in 'processing' indefinitely.
+        Because consolidation uses per-bank serialization, stale claims also
+        block new work on the affected banks.
+
+        This method periodically resets those tasks back to 'pending' when
+        claimed_at exceeds stale_claim_timeout_minutes.
+
+        Only reclaims tasks from OTHER workers — this worker's own in-flight
+        tasks may be legitimately long-running.
+
+        Returns:
+            Number of tasks reclaimed
+        """
+        if self._stale_claim_timeout_minutes <= 0:
+            return 0
+
+        schemas = await self._get_schemas()
+        total_reclaimed = 0
+
+        for schema in schemas:
+            try:
+                table = fq_table("async_operations", schema)
+                result = await self._pool.execute(
+                    f"""
+                    UPDATE {table}
+                    SET status = 'pending', worker_id = NULL, claimed_at = NULL,
+                        retry_count = retry_count + 1, updated_at = now()
+                    WHERE status = 'processing'
+                      AND claimed_at < NOW() - make_interval(mins => $1)
+                      AND worker_id IS DISTINCT FROM $2
+                    """,
+                    self._stale_claim_timeout_minutes,
+                    self._worker_id,
+                )
+                count = int(result.split()[-1]) if result else 0
+                total_reclaimed += count
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else str(schema)
+                logger.warning(
+                    f"Worker {self._worker_id} failed to reclaim stale tasks "
+                    f"for schema {schema_display}: {e}"
+                )
+
+        if total_reclaimed > 0:
+            logger.info(
+                f"Worker {self._worker_id} reclaimed {total_reclaimed} stale tasks "
+                f"(claimed_at > {self._stale_claim_timeout_minutes}m ago)"
+            )
+        return total_reclaimed
+
+    async def _reclaim_stale_if_due(self):
+        """Run stale-claim reclamation at most once per RECLAIM_CHECK_INTERVAL."""
+        now = time.time()
+        if now - self._last_reclaim_check < RECLAIM_CHECK_INTERVAL:
+            return
+        self._last_reclaim_check = now
+        await self.reclaim_stale_tasks()
+
     async def _recover_batch_operations(self, schema: str | None) -> int:
         """
         Recover batch API operations that were in-flight when worker crashed.
@@ -656,6 +728,9 @@ class WorkerPoller:
 
                 # Log progress stats periodically
                 await self._log_progress_if_due()
+
+                # Reclaim stale tasks from dead workers
+                await self._reclaim_stale_if_due()
 
             except asyncio.CancelledError:
                 logger.info(f"Worker {self._worker_id} polling loop cancelled")

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1646,3 +1646,142 @@ class TestMarkFailedParentPropagation:
             f"Parent batch_retain should be 'failed' after child fails via unhandled exception, "
             f"got '{parent_row['status']}'"
         )
+
+
+
+class TestStaleClaimReclamation:
+    """Tests for reclaiming tasks from dead workers (stale_claim_timeout_minutes)."""
+
+    @pytest.mark.asyncio
+    async def test_reclaim_stale_tasks_from_dead_worker(self, pool, clean_operations):
+        """Tasks stuck in 'processing' from a dead worker are reclaimed after timeout."""
+        from hindsight_api.worker.poller import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+
+        # Simulate a dead worker's stale claim (claimed 20 minutes ago)
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', 'dead-worker-abc', NOW() - INTERVAL '20 minutes', NOW())
+            """,
+            op_id,
+            bank_id,
+        )
+
+        async def noop_executor(task_dict):
+            pass
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="live-worker-xyz",
+            executor=noop_executor,
+            stale_claim_timeout_minutes=15,
+        )
+
+        reclaimed = await poller.reclaim_stale_tasks()
+        assert reclaimed == 1
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id, claimed_at, retry_count FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending"
+        assert row["worker_id"] is None
+        assert row["claimed_at"] is None
+        assert row["retry_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reclaim_does_not_touch_recent_claims(self, pool, clean_operations):
+        """Tasks claimed recently by another worker are NOT reclaimed."""
+        from hindsight_api.worker.poller import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+
+        # Another worker claimed this task 5 minutes ago (within 15-minute timeout)
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'retain', 'processing', 'other-worker-456', NOW() - INTERVAL '5 minutes', NOW())
+            """,
+            op_id,
+            bank_id,
+        )
+
+        async def noop_executor(task_dict):
+            pass
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="live-worker-xyz",
+            executor=noop_executor,
+            stale_claim_timeout_minutes=15,
+        )
+
+        reclaimed = await poller.reclaim_stale_tasks()
+        assert reclaimed == 0
+
+        row = await pool.fetchrow("SELECT status, worker_id FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "other-worker-456"
+
+    @pytest.mark.asyncio
+    async def test_reclaim_does_not_touch_own_tasks(self, pool, clean_operations):
+        """This worker's own in-flight tasks are never reclaimed, even if old."""
+        from hindsight_api.worker.poller import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+
+        # This worker's own task claimed 30 minutes ago (legitimately long-running)
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', 'live-worker-xyz', NOW() - INTERVAL '30 minutes', NOW())
+            """,
+            op_id,
+            bank_id,
+        )
+
+        async def noop_executor(task_dict):
+            pass
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="live-worker-xyz",
+            executor=noop_executor,
+            stale_claim_timeout_minutes=15,
+        )
+
+        reclaimed = await poller.reclaim_stale_tasks()
+        assert reclaimed == 0
+
+        row = await pool.fetchrow("SELECT status, worker_id FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "live-worker-xyz"
+
+    @pytest.mark.asyncio
+    async def test_reclaim_disabled_when_timeout_zero(self, pool, clean_operations):
+        """Setting stale_claim_timeout_minutes=0 disables reclamation."""
+        from hindsight_api.worker.poller import WorkerPoller
+
+        async def noop_executor(task_dict):
+            pass
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="live-worker-xyz",
+            executor=noop_executor,
+            stale_claim_timeout_minutes=0,
+        )
+
+        reclaimed = await poller.reclaim_stale_tasks()
+        assert reclaimed == 0


### PR DESCRIPTION
## Summary

When a worker dies without graceful shutdown (OOM-killed, node failure, container restart with new hostname), its claimed `async_operations` rows stay in `processing` indefinitely. The existing `recover_own_tasks` only recovers tasks for the **same** `worker_id`, which doesn't help when a container restarts with a new hostname.

Because consolidation uses per-bank serialization (`NOT EXISTS ... status='processing'`), stale claims also **block all new work on affected banks** — the live worker sees slots occupied by a dead hostname and never claims pending tasks.

## Changes

- Add `reclaim_stale_tasks()` method to `WorkerPoller` that periodically resets tasks from **other** workers when `claimed_at` exceeds a configurable timeout (default 15 minutes)
- Own in-flight tasks are never touched (`worker_id IS DISTINCT FROM $2`)
- Reclamation runs at most once per 60 seconds (not every poll tick)
- New `stale_claim_timeout_minutes` constructor parameter (set to 0 to disable)
- 4 focused tests covering: stale reclaim, recent-claim safety, own-task safety, disable path

## Root cause (from #991)

```
async_operations WHERE status='processing' AND worker_id='<dead hostname>'
```
→ never reclaimed → per-bank serialization blocks new work → bank permanently wedged

Manual `UPDATE ... SET status='pending' WHERE worker_id='<dead>'` immediately unblocks the bank (confirmed by reporter).

Fixes #991