### PR TITLE
fix(reranker): surface real import errors and fix transformers 5.x race in jina-mlx

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1207,14 +1207,31 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
         if self._reranker is not None:
             return
 
+        # Pre-warm transformers.AutoTokenizer to fully populate the transformers
+        # namespace before mlx_lm imports it. transformers 5.x uses _LazyModule,
+        # which has an unguarded window where `from transformers import AutoTokenizer`
+        # raises ImportError if another thread is concurrently initializing the
+        # namespace (e.g. embeddings init in an executor thread).
+        # See: https://github.com/vectorize-io/hindsight/issues/994
+        import transformers
+
+        _ = transformers.AutoTokenizer
+
         try:
             import mlx.core  # noqa: F401
             import mlx_lm  # noqa: F401
-        except ImportError:
+        except ImportError as exc:
+            # Only swallow "package not installed" errors. Anything else (e.g. a
+            # transitive import failure inside mlx_lm) must surface verbatim so
+            # the real cause is debuggable instead of being masked by a generic
+            # "install mlx" message.
+            msg = str(exc)
+            if "mlx" not in msg and "mlx_lm" not in msg:
+                raise
             raise ImportError(
                 "mlx and mlx-lm are required for JinaMLXCrossEncoder. "
                 "Install with: pip install mlx>=0.31.0 mlx-lm>=0.31.1 safetensors>=0.6.2"
-            )
+            ) from exc
 
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, self._load_model)

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -776,17 +776,13 @@ async def compute_semantic_links_ann(
         await conn.execute("SET LOCAL hnsw.ef_search = 60")
 
         t_setup = time_mod.time()
-        await conn.execute(
-            "CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP"
-        )
+        await conn.execute("CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP")
 
         records = [
             (uid, emb if isinstance(emb, str) else str(emb), ft)
             for uid, emb, ft in zip(unit_ids, embeddings, fact_types)
         ]
-        await conn.copy_records_to_table(
-            "_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"]
-        )
+        await conn.copy_records_to_table("_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"])
         logger.debug(f"[ANN] Temp table setup: {time_mod.time() - t_setup:.3f}s ({len(records)} seeds)")
 
         # Run one ANN query per fact_type so each uses the right HNSW index.

--- a/hindsight-api-slim/tests/test_jina_mlx_import_error.py
+++ b/hindsight-api-slim/tests/test_jina_mlx_import_error.py
@@ -1,0 +1,65 @@
+"""
+Regression test for the JinaMLXCrossEncoder import-error handling.
+
+See: https://github.com/vectorize-io/hindsight/issues/994
+
+Before the fix, the bare `except ImportError` around `import mlx_lm` masked
+*any* ImportError raised transitively during mlx_lm's own initialization
+(e.g. transformers 5.x's _LazyModule race producing
+`ImportError: cannot import name 'AutoTokenizer' from 'transformers'`),
+replacing it with a misleading "install mlx" message.
+
+These tests verify:
+1. A transitive ImportError raised from inside mlx_lm surfaces verbatim.
+2. A genuine "package not installed" ImportError still produces the install hint.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.engine.cross_encoder import JinaMLXCrossEncoder
+
+
+@pytest.mark.asyncio
+async def test_initialize_surfaces_transitive_import_error():
+    """A transformers-lazy-load-style failure must propagate, not be masked."""
+    encoder = JinaMLXCrossEncoder()
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mlx_lm":
+            raise ImportError("cannot import name 'AutoTokenizer' from 'transformers'")
+        return real_import(name, *args, **kwargs)
+
+    # Ensure mlx_lm isn't already cached from an earlier import
+    sys.modules.pop("mlx_lm", None)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(ImportError, match="AutoTokenizer"):
+            await encoder.initialize()
+
+
+@pytest.mark.asyncio
+async def test_initialize_reports_install_hint_when_mlx_missing():
+    """A genuine 'package not installed' error still gets the friendly install hint."""
+    encoder = JinaMLXCrossEncoder()
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mlx_lm" or name.startswith("mlx_lm."):
+            raise ImportError("No module named 'mlx_lm'")
+        if name == "mlx" or name.startswith("mlx."):
+            raise ImportError("No module named 'mlx'")
+        return real_import(name, *args, **kwargs)
+
+    sys.modules.pop("mlx_lm", None)
+    sys.modules.pop("mlx", None)
+    sys.modules.pop("mlx.core", None)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(ImportError, match="mlx and mlx-lm are required"):
+            await encoder.initialize()

--- a/hindsight-api-slim/tests/test_jina_mlx_import_error.py
+++ b/hindsight-api-slim/tests/test_jina_mlx_import_error.py
@@ -15,11 +15,24 @@ These tests verify:
 """
 
 import sys
+import types
 from unittest.mock import patch
 
 import pytest
 
 from hindsight_api.engine.cross_encoder import JinaMLXCrossEncoder
+
+
+def _stub_mlx_modules() -> dict[str, types.ModuleType]:
+    """Stub mlx + mlx.core so `import mlx.core` succeeds even without mlx installed."""
+    import importlib.machinery
+
+    mlx = types.ModuleType("mlx")
+    mlx.__spec__ = importlib.machinery.ModuleSpec("mlx", loader=None)
+    mlx_core = types.ModuleType("mlx.core")
+    mlx_core.__spec__ = importlib.machinery.ModuleSpec("mlx.core", loader=None)
+    mlx.core = mlx_core
+    return {"mlx": mlx, "mlx.core": mlx_core}
 
 
 @pytest.mark.asyncio
@@ -30,16 +43,16 @@ async def test_initialize_surfaces_transitive_import_error():
     real_import = __import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "mlx_lm":
+        if name == "mlx_lm" or name.startswith("mlx_lm."):
             raise ImportError("cannot import name 'AutoTokenizer' from 'transformers'")
         return real_import(name, *args, **kwargs)
 
-    # Ensure mlx_lm isn't already cached from an earlier import
     sys.modules.pop("mlx_lm", None)
 
-    with patch("builtins.__import__", side_effect=fake_import):
-        with pytest.raises(ImportError, match="AutoTokenizer"):
-            await encoder.initialize()
+    with patch.dict(sys.modules, _stub_mlx_modules()):
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ImportError, match="AutoTokenizer"):
+                await encoder.initialize()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #994

## Summary
- Pre-warm `transformers.AutoTokenizer` in `JinaMLXCrossEncoder.initialize()` before importing `mlx_lm` to close the transformers 5.x `_LazyModule` race that fires when local embeddings init runs concurrently in an executor thread.
- Narrow the `except ImportError` so transitive failures inside `mlx_lm` surface verbatim (with chained traceback) instead of being masked by the generic "install mlx" message.

## Test plan
- [x] New unit tests in `tests/test_jina_mlx_import_error.py`:
  - Transitive `ImportError` from inside `mlx_lm` propagates verbatim (regression test for the transformers race symptom).
  - Genuine "package not installed" error still produces the friendly install hint.
- [x] `./scripts/hooks/lint.sh` passes