### PR TITLE
fix(openclaw): ignore ctx.channelId when it is a provider name (#854)

### DIFF
--- a/hindsight-integrations/openclaw/src/derive-bank-id.test.ts
+++ b/hindsight-integrations/openclaw/src/derive-bank-id.test.ts
@@ -102,6 +102,17 @@ describe('deriveBankId', () => {
     expect(bankId).toBe('prod-shared-bank');
   });
 
+  it('should ignore ctx.channelId when it is a provider name and fall back to sessionKey (issue #854)', () => {
+    const ctxDiscord: PluginHookAgentContext = {
+      agentId: 'main',
+      channelId: 'discord',
+      sessionKey: 'agent:main:discord:channel:1472750640760623226',
+    };
+    const config: PluginConfig = { ...baseConfig, dynamicBankGranularity: ['agent', 'channel'] };
+    const bankId = deriveBankId(ctxDiscord, config);
+    expect(bankId).toBe('main::channel%3A1472750640760623226');
+  });
+
   it('should encode segments to prevent separator collisions', () => {
     const ctxWithSeparator: PluginHookAgentContext = {
       agentId: 'a::b',

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -592,6 +592,20 @@ export function truncateRecallQuery(query: string, latestQuery: string, maxChars
  * Format: "agent:{agentId}:{provider}:{channelType}:{channelId}[:{extra}]"
  * Example: "agent:c0der:telegram:group:-1003825475854:topic:42"
  */
+// Some OpenClaw hook contexts populate `ctx.channelId` with the provider name
+// (e.g. "discord") instead of the actual channel ID. Treat those as missing so
+// we fall through to the sessionKey-derived channel. See issue #854.
+const PROVIDER_CHANNEL_ID_TOKENS = new Set([
+  'discord', 'telegram', 'slack', 'matrix', 'whatsapp', 'signal', 'messenger', 'sms', 'email', 'web', 'cli',
+]);
+
+function sanitizeChannelId(channelId: string | undefined, provider?: string): string | undefined {
+  if (!channelId) return undefined;
+  if (provider && channelId === provider) return undefined;
+  if (PROVIDER_CHANNEL_ID_TOKENS.has(channelId.toLowerCase())) return undefined;
+  return channelId;
+}
+
 function parseSessionKey(sessionKey: string): { agentId?: string; provider?: string; channel?: string } {
   const parts = sessionKey.split(':');
   if (parts.length < 5 || parts[0] !== 'agent') return {};
@@ -634,7 +648,7 @@ export function deriveBankId(ctx: PluginHookAgentContext | undefined, pluginConf
 
   const fieldMap: Record<string, string> = {
     agent: ctx?.agentId || sessionParsed.agentId || 'default',
-    channel: ctx?.channelId || sessionParsed.channel || 'unknown',
+    channel: sanitizeChannelId(ctx?.channelId, ctx?.messageProvider || sessionParsed.provider) || sessionParsed.channel || 'unknown',
     user: ctx?.senderId || 'anonymous',
     provider: ctx?.messageProvider || sessionParsed.provider || 'unknown',
   };
@@ -1574,8 +1588,8 @@ export function buildRetainRequest(
   const documentBase = getSessionDocumentBase(effectiveCtx);
   const documentKind = retentionScope === 'window' ? 'window' : 'turn';
   const documentId = `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, '0')}`;
-  const channelId = effectiveCtx?.channelId || parsedSession.channel;
   const provider = effectiveCtx?.messageProvider || parsedSession.provider;
+  const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const threadId = extractThreadId(channelId);
 
   return {


### PR DESCRIPTION
## Summary
- Fixes #854: Discord (and other multi-channel providers) channel memories all collapsed into a single `main::discord` bank because `ctx.channelId` is populated with the provider name in some OpenClaw hook contexts, short-circuiting the `sessionKey` fallback in `deriveBankId`.
- Adds `sanitizeChannelId()` that treats `ctx.channelId` as missing when it equals the provider or matches a known provider token (`discord`, `telegram`, `slack`, `matrix`, `whatsapp`, etc.), so the channel parsed from `sessionKey` is used instead.
- Applies the helper to both `deriveBankId` and `buildRetainRequest`, so the `channel_id` metadata field and `extractThreadId` also benefit.

## Test plan
- [x] New regression test in `derive-bank-id.test.ts` mirroring the issue: `ctx.channelId="discord"` + Discord sessionKey now resolves to `main::channel%3A1472750640760623226` instead of `main::discord`.
- [x] All 15 `derive-bank-id` tests pass; existing 83 openclaw tests still pass (one pre-existing symlink-related failure on main is unrelated).
- [x] `./scripts/hooks/lint.sh` passes.