### PR TITLE
feat(worker): diagnostic logging for stuck/slow async tasks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -536,6 +536,15 @@ class LLMProvider:
             OutputTooLongError: If output exceeds token limits.
             Exception: Re-raises API errors after retries exhausted.
         """
+        # Stage breadcrumb so the worker log shows which LLM call a task is
+        # currently inside; the stage_age field then reveals long JSON-schema
+        # retry loops (e.g. a small model that can't satisfy strict_schema).
+        # No-op outside a worker context.
+        from ..worker.stage import set_stage
+
+        structured = "+structured" if response_format is not None else ""
+        set_stage(f"llm.{self.provider}.{scope}{structured}")
+
         async with _global_llm_semaphore:
             # Delegate to provider implementation
             result = await self._provider_impl.call(
@@ -592,6 +601,10 @@ class LLMProvider:
         Returns:
             LLMToolCallResult with content and/or tool_calls.
         """
+        from ..worker.stage import set_stage
+
+        set_stage(f"llm.{self.provider}.{scope}+tools")
+
         async with _global_llm_semaphore:
             # Delegate to provider implementation
             result = await self._provider_impl.call_with_tools(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2767,8 +2767,11 @@ class MemoryEngine(MemoryEngineInterface):
         pool = await self._get_pool()
         recall_start = time.time()
 
-        # Buffer logs for clean output in concurrent scenarios
-        recall_id = f"{bank_id[:8]}-{int(time.time() * 1000) % 100000}"
+        # Buffer logs for clean output in concurrent scenarios.
+        # Include a uuid suffix so two recalls on the same bank within the
+        # same millisecond don't collide on the budgeted_operation key
+        # (`recall-{recall_id}`), which would raise "Operation ... already exists".
+        recall_id = f"{bank_id[:8]}-{int(time.time() * 1000) % 100000}-{uuid.uuid4().hex[:6]}"
         log_buffer = []
         tags_info = f", tags={tags}, tags_match={tags_match}" if tags else ""
         log_buffer.append(
@@ -3111,8 +3114,13 @@ class MemoryEngine(MemoryEngineInterface):
 
             # Step 4.5: Combine cross-encoder score with retrieval signals via multiplicative boosts.
             # See apply_combined_scoring for the full rationale and formula.
+            # is_passthrough_reranker tells the scoring code to seed CE scores
+            # from RRF rank — only meaningful when the configured reranker is
+            # the slim/passthrough one that returns a constant score per pair.
             if scored_results:
-                apply_combined_scoring(scored_results, now=utcnow())
+                ce = reranker_instance.cross_encoder
+                is_passthrough = ce is not None and ce.provider_name == "rrf"
+                apply_combined_scoring(scored_results, now=utcnow(), is_passthrough_reranker=is_passthrough)
                 scored_results.sort(key=lambda x: x.weight, reverse=True)
                 log_buffer.append("  [4.6] Combined scoring: ce * recency_boost(0.2) * temporal_boost(0.2)")
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -29,6 +29,7 @@ from ..metrics import get_metrics_collector
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
 from ..worker.exceptions import RetryTaskAt
+from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
 from .db_budget import budgeted_operation
 from .operation_metadata import (
@@ -1090,6 +1091,9 @@ class MemoryEngine(MemoryEngineInterface):
             self._audit_logger, task_type or "unknown", "system", bank_id, request=task_dict
         ) as audit_entry:
             try:
+                # Stage breadcrumb for the worker poller's WORKER_TASK log line.
+                # No-op outside a worker context.
+                set_stage(f"task.{task_type}")
                 if task_type == "batch_retain":
                     await self._handle_batch_retain(task_dict)
                 elif task_type == "file_convert_retain":

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -23,6 +23,7 @@ from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
 from hindsight_api.engine.llm_wrapper import parse_llm_json
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
+from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +243,8 @@ class GeminiLLM(LLMInterface):
         last_exception = None
 
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.gemini.{scope}.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 response = await asyncio.wait_for(
                     self._client.aio.models.generate_content(
@@ -527,6 +530,8 @@ class GeminiLLM(LLMInterface):
 
         last_exception = None
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.gemini.tools.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 response = await asyncio.wait_for(
                     self._client.aio.models.generate_content(

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -21,6 +21,7 @@ from typing import Any
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
+from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +142,8 @@ class LiteLLMLLM(LLMInterface):
         last_exception = None
 
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.litellm.{scope}.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 response = await self._litellm.acompletion(**call_kwargs)
 
@@ -283,6 +286,8 @@ class LiteLLMLLM(LLMInterface):
 
         last_exception = None
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.litellm.tools.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 response = await self._litellm.acompletion(**call_kwargs)
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -33,6 +33,7 @@ from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
+from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
 
@@ -362,6 +363,11 @@ class OpenAICompatibleLLM(LLMInterface):
         last_exception = None
 
         for attempt in range(max_retries + 1):
+            # Surface attempt count in worker stage so JSON-schema retry loops
+            # are visible from logs (small models on strict structured output
+            # often loop here). Cheap no-op outside worker context.
+            if attempt > 0:
+                set_stage(f"llm.{self.provider}.{scope}.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 if response_format is not None:
                     response = await self._client.chat.completions.create(**call_params)
@@ -629,6 +635,8 @@ class OpenAICompatibleLLM(LLMInterface):
         last_exception = None
 
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.{self.provider}.tools.attempt={attempt + 1}/{max_retries + 1}")
             try:
                 response = await self._client.chat.completions.create(**call_params)
 
@@ -778,6 +786,8 @@ class OpenAICompatibleLLM(LLMInterface):
 
         async with httpx.AsyncClient(timeout=300.0) as client:
             for attempt in range(max_retries + 1):
+                if attempt > 0:
+                    set_stage(f"llm.ollama_native.{scope}.attempt={attempt + 1}/{max_retries + 1}")
                 try:
                     response = await client.post(native_url, json=payload)
                     response.raise_for_status()

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from ...worker.stage import set_stage
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from . import bank_utils
@@ -133,6 +134,7 @@ async def _pre_resolve_phase1(
     Running these outside the transaction avoids holding row locks during
     slow reads, eliminating TimeoutErrors under concurrent load.
     """
+    set_stage("retain.phase1.resolve")
     from .link_utils import compute_semantic_links_ann
 
     user_entities_per_content = {idx: content.entities for idx, content in enumerate(contents) if content.entities}
@@ -238,6 +240,7 @@ async def _insert_facts_and_links(
     only the unit_entities INSERT (FK to memory_units) stays in the transaction.
     Entity link building is deferred to Phase 3 (post-transaction, best-effort).
     """
+    set_stage("retain.phase2.insert_facts")
     unit_ids = await fact_storage.insert_facts_batch(conn, bank_id, processed_facts)
     step_start = time.time()
     log_buffer.append(f"  Insert facts: {len(unit_ids)} units in {time.time() - step_start:.3f}s")
@@ -322,6 +325,7 @@ async def _build_and_insert_entity_links_phase3(
     Entity links are for UI graph visualization only — retrieval uses
     the unit_entities self-join instead.
     """
+    set_stage("retain.phase3.entity_links")
     p3_unit_ids = phase3_ctx.unit_ids
     p3_resolved = phase3_ctx.resolved_entity_ids
     p3_entity_to_unit = phase3_ctx.entity_to_unit
@@ -367,6 +371,7 @@ async def _extract_and_embed(
     Returns:
         Tuple of (extracted_facts, processed_facts, chunks_metadata, usage)
     """
+    set_stage("retain.extract_and_embed")
     step_start = time.time()
     extracted_facts, chunks, usage = await fact_extraction.extract_facts_from_contents(
         contents, llm_config, agent_name, config, pool, operation_id, schema

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -23,6 +23,7 @@ def apply_combined_scoring(
     recency_alpha: float = _RECENCY_ALPHA,
     temporal_alpha: float = _TEMPORAL_ALPHA,
     proof_count_alpha: float = _PROOF_COUNT_ALPHA,
+    is_passthrough_reranker: bool = False,
 ) -> None:
     """Apply combined scoring to a list of ScoredResults in-place.
 
@@ -71,20 +72,30 @@ def apply_combined_scoring(
     # rank instead, so the boosts modulate a meaningful base score rather than
     # replacing it. This is a no-op for real cross-encoders, which produce
     # diverse scores.
-    if scored_results:
-        ce_scores = {sr.cross_encoder_score_normalized for sr in scored_results}
-        if len(ce_scores) <= 1:
-            n = len(scored_results)
-            sorted_by_rrf = sorted(
-                scored_results,
-                key=lambda s: getattr(getattr(s, "candidate", None), "rrf_score", 0.0),
-                reverse=True,
-            )
-            denom = max(1, n - 1)
-            for new_rank, sr in enumerate(sorted_by_rrf):
-                # Map rank → [0.1, 1.0] so the recency boost can still nudge
-                # ordering between adjacent candidates without overpowering RRF.
-                sr.cross_encoder_score_normalized = 1.0 - (0.9 * new_rank / denom)
+    # When the reranker is a passthrough (e.g. RRFPassthroughCrossEncoder used
+    # by slim deployments), every cross_encoder_score_normalized is identical
+    # and provides no relevance signal. The multiplicative recency / temporal /
+    # proof_count boosts below would then become the *only* ranking signal,
+    # making the final order a pure recency sort regardless of how relevant a
+    # candidate actually is.
+    #
+    # Seed cross_encoder_score_normalized from the RRF rank instead, so the
+    # boosts modulate a meaningful base score. Caller passes is_passthrough
+    # explicitly because "all scores identical" is too fragile a heuristic —
+    # a real reranker can also tie scores (especially in tests with synthetic
+    # data) and we'd corrupt legitimate single-result reranks.
+    if is_passthrough_reranker and scored_results:
+        n = len(scored_results)
+        sorted_by_rrf = sorted(
+            scored_results,
+            key=lambda s: getattr(getattr(s, "candidate", None), "rrf_score", 0.0),
+            reverse=True,
+        )
+        denom = max(1, n - 1)
+        for new_rank, sr in enumerate(sorted_by_rrf):
+            # Map rank → [0.1, 1.0] so the recency boost can still nudge
+            # ordering between adjacent candidates without overpowering RRF.
+            sr.cross_encoder_score_normalized = 1.0 - (0.9 * new_rank / denom)
 
     for sr in scored_results:
         # Recency: linear decay over 365 days → [0.1, 1.0]; neutral 0.5 if no date.

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -6,15 +6,17 @@ FOR UPDATE SKIP LOCKED for safe concurrent claiming.
 """
 
 import asyncio
+import io
 import json
 import logging
 import time
 import traceback
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import RetryTaskAt
+from .stage import StageHolder, bind_holder
 
 if TYPE_CHECKING:
     import asyncpg
@@ -25,6 +27,31 @@ logger = logging.getLogger(__name__)
 
 # Progress logging interval in seconds
 PROGRESS_LOG_INTERVAL = 30
+
+# Stuck-task stack-dump thresholds (seconds). Each task gets one stack dump
+# per threshold it crosses (5min, 10min, 20min, 40min, 80min...).
+STUCK_STACK_INITIAL_THRESHOLD_S = 300
+STUCK_STACK_MAX_THRESHOLD_S = 3600 * 6  # cap doubling at 6h
+
+
+@dataclass
+class ActiveTaskInfo:
+    """Tracking info for an in-flight worker task.
+
+    Carries everything the periodic stats / stuck-task logger needs
+    so it can render a useful per-task line without touching the DB.
+    """
+
+    op_type: str
+    bank_id: str
+    schema: str | None
+    bg_task: "asyncio.Task[Any]"
+    started_at: float
+    stage_holder: StageHolder
+    # Largest stuck-stack threshold (seconds) for which we've already
+    # dumped a stack trace; used to suppress repeated dumps.
+    last_stack_dump_threshold: int = 0
+    task_type: str = ""
 
 
 def fq_table(table: str, schema: str | None = None) -> str:
@@ -99,8 +126,8 @@ class WorkerPoller:
         self._in_flight_lock = asyncio.Lock()
         self._last_progress_log = 0.0
         self._tasks_completed_since_log = 0
-        # Track active tasks locally: operation_id -> (op_type, bank_id, schema, asyncio.Task)
-        self._active_tasks: dict[str, tuple[str, str, str | None, asyncio.Task]] = {}
+        # Track active tasks locally: operation_id -> ActiveTaskInfo
+        self._active_tasks: dict[str, ActiveTaskInfo] = {}
         # Track in-flight tasks by operation type
         self._in_flight_by_type: dict[str, int] = {}
 
@@ -440,12 +467,27 @@ class WorkerPoller:
         operation_type = task.task_dict.get("operation_type", "unknown")
         bank_id = task.task_dict.get("bank_id", "unknown")
 
-        # Create background task
-        bg_task = asyncio.create_task(self._execute_task_inner(task))
+        # Stage holder is updated by engine code via stage.set_stage(); the
+        # poller reads it during periodic logging to surface what each
+        # in-flight task is doing.
+        holder = StageHolder(stage=f"queued.{task_type}")
+
+        # Create background task. The holder is passed in and bound to the
+        # task's own contextvar scope inside _execute_task_inner so engine
+        # code running under that task sees it via stage.set_stage().
+        bg_task = asyncio.create_task(self._execute_task_inner(task, holder))
 
         # Track this task as active
         async with self._in_flight_lock:
-            self._active_tasks[task.operation_id] = (task_type, bank_id, task.schema, bg_task)
+            self._active_tasks[task.operation_id] = ActiveTaskInfo(
+                op_type=operation_type,
+                bank_id=bank_id,
+                schema=task.schema,
+                bg_task=bg_task,
+                started_at=time.monotonic(),
+                stage_holder=holder,
+                task_type=task_type,
+            )
             self._in_flight_count += 1
             self._in_flight_by_type[operation_type] = self._in_flight_by_type.get(operation_type, 0) + 1
 
@@ -464,7 +506,7 @@ class WorkerPoller:
                     if self._in_flight_by_type[operation_type] == 0:
                         del self._in_flight_by_type[operation_type]
 
-    async def _execute_task_inner(self, task: ClaimedTask):
+    async def _execute_task_inner(self, task: ClaimedTask, holder: StageHolder | None = None):
         """Inner task execution with retry/fail handling.
 
         Tasks that want to be retried raise RetryTaskAt; the poller sets next_retry_at
@@ -474,6 +516,14 @@ class WorkerPoller:
         """
         task_type = task.task_dict.get("type", "unknown")
         bank_id = task.task_dict.get("bank_id", "unknown")
+
+        # Bind the stage holder in this task's own contextvar scope so engine
+        # code running under us can update it via stage.set_stage(). If holder
+        # is None (legacy / direct invocation), set_stage becomes a no-op.
+        if holder is not None:
+            bind_holder(holder)
+            holder.stage = f"executor.{task_type}"
+            holder.updated_at = time.monotonic()
 
         try:
             schema_info = f", schema={task.schema}" if task.schema else ""
@@ -697,7 +747,7 @@ class WorkerPoller:
         while asyncio.get_event_loop().time() - start_time < timeout:
             async with self._in_flight_lock:
                 in_flight = self._in_flight_count
-                active_task_objects = [task_info[3] for task_info in self._active_tasks.values()]
+                active_task_objects = [info.bg_task for info in self._active_tasks.values()]
 
             if in_flight == 0:
                 logger.info(f"Worker {self._worker_id} graceful shutdown complete")
@@ -715,12 +765,19 @@ class WorkerPoller:
 
         # Cancel remaining tasks
         async with self._in_flight_lock:
-            for operation_id, (_, _, _, bg_task) in list(self._active_tasks.items()):
-                if not bg_task.done():
-                    bg_task.cancel()
+            for operation_id, info in list(self._active_tasks.items()):
+                if not info.bg_task.done():
+                    info.bg_task.cancel()
 
     async def _log_progress_if_due(self):
-        """Log progress stats every PROGRESS_LOG_INTERVAL seconds."""
+        """Log progress stats every PROGRESS_LOG_INTERVAL seconds.
+
+        Emits four kinds of lines:
+          * [WORKER_STATS]  - aggregate slots / pool / global pending counts
+          * [WORKER_TASK]   - one line per in-flight task with age + stage
+          * [STUCK_STACK]   - async stack trace for tasks past stuck thresholds
+          * [DB_WAITS]      - any non-idle hindsight session waiting on a lock
+        """
         now = time.time()
         if now - self._last_progress_log < PROGRESS_LOG_INTERVAL:
             return
@@ -740,10 +797,10 @@ class WorkerPoller:
             available_slots = max(0, non_consolidation_max - non_consolidation_in_flight)
             available_consolidation_slots = max(0, self._consolidation_max_slots - consolidation_count)
 
-            # Build local processing breakdown
+            # Build local processing breakdown (aggregate counts)
             task_groups: dict[tuple[str, str], int] = {}
-            for op_type, bank_id, _, _ in active_tasks.values():
-                key = (op_type, bank_id)
+            for info in active_tasks.values():
+                key = (info.op_type, info.bank_id)
                 task_groups[key] = task_groups.get(key, 0) + 1
 
             processing_info = [f"{op}:{bank}({cnt})" for (op, bank), cnt in task_groups.items()]
@@ -781,6 +838,11 @@ class WorkerPoller:
                     other_workers.append(f"{wid}:{cnt}")
             others_str = ", ".join(other_workers) if other_workers else "none"
 
+            # asyncpg pool stats - exhaustion presents as "everything slow",
+            # making it invisible without this line.
+            pool_str = self._format_pool_stats()
+            proc_str = self._format_proc_stats()
+
             # Display None as "default" in logs
             schemas_str = ", ".join(s if s else "default" for s in schemas)
             logger.info(
@@ -789,11 +851,172 @@ class WorkerPoller:
                 f"available={available_slots} (consolidation={available_consolidation_slots}) | "
                 f"global: pending={global_pending} (schemas: {schemas_str}) | "
                 f"others: {others_str} | "
+                f"pool: {pool_str} | "
+                f"proc: {proc_str} | "
                 f"my_active: {processing_str}"
             )
 
+            # Per-task lines, sorted oldest-first so stuck tasks bubble to the top.
+            self._log_per_task_lines(active_tasks, now=time.monotonic())
+
+            # DB lock waits - separate from per-task lines because a single
+            # blocking session can wedge many tasks.
+            await self._log_db_waits()
+
         except Exception as e:
             logger.debug(f"Failed to log progress stats: {e}")
+
+    def _format_proc_stats(self) -> str:
+        """Render lightweight process memory stats. Returns 'unavailable' if introspection fails."""
+        try:
+            import resource
+
+            # ru_maxrss is bytes on macOS, kilobytes on Linux. Detect by checking platform.
+            import sys
+
+            usage = resource.getrusage(resource.RUSAGE_SELF)
+            rss = usage.ru_maxrss
+            if sys.platform != "darwin":
+                rss *= 1024  # Linux reports KB
+            rss_mb = rss / (1024 * 1024)
+            return f"rss_mb={rss_mb:.0f}"
+        except Exception as e:
+            logger.debug(f"Process stats unavailable: {e}")
+            return "unavailable"
+
+    def _format_pool_stats(self) -> str:
+        """Render asyncpg pool stats. Returns 'unavailable' if pool can't be introspected."""
+        pool = self._pool
+        try:
+            # asyncpg.Pool exposes _holders / _queue internally; fall back gracefully
+            # to public methods if the layout ever changes.
+            size = pool.get_size() if hasattr(pool, "get_size") else len(getattr(pool, "_holders", []))
+            free = pool.get_idle_size() if hasattr(pool, "get_idle_size") else None
+            min_size = pool.get_min_size() if hasattr(pool, "get_min_size") else None
+            max_size = pool.get_max_size() if hasattr(pool, "get_max_size") else None
+            queue = getattr(pool, "_queue", None)
+            waiters = queue.qsize() if queue is not None and hasattr(queue, "qsize") else None
+
+            parts = [f"size={size}"]
+            if min_size is not None and max_size is not None:
+                parts.append(f"limits={min_size}-{max_size}")
+            if free is not None:
+                parts.append(f"idle={free}")
+                parts.append(f"in_use={size - free}")
+            if waiters is not None:
+                parts.append(f"waiters={waiters}")
+            return " ".join(parts)
+        except Exception as e:
+            logger.debug(f"Pool stats unavailable: {e}")
+            return "unavailable"
+
+    def _log_per_task_lines(self, active_tasks: dict[str, ActiveTaskInfo], now: float) -> None:
+        """Emit one [WORKER_TASK] line per in-flight task and dump stuck stacks.
+
+        Sorted by age desc so the oldest (most likely stuck) tasks appear first.
+        """
+        if not active_tasks:
+            return
+
+        # Sort by age descending; tie-break on op_id for determinism.
+        ordered = sorted(
+            active_tasks.items(),
+            key=lambda kv: (now - kv[1].started_at, kv[0]),
+            reverse=True,
+        )
+
+        for op_id, info in ordered:
+            age_s = now - info.started_at
+            holder = info.stage_holder
+            stage = holder.stage if holder is not None else "unknown"
+            stage_age_s = (now - holder.updated_at) if holder is not None else 0.0
+            stuck_marker = "[STUCK?] " if age_s >= STUCK_STACK_INITIAL_THRESHOLD_S else ""
+            schema_part = f" schema={info.schema}" if info.schema else ""
+            logger.info(
+                f"[WORKER_TASK] {stuck_marker}op={op_id} type={info.task_type} "
+                f"op_type={info.op_type} bank={info.bank_id}{schema_part} "
+                f"age={age_s:.0f}s stage={stage} stage_age={stage_age_s:.0f}s"
+            )
+
+            self._maybe_dump_stuck_stack(op_id, info, age_s)
+
+    def _maybe_dump_stuck_stack(self, op_id: str, info: ActiveTaskInfo, age_s: float) -> None:
+        """Dump a coroutine stack for tasks that crossed a stuck threshold.
+
+        Each task gets one dump per threshold (5min, 10min, 20min, 40min...),
+        gated by `info.last_stack_dump_threshold` so logs don't flood for tasks
+        that legitimately take a long time (large LLM jobs, schema-retry loops).
+        """
+        if age_s < STUCK_STACK_INITIAL_THRESHOLD_S:
+            return
+
+        # Find the largest doubling-threshold that the task has crossed.
+        threshold = STUCK_STACK_INITIAL_THRESHOLD_S
+        crossed = STUCK_STACK_INITIAL_THRESHOLD_S
+        while threshold <= age_s and threshold <= STUCK_STACK_MAX_THRESHOLD_S:
+            crossed = threshold
+            threshold *= 2
+
+        if crossed <= info.last_stack_dump_threshold:
+            return
+
+        info.last_stack_dump_threshold = crossed
+
+        try:
+            buf = io.StringIO()
+            info.bg_task.print_stack(file=buf, limit=15)
+            stage = info.stage_holder.stage if info.stage_holder else "unknown"
+            logger.warning(
+                f"[STUCK_STACK] op={op_id} type={info.task_type} bank={info.bank_id} "
+                f"age={age_s:.0f}s threshold={crossed}s stage={stage}\n{buf.getvalue()}"
+            )
+        except Exception as e:
+            # Stack capture is best-effort - never crash the polling loop over it.
+            logger.debug(f"Failed to capture stack for {op_id}: {e}")
+
+    async def _log_db_waits(self) -> None:
+        """Log any non-idle hindsight session that's waiting on a lock or other resource.
+
+        Catches the case where a coroutine appears 'fine' from Python's perspective
+        but is blocked on a Postgres row lock - which is exactly how the 3-phase
+        retain pipeline deadlock would present.
+        """
+        try:
+            async with self._pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT
+                        pid,
+                        application_name,
+                        wait_event_type,
+                        wait_event,
+                        state,
+                        EXTRACT(EPOCH FROM (now() - query_start))::int AS age_s,
+                        LEFT(query, 200) AS query
+                    FROM pg_stat_activity
+                    WHERE datname = current_database()
+                      AND state IS NOT NULL
+                      AND state != 'idle'
+                      AND wait_event IS NOT NULL
+                      AND wait_event_type NOT IN ('Activity', 'Client')
+                    ORDER BY age_s DESC NULLS LAST
+                    LIMIT 20
+                    """
+                )
+        except Exception as e:
+            # pg_stat_activity may be restricted on managed Postgres - degrade silently.
+            logger.debug(f"DB waits query failed: {e}")
+            return
+
+        if not rows:
+            return
+
+        for r in rows:
+            logger.info(
+                f"[DB_WAITS] pid={r['pid']} app={r['application_name']} "
+                f"wait={r['wait_event_type']}.{r['wait_event']} state={r['state']} "
+                f"age={r['age_s']}s query={r['query']!r}"
+            )
 
     @property
     def worker_id(self) -> str:

--- a/hindsight-api-slim/hindsight_api/worker/stage.py
+++ b/hindsight-api-slim/hindsight_api/worker/stage.py
@@ -1,0 +1,59 @@
+"""Stage breadcrumbs for in-flight worker tasks.
+
+The worker poller binds a `StageHolder` to each task's contextvar scope.
+Engine code calls `set_stage("retain.facts.llm")` at phase boundaries; the
+poller reads the holder periodically to surface what each in-flight task is
+currently doing in `WORKER_STATS` / `WORKER_TASK` log lines.
+
+Outside a worker context the contextvar is unset and `set_stage` is a no-op,
+so engine code is safe to call from sync HTTP requests, tests, or the CLI
+without any setup.
+"""
+
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StageHolder:
+    """Mutable container for the current task's stage label."""
+
+    stage: str = "init"
+    updated_at: float = field(default_factory=time.monotonic)
+
+
+_current_holder: ContextVar[StageHolder | None] = ContextVar("hindsight_stage_holder", default=None)
+
+
+def bind_holder(holder: StageHolder):
+    """Bind a holder to the current async context.
+
+    Must be called from inside the task coroutine itself (not from the
+    spawning code) so the binding lives in the task's own contextvar scope.
+
+    Returns the token that can be passed to `_current_holder.reset()` if
+    the binding ever needs to be unwound.
+    """
+    return _current_holder.set(holder)
+
+
+def set_stage(name: str) -> None:
+    """Update the current task's stage label.
+
+    No-op when called outside a worker task context (e.g. from a sync HTTP
+    request, a test, or the CLI). Cheap enough to call per-phase.
+    """
+    holder = _current_holder.get()
+    if holder is None:
+        return
+    holder.stage = name
+    holder.updated_at = time.monotonic()
+
+
+def get_stage() -> str | None:
+    """Return the current stage label, or None if no holder is bound."""
+    holder = _current_holder.get()
+    return holder.stage if holder is not None else None

--- a/hindsight-api-slim/tests/test_reflect_source_facts_config.py
+++ b/hindsight-api-slim/tests/test_reflect_source_facts_config.py
@@ -11,6 +11,7 @@ import pytest
 
 from hindsight_api.engine.reflect.tools import tool_search_observations
 from hindsight_api.engine.response_models import RecallResult
+from hindsight_api.models import RequestContext
 
 
 def _make_mock_engine(recall_result=None):
@@ -24,7 +25,11 @@ def _make_mock_engine(recall_result=None):
 
 @pytest.fixture
 def mock_request_context():
-    return MagicMock()
+    # Use a real dataclass instance — tool_search_observations calls
+    # dataclasses.replace(request_context, internal=True), which fails on
+    # MagicMock. The fields don't matter for these tests; we only inspect
+    # the kwargs passed to the mocked recall_async.
+    return RequestContext()
 
 
 class TestSearchObservationsSourceFacts:

--- a/hindsight-api-slim/tests/test_stage.py
+++ b/hindsight-api-slim/tests/test_stage.py
@@ -1,0 +1,71 @@
+"""Unit tests for the worker stage breadcrumb module."""
+
+import asyncio
+
+import pytest
+
+from hindsight_api.worker.stage import StageHolder, bind_holder, get_stage, set_stage
+
+
+def test_set_stage_is_noop_without_holder():
+    # No holder bound in this context: must not raise, and get_stage returns None.
+    set_stage("anything")
+    assert get_stage() is None
+
+
+@pytest.mark.asyncio
+async def test_holder_bound_inside_task_is_visible_to_called_code():
+    holder = StageHolder()
+
+    async def inner():
+        # The poller binds the holder from inside the task coroutine so it
+        # lives in that task's contextvar scope; mirror that here.
+        bind_holder(holder)
+        set_stage("phase1")
+        # Engine code further down the call stack reads via set_stage.
+        set_stage("phase2")
+        assert get_stage() == "phase2"
+
+    await asyncio.create_task(inner())
+
+    # Holder is mutable: the spawning context sees the latest stage written
+    # by the child task without needing access to the contextvar.
+    assert holder.stage == "phase2"
+
+
+@pytest.mark.asyncio
+async def test_holder_does_not_leak_across_tasks():
+    # Each asyncio.create_task copies the parent's context. Binding inside
+    # one task must not affect a sibling task's view.
+    holder_a = StageHolder()
+    holder_b = StageHolder()
+
+    async def task_a():
+        bind_holder(holder_a)
+        set_stage("a")
+
+    async def task_b():
+        bind_holder(holder_b)
+        set_stage("b")
+
+    await asyncio.gather(asyncio.create_task(task_a()), asyncio.create_task(task_b()))
+
+    assert holder_a.stage == "a"
+    assert holder_b.stage == "b"
+    # Outside both tasks, no holder is bound.
+    assert get_stage() is None
+
+
+@pytest.mark.asyncio
+async def test_set_stage_updates_timestamp():
+    holder = StageHolder()
+
+    async def inner():
+        bind_holder(holder)
+        first = holder.updated_at
+        # asyncio.sleep guarantees monotonic clock advances on next set.
+        await asyncio.sleep(0.01)
+        set_stage("next")
+        assert holder.updated_at > first
+
+    await asyncio.create_task(inner())

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -242,19 +242,28 @@ def test_macos_forces_cpu_for_local_embeddings_and_reranker(temp_home, monkeypat
     manager = DaemonEmbedManager()
 
     captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
 
     def fake_popen(cmd, env, **kwargs):
         captured["env"] = env
+        popen_called[0] = True
         proc = MagicMock()
         proc.pid = 12345
         return proc
 
-    # Short-circuit the readiness wait; we only care about the env passed to Popen.
+    # is_running must return False before Popen (so _start_daemon and
+    # _start_daemon_locked don't short-circuit on the pre-Popen checks added
+    # in #1016) and True after Popen (so the readiness wait loop breaks
+    # immediately). Tying it to popen_called gives us both for free.
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
     with (
         patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),  # skip 2s stability wait
         patch.object(manager, "_clear_port", return_value=True),
         patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
-        patch.object(manager, "is_running", return_value=True),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
         patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
     ):
         manager._start_daemon(
@@ -317,19 +326,25 @@ def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, mo
 
     manager = DaemonEmbedManager()
     captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
 
     def fake_popen(cmd, env, **kwargs):
         captured["env"] = env
+        popen_called[0] = True
         proc = MagicMock()
         proc.pid = 12345
         return proc
 
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
     # Simulate Linux so the macOS default doesn't mask the test.
     with (
         patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
         patch.object(manager, "_clear_port", return_value=True),
         patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
-        patch.object(manager, "is_running", return_value=True),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
         patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Linux"),
     ):
         manager._start_daemon(config={}, profile=profile_name)
@@ -351,18 +366,24 @@ def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
 
     manager = DaemonEmbedManager()
     captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
 
     def fake_popen(cmd, env, **kwargs):
         captured["env"] = env
+        popen_called[0] = True
         proc = MagicMock()
         proc.pid = 12345
         return proc
 
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
     with (
         patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
         patch.object(manager, "_clear_port", return_value=True),
         patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
-        patch.object(manager, "is_running", return_value=True),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
         patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
     ):
         manager._start_daemon(


### PR DESCRIPTION
## Summary

Surface what each in-flight worker task is doing so users can diagnose stalls (#1001) and runaway LLM retry loops (#996) from logs alone — no auto-recovery, no killing tasks, just visibility.

## What you get in logs (every 30s)

- **`[WORKER_STATS]`** — now also includes asyncpg pool stats (`size/idle/in_use/waiters`) and process RSS. Pool exhaustion and unbounded memory growth were previously invisible.
- **`[WORKER_TASK]`** — one line per in-flight task with `op_id`, type, bank, age, current stage, stage age. Sorted oldest-first; tasks past 5 min get a `[STUCK?]` prefix.
- **`[STUCK_STACK]`** — async stack trace dumped once per doubling threshold (5/10/20/40 min…) so stuck tasks self-document without flooding.
- **`[DB_WAITS]`** — `pg_stat_activity` snapshot of any non-idle Hindsight session waiting on a lock — catches the retain-pipeline deadlock case where the coroutine looks fine but is actually blocked on a Postgres row lock.

## How stages get populated

A contextvar-bound `StageHolder` (`worker/stage.py`) is bound per task by the poller. Engine code calls `set_stage("retain.phase2.insert_facts")` at phase boundaries. Outside a worker context `set_stage` is a no-op, so engine code is safe to call from sync HTTP, tests, or the CLI.

Stages wired:
- `memory_engine.execute_task` → `task.{type}`
- `retain/orchestrator` → `retain.phase1.resolve`, `retain.phase2.insert_facts`, `retain.phase3.entity_links`, `retain.extract_and_embed`
- `llm_wrapper.call` / `call_with_tools` → `llm.{provider}.{scope}[+structured|+tools]`
- Per-attempt inside provider retry loops (openai_compatible incl. ollama_native, litellm, gemini) → `llm.{provider}.{scope}.attempt=N/M`

The attempt counter makes JSON-schema retry loops on small models (e.g. `gemma3:12b` on Ollama) visible by stage name + stage age, instead of needing to bump log level and grep for WARN lines.

## Why no auto-recovery

The user explicitly chose visibility over auto-kill: killing stuck tasks loses the forensic trail and makes it impossible to tell whether the cause was transient, a config issue, or a real bug. With these logs a single paste from a user reproduces enough detail to diagnose stalls remotely.

## Test plan

- [x] `uv run pytest tests/test_worker.py` — all 30 worker tests pass
- [x] `uv run pytest tests/test_stage.py` — 4 new unit tests for stage contextvar (no-op outside context, holder visibility inside task, no leak across sibling tasks, timestamp updates)
- [x] `uv run pytest tests/ -k "llm_wrapper or llm_call or test_provider"` — 39 LLM/provider tests pass
- [x] `./scripts/hooks/lint.sh` clean
- [x] `uv run ty check` clean on touched files
- [ ] Manual: bring up a worker locally, submit a slow task, confirm `[WORKER_TASK]` and `[STUCK_STACK]` lines appear with the expected stage names