### PR TITLE
fix(opencode): shared state across sessions and post-compaction retain

### DIFF
--- a/hindsight-integrations/opencode/src/hooks.test.ts
+++ b/hindsight-integrations/opencode/src/hooks.test.ts
@@ -232,6 +232,25 @@ describe('compacting hook', () => {
         expect(opts.documentId).toMatch(/^sess-1-\d+$/);
     });
 
+    it('resets lastRetainedTurn so idle-retain resumes after compaction', async () => {
+        const client = makeClient();
+        client.recall.mockResolvedValue({ results: [] });
+        const messages = [
+            { info: { role: 'user' }, parts: [{ type: 'text', text: 'Hello' }] },
+            { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'Hi' }] },
+        ];
+        const state = makeState();
+        // Simulate prior retain at turn 10
+        state.lastRetainedTurn.set('sess-1', 10);
+        const output = { context: [] as string[] };
+        const hooks = createHooks(client, 'bank', makeConfig(), state, makeOpencodeClient(messages));
+
+        await hooks['experimental.session.compacting']({ sessionID: 'sess-1' }, output);
+
+        // After compaction, lastRetainedTurn should be cleared so idle-retain works again
+        expect(state.lastRetainedTurn.has('sess-1')).toBe(false);
+    });
+
     it('does not throw on error', async () => {
         const client = makeClient();
         client.recall.mockRejectedValue(new Error('Failed'));

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -260,6 +260,9 @@ export function createHooks(
             if (messages.length && config.autoRetain) {
                 try {
                     await retainSession(input.sessionID, messages);
+                    // Reset turn tracking — after compaction the message list shrinks,
+                    // so the old lastRetainedTurn value would block future idle retains.
+                    state.lastRetainedTurn.delete(input.sessionID);
                     debugLog(config, 'Pre-compaction retain completed');
                 } catch (e) {
                     debugLog(config, 'Pre-compaction retain failed:', e);

--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -25,6 +25,15 @@ import { createTools } from './tools.js';
 import { createHooks, type PluginState } from './hooks.js';
 import { debugLog } from './config.js';
 
+// Module-level state persists across sessions (plugin is instantiated per session,
+// but the module is loaded once per OpenCode server process).
+const state: PluginState = {
+    turnCount: 0,
+    missionsSet: new Set(),
+    recalledSessions: new Set(),
+    lastRetainedTurn: new Map(),
+};
+
 const HindsightPlugin: Plugin = async (input, options) => {
     const config = loadConfig(options);
 
@@ -45,13 +54,6 @@ const HindsightPlugin: Plugin = async (input, options) => {
 
     const bankId = deriveBankId(config, input.directory);
     debugLog(config, `Initialized with bank: ${bankId}, API: ${apiUrl}`);
-
-    const state: PluginState = {
-        turnCount: 0,
-        missionsSet: new Set(),
-        recalledSessions: new Set(),
-        lastRetainedTurn: new Map(),
-    };
 
     const tools = createTools(client, bankId, config, state.missionsSet);
     const hooks = createHooks(client, bankId, config, state, input.client as unknown as Parameters<typeof createHooks>[4]);

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -92,6 +92,41 @@ describe('HindsightPlugin', () => {
     });
 });
 
+describe('HindsightPlugin state sharing', () => {
+    beforeEach(() => {
+        for (const key of Object.keys(process.env)) {
+            if (key.startsWith('HINDSIGHT_')) delete process.env[key];
+        }
+        vi.clearAllMocks();
+    });
+
+    it('shares state across multiple plugin instantiations (sessions)', async () => {
+        process.env.HINDSIGHT_API_URL = 'http://localhost:8888';
+
+        // Simulate two sessions calling the plugin (OpenCode instantiates per session)
+        const result1 = await HindsightPlugin(mockPluginInput as any);
+        const result2 = await HindsightPlugin(mockPluginInput as any);
+
+        // Trigger session.created on session 1 — should track 'sess-A'
+        await result1.event!({
+            event: { type: 'session.created', properties: { info: { id: 'sess-A' } } },
+        });
+
+        // Session 2's system transform should see 'sess-A' because state is shared
+        const output = { system: [] as string[] };
+        await result2['experimental.chat.system.transform']!(
+            { sessionID: 'sess-A', model: {} },
+            output,
+        );
+
+        // The recall was attempted (state was shared — sess-A was found in recalledSessions).
+        // If state were per-instance, result2 would have an empty recalledSessions and skip recall.
+        // result2 uses the second HindsightClient instance (index 1).
+        const clientInstance = (HindsightClient as any).mock.instances[1];
+        expect(clientInstance.recall).toHaveBeenCalled();
+    });
+});
+
 describe('PluginModule default export', () => {
     it('exports correct module shape', async () => {
         const mod = await import('./index.js');


### PR DESCRIPTION
## Summary

Fixes two remaining bugs in the OpenCode plugin after #993 landed the `msg.info.role` fix:

- **Module-level state**: `PluginState` was created inside `HindsightPlugin` which runs per-session. Moved to module scope so `recalledSessions`, `lastRetainedTurn`, and `missionsSet` persist across sessions within the same OpenCode server process. Without this, each session got fresh tracking state — redundant `createBank` calls, no cross-session dedup, and turn tracking that reset on every session.
- **Post-compaction retain**: After pre-compaction retain, `lastRetainedTurn` is now reset. Previously, compaction shrank the message list but the old turn count remained, making `userTurns - lastRetained` negative and permanently blocking idle-retain for that session.

Closes #941

## Test plan

- [x] All 91 opencode plugin tests pass (6 test files)
- [x] New test: `resets lastRetainedTurn so idle-retain resumes after compaction`
- [x] New test: `shares state across multiple plugin instantiations (sessions)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)