### PR TITLE
fix(cli): memory list shows [UNKNOWN] for all fact types

### DIFF
--- a/hindsight-cli/src/commands/memory.rs
+++ b/hindsight-cli/src/commands/memory.rs
@@ -21,7 +21,7 @@ use serde_json;
 struct MemoryUnitDetail {
     id: String,
     text: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "fact_type")]
     type_: Option<String>,
     document_id: Option<String>,
     context: Option<String>,
@@ -106,13 +106,14 @@ pub fn list(
                 } else {
                     for item in &result.items {
                         let fact_type = item
-                            .get("type")
+                            .get("fact_type")
                             .and_then(|v| v.as_str())
                             .unwrap_or("unknown");
                         let type_t = match fact_type {
                             "world" => 0.0,
                             "experience" => 0.5,
                             "opinion" => 1.0,
+                            "observation" => 0.25,
                             _ => 0.5,
                         };
 
@@ -179,6 +180,7 @@ pub fn get(
                     "world" => 0.0,
                     "experience" => 0.5,
                     "opinion" => 1.0,
+                    "observation" => 0.25,
                     _ => 0.5,
                 };
 

--- a/hindsight-cli/src/ui.rs
+++ b/hindsight-cli/src/ui.rs
@@ -84,6 +84,8 @@ pub fn print_fact(fact: &RecallResult, _show_activation: bool) {
     let type_t = match fact_type {
         "world" => 0.0,
         "agent" => 0.5,
+        "experience" => 0.5,
+        "observation" => 0.25,
         "opinion" => 1.0,
         _ => 0.5,
     };


### PR DESCRIPTION
## Summary

Fixes #997.

`hindsight memory list` and `hindsight memory get` display `[UNKNOWN]` as the fact type for every memory in pretty output, even though JSON output is correct.

## Root cause

Two bugs in the CLI pretty formatter:

1. **`commands/memory.rs` `list()`** reads `item.get("type")` but the API response uses the key `fact_type`. Always returns `None` → falls through to `"unknown"`.

2. **`commands/memory.rs` `MemoryUnitDetail` struct** uses `#[serde(rename = "type")]` but the API returns `fact_type`. The `get()` pretty output also always shows `[UNKNOWN]`.

## Fix

- `commands/memory.rs`: Change `.get("type")` → `.get("fact_type")` in `list()`, and `#[serde(rename = "type")]` → `#[serde(rename = "fact_type")]` in `MemoryUnitDetail`.
- Add `"observation"` match arm to all three gradient blocks (`memory.rs` list + get, `ui.rs` `print_fact`) so the color is stable for all known fact types.

## Changes

- `hindsight-cli/src/commands/memory.rs`: Fix JSON key name + add observation arm (4 lines changed)
- `hindsight-cli/src/ui.rs`: Add experience + observation arms (2 lines added)

## Before / After

**Before:**
```
  [UNKNOWN] 98ba9069-c3e7-4229-b0b4-bed095dfb927
    I analyzed the VPS memory usage ...
```

**After:**
```
  [EXPERIENCE] 98ba9069-c3e7-4229-b0b4-bed095dfb927
    I analyzed the VPS memory usage ...
```