### PR TITLE
fix(worker): reserve consolidation slots within max_slots (#1006)

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -116,17 +116,25 @@ class WorkerPoller:
         """
         Calculate available slots for claiming tasks.
 
+        Consolidation has a reserved pool of ``consolidation_max_slots`` within
+        ``max_slots``. Non-consolidation tasks may use at most
+        ``max_slots - consolidation_max_slots`` slots, leaving the remainder
+        always available for consolidation. This prevents consolidation from
+        being starved when retain throughput continuously saturates the queue.
+
         Returns:
-            (total_available, consolidation_available) tuple
+            (non_consolidation_available, consolidation_available) tuple
         """
         async with self._in_flight_lock:
             total_in_flight = self._in_flight_count
             consolidation_in_flight = self._in_flight_by_type.get("consolidation", 0)
 
-        total_available = max(0, self._max_slots - total_in_flight)
+        non_consolidation_in_flight = max(0, total_in_flight - consolidation_in_flight)
+        non_consolidation_max = max(0, self._max_slots - self._consolidation_max_slots)
+        non_consolidation_available = max(0, non_consolidation_max - non_consolidation_in_flight)
         consolidation_available = max(0, self._consolidation_max_slots - consolidation_in_flight)
 
-        return total_available, consolidation_available
+        return non_consolidation_available, consolidation_available
 
     async def wait_for_active_tasks(self, timeout: float = 10.0) -> bool:
         """
@@ -164,40 +172,40 @@ class WorkerPoller:
         Returns:
             List of ClaimedTask objects containing operation_id, task_dict, and schema
         """
-        # Calculate available slots
-        total_available, consolidation_available = await self._get_available_slots()
+        # Calculate available slots (independent pools after reservation)
+        non_consolidation_available, consolidation_available = await self._get_available_slots()
 
-        if total_available <= 0:
+        if non_consolidation_available <= 0 and consolidation_available <= 0:
             return []
 
         schemas = await self._get_schemas()
         all_tasks: list[ClaimedTask] = []
-        remaining_total = total_available
+        remaining_non_consolidation = non_consolidation_available
         remaining_consolidation = consolidation_available
 
         for schema in schemas:
-            if remaining_total <= 0:
+            if remaining_non_consolidation <= 0 and remaining_consolidation <= 0:
                 break
 
-            tasks = await self._claim_batch_for_schema(schema, remaining_total, remaining_consolidation)
+            tasks = await self._claim_batch_for_schema(schema, remaining_non_consolidation, remaining_consolidation)
 
-            # Update remaining slots based on what was claimed
             for task in tasks:
                 op_type = task.task_dict.get("operation_type", "unknown")
                 if op_type == "consolidation":
                     remaining_consolidation -= 1
+                else:
+                    remaining_non_consolidation -= 1
 
             all_tasks.extend(tasks)
-            remaining_total -= len(tasks)
 
         return all_tasks
 
     async def _claim_batch_for_schema(
-        self, schema: str | None, limit: int, consolidation_limit: int
+        self, schema: str | None, non_consolidation_limit: int, consolidation_limit: int
     ) -> list[ClaimedTask]:
         """Claim tasks from a specific schema respecting slot limits."""
         try:
-            return await self._claim_batch_for_schema_inner(schema, limit, consolidation_limit)
+            return await self._claim_batch_for_schema_inner(schema, non_consolidation_limit, consolidation_limit)
         except Exception as e:
             # Format schema for logging: custom schemas in quotes, None as-is
             schema_display = f'"{schema}"' if schema else str(schema)
@@ -205,37 +213,38 @@ class WorkerPoller:
             return []
 
     async def _claim_batch_for_schema_inner(
-        self, schema: str | None, limit: int, consolidation_limit: int
+        self, schema: str | None, non_consolidation_limit: int, consolidation_limit: int
     ) -> list[ClaimedTask]:
-        """Inner implementation for claiming tasks from a specific schema with slot limits."""
+        """Inner implementation for claiming tasks from a specific schema with slot limits.
+
+        Non-consolidation and consolidation pools are independent: each is bounded by
+        its own limit and they do not borrow from each other.
+        """
         table = fq_table("async_operations", schema)
 
         async with self._pool.acquire() as conn:
             async with conn.transaction():
-                # Strategy: Claim non-consolidation tasks first, then consolidation up to limit
+                # 1. Claim non-consolidation tasks
+                non_consolidation_rows = []
+                if non_consolidation_limit > 0:
+                    non_consolidation_rows = await conn.fetch(
+                        f"""
+                        SELECT operation_id, task_payload, retry_count
+                        FROM {table}
+                        WHERE status = 'pending'
+                          AND task_payload IS NOT NULL
+                          AND operation_type != 'consolidation'
+                          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                        ORDER BY created_at
+                        LIMIT $1
+                        FOR UPDATE SKIP LOCKED
+                        """,
+                        non_consolidation_limit,
+                    )
 
-                # 1. Claim non-consolidation tasks (up to limit)
-                non_consolidation_rows = await conn.fetch(
-                    f"""
-                    SELECT operation_id, task_payload, retry_count
-                    FROM {table}
-                    WHERE status = 'pending'
-                      AND task_payload IS NOT NULL
-                      AND operation_type != 'consolidation'
-                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                    ORDER BY created_at
-                    LIMIT $1
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    limit,
-                )
-
-                claimed_count = len(non_consolidation_rows)
-                remaining_limit = limit - claimed_count
-
-                # 2. Claim consolidation tasks (up to consolidation_limit and remaining_limit)
+                # 2. Claim consolidation tasks from their reserved pool
                 consolidation_rows = []
-                if consolidation_limit > 0 and remaining_limit > 0:
+                if consolidation_limit > 0:
                     consolidation_rows = await conn.fetch(
                         f"""
                         SELECT operation_id, task_payload, retry_count
@@ -254,16 +263,17 @@ class WorkerPoller:
                         LIMIT $1
                         FOR UPDATE SKIP LOCKED
                         """,
-                        min(consolidation_limit, remaining_limit),
+                        consolidation_limit,
                     )
 
-                all_rows = non_consolidation_rows + consolidation_rows
+                tagged_rows = [(row, False) for row in non_consolidation_rows] + [
+                    (row, True) for row in consolidation_rows
+                ]
 
-                if not all_rows:
+                if not tagged_rows:
                     return []
 
-                # Claim the tasks by updating status and worker_id
-                operation_ids = [row["operation_id"] for row in all_rows]
+                operation_ids = [row["operation_id"] for row, _ in tagged_rows]
                 await conn.execute(
                     f"""
                     UPDATE {table}
@@ -274,12 +284,16 @@ class WorkerPoller:
                     operation_ids,
                 )
 
-                # Parse and return task payloads with schema context
                 result = []
-                for row in all_rows:
+                for row, is_consolidation in tagged_rows:
                     task_dict = json.loads(row["task_payload"])
                     task_dict["_retry_count"] = row["retry_count"]
                     task_dict["_operation_id"] = str(row["operation_id"])
+                    # The DB row knows the operation_type, but the JSON payload may not
+                    # carry it. Inject it so in-flight tracking and slot accounting
+                    # (which key off task_dict["operation_type"]) work correctly.
+                    if is_consolidation:
+                        task_dict["operation_type"] = "consolidation"
                     result.append(
                         ClaimedTask(
                             operation_id=str(row["operation_id"]),
@@ -721,8 +735,10 @@ class WorkerPoller:
                 active_tasks = dict(self._active_tasks)
 
             consolidation_count = in_flight_by_type.get("consolidation", 0)
-            available_slots = self._max_slots - in_flight
-            available_consolidation_slots = self._consolidation_max_slots - consolidation_count
+            non_consolidation_in_flight = max(0, in_flight - consolidation_count)
+            non_consolidation_max = max(0, self._max_slots - self._consolidation_max_slots)
+            available_slots = max(0, non_consolidation_max - non_consolidation_in_flight)
+            available_consolidation_slots = max(0, self._consolidation_max_slots - consolidation_count)
 
             # Build local processing breakdown
             task_groups: dict[tuple[str, str], int] = {}

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -217,6 +217,7 @@ class TestWorkerPoller:
             worker_id="test-worker-1",
             executor=lambda x: None,
             max_slots=3,  # Limit to 3 concurrent tasks
+            consolidation_max_slots=0,  # No reservation; all 3 slots available for non-consolidation
         )
 
         claimed = await poller.claim_batch()
@@ -1363,7 +1364,7 @@ async def test_worker_slot_limits_enforced(pool, clean_operations):
         executor=controlled_executor,
         poll_interval_ms=50,
         max_slots=3,  # Only allow 3 concurrent tasks
-        consolidation_max_slots=1,
+        consolidation_max_slots=0,  # No consolidation reservation; all 3 slots available for retain
     )
 
     # Submit 10 tasks
@@ -1420,6 +1421,106 @@ async def test_worker_slot_limits_enforced(pool, clean_operations):
 
     finally:
         for event in task_events.values():
+            event.set()
+        await poller.shutdown_graceful(timeout=2.0)
+        try:
+            await asyncio.wait_for(poll_task, timeout=1.0)
+        except asyncio.CancelledError:
+            pass
+
+
+async def test_consolidation_slots_reserved_when_retain_saturates(pool, clean_operations):
+    """Regression: consolidation must not be starved when retain saturates the queue.
+
+    With ``max_slots=5`` and ``consolidation_max_slots=2``, retain tasks may use at
+    most 3 concurrent slots, leaving 2 slots reserved for consolidation. Without
+    the reservation (issue #1006), a continuous stream of retain tasks would fill
+    every slot and consolidation would never run.
+    """
+    from hindsight_api.worker.poller import WorkerPoller
+
+    started: dict[str, str] = {}  # op_id -> op_type
+    finish_events: dict[str, asyncio.Event] = {}
+
+    async def blocking_executor(task_dict: dict):
+        op_id = task_dict["operation_id"]
+        started[op_id] = task_dict.get("operation_type", "unknown")
+        event = asyncio.Event()
+        finish_events[op_id] = event
+        await event.wait()
+
+    poller = WorkerPoller(
+        pool=pool,
+        worker_id="test-worker-consolidation-reservation",
+        executor=blocking_executor,
+        poll_interval_ms=50,
+        max_slots=5,
+        consolidation_max_slots=2,
+    )
+
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    await _ensure_bank(pool, bank_id)
+
+    # Submit 10 retain tasks first — these should be claimed up to the
+    # non-consolidation cap (max_slots - consolidation_max_slots = 3).
+    for _ in range(10):
+        op_id = uuid.uuid4()
+        payload = json.dumps(
+            {"type": "test", "operation_type": "retain", "operation_id": str(op_id), "bank_id": bank_id}
+        )
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'retain', 'pending', $3::jsonb)
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+
+    # Submit 1 consolidation task. Note the payload deliberately omits operation_type
+    # to verify the poller injects it from the DB column.
+    consolidation_op_id = uuid.uuid4()
+    consolidation_payload = json.dumps({"type": "test", "operation_id": str(consolidation_op_id), "bank_id": bank_id})
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+        """,
+        consolidation_op_id,
+        bank_id,
+        consolidation_payload,
+    )
+
+    poll_task = asyncio.create_task(poller.run())
+
+    try:
+        # Wait for the worker to fill its slots: 3 retain + 1 consolidation = 4 active.
+        for _ in range(200):
+            if len(started) >= 4:
+                break
+            await asyncio.sleep(0.01)
+
+        retain_started = [op for op, t in started.items() if t == "retain"]
+        consolidation_started = [op for op, t in started.items() if t == "consolidation"]
+
+        assert len(retain_started) == 3, (
+            f"Retain should be capped at max_slots - consolidation_max_slots = 3, "
+            f"got {len(retain_started)}"
+        )
+        assert len(consolidation_started) == 1, (
+            f"Consolidation should claim its reserved slot even while retain saturates, "
+            f"got {len(consolidation_started)}"
+        )
+        assert str(consolidation_op_id) in consolidation_started
+
+        # In-flight tracking must record the consolidation task under the right key,
+        # otherwise the consolidation pool accounting drifts on subsequent claims.
+        async with poller._in_flight_lock:
+            assert poller._in_flight_by_type.get("consolidation", 0) == 1
+
+    finally:
+        for event in finish_events.values():
             event.set()
         await poller.shutdown_graceful(timeout=2.0)
         try:

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1103,8 +1103,12 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_POLL_INTERVAL_MS` | Database polling interval in milliseconds | `500` |
 | `HINDSIGHT_API_WORKER_MAX_RETRIES` | Max retries before marking task failed | `3` |
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
-| `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker | `10` |
-| `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Maximum concurrent consolidation tasks per worker | `2` |
+| `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
+| `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Slots reserved for consolidation tasks within `WORKER_MAX_SLOTS` | `2` |
+
+:::note Slot reservation
+`WORKER_CONSOLIDATION_MAX_SLOTS` is a **reservation within** `WORKER_MAX_SLOTS`, not an additive pool. With the defaults (`MAX_SLOTS=10`, `CONSOLIDATION_MAX_SLOTS=2`), retain and other non-consolidation tasks may use at most `10 - 2 = 8` concurrent slots, leaving 2 always available for consolidation. This prevents consolidation from being starved when retain throughput continuously saturates the queue. Set `CONSOLIDATION_MAX_SLOTS=0` to give all slots to non-consolidation work.
+:::
 
 ### Performance Optimization
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1103,8 +1103,12 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_POLL_INTERVAL_MS` | Database polling interval in milliseconds | `500` |
 | `HINDSIGHT_API_WORKER_MAX_RETRIES` | Max retries before marking task failed | `3` |
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
-| `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker | `10` |
-| `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Maximum concurrent consolidation tasks per worker | `2` |
+| `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
+| `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Slots reserved for consolidation tasks within `WORKER_MAX_SLOTS` | `2` |
+
+:::note Slot reservation
+`WORKER_CONSOLIDATION_MAX_SLOTS` is a **reservation within** `WORKER_MAX_SLOTS`, not an additive pool. With the defaults (`MAX_SLOTS=10`, `CONSOLIDATION_MAX_SLOTS=2`), retain and other non-consolidation tasks may use at most `10 - 2 = 8` concurrent slots, leaving 2 always available for consolidation. This prevents consolidation from being starved when retain throughput continuously saturates the queue. Set `CONSOLIDATION_MAX_SLOTS=0` to give all slots to non-consolidation work.
+:::
 
 ### Performance Optimization
 


### PR DESCRIPTION
## Summary

Fixes #1006 — consolidation tasks were starved when retain saturated the worker queue.

`consolidation_max_slots` was a sub-cap that competed with retain in the same pool, and could only claim leftover slots after retains were claimed. With a continuous retain queue (e.g. multiple Claude Code sessions), consolidation never ran.

- Make `consolidation_max_slots` a true **reservation** within `max_slots`. Non-consolidation tasks may use at most `max_slots - consolidation_max_slots` slots; the remainder is reserved for consolidation.
- Inject `operation_type = "consolidation"` on claimed consolidation rows. The enqueued JSON payload didn't include the field, so `_in_flight_by_type["consolidation"]` was never incremented and slot accounting drifted.
- Update `configuration.md` to document the reservation semantics.

## Test plan

- [x] New regression test `test_consolidation_slots_reserved_when_retain_saturates`: submits 10 retains + 1 consolidation with `max_slots=5, consolidation_max_slots=2`; asserts retain caps at 3, consolidation still claims its reserved slot, and `_in_flight_by_type` records it correctly.
- [x] Existing retain-only saturation tests updated to set `consolidation_max_slots=0`.
- [x] All 31 worker tests pass.
- [x] `ruff check` and `ty check` pass on changed files.