### PR TITLE
fix(cross-encoder): propagate transitive ImportErrors from mlx_lm instead of masking them

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1210,7 +1210,7 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
         try:
             import mlx.core  # noqa: F401
             import mlx_lm  # noqa: F401
-        except ImportError:
+        except ModuleNotFoundError:
             raise ImportError(
                 "mlx and mlx-lm are required for JinaMLXCrossEncoder. "
                 "Install with: pip install mlx>=0.31.0 mlx-lm>=0.31.1 safetensors>=0.6.2"


### PR DESCRIPTION
Fixes #994

## Problem

When mlx_lm is installed but one of its transitive dependencies raises an ImportError (e.g. the transformers 5.x lazy-import race on Apple Silicon), the broad except ImportError clause in JinaMLXCrossEncoder.initialize() catches it and replaces it with a misleading message saying to install mlx and mlx-lm even when both are correctly installed.

## Solution

Change except ImportError to except ModuleNotFoundError. ModuleNotFoundError is only raised when a package itself cannot be found. Transitive ImportErrors from inside a package's own code now propagate as-is, surfacing the true root cause.

## Testing

Verified with the reproducer from the issue: on Apple Silicon with transformers 5.x, the transitive ImportError from mlx_lm now propagates directly instead of being masked.