### PR TITLE
feat(openclaw): retain as Anthropic-shaped JSON with tool_use/tool_result blocks

### DIFF
--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -99,6 +99,7 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `autoRetain` | `true` | Auto-retain conversations after each turn |
 | `retainRoles` | `["user", "assistant"]` | Which message roles to retain. Options: `user`, `assistant`, `system`, `tool` |
 | `retainFormat` | `"json"` | Serialization format for retained conversation content. `"json"` emits a structured array of `{role, content}` messages (matches Claude Code). `"text"` emits legacy `[role: x] … [x:end]` markers. |
+| `retainToolCalls` | `true` | With `retainFormat: "json"`, each message's content is an Anthropic-shaped block array (`text` / `tool_use` / `tool_result`). Tool results are truncated at 2000 chars. Hindsight's own MCP tools (recall/retain/search/…) are filtered to prevent feedback loops. Set `false` to retain text-only content. |
 | `retainEveryNTurns` | `1` | Retain every Nth turn. `1` = every turn (default). Values > 1 enable chunked retention with a sliding window. |
 | `retainOverlapTurns` | `0` | Extra prior turns included when chunked retention fires. Window = `retainEveryNTurns + retainOverlapTurns`. Only applies when `retainEveryNTurns > 1`. |
 | `recallBudget` | `"mid"` | Recall effort: `low`, `mid`, or `high`. Higher budgets use more retrieval strategies. |

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -98,6 +98,7 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `autoRecall` | `true` | Auto-inject memories before each turn. Set to `false` when the agent has its own recall tool. |
 | `autoRetain` | `true` | Auto-retain conversations after each turn |
 | `retainRoles` | `["user", "assistant"]` | Which message roles to retain. Options: `user`, `assistant`, `system`, `tool` |
+| `retainFormat` | `"json"` | Serialization format for retained conversation content. `"json"` emits a structured array of `{role, content}` messages (matches Claude Code). `"text"` emits legacy `[role: x] … [x:end]` markers. |
 | `retainEveryNTurns` | `1` | Retain every Nth turn. `1` = every turn (default). Values > 1 enable chunked retention with a sliding window. |
 | `retainOverlapTurns` | `0` | Extra prior turns included when chunked retention fires. Window = `retainEveryNTurns + retainOverlapTurns`. Only applies when `retainEveryNTurns > 1`. |
 | `recallBudget` | `"mid"` | Recall effort: `low`, `mid`, or `high`. Higher budgets use more retrieval strategies. |

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -159,6 +159,11 @@
         "enum": ["json", "text"],
         "default": "json"
       },
+      "retainToolCalls": {
+        "type": "boolean",
+        "description": "When true (default) and retainFormat is 'json', each message's content is an Anthropic-shaped array of typed blocks including tool_use (agent tool calls) and tool_result (truncated at 2000 chars). Operational MCP tools — Hindsight's own recall/retain/search — are filtered out to avoid feedback loops. Set to false to retain text-only content, one string per message.",
+        "default": true
+      },
       "retainEveryNTurns": {
         "type": "integer",
         "description": "Retain every Nth turn instead of every turn. 1 = every turn (default). Values > 1 enable chunked retention with a sliding window.",
@@ -377,6 +382,10 @@
     "retainFormat": {
       "label": "Retain Format",
       "placeholder": "json (default) or text (legacy markers)"
+    },
+    "retainToolCalls": {
+      "label": "Retain Tool Calls",
+      "placeholder": "true (default) — include tool_use / tool_result blocks in retained JSON"
     },
     "retainEveryNTurns": {
       "label": "Retain Every N Turns",

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -153,6 +153,12 @@
           "assistant"
         ]
       },
+      "retainFormat": {
+        "type": "string",
+        "description": "Serialization format for retained conversation content. 'json' (default) emits a structured array of {role, content} messages, matching the Claude Code integration. 'text' emits the legacy '[role: x] ... [x:end]' markers.",
+        "enum": ["json", "text"],
+        "default": "json"
+      },
       "retainEveryNTurns": {
         "type": "integer",
         "description": "Retain every Nth turn instead of every turn. 1 = every turn (default). Values > 1 enable chunked retention with a sliding window.",
@@ -367,6 +373,10 @@
     "retainRoles": {
       "label": "Retain Roles",
       "placeholder": "e.g. ['user', 'assistant']"
+    },
+    "retainFormat": {
+      "label": "Retain Format",
+      "placeholder": "json (default) or text (legacy markers)"
     },
     "retainEveryNTurns": {
       "label": "Retain Every N Turns",

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -376,7 +376,7 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).toContain('Dark mode is a display setting.');
   });
 
-  it('emits JSON by default (array of {role, content})', () => {
+  it('emits Anthropic-shaped typed blocks by default (retainToolCalls=true)', () => {
     const messages = [
       { role: 'user', content: 'Hello there' },
       { role: 'assistant', content: 'Hi back' },
@@ -385,11 +385,87 @@ describe('prepareRetentionTranscript', () => {
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!.transcript);
     expect(parsed).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Hello there' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi back' }] },
+    ]);
+    expect(result!.transcript).not.toContain('[role:');
+  });
+
+  it('flattens content to a string when retainToolCalls is false', () => {
+    const config: PluginConfig = { ...baseConfig, retainToolCalls: false };
+    const messages = [
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'Hi back' },
+    ];
+    const result = prepareRetentionTranscript(messages, config);
+    expect(JSON.parse(result!.transcript)).toEqual([
       { role: 'user', content: 'Hello there' },
       { role: 'assistant', content: 'Hi back' },
     ]);
-    // No legacy [role: x] markers in the JSON payload.
-    expect(result!.transcript).not.toContain('[role:');
+  });
+
+  it('retains assistant tool_use blocks and folds toolResult into a user tool_result block', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'text', text: 'What is the weather?' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'deliberation — should be stripped' },
+          { type: 'text', text: 'Let me check.' },
+          { type: 'toolCall', id: 'call_abc', name: 'get_weather', arguments: { city: 'SF' } },
+        ],
+      },
+      { role: 'toolResult', toolCallId: 'call_abc', toolName: 'get_weather', content: [{ type: 'text', text: 'sunny, 62F' }] },
+      { role: 'assistant', content: [{ type: 'text', text: "It's sunny, 62F." }] },
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.transcript);
+    expect(parsed).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'What is the weather?' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me check.' },
+          { type: 'tool_use', name: 'get_weather', input: { city: 'SF' }, id: 'call_abc' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'tool_result', content: 'sunny, 62F', tool_use_id: 'call_abc' }] },
+      { role: 'assistant', content: [{ type: 'text', text: "It's sunny, 62F." }] },
+    ]);
+  });
+
+  it('filters operational MCP tool calls to avoid feedback loops', () => {
+    const messages = [
+      { role: 'user', content: 'recall stuff' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'toolCall', id: 'c1', name: 'mcp__hindsight__recall', arguments: { query: 'x' } },
+          { type: 'toolCall', id: 'c2', name: 'mcp__other__send_message', arguments: { text: 'hi' } },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    const parsed = JSON.parse(result!.transcript);
+    const assistantBlocks = parsed[1].content;
+    expect(assistantBlocks.some((b: any) => b.type === 'tool_use' && b.name === 'mcp__hindsight__recall')).toBe(false);
+    expect(assistantBlocks.some((b: any) => b.type === 'tool_use' && b.name === 'mcp__other__send_message')).toBe(true);
+  });
+
+  it('truncates tool_result content at 2000 chars', () => {
+    const big = 'x'.repeat(3000);
+    const messages = [
+      { role: 'user', content: 'run tool' },
+      { role: 'assistant', content: [{ type: 'toolCall', id: 'c1', name: 'noop', arguments: {} }] },
+      { role: 'toolResult', toolCallId: 'c1', content: [{ type: 'text', text: big }] },
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    const parsed = JSON.parse(result!.transcript);
+    const toolResult = parsed.find((m: any) => m.content.some((b: any) => b.type === 'tool_result')).content[0];
+    expect(toolResult.content.endsWith('... (truncated)')).toBe(true);
+    expect(toolResult.content.length).toBe(2000 + '... (truncated)'.length);
   });
 
   it('emits legacy text markers when retainFormat is "text"', () => {

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -376,6 +376,34 @@ describe('prepareRetentionTranscript', () => {
     expect(result?.transcript).toContain('Dark mode is a display setting.');
   });
 
+  it('emits JSON by default (array of {role, content})', () => {
+    const messages = [
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'Hi back' },
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.transcript);
+    expect(parsed).toEqual([
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'Hi back' },
+    ]);
+    // No legacy [role: x] markers in the JSON payload.
+    expect(result!.transcript).not.toContain('[role:');
+  });
+
+  it('emits legacy text markers when retainFormat is "text"', () => {
+    const config: PluginConfig = { ...baseConfig, retainFormat: 'text' };
+    const messages = [
+      { role: 'user', content: 'Hello there' },
+      { role: 'assistant', content: 'Hi back' },
+    ];
+    const result = prepareRetentionTranscript(messages, config);
+    expect(result).not.toBeNull();
+    expect(result!.transcript).toContain('[role: user]\nHello there\n[user:end]');
+    expect(result!.transcript).toContain('[role: assistant]\nHi back\n[assistant:end]');
+  });
+
   it('reports accurate messageCount excluding empty messages', () => {
     const messages = [
       { role: 'user', content: 'Real message' },

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -828,6 +828,7 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     autoRetain: config.autoRetain !== false, // Default: true
     retainRoles: Array.isArray(config.retainRoles) ? config.retainRoles : undefined,
     retainFormat: config.retainFormat === 'text' ? 'text' : 'json',
+    retainToolCalls: config.retainToolCalls !== false,
     recallBudget: config.recallBudget || 'mid',
     recallMaxTokens: config.recallMaxTokens || 1024,
     recallTypes: Array.isArray(config.recallTypes) ? config.recallTypes : ['world', 'experience'],
@@ -1643,7 +1644,18 @@ export function prepareRetentionTranscript(
     targetMessages = messages.slice(lastUserIdx);
   }
 
-  // Role filtering
+  const format = pluginConfig.retainFormat ?? 'json';
+  const includeToolCalls = format === 'json' && pluginConfig.retainToolCalls !== false;
+
+  if (includeToolCalls) {
+    const structured = buildAnthropicStructuredMessages(targetMessages, pluginConfig);
+    if (structured.length === 0) return null;
+    const transcript = JSON.stringify(structured);
+    if (!transcript.trim() || transcript.length < 10) return null;
+    return { transcript, messageCount: structured.length };
+  }
+
+  // Role filtering (text-only path)
   const allowedRoles = new Set(pluginConfig.retainRoles || ['user', 'assistant']);
   const filteredMessages = targetMessages.filter((m: any) => allowedRoles.has(m.role));
 
@@ -1651,8 +1663,6 @@ export function prepareRetentionTranscript(
     return null; // No messages to retain
   }
 
-  // Normalize each message to { role, content: <cleaned string> }, dropping
-  // anything that's empty after stripping memory/metadata markers.
   const normalized: Array<{ role: string; content: string }> = [];
   for (const msg of filteredMessages) {
     const role = msg.role || 'unknown';
@@ -1667,7 +1677,6 @@ export function prepareRetentionTranscript(
         .join('\n');
     }
 
-    // Strip plugin-injected memory tags and metadata envelopes to prevent feedback loop
     content = stripMemoryTags(content);
     content = stripMetadataEnvelopes(content);
 
@@ -1676,21 +1685,121 @@ export function prepareRetentionTranscript(
     }
   }
 
-  if (normalized.length === 0) {
-    return null;
-  }
+  if (normalized.length === 0) return null;
 
-  const format = pluginConfig.retainFormat ?? 'json';
   const transcript =
     format === 'text'
       ? normalized.map(({ role, content }) => `[role: ${role}]\n${content}\n[${role}:end]`).join('\n\n')
       : JSON.stringify(normalized);
 
-  if (!transcript.trim() || transcript.length < 10) {
-    return null; // Transcript too short
-  }
+  if (!transcript.trim() || transcript.length < 10) return null;
 
   return { transcript, messageCount: normalized.length };
+}
+
+// MCP tool name suffixes that are operational (recall/retain/search/CRUD) and
+// shouldn't be retained — preserves agent reasoning without creating feedback
+// loops on Hindsight's own MCP surface. Mirrors the claude-code integration.
+const OPERATIONAL_TOOL_PATTERN = /(?:recall|retain|reflect|search|extract|create_|delete_|update_|get_|list_)/i;
+const TOOL_RESULT_MAX_CHARS = 2000;
+
+/**
+ * Build an Anthropic-shaped message array from OpenClaw's session messages.
+ *
+ * OpenClaw stores assistant content as a block array that may contain
+ * `text`, `thinking`, and `toolCall` entries, and emits tool results as
+ * separate messages with `role: "toolResult"`. The Anthropic wire format
+ * expected by Hindsight's Claude Code integration (and downstream consumers)
+ * is: assistant messages carry `text` and `tool_use` blocks, and tool
+ * results live in a following `user` message as `tool_result` blocks.
+ * We translate to that shape here so stored documents are consistent
+ * across integrations.
+ */
+function buildAnthropicStructuredMessages(
+  messages: any[],
+  pluginConfig: PluginConfig,
+): Array<{ role: string; content: any[] }> {
+  const allowedRoles = new Set(pluginConfig.retainRoles || ['user', 'assistant']);
+  const out: Array<{ role: string; content: any[] }> = [];
+
+  for (const msg of messages) {
+    const rawRole = msg?.role;
+    if (rawRole === 'toolResult') {
+      const toolResultBlock = buildToolResultBlock(msg);
+      if (!toolResultBlock) continue;
+      // Fold tool_result into a synthetic user message (Anthropic convention),
+      // merging with an immediately-preceding synthetic user if one exists so
+      // consecutive tool results stay together.
+      const last = out[out.length - 1];
+      if (last && last.role === 'user' && last.content.every((b: any) => b.type === 'tool_result')) {
+        last.content.push(toolResultBlock);
+      } else {
+        out.push({ role: 'user', content: [toolResultBlock] });
+      }
+      continue;
+    }
+
+    if (!allowedRoles.has(rawRole)) continue;
+
+    const blocks = extractStructuredBlocks(msg.content, rawRole);
+    if (blocks.length > 0) {
+      out.push({ role: rawRole, content: blocks });
+    }
+  }
+
+  return out;
+}
+
+function extractStructuredBlocks(content: any, role: string): any[] {
+  if (typeof content === 'string') {
+    const cleaned = stripMetadataEnvelopes(stripMemoryTags(content)).trim();
+    return cleaned ? [{ type: 'text', text: cleaned }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+
+  const blocks: any[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const blockType = block.type;
+
+    if (blockType === 'text') {
+      const cleaned = stripMetadataEnvelopes(stripMemoryTags(block.text ?? '')).trim();
+      if (cleaned) blocks.push({ type: 'text', text: cleaned });
+    } else if (blockType === 'toolCall' && role === 'assistant') {
+      const name = typeof block.name === 'string' ? block.name : 'unknown';
+      // Skip Hindsight's own MCP operational tools to avoid feedback loops.
+      if (name.startsWith('mcp__') && OPERATIONAL_TOOL_PATTERN.test(name.split('__').pop() ?? '')) continue;
+      const input = block.arguments && typeof block.arguments === 'object' ? block.arguments : {};
+      const id = typeof block.id === 'string' ? block.id : undefined;
+      const toolUse: any = { type: 'tool_use', name, input };
+      if (id) toolUse.id = id;
+      blocks.push(toolUse);
+    }
+    // thinking / unknown types are dropped
+  }
+  return blocks;
+}
+
+function buildToolResultBlock(msg: any): any | null {
+  const toolUseId = typeof msg.toolCallId === 'string' ? msg.toolCallId : '';
+  const raw = msg.content;
+  let text = '';
+  if (typeof raw === 'string') {
+    text = raw;
+  } else if (Array.isArray(raw)) {
+    text = raw
+      .filter((b: any) => b && b.type === 'text' && typeof b.text === 'string')
+      .map((b: any) => b.text)
+      .join('\n');
+  }
+  text = text.trim();
+  if (!text) return null;
+  if (text.length > TOOL_RESULT_MAX_CHARS) {
+    text = text.slice(0, TOOL_RESULT_MAX_CHARS) + '... (truncated)';
+  }
+  const block: any = { type: 'tool_result', content: text };
+  if (toolUseId) block.tool_use_id = toolUseId;
+  return block;
 }
 
 export function sliceLastTurnsByUserBoundary(messages: any[], turns: number): any[] {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -827,6 +827,7 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     dynamicBankGranularity: Array.isArray(config.dynamicBankGranularity) ? config.dynamicBankGranularity : undefined,
     autoRetain: config.autoRetain !== false, // Default: true
     retainRoles: Array.isArray(config.retainRoles) ? config.retainRoles : undefined,
+    retainFormat: config.retainFormat === 'text' ? 'text' : 'json',
     recallBudget: config.recallBudget || 'mid',
     recallMaxTokens: config.recallMaxTokens || 1024,
     recallTypes: Array.isArray(config.recallTypes) ? config.recallTypes : ['world', 'experience'],
@@ -1650,37 +1651,46 @@ export function prepareRetentionTranscript(
     return null; // No messages to retain
   }
 
-  // Format messages into a transcript
-  const transcriptParts = filteredMessages
-    .map((msg: any) => {
-      const role = msg.role || 'unknown';
-      let content = '';
+  // Normalize each message to { role, content: <cleaned string> }, dropping
+  // anything that's empty after stripping memory/metadata markers.
+  const normalized: Array<{ role: string; content: string }> = [];
+  for (const msg of filteredMessages) {
+    const role = msg.role || 'unknown';
+    let content = '';
 
-      // Handle different content formats
-      if (typeof msg.content === 'string') {
-        content = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        content = msg.content
-          .filter((block: any) => block.type === 'text')
-          .map((block: any) => block.text)
-          .join('\n');
-      }
+    if (typeof msg.content === 'string') {
+      content = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      content = msg.content
+        .filter((block: any) => block.type === 'text')
+        .map((block: any) => block.text)
+        .join('\n');
+    }
 
-      // Strip plugin-injected memory tags and metadata envelopes to prevent feedback loop
-      content = stripMemoryTags(content);
-      content = stripMetadataEnvelopes(content);
+    // Strip plugin-injected memory tags and metadata envelopes to prevent feedback loop
+    content = stripMemoryTags(content);
+    content = stripMetadataEnvelopes(content);
 
-      return content.trim() ? `[role: ${role}]\n${content}\n[${role}:end]` : null;
-    })
-    .filter(Boolean);
+    if (content.trim()) {
+      normalized.push({ role, content });
+    }
+  }
 
-  const transcript = transcriptParts.join('\n\n');
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const format = pluginConfig.retainFormat ?? 'json';
+  const transcript =
+    format === 'text'
+      ? normalized.map(({ role, content }) => `[role: ${role}]\n${content}\n[${role}:end]`).join('\n\n')
+      : JSON.stringify(normalized);
 
   if (!transcript.trim() || transcript.length < 10) {
     return null; // Transcript too short
   }
 
-  return { transcript, messageCount: transcriptParts.length };
+  return { transcript, messageCount: normalized.length };
 }
 
 export function sliceLastTurnsByUserBoundary(messages: any[], turns: number): any[] {

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -73,6 +73,7 @@ export interface PluginConfig {
   autoRetain?: boolean; // Default: true
   retainRoles?: Array<'user' | 'assistant' | 'system' | 'tool'>; // Roles to include in retained transcript. Default: ['user', 'assistant']
   retainFormat?: 'json' | 'text'; // Serialization format for retained conversation content. Default: 'json' (structured array of {role, content}); 'text' emits legacy '[role: x] ... [x:end]' markers.
+  retainToolCalls?: boolean; // When true (default) and retainFormat='json', each message's content is an Anthropic-shaped array of typed blocks (text, tool_use, tool_result) including the agent's tool calls and their results. When false, content is a flat string with only text.
   recallBudget?: 'low' | 'mid' | 'high'; // Recall effort. Default: 'mid'
   recallMaxTokens?: number; // Max tokens for recall response. Default: 1024
   recallTypes?: Array<'world' | 'experience' | 'observation'>; // Memory types to recall. Default: ['world', 'experience']

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -72,6 +72,7 @@ export interface PluginConfig {
   dynamicBankGranularity?: Array<'agent' | 'provider' | 'channel' | 'user'>; // Fields for bank ID derivation. Default: ['agent', 'channel', 'user']
   autoRetain?: boolean; // Default: true
   retainRoles?: Array<'user' | 'assistant' | 'system' | 'tool'>; // Roles to include in retained transcript. Default: ['user', 'assistant']
+  retainFormat?: 'json' | 'text'; // Serialization format for retained conversation content. Default: 'json' (structured array of {role, content}); 'text' emits legacy '[role: x] ... [x:end]' markers.
   recallBudget?: 'low' | 'mid' | 'high'; // Recall effort. Default: 'mid'
   recallMaxTokens?: number; // Max tokens for recall response. Default: 1024
   recallTypes?: Array<'world' | 'experience' | 'observation'>; // Memory types to recall. Default: ['world', 'experience']


### PR DESCRIPTION
## Summary

Retain payload now mirrors what the Claude Code integration stores. Two config knobs:

- `retainFormat: "json" | "text"` — default `"json"`. JSON emits a structured message array; `"text"` keeps the legacy `[role: x] ... [x:end]` markers.
- `retainToolCalls: boolean` — default `true`. When on (and format is JSON), each message's content is an Anthropic-shaped block array:
  - `text` blocks for text
  - `tool_use` blocks for agent tool calls (with full `input`)
  - `tool_result` blocks for tool results (truncated at 2000 chars), synthesized as a following user message per Anthropic convention

OpenClaw's native storage shape (assistant messages with `toolCall` blocks and separate `role: "toolResult"` messages) is normalized on the way out. `thinking` blocks are dropped. Hindsight's own MCP operational tools (recall/retain/reflect/search/CRUD) are filtered from `tool_use` to prevent feedback loops.

Why: tool calls + results carry a large share of the useful signal for fact extraction and recall reranking. Dropping them was the biggest retained-content gap vs Claude Code.

Verified live on Hindsight Cloud — a fresh agent turn now stores:

\`\`\`json
[{"role":"user","content":[{"type":"text","text":"..."}]},
 {"role":"assistant","content":[{"type":"text","text":"..."},{"type":"tool_use","name":"…","input":{…},"id":"…"}]},
 {"role":"user","content":[{"type":"tool_result","content":"…","tool_use_id":"…"}]}]
\`\`\`

## Test plan

- [x] \`npm test\` — 148/148 passing (6 new tests: typed-block default, \`retainToolCalls: false\`, tool_use/tool_result folding, operational MCP filter, truncation, text-mode unchanged)
- [x] Live end-to-end: \`openclaw agent --local\` → retrieved document on Cloud has block-array content matching the schema
- [ ] Cut next openclaw release via \`./scripts/release-integration.sh openclaw\` after merge