### PR TITLE
fix(recall): use async embedding in _search_with_retries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2765,7 +2765,8 @@ class MemoryEngine(MemoryEngineInterface):
             embedding_span.set_attribute("hindsight.query", query[:100])
 
             try:
-                query_embedding = embedding_utils.generate_embedding(self.embeddings, query)
+                query_embeddings = await embedding_utils.generate_embeddings_batch(self.embeddings, [query])
+                query_embedding = query_embeddings[0]
                 step_duration = time.time() - step_start
                 log_buffer.append(f"  [1] Generate query embedding: {step_duration:.3f}s")
             finally:


### PR DESCRIPTION
## Summary

- `_search_with_retries` in `memory_engine.py` (line 2768 on main) calls `embedding_utils.generate_embedding()` **synchronously**, running sentence-transformers GPU inference directly on the asyncio event loop thread
- This blocks `/health` and all concurrent HTTP requests for the duration of each query embedding call
- Under consolidation load (`WorkerPoller` runs in-process with `consolidation_max_slots=2`), stacked sync embedding calls cause `/health` to exceed watchdog timeouts and trigger destructive service restarts
- **Fix:** Replace the sync `generate_embedding()` with the async `generate_embeddings_batch()` wrapper that already exists in the same file and is used correctly at 3 other call sites (lines 5469, 6655, 6877)

This was the **only remaining sync embedding call** in `memory_engine.py`. The retain path and all other callers already use the async batch wrapper correctly.

## Root cause analysis

The `generate_embeddings_batch` function in `embedding_utils` wraps the GPU inference call in `loop.run_in_executor()`, offloading it to a thread pool and keeping the event loop free. The sync `generate_embedding` skips this and calls `model.encode()` directly, blocking the entire uvicorn worker (default: single process, single thread) for the duration of GPU inference.

In production, with a bank under active consolidation (e.g. 2,800+ pending consolidations), the WorkerPoller issues frequent recall calls from the same event loop. Each recall triggers the sync embedding, and the stacked blocks prevent `/health` from responding within the configured watchdog timeout. The watchdog then restarts the service, killing in-flight consolidation work and creating a restart cycle.

## Evidence

Discovered in a production deployment running v0.4.22 on NVIDIA DGX Spark (GB10 Blackwell). After applying the existing hysteresis fix to the watchdog (HTTP_TIMEOUT_SEC 5→20, require 2 consecutive failures), `/health` stopped timing out — confirming the event-loop block was the cause, not database contention or network issues. The `/health` endpoint itself is clean async (`await pool.acquire() → SELECT 1`, measured at 1-3ms).

## Diff

```python
# Before (line 2768):
query_embedding = embedding_utils.generate_embedding(self.embeddings, query)

# After:
query_embeddings = await embedding_utils.generate_embeddings_batch(self.embeddings, [query])
query_embedding = query_embeddings[0]
```

## Test plan

- [ ] Verify `/health` responds consistently under consolidation load (concurrent recall + consolidation on a bank with 1000+ pending)
- [ ] Verify recall results are identical (same embedding model, same output, just async dispatch)
- [ ] Existing test suite passes (the batch wrapper is already tested via retain and other recall paths)