### PR TITLE
fix(openclaw): setup wizard now asks for token value, not env var name

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -32,24 +32,32 @@ npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup
 
 The wizard walks you through picking one of three install modes:
 
-- **Cloud** — managed Hindsight at `https://api.hindsight.vectorize.io`. Prompts for the env var that holds your cloud API token. No local setup needed.
-- **External API** — your own running Hindsight deployment. Prompts for the URL and, optionally, the env var that holds an auth token.
-- **Embedded daemon** — spawns a local `hindsight-embed` daemon on this machine. Prompts for the LLM provider (OpenAI / Anthropic / Gemini / Groq / Claude Code / OpenAI Codex / Ollama) and the env var that holds the API key.
+- **Cloud** — managed Hindsight at `https://api.hindsight.vectorize.io`. Paste your cloud API token when prompted (masked input). No local setup needed.
+- **External API** — your own running Hindsight deployment. Prompts for the URL and, optionally, the token value (masked).
+- **Embedded daemon** — spawns a local `hindsight-embed` daemon on this machine. Prompts for the LLM provider (OpenAI / Anthropic / Gemini / Groq / Claude Code / OpenAI Codex / Ollama) and the API key (masked).
 
-Credentials are always written as [`SecretRef`](#llm-configuration) objects that reference an environment variable — the key itself never ends up in plaintext on disk.
+The interactive wizard stores credentials **inline** in `openclaw.json` for simplicity. For CI / production you can store credentials as a [`SecretRef`](#llm-configuration) (resolved from an env var, file, or exec source at startup, never saved on disk) by either passing `--token-env` / `--api-key-env` to the non-interactive wizard or switching an existing field afterwards via `openclaw config set ... --ref-source env|file|exec`.
 
-For CI and scripted setups the wizard also runs non-interactively:
+For CI and scripted setups the wizard also runs non-interactively — either with an inline value or with an env var reference:
 
 ```bash
-# Cloud
+# Cloud — inline token (simplest)
+npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup \
+    --mode cloud --token hsk_your_cloud_token
+
+# Cloud — SecretRef (read from env at gateway startup)
 npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup \
     --mode cloud --token-env HINDSIGHT_CLOUD_TOKEN
 
-# External API
+# External API (no auth)
 npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup \
     --mode api --api-url https://mcp.hindsight.example.com --no-token
 
-# Embedded daemon with OpenAI
+# Embedded daemon with OpenAI — inline API key
+npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup \
+    --mode embedded --provider openai --api-key sk-...
+
+# Embedded daemon with OpenAI — SecretRef
 npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup \
     --mode embedded --provider openai --api-key-env OPENAI_API_KEY
 

--- a/hindsight-docs/src/pages/changelog/integrations/openclaw.md
+++ b/hindsight-docs/src/pages/changelog/integrations/openclaw.md
@@ -8,6 +8,13 @@ import PageHero from '@site/src/components/PageHero';
 
 [← OpenClaw integration](/sdks/integrations/openclaw)
 
+## 0.6.1 (Unreleased)
+
+**Improvements**
+
+- `hindsight-openclaw-setup` interactive wizard now asks for the API token/API key **value** instead of the env var name holding it. Pasted values are masked and stored inline in `openclaw.json` — no more two-step "pick an env var name, then export it" flow that confused first-time users. For CI / production, the SecretRef path is still available via the non-interactive flags (`--token-env`, `--api-key-env`) or after-the-fact with `openclaw config set ... --ref-source env --ref-id …`.
+- Added non-interactive CLI flags for direct-value credentials: `--token` (cloud / external API modes) and `--api-key` (embedded mode). `--token` and `--token-env` are mutually exclusive within a mode; same for `--api-key` / `--api-key-env`.
+
 ## [0.6.0](https://github.com/vectorize-io/hindsight/tree/integrations/openclaw/v0.6.0)
 
 **Breaking Changes**

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -17,11 +17,11 @@ openclaw gateway
 
 `hindsight-openclaw-setup` walks you through picking one of three modes:
 
-- **Cloud** — managed Hindsight. Pick an API token env var, done.
+- **Cloud** — managed Hindsight. Paste your cloud API token, done.
 - **External API** — your own running Hindsight deployment. Prompts for the URL and optional token.
-- **Embedded daemon** — spawns a local `hindsight-embed` daemon on this machine. Prompts for the LLM provider (OpenAI / Anthropic / Gemini / Groq / Claude Code / Codex / Ollama) and the env var that holds the API key.
+- **Embedded daemon** — spawns a local `hindsight-embed` daemon on this machine. Prompts for the LLM provider (OpenAI / Anthropic / Gemini / Groq / Claude Code / Codex / Ollama) and its API key.
 
-Credentials are always written as `SecretRef` objects that reference an environment variable — the key itself never ends up in plaintext on disk. `--ref-source file` and `--ref-source exec` are also supported by OpenClaw for mounted-secret and Vault-style setups; once you want to use them, set them via `openclaw config set` (see below).
+The interactive wizard stores credentials **inline** in `openclaw.json` for simplicity — the value is masked as you paste it. For CI / production you can store credentials as a `SecretRef` (resolved from an env var, file, or exec source at startup) by using the non-interactive flags with `--token-env` / `--api-key-env`, or by switching an existing field afterwards with `openclaw config set ... --ref-source env --ref-id …`.
 
 ### Manual configuration (without the wizard)
 

--- a/hindsight-integrations/openclaw/scripts/smoke-test.sh
+++ b/hindsight-integrations/openclaw/scripts/smoke-test.sh
@@ -119,6 +119,29 @@ get_config_value() {
   openclaw config get "$1" 2>/dev/null | tail -1
 }
 
+# Read a value directly from the raw openclaw.json. `openclaw config get`
+# redacts sensitive fields (renders them as "__OPENCLAW_REDACTED__"), so we
+# can't use it to assert the actual token/key value stored inline. This
+# helper bypasses the redaction for smoke-test assertions.
+get_raw_config_value() {
+  python3 -c "
+import json, sys
+path = sys.argv[1]
+dotted = sys.argv[2]
+with open(path) as f:
+    node = json.load(f)
+for part in dotted.split('.'):
+    if isinstance(node, dict) and part in node:
+        node = node[part]
+    else:
+        sys.exit(0)
+if isinstance(node, (dict, list)):
+    print(json.dumps(node))
+else:
+    print(node)
+" "$CONFIG_PATH" "$1"
+}
+
 main() {
   require openclaw
   require node
@@ -195,22 +218,38 @@ main() {
   # -------------------------------------------------------------------------
   # Phase 2 — non-interactive setup for each mode
   # -------------------------------------------------------------------------
-  run_setup_mode "cloud (default URL)" \
+  run_setup_mode "cloud (default URL, SecretRef)" \
     --mode cloud --token-env HINDSIGHT_CLOUD_TOKEN
   [[ "$(get_config_value plugins.entries.hindsight-openclaw.config.hindsightApiUrl)" == "https://api.hindsight.vectorize.io" ]] \
     || fail "cloud mode: hindsightApiUrl not set to the default URL"
+
+  run_setup_mode "cloud (inline --token)" \
+    --mode cloud --token hsk_smoke_test_inline_value
+  # Read the raw file — `openclaw config get` redacts sensitive fields.
+  [[ "$(get_raw_config_value plugins.entries.hindsight-openclaw.config.hindsightApiToken)" == "hsk_smoke_test_inline_value" ]] \
+    || fail "cloud mode: --token did not roundtrip as inline string"
 
   run_setup_mode "external API (no auth)" \
     --mode api --api-url "$HINDSIGHT_API_URL" --no-token
   [[ "$(get_config_value plugins.entries.hindsight-openclaw.config.hindsightApiUrl)" == "$HINDSIGHT_API_URL" ]] \
     || fail "api mode: hindsightApiUrl did not roundtrip"
 
-  run_setup_mode "embedded (openai with model override)" \
+  run_setup_mode "external API (inline --token)" \
+    --mode api --api-url "$HINDSIGHT_API_URL" --token api_smoke_test_inline
+  [[ "$(get_raw_config_value plugins.entries.hindsight-openclaw.config.hindsightApiToken)" == "api_smoke_test_inline" ]] \
+    || fail "api mode: --token did not roundtrip as inline string"
+
+  run_setup_mode "embedded (openai --api-key-env + model override)" \
     --mode embedded --provider openai --api-key-env OPENAI_API_KEY --model gpt-4o-mini
   [[ "$(get_config_value plugins.entries.hindsight-openclaw.config.llmProvider)" == "openai" ]] \
     || fail "embedded mode: llmProvider not set to openai"
   [[ "$(get_config_value plugins.entries.hindsight-openclaw.config.llmModel)" == "gpt-4o-mini" ]] \
     || fail "embedded mode: llmModel not set to gpt-4o-mini"
+
+  run_setup_mode "embedded (openai --api-key inline)" \
+    --mode embedded --provider openai --api-key sk-smoke-test-inline
+  [[ "$(get_raw_config_value plugins.entries.hindsight-openclaw.config.llmApiKey)" == "sk-smoke-test-inline" ]] \
+    || fail "embedded mode: --api-key did not roundtrip as inline string"
 
   run_setup_mode "embedded (claude-code, no key)" \
     --mode embedded --provider claude-code
@@ -220,13 +259,19 @@ main() {
   # -------------------------------------------------------------------------
   log "verifying setup wizard rejects bad args…"
   if node "$EXT_DIR/dist/setup.js" --config-path "$CONFIG_PATH" --mode cloud 2>/dev/null; then
-    fail "cloud mode without --token-env should have failed"
+    fail "cloud mode without --token or --token-env should have failed"
+  fi
+  if node "$EXT_DIR/dist/setup.js" --config-path "$CONFIG_PATH" --mode cloud --token hsk_x --token-env T 2>/dev/null; then
+    fail "cloud mode with both --token and --token-env should have failed"
   fi
   if node "$EXT_DIR/dist/setup.js" --config-path "$CONFIG_PATH" --mode api --api-url "$HINDSIGHT_API_URL" --token-env TOK --no-token 2>/dev/null; then
     fail "--token-env + --no-token together should have failed"
   fi
   if node "$EXT_DIR/dist/setup.js" --config-path "$CONFIG_PATH" --mode embedded --provider openai 2>/dev/null; then
-    fail "openai without --api-key-env should have failed"
+    fail "openai without --api-key or --api-key-env should have failed"
+  fi
+  if node "$EXT_DIR/dist/setup.js" --config-path "$CONFIG_PATH" --mode embedded --provider openai --api-key sk-x --api-key-env OPENAI_API_KEY 2>/dev/null; then
+    fail "embedded with both --api-key and --api-key-env should have failed"
   fi
   log "✓ bad args rejected"
 

--- a/hindsight-integrations/openclaw/src/setup-lib.test.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.test.ts
@@ -77,6 +77,36 @@ describe('ensurePluginConfig', () => {
   });
 });
 
+describe('applyCloudMode — direct token value', () => {
+  it('stores the token inline when a literal value is provided', () => {
+    const pc: Record<string, unknown> = {
+      llmProvider: 'openai',
+      llmApiKey: { source: 'env', provider: 'default', id: 'OPENAI_API_KEY' },
+    };
+    applyCloudMode(pc, { token: 'hsk_literal_value' });
+    expect(pc.hindsightApiUrl).toBe(HINDSIGHT_CLOUD_URL);
+    expect(pc.hindsightApiToken).toBe('hsk_literal_value');
+    expect(pc.llmProvider).toBeUndefined();
+    expect(pc.llmApiKey).toBeUndefined();
+  });
+
+  it('trims whitespace around an inline token', () => {
+    const pc: Record<string, unknown> = {};
+    applyCloudMode(pc, { token: '  hsk_padded  ' });
+    expect(pc.hindsightApiToken).toBe('hsk_padded');
+  });
+
+  it('throws when neither token nor tokenEnvVar is provided', () => {
+    const pc: Record<string, unknown> = {};
+    expect(() => applyCloudMode(pc, {})).toThrow(/requires either/);
+  });
+
+  it('throws when both token and tokenEnvVar are provided', () => {
+    const pc: Record<string, unknown> = {};
+    expect(() => applyCloudMode(pc, { token: 'x', tokenEnvVar: 'Y' })).toThrow(/either a direct value or an env var name/);
+  });
+});
+
 describe('applyCloudMode', () => {
   it('writes the default URL and a SecretRef, stripping local LLM state', () => {
     const pc: Record<string, unknown> = {
@@ -109,6 +139,22 @@ describe('applyCloudMode', () => {
   });
 });
 
+describe('applyApiMode — direct token value', () => {
+  it('stores the token inline when a literal value is provided', () => {
+    const pc: Record<string, unknown> = {};
+    applyApiMode(pc, { apiUrl: 'https://mcp.example.com', token: 'api_literal' });
+    expect(pc.hindsightApiUrl).toBe('https://mcp.example.com');
+    expect(pc.hindsightApiToken).toBe('api_literal');
+  });
+
+  it('throws when both token and tokenEnvVar are provided', () => {
+    const pc: Record<string, unknown> = {};
+    expect(() =>
+      applyApiMode(pc, { apiUrl: 'https://mcp.example.com', token: 'x', tokenEnvVar: 'Y' }),
+    ).toThrow(/either a direct value or an env var name/);
+  });
+});
+
 describe('applyApiMode', () => {
   it('writes the URL without a token when none is provided', () => {
     const pc: Record<string, unknown> = {
@@ -138,6 +184,22 @@ describe('applyApiMode', () => {
   });
 });
 
+describe('applyEmbeddedMode — direct API key value', () => {
+  it('stores the API key inline when a literal value is provided', () => {
+    const pc: Record<string, unknown> = {};
+    applyEmbeddedMode(pc, { llmProvider: 'openai', apiKey: 'sk-literal' });
+    expect(pc.llmProvider).toBe('openai');
+    expect(pc.llmApiKey).toBe('sk-literal');
+  });
+
+  it('throws when both apiKey and apiKeyEnvVar are provided', () => {
+    const pc: Record<string, unknown> = {};
+    expect(() =>
+      applyEmbeddedMode(pc, { llmProvider: 'openai', apiKey: 'sk-x', apiKeyEnvVar: 'OPENAI_API_KEY' }),
+    ).toThrow(/either a direct value or an env var name/);
+  });
+});
+
 describe('applyEmbeddedMode', () => {
   it('writes llmProvider + SecretRef for providers that require a key', () => {
     const pc: Record<string, unknown> = {
@@ -162,9 +224,11 @@ describe('applyEmbeddedMode', () => {
     expect(pc.llmApiKey).toBeUndefined();
   });
 
-  it('throws when a key-requiring provider is given without an env var name', () => {
+  it('throws when a key-requiring provider is given without a key', () => {
     const pc: Record<string, unknown> = {};
-    expect(() => applyEmbeddedMode(pc, { llmProvider: 'openai' })).toThrow(/requires an apiKeyEnvVar/);
+    expect(() => applyEmbeddedMode(pc, { llmProvider: 'openai' })).toThrow(
+      /requires either `apiKey` or `apiKeyEnvVar`/,
+    );
   });
 
   it('persists llmModel when provided and clears it when absent', () => {
@@ -183,13 +247,19 @@ describe('summarize*', () => {
       'Cloud → https://api.hindsight.vectorize.io (token from ${HINDSIGHT_CLOUD_TOKEN})',
     );
     expect(summarizeApi({ apiUrl: 'https://api.example.com', tokenEnvVar: 'T' })).toBe(
-      'External API → https://api.example.com (authenticated)',
+      'External API → https://api.example.com (token from ${T})',
+    );
+    expect(summarizeApi({ apiUrl: 'https://api.example.com', token: 'literal' })).toBe(
+      'External API → https://api.example.com (token stored inline)',
     );
     expect(summarizeApi({ apiUrl: 'https://api.example.com' })).toBe(
       'External API → https://api.example.com (no auth)',
     );
     expect(summarizeEmbedded({ llmProvider: 'openai', apiKeyEnvVar: 'X' })).toBe(
-      'Embedded daemon → openai (key via SecretRef)',
+      'Embedded daemon → openai (key from ${X})',
+    );
+    expect(summarizeEmbedded({ llmProvider: 'openai', apiKey: 'sk-test' })).toBe(
+      'Embedded daemon → openai (key stored inline)',
     );
     expect(summarizeEmbedded({ llmProvider: 'claude-code' })).toBe(
       'Embedded daemon → claude-code',

--- a/hindsight-integrations/openclaw/src/setup-lib.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.ts
@@ -107,49 +107,83 @@ export function defaultApiKeyEnvVar(provider: string): string {
   return `${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`;
 }
 
+/**
+ * Cloud mode credential: either a direct token value (stored inline as a
+ * plaintext string in openclaw.json) or an env var name (stored as a
+ * SecretRef that OpenClaw resolves from `process.env` at startup).
+ *
+ * Interactive wizard defaults to the direct-value form — simpler UX for
+ * users pasting a freshly-issued cloud token. CI / production flows should
+ * prefer `tokenEnvVar` via `openclaw config set ... --ref-source env` or
+ * `--token-env` to keep secrets off disk.
+ */
 export interface CloudSetupInput {
   apiUrl?: string;
-  tokenEnvVar: string;
+  token?: string;
+  tokenEnvVar?: string;
 }
 
 export interface ApiSetupInput {
   apiUrl: string;
+  token?: string;
   tokenEnvVar?: string;
 }
 
 export interface EmbeddedSetupInput {
   llmProvider: string;
+  apiKey?: string;
   apiKeyEnvVar?: string;
   llmModel?: string;
 }
 
+function pickCredential(
+  token: string | undefined,
+  tokenEnvVar: string | undefined,
+): string | SecretRef | undefined {
+  const hasToken = token && token.trim().length > 0;
+  const hasEnvVar = tokenEnvVar && tokenEnvVar.trim().length > 0;
+  if (hasToken && hasEnvVar) {
+    throw new Error('provide either a direct value or an env var name — not both');
+  }
+  if (hasToken) return token!.trim();
+  if (hasEnvVar) return envSecretRef(tokenEnvVar!.trim());
+  return undefined;
+}
+
 /**
  * Apply the Cloud mode to a plugin config in place: sets `hindsightApiUrl` and
- * a `hindsightApiToken` SecretRef, strips any leftover local-LLM fields so we
- * don't carry stale credentials across mode switches.
+ * `hindsightApiToken` (either as a plaintext string or as a SecretRef —
+ * whichever the caller provided), strips any leftover local-LLM fields so
+ * mode switches don't carry stale state.
  */
 export function applyCloudMode(
   pluginConfig: Record<string, unknown>,
   input: CloudSetupInput,
 ): void {
+  const token = pickCredential(input.token, input.tokenEnvVar);
+  if (token === undefined) {
+    throw new Error('Cloud mode requires either `token` or `tokenEnvVar`');
+  }
   clearLocalLlmFields(pluginConfig);
   pluginConfig.hindsightApiUrl = (input.apiUrl ?? HINDSIGHT_CLOUD_URL).trim();
-  pluginConfig.hindsightApiToken = envSecretRef(input.tokenEnvVar.trim());
+  pluginConfig.hindsightApiToken = token;
 }
 
 /**
  * Apply the external-API mode to a plugin config in place: sets a required
- * `hindsightApiUrl`, optional `hindsightApiToken` SecretRef, and strips any
- * leftover local-LLM fields so mode switches don't carry stale state.
+ * `hindsightApiUrl`, optional `hindsightApiToken` (plaintext or SecretRef),
+ * and strips any leftover local-LLM fields so mode switches don't carry
+ * stale state.
  */
 export function applyApiMode(
   pluginConfig: Record<string, unknown>,
   input: ApiSetupInput,
 ): void {
+  const token = pickCredential(input.token, input.tokenEnvVar);
   clearLocalLlmFields(pluginConfig);
   pluginConfig.hindsightApiUrl = input.apiUrl.trim();
-  if (input.tokenEnvVar && input.tokenEnvVar.trim().length > 0) {
-    pluginConfig.hindsightApiToken = envSecretRef(input.tokenEnvVar.trim());
+  if (token !== undefined) {
+    pluginConfig.hindsightApiToken = token;
   } else {
     delete pluginConfig.hindsightApiToken;
   }
@@ -157,22 +191,24 @@ export function applyApiMode(
 
 /**
  * Apply the embedded-daemon mode to a plugin config in place: sets
- * `llmProvider`, optional `llmApiKey` SecretRef, optional `llmModel`, and
- * strips any external-API settings so mode switches don't carry stale state.
+ * `llmProvider`, optional `llmApiKey` (plaintext or SecretRef), optional
+ * `llmModel`, and strips any external-API settings so mode switches don't
+ * carry stale state.
  */
 export function applyEmbeddedMode(
   pluginConfig: Record<string, unknown>,
   input: EmbeddedSetupInput,
 ): void {
+  const key = pickCredential(input.apiKey, input.apiKeyEnvVar);
   clearCloudFields(pluginConfig);
   pluginConfig.llmProvider = input.llmProvider;
   if (NO_KEY_PROVIDERS.has(input.llmProvider)) {
     delete pluginConfig.llmApiKey;
   } else {
-    if (!input.apiKeyEnvVar) {
-      throw new Error(`llmProvider "${input.llmProvider}" requires an apiKeyEnvVar`);
+    if (key === undefined) {
+      throw new Error(`llmProvider "${input.llmProvider}" requires either \`apiKey\` or \`apiKeyEnvVar\``);
     }
-    pluginConfig.llmApiKey = envSecretRef(input.apiKeyEnvVar.trim());
+    pluginConfig.llmApiKey = key;
   }
   if (input.llmModel && input.llmModel.trim().length > 0) {
     pluginConfig.llmModel = input.llmModel.trim();
@@ -181,17 +217,29 @@ export function applyEmbeddedMode(
   }
 }
 
+function credentialSuffix(token: string | undefined, tokenEnvVar: string | undefined): string {
+  if (tokenEnvVar && tokenEnvVar.trim().length > 0) {
+    return ` (token from \${${tokenEnvVar.trim()}})`;
+  }
+  if (token && token.trim().length > 0) {
+    return ' (token stored inline)';
+  }
+  return ' (no auth)';
+}
+
 export function summarizeCloud(input: CloudSetupInput): string {
   const url = (input.apiUrl ?? HINDSIGHT_CLOUD_URL).trim();
-  return `Cloud → ${url} (token from \${${input.tokenEnvVar.trim()}})`;
+  return `Cloud → ${url}${credentialSuffix(input.token, input.tokenEnvVar)}`;
 }
 
 export function summarizeApi(input: ApiSetupInput): string {
-  const suffix = input.tokenEnvVar ? ' (authenticated)' : ' (no auth)';
-  return `External API → ${input.apiUrl.trim()}${suffix}`;
+  return `External API → ${input.apiUrl.trim()}${credentialSuffix(input.token, input.tokenEnvVar)}`;
 }
 
 export function summarizeEmbedded(input: EmbeddedSetupInput): string {
-  const keyHint = NO_KEY_PROVIDERS.has(input.llmProvider) ? '' : ' (key via SecretRef)';
+  if (NO_KEY_PROVIDERS.has(input.llmProvider)) {
+    return `Embedded daemon → ${input.llmProvider}`;
+  }
+  const keyHint = input.apiKeyEnvVar ? ` (key from \${${input.apiKeyEnvVar.trim()}})` : ' (key stored inline)';
   return `Embedded daemon → ${input.llmProvider}${keyHint}`;
 }

--- a/hindsight-integrations/openclaw/src/setup.test.ts
+++ b/hindsight-integrations/openclaw/src/setup.test.ts
@@ -21,7 +21,15 @@ describe('parseCliArgs', () => {
     expect(parseCliArgs(['/tmp/b.json']).positional).toBe('/tmp/b.json');
   });
 
-  it('parses cloud-mode flags', () => {
+  it('parses cloud-mode flags (direct token value)', () => {
+    const args = parseCliArgs([
+      '--mode', 'cloud',
+      '--token', 'hsk_literal',
+    ]);
+    expect(args).toMatchObject({ mode: 'cloud', token: 'hsk_literal' });
+  });
+
+  it('parses cloud-mode flags (token env var)', () => {
     const args = parseCliArgs([
       '--mode', 'cloud',
       '--api-url', 'https://cloud.example.com',
@@ -31,6 +39,19 @@ describe('parseCliArgs', () => {
       mode: 'cloud',
       apiUrl: 'https://cloud.example.com',
       tokenEnv: 'HINDSIGHT_CLOUD_TOKEN',
+    });
+  });
+
+  it('parses embedded-mode direct apiKey flag', () => {
+    const args = parseCliArgs([
+      '--mode', 'embedded',
+      '--provider', 'openai',
+      '--api-key', 'sk-literal',
+    ]);
+    expect(args).toMatchObject({
+      mode: 'embedded',
+      provider: 'openai',
+      apiKey: 'sk-literal',
     });
   });
 
@@ -125,9 +146,27 @@ describe('runNonInteractive', () => {
     expect((pc.hindsightApiToken as { id: string }).id).toBe('MY_TOKEN');
   });
 
-  it('rejects cloud mode without --token-env', async () => {
+  it('writes a cloud-mode config with an inline token (--token)', async () => {
+    const args = parseCliArgs(['--mode', 'cloud', '--token', 'hsk_direct_value']);
+    await runNonInteractive(args, configPath);
+    const cfg = await readBack();
+    const pc = cfg.plugins?.entries?.[PLUGIN_ID]?.config ?? {};
+    expect(pc.hindsightApiUrl).toBe('https://api.hindsight.vectorize.io');
+    expect(pc.hindsightApiToken).toBe('hsk_direct_value');
+  });
+
+  it('rejects cloud mode without --token or --token-env', async () => {
     const args = parseCliArgs(['--mode', 'cloud']);
-    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/--token-env/);
+    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/--token .*--token-env/);
+  });
+
+  it('rejects cloud mode with both --token and --token-env', async () => {
+    const args = parseCliArgs([
+      '--mode', 'cloud',
+      '--token', 'hsk_x',
+      '--token-env', 'HINDSIGHT_CLOUD_TOKEN',
+    ]);
+    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/mutually exclusive/);
   });
 
   it('rejects cloud mode with a bad token env var name', async () => {
@@ -172,7 +211,7 @@ describe('runNonInteractive', () => {
       '--token-env', 'FOO',
       '--no-token',
     ]);
-    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/cannot both be set/);
+    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/mutually exclusive/);
   });
 
   it('writes an embedded-mode config for openai', async () => {
@@ -205,9 +244,29 @@ describe('runNonInteractive', () => {
     await expect(runNonInteractive(args, configPath)).rejects.toThrow(/--provider/);
   });
 
-  it('rejects embedded mode with a key-requiring provider but no --api-key-env', async () => {
+  it('rejects embedded mode with a key-requiring provider but no --api-key or --api-key-env', async () => {
     const args = parseCliArgs(['--mode', 'embedded', '--provider', 'openai']);
-    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/--api-key-env/);
+    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/--api-key .*--api-key-env/);
+  });
+
+  it('rejects embedded mode with both --api-key and --api-key-env', async () => {
+    const args = parseCliArgs([
+      '--mode', 'embedded', '--provider', 'openai',
+      '--api-key', 'sk-x', '--api-key-env', 'OPENAI_API_KEY',
+    ]);
+    await expect(runNonInteractive(args, configPath)).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it('writes an embedded-mode config with an inline API key (--api-key)', async () => {
+    const args = parseCliArgs([
+      '--mode', 'embedded', '--provider', 'openai', '--api-key', 'sk-inline',
+    ]);
+    await runNonInteractive(args, configPath);
+    const cfg = await readBack();
+    const pc = cfg.plugins?.entries?.[PLUGIN_ID]?.config ?? {};
+    expect(pc.llmProvider).toBe('openai');
+    expect(pc.llmApiKey).toBe('sk-inline');
+    expect(typeof pc.llmApiKey).toBe('string');
   });
 
   it('clears stale fields when switching between modes', async () => {

--- a/hindsight-integrations/openclaw/src/setup.ts
+++ b/hindsight-integrations/openclaw/src/setup.ts
@@ -49,9 +49,11 @@ export interface ParsedCliArgs {
   configPath?: string;
   mode?: SetupMode;
   apiUrl?: string;
+  token?: string;
   tokenEnv?: string;
   noToken: boolean;
   provider?: string;
+  apiKey?: string;
   apiKeyEnv?: string;
   model?: string;
   positional?: string;
@@ -72,24 +74,29 @@ function usage(): string {
     '  --config-path <path>    Path to openclaw.json (default: ~/.openclaw/openclaw.json)',
     '  --mode <mode>           cloud | api | embedded (enables non-interactive mode)',
     '',
-    'Cloud mode:',
+    'Cloud mode (must pass exactly one of --token or --token-env):',
     `  --api-url <url>         Override the Hindsight Cloud URL (default: ${HINDSIGHT_CLOUD_URL})`,
-    '  --token-env <VAR>       Env var holding the cloud API token (required)',
+    '  --token <value>         Store the token inline in openclaw.json (simple)',
+    '  --token-env <VAR>       Reference an env var instead — resolved at startup',
+    '                          via SecretRef (keeps the secret off disk)',
     '',
-    'External API mode:',
+    'External API mode (token is optional; pass at most one of --token / --token-env / --no-token):',
     '  --api-url <url>         Hindsight API URL (required)',
-    '  --token-env <VAR>       Env var holding the API token (optional)',
+    '  --token <value>         Inline token value in openclaw.json',
+    '  --token-env <VAR>       Env var holding the token (SecretRef)',
     '  --no-token              Explicitly disable token auth',
     '',
-    'Embedded mode:',
+    'Embedded mode (for providers that need a key, pass exactly one of --api-key or --api-key-env):',
     `  --provider <id>         LLM provider: ${['openai', 'anthropic', 'gemini', 'groq', ...NO_KEY_PROVIDERS].join(' | ')}`,
-    '  --api-key-env <VAR>     Env var holding the LLM API key (required unless provider needs no key)',
+    '  --api-key <value>       Store the LLM API key inline in openclaw.json',
+    '  --api-key-env <VAR>     Env var holding the LLM API key (SecretRef)',
     '  --model <id>            Optional model override (otherwise uses the provider default)',
     '',
     '  -h, --help              Show this help',
     '',
     'Examples:',
     '  hindsight-openclaw-setup',
+    '  hindsight-openclaw-setup --mode cloud --token hsk_...',
     '  hindsight-openclaw-setup --mode cloud --token-env HINDSIGHT_CLOUD_TOKEN',
     '  hindsight-openclaw-setup --mode api --api-url https://mcp.hindsight.example.com --no-token',
     '  hindsight-openclaw-setup --mode embedded --provider openai --api-key-env OPENAI_API_KEY',
@@ -129,6 +136,9 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
       case '--api-url':
         args.apiUrl = next();
         break;
+      case '--token':
+        args.token = next();
+        break;
       case '--token-env':
         args.tokenEnv = next();
         break;
@@ -137,6 +147,9 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
         break;
       case '--provider':
         args.provider = next();
+        break;
+      case '--api-key':
+        args.apiKey = next();
         break;
       case '--api-key-env':
         args.apiKeyEnv = next();
@@ -163,14 +176,18 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
 // ---------------------------------------------------------------------------
 
 function buildCloudInput(args: ParsedCliArgs): CloudSetupInput {
-  if (!args.tokenEnv) {
-    throw new Error('--mode cloud requires --token-env <VAR>');
+  if (!args.token && !args.tokenEnv) {
+    throw new Error('--mode cloud requires --token <value> or --token-env <VAR>');
   }
-  if (!isValidEnvVarName(args.tokenEnv)) {
+  if (args.token && args.tokenEnv) {
+    throw new Error('--token and --token-env are mutually exclusive — pick one');
+  }
+  if (args.tokenEnv && !isValidEnvVarName(args.tokenEnv)) {
     throw new Error(`--token-env must be an UPPER_SNAKE_CASE env var name, got: ${args.tokenEnv}`);
   }
   return {
     apiUrl: args.apiUrl,
+    token: args.token,
     tokenEnvVar: args.tokenEnv,
   };
 }
@@ -179,14 +196,17 @@ function buildApiInput(args: ParsedCliArgs): ApiSetupInput {
   if (!args.apiUrl) {
     throw new Error('--mode api requires --api-url <url>');
   }
-  if (args.tokenEnv && args.noToken) {
-    throw new Error('--token-env and --no-token cannot both be set');
+  const credFlagCount =
+    (args.token ? 1 : 0) + (args.tokenEnv ? 1 : 0) + (args.noToken ? 1 : 0);
+  if (credFlagCount > 1) {
+    throw new Error('--token, --token-env, and --no-token are mutually exclusive — pick at most one');
   }
   if (args.tokenEnv && !isValidEnvVarName(args.tokenEnv)) {
     throw new Error(`--token-env must be an UPPER_SNAKE_CASE env var name, got: ${args.tokenEnv}`);
   }
   return {
     apiUrl: args.apiUrl,
+    token: args.token,
     tokenEnvVar: args.tokenEnv,
   };
 }
@@ -195,19 +215,23 @@ function buildEmbeddedInput(args: ParsedCliArgs): EmbeddedSetupInput {
   if (!args.provider) {
     throw new Error('--mode embedded requires --provider <id>');
   }
+  if (args.apiKey && args.apiKeyEnv) {
+    throw new Error('--api-key and --api-key-env are mutually exclusive — pick one');
+  }
   const needsKey = !NO_KEY_PROVIDERS.has(args.provider);
   if (needsKey) {
-    if (!args.apiKeyEnv) {
+    if (!args.apiKey && !args.apiKeyEnv) {
       throw new Error(
-        `--provider ${args.provider} requires --api-key-env <VAR> (providers that need no key: ${[...NO_KEY_PROVIDERS].join(', ')})`,
+        `--provider ${args.provider} requires --api-key <value> or --api-key-env <VAR> (providers that need no key: ${[...NO_KEY_PROVIDERS].join(', ')})`,
       );
     }
-    if (!isValidEnvVarName(args.apiKeyEnv)) {
+    if (args.apiKeyEnv && !isValidEnvVarName(args.apiKeyEnv)) {
       throw new Error(`--api-key-env must be an UPPER_SNAKE_CASE env var name, got: ${args.apiKeyEnv}`);
     }
   }
   return {
     llmProvider: args.provider,
+    apiKey: args.apiKey,
     apiKeyEnvVar: args.apiKeyEnv,
     llmModel: args.model,
   };
@@ -280,15 +304,13 @@ async function promptCloud(pluginConfig: Record<string, unknown>): Promise<strin
     apiUrl = custom;
   }
 
-  const tokenEnvVar = await p.text({
-    message: 'Environment variable holding your Hindsight Cloud API token',
-    placeholder: 'HINDSIGHT_CLOUD_TOKEN',
-    initialValue: 'HINDSIGHT_CLOUD_TOKEN',
-    validate: validateEnvVar,
+  const token = await p.password({
+    message: 'Hindsight Cloud API token (paste the value, it will be masked)',
+    validate: validateRequired('Token is required'),
   });
-  assertNotCancelled(tokenEnvVar);
+  assertNotCancelled(token);
 
-  const input = { apiUrl, tokenEnvVar };
+  const input = { apiUrl, token };
   applyCloudMode(pluginConfig, input);
   return summarizeCloud(input);
 }
@@ -307,19 +329,17 @@ async function promptApi(pluginConfig: Record<string, unknown>): Promise<string>
   });
   assertNotCancelled(needsToken);
 
-  let tokenEnvVar: string | undefined;
+  let token: string | undefined;
   if (needsToken) {
-    const value = await p.text({
-      message: 'Environment variable holding the API token',
-      placeholder: 'HINDSIGHT_API_TOKEN',
-      initialValue: 'HINDSIGHT_API_TOKEN',
-      validate: validateEnvVar,
+    const value = await p.password({
+      message: 'API token (paste the value, it will be masked)',
+      validate: validateRequired('Token is required'),
     });
     assertNotCancelled(value);
-    tokenEnvVar = value;
+    token = value;
   }
 
-  const input = { apiUrl, tokenEnvVar };
+  const input = { apiUrl, token };
   applyApiMode(pluginConfig, input);
   return summarizeApi(input);
 }
@@ -348,17 +368,14 @@ async function promptEmbedded(pluginConfig: Record<string, unknown>): Promise<st
   assertNotCancelled(provider);
   const llmProvider = provider as string;
 
-  let apiKeyEnvVar: string | undefined;
+  let apiKey: string | undefined;
   if (!NO_KEY_PROVIDERS.has(llmProvider)) {
-    const defaultEnvId = defaultApiKeyEnvVar(llmProvider);
-    const envId = await p.text({
-      message: `Environment variable holding your ${llmProvider} API key`,
-      placeholder: defaultEnvId,
-      initialValue: defaultEnvId,
-      validate: validateEnvVar,
+    const value = await p.password({
+      message: `${llmProvider} API key (paste the value, it will be masked)`,
+      validate: validateRequired('API key is required'),
     });
-    assertNotCancelled(envId);
-    apiKeyEnvVar = envId;
+    assertNotCancelled(value);
+    apiKey = value;
   }
 
   const overrideModel = await p.confirm({
@@ -378,7 +395,7 @@ async function promptEmbedded(pluginConfig: Record<string, unknown>): Promise<st
     llmModel = value;
   }
 
-  const input = { llmProvider, apiKeyEnvVar, llmModel };
+  const input = { llmProvider, apiKey, llmModel };
   applyEmbeddedMode(pluginConfig, input);
   return summarizeEmbedded(input);
 }
@@ -423,9 +440,13 @@ async function runInteractive(configPath: string): Promise<{ summary: string; co
       summary,
       '',
       'Next steps:',
-      '  1. Ensure any referenced env vars are exported in the shell that runs the gateway.',
-      '  2. Restart the gateway:  openclaw gateway restart',
-      '  3. Verify config:        openclaw config validate',
+      '  1. Restart the gateway:  openclaw gateway restart',
+      '  2. Verify config:        openclaw config validate',
+      '',
+      'Secrets were stored inline in openclaw.json. To reference an env var',
+      'instead (recommended for CI/production), use:',
+      '  openclaw config set plugins.entries.hindsight-openclaw.config.hindsightApiToken \\',
+      '      --ref-source env --ref-id HINDSIGHT_CLOUD_TOKEN',
     ].join('\n'),
     'Hindsight Memory configured',
   );

--- a/skills/hindsight-docs/references/changelog/integrations/openclaw.md
+++ b/skills/hindsight-docs/references/changelog/integrations/openclaw.md
@@ -8,6 +8,13 @@ import PageHero from '@site/src/components/PageHero';
 
 ← OpenClaw integration
 
+## 0.6.1 (Unreleased)
+
+**Improvements**
+
+- `hindsight-openclaw-setup` interactive wizard now asks for the API token/API key **value** instead of the env var name holding it. Pasted values are masked and stored inline in `openclaw.json` — no more two-step "pick an env var name, then export it" flow that confused first-time users. For CI / production, the SecretRef path is still available via the non-interactive flags (`--token-env`, `--api-key-env`) or after-the-fact with `openclaw config set ... --ref-source env --ref-id …`.
+- Added non-interactive CLI flags for direct-value credentials: `--token` (cloud / external API modes) and `--api-key` (embedded mode). `--token` and `--token-env` are mutually exclusive within a mode; same for `--api-key` / `--api-key-env`.
+
 ## [0.6.0](https://github.com/vectorize-io/hindsight/tree/integrations/openclaw/v0.6.0)
 
 **Breaking Changes**


### PR DESCRIPTION
## Summary

The 0.6.0 `hindsight-openclaw-setup` wizard asked first-time users for the **env var name** holding their API token ("Environment variable holding your Hindsight Cloud API token"). Real user feedback: people pasted the token value (or worse, the whole `NAME=value` pair), hit the UPPER_SNAKE_CASE validator, and had no idea the wizard wanted a name. This PR rewires the interactive flow to ask for the **value**.

## What changes

- **Interactive wizard**: `p.password()` (masked) prompt for the token / API key value. Cloud, External API, and Embedded modes all updated. The outro note tells users the secret was stored inline and shows the one-liner to switch to a `SecretRef` later.
- **Config shape**: `hindsightApiToken` / `llmApiKey` fields now accept either a literal string (stored inline) or a `SecretRef` object (unchanged). The plugin manifest already allowed both types and marks them sensitive, so `openclaw config get` continues to redact them regardless of storage shape.
- **Non-interactive CLI**: added direct-value flags alongside the existing env-var flags. Mutually exclusive within a mode:

  ```
  --token <value>       ← new: stores inline
  --token-env <VAR>     ← existing: SecretRef

  --api-key <value>     ← new: stores inline
  --api-key-env <VAR>   ← existing: SecretRef
  ```

- **Lib API**: `CloudSetupInput` / `ApiSetupInput` / `EmbeddedSetupInput` gained optional `token`/`apiKey` fields. `applyCloudMode` / `applyApiMode` / `applyEmbeddedMode` accept whichever is present; both-or-neither throws clearly.

## Test plan

- **142 unit tests pass** (was 127 pre-change; 15 new tests cover direct-value path + mutual-exclusivity errors across all three modes).
- **`scripts/smoke-test.sh` green end-to-end**: 7 setup variants (up from 4) + 5 negative tests (up from 3), asserts both inline-string and SecretRef values roundtrip.
- `tsc --noEmit` clean, `./scripts/hooks/lint.sh` clean, `./scripts/check-integration-lockfiles.sh` clean.
- Since credentials are sensitive, smoke-test reads the raw `openclaw.json` (not `openclaw config get`, which redacts) to verify direct-value storage.

## User impact

### Before (0.6.0)
```
◆  Environment variable holding your Hindsight Cloud API token
│  HINDSIGHT_CLOUD_TOKEN=hsk_abc123…      ← user pastes full pair
└  Must be an UPPER_SNAKE_CASE env var name   ← validation fails
```

### After (this PR)
```
◆  Hindsight Cloud API token (paste the value, it will be masked)
│  ••••••••••••••••••••
└
```

Then the token goes straight into `openclaw.json`, `openclaw config get` redacts it at read-time. For CI / production where storing inline is undesirable, `--token-env HINDSIGHT_CLOUD_TOKEN` (non-interactive) or `openclaw config set ... --ref-source env --ref-id HINDSIGHT_CLOUD_TOKEN` (after the fact) produce the SecretRef shape.

## Release

Changelog entry added as `0.6.1 (Unreleased)`. The release script can cut 0.6.1 post-merge via `./scripts/release-integration.sh openclaw 0.6.1`.