### PR TITLE
fix(openclaw): follow up review feedback on session identity guardrails

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -8,6 +8,12 @@ import {
   composeRecallQuery,
   truncateRecallQuery,
   buildRetainRequest,
+  parseSessionKey,
+  extractTelegramDirectSenderId,
+  resolveSessionIdentity,
+  getIdentitySkipReason,
+  isEphemeralOperationalText,
+  deriveBankId,
 } from './index.js';
 import type { PluginConfig, MemoryResult } from './types.js';
 
@@ -498,6 +504,90 @@ describe('truncateRecallQuery', () => {
     const truncated = truncateRecallQuery(composed, latest, 180);
     expect(truncated).toContain(latest);
     expect(truncated.length).toBeLessThanOrEqual(180);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// session identity + operational guardrails
+// ---------------------------------------------------------------------------
+
+describe('session identity helpers', () => {
+  const baseConfig: PluginConfig = {
+    dynamicBankId: true,
+    dynamicBankGranularity: ['agent', 'channel', 'user'],
+  };
+
+  it('parses main sessions', () => {
+    expect(parseSessionKey('agent:main:main')).toEqual({
+      agentId: 'main',
+      provider: 'main',
+      channel: 'main',
+    });
+  });
+
+  it('parses operational cron-like sessions', () => {
+    expect(parseSessionKey('agent:worker:cron:nightly:cleanup')).toEqual({
+      agentId: 'worker',
+      provider: 'cron',
+      channel: 'nightly:cleanup',
+    });
+  });
+
+  it('extracts telegram direct sender ids from channel ids', () => {
+    expect(extractTelegramDirectSenderId('direct:12345')).toBe('12345');
+    expect(extractTelegramDirectSenderId('group:12345')).toBeUndefined();
+  });
+
+  it('resolves telegram direct identity from session key when senderId is missing', () => {
+    const resolved = resolveSessionIdentity({
+      agentId: 'main',
+      sessionKey: 'agent:main:telegram:direct:12345',
+    });
+
+    expect(resolved).toMatchObject({
+      agentId: 'main',
+      messageProvider: 'telegram',
+      channelId: 'direct:12345',
+      senderId: '12345',
+    });
+  });
+
+  it('derives bank ids from resolved telegram direct identity', () => {
+    const bankId = deriveBankId(
+      {
+        agentId: 'main',
+        sessionKey: 'agent:main:telegram:direct:12345',
+      },
+      baseConfig,
+    );
+
+    expect(bankId).toBe('main::direct%3A12345::12345');
+  });
+
+  it('marks operational main sessions as skippable', () => {
+    const result = getIdentitySkipReason({ sessionKey: 'agent:main:main' });
+    expect(result.reason).toBe('internal main session agent:main:main');
+  });
+
+  it('marks telegram direct sender mismatches as skippable', () => {
+    const result = getIdentitySkipReason({
+      sessionKey: 'agent:main:telegram:direct:12345',
+      messageProvider: 'telegram',
+      channelId: 'direct:12345',
+      senderId: '99999',
+    });
+
+    expect(result.reason).toContain('telegram direct identity mismatch');
+  });
+
+  it('detects ephemeral operational text with or without transcript wrappers', () => {
+    expect(isEphemeralOperationalText('A new session was started via /reset.')).toBe(true);
+    expect(
+      isEphemeralOperationalText(
+        '[role: user]\nA new session was started via /new.\n[user:end]',
+      ),
+    ).toBe(true);
+    expect(isEphemeralOperationalText('Tell me what I said about dark mode.')).toBe(false);
   });
 });
 

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -300,6 +300,19 @@ describe('buildRetainRequest', () => {
     expect(request.metadata?.source).toBe('openclaw');
     expect(request.tags).toBeUndefined();
   });
+
+  it('preserves provider fallback without backfilling channel_type from the session key', () => {
+    const request = buildRetainRequest('hello world', 1, {
+      sessionKey: 'agent:main:telegram:direct:12345',
+    }, {}, 1700000000000, { turnIndex: 1 });
+
+    expect(request.metadata).toMatchObject({
+      provider: 'telegram',
+      channel_type: undefined,
+      channel_id: 'direct:12345',
+      sender_id: '12345',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -566,10 +579,49 @@ describe('session identity helpers', () => {
 
   it('marks operational main sessions as skippable', () => {
     const result = getIdentitySkipReason({ sessionKey: 'agent:main:main' });
-    expect(result.reason).toBe('internal main session agent:main:main');
+    expect(result.reason).toEqual({
+      kind: 'final',
+      detail: 'internal main session agent:main:main',
+    });
   });
 
-  it('marks telegram direct sender mismatches as skippable', () => {
+  it.each([
+    'agent:worker:cron:nightly:cleanup',
+    'agent:worker:heartbeat:node-1',
+    'agent:worker:subagent:abc123',
+  ])('marks operational sessions as final skips: %s', (sessionKey) => {
+    const result = getIdentitySkipReason({ sessionKey });
+    expect(result.reason).toEqual({
+      kind: 'final',
+      detail: `operational session ${sessionKey}`,
+    });
+  });
+
+  it('marks temp sessions as final skips', () => {
+    const result = getIdentitySkipReason({ sessionKey: 'temp:compose:123' });
+    expect(result.reason).toEqual({
+      kind: 'final',
+      detail: 'ephemeral temp session temp:compose:123',
+    });
+  });
+
+  it('marks missing provider as retryable', () => {
+    const result = getIdentitySkipReason({ senderId: '12345' });
+    expect(result.reason).toEqual({
+      kind: 'retryable',
+      detail: 'missing stable message provider',
+    });
+  });
+
+  it('marks missing sender as retryable', () => {
+    const result = getIdentitySkipReason({ messageProvider: 'telegram', channelId: 'group:12345' });
+    expect(result.reason).toEqual({
+      kind: 'retryable',
+      detail: 'missing stable sender identity',
+    });
+  });
+
+  it('marks telegram direct sender mismatches as final skips', () => {
     const result = getIdentitySkipReason({
       sessionKey: 'agent:main:telegram:direct:12345',
       messageProvider: 'telegram',
@@ -577,7 +629,10 @@ describe('session identity helpers', () => {
       senderId: '99999',
     });
 
-    expect(result.reason).toContain('telegram direct identity mismatch');
+    expect(result.reason).toEqual({
+      kind: 'final',
+      detail: 'telegram direct identity mismatch (direct:12345 vs 99999)',
+    });
   });
 
   it('detects ephemeral operational text with or without transcript wrappers', () => {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -132,6 +132,11 @@ const DEFAULT_RECALL_TIMEOUT_MS = 10_000;
 // Cache sender IDs discovered in before_prompt_build (where event.prompt has the metadata
 // blocks) so agent_end can look them up — event.messages in agent_end is clean history.
 const senderIdBySession = new Map<string, string>();
+const sessionIdentityBySession = new Map<
+  string,
+  Pick<PluginHookAgentContext, 'senderId' | 'messageProvider' | 'channelId'>
+>();
+const skipHindsightTurnBySession = new Map<string, string>();
 const documentSequenceBySession = new Map<string, number>();
 
 // Guard against duplicate hook registration within a single runtime load.
@@ -583,18 +588,28 @@ export function truncateRecallQuery(query: string, latestQuery: string, maxChars
 }
 
 /**
- * Derive a bank ID from the agent context.
- * Uses configurable dynamicBankGranularity to determine bank segmentation.
- * Falls back to default bank when context is unavailable.
- */
-/**
  * Parse the OpenClaw sessionKey to extract context fields.
  * Format: "agent:{agentId}:{provider}:{channelType}:{channelId}[:{extra}]"
  * Example: "agent:c0der:telegram:group:-1003825475854:topic:42"
  */
-function parseSessionKey(sessionKey: string): { agentId?: string; provider?: string; channel?: string } {
+export function parseSessionKey(sessionKey: string): { agentId?: string; provider?: string; channel?: string } {
   const parts = sessionKey.split(':');
-  if (parts.length < 5 || parts[0] !== 'agent') return {};
+  if (parts[0] !== 'agent') return {};
+  if (parts.length === 3 && parts[2] === 'main') {
+    return {
+      agentId: parts[1],
+      provider: 'main',
+      channel: 'main',
+    };
+  }
+  if (parts.length >= 4 && ['cron', 'heartbeat', 'subagent'].includes(parts[2])) {
+    return {
+      agentId: parts[1],
+      provider: parts[2],
+      channel: parts.slice(3).join(':'),
+    };
+  }
+  if (parts.length < 5) return {};
   // parts[1] = agentId, parts[2] = provider, parts[3] = channelType, parts[4..] = channelId + extras
   return {
     agentId: parts[1],
@@ -604,6 +619,105 @@ function parseSessionKey(sessionKey: string): { agentId?: string; provider?: str
   };
 }
 
+export function extractTelegramDirectSenderId(channelId: string | undefined): string | undefined {
+  if (typeof channelId !== 'string') return undefined;
+  const match = channelId.match(/^direct:([^:]+)$/);
+  return match?.[1];
+}
+
+export function resolveSessionIdentity(
+  ctx: PluginHookAgentContext | undefined,
+): PluginHookAgentContext | undefined {
+  if (!ctx) return undefined;
+
+  const sessionParsed = ctx.sessionKey ? parseSessionKey(ctx.sessionKey) : {};
+  const messageProvider = ctx.messageProvider || sessionParsed.provider;
+  const channelId = ctx.channelId || sessionParsed.channel;
+  const senderId =
+    ctx.senderId ||
+    (messageProvider === 'telegram' ? extractTelegramDirectSenderId(channelId) : undefined);
+
+  return {
+    ...ctx,
+    agentId: ctx.agentId || sessionParsed.agentId,
+    messageProvider,
+    channelId,
+    senderId,
+  };
+}
+
+export function getIdentitySkipReason(
+  ctx: PluginHookAgentContext | undefined,
+): { resolvedCtx: PluginHookAgentContext | undefined; reason?: string } {
+  const resolvedCtx = resolveSessionIdentity(ctx);
+  const sessionKey = resolvedCtx?.sessionKey;
+
+  if (typeof sessionKey === 'string') {
+    if (/^agent:[^:]+:(cron|heartbeat|subagent):/i.test(sessionKey)) {
+      return { resolvedCtx, reason: `operational session ${sessionKey}` };
+    }
+    if (/^agent:[^:]+:main$/i.test(sessionKey)) {
+      return { resolvedCtx, reason: `internal main session ${sessionKey}` };
+    }
+    if (/^temp:/i.test(sessionKey)) {
+      return { resolvedCtx, reason: `ephemeral temp session ${sessionKey}` };
+    }
+  }
+
+  if (resolvedCtx?.messageProvider && ['cron', 'heartbeat', 'subagent', 'main'].includes(resolvedCtx.messageProvider)) {
+    return { resolvedCtx, reason: `operational provider ${resolvedCtx.messageProvider}` };
+  }
+  if (!resolvedCtx?.messageProvider || resolvedCtx.messageProvider === 'unknown') {
+    return { resolvedCtx, reason: 'missing stable message provider' };
+  }
+  if (!resolvedCtx?.senderId || resolvedCtx.senderId === 'anonymous') {
+    return { resolvedCtx, reason: 'missing stable sender identity' };
+  }
+  if (
+    resolvedCtx.messageProvider === 'telegram' &&
+    typeof resolvedCtx.channelId === 'string' &&
+    resolvedCtx.channelId.startsWith('direct:')
+  ) {
+    const directSenderId = extractTelegramDirectSenderId(resolvedCtx.channelId);
+    if (!directSenderId || directSenderId !== resolvedCtx.senderId) {
+      return {
+        resolvedCtx,
+        reason: `telegram direct identity mismatch (${resolvedCtx.channelId} vs ${resolvedCtx.senderId})`,
+      };
+    }
+  }
+
+  return { resolvedCtx, reason: undefined };
+}
+
+export function isEphemeralOperationalText(text: string | undefined): boolean {
+  if (!text || typeof text !== 'string') return false;
+
+  const normalized = text
+    .replace(/\[role:\s*[^\]]+\]\s*/gi, '')
+    .replace(/\[[a-z]+:end\]\s*/gi, '')
+    .trim();
+
+  return [
+    /^A new session was started via \/(?:new|reset)\./i,
+    /^Based on this conversation, generate a short 1-2/i,
+    /^This (?:script|task|job|workflow) updates .* index/i,
+  ].some(pattern => pattern.test(normalized));
+}
+
+function setCappedMapValue<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.set(key, value);
+  if (map.size > MAX_TRACKED_SESSIONS) {
+    const oldest = map.keys().next().value;
+    if (oldest) map.delete(oldest);
+  }
+}
+
+/**
+ * Derive a bank ID from the agent context.
+ * Uses configurable dynamicBankGranularity to determine bank segmentation.
+ * Falls back to default bank when context is unavailable.
+ */
 export function deriveBankId(ctx: PluginHookAgentContext | undefined, pluginConfig: PluginConfig): string {
   if (pluginConfig.dynamicBankId === false) {
     return getStaticBankId(pluginConfig);
@@ -614,6 +728,7 @@ export function deriveBankId(ctx: PluginHookAgentContext | undefined, pluginConf
     return getDefaultBankId(pluginConfig);
   }
 
+  const resolvedCtx = resolveSessionIdentity(ctx);
   const fields = pluginConfig.dynamicBankGranularity?.length ? pluginConfig.dynamicBankGranularity : ['agent', 'channel', 'user'];
 
   // Validate field names at runtime — typos silently produce 'unknown' segments
@@ -625,18 +740,18 @@ export function deriveBankId(ctx: PluginHookAgentContext | undefined, pluginConf
   }
 
   // Parse sessionKey as fallback when direct context fields are missing
-  const sessionParsed = ctx?.sessionKey ? parseSessionKey(ctx.sessionKey) : {};
+  const sessionParsed = resolvedCtx?.sessionKey ? parseSessionKey(resolvedCtx.sessionKey) : {};
 
   // Warn when 'user' is in active fields but senderId is missing — bank ID will contain "anonymous"
-  if (fields.includes('user') && ctx && !ctx.senderId) {
+  if (fields.includes('user') && resolvedCtx && !resolvedCtx.senderId) {
     debug('[Hindsight] senderId not available in context — bank ID will use "anonymous". Ensure your OpenClaw provider passes senderId.');
   }
 
   const fieldMap: Record<string, string> = {
-    agent: ctx?.agentId || sessionParsed.agentId || 'default',
-    channel: ctx?.channelId || sessionParsed.channel || 'unknown',
-    user: ctx?.senderId || 'anonymous',
-    provider: ctx?.messageProvider || sessionParsed.provider || 'unknown',
+    agent: resolvedCtx?.agentId || sessionParsed.agentId || 'default',
+    channel: resolvedCtx?.channelId || sessionParsed.channel || 'unknown',
+    user: resolvedCtx?.senderId || 'anonymous',
+    provider: resolvedCtx?.messageProvider || sessionParsed.provider || 'unknown',
   };
 
   const baseBankId = fields
@@ -1197,6 +1312,51 @@ export default function (api: MoltbotPluginAPI) {
     debug('[Hindsight] Registering agent hooks...');
     log.info('registering agent hooks');
 
+    api.on('before_agent_start', async (event: any, ctx?: PluginHookAgentContext) => {
+      try {
+        const sessionKey = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);
+        const baseCtx = ctx || (sessionKey ? ({ sessionKey } as PluginHookAgentContext) : undefined);
+        const cachedSessionIdentity = sessionKey ? sessionIdentityBySession.get(sessionKey) : undefined;
+        const effectiveCtx = resolveSessionIdentity(
+          cachedSessionIdentity
+            ? {
+                ...baseCtx,
+                senderId: baseCtx?.senderId || cachedSessionIdentity.senderId,
+                messageProvider: cachedSessionIdentity.messageProvider ?? baseCtx?.messageProvider,
+                channelId: cachedSessionIdentity.channelId ?? baseCtx?.channelId,
+              }
+            : baseCtx,
+        );
+
+        if (sessionKey && effectiveCtx && (effectiveCtx.messageProvider || effectiveCtx.channelId || effectiveCtx.senderId)) {
+          setCappedMapValue(sessionIdentityBySession, sessionKey, {
+            senderId: effectiveCtx.senderId,
+            messageProvider: effectiveCtx.messageProvider,
+            channelId: effectiveCtx.channelId,
+          });
+          if (effectiveCtx.senderId) {
+            setCappedMapValue(senderIdBySession, sessionKey, effectiveCtx.senderId);
+          }
+        }
+
+        const { resolvedCtx, reason } = getIdentitySkipReason(effectiveCtx);
+        if (sessionKey && reason) {
+          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
+          debug(`[Hindsight] before_agent_start skipping session ${sessionKey}: ${reason}`);
+          return;
+        }
+        if (!resolvedCtx) {
+          return;
+        }
+        if (sessionKey) {
+          skipHindsightTurnBySession.delete(sessionKey);
+        }
+        const bankId = deriveBankId(resolvedCtx, pluginConfig);
+        debug(`[Hindsight] before_agent_start - bank: ${bankId}, channel: ${resolvedCtx.messageProvider}/${resolvedCtx.channelId}`);
+      } catch (error) {
+        log.warn(`before_agent_start identity resolution error: ${error}`);
+      }
+    });
     // Auto-recall: Inject relevant memories before agent processes the message
     // Hook signature: (event, ctx) where event has {prompt, messages?} and ctx has agent context
     api.on('before_prompt_build', async (event: any, ctx?: PluginHookAgentContext) => {
@@ -1231,25 +1391,54 @@ export default function (api: MoltbotPluginAPI) {
           return;
         }
 
-        // Derive bank ID from context — enrich ctx.senderId from the inbound metadata
-        // block when it's missing (agent-phase hooks don't carry senderId in ctx directly).
-        const senderIdFromPrompt = !ctx?.senderId ? extractSenderIdFromText(event.prompt ?? event.rawMessage ?? '') : undefined;
-        const effectiveCtxForRecall = senderIdFromPrompt ? { ...ctx, senderId: senderIdFromPrompt } : ctx;
+        const sessionKeyForCache = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);
+        const skipTurnReason = sessionKeyForCache ? skipHindsightTurnBySession.get(sessionKeyForCache) : undefined;
+        const canRetryIdentityResolution = typeof skipTurnReason === 'string' && skipTurnReason.startsWith('missing stable ');
+        if (skipTurnReason && !canRetryIdentityResolution) {
+          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${skipTurnReason}`);
+          return;
+        }
 
-        // Cache the resolved sender ID keyed by sessionKey so agent_end can use it.
-        // event.messages in agent_end is clean history without the metadata blocks.
-        const resolvedSenderId = effectiveCtxForRecall?.senderId;
-        const sessionKeyForCache = ctx?.sessionKey;
-        if (resolvedSenderId && sessionKeyForCache) {
-          senderIdBySession.set(sessionKeyForCache, resolvedSenderId);
-          if (senderIdBySession.size > MAX_TRACKED_SESSIONS) {
-            const oldest = senderIdBySession.keys().next().value;
-            if (oldest) senderIdBySession.delete(oldest);
+        const cachedSessionIdentity = sessionKeyForCache ? sessionIdentityBySession.get(sessionKeyForCache) : undefined;
+        const senderIdFromPrompt = !ctx?.senderId ? extractSenderIdFromText(event.prompt ?? event.rawMessage ?? '') : undefined;
+        let effectiveCtxForRecall = ctx;
+        if (cachedSessionIdentity) {
+          effectiveCtxForRecall = {
+            ...effectiveCtxForRecall,
+            senderId: effectiveCtxForRecall?.senderId || cachedSessionIdentity.senderId || senderIdFromPrompt,
+            messageProvider: cachedSessionIdentity.messageProvider ?? effectiveCtxForRecall?.messageProvider,
+            channelId: cachedSessionIdentity.channelId ?? effectiveCtxForRecall?.channelId,
+          };
+        } else if (senderIdFromPrompt) {
+          effectiveCtxForRecall = { ...effectiveCtxForRecall, senderId: senderIdFromPrompt };
+        }
+
+        const resolvedCtxForRecall = resolveSessionIdentity(effectiveCtxForRecall);
+        if (resolvedCtxForRecall && sessionKeyForCache && (resolvedCtxForRecall.messageProvider || resolvedCtxForRecall.channelId || resolvedCtxForRecall.senderId)) {
+          setCappedMapValue(sessionIdentityBySession, sessionKeyForCache, {
+            senderId: resolvedCtxForRecall.senderId,
+            messageProvider: resolvedCtxForRecall.messageProvider,
+            channelId: resolvedCtxForRecall.channelId,
+          });
+          if (resolvedCtxForRecall.senderId) {
+            setCappedMapValue(senderIdBySession, sessionKeyForCache, resolvedCtxForRecall.senderId);
           }
         }
 
-        const bankId = deriveBankId(effectiveCtxForRecall, pluginConfig);
-        debug(`[Hindsight] before_prompt_build - bank: ${bankId}, channel: ${ctx?.messageProvider}/${ctx?.channelId}`);
+        const { reason: identitySkipReason } = getIdentitySkipReason(resolvedCtxForRecall);
+        if (identitySkipReason) {
+          if (sessionKeyForCache) {
+            setCappedMapValue(skipHindsightTurnBySession, sessionKeyForCache, identitySkipReason);
+          }
+          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${identitySkipReason}`);
+          return;
+        }
+        if (sessionKeyForCache) {
+          skipHindsightTurnBySession.delete(sessionKeyForCache);
+        }
+
+        const bankId = deriveBankId(resolvedCtxForRecall, pluginConfig);
+        debug(`[Hindsight] before_prompt_build - bank: ${bankId}, channel: ${resolvedCtxForRecall?.messageProvider}/${resolvedCtxForRecall?.channelId}`);
         debug(`[Hindsight] event keys: ${Object.keys(event).join(', ')}`);
         debug(`[Hindsight] event.context keys: ${Object.keys(event.context ?? {}).join(', ')}`);
 
@@ -1259,6 +1448,10 @@ export default function (api: MoltbotPluginAPI) {
         const extracted = extractRecallQuery(event.rawMessage, event.prompt);
         if (!extracted) {
           debug('[Hindsight] extractRecallQuery returned null, skipping recall');
+          return;
+        }
+        if (isEphemeralOperationalText(extracted)) {
+          debug('[Hindsight] Recall query is operational/ephemeral noise, skipping recall');
           return;
         }
         debug(`[Hindsight] extractRecallQuery result length: ${extracted.length}`);
@@ -1289,7 +1482,7 @@ export default function (api: MoltbotPluginAPI) {
         await clientGlobal.waitForReady();
 
         // Get client configured for this context's bank (async to handle mission setup)
-        const client = await clientGlobal.getClientForContext(effectiveCtxForRecall);
+        const client = await clientGlobal.getClientForContext(resolvedCtxForRecall);
         if (!client) {
           debug('[Hindsight] Client not initialized, skipping auto-recall');
           return;
@@ -1392,15 +1585,58 @@ ${memoriesFormatted}
           }
         }
 
-        // Derive bank ID from context — enrich ctx.senderId from the session cache.
-        // event.messages in agent_end is clean history without OpenClaw's metadata blocks;
-        // the sender ID was captured during before_prompt_build where event.prompt has them.
         const sessionKeyForLookup = effectiveCtx?.sessionKey;
+        const skipTurnReason = sessionKeyForLookup ? skipHindsightTurnBySession.get(sessionKeyForLookup) : undefined;
+        const canRetryIdentityResolution = typeof skipTurnReason === 'string' && skipTurnReason.startsWith('missing stable ');
+        if (skipTurnReason && !canRetryIdentityResolution) {
+          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${skipTurnReason}`);
+          if (sessionKeyForLookup) {
+            skipHindsightTurnBySession.delete(sessionKeyForLookup);
+          }
+          return;
+        }
+
+        const cachedSessionIdentity = sessionKeyForLookup ? sessionIdentityBySession.get(sessionKeyForLookup) : undefined;
         const senderIdFromCache = !effectiveCtx?.senderId && sessionKeyForLookup
           ? senderIdBySession.get(sessionKeyForLookup)
           : undefined;
-        const effectiveCtxForRetain = senderIdFromCache ? { ...effectiveCtx, senderId: senderIdFromCache } : effectiveCtx;
-        const bankId = deriveBankId(effectiveCtxForRetain, pluginConfig);
+        let effectiveCtxForRetain = effectiveCtx;
+        if (cachedSessionIdentity) {
+          effectiveCtxForRetain = {
+            ...effectiveCtxForRetain,
+            senderId: effectiveCtxForRetain?.senderId || cachedSessionIdentity.senderId || senderIdFromCache,
+            messageProvider: cachedSessionIdentity.messageProvider ?? effectiveCtxForRetain?.messageProvider,
+            channelId: cachedSessionIdentity.channelId ?? effectiveCtxForRetain?.channelId,
+          };
+        } else if (senderIdFromCache) {
+          effectiveCtxForRetain = { ...effectiveCtxForRetain, senderId: senderIdFromCache };
+        }
+
+        const resolvedCtxForRetain = resolveSessionIdentity(effectiveCtxForRetain);
+        if (resolvedCtxForRetain && sessionKeyForLookup && (resolvedCtxForRetain.messageProvider || resolvedCtxForRetain.channelId || resolvedCtxForRetain.senderId)) {
+          setCappedMapValue(sessionIdentityBySession, sessionKeyForLookup, {
+            senderId: resolvedCtxForRetain.senderId,
+            messageProvider: resolvedCtxForRetain.messageProvider,
+            channelId: resolvedCtxForRetain.channelId,
+          });
+          if (resolvedCtxForRetain.senderId) {
+            setCappedMapValue(senderIdBySession, sessionKeyForLookup, resolvedCtxForRetain.senderId);
+          }
+        }
+
+        const { reason: identitySkipReason } = getIdentitySkipReason(resolvedCtxForRetain);
+        if (identitySkipReason) {
+          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${identitySkipReason}`);
+          if (sessionKeyForLookup) {
+            skipHindsightTurnBySession.delete(sessionKeyForLookup);
+          }
+          return;
+        }
+        if (sessionKeyForLookup) {
+          skipHindsightTurnBySession.delete(sessionKeyForLookup);
+        }
+
+        const bankId = deriveBankId(resolvedCtxForRetain, pluginConfig);
         debug(`[Hindsight Hook] agent_end triggered - bank: ${bankId}`);
 
         if (event.success === false) {
@@ -1427,13 +1663,7 @@ ${memoriesFormatted}
         if (retainEveryN > 1) {
           const sessionTrackingKey = `${bankId}:${effectiveCtx?.sessionKey || 'session'}`;
           const turnCount = (turnCountBySession.get(sessionTrackingKey) || 0) + 1;
-          turnCountBySession.set(sessionTrackingKey, turnCount);
-          if (turnCountBySession.size > MAX_TRACKED_SESSIONS) {
-            const oldestKey = turnCountBySession.keys().next().value;
-            if (oldestKey) {
-              turnCountBySession.delete(oldestKey);
-            }
-          }
+          setCappedMapValue(turnCountBySession, sessionTrackingKey, turnCount);
 
           if (turnCount % retainEveryN !== 0) {
             const nextRetainAt = Math.ceil(turnCount / retainEveryN) * retainEveryN;
@@ -1458,6 +1688,11 @@ ${memoriesFormatted}
         }
         const { transcript, messageCount } = retention;
 
+        if (isEphemeralOperationalText(transcript)) {
+          debug('[Hindsight Hook] Transcript is operational/ephemeral noise, skipping retention');
+          return;
+        }
+
         // Wait for client to be ready
         const clientGlobal = (global as any).__hindsightClient;
         if (!clientGlobal) {
@@ -1468,7 +1703,7 @@ ${memoriesFormatted}
         await clientGlobal.waitForReady();
 
         // Get client configured for this context's bank (async to handle mission setup)
-        const client = await clientGlobal.getClientForContext(effectiveCtxForRetain);
+        const client = await clientGlobal.getClientForContext(resolvedCtxForRetain);
         if (!client) {
           log.warn('client not initialized, skipping retain');
           return;
@@ -1479,7 +1714,7 @@ ${memoriesFormatted}
         const retainRequest = buildRetainRequest(
           transcript,
           messageCount,
-          effectiveCtxForRetain,
+          resolvedCtxForRetain,
           pluginConfig,
           retainNow,
           {
@@ -1544,13 +1779,7 @@ function getSessionDocumentBase(effectiveCtx: PluginHookAgentContext | undefined
 function nextDocumentSequence(effectiveCtx: PluginHookAgentContext | undefined): number {
   const sequenceKey = effectiveCtx?.sessionKey || 'session';
   const next = (documentSequenceBySession.get(sequenceKey) || 0) + 1;
-  documentSequenceBySession.set(sequenceKey, next);
-  if (documentSequenceBySession.size > MAX_TRACKED_SESSIONS) {
-    const oldestKey = documentSequenceBySession.keys().next().value;
-    if (oldestKey) {
-      documentSequenceBySession.delete(oldestKey);
-    }
-  }
+  setCappedMapValue(documentSequenceBySession, sequenceKey, next);
   return next;
 }
 
@@ -1568,14 +1797,15 @@ export function buildRetainRequest(
   now = Date.now(),
   options?: { retentionScope?: 'turn' | 'window' | 'manual'; windowTurns?: number; turnIndex?: number },
 ): RetainRequest {
-  const parsedSession = effectiveCtx?.sessionKey ? parseSessionKey(effectiveCtx.sessionKey) : {};
-  const turnIndex = options?.turnIndex ?? nextDocumentSequence(effectiveCtx);
+  const resolvedCtx = resolveSessionIdentity(effectiveCtx);
+  const parsedSession = resolvedCtx?.sessionKey ? parseSessionKey(resolvedCtx.sessionKey) : {};
+  const turnIndex = options?.turnIndex ?? nextDocumentSequence(resolvedCtx);
   const retentionScope = options?.retentionScope || 'turn';
-  const documentBase = getSessionDocumentBase(effectiveCtx);
+  const documentBase = getSessionDocumentBase(resolvedCtx);
   const documentKind = retentionScope === 'window' ? 'window' : 'turn';
   const documentId = `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, '0')}`;
-  const channelId = effectiveCtx?.channelId || parsedSession.channel;
-  const provider = effectiveCtx?.messageProvider || parsedSession.provider;
+  const channelId = resolvedCtx?.channelId || parsedSession.channel;
+  const provider = resolvedCtx?.messageProvider || parsedSession.provider;
   const threadId = extractThreadId(channelId);
 
   return {
@@ -1587,13 +1817,13 @@ export function buildRetainRequest(
       source: pluginConfig.retainSource || 'openclaw',
       retention_scope: retentionScope,
       turn_index: String(turnIndex),
-      session_key: effectiveCtx?.sessionKey,
-      agent_id: effectiveCtx?.agentId || parsedSession.agentId,
+      session_key: resolvedCtx?.sessionKey,
+      agent_id: resolvedCtx?.agentId || parsedSession.agentId,
       provider,
-      channel_type: effectiveCtx?.messageProvider,
+      channel_type: provider,
       channel_id: channelId,
       thread_id: threadId,
-      sender_id: effectiveCtx?.senderId,
+      sender_id: resolvedCtx?.senderId,
       ...(options?.windowTurns !== undefined ? { window_turns: String(options.windowTurns) } : {}),
     },
     tags: pluginConfig.retainTags && pluginConfig.retainTags.length > 0 ? pluginConfig.retainTags : undefined,

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1312,6 +1312,65 @@ export default function (api: MoltbotPluginAPI) {
     debug('[Hindsight] Registering agent hooks...');
     log.info('registering agent hooks');
 
+    api.on('before_dispatch', async (event: any, ctx?: PluginHookAgentContext) => {
+      try {
+        const sessionKey = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);
+        if (!sessionKey) {
+          return;
+        }
+
+        const parsedSession = parseSessionKey(sessionKey);
+        const dispatchChannel =
+          (typeof event?.channel === 'string' ? event.channel : undefined) ||
+          ctx?.messageProvider ||
+          parsedSession.provider;
+        const dispatchCtx = resolveSessionIdentity({
+          ...ctx,
+          sessionKey,
+          agentId: ctx?.agentId || parsedSession.agentId,
+          messageProvider: ctx?.messageProvider ?? parsedSession.provider ?? dispatchChannel,
+          channelId: ctx?.channelId || parsedSession.channel,
+          senderId:
+            (typeof event?.senderId === 'string' ? event.senderId : undefined) ||
+            ctx?.senderId,
+        });
+
+        const surfaceMismatch = Boolean(
+          parsedSession.provider && dispatchChannel && parsedSession.provider !== dispatchChannel,
+        );
+        if (surfaceMismatch) {
+          const reason = `dispatch surface ${dispatchChannel} does not match session provider ${parsedSession.provider}`;
+          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
+          debug(`[Hindsight] before_dispatch marked session ${sessionKey} to skip this turn: ${reason}`);
+          return;
+        }
+
+        const { resolvedCtx, reason } = getIdentitySkipReason(dispatchCtx);
+        if (reason) {
+          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
+          debug(`[Hindsight] before_dispatch marked session ${sessionKey} to skip this turn: ${reason}`);
+          return;
+        }
+
+        skipHindsightTurnBySession.delete(sessionKey);
+        if (!resolvedCtx?.senderId || typeof resolvedCtx.senderId !== 'string') {
+          return;
+        }
+
+        setCappedMapValue(sessionIdentityBySession, sessionKey, {
+          senderId: resolvedCtx.senderId,
+          messageProvider: resolvedCtx.messageProvider,
+          channelId: resolvedCtx.channelId,
+        });
+        setCappedMapValue(senderIdBySession, sessionKey, resolvedCtx.senderId);
+        debug(
+          `[Hindsight] before_dispatch cached identity for ${sessionKey}: ${resolvedCtx.messageProvider}/${resolvedCtx.channelId} sender=${resolvedCtx.senderId}`,
+        );
+      } catch (error) {
+        log.warn(`before_dispatch identity cache error: ${error}`);
+      }
+    });
+
     api.on('before_agent_start', async (event: any, ctx?: PluginHookAgentContext) => {
       try {
         const sessionKey = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -129,14 +129,13 @@ const turnCountBySession = new Map<string, number>();
 const MAX_TRACKED_SESSIONS = 10_000;
 const DEFAULT_RECALL_TIMEOUT_MS = 10_000;
 
-// Cache sender IDs discovered in before_prompt_build (where event.prompt has the metadata
-// blocks) so agent_end can look them up — event.messages in agent_end is clean history.
-const senderIdBySession = new Map<string, string>();
-const sessionIdentityBySession = new Map<
-  string,
-  Pick<PluginHookAgentContext, 'senderId' | 'messageProvider' | 'channelId'>
->();
-const skipHindsightTurnBySession = new Map<string, string>();
+type SessionIdentityRecord = Pick<PluginHookAgentContext, 'senderId' | 'messageProvider' | 'channelId'>;
+export type IdentitySkipReason =
+  | { kind: 'retryable'; detail: 'missing stable message provider' | 'missing stable sender identity' }
+  | { kind: 'final'; detail: string };
+
+const sessionIdentityBySession = new Map<string, SessionIdentityRecord>();
+const skipHindsightTurnBySession = new Map<string, IdentitySkipReason>();
 const documentSequenceBySession = new Map<string, number>();
 
 // Guard against duplicate hook registration within a single runtime load.
@@ -592,7 +591,13 @@ export function truncateRecallQuery(query: string, latestQuery: string, maxChars
  * Format: "agent:{agentId}:{provider}:{channelType}:{channelId}[:{extra}]"
  * Example: "agent:c0der:telegram:group:-1003825475854:topic:42"
  */
-export function parseSessionKey(sessionKey: string): { agentId?: string; provider?: string; channel?: string } {
+export interface ParsedSessionKey {
+  agentId?: string;
+  provider?: string;
+  channel?: string;
+}
+
+export function parseSessionKey(sessionKey: string): ParsedSessionKey {
   const parts = sessionKey.split(':');
   if (parts[0] !== 'agent') return {};
   if (parts.length === 3 && parts[2] === 'main') {
@@ -646,32 +651,124 @@ export function resolveSessionIdentity(
   };
 }
 
+function retryableSkipReason(
+  detail: 'missing stable message provider' | 'missing stable sender identity',
+): IdentitySkipReason {
+  return { kind: 'retryable', detail };
+}
+
+function finalSkipReason(detail: string): IdentitySkipReason {
+  return { kind: 'final', detail };
+}
+
+function formatIdentitySkipReason(reason: IdentitySkipReason | undefined): string | undefined {
+  return reason?.detail;
+}
+
+function isRetryableIdentitySkipReason(reason: IdentitySkipReason | undefined): boolean {
+  return reason?.kind === 'retryable';
+}
+
+function cacheSessionIdentity(sessionKey: string | undefined, resolvedCtx: PluginHookAgentContext | undefined): void {
+  if (!sessionKey || !resolvedCtx) return;
+  if (!resolvedCtx.messageProvider && !resolvedCtx.channelId && !resolvedCtx.senderId) return;
+
+  setCappedMapValue(sessionIdentityBySession, sessionKey, {
+    senderId: resolvedCtx.senderId,
+    messageProvider: resolvedCtx.messageProvider,
+    channelId: resolvedCtx.channelId,
+  });
+}
+
+interface ResolveAndCacheIdentityOptions {
+  sessionKey?: string;
+  ctx?: PluginHookAgentContext;
+  senderIdHint?: string;
+  dispatchChannel?: string;
+}
+
+function resolveAndCacheIdentity(
+  options: ResolveAndCacheIdentityOptions,
+): {
+  effectiveCtx: PluginHookAgentContext | undefined;
+  resolvedCtx: PluginHookAgentContext | undefined;
+  skipReason?: IdentitySkipReason;
+} {
+  const sessionKey = options.sessionKey ?? options.ctx?.sessionKey;
+  const parsedSession = sessionKey ? parseSessionKey(sessionKey) : {};
+  const cachedIdentity = sessionKey ? sessionIdentityBySession.get(sessionKey) : undefined;
+  const baseCtx = options.ctx || (sessionKey ? ({ sessionKey } as PluginHookAgentContext) : undefined);
+  const effectiveCtx =
+    baseCtx || cachedIdentity || options.senderIdHint || options.dispatchChannel || sessionKey
+      ? {
+          ...baseCtx,
+          sessionKey: baseCtx?.sessionKey || sessionKey,
+          agentId: baseCtx?.agentId || parsedSession.agentId,
+          messageProvider: baseCtx?.messageProvider ?? cachedIdentity?.messageProvider,
+          channelId: baseCtx?.channelId ?? cachedIdentity?.channelId,
+          senderId: baseCtx?.senderId || cachedIdentity?.senderId || options.senderIdHint,
+        }
+      : undefined;
+  const resolvedCtx = resolveSessionIdentity(
+    effectiveCtx
+      ? {
+          ...effectiveCtx,
+          messageProvider: effectiveCtx.messageProvider ?? parsedSession.provider ?? options.dispatchChannel,
+          channelId: effectiveCtx.channelId ?? parsedSession.channel,
+        }
+      : undefined,
+  );
+
+  if (parsedSession.provider && options.dispatchChannel && parsedSession.provider !== options.dispatchChannel) {
+    const skipReason = finalSkipReason(
+      `dispatch surface ${options.dispatchChannel} does not match session provider ${parsedSession.provider}`,
+    );
+    if (sessionKey) {
+      setCappedMapValue(skipHindsightTurnBySession, sessionKey, skipReason);
+    }
+    return { effectiveCtx, resolvedCtx, skipReason };
+  }
+
+  cacheSessionIdentity(sessionKey, resolvedCtx);
+
+  const { reason: skipReason } = getIdentitySkipReason(resolvedCtx);
+  if (sessionKey) {
+    if (skipReason) {
+      setCappedMapValue(skipHindsightTurnBySession, sessionKey, skipReason);
+    } else {
+      skipHindsightTurnBySession.delete(sessionKey);
+    }
+  }
+
+  return { effectiveCtx, resolvedCtx, skipReason };
+}
+
 export function getIdentitySkipReason(
   ctx: PluginHookAgentContext | undefined,
-): { resolvedCtx: PluginHookAgentContext | undefined; reason?: string } {
+): { resolvedCtx: PluginHookAgentContext | undefined; reason?: IdentitySkipReason } {
   const resolvedCtx = resolveSessionIdentity(ctx);
   const sessionKey = resolvedCtx?.sessionKey;
 
   if (typeof sessionKey === 'string') {
-    if (/^agent:[^:]+:(cron|heartbeat|subagent):/i.test(sessionKey)) {
-      return { resolvedCtx, reason: `operational session ${sessionKey}` };
+    if (/^agent:[^:]+:(cron|heartbeat|subagent):/.test(sessionKey)) {
+      return { resolvedCtx, reason: finalSkipReason(`operational session ${sessionKey}`) };
     }
-    if (/^agent:[^:]+:main$/i.test(sessionKey)) {
-      return { resolvedCtx, reason: `internal main session ${sessionKey}` };
+    if (/^agent:[^:]+:main$/.test(sessionKey)) {
+      return { resolvedCtx, reason: finalSkipReason(`internal main session ${sessionKey}`) };
     }
-    if (/^temp:/i.test(sessionKey)) {
-      return { resolvedCtx, reason: `ephemeral temp session ${sessionKey}` };
+    if (/^temp:/.test(sessionKey)) {
+      return { resolvedCtx, reason: finalSkipReason(`ephemeral temp session ${sessionKey}`) };
     }
   }
 
   if (resolvedCtx?.messageProvider && ['cron', 'heartbeat', 'subagent', 'main'].includes(resolvedCtx.messageProvider)) {
-    return { resolvedCtx, reason: `operational provider ${resolvedCtx.messageProvider}` };
+    return { resolvedCtx, reason: finalSkipReason(`operational provider ${resolvedCtx.messageProvider}`) };
   }
   if (!resolvedCtx?.messageProvider || resolvedCtx.messageProvider === 'unknown') {
-    return { resolvedCtx, reason: 'missing stable message provider' };
+    return { resolvedCtx, reason: retryableSkipReason('missing stable message provider') };
   }
   if (!resolvedCtx?.senderId || resolvedCtx.senderId === 'anonymous') {
-    return { resolvedCtx, reason: 'missing stable sender identity' };
+    return { resolvedCtx, reason: retryableSkipReason('missing stable sender identity') };
   }
   if (
     resolvedCtx.messageProvider === 'telegram' &&
@@ -682,7 +779,9 @@ export function getIdentitySkipReason(
     if (!directSenderId || directSenderId !== resolvedCtx.senderId) {
       return {
         resolvedCtx,
-        reason: `telegram direct identity mismatch (${resolvedCtx.channelId} vs ${resolvedCtx.senderId})`,
+        reason: finalSkipReason(
+          `telegram direct identity mismatch (${resolvedCtx.channelId} vs ${resolvedCtx.senderId})`,
+        ),
       };
     }
   }
@@ -698,6 +797,8 @@ export function isEphemeralOperationalText(text: string | undefined): boolean {
     .replace(/\[[a-z]+:end\]\s*/gi, '')
     .trim();
 
+  // These prefixes are OpenClaw-generated operational/session-bootstrap strings,
+  // not user-authored content, so they should not create recall/retain entries.
   return [
     /^A new session was started via \/(?:new|reset)\./i,
     /^Based on this conversation, generate a short 1-2/i,
@@ -706,6 +807,7 @@ export function isEphemeralOperationalText(text: string | undefined): boolean {
 }
 
 function setCappedMapValue<K, V>(map: Map<K, V>, key: K, value: V): void {
+  // FIFO cap, not LRU: updating an existing key keeps its original insertion order.
   map.set(key, value);
   if (map.size > MAX_TRACKED_SESSIONS) {
     const oldest = map.keys().next().value;
@@ -1319,50 +1421,32 @@ export default function (api: MoltbotPluginAPI) {
           return;
         }
 
-        const parsedSession = parseSessionKey(sessionKey);
         const dispatchChannel =
           (typeof event?.channel === 'string' ? event.channel : undefined) ||
           ctx?.messageProvider ||
-          parsedSession.provider;
-        const dispatchCtx = resolveSessionIdentity({
-          ...ctx,
+          parseSessionKey(sessionKey).provider;
+        const { resolvedCtx, skipReason } = resolveAndCacheIdentity({
           sessionKey,
-          agentId: ctx?.agentId || parsedSession.agentId,
-          messageProvider: ctx?.messageProvider ?? parsedSession.provider ?? dispatchChannel,
-          channelId: ctx?.channelId || parsedSession.channel,
-          senderId:
-            (typeof event?.senderId === 'string' ? event.senderId : undefined) ||
-            ctx?.senderId,
+          ctx: {
+            ...ctx,
+            sessionKey,
+            senderId:
+              (typeof event?.senderId === 'string' ? event.senderId : undefined) ||
+              ctx?.senderId,
+          },
+          dispatchChannel,
         });
 
-        const surfaceMismatch = Boolean(
-          parsedSession.provider && dispatchChannel && parsedSession.provider !== dispatchChannel,
-        );
-        if (surfaceMismatch) {
-          const reason = `dispatch surface ${dispatchChannel} does not match session provider ${parsedSession.provider}`;
-          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
-          debug(`[Hindsight] before_dispatch marked session ${sessionKey} to skip this turn: ${reason}`);
+        if (skipReason) {
+          debug(
+            `[Hindsight] before_dispatch marked session ${sessionKey} to skip this turn: ${formatIdentitySkipReason(skipReason)}`,
+          );
           return;
         }
-
-        const { resolvedCtx, reason } = getIdentitySkipReason(dispatchCtx);
-        if (reason) {
-          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
-          debug(`[Hindsight] before_dispatch marked session ${sessionKey} to skip this turn: ${reason}`);
-          return;
-        }
-
-        skipHindsightTurnBySession.delete(sessionKey);
         if (!resolvedCtx?.senderId || typeof resolvedCtx.senderId !== 'string') {
           return;
         }
 
-        setCappedMapValue(sessionIdentityBySession, sessionKey, {
-          senderId: resolvedCtx.senderId,
-          messageProvider: resolvedCtx.messageProvider,
-          channelId: resolvedCtx.channelId,
-        });
-        setCappedMapValue(senderIdBySession, sessionKey, resolvedCtx.senderId);
         debug(
           `[Hindsight] before_dispatch cached identity for ${sessionKey}: ${resolvedCtx.messageProvider}/${resolvedCtx.channelId} sender=${resolvedCtx.senderId}`,
         );
@@ -1374,41 +1458,14 @@ export default function (api: MoltbotPluginAPI) {
     api.on('before_agent_start', async (event: any, ctx?: PluginHookAgentContext) => {
       try {
         const sessionKey = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);
-        const baseCtx = ctx || (sessionKey ? ({ sessionKey } as PluginHookAgentContext) : undefined);
-        const cachedSessionIdentity = sessionKey ? sessionIdentityBySession.get(sessionKey) : undefined;
-        const effectiveCtx = resolveSessionIdentity(
-          cachedSessionIdentity
-            ? {
-                ...baseCtx,
-                senderId: baseCtx?.senderId || cachedSessionIdentity.senderId,
-                messageProvider: cachedSessionIdentity.messageProvider ?? baseCtx?.messageProvider,
-                channelId: cachedSessionIdentity.channelId ?? baseCtx?.channelId,
-              }
-            : baseCtx,
-        );
+        const { resolvedCtx, skipReason } = resolveAndCacheIdentity({ sessionKey, ctx });
 
-        if (sessionKey && effectiveCtx && (effectiveCtx.messageProvider || effectiveCtx.channelId || effectiveCtx.senderId)) {
-          setCappedMapValue(sessionIdentityBySession, sessionKey, {
-            senderId: effectiveCtx.senderId,
-            messageProvider: effectiveCtx.messageProvider,
-            channelId: effectiveCtx.channelId,
-          });
-          if (effectiveCtx.senderId) {
-            setCappedMapValue(senderIdBySession, sessionKey, effectiveCtx.senderId);
-          }
-        }
-
-        const { resolvedCtx, reason } = getIdentitySkipReason(effectiveCtx);
-        if (sessionKey && reason) {
-          setCappedMapValue(skipHindsightTurnBySession, sessionKey, reason);
-          debug(`[Hindsight] before_agent_start skipping session ${sessionKey}: ${reason}`);
+        if (sessionKey && skipReason) {
+          debug(`[Hindsight] before_agent_start skipping session ${sessionKey}: ${formatIdentitySkipReason(skipReason)}`);
           return;
         }
         if (!resolvedCtx) {
           return;
-        }
-        if (sessionKey) {
-          skipHindsightTurnBySession.delete(sessionKey);
         }
         const bankId = deriveBankId(resolvedCtx, pluginConfig);
         debug(`[Hindsight] before_agent_start - bank: ${bankId}, channel: ${resolvedCtx.messageProvider}/${resolvedCtx.channelId}`);
@@ -1452,48 +1509,20 @@ export default function (api: MoltbotPluginAPI) {
 
         const sessionKeyForCache = ctx?.sessionKey ?? (typeof event?.sessionKey === 'string' ? event.sessionKey : undefined);
         const skipTurnReason = sessionKeyForCache ? skipHindsightTurnBySession.get(sessionKeyForCache) : undefined;
-        const canRetryIdentityResolution = typeof skipTurnReason === 'string' && skipTurnReason.startsWith('missing stable ');
-        if (skipTurnReason && !canRetryIdentityResolution) {
-          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${skipTurnReason}`);
+        if (skipTurnReason && !isRetryableIdentitySkipReason(skipTurnReason)) {
+          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${formatIdentitySkipReason(skipTurnReason)}`);
           return;
         }
 
-        const cachedSessionIdentity = sessionKeyForCache ? sessionIdentityBySession.get(sessionKeyForCache) : undefined;
         const senderIdFromPrompt = !ctx?.senderId ? extractSenderIdFromText(event.prompt ?? event.rawMessage ?? '') : undefined;
-        let effectiveCtxForRecall = ctx;
-        if (cachedSessionIdentity) {
-          effectiveCtxForRecall = {
-            ...effectiveCtxForRecall,
-            senderId: effectiveCtxForRecall?.senderId || cachedSessionIdentity.senderId || senderIdFromPrompt,
-            messageProvider: cachedSessionIdentity.messageProvider ?? effectiveCtxForRecall?.messageProvider,
-            channelId: cachedSessionIdentity.channelId ?? effectiveCtxForRecall?.channelId,
-          };
-        } else if (senderIdFromPrompt) {
-          effectiveCtxForRecall = { ...effectiveCtxForRecall, senderId: senderIdFromPrompt };
-        }
-
-        const resolvedCtxForRecall = resolveSessionIdentity(effectiveCtxForRecall);
-        if (resolvedCtxForRecall && sessionKeyForCache && (resolvedCtxForRecall.messageProvider || resolvedCtxForRecall.channelId || resolvedCtxForRecall.senderId)) {
-          setCappedMapValue(sessionIdentityBySession, sessionKeyForCache, {
-            senderId: resolvedCtxForRecall.senderId,
-            messageProvider: resolvedCtxForRecall.messageProvider,
-            channelId: resolvedCtxForRecall.channelId,
-          });
-          if (resolvedCtxForRecall.senderId) {
-            setCappedMapValue(senderIdBySession, sessionKeyForCache, resolvedCtxForRecall.senderId);
-          }
-        }
-
-        const { reason: identitySkipReason } = getIdentitySkipReason(resolvedCtxForRecall);
+        const { resolvedCtx: resolvedCtxForRecall, skipReason: identitySkipReason } = resolveAndCacheIdentity({
+          sessionKey: sessionKeyForCache,
+          ctx,
+          senderIdHint: senderIdFromPrompt,
+        });
         if (identitySkipReason) {
-          if (sessionKeyForCache) {
-            setCappedMapValue(skipHindsightTurnBySession, sessionKeyForCache, identitySkipReason);
-          }
-          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${identitySkipReason}`);
+          debug(`[Hindsight] Skipping recall for session ${sessionKeyForCache}: ${formatIdentitySkipReason(identitySkipReason)}`);
           return;
-        }
-        if (sessionKeyForCache) {
-          skipHindsightTurnBySession.delete(sessionKeyForCache);
         }
 
         const bankId = deriveBankId(resolvedCtxForRecall, pluginConfig);
@@ -1646,46 +1675,19 @@ ${memoriesFormatted}
 
         const sessionKeyForLookup = effectiveCtx?.sessionKey;
         const skipTurnReason = sessionKeyForLookup ? skipHindsightTurnBySession.get(sessionKeyForLookup) : undefined;
-        const canRetryIdentityResolution = typeof skipTurnReason === 'string' && skipTurnReason.startsWith('missing stable ');
-        if (skipTurnReason && !canRetryIdentityResolution) {
-          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${skipTurnReason}`);
+        if (skipTurnReason && !isRetryableIdentitySkipReason(skipTurnReason)) {
+          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${formatIdentitySkipReason(skipTurnReason)}`);
           if (sessionKeyForLookup) {
             skipHindsightTurnBySession.delete(sessionKeyForLookup);
           }
           return;
         }
 
-        const cachedSessionIdentity = sessionKeyForLookup ? sessionIdentityBySession.get(sessionKeyForLookup) : undefined;
-        const senderIdFromCache = !effectiveCtx?.senderId && sessionKeyForLookup
-          ? senderIdBySession.get(sessionKeyForLookup)
-          : undefined;
-        let effectiveCtxForRetain = effectiveCtx;
-        if (cachedSessionIdentity) {
-          effectiveCtxForRetain = {
-            ...effectiveCtxForRetain,
-            senderId: effectiveCtxForRetain?.senderId || cachedSessionIdentity.senderId || senderIdFromCache,
-            messageProvider: cachedSessionIdentity.messageProvider ?? effectiveCtxForRetain?.messageProvider,
-            channelId: cachedSessionIdentity.channelId ?? effectiveCtxForRetain?.channelId,
-          };
-        } else if (senderIdFromCache) {
-          effectiveCtxForRetain = { ...effectiveCtxForRetain, senderId: senderIdFromCache };
-        }
+        const { effectiveCtx: effectiveCtxForRetain, resolvedCtx: resolvedCtxForRetain, skipReason: identitySkipReason } =
+          resolveAndCacheIdentity({ sessionKey: sessionKeyForLookup, ctx: effectiveCtx });
 
-        const resolvedCtxForRetain = resolveSessionIdentity(effectiveCtxForRetain);
-        if (resolvedCtxForRetain && sessionKeyForLookup && (resolvedCtxForRetain.messageProvider || resolvedCtxForRetain.channelId || resolvedCtxForRetain.senderId)) {
-          setCappedMapValue(sessionIdentityBySession, sessionKeyForLookup, {
-            senderId: resolvedCtxForRetain.senderId,
-            messageProvider: resolvedCtxForRetain.messageProvider,
-            channelId: resolvedCtxForRetain.channelId,
-          });
-          if (resolvedCtxForRetain.senderId) {
-            setCappedMapValue(senderIdBySession, sessionKeyForLookup, resolvedCtxForRetain.senderId);
-          }
-        }
-
-        const { reason: identitySkipReason } = getIdentitySkipReason(resolvedCtxForRetain);
         if (identitySkipReason) {
-          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${identitySkipReason}`);
+          debug(`[Hindsight Hook] Skipping retain for session ${sessionKeyForLookup}: ${formatIdentitySkipReason(identitySkipReason)}`);
           if (sessionKeyForLookup) {
             skipHindsightTurnBySession.delete(sessionKeyForLookup);
           }
@@ -1773,7 +1775,7 @@ ${memoriesFormatted}
         const retainRequest = buildRetainRequest(
           transcript,
           messageCount,
-          resolvedCtxForRetain,
+          effectiveCtxForRetain,
           pluginConfig,
           retainNow,
           {
@@ -1865,6 +1867,7 @@ export function buildRetainRequest(
   const documentId = `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, '0')}`;
   const channelId = resolvedCtx?.channelId || parsedSession.channel;
   const provider = resolvedCtx?.messageProvider || parsedSession.provider;
+  const channelType = effectiveCtx?.messageProvider;
   const threadId = extractThreadId(channelId);
 
   return {
@@ -1879,7 +1882,7 @@ export function buildRetainRequest(
       session_key: resolvedCtx?.sessionKey,
       agent_id: resolvedCtx?.agentId || parsedSession.agentId,
       provider,
-      channel_type: provider,
+      channel_type: channelType,
       channel_id: channelId,
       thread_id: threadId,
       sender_id: resolvedCtx?.senderId,

--- a/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
+++ b/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
@@ -365,6 +365,53 @@ describe('before_prompt_build hook', () => {
     expect(result.prependSystemContext).toContain('User loves hiking');
     expect(result.prependSystemContext).toContain('<hindsight_memories>');
   });
+
+  it('uses identity cached in before_dispatch when later hooks lack sender metadata', async () => {
+    if (!apiReachable) return;
+    recallSpy.mockResolvedValue(EMPTY_RECALL);
+
+    await triggerHook(
+      'before_dispatch',
+      {
+        sessionKey: 'agent:main:telegram:direct:U020',
+        channel: 'telegram',
+        senderId: 'U020',
+      },
+      { sessionKey: 'agent:main:telegram:direct:U020' },
+    );
+
+    await triggerHook(
+      'before_prompt_build',
+      { rawMessage: 'What do I like?', prompt: '', messages: [] },
+      { sessionKey: 'agent:main:telegram:direct:U020' },
+    );
+
+    expect(recallSpy).toHaveBeenCalledOnce();
+  });
+
+  it('skips recall when before_dispatch detects a provider mismatch for the session', async () => {
+    if (!apiReachable) return;
+    recallSpy.mockResolvedValue(EMPTY_RECALL);
+
+    await triggerHook(
+      'before_dispatch',
+      {
+        sessionKey: 'agent:main:telegram:direct:U021',
+        channel: 'discord',
+        senderId: 'U021',
+      },
+      { sessionKey: 'agent:main:telegram:direct:U021' },
+    );
+
+    const result = await triggerHook(
+      'before_prompt_build',
+      { rawMessage: 'What do I like?', prompt: '', messages: [] },
+      { sessionKey: 'agent:main:telegram:direct:U021' },
+    );
+
+    expect(recallSpy).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -481,6 +528,36 @@ describe('agent_end hook', () => {
     expect(options?.metadata?.sender_id).toBe('U015');
     expect(options?.metadata?.retained_at).toBeDefined();
     expect(options?.metadata?.message_count).toBe('1');
+  });
+
+  it('uses identity cached in before_dispatch for retain metadata when agent_end ctx is sparse', async () => {
+    if (!apiReachable) return;
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    await triggerHook(
+      'before_dispatch',
+      {
+        sessionKey: 'agent:main:telegram:direct:U015B',
+        channel: 'telegram',
+        senderId: 'U015B',
+      },
+      { sessionKey: 'agent:main:telegram:direct:U015B' },
+    );
+
+    await triggerHook(
+      'agent_end',
+      {
+        success: true,
+        messages: [{ role: 'user', content: 'I like midnight blue.' }],
+      },
+      { sessionKey: 'agent:main:telegram:direct:U015B' },
+    );
+
+    expect(retainSpy).toHaveBeenCalledOnce();
+    const [, , options] = retainSpy.mock.calls[0];
+    expect(options?.metadata?.channel_type).toBe('telegram');
+    expect(options?.metadata?.channel_id).toBe('direct:U015B');
+    expect(options?.metadata?.sender_id).toBe('U015B');
   });
 
   it('strips <hindsight_memories> tags from content before retaining', async () => {

--- a/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
+++ b/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
@@ -560,6 +560,27 @@ describe('agent_end hook', () => {
     expect(options?.metadata?.sender_id).toBe('U015B');
   });
 
+  it('keeps provider fallback without backfilling channel_type when only session parsing provides it', async () => {
+    if (!apiReachable) return;
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    await triggerHook(
+      'agent_end',
+      {
+        success: true,
+        messages: [{ role: 'user', content: 'I prefer espresso.' }],
+      },
+      { sessionKey: 'agent:main:telegram:direct:U015C' },
+    );
+
+    expect(retainSpy).toHaveBeenCalledOnce();
+    const [, , options] = retainSpy.mock.calls[0];
+    expect(options?.metadata?.provider).toBe('telegram');
+    expect(options?.metadata?.channel_type).toBeUndefined();
+    expect(options?.metadata?.channel_id).toBe('direct:U015C');
+    expect(options?.metadata?.sender_id).toBe('U015C');
+  });
+
   it('strips <hindsight_memories> tags from content before retaining', async () => {
     if (!apiReachable) return;
     retainSpy.mockResolvedValue(OK_RETAIN);


### PR DESCRIPTION
## Summary
- follow up on the review feedback from #987 without changing `channel_type` semantics
- extract shared identity resolution and cache handling across the hook pipeline
- replace stringly retry handling with typed skip reasons and expand regression coverage

## What changed
- preserve the previous `channel_type` behavior in retain metadata, while still allowing `provider` to fall back from the parsed session key
- consolidate the repeated resolve/cache/skip flow into a shared helper used by `before_dispatch`, `before_agent_start`, `before_prompt_build`, and `agent_end`
- remove the redundant sender-id map and derive sender identity from the single cached identity record
- remove unnecessary case-insensitive flags from lowercase session-key regexes
- add unit and integration coverage for operational sessions, `temp:` sessions, missing provider or sender cases, retryable vs final skip reasons, and the `channel_type` fallback regression

## Validation
- `cd hindsight-integrations/openclaw && npx vitest run src/index.test.ts`
- `cd hindsight-integrations/openclaw && npm run build`
- `cd hindsight-integrations/openclaw && npx vitest run --config vitest.integration.config.ts tests/hooks.integration.test.ts`

## Note
- local pre-commit lint currently fails in this environment because a repo-wide ESLint dependency (`@eslint/js`) is missing under `hindsight-control-plane`; the targeted OpenClaw tests and build above passed
- this PR supersedes the implementation in #987 and folds in the requested review follow-up
