### PR TITLE
docs: 0.5.1 changelog entry and release blog post

### DIFF
--- a/hindsight-docs/blog/2026-04-13-version-0-5-1.md
+++ b/hindsight-docs/blog/2026-04-13-version-0-5-1.md
@@ -1,0 +1,75 @@
+---
+title: "What's new in Hindsight 0.5.1"
+description: New features and improvements in Hindsight 0.5.1
+authors: [nicoloboschi]
+date: 2026-04-13
+hide_table_of_contents: true
+---
+
+Hindsight 0.5.1 is a polish release focused on the CLI and reliability fixes across retain, recall, and the embedded daemon. It also introduces a Cloudflare OAuth proxy for self-hosted deployments, SiliconFlow as a reranker provider, a default bank template applied at bank creation, and a new `@vectorize-io/hindsight-all` daemon lifecycle package.
+
+<!-- truncate -->
+
+- [**CLI Coverage**](#cli-coverage): Every OpenAPI endpoint and request-body parameter is now reachable from `hindsight`.
+- [**Cloudflare OAuth Proxy**](#cloudflare-oauth-proxy): Drop-in OAuth front door for self-hosted Hindsight.
+- [**Default Bank Template**](#default-bank-template): Apply a template manifest to every newly created bank via a single env var.
+- [**SiliconFlow Reranker**](#siliconflow-reranker): New reranker provider option.
+- [**Daemon Lifecycle Package**](#daemon-lifecycle-package): `@vectorize-io/hindsight-all` for programmatic daemon start/stop.
+- [**Reliability Fixes**](#reliability-fixes): Recall, retain, consolidation worker, and embedded daemon fixes.
+
+## CLI Coverage
+
+The `hindsight` CLI has been expanded to cover every endpoint in the OpenAPI spec, including every request-body parameter — no more dropping down to `curl` for operations the CLI didn't implement yet. Webhook, audit, operation, and memory-history subcommands are now fully documented.
+
+Error output is also easier to debug: API errors now surface the HTTP response body, and the `memory list` command correctly labels fact types instead of showing `[UNKNOWN]` for every row.
+
+## Cloudflare OAuth Proxy
+
+Self-hosted Hindsight deployments often want OAuth in front of the API without running a full identity provider. The new Cloudflare OAuth proxy is a Cloudflare Worker that sits in front of Hindsight, handles the OAuth handshake, and forwards authenticated requests downstream. It ships with tests, CI, and security hardening, and is intended as a drop-in option for teams already using Cloudflare as their edge.
+
+## Default Bank Template
+
+A new `HINDSIGHT_API_DEFAULT_BANK_TEMPLATE` environment variable applies a template manifest to every newly created bank. This makes it easy to standardize bank configuration — retain mission, observations, mental models, directives — across a deployment without touching application code or post-provisioning hooks.
+
+Pair it with the Bank Template Hub introduced in 0.5.0 to export a known-good bank once and have every new bank come up with the same baseline.
+
+## SiliconFlow Reranker
+
+SiliconFlow is now a supported reranker provider alongside the existing options, giving self-hosted and cost-sensitive deployments another hosted reranker to choose from. Configure it like any other provider via `HINDSIGHT_API_RERANKER_PROVIDER`.
+
+## Daemon Lifecycle Package
+
+`@vectorize-io/hindsight-all` is a new npm package that manages the lifecycle of the all-in-one daemon — start, stop, health checks — so Node-based applications can boot and shut down Hindsight locally without shelling out. Useful for local development, embedded deployments, and test harnesses that need a fresh Hindsight instance per run.
+
+## Reliability Fixes
+
+A cluster of fixes addresses edge cases spotted in production:
+
+- **Recall RRF ranking.** When the reranker is configured as a passthrough, RRF ordering is now preserved end-to-end instead of being silently replaced.
+- **Async query embeddings.** Recall now uses the async batch embeddings path for the query, removing a blocking call on the event loop.
+- **Idempotent retain chunk inserts.** Chunk insertion no longer retries on integrity errors, eliminating a class of duplicate-insert loops under concurrent retain.
+- **ANN seeds inside a transaction.** The retain ANN seeds temp table is now created inside its transaction, fixing an intermittent "relation does not exist" under concurrent load.
+- **Consolidation slot accounting.** The worker now reserves consolidation slots within the configured `max_slots` instead of occasionally exceeding it.
+- **Embedded daemon lifecycle.** Daemon start and stop are now serialized so that starting a new instance can no longer kill a healthy one mid-request.
+- **macOS local embeddings/reranker.** The macOS `FORCE_CPU` default for local embeddings and reranker has been restored after a regression caused GPU initialization to fail on some Apple Silicon setups.
+- **Reranker error surfacing.** Reranker initialization now surfaces the real import error instead of a generic failure, and works around a Transformers 5.x race in the jina-mlx path.
+- **Reasoning models & Azure OpenAI.** LLM calls now send `max_completion_tokens` (instead of `max_tokens`) for reasoning models and Azure OpenAI, fixing request failures for recent OpenAI reasoning-family models.
+- **Billing for reflect sub-recalls.** Internal recall calls made by reflect are now marked as internal so they don't double-bill against the caller's usage.
+
+## Documentation
+
+- Mental model tag filtering now clarifies that tags filter the source memories used during refresh.
+- Audit logging is clearly documented as off by default.
+- The retain `update_mode` parameter is fully documented.
+- CLI reference gains docs for webhook, audit, operation, and memory history subcommands.
+
+## Feedback and Community
+
+Hindsight 0.5.1 is a drop-in replacement for 0.5.0 with no breaking changes to the core API.
+
+Share your feedback:
+
+- [GitHub Discussions](https://github.com/vectorize-io/hindsight/discussions)
+- [GitHub Issues](https://github.com/vectorize-io/hindsight/issues)
+
+For detailed changes, see the [full changelog](/changelog).

--- a/hindsight-docs/src/pages/changelog/index.md
+++ b/hindsight-docs/src/pages/changelog/index.md
@@ -6,6 +6,41 @@ import PageHero from '@site/src/components/PageHero';
 
 <PageHero title="Changelog" subtitle="User-facing changes only. Internal maintenance and infrastructure updates are omitted." />
 
+## [0.5.1](https://github.com/vectorize-io/hindsight/releases/tag/v0.5.1)
+
+**Breaking Changes**
+
+- OpenClaw now reads configuration from plugin config instead of environment variables. ([`e22ae05f`](https://github.com/vectorize-io/hindsight/commit/e22ae05f))
+
+**Features**
+
+- Added SiliconFlow as a supported reranker provider. ([`d0b2ab9a`](https://github.com/vectorize-io/hindsight/commit/d0b2ab9a))
+- Added an interactive OpenClaw setup wizard with Cloud / API / Embedded modes. ([`87322396`](https://github.com/vectorize-io/hindsight/commit/87322396))
+- Added a config-aware CLI to backfill OpenClaw history. ([`72fd3d59`](https://github.com/vectorize-io/hindsight/commit/72fd3d59))
+- Added OpenClaw session pattern filtering to ignore or treat sessions as stateless. ([`5a61ac50`](https://github.com/vectorize-io/hindsight/commit/5a61ac50))
+- Added a Cloudflare OAuth proxy integration option for self-hosted Hindsight. ([`aad07a14`](https://github.com/vectorize-io/hindsight/commit/aad07a14))
+- Expanded the CLI to cover all OpenAPI endpoints and request-body parameters. ([`c05c491d`](https://github.com/vectorize-io/hindsight/commit/c05c491d))
+- Added a default bank template environment variable (HINDSIGHT_API_DEFAULT_BANK_TEMPLATE). ([`fc941d5c`](https://github.com/vectorize-io/hindsight/commit/fc941d5c))
+- Added a daemon lifecycle package (@vectorize-io/hindsight-all) to simplify running the all-in-one daemon. ([`576016f5`](https://github.com/vectorize-io/hindsight/commit/576016f5))
+- Added recallTags and recallTagsMatch configuration options to control which tagged memories are recalled. ([`b57e337f`](https://github.com/vectorize-io/hindsight/commit/b57e337f))
+
+**Improvements**
+
+- Improved OpenClaw reliability with more resilient startup behavior and richer retain metadata. ([`1f1716bd`](https://github.com/vectorize-io/hindsight/commit/1f1716bd))
+
+**Bug Fixes**
+
+- OpenClaw setup wizard now prompts for the token value (not the env var name). ([`9679d813`](https://github.com/vectorize-io/hindsight/commit/9679d813))
+- Fixed embedded mode daemon start/stop race that could terminate healthy daemons. ([`e5724fcb`](https://github.com/vectorize-io/hindsight/commit/e5724fcb))
+- Fixed reranker initialization issues to show real import errors and avoid a Transformers 5.x race in jina-mlx. ([`f82f58fa`](https://github.com/vectorize-io/hindsight/commit/f82f58fa))
+- Fixed worker consolidation slot accounting to respect the configured maximum concurrency. ([`2d74007d`](https://github.com/vectorize-io/hindsight/commit/2d74007d))
+- Improved CLI API error output by including the HTTP response body. ([`93300b91`](https://github.com/vectorize-io/hindsight/commit/93300b91))
+- Fixed CLI memory listing showing "[UNKNOWN]" for fact types. ([`2635bbb4`](https://github.com/vectorize-io/hindsight/commit/2635bbb4))
+- Fixed recall ranking so RRF ordering is preserved when the reranker is configured as a passthrough. ([`4f9cf15c`](https://github.com/vectorize-io/hindsight/commit/4f9cf15c))
+- Fixed retain chunk insertion to be idempotent and avoid repeated retries on integrity errors. ([`2d95f78b`](https://github.com/vectorize-io/hindsight/commit/2d95f78b))
+- Fixed retain ANN seed temp table creation to run inside a transaction for better reliability. ([`3fc87e76`](https://github.com/vectorize-io/hindsight/commit/3fc87e76))
+- Fixed LLM requests to use the correct max token parameter for reasoning models and Azure OpenAI. ([`7b2263ba`](https://github.com/vectorize-io/hindsight/commit/7b2263ba))
+
 ## [0.5.0](https://github.com/vectorize-io/hindsight/releases/tag/v0.5.0)
 
 **Breaking Changes**


### PR DESCRIPTION
## Summary
- Generated the `0.5.1` section in the changelog via `scripts/dev/generate-changelog.sh`.
- Added "What's new in Hindsight 0.5.1" blog post covering CLI coverage, Cloudflare OAuth proxy, default bank template, SiliconFlow reranker, `@vectorize-io/hindsight-all` daemon lifecycle package, and reliability fixes across retain, recall, consolidation, and the embedded daemon.
- Blog post intentionally excludes framework/integration-specific changes (those remain in the changelog).

## Test plan
- [ ] Docs build passes in CI