### PR TITLE
fix(embedded): add timeout to _cleanup lock acquisition

### DIFF
--- a/hindsight-all/hindsight/embedded.py
+++ b/hindsight-all/hindsight/embedded.py
@@ -190,12 +190,22 @@ class HindsightEmbedded:
         if self._closed:
             return
 
-        with self._lock:
+        acquired = self._lock.acquire(timeout=5.0)
+        if not acquired:
+            logger.warning(
+                "Cleanup lock acquisition timed out for profile '%s', "
+                "proceeding with best-effort cleanup",
+                self.profile,
+            )
+        try:
             if self._closed:
                 return
 
             if self._client is not None:
-                self._client.close()
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
                 self._client = None
 
             # Stop UI if it was started
@@ -209,6 +219,9 @@ class HindsightEmbedded:
                 self._manager.stop(self.profile)
 
             self._closed = True
+        finally:
+            if acquired:
+                self._lock.release()
 
     def close(self, stop_daemon: bool = False):
         """

--- a/hindsight-all/hindsight/embedded.py
+++ b/hindsight-all/hindsight/embedded.py
@@ -192,11 +192,17 @@ class HindsightEmbedded:
 
         acquired = self._lock.acquire(timeout=5.0)
         if not acquired:
+            # Lock is held by another thread (e.g. _ensure_started).
+            # Mark closed to prevent new operations but skip shared-state
+            # teardown — the daemon's idle timeout handles the rest.
             logger.warning(
-                "Cleanup lock acquisition timed out for profile '%s', "
-                "proceeding with best-effort cleanup",
+                "Cleanup lock acquisition timed out for profile '%s'; "
+                "marking closed, daemon will idle-stop on its own",
                 self.profile,
             )
+            self._closed = True
+            return
+
         try:
             if self._closed:
                 return
@@ -205,7 +211,11 @@ class HindsightEmbedded:
                 try:
                     self._client.close()
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Error closing client for profile '%s'",
+                        self.profile,
+                        exc_info=True,
+                    )
                 self._client = None
 
             # Stop UI if it was started
@@ -220,8 +230,7 @@ class HindsightEmbedded:
 
             self._closed = True
         finally:
-            if acquired:
-                self._lock.release()
+            self._lock.release()
 
     def close(self, stop_daemon: bool = False):
         """

--- a/hindsight-all/tests/test_cleanup_timeout.py
+++ b/hindsight-all/tests/test_cleanup_timeout.py
@@ -1,0 +1,56 @@
+"""
+Unit test for _cleanup lock timeout behavior.
+
+Verifies that _cleanup completes even when the lock is held by another thread,
+instead of hanging indefinitely (fixes #952).
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_cleanup_completes_when_lock_held():
+    """
+    _cleanup should complete (best-effort) even when self._lock is held
+    by another thread, e.g. during a long _ensure_started call.
+    """
+    with patch.dict("sys.modules", {
+        "hindsight_client": MagicMock(),
+        "hindsight_embed": MagicMock(),
+        "hindsight.api_namespaces": MagicMock(),
+    }):
+        from hindsight.embedded import HindsightEmbedded
+
+        client = HindsightEmbedded.__new__(HindsightEmbedded)
+        client.profile = "test"
+        client._lock = threading.Lock()
+        client._closed = False
+        client._client = None
+        client._started = False
+        client._ui = False
+
+        # Simulate another thread holding the lock
+        client._lock.acquire()
+
+        cleanup_done = threading.Event()
+
+        def run_cleanup():
+            client._cleanup()
+            cleanup_done.set()
+
+        t = threading.Thread(target=run_cleanup)
+        t.start()
+
+        # Cleanup should complete within the timeout (5s) + margin
+        assert cleanup_done.wait(timeout=8.0), (
+            "_cleanup hung instead of timing out on lock acquisition"
+        )
+
+        # Release the lock from the simulating thread
+        client._lock.release()
+        t.join(timeout=1.0)
+
+        assert client._closed, "Client should be marked as closed after cleanup"


### PR DESCRIPTION
## Summary

Fixes #1022 (originally reported in #952).

`HindsightEmbedded._cleanup()` acquires `self._lock` with a bare `with` statement. When SIGINT fires while another thread holds the lock (e.g. `_ensure_started` mid-operation), the shutdown path hangs indefinitely. A second Ctrl+C force-kills with an unhandled `KeyboardInterrupt` traceback.

**Fix**: Replace bare `with self._lock:` with `self._lock.acquire(timeout=5.0)`:
- **Lock acquired**: full teardown runs as before (client close, UI stop, daemon stop)
- **Lock timeout**: only sets `self._closed = True` to prevent new operations, then returns. Shared-state teardown is skipped — the daemon's idle timeout handles cleanup on its own. This avoids racing with the thread that holds the lock.

Also logs `client.close()` exceptions at DEBUG level instead of silently ignoring them.

## Changes

- `hindsight-all/hindsight/embedded.py`: timeout-guarded lock in `_cleanup()`
- `hindsight-all/tests/test_cleanup_timeout.py`: unit test verifying cleanup completes when lock is held

## Test plan

- [ ] New unit test `test_cleanup_completes_when_lock_held` passes
- [ ] Existing `test_embedded.py` integration tests unaffected
- [ ] Manual: start HindsightEmbedded, Ctrl+C mid-operation → exits within 5s