### PR TITLE
fix(embed): serialize daemon start and stop killing healthy daemons

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -776,17 +776,13 @@ async def compute_semantic_links_ann(
         await conn.execute("SET LOCAL hnsw.ef_search = 60")
 
         t_setup = time_mod.time()
-        await conn.execute(
-            "CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP"
-        )
+        await conn.execute("CREATE TEMP TABLE _ann_seeds (unit_id text, emb_text text, fact_type text) ON COMMIT DROP")
 
         records = [
             (uid, emb if isinstance(emb, str) else str(emb), ft)
             for uid, emb, ft in zip(unit_ids, embeddings, fact_types)
         ]
-        await conn.copy_records_to_table(
-            "_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"]
-        )
+        await conn.copy_records_to_table("_ann_seeds", records=records, columns=["unit_id", "emb_text", "fact_type"])
         logger.debug(f"[ANN] Temp table setup: {time_mod.time() - t_setup:.3f}s ({len(records)} seeds)")
 
         # Run one ANN query per fact_type so each uses the right HNSW index.

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -20,7 +20,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from .embed_manager import EmbedManager
-from .profile_manager import UI_PORT_OFFSET, ProfileManager, resolve_active_profile
+from .profile_manager import UI_PORT_OFFSET, ProfileManager, lock_file, resolve_active_profile, unlock_file
 
 logger = logging.getLogger(__name__)
 console = Console(stderr=True)
@@ -163,43 +163,83 @@ class DaemonEmbedManager(EmbedManager):
         """
         Ensure the port is free before starting a daemon.
 
-        If the port is occupied by a hindsight daemon, stop it gracefully.
-        If occupied by something else, return False.
-
-        Returns:
-            True if port is free (or was freed), False if occupied by non-hindsight process.
+        Behavior:
+          * Port free → True (nothing to do).
+          * Port occupied by a *healthy* hindsight daemon → True without killing.
+            The caller's "start" is effectively a no-op: the daemon is already up.
+            Killing it would race concurrent starts (one process kills the other's
+            freshly-started daemon, both rush to rebind the port).
+          * Port occupied but /health is unreachable / non-200 → treat as a stale
+            hindsight daemon (or foreign process) and attempt to reclaim by killing
+            the PID listening on the port. This preserves the original intent of
+            clearing stale daemons from version upgrades.
+          * Kill failed, or non-hindsight process occupying the port → False.
         """
         if not self._is_port_in_use(port):
             return True
 
-        # Port is occupied — check if it's a hindsight daemon via /health
+        # Port is occupied — check if it's a healthy hindsight daemon.
+        health_ok = False
         try:
             with httpx.Client(timeout=2) as client:
                 response = client.get(f"http://127.0.0.1:{port}/health")
-                if response.status_code != 200:
-                    logger.warning(f"Port {port} is in use by another process")
-                    return False
+                health_ok = response.status_code == 200
         except Exception:
+            health_ok = False
+
+        if health_ok:
+            logger.debug(f"Port {port} already serving a healthy hindsight daemon; reusing it")
+            return True
+
+        # Unhealthy — attempt to reclaim by killing the listener.
+        pid = self._find_pid_on_port(port)
+        if pid is None:
             logger.warning(f"Port {port} is in use by another process")
             return False
 
-        # It's a hindsight daemon — find its PID and stop it
-        pid = self._find_pid_on_port(port)
-        if pid is None:
-            logger.warning(f"Port {port} has a hindsight daemon but could not find its PID")
-            return False
-
-        logger.info(f"Stopping existing daemon on port {port} (PID {pid})")
+        logger.info(f"Clearing unhealthy process on port {port} (PID {pid})")
         if self._kill_process(pid):
-            logger.info(f"Old daemon (PID {pid}) stopped")
+            logger.info(f"Stale process (PID {pid}) stopped")
             return True
 
-        logger.warning(f"Old daemon (PID {pid}) did not stop in time")
+        logger.warning(f"Process (PID {pid}) did not stop in time")
         return False
 
     def _start_daemon(self, config: dict, profile: str, extra_args: list[str] | None = None) -> bool:
-        """Start the daemon in background."""
+        """Start the daemon in background.
+
+        Serializes concurrent start attempts via an exclusive flock on the
+        profile's lock file, so two processes calling `start()` at the same
+        time cannot race into `_clear_port` and kill each other's daemons.
+        Inside the lock we re-check `is_running()`; the second caller sees
+        the first caller's daemon and short-circuits.
+        """
         paths = self._profile_manager.resolve_profile_paths(profile)
+        paths.lock.parent.mkdir(parents=True, exist_ok=True)
+
+        # Hold the per-profile start lock for the full startup sequence.
+        # lock_file() blocks until the lock is acquired on Unix (flock) and
+        # Windows (msvcrt), so concurrent callers serialize here.
+        with open(paths.lock, "w") as lock_fd:
+            lock_file(lock_fd)
+            try:
+                if self.is_running(profile):
+                    logger.debug(f"Daemon for profile '{profile}' came up while waiting for start lock")
+                    if profile:
+                        self._register_profile(profile, paths.port, config)
+                    return True
+                return self._start_daemon_locked(config, profile, paths, extra_args=extra_args)
+            finally:
+                unlock_file(lock_fd)
+
+    def _start_daemon_locked(
+        self,
+        config: dict,
+        profile: str,
+        paths,
+        extra_args: list[str] | None = None,
+    ) -> bool:
+        """Perform the actual daemon startup. Caller must hold paths.lock."""
         profile_label = f"profile '{profile}'" if profile else "default profile"
         daemon_log = paths.log
         port = paths.port
@@ -208,6 +248,16 @@ class DaemonEmbedManager(EmbedManager):
         if not self._clear_port(port):
             logger.error(f"Cannot start daemon: port {port} is in use by a non-hindsight process")
             return False
+
+        # _clear_port returns True without killing when a healthy hindsight daemon
+        # already owns the port (started out-of-band, e.g. by another user or a
+        # previous version upgrade). Re-check is_running so we don't spawn a
+        # second daemon that would fail to bind.
+        if self.is_running(profile):
+            logger.debug(f"Daemon for profile '{profile}' already healthy; skipping spawn")
+            if profile:
+                self._register_profile(profile, port, config)
+            return True
 
         # Load profile's .env file and merge with provided config
         # This fixes issue #305 where profile env vars were ignored

--- a/hindsight-embed/tests/test_daemon_client.py
+++ b/hindsight-embed/tests/test_daemon_client.py
@@ -190,14 +190,19 @@ class TestClearPort:
         with patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=False):
             assert manager._clear_port(9555) is True
 
-    def test_port_occupied_by_hindsight_stops_it(self):
-        """Port occupied by a hindsight daemon — kills it and returns True."""
+    def test_port_occupied_by_healthy_hindsight_is_reused(self):
+        """Port occupied by a healthy hindsight daemon — reused without killing.
+
+        Regression: previously _clear_port killed any hindsight daemon on the
+        target port, which meant two concurrent `start` calls would kill each
+        other's freshly-started daemons.
+        """
         manager = DaemonEmbedManager()
         with (
             patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
             patch("httpx.Client") as mock_httpx_cls,
-            patch.object(DaemonEmbedManager, "_find_pid_on_port", return_value=12345),
-            patch.object(DaemonEmbedManager, "_kill_process", return_value=True),
+            patch.object(DaemonEmbedManager, "_find_pid_on_port") as mock_find_pid,
+            patch.object(DaemonEmbedManager, "_kill_process") as mock_kill,
         ):
             mock_client = MagicMock()
             mock_client.__enter__ = Mock(return_value=mock_client)
@@ -206,6 +211,8 @@ class TestClearPort:
             mock_httpx_cls.return_value = mock_client
 
             assert manager._clear_port(9555) is True
+            mock_find_pid.assert_not_called()
+            mock_kill.assert_not_called()
 
     def test_port_occupied_by_non_hindsight_returns_false(self):
         """Port occupied by non-hindsight process — returns False."""
@@ -237,8 +244,8 @@ class TestClearPort:
 
             assert manager._clear_port(9555) is False
 
-    def test_pid_not_found_returns_false(self):
-        """Hindsight daemon on port but can't find PID — returns False."""
+    def test_unhealthy_daemon_pid_not_found_returns_false(self):
+        """Unhealthy process on port, no PID — cannot reclaim, returns False."""
         manager = DaemonEmbedManager()
         with (
             patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
@@ -248,13 +255,13 @@ class TestClearPort:
             mock_client = MagicMock()
             mock_client.__enter__ = Mock(return_value=mock_client)
             mock_client.__exit__ = Mock(return_value=False)
-            mock_client.get.return_value = Mock(status_code=200)
+            mock_client.get.return_value = Mock(status_code=500)
             mock_httpx_cls.return_value = mock_client
 
             assert manager._clear_port(9555) is False
 
-    def test_kill_fails_returns_false(self):
-        """Hindsight daemon found but won't die — returns False."""
+    def test_unhealthy_daemon_kill_fails_returns_false(self):
+        """Unhealthy process on port, kill failed — returns False."""
         manager = DaemonEmbedManager()
         with (
             patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
@@ -265,8 +272,80 @@ class TestClearPort:
             mock_client = MagicMock()
             mock_client.__enter__ = Mock(return_value=mock_client)
             mock_client.__exit__ = Mock(return_value=False)
-            mock_client.get.return_value = Mock(status_code=200)
+            mock_client.get.side_effect = httpx.ConnectError("refused")
             mock_httpx_cls.return_value = mock_client
 
             assert manager._clear_port(9555) is False
 
+    def test_unhealthy_daemon_kill_succeeds_returns_true(self):
+        """Unhealthy hindsight daemon (stale from version upgrade) reclaimed via kill."""
+        manager = DaemonEmbedManager()
+        with (
+            patch.object(DaemonEmbedManager, "_is_port_in_use", return_value=True),
+            patch("httpx.Client") as mock_httpx_cls,
+            patch.object(DaemonEmbedManager, "_find_pid_on_port", return_value=12345),
+            patch.object(DaemonEmbedManager, "_kill_process", return_value=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.__enter__ = Mock(return_value=mock_client)
+            mock_client.__exit__ = Mock(return_value=False)
+            mock_client.get.return_value = Mock(status_code=503)
+            mock_httpx_cls.return_value = mock_client
+
+            assert manager._clear_port(9555) is True
+
+
+class TestStartDaemonSerialization:
+    """Tests that _start_daemon serializes concurrent starts via the profile lock.
+
+    Regression: two processes calling start() concurrently used to race into
+    _clear_port and kill each other's daemons. The per-profile flock
+    serializes them; the losing caller discovers the winner's daemon via
+    is_running() and short-circuits without spawning.
+    """
+
+    def test_second_start_sees_daemon_up_and_skips_spawn(self, tmp_path, monkeypatch):
+        """If is_running() is true inside the lock, _start_daemon returns without spawning."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        manager = DaemonEmbedManager()
+
+        with (
+            patch.object(DaemonEmbedManager, "is_running", return_value=True),
+            patch.object(DaemonEmbedManager, "_clear_port") as mock_clear,
+            patch.object(DaemonEmbedManager, "_start_daemon_locked") as mock_locked,
+            patch.object(DaemonEmbedManager, "_register_profile") as mock_register,
+        ):
+            assert manager._start_daemon({}, "codex") is True
+            mock_clear.assert_not_called()
+            mock_locked.assert_not_called()
+            mock_register.assert_called_once()
+
+    def test_start_daemon_locked_skips_spawn_when_port_already_healthy(self, tmp_path, monkeypatch):
+        """Inside _start_daemon_locked: healthy daemon appearing between checks skips spawn.
+
+        Simulates a healthy foreign-started daemon showing up after is_running()
+        first returned False. _clear_port keeps it; _start_daemon_locked's
+        second is_running() check returns True and we must NOT proceed to
+        subprocess.Popen.
+        """
+        from hindsight_embed.profile_manager import ProfilePaths
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        manager = DaemonEmbedManager()
+
+        log_path = tmp_path / "daemon.log"
+        paths = ProfilePaths(
+            config=tmp_path / "embed",
+            lock=tmp_path / "daemon.lock",
+            log=log_path,
+            port=9600,
+        )
+
+        with (
+            patch.object(DaemonEmbedManager, "_clear_port", return_value=True),
+            patch.object(DaemonEmbedManager, "is_running", return_value=True),
+            patch.object(DaemonEmbedManager, "_register_profile"),
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            assert manager._start_daemon_locked({}, "codex", paths) is True
+            mock_popen.assert_not_called()


### PR DESCRIPTION
## Summary
- Stop `_clear_port` from killing a healthy hindsight daemon. Two concurrent `hindsight-embed daemon start` calls each saw the other's freshly-started daemon as \"a hindsight daemon on the port\" and SIGTERM'd it — the surviving caller was then racing to rebind, and the losing daemon's shutdown tore down the shared embedded Postgres.
- Wrap `_start_daemon` in an exclusive flock on the profile's lock file so concurrent starts serialize instead of racing, with a double-checked `is_running()` inside the lock and after `_clear_port` so the loser short-circuits without spawning.

## Root cause
`daemon_embed_manager.py:_clear_port` was documented as \"handles stale daemons from version upgrades\" but implemented as \"kill any hindsight daemon on the target port before starting a new one.\" That made every `daemon start` effectively a restart, even when a perfectly healthy same-version daemon was already serving the profile.

This caused the April 2026 Codex incident: two Codex hooks fired `daemon start` concurrently, each detected the other's healthy daemon via `/health`, killed it, then rushed to rebind. One process's shutdown cleanup took down the shared embedded Postgres, leaving the surviving API worker on connection-refused errors.

## Behavioral changes
| Scenario | Before | After |
|---|---|---|
| Port free | Start new daemon | (unchanged) Start new daemon |
| Port has healthy hindsight daemon | **Kill it, start new** | **Reuse it, start is a no-op** |
| Port has unhealthy/stale hindsight daemon | Kill it, start new | (unchanged) Kill it, start new |
| Port has non-hindsight process | Fail | (unchanged) Fail |
| Concurrent `start` from two processes | Race, kill each other | Serialize via flock; loser reuses winner's daemon |

This means every integration (codex, claude-code, openclaw, etc.) gets the fix for free — no per-integration locking needed.

## Verification
- `uv run pytest hindsight-embed/tests -q` — 60 passed
- `./scripts/hooks/lint.sh` — clean

## Test plan
- [x] Unit: `_clear_port` reuses a healthy daemon without invoking `_find_pid_on_port` or `_kill_process`
- [x] Unit: `_clear_port` still reclaims unhealthy daemons (status_code != 200 or connection refused)
- [x] Unit: `_start_daemon` short-circuits when `is_running()` is true inside the profile lock
- [x] Unit: `_start_daemon_locked` does not spawn when `_clear_port` reuses a healthy daemon
- [ ] Manual: `hindsight-embed daemon start` x2 back-to-back does not tear down the already-running daemon

## Note
Supersedes #1015, which attempted to fix this via a flock in the codex integration. The proper fix is in hindsight-embed so we don't have to replicate serialization in every integration.

Also includes a tiny unrelated lint-reformat commit for `link_utils.py` (two SQL calls pulled onto single lines to match ruff's preferred formatting).