### PR TITLE
fix(embed): restore macOS FORCE_CPU default for local embeddings/reranker

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -7,6 +7,7 @@ consolidating daemon lifecycle, profile management, and database URL resolution.
 
 import logging
 import os
+import platform
 import re
 import subprocess
 import time
@@ -251,6 +252,15 @@ class DaemonEmbedManager(EmbedManager):
             env["HINDSIGHT_API_LOG_LEVEL"] = "info"
         if "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT" not in env:
             env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(DEFAULT_DAEMON_IDLE_TIMEOUT)
+
+        # On macOS, force CPU for local embeddings/reranker to avoid MPS/XPC
+        # hangs during sentence-transformers init in daemon mode (issue #962).
+        # Users can opt back into MPS by explicitly setting these to "0".
+        if platform.system() == "Darwin":
+            if "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU" not in env:
+                env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
+            if "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU" not in env:
+                env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
 
         # Get idle timeout from env
         idle_timeout = int(env.get("HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT", str(DEFAULT_DAEMON_IDLE_TIMEOUT)))

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -237,6 +237,15 @@ class DaemonEmbedManager(EmbedManager):
             if value:
                 env[env_key] = str(value)
 
+        # Propagate any other HINDSIGHT_* keys from the merged profile/explicit
+        # config into the daemon env. Without this, arbitrary settings in the
+        # profile's .env file (e.g. HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU,
+        # HINDSIGHT_API_EMBEDDINGS_PROVIDER) are silently dropped because the
+        # whitelist above only covers LLM/log/idle_timeout keys.
+        for key, value in config.items():
+            if key.startswith("HINDSIGHT_") and value is not None:
+                env[key] = str(value)
+
         # Use profile-specific database (check config for override)
         db_override = config.get("HINDSIGHT_EMBED_API_DATABASE_URL") or env.get("HINDSIGHT_EMBED_API_DATABASE_URL")
         if db_override:

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -221,3 +221,82 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
     assert config["llm_model"] == "claude-sonnet-4-20250514", "Should use profile's model"
     assert config["llm_api_key"] == "sk-ant-production", "Should use profile's API key"
     assert config["bank_id"] == "production-bank", "Should use profile's bank_id"
+
+
+def test_macos_forces_cpu_for_local_embeddings_and_reranker(temp_home, monkeypatch):
+    """Regression test for issue #962.
+
+    On macOS, the daemon must force CPU for local embeddings/reranker by default to
+    avoid sentence-transformers selecting MPS and hanging during startup. PR #933
+    removed this default when adding the llamacpp provider; this test guards against
+    that regression.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    # Clear any caller-supplied force-cpu env so we test the default behavior.
+    monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", raising=False)
+
+    manager = DaemonEmbedManager()
+
+    captured: dict[str, dict[str, str]] = {}
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    # Short-circuit the readiness wait; we only care about the env passed to Popen.
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", return_value=True),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+    ):
+        manager._start_daemon(
+            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
+            profile="",
+        )
+
+    env = captured["env"]
+    assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "1"
+    assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "1"
+
+
+def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
+    """Users who explicitly disable FORCE_CPU (e.g. to use MPS) must not be overridden."""
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", "0")
+    monkeypatch.setenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", "0")
+
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", return_value=True),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+    ):
+        manager._start_daemon(
+            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
+            profile="",
+        )
+
+    env = captured["env"]
+    assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "0"
+    assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "0"

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -267,6 +267,79 @@ def test_macos_forces_cpu_for_local_embeddings_and_reranker(temp_home, monkeypat
     assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "1"
 
 
+def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, monkeypatch):
+    """Regression test: HINDSIGHT_* keys in profile .env must reach the daemon subprocess env.
+
+    Previously `_start_daemon` only copied a whitelist of keys (llm_*, log_level,
+    idle_timeout) from the merged profile config into the daemon env. Anything else
+    in the profile's .env — e.g. HINDSIGHT_API_EMBEDDINGS_PROVIDER or
+    HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU on non-macOS — was silently dropped.
+    """
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    # Write a profile .env containing non-whitelisted HINDSIGHT_API_* keys.
+    profile_dir = temp_home / ".hindsight" / "profiles"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    profile_name = "forwarding"
+    (profile_dir / f"{profile_name}.env").write_text(
+        "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+        "HINDSIGHT_API_LLM_API_KEY=sk-x\n"
+        "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
+        "HINDSIGHT_API_EMBEDDINGS_PROVIDER=tei\n"
+        "HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080\n"
+        "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=1\n"
+    )
+    (profile_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    profile_name: {
+                        "port": 9877,
+                        "created_at": "2024-01-01T00:00:00+00:00",
+                        "last_used": "2024-01-01T00:00:00+00:00",
+                    }
+                },
+            }
+        )
+    )
+
+    # Clear shell env so we're only testing profile propagation.
+    for key in (
+        "HINDSIGHT_API_EMBEDDINGS_PROVIDER",
+        "HINDSIGHT_API_EMBEDDINGS_TEI_URL",
+        "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    # Simulate Linux so the macOS default doesn't mask the test.
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", return_value=True),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Linux"),
+    ):
+        manager._start_daemon(config={}, profile=profile_name)
+
+    env = captured["env"]
+    assert env.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") == "tei"
+    assert env.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL") == "http://localhost:8080"
+    assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "1"
+
+
 def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
     """Users who explicitly disable FORCE_CPU (e.g. to use MPS) must not be overridden."""
     from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

Two related fixes to restore macOS local-mode daemon startup (issue #962):

1. **Restore the macOS FORCE_CPU default** in `DaemonEmbedManager._start_daemon` that PR #933 removed in 0.5.0. Without it, local embeddings/reranker select MPS and hang `sentence-transformers` init during daemon startup. Explicit `HINDSIGHT_API_*_LOCAL_FORCE_CPU=0` still wins, so users can opt into MPS.
2. **Propagate all `HINDSIGHT_*` keys from the profile config into the daemon env.** The builder previously copied only a whitelist (`llm_*`, `log_level`, `idle_timeout`), silently dropping anything else a user put in their profile `.env` — including the FORCE_CPU flags the `hindsight-embed configure` wizard writes on macOS, as well as settings like `HINDSIGHT_API_EMBEDDINGS_PROVIDER` / `HINDSIGHT_API_EMBEDDINGS_TEI_URL`.

Together, (1) makes the macOS default safe again and (2) makes any profile-level override (including `FORCE_CPU=0` to opt into MPS, or TEI endpoint config) actually reach the daemon.

## Test plan

- [x] `uv run pytest tests/ -v` (hindsight-embed) — 60 passed, including 3 new regression tests
- [x] `./scripts/hooks/lint.sh` — clean

Fixes #962