### PR TITLE
fix(openclaw): register agent hooks on every plugin entry invocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,10 @@ Every new integration in `hindsight-integrations/` must satisfy all of the follo
 
 If any of these are missing, the integration is incomplete and must not be pushed or merged.
 
+### Changelogs
+
+Never add "Unreleased" entries to changelogs (e.g. `hindsight-docs/src/pages/changelog/**`). Changelog entries are written by the release script (`./scripts/release-integration.sh`) when a version is actually cut. If a bug fix or feature needs documenting before release, describe it in the PR/commit — the release tooling will surface it in the published changelog section.
+
 ### Adding New API Configuration Flags
 
 Configuration follows a hierarchical system: **Global (env vars) → Tenant (via extension) → Bank (database)**.

--- a/hindsight-docs/src/pages/changelog/integrations/openclaw.md
+++ b/hindsight-docs/src/pages/changelog/integrations/openclaw.md
@@ -14,13 +14,6 @@ import PageHero from '@site/src/components/PageHero';
 
 - Openclaw setup wizard now prompts for the actual token value instead of an environment variable name. ([`9679d813`](https://github.com/vectorize-io/hindsight/commit/9679d813))
 
-## 0.6.1 (Unreleased)
-
-**Improvements**
-
-- `hindsight-openclaw-setup` interactive wizard now asks for the API token/API key **value** instead of the env var name holding it. Pasted values are masked and stored inline in `openclaw.json` — no more two-step "pick an env var name, then export it" flow that confused first-time users. For CI / production, the SecretRef path is still available via the non-interactive flags (`--token-env`, `--api-key-env`) or after-the-fact with `openclaw config set ... --ref-source env --ref-id …`.
-- Added non-interactive CLI flags for direct-value credentials: `--token` (cloud / external API modes) and `--api-key` (embedded mode). `--token` and `--token-env` are mutually exclusive within a mode; same for `--api-key` / `--api-key-env`.
-
 ## [0.6.0](https://github.com/vectorize-io/hindsight/tree/integrations/openclaw/v0.6.0)
 
 **Breaking Changes**
@@ -45,23 +38,6 @@ import PageHero from '@site/src/components/PageHero';
 **Bug Fixes**
 
 - Avoids misrouting by ignoring ctx.channelId when it contains a provider name. ([`d4b8b354`](https://github.com/vectorize-io/hindsight/commit/d4b8b354))
-
-## 0.6.0 (Unreleased)
-
-**Breaking Changes**
-
-- The plugin no longer reads any configuration from process environment variables. All settings — including the LLM provider, model, API key, base URL, external Hindsight API URL/token, and bank ID — must now be set through OpenClaw's plugin config (e.g. `openclaw config set plugins.entries.hindsight-openclaw.config.<field> <value>`). API keys and other secrets should be configured as `SecretRef` values via `--ref-source env|file|exec` so they're resolved from your secret store at runtime instead of being stored in plaintext on disk.
-- Removed the `llmApiKeyEnv` plugin config field. Use the new `llmApiKey` field configured as a SecretRef instead (e.g. `openclaw config set plugins.entries.hindsight-openclaw.config.llmApiKey --ref-source env --ref-id OPENAI_API_KEY`).
-- Removed automatic LLM provider detection from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `GROQ_API_KEY`. Set `llmProvider` and `llmApiKey` explicitly via `openclaw config set`.
-- Removed support for the `HINDSIGHT_API_LLM_PROVIDER`, `HINDSIGHT_API_LLM_MODEL`, `HINDSIGHT_API_LLM_API_KEY`, `HINDSIGHT_API_LLM_BASE_URL`, `HINDSIGHT_EMBED_API_URL`, `HINDSIGHT_EMBED_API_TOKEN`, and `HINDSIGHT_BANK_ID` environment variables. The same values now live in plugin config — see the [migration guide](/sdks/integrations/openclaw#migration-from-05x).
-
-**Features**
-
-- Added `hindsight-openclaw-setup`, an interactive setup wizard that walks users through picking one of three install modes — **Cloud** (managed Hindsight at `https://api.hindsight.vectorize.io`), **External API** (your own running Hindsight deployment), or **Embedded daemon** (local `hindsight-embed` daemon). The wizard writes a valid plugin config with env-backed `SecretRef` credentials and no plaintext secrets on disk.
-- `hindsight-openclaw-setup` also runs non-interactively via `--mode cloud|api|embedded` plus mode-specific flags (`--api-url`, `--token-env`, `--no-token`, `--provider`, `--api-key-env`, `--model`) for CI and scripted installs.
-- Added the `llmApiKey` plugin config field, marked as a sensitive field so OpenClaw resolves it as a `SecretRef` from env, file, or exec sources.
-- Added the `llmBaseUrl` plugin config field for OpenAI-compatible endpoint overrides (OpenRouter, Azure OpenAI, vLLM, etc.).
-- Marked `hindsightApiToken` as a sensitive field — it can now be configured as a `SecretRef` the same way as `llmApiKey`.
 
 ## [0.5.1](https://github.com/vectorize-io/hindsight/tree/integrations/openclaw/v0.5.1)
 

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -134,10 +134,6 @@ const DEFAULT_RECALL_TIMEOUT_MS = 10_000;
 const senderIdBySession = new Map<string, string>();
 const documentSequenceBySession = new Map<string, number>();
 
-// Guard against duplicate hook registration within a single runtime load.
-// Do not tie this to api instance identity, which can be brittle across loader phases.
-let hooksRegistered = false;
-
 // Cooldown + guard to prevent concurrent reinit attempts
 let lastReinitAttempt = 0;
 let isReinitInProgress = false;
@@ -1202,12 +1198,15 @@ export default function (api: MoltbotPluginAPI) {
 
     debug('[Hindsight] Plugin loaded successfully');
 
-    // Register agent hooks for auto-recall and auto-retention
-    if (hooksRegistered) {
-      debug('[Hindsight] Hooks already registered in this runtime, skipping duplicate hook registration');
-      return;
-    }
-    hooksRegistered = true;
+    // Register agent hooks for auto-recall and auto-retention.
+    //
+    // Why no module-level "already registered" guard: each plugin entry invocation
+    // hands us a fresh `api` tied to a specific plugin registry. OpenClaw may call
+    // the plugin entry multiple times per process (CLI vs gateway vs lazy reloads),
+    // and the registry that's active when an agent actually runs is not guaranteed
+    // to be the first one we saw. A process-global flag would let the first call
+    // "win" and leave subsequent registries with zero hindsight hooks — which is
+    // exactly how auto-recall/auto-retain silently stopped firing in 0.6.x.
     debug('[Hindsight] Registering agent hooks...');
     log.info('registering agent hooks');
 


### PR DESCRIPTION
## Summary

- Removed the module-level `hooksRegistered` guard so hindsight's hooks get registered on every plugin entry OpenClaw invokes. The first-call-wins behavior left later plugin registries with zero hindsight hooks, which is why auto-recall / auto-retain silently stopped firing on live agent turns in 0.6.0 and 0.6.1.
- Added a CLAUDE.md rule: changelogs never carry "Unreleased" sections — the release script owns changelog writes at cut time.

## Test plan

- [x] `npm test` (142/142 passing)
- [x] Live end-to-end: `openclaw agent --local` turn → both `before_prompt_build` and `agent_end` hooks fire, 4 memories auto-injected into context, new facts ("favorite animal = axolotl", "favorite color = indigo") retained to Hindsight Cloud (`my-agent::unknown::anonymous`) and queryable via recall
- [ ] Cut 0.6.2 via `./scripts/release-integration.sh openclaw` after merge