### PR TITLE
chore(ci): guard against workspace-resolved deps in integration lockfiles

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -82,6 +82,15 @@ jobs:
         node-version: '22'
         registry-url: 'https://registry.npmjs.org'
 
+    # Guard: fail fast if the integration's lockfile resolves any dep from a
+    # monorepo workspace (link=true) or a relative file path. The release
+    # runner has no pre-built workspace `dist/` so `npm run build` would
+    # later fail at tsc with "Cannot find module". See:
+    # https://github.com/vectorize-io/hindsight/issues/… (0.6.0 openclaw retry)
+    - name: Check integration lockfile
+      if: steps.type.outputs.type == 'typescript'
+      run: ./scripts/check-integration-lockfiles.sh
+
     - name: Install dependencies
       if: steps.type.outputs.type == 'typescript'
       working-directory: ./hindsight-integrations/${{ steps.info.outputs.integration }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
       integrations-paperclip: ${{ steps.filter.outputs.integrations-paperclip }}
       integrations-opencode: ${{ steps.filter.outputs.integrations-opencode }}
       integrations-cloudflare-oauth-proxy: ${{ steps.filter.outputs.integrations-cloudflare-oauth-proxy }}
+      integrations-lockfiles: ${{ steps.filter.outputs.integrations-lockfiles }}
       dev: ${{ steps.filter.outputs.dev }}
       ci: ${{ steps.filter.outputs.ci }}
       # Secrets are available for internal PRs, pull_request_review, and workflow_dispatch.
@@ -128,10 +129,37 @@ jobs:
             - 'hindsight-integrations/opencode/**'
           integrations-cloudflare-oauth-proxy:
             - 'hindsight-integrations/cloudflare-oauth-proxy/**'
+          integrations-lockfiles:
+            - 'hindsight-integrations/*/package-lock.json'
+            - 'hindsight-integrations/*/package.json'
+            - 'scripts/check-integration-lockfiles.sh'
           dev:
             - 'hindsight-dev/**'
           ci:
             - '.github/**'
+
+  # Fail fast if any hindsight-integrations/*/package-lock.json was regenerated
+  # from the monorepo root and ended up symlinked at a workspace path instead
+  # of the npm registry. That bit us on the 0.6.0 openclaw release — tsc in
+  # the release workflow couldn't find `@vectorize-io/hindsight-client`
+  # because its `resolved` url pointed at a workspace dir whose `dist/` was
+  # gitignored and unbuilt. Catching this at PR time means the release CI
+  # never hits that class of failure.
+  check-integration-lockfiles:
+    needs: [detect-changes]
+    if: >-
+      github.event_name != 'pull_request_review' &&
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.integrations-lockfiles == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Check integration lockfiles resolve from the npm registry
+      run: ./scripts/check-integration-lockfiles.sh
 
   build-api-python-versions:
     needs: [detect-changes]
@@ -2640,6 +2668,7 @@ jobs:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && always()
     needs:
       - detect-changes
+      - check-integration-lockfiles
       - build-api-python-versions
       - build-typescript-client
       - build-openclaw-integration

--- a/scripts/check-integration-lockfiles.sh
+++ b/scripts/check-integration-lockfiles.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Ensures every `hindsight-integrations/*/package-lock.json` resolves its
+# dependencies from a public npm registry — not from a monorepo workspace
+# symlink, a `file:` URL, or a relative path.
+#
+# Why this matters: integrations are published by `.github/workflows/
+# release-integration.yml`, which runs `npm ci && npm run build` inside the
+# integration directory. If the lockfile points at a workspace path whose
+# `dist/` is gitignored and not pre-built in the release runner, tsc fails
+# with `Cannot find module '@vectorize-io/...'`.
+#
+# This bit us once on integrations/openclaw/v0.6.0 — the lockfile had
+# @vectorize-io/hindsight-client resolved to ../../hindsight-clients/typescript
+# because `npm install` was originally run from the monorepo root, where npm
+# silently preferred the workspace even though openclaw isn't itself listed
+# in the root `workspaces` array. The test CI job masked it (it pre-builds
+# workspace deps), but the release workflow doesn't.
+#
+# How to fix a flagged lockfile: from inside the integration directory,
+#   rm -rf node_modules package-lock.json
+#   npm install
+# Never run `npm install` from the monorepo root for these integrations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+FAIL=0
+
+shopt -s nullglob
+lockfiles=(hindsight-integrations/*/package-lock.json)
+shopt -u nullglob
+
+if [[ ${#lockfiles[@]} -eq 0 ]]; then
+  echo -e "${YELLOW}[check-integration-lockfiles]${NC} no integration lockfiles found (nothing to check)"
+  exit 0
+fi
+
+for lockfile in "${lockfiles[@]}"; do
+  integration="$(basename "$(dirname "$lockfile")")"
+
+  violations="$(python3 - "$lockfile" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+
+bad = []
+for name, info in data.get("packages", {}).items():
+    # Only check actual node_modules entries. The root entry is "".
+    if not name.startswith("node_modules/"):
+        continue
+
+    # Ignore optional deps that didn't install (they have no resolved URL
+    # and no link path — they're legitimately absent for the current
+    # platform).
+    if info.get("optional") and "resolved" not in info and "link" not in info:
+        continue
+
+    resolved = info.get("resolved", "")
+    link = info.get("link")
+
+    if link is True:
+        # Workspace symlink, no registry URL. This is the bug that broke
+        # the openclaw 0.6.0 release — npm had resolved a registry-ranged
+        # dep to a workspace symlink because `npm install` was run from
+        # the monorepo root.
+        bad.append(f"{name}: (link=true — workspace symlink)")
+    elif not resolved:
+        # Empty resolved on a non-link entry shouldn't happen, but flag
+        # it anyway rather than silently accepting it.
+        bad.append(f"{name}: (no `resolved` URL)")
+    elif resolved.startswith("file:"):
+        bad.append(f"{name}: {resolved}")
+    elif resolved.startswith(("../", "./")):
+        bad.append(f"{name}: {resolved}")
+
+if bad:
+    print("\n".join(bad))
+PY
+)"
+
+  if [[ -n "$violations" ]]; then
+    echo -e "${RED}[check-integration-lockfiles]${NC} $lockfile resolves dependencies outside the npm registry:"
+    echo "$violations" | sed 's/^/    /'
+    FAIL=1
+  fi
+done
+
+if [[ $FAIL -eq 1 ]]; then
+  cat >&2 <<'EOF'
+
+How to fix a flagged lockfile: from inside the integration directory,
+    rm -rf node_modules package-lock.json
+    npm install
+
+Do not run `npm install` from the monorepo root for these integrations
+— it silently resolves `@vectorize-io/...` names to the workspace copy
+even when the package.json declares a registry version range.
+EOF
+  exit 1
+fi
+
+echo -e "${GREEN}[check-integration-lockfiles]${NC} ✓ ${#lockfiles[@]} integration lockfile(s) resolve cleanly from the npm registry"


### PR DESCRIPTION
## Summary

Prevents the class of release failure that hit the 0.6.0 openclaw release (see commit `e9270fd3`).

**Root cause of the original failure**: `hindsight-integrations/openclaw/package-lock.json` had `@vectorize-io/hindsight-client` resolved as a workspace symlink (`link: true`) instead of a registry URL. npm silently preferred the workspace when `npm install` was originally run from the monorepo root — even though openclaw isn't listed in the root `workspaces` array — so the lockfile captured a workspace link. The release runner has no pre-built workspace `dist/`, so `tsc` couldn't find types and the publish never happened. The test CI job masked it because it explicitly pre-builds workspace deps before `npm ci`; the release workflow doesn't.

## Three guards

1. **`scripts/check-integration-lockfiles.sh`** — standalone script that scans every `hindsight-integrations/*/package-lock.json` and fails if any dep's `resolved` URL is empty, a `file:` URL, a relative path, or the entry is a `link: true` workspace symlink. Prints the exact fix (regenerate the lockfile from inside the integration directory, not the monorepo root).
2. **`check-integration-lockfiles` job in `.github/workflows/test.yml`** — runs the script on every PR that touches an integration lockfile or package.json. Gated on a new `integrations-lockfiles` detect-changes output. Added to `report-pr-status` needs list.
3. **Inline `Check integration lockfile` step in `release-integration.yml`** — belt + suspenders for the TypeScript branch in case a bad lockfile ever slips past PR gating.

## Verification

- Regression test: ran the script against the broken pre-release lockfile from `da21e072` → correctly identified `node_modules/@vectorize-io/hindsight-client: (link=true — workspace symlink)` and exited 1.
- Current tree: all 7 integration lockfiles (`ai-sdk`, `chat`, `cloudflare-oauth-proxy`, `nemoclaw`, `openclaw`, `opencode`, `paperclip`) pass cleanly.
- Repo lint green.

## Test plan

- [ ] CI `check-integration-lockfiles` job passes on this PR
- [ ] Reviewer eyeballs the script and the new workflow job/step
- [ ] Next integration release: release workflow runs the new guard step and succeeds