### PR TITLE
feat(scripts): openclaw-agent — install self-improving OpenClaw agent from a boilerplate dir

### DIFF
--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -294,21 +294,28 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
     existing = run(["openclaw", "agents", "list", "--json"], check=False)
     already = False
     if existing.returncode == 0:
-        # `openclaw … --json` prefixes its output with config warnings, so
-        # scan for the JSON payload rather than parsing stdout directly.
-        idx = existing.stdout.find("[")
-        if idx >= 0:
+        # `openclaw … --json` prefixes its output with config warnings AND
+        # plugin-load logs that contain stray `[` chars (e.g. "[plugins]"),
+        # so we can't grab the first `[` and call `json.loads`. Walk
+        # candidates from the end until one parses as a list.
+        out = existing.stdout
+        for start in range(len(out) - 1, -1, -1):
+            if out[start] != "[":
+                continue
             try:
-                for a in json.loads(existing.stdout[idx:]) or []:
-                    if isinstance(a, dict) and (
-                        a.get("agentId") == name
-                        or a.get("id") == name
-                        or a.get("name") == name
-                    ):
-                        already = True
-                        break
+                payload = json.loads(out[start:])
             except json.JSONDecodeError:
-                pass
+                continue
+            if not isinstance(payload, list):
+                continue
+            for a in payload:
+                if isinstance(a, dict) and (
+                    a.get("agentId") == name
+                    or a.get("id") == name
+                    or a.get("name") == name
+                ):
+                    already = True
+            break
     if already:
         ok(f"openclaw agent '{name}' already exists, skipping create")
     else:

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""openclaw-agent — install a self-improving OpenClaw agent from a boilerplate dir.
+
+Usage:
+    openclaw-agent install <agent-dir>
+
+<agent-dir> is a directory containing:
+  - agent.yaml                 (manifest: name, skills, harness.openclaw.config, …)
+  - skills/<skill>/SKILL.md    (one dir per skill listed in agent.yaml)
+  - setup/hindsight-config.yaml (bank + mental-model spec — optional)
+
+Assumes:
+  - openclaw CLI on PATH and the gateway already running
+  - The hindsight-openclaw plugin is already installed AND configured
+    (hindsightApiUrl + hindsightApiToken set in ~/.openclaw/openclaw.json)
+
+What the installer does, in order:
+  1. Validates the boilerplate dir + reads agent.yaml.
+  2. Reads Hindsight URL/token from the openclaw plugin config (raw file,
+     so we can resolve SecretRef sources too).
+  3. Calls `openclaw agents add` to create the agent with the boilerplate
+     dir as its workspace — OpenClaw will auto-discover the skills/.
+  4. Applies harness.openclaw.config overrides (bankIdPrefix, dynamicBankId)
+     to the global plugin config in openclaw.json.
+  5. Copies the hindsight-skill-builder meta-skill from this repo into
+     <agent-dir>/skills/ if it's listed in agent.yaml and missing locally.
+  6. Provisions the Hindsight bank + mental models via the REST API
+     (idempotent: PUT bank, PATCH config, POST/PATCH mental-models).
+  7. Tells the user to restart the gateway.
+
+PoC. No tests. No rollback if a step fails mid-flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+META_SKILL_DIR = REPO_ROOT / "skills" / "hindsight-skill-builder"
+OPENCLAW_CONFIG_PATH = Path.home() / ".openclaw" / "openclaw.json"
+INSTALL_ROOT = Path.home() / ".hindsight-agents" / "openclaw"
+PLUGIN_ID = "hindsight-openclaw"
+
+
+# ────────────────────── output helpers ──────────────────────
+
+
+def info(msg: str) -> None:
+    print(f"  • {msg}", file=sys.stderr)
+
+
+def ok(msg: str) -> None:
+    print(f"  ✓ {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"  ! {msg}", file=sys.stderr)
+
+
+def die(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    info("$ " + " ".join(cmd))
+    return subprocess.run(cmd, check=check, text=True, capture_output=True)
+
+
+# ────────────────────── yaml ──────────────────────
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        die(
+            "PyYAML is required. Install with `uv pip install pyyaml` or "
+            "`pip install pyyaml`."
+        )
+    with path.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+# ────────────────────── openclaw plugin config ──────────────────────
+
+
+def load_openclaw_config() -> dict[str, Any]:
+    if not OPENCLAW_CONFIG_PATH.exists():
+        die(f"openclaw config not found at {OPENCLAW_CONFIG_PATH}")
+    return json.loads(OPENCLAW_CONFIG_PATH.read_text())
+
+
+def save_openclaw_config(cfg: dict[str, Any]) -> None:
+    OPENCLAW_CONFIG_PATH.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def get_plugin_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    entries = cfg.get("plugins", {}).get("entries", {})
+    entry = entries.get(PLUGIN_ID)
+    if not entry:
+        die(
+            f"hindsight-openclaw plugin not configured. Run "
+            f"`hindsight-openclaw-setup` first."
+        )
+    return entry.setdefault("config", {})
+
+
+def resolve_secret(value: Any) -> str | None:
+    """Resolve a SecretRef ({source:'env'|'file'|'exec', id:…}) or pass through string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict) and value.get("source") == "env":
+        env_var = value.get("id")
+        if not env_var:
+            return None
+        return os.environ.get(env_var)
+    if isinstance(value, dict) and value.get("source") == "file":
+        p = value.get("id")
+        return Path(p).read_text().strip() if p else None
+    if isinstance(value, dict) and value.get("source") == "exec":
+        cmd = value.get("id")
+        if not cmd:
+            return None
+        return subprocess.check_output(cmd, shell=True, text=True).strip()
+    return None
+
+
+# ────────────────────── hindsight HTTP ──────────────────────
+
+
+def http(method: str, url: str, token: str, body: dict | None = None) -> tuple[int, dict | None]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = resp.read().decode() or ""
+            return resp.status, (json.loads(payload) if payload else None)
+    except urllib.error.HTTPError as e:
+        payload = e.read().decode() or ""
+        try:
+            parsed = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            parsed = {"raw": payload}
+        return e.code, parsed
+
+
+def hindsight_health(api_url: str, token: str) -> None:
+    status, _ = http("GET", f"{api_url}/v1/default/banks?limit=1", token)
+    if status >= 400:
+        die(f"Hindsight API health check failed (status {status}) at {api_url}")
+    ok(f"Hindsight reachable at {api_url}")
+
+
+def upsert_bank(api_url: str, token: str, bank_id: str, name: str | None) -> None:
+    body: dict[str, Any] = {}
+    if name:
+        body["name"] = name
+    status, payload = http("PUT", f"{api_url}/v1/default/banks/{bank_id}", token, body)
+    if status >= 400:
+        die(f"create/update bank '{bank_id}' failed: {status} {payload}")
+    ok(f"bank '{bank_id}' upserted")
+
+
+def patch_bank_config(api_url: str, token: str, bank_id: str, updates: dict[str, Any]) -> None:
+    if not updates:
+        return
+    status, payload = http(
+        "PATCH", f"{api_url}/v1/default/banks/{bank_id}/config", token, {"updates": updates}
+    )
+    if status >= 400:
+        die(f"update bank config failed: {status} {payload}")
+    ok(f"bank '{bank_id}' missions configured ({', '.join(updates)})")
+
+
+def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, Any]) -> None:
+    mm_id = spec.get("id")
+    if not mm_id:
+        die("mental-model entry missing 'id'")
+    name = spec.get("name") or mm_id
+    source_query = spec.get("source_query")
+    if not source_query:
+        die(f"mental-model '{mm_id}' missing 'source_query'")
+    tags = spec.get("tags") or []
+    trigger = {}
+    if spec.get("refresh_after_consolidation"):
+        trigger["refresh_after_consolidation"] = True
+
+    base = f"{api_url}/v1/default/banks/{bank_id}/mental-models"
+    status, _ = http("GET", f"{base}/{mm_id}", token)
+
+    if status == 404:
+        body: dict[str, Any] = {"id": mm_id, "name": name, "source_query": source_query, "tags": tags}
+        if trigger:
+            body["trigger"] = trigger
+        s, payload = http("POST", base, token, body)
+        if s >= 400:
+            die(f"create mental-model '{mm_id}' failed: {s} {payload}")
+        ok(f"mental-model '{mm_id}' created")
+        return
+
+    if status >= 400:
+        die(f"check mental-model '{mm_id}' failed: {status}")
+
+    # exists → patch
+    body = {"name": name, "source_query": source_query, "tags": tags}
+    if trigger:
+        body["trigger"] = trigger
+    s, payload = http("PATCH", f"{base}/{mm_id}", token, body)
+    if s >= 400:
+        die(f"update mental-model '{mm_id}' failed: {s} {payload}")
+    ok(f"mental-model '{mm_id}' updated")
+
+
+# ────────────────────── workflow ──────────────────────
+
+
+def cmd_install(source_dir: Path, model: str | None = None) -> None:
+    source_dir = source_dir.expanduser().resolve()
+    if not source_dir.is_dir():
+        die(f"not a directory: {source_dir}")
+
+    manifest_path = source_dir / "agent.yaml"
+    if not manifest_path.exists():
+        die(f"missing {manifest_path}")
+    manifest = read_yaml(manifest_path)
+
+    name = manifest.get("name")
+    if not name:
+        die("agent.yaml: 'name' is required")
+
+    skills: list[str] = manifest.get("skills") or []
+    harness_cfg = (manifest.get("harness") or {}).get("openclaw") or {}
+    plugin_overrides = harness_cfg.get("config") or {}
+    # Model precedence: --model CLI > harness.openclaw.model > harness fallback.
+    # OpenClaw's gateway default is `openai/codex-mini-latest`, which requires a
+    # paid OpenAI key — many users only have Codex OAuth, so we fall back to
+    # `openai-codex/gpt-5.4` (the OAuth-friendly model `my-agent` uses) to keep
+    # first-run zero-config.
+    effective_model = model or harness_cfg.get("model") or "openai-codex/gpt-5.4"
+
+    hindsight_spec = manifest.get("hindsight") or {}
+    bank_from_manifest = hindsight_spec.get("bank")
+
+    # Copy the source dir into an isolated workspace under
+    # ~/.hindsight-agents/openclaw/<agent_id>/ so the boilerplate stays
+    # untouched and the agent's runtime files (skills, context, generated
+    # output) live under our control.
+    agent_dir = INSTALL_ROOT / name
+    INSTALL_ROOT.mkdir(parents=True, exist_ok=True)
+    info(f"agent name: {name}")
+    info(f"source:     {source_dir}")
+    info(f"workspace:  {agent_dir}")
+    info(f"skills:     {', '.join(skills) if skills else '(none listed)'}")
+    if agent_dir.exists():
+        ok(f"workspace exists, syncing on top of it")
+    shutil.copytree(source_dir, agent_dir, dirs_exist_ok=True)
+    ok(f"copied boilerplate → {agent_dir}")
+
+    setup_yaml_path = agent_dir / "setup" / "hindsight-config.yaml"
+
+    # 1. Read openclaw config + resolve hindsight creds.
+    cfg = load_openclaw_config()
+    plugin_cfg = get_plugin_config(cfg)
+    api_url = plugin_cfg.get("hindsightApiUrl")
+    if not api_url:
+        die(
+            "plugin config has no hindsightApiUrl. Configure the plugin first "
+            "(`hindsight-openclaw-setup`)."
+        )
+    token = resolve_secret(plugin_cfg.get("hindsightApiToken"))
+    if not token:
+        die(
+            "could not resolve hindsightApiToken from plugin config "
+            "(check SecretRef env var is exported)"
+        )
+    hindsight_health(api_url, token)
+
+    # 2. Create the OpenClaw agent (idempotent: skip if already exists).
+    existing = run(["openclaw", "agents", "list", "--json"], check=False)
+    already = False
+    if existing.returncode == 0:
+        # `openclaw … --json` prefixes its output with config warnings, so
+        # scan for the JSON payload rather than parsing stdout directly.
+        idx = existing.stdout.find("[")
+        if idx >= 0:
+            try:
+                for a in json.loads(existing.stdout[idx:]) or []:
+                    if isinstance(a, dict) and (
+                        a.get("agentId") == name
+                        or a.get("id") == name
+                        or a.get("name") == name
+                    ):
+                        already = True
+                        break
+            except json.JSONDecodeError:
+                pass
+    if already:
+        ok(f"openclaw agent '{name}' already exists, skipping create")
+    else:
+        proc = run(
+            [
+                "openclaw", "agents", "add",
+                "--workspace", str(agent_dir),
+                "--model", effective_model,
+                "--non-interactive",
+                "--json",
+                name,
+            ],
+            check=False,
+        )
+        if proc.returncode != 0:
+            die(f"`openclaw agents add` failed:\n{proc.stderr or proc.stdout}")
+        ok(f"openclaw agent '{name}' created (model={effective_model})")
+
+    # 3. Apply harness.openclaw.config overrides to the global plugin config.
+    # Re-load openclaw.json *after* `agents add` ran — that command rewrites
+    # the file too, so reusing the in-memory copy from before would clobber
+    # the new agent registration.
+    if plugin_overrides:
+        cfg = load_openclaw_config()
+        plugin_cfg = get_plugin_config(cfg)
+        for k, v in plugin_overrides.items():
+            plugin_cfg[k] = v
+        save_openclaw_config(cfg)
+        ok(f"plugin config updated: {', '.join(plugin_overrides)}")
+
+    # 4. Copy the hindsight-skill-builder meta-skill into the agent's
+    # workspace if listed and missing.
+    if "hindsight-skill-builder" in skills:
+        target = agent_dir / "skills" / "hindsight-skill-builder"
+        if target.exists():
+            ok("hindsight-skill-builder already present in workspace")
+        elif META_SKILL_DIR.exists():
+            shutil.copytree(META_SKILL_DIR, target)
+            ok(f"copied hindsight-skill-builder → {target}")
+        else:
+            warn(
+                f"hindsight-skill-builder listed but source skill not found "
+                f"at {META_SKILL_DIR} — skipping"
+            )
+
+    # 5. Provision Hindsight bank + mental models from setup/hindsight-config.yaml.
+    if not setup_yaml_path.exists():
+        warn(
+            f"no {setup_yaml_path.relative_to(agent_dir)} — skipping bank/mental-model provisioning"
+        )
+    else:
+        spec = read_yaml(setup_yaml_path)
+        bank_spec = spec.get("bank") or {}
+        bank_id = bank_spec.get("id") or bank_from_manifest
+        if not bank_id:
+            die(
+                f"{setup_yaml_path.name}: bank.id missing and not derivable from agent.yaml"
+            )
+        upsert_bank(api_url, token, bank_id, bank_spec.get("name"))
+
+        updates: dict[str, str] = {}
+        for key in ("retain_mission", "observations_mission", "reflect_mission"):
+            val = bank_spec.get(key)
+            if val:
+                updates[key] = val.strip()
+        patch_bank_config(api_url, token, bank_id, updates)
+
+        for mm in spec.get("mental_models") or []:
+            upsert_mental_model(api_url, token, bank_id, mm)
+
+    # 6. Restart the gateway so plugin-config changes + the new agent
+    # registration take effect, then bootstrap a starter session — without
+    # one, the control-plane chat dropdown (which lists from sessions, not
+    # agents) won't show the agent at all.
+    info("restarting gateway to pick up new agent + plugin config")
+    rc = subprocess.call(["openclaw", "gateway", "restart"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if rc != 0:
+        warn("gateway restart returned non-zero — restart manually with `openclaw gateway restart`")
+    else:
+        # Wait for RPC to come back before bootstrapping.
+        import time
+        for _ in range(30):
+            probe = subprocess.run(
+                ["openclaw", "gateway", "status"], capture_output=True, text=True
+            )
+            if "RPC probe: ok" in probe.stdout:
+                ok("gateway back online")
+                break
+            time.sleep(1)
+        else:
+            warn("gateway did not come back within 30s — skipping bootstrap")
+            rc = 1
+
+    if rc == 0:
+        info(f"bootstrapping initial session so '{name}' shows up in the chat UI")
+        boot = subprocess.run(
+            [
+                "openclaw", "agent",
+                "--agent", name,
+                "--session-id", f"{name}-bootstrap",
+                "--message", "hello",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if boot.returncode == 0:
+            ok(f"session '{name}-bootstrap' created — refresh the chat UI to see it")
+        else:
+            warn(
+                f"bootstrap session failed (likely a model auth issue):\n"
+                f"{(boot.stderr or boot.stdout).strip().splitlines()[-1] if (boot.stderr or boot.stdout).strip() else '(no output)'}"
+            )
+
+    # 7. Done — tell the user.
+    bank_id_print = bank_from_manifest or (
+        (read_yaml(setup_yaml_path).get("bank") or {}).get("id")
+        if setup_yaml_path.exists()
+        else None
+    )
+    print()
+    print("━" * 64)
+    print(f"  ✅ openclaw agent '{name}' installed")
+    print("━" * 64)
+    print()
+    print(f"workspace : {agent_dir}")
+    if bank_id_print:
+        print(f"bank      : {bank_id_print}")
+    print(f"model     : {effective_model}")
+    print()
+    print(f"Chat:  openclaw agent --agent {name} --message 'hello'")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_install = sub.add_parser("install", help="install an agent from a boilerplate directory")
+    p_install.add_argument("agent_dir", type=Path, help="path to the agent boilerplate directory")
+    p_install.add_argument(
+        "--model",
+        help="OpenClaw model id for the agent (overrides agent.yaml harness.openclaw.model)",
+    )
+    args = parser.parse_args()
+    if args.cmd == "install":
+        cmd_install(args.agent_dir, model=args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -137,53 +137,67 @@ def resolve_secret(value: Any) -> str | None:
     return None
 
 
-# ────────────────────── hindsight HTTP ──────────────────────
+# ────────────────────── hindsight CLI ──────────────────────
+#
+# We drive bank + mental-model setup through the `hindsight` CLI rather than
+# raw HTTP so credentials live in `~/.hindsight/config` (the CLI's source of
+# truth) instead of being sprinkled across env files. The one exception is
+# the mental-model `refresh_after_consolidation` trigger — `hindsight
+# mental-model create/update` doesn't expose that flag yet, so we PATCH it
+# directly via urllib using the same plugin creds.
 
 
-def http(method: str, url: str, token: str, body: dict | None = None) -> tuple[int, dict | None]:
-    data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(url, data=data, method=method)
-    req.add_header("Authorization", f"Bearer {token}")
-    if data is not None:
-        req.add_header("Content-Type", "application/json")
-    try:
-        with urllib.request.urlopen(req) as resp:
-            payload = resp.read().decode() or ""
-            return resp.status, (json.loads(payload) if payload else None)
-    except urllib.error.HTTPError as e:
-        payload = e.read().decode() or ""
-        try:
-            parsed = json.loads(payload) if payload else None
-        except json.JSONDecodeError:
-            parsed = {"raw": payload}
-        return e.code, parsed
+def configure_hindsight_cli(api_url: str, token: str) -> None:
+    """Point the hindsight CLI at the openclaw plugin's URL/token.
+
+    Writes ~/.hindsight/config so all subsequent `hindsight …` calls
+    (and any skill that shells out to the CLI) hit the configured Cloud /
+    external API instead of the CLI's localhost:8888 default.
+    """
+    cmd = ["hindsight", "configure", "--api-url", api_url]
+    if token:
+        cmd += ["--api-key", token]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        die(f"`hindsight configure` failed:\n{proc.stderr or proc.stdout}")
+    ok(f"hindsight CLI pointed at {api_url}")
 
 
-def hindsight_health(api_url: str, token: str) -> None:
-    status, _ = http("GET", f"{api_url}/v1/default/banks?limit=1", token)
-    if status >= 400:
-        die(f"Hindsight API health check failed (status {status}) at {api_url}")
-    ok(f"Hindsight reachable at {api_url}")
+def hindsight_cli(args: list[str], *, allow_fail: bool = False) -> subprocess.CompletedProcess:
+    info("$ hindsight " + " ".join(args))
+    proc = subprocess.run(["hindsight", *args], capture_output=True, text=True)
+    if proc.returncode != 0 and not allow_fail:
+        die(f"`hindsight {' '.join(args)}` failed:\n{(proc.stderr or proc.stdout).strip()}")
+    return proc
 
 
-def upsert_bank(api_url: str, token: str, bank_id: str, name: str | None) -> None:
-    body: dict[str, Any] = {}
+def hindsight_health() -> None:
+    proc = hindsight_cli(["health"], allow_fail=True)
+    if proc.returncode != 0:
+        die(f"hindsight health check failed:\n{(proc.stderr or proc.stdout).strip()}")
+    ok("Hindsight reachable")
+
+
+def upsert_bank(bank_id: str, name: str | None) -> None:
+    cmd = ["bank", "create", bank_id]
     if name:
-        body["name"] = name
-    status, payload = http("PUT", f"{api_url}/v1/default/banks/{bank_id}", token, body)
-    if status >= 400:
-        die(f"create/update bank '{bank_id}' failed: {status} {payload}")
-    ok(f"bank '{bank_id}' upserted")
+        cmd += ["--name", name]
+    proc = hindsight_cli(cmd, allow_fail=True)
+    if proc.returncode == 0:
+        ok(f"bank '{bank_id}' created")
+    elif "already exists" in (proc.stderr + proc.stdout).lower():
+        ok(f"bank '{bank_id}' already exists")
+    else:
+        die(f"create bank '{bank_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
 
 
-def patch_bank_config(api_url: str, token: str, bank_id: str, updates: dict[str, Any]) -> None:
+def patch_bank_config(bank_id: str, updates: dict[str, str]) -> None:
     if not updates:
         return
-    status, payload = http(
-        "PATCH", f"{api_url}/v1/default/banks/{bank_id}/config", token, {"updates": updates}
-    )
-    if status >= 400:
-        die(f"update bank config failed: {status} {payload}")
+    cmd = ["bank", "set-config", bank_id]
+    for key, value in updates.items():
+        cmd += [f"--{key.replace('_', '-')}", value]
+    hindsight_cli(cmd)
     ok(f"bank '{bank_id}' missions configured ({', '.join(updates)})")
 
 
@@ -195,35 +209,47 @@ def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, 
     source_query = spec.get("source_query")
     if not source_query:
         die(f"mental-model '{mm_id}' missing 'source_query'")
+
+    # `hindsight mental-model create` returns a generic 500 when an MM with
+    # the same id already exists, so we probe with `get` first instead of
+    # relying on an "already exists" error message.
+    existing = hindsight_cli(
+        ["mental-model", "get", bank_id, mm_id], allow_fail=True
+    )
+    if existing.returncode == 0:
+        ok(f"mental-model '{mm_id}' already exists")
+    else:
+        proc = hindsight_cli(
+            ["mental-model", "create", bank_id, name, source_query, "--id", mm_id],
+            allow_fail=True,
+        )
+        if proc.returncode != 0:
+            die(f"create mental-model '{mm_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
+        ok(f"mental-model '{mm_id}' created")
+
+    # The CLI doesn't expose the trigger field yet — PATCH it ourselves.
     tags = spec.get("tags") or []
     trigger = {}
     if spec.get("refresh_after_consolidation"):
         trigger["refresh_after_consolidation"] = True
-
-    base = f"{api_url}/v1/default/banks/{bank_id}/mental-models"
-    status, _ = http("GET", f"{base}/{mm_id}", token)
-
-    if status == 404:
-        body: dict[str, Any] = {"id": mm_id, "name": name, "source_query": source_query, "tags": tags}
-        if trigger:
-            body["trigger"] = trigger
-        s, payload = http("POST", base, token, body)
-        if s >= 400:
-            die(f"create mental-model '{mm_id}' failed: {s} {payload}")
-        ok(f"mental-model '{mm_id}' created")
+    if not trigger and not tags:
         return
-
-    if status >= 400:
-        die(f"check mental-model '{mm_id}' failed: {status}")
-
-    # exists → patch
-    body = {"name": name, "source_query": source_query, "tags": tags}
+    body: dict[str, Any] = {}
     if trigger:
         body["trigger"] = trigger
-    s, payload = http("PATCH", f"{base}/{mm_id}", token, body)
-    if s >= 400:
-        die(f"update mental-model '{mm_id}' failed: {s} {payload}")
-    ok(f"mental-model '{mm_id}' updated")
+    if tags:
+        body["tags"] = tags
+    url = f"{api_url}/v1/default/banks/{bank_id}/mental-models/{mm_id}"
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), method="PATCH"
+    )
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        urllib.request.urlopen(req).read()
+    except urllib.error.HTTPError as e:
+        die(f"set mental-model '{mm_id}' trigger failed: {e.code} {e.read().decode()[:200]}")
+    ok(f"mental-model '{mm_id}' trigger configured ({list(trigger) or 'tags only'})")
 
 
 # ────────────────────── workflow ──────────────────────
@@ -282,33 +308,41 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             "plugin config has no hindsightApiUrl. Configure the plugin first "
             "(`hindsight-openclaw-setup`)."
         )
-    token = resolve_secret(plugin_cfg.get("hindsightApiToken"))
-    if not token:
-        die(
-            "could not resolve hindsightApiToken from plugin config "
-            "(check SecretRef env var is exported)"
-        )
-    hindsight_health(api_url, token)
+    token = resolve_secret(plugin_cfg.get("hindsightApiToken")) or ""
+    # Configure the hindsight CLI so subsequent `hindsight …` commands (and
+    # any skill that shells out to the CLI) hit the same Hindsight instance
+    # the openclaw plugin is configured for, instead of falling back to the
+    # CLI's localhost:8888 default.
+    configure_hindsight_cli(api_url, token)
+    hindsight_health()
 
     # 2. Create the OpenClaw agent (idempotent: skip if already exists).
     existing = run(["openclaw", "agents", "list", "--json"], check=False)
     already = False
     if existing.returncode == 0:
-        # `openclaw … --json` prefixes its output with config warnings, so
-        # scan for the JSON payload rather than parsing stdout directly.
-        idx = existing.stdout.find("[")
-        if idx >= 0:
+        # `openclaw … --json` prefixes its output with config warnings AND
+        # plugin-load logs that contain stray `[` chars, so we can't grab the
+        # first `[` and call `json.loads`. Find the last `[` that opens a
+        # balanced array containing the agent list — easiest just to walk
+        # candidates from the end.
+        out = existing.stdout
+        for start in range(len(out) - 1, -1, -1):
+            if out[start] != "[":
+                continue
             try:
-                for a in json.loads(existing.stdout[idx:]) or []:
-                    if isinstance(a, dict) and (
-                        a.get("agentId") == name
-                        or a.get("id") == name
-                        or a.get("name") == name
-                    ):
-                        already = True
-                        break
+                payload = json.loads(out[start:])
             except json.JSONDecodeError:
-                pass
+                continue
+            if not isinstance(payload, list):
+                continue
+            for a in payload:
+                if isinstance(a, dict) and (
+                    a.get("agentId") == name
+                    or a.get("id") == name
+                    or a.get("name") == name
+                ):
+                    already = True
+            break
     if already:
         ok(f"openclaw agent '{name}' already exists, skipping create")
     else:
@@ -367,14 +401,14 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             die(
                 f"{setup_yaml_path.name}: bank.id missing and not derivable from agent.yaml"
             )
-        upsert_bank(api_url, token, bank_id, bank_spec.get("name"))
+        upsert_bank(bank_id, bank_spec.get("name"))
 
         updates: dict[str, str] = {}
         for key in ("retain_mission", "observations_mission", "reflect_mission"):
             val = bank_spec.get(key)
             if val:
                 updates[key] = val.strip()
-        patch_bank_config(api_url, token, bank_id, updates)
+        patch_bank_config(bank_id, updates)
 
         for mm in spec.get("mental_models") or []:
             upsert_mental_model(api_url, token, bank_id, mm)

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -39,6 +39,8 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -137,10 +139,12 @@ def resolve_secret(value: Any) -> str | None:
 
 # ────────────────────── hindsight CLI ──────────────────────
 #
-# All bank + mental-model setup goes through the `hindsight` CLI so
-# credentials live in `~/.hindsight/config` (the CLI's source of truth)
-# instead of being sprinkled across env files, and the installer stays in
-# lockstep with whatever endpoints the current CLI understands.
+# We drive bank + mental-model setup through the `hindsight` CLI rather than
+# raw HTTP so credentials live in `~/.hindsight/config` (the CLI's source of
+# truth) instead of being sprinkled across env files. The one exception is
+# the mental-model `refresh_after_consolidation` trigger — `hindsight
+# mental-model create/update` doesn't expose that flag yet, so we PATCH it
+# directly via urllib using the same plugin creds.
 
 
 def configure_hindsight_cli(api_url: str, token: str) -> None:
@@ -197,7 +201,7 @@ def patch_bank_config(bank_id: str, updates: dict[str, str]) -> None:
     ok(f"bank '{bank_id}' missions configured ({', '.join(updates)})")
 
 
-def upsert_mental_model(bank_id: str, spec: dict[str, Any]) -> None:
+def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, Any]) -> None:
     mm_id = spec.get("id")
     if not mm_id:
         die("mental-model entry missing 'id'")
@@ -205,32 +209,47 @@ def upsert_mental_model(bank_id: str, spec: dict[str, Any]) -> None:
     source_query = spec.get("source_query")
     if not source_query:
         die(f"mental-model '{mm_id}' missing 'source_query'")
-    tags = spec.get("tags") or []
-    refresh = bool(spec.get("refresh_after_consolidation"))
 
-    # Probe with `get` first — `mental-model create` returns a generic 500
-    # on duplicate id instead of a clean 409, so we can't rely on the error
-    # message to distinguish conflict from real failure.
+    # `hindsight mental-model create` returns a generic 500 when an MM with
+    # the same id already exists, so we probe with `get` first instead of
+    # relying on an "already exists" error message.
     existing = hindsight_cli(
         ["mental-model", "get", bank_id, mm_id], allow_fail=True
     )
-
     if existing.returncode == 0:
-        cmd = ["mental-model", "update", bank_id, mm_id, "--name", name, "--source-query", source_query]
-        if tags:
-            cmd += ["--tags", ",".join(tags)]
-        if refresh:
-            cmd += ["--trigger-refresh-after-consolidation", "true"]
-        hindsight_cli(cmd)
-        ok(f"mental-model '{mm_id}' updated")
+        ok(f"mental-model '{mm_id}' already exists")
     else:
-        cmd = ["mental-model", "create", bank_id, name, source_query, "--id", mm_id]
-        if tags:
-            cmd += ["--tags", ",".join(tags)]
-        if refresh:
-            cmd.append("--trigger-refresh-after-consolidation")
-        hindsight_cli(cmd)
+        proc = hindsight_cli(
+            ["mental-model", "create", bank_id, name, source_query, "--id", mm_id],
+            allow_fail=True,
+        )
+        if proc.returncode != 0:
+            die(f"create mental-model '{mm_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
         ok(f"mental-model '{mm_id}' created")
+
+    # The CLI doesn't expose the trigger field yet — PATCH it ourselves.
+    tags = spec.get("tags") or []
+    trigger = {}
+    if spec.get("refresh_after_consolidation"):
+        trigger["refresh_after_consolidation"] = True
+    if not trigger and not tags:
+        return
+    body: dict[str, Any] = {}
+    if trigger:
+        body["trigger"] = trigger
+    if tags:
+        body["tags"] = tags
+    url = f"{api_url}/v1/default/banks/{bank_id}/mental-models/{mm_id}"
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), method="PATCH"
+    )
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        urllib.request.urlopen(req).read()
+    except urllib.error.HTTPError as e:
+        die(f"set mental-model '{mm_id}' trigger failed: {e.code} {e.read().decode()[:200]}")
+    ok(f"mental-model '{mm_id}' trigger configured ({list(trigger) or 'tags only'})")
 
 
 # ────────────────────── workflow ──────────────────────
@@ -392,7 +411,7 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
         patch_bank_config(bank_id, updates)
 
         for mm in spec.get("mental_models") or []:
-            upsert_mental_model(bank_id, mm)
+            upsert_mental_model(api_url, token, bank_id, mm)
 
     # 6. Restart the gateway so plugin-config changes + the new agent
     # registration take effect, then bootstrap a starter session — without

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -143,57 +143,6 @@ def resolve_secret(value: Any) -> str | None:
 # lockstep with whatever endpoints the current CLI understands.
 
 
-CLI_INSTALLER_URL = "https://hindsight.vectorize.io/get-cli"
-
-
-def ensure_hindsight_cli() -> None:
-    """Install or upgrade the `hindsight` CLI to the latest release.
-
-    The installer is idempotent and writes to ~/.local/bin, so we always
-    try to run it — that way the installer doesn't depend on whatever
-    `hindsight` happens to be on PATH (which may pre-date features we rely
-    on, e.g. the `--trigger-refresh-after-consolidation` flag).
-
-    The upstream installer hits the unauthenticated GitHub releases API,
-    which gets rate-limited (60 req/h per IP). When that fails, we fall
-    back to whatever `hindsight` is already on PATH and let the rest of
-    the install proceed — only erroring out if no CLI is reachable at all.
-    """
-    info(f"installing/upgrading hindsight CLI from {CLI_INSTALLER_URL}")
-    proc = subprocess.run(
-        f"curl -fsSL {CLI_INSTALLER_URL} | bash",
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
-
-    # Make sure ~/.local/bin (where the installer writes) is on PATH for
-    # the rest of this process before we probe for the binary.
-    local_bin = str(Path.home() / ".local" / "bin")
-    if local_bin not in os.environ.get("PATH", "").split(os.pathsep):
-        os.environ["PATH"] = local_bin + os.pathsep + os.environ.get("PATH", "")
-
-    version_proc = subprocess.run(
-        ["hindsight", "--version"], capture_output=True, text=True
-    )
-    have_cli = version_proc.returncode == 0
-    version = version_proc.stdout.strip() if have_cli else "(none)"
-
-    if proc.returncode == 0:
-        ok(f"hindsight CLI ready: {version}")
-        return
-    if have_cli:
-        warn(
-            f"hindsight CLI install failed (likely GitHub rate limit) — "
-            f"continuing with already-installed {version}"
-        )
-        return
-    die(
-        f"hindsight CLI install failed and no `hindsight` binary on PATH:\n"
-        f"{(proc.stderr or proc.stdout).strip()[-400:]}"
-    )
-
-
 def configure_hindsight_cli(api_url: str, token: str) -> None:
     """Point the hindsight CLI at the openclaw plugin's URL/token.
 
@@ -341,13 +290,10 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             "(`hindsight-openclaw-setup`)."
         )
     token = resolve_secret(plugin_cfg.get("hindsightApiToken")) or ""
-    # Make sure the hindsight CLI is installed AND fresh enough to know about
-    # the flags we use (--trigger-refresh-after-consolidation, --tags), then
-    # point it at the same URL/token the openclaw plugin uses so subsequent
-    # `hindsight …` calls (and any skill that shells out to the CLI) hit the
-    # configured Cloud / external API instead of the CLI's localhost:8888
-    # default.
-    ensure_hindsight_cli()
+    # Configure the hindsight CLI so subsequent `hindsight …` commands (and
+    # any skill that shells out to the CLI) hit the same Hindsight instance
+    # the openclaw plugin is configured for, instead of falling back to the
+    # CLI's localhost:8888 default.
     configure_hindsight_cli(api_url, token)
     hindsight_health()
 

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -39,8 +39,6 @@ import os
 import shutil
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -139,12 +137,10 @@ def resolve_secret(value: Any) -> str | None:
 
 # ────────────────────── hindsight CLI ──────────────────────
 #
-# We drive bank + mental-model setup through the `hindsight` CLI rather than
-# raw HTTP so credentials live in `~/.hindsight/config` (the CLI's source of
-# truth) instead of being sprinkled across env files. The one exception is
-# the mental-model `refresh_after_consolidation` trigger — `hindsight
-# mental-model create/update` doesn't expose that flag yet, so we PATCH it
-# directly via urllib using the same plugin creds.
+# All bank + mental-model setup goes through the `hindsight` CLI so
+# credentials live in `~/.hindsight/config` (the CLI's source of truth)
+# instead of being sprinkled across env files, and the installer stays in
+# lockstep with whatever endpoints the current CLI understands.
 
 
 def configure_hindsight_cli(api_url: str, token: str) -> None:
@@ -201,7 +197,7 @@ def patch_bank_config(bank_id: str, updates: dict[str, str]) -> None:
     ok(f"bank '{bank_id}' missions configured ({', '.join(updates)})")
 
 
-def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, Any]) -> None:
+def upsert_mental_model(bank_id: str, spec: dict[str, Any]) -> None:
     mm_id = spec.get("id")
     if not mm_id:
         die("mental-model entry missing 'id'")
@@ -209,47 +205,32 @@ def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, 
     source_query = spec.get("source_query")
     if not source_query:
         die(f"mental-model '{mm_id}' missing 'source_query'")
+    tags = spec.get("tags") or []
+    refresh = bool(spec.get("refresh_after_consolidation"))
 
-    # `hindsight mental-model create` returns a generic 500 when an MM with
-    # the same id already exists, so we probe with `get` first instead of
-    # relying on an "already exists" error message.
+    # Probe with `get` first — `mental-model create` returns a generic 500
+    # on duplicate id instead of a clean 409, so we can't rely on the error
+    # message to distinguish conflict from real failure.
     existing = hindsight_cli(
         ["mental-model", "get", bank_id, mm_id], allow_fail=True
     )
-    if existing.returncode == 0:
-        ok(f"mental-model '{mm_id}' already exists")
-    else:
-        proc = hindsight_cli(
-            ["mental-model", "create", bank_id, name, source_query, "--id", mm_id],
-            allow_fail=True,
-        )
-        if proc.returncode != 0:
-            die(f"create mental-model '{mm_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
-        ok(f"mental-model '{mm_id}' created")
 
-    # The CLI doesn't expose the trigger field yet — PATCH it ourselves.
-    tags = spec.get("tags") or []
-    trigger = {}
-    if spec.get("refresh_after_consolidation"):
-        trigger["refresh_after_consolidation"] = True
-    if not trigger and not tags:
-        return
-    body: dict[str, Any] = {}
-    if trigger:
-        body["trigger"] = trigger
-    if tags:
-        body["tags"] = tags
-    url = f"{api_url}/v1/default/banks/{bank_id}/mental-models/{mm_id}"
-    req = urllib.request.Request(
-        url, data=json.dumps(body).encode(), method="PATCH"
-    )
-    req.add_header("Authorization", f"Bearer {token}")
-    req.add_header("Content-Type", "application/json")
-    try:
-        urllib.request.urlopen(req).read()
-    except urllib.error.HTTPError as e:
-        die(f"set mental-model '{mm_id}' trigger failed: {e.code} {e.read().decode()[:200]}")
-    ok(f"mental-model '{mm_id}' trigger configured ({list(trigger) or 'tags only'})")
+    if existing.returncode == 0:
+        cmd = ["mental-model", "update", bank_id, mm_id, "--name", name, "--source-query", source_query]
+        if tags:
+            cmd += ["--tags", ",".join(tags)]
+        if refresh:
+            cmd += ["--trigger-refresh-after-consolidation", "true"]
+        hindsight_cli(cmd)
+        ok(f"mental-model '{mm_id}' updated")
+    else:
+        cmd = ["mental-model", "create", bank_id, name, source_query, "--id", mm_id]
+        if tags:
+            cmd += ["--tags", ",".join(tags)]
+        if refresh:
+            cmd.append("--trigger-refresh-after-consolidation")
+        hindsight_cli(cmd)
+        ok(f"mental-model '{mm_id}' created")
 
 
 # ────────────────────── workflow ──────────────────────
@@ -411,7 +392,7 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
         patch_bank_config(bank_id, updates)
 
         for mm in spec.get("mental_models") or []:
-            upsert_mental_model(api_url, token, bank_id, mm)
+            upsert_mental_model(bank_id, mm)
 
     # 6. Restart the gateway so plugin-config changes + the new agent
     # registration take effect, then bootstrap a starter session — without

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -137,67 +137,53 @@ def resolve_secret(value: Any) -> str | None:
     return None
 
 
-# ────────────────────── hindsight CLI ──────────────────────
-#
-# We drive bank + mental-model setup through the `hindsight` CLI rather than
-# raw HTTP so credentials live in `~/.hindsight/config` (the CLI's source of
-# truth) instead of being sprinkled across env files. The one exception is
-# the mental-model `refresh_after_consolidation` trigger — `hindsight
-# mental-model create/update` doesn't expose that flag yet, so we PATCH it
-# directly via urllib using the same plugin creds.
+# ────────────────────── hindsight HTTP ──────────────────────
 
 
-def configure_hindsight_cli(api_url: str, token: str) -> None:
-    """Point the hindsight CLI at the openclaw plugin's URL/token.
-
-    Writes ~/.hindsight/config so all subsequent `hindsight …` calls
-    (and any skill that shells out to the CLI) hit the configured Cloud /
-    external API instead of the CLI's localhost:8888 default.
-    """
-    cmd = ["hindsight", "configure", "--api-url", api_url]
-    if token:
-        cmd += ["--api-key", token]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-        die(f"`hindsight configure` failed:\n{proc.stderr or proc.stdout}")
-    ok(f"hindsight CLI pointed at {api_url}")
-
-
-def hindsight_cli(args: list[str], *, allow_fail: bool = False) -> subprocess.CompletedProcess:
-    info("$ hindsight " + " ".join(args))
-    proc = subprocess.run(["hindsight", *args], capture_output=True, text=True)
-    if proc.returncode != 0 and not allow_fail:
-        die(f"`hindsight {' '.join(args)}` failed:\n{(proc.stderr or proc.stdout).strip()}")
-    return proc
+def http(method: str, url: str, token: str, body: dict | None = None) -> tuple[int, dict | None]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = resp.read().decode() or ""
+            return resp.status, (json.loads(payload) if payload else None)
+    except urllib.error.HTTPError as e:
+        payload = e.read().decode() or ""
+        try:
+            parsed = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            parsed = {"raw": payload}
+        return e.code, parsed
 
 
-def hindsight_health() -> None:
-    proc = hindsight_cli(["health"], allow_fail=True)
-    if proc.returncode != 0:
-        die(f"hindsight health check failed:\n{(proc.stderr or proc.stdout).strip()}")
-    ok("Hindsight reachable")
+def hindsight_health(api_url: str, token: str) -> None:
+    status, _ = http("GET", f"{api_url}/v1/default/banks?limit=1", token)
+    if status >= 400:
+        die(f"Hindsight API health check failed (status {status}) at {api_url}")
+    ok(f"Hindsight reachable at {api_url}")
 
 
-def upsert_bank(bank_id: str, name: str | None) -> None:
-    cmd = ["bank", "create", bank_id]
+def upsert_bank(api_url: str, token: str, bank_id: str, name: str | None) -> None:
+    body: dict[str, Any] = {}
     if name:
-        cmd += ["--name", name]
-    proc = hindsight_cli(cmd, allow_fail=True)
-    if proc.returncode == 0:
-        ok(f"bank '{bank_id}' created")
-    elif "already exists" in (proc.stderr + proc.stdout).lower():
-        ok(f"bank '{bank_id}' already exists")
-    else:
-        die(f"create bank '{bank_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
+        body["name"] = name
+    status, payload = http("PUT", f"{api_url}/v1/default/banks/{bank_id}", token, body)
+    if status >= 400:
+        die(f"create/update bank '{bank_id}' failed: {status} {payload}")
+    ok(f"bank '{bank_id}' upserted")
 
 
-def patch_bank_config(bank_id: str, updates: dict[str, str]) -> None:
+def patch_bank_config(api_url: str, token: str, bank_id: str, updates: dict[str, Any]) -> None:
     if not updates:
         return
-    cmd = ["bank", "set-config", bank_id]
-    for key, value in updates.items():
-        cmd += [f"--{key.replace('_', '-')}", value]
-    hindsight_cli(cmd)
+    status, payload = http(
+        "PATCH", f"{api_url}/v1/default/banks/{bank_id}/config", token, {"updates": updates}
+    )
+    if status >= 400:
+        die(f"update bank config failed: {status} {payload}")
     ok(f"bank '{bank_id}' missions configured ({', '.join(updates)})")
 
 
@@ -209,47 +195,35 @@ def upsert_mental_model(api_url: str, token: str, bank_id: str, spec: dict[str, 
     source_query = spec.get("source_query")
     if not source_query:
         die(f"mental-model '{mm_id}' missing 'source_query'")
-
-    # `hindsight mental-model create` returns a generic 500 when an MM with
-    # the same id already exists, so we probe with `get` first instead of
-    # relying on an "already exists" error message.
-    existing = hindsight_cli(
-        ["mental-model", "get", bank_id, mm_id], allow_fail=True
-    )
-    if existing.returncode == 0:
-        ok(f"mental-model '{mm_id}' already exists")
-    else:
-        proc = hindsight_cli(
-            ["mental-model", "create", bank_id, name, source_query, "--id", mm_id],
-            allow_fail=True,
-        )
-        if proc.returncode != 0:
-            die(f"create mental-model '{mm_id}' failed:\n{(proc.stderr or proc.stdout).strip()}")
-        ok(f"mental-model '{mm_id}' created")
-
-    # The CLI doesn't expose the trigger field yet — PATCH it ourselves.
     tags = spec.get("tags") or []
     trigger = {}
     if spec.get("refresh_after_consolidation"):
         trigger["refresh_after_consolidation"] = True
-    if not trigger and not tags:
+
+    base = f"{api_url}/v1/default/banks/{bank_id}/mental-models"
+    status, _ = http("GET", f"{base}/{mm_id}", token)
+
+    if status == 404:
+        body: dict[str, Any] = {"id": mm_id, "name": name, "source_query": source_query, "tags": tags}
+        if trigger:
+            body["trigger"] = trigger
+        s, payload = http("POST", base, token, body)
+        if s >= 400:
+            die(f"create mental-model '{mm_id}' failed: {s} {payload}")
+        ok(f"mental-model '{mm_id}' created")
         return
-    body: dict[str, Any] = {}
+
+    if status >= 400:
+        die(f"check mental-model '{mm_id}' failed: {status}")
+
+    # exists → patch
+    body = {"name": name, "source_query": source_query, "tags": tags}
     if trigger:
         body["trigger"] = trigger
-    if tags:
-        body["tags"] = tags
-    url = f"{api_url}/v1/default/banks/{bank_id}/mental-models/{mm_id}"
-    req = urllib.request.Request(
-        url, data=json.dumps(body).encode(), method="PATCH"
-    )
-    req.add_header("Authorization", f"Bearer {token}")
-    req.add_header("Content-Type", "application/json")
-    try:
-        urllib.request.urlopen(req).read()
-    except urllib.error.HTTPError as e:
-        die(f"set mental-model '{mm_id}' trigger failed: {e.code} {e.read().decode()[:200]}")
-    ok(f"mental-model '{mm_id}' trigger configured ({list(trigger) or 'tags only'})")
+    s, payload = http("PATCH", f"{base}/{mm_id}", token, body)
+    if s >= 400:
+        die(f"update mental-model '{mm_id}' failed: {s} {payload}")
+    ok(f"mental-model '{mm_id}' updated")
 
 
 # ────────────────────── workflow ──────────────────────
@@ -308,41 +282,33 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             "plugin config has no hindsightApiUrl. Configure the plugin first "
             "(`hindsight-openclaw-setup`)."
         )
-    token = resolve_secret(plugin_cfg.get("hindsightApiToken")) or ""
-    # Configure the hindsight CLI so subsequent `hindsight …` commands (and
-    # any skill that shells out to the CLI) hit the same Hindsight instance
-    # the openclaw plugin is configured for, instead of falling back to the
-    # CLI's localhost:8888 default.
-    configure_hindsight_cli(api_url, token)
-    hindsight_health()
+    token = resolve_secret(plugin_cfg.get("hindsightApiToken"))
+    if not token:
+        die(
+            "could not resolve hindsightApiToken from plugin config "
+            "(check SecretRef env var is exported)"
+        )
+    hindsight_health(api_url, token)
 
     # 2. Create the OpenClaw agent (idempotent: skip if already exists).
     existing = run(["openclaw", "agents", "list", "--json"], check=False)
     already = False
     if existing.returncode == 0:
-        # `openclaw … --json` prefixes its output with config warnings AND
-        # plugin-load logs that contain stray `[` chars, so we can't grab the
-        # first `[` and call `json.loads`. Find the last `[` that opens a
-        # balanced array containing the agent list — easiest just to walk
-        # candidates from the end.
-        out = existing.stdout
-        for start in range(len(out) - 1, -1, -1):
-            if out[start] != "[":
-                continue
+        # `openclaw … --json` prefixes its output with config warnings, so
+        # scan for the JSON payload rather than parsing stdout directly.
+        idx = existing.stdout.find("[")
+        if idx >= 0:
             try:
-                payload = json.loads(out[start:])
+                for a in json.loads(existing.stdout[idx:]) or []:
+                    if isinstance(a, dict) and (
+                        a.get("agentId") == name
+                        or a.get("id") == name
+                        or a.get("name") == name
+                    ):
+                        already = True
+                        break
             except json.JSONDecodeError:
-                continue
-            if not isinstance(payload, list):
-                continue
-            for a in payload:
-                if isinstance(a, dict) and (
-                    a.get("agentId") == name
-                    or a.get("id") == name
-                    or a.get("name") == name
-                ):
-                    already = True
-            break
+                pass
     if already:
         ok(f"openclaw agent '{name}' already exists, skipping create")
     else:
@@ -401,14 +367,14 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             die(
                 f"{setup_yaml_path.name}: bank.id missing and not derivable from agent.yaml"
             )
-        upsert_bank(bank_id, bank_spec.get("name"))
+        upsert_bank(api_url, token, bank_id, bank_spec.get("name"))
 
         updates: dict[str, str] = {}
         for key in ("retain_mission", "observations_mission", "reflect_mission"):
             val = bank_spec.get(key)
             if val:
                 updates[key] = val.strip()
-        patch_bank_config(bank_id, updates)
+        patch_bank_config(api_url, token, bank_id, updates)
 
         for mm in spec.get("mental_models") or []:
             upsert_mental_model(api_url, token, bank_id, mm)

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -143,6 +143,57 @@ def resolve_secret(value: Any) -> str | None:
 # lockstep with whatever endpoints the current CLI understands.
 
 
+CLI_INSTALLER_URL = "https://hindsight.vectorize.io/get-cli"
+
+
+def ensure_hindsight_cli() -> None:
+    """Install or upgrade the `hindsight` CLI to the latest release.
+
+    The installer is idempotent and writes to ~/.local/bin, so we always
+    try to run it — that way the installer doesn't depend on whatever
+    `hindsight` happens to be on PATH (which may pre-date features we rely
+    on, e.g. the `--trigger-refresh-after-consolidation` flag).
+
+    The upstream installer hits the unauthenticated GitHub releases API,
+    which gets rate-limited (60 req/h per IP). When that fails, we fall
+    back to whatever `hindsight` is already on PATH and let the rest of
+    the install proceed — only erroring out if no CLI is reachable at all.
+    """
+    info(f"installing/upgrading hindsight CLI from {CLI_INSTALLER_URL}")
+    proc = subprocess.run(
+        f"curl -fsSL {CLI_INSTALLER_URL} | bash",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # Make sure ~/.local/bin (where the installer writes) is on PATH for
+    # the rest of this process before we probe for the binary.
+    local_bin = str(Path.home() / ".local" / "bin")
+    if local_bin not in os.environ.get("PATH", "").split(os.pathsep):
+        os.environ["PATH"] = local_bin + os.pathsep + os.environ.get("PATH", "")
+
+    version_proc = subprocess.run(
+        ["hindsight", "--version"], capture_output=True, text=True
+    )
+    have_cli = version_proc.returncode == 0
+    version = version_proc.stdout.strip() if have_cli else "(none)"
+
+    if proc.returncode == 0:
+        ok(f"hindsight CLI ready: {version}")
+        return
+    if have_cli:
+        warn(
+            f"hindsight CLI install failed (likely GitHub rate limit) — "
+            f"continuing with already-installed {version}"
+        )
+        return
+    die(
+        f"hindsight CLI install failed and no `hindsight` binary on PATH:\n"
+        f"{(proc.stderr or proc.stdout).strip()[-400:]}"
+    )
+
+
 def configure_hindsight_cli(api_url: str, token: str) -> None:
     """Point the hindsight CLI at the openclaw plugin's URL/token.
 
@@ -290,10 +341,13 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             "(`hindsight-openclaw-setup`)."
         )
     token = resolve_secret(plugin_cfg.get("hindsightApiToken")) or ""
-    # Configure the hindsight CLI so subsequent `hindsight …` commands (and
-    # any skill that shells out to the CLI) hit the same Hindsight instance
-    # the openclaw plugin is configured for, instead of falling back to the
-    # CLI's localhost:8888 default.
+    # Make sure the hindsight CLI is installed AND fresh enough to know about
+    # the flags we use (--trigger-refresh-after-consolidation, --tags), then
+    # point it at the same URL/token the openclaw plugin uses so subsequent
+    # `hindsight …` calls (and any skill that shells out to the CLI) hit the
+    # configured Cloud / external API instead of the CLI's localhost:8888
+    # default.
+    ensure_hindsight_cli()
     configure_hindsight_cli(api_url, token)
     hindsight_health()
 

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -338,6 +338,34 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
     # Re-load openclaw.json *after* `agents add` ran — that command rewrites
     # the file too, so reusing the in-memory copy from before would clobber
     # the new agent registration.
+    #
+    # When the manifest declares a hindsight.bank but the harness.openclaw
+    # config doesn't set bankId, auto-wire it. With dynamicBankId=false the
+    # plugin otherwise defaults to "<prefix>-openclaw" and silently retains
+    # to the wrong bank — the one we never provisioned missions on.
+    # Force per-agent bank routing so multiple installed agents don't share
+    # one global bank. With dynamicBankGranularity=['agent'] the plugin
+    # derives the bank id from the session's resolved agentId at runtime,
+    # so installing a second agent doesn't clobber the first.
+    #
+    # NOTE: relies on issue #1046's skip-filter carve-out (PR #1054) so that
+    # agent:<id>:main webchat sessions actually reach the retain hook.
+    plugin_overrides = {
+        **plugin_overrides,
+        "dynamicBankId": True,
+        "dynamicBankGranularity": ["agent"],
+    }
+    plugin_overrides.pop("bankId", None)
+    bank_prefix = plugin_overrides.get("bankIdPrefix") or ""
+    derived_bank_id = f"{bank_prefix}-{name}" if bank_prefix else name
+    if bank_from_manifest and bank_from_manifest != derived_bank_id:
+        warn(
+            f"agent.yaml hindsight.bank='{bank_from_manifest}' but per-agent "
+            f"granularity will route this agent to '{derived_bank_id}' "
+            f"(set bankIdPrefix='{bank_from_manifest.rsplit('-', 1)[0] if '-' in bank_from_manifest else ''}' "
+            f"and rename the agent to '{bank_from_manifest.rsplit('-', 1)[-1]}' to match)"
+        )
+
     if plugin_overrides:
         cfg = load_openclaw_config()
         plugin_cfg = get_plugin_config(cfg)
@@ -369,12 +397,11 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
     else:
         spec = read_yaml(setup_yaml_path)
         bank_spec = spec.get("bank") or {}
-        bank_id = bank_spec.get("id") or bank_from_manifest
-        if not bank_id:
-            die(
-                f"{setup_yaml_path.name}: bank.id missing and not derivable from agent.yaml"
-            )
-        upsert_bank(api_url, token, bank_id, bank_spec.get("name"))
+        # Provision missions on the bank the plugin will actually route to
+        # (derived from prefix + agentName), not whatever id the user wrote
+        # in setup/hindsight-config.yaml — those would silently disagree.
+        bank_id = derived_bank_id
+        upsert_bank(api_url, token, bank_id, bank_spec.get("name") or name)
 
         updates: dict[str, str] = {}
         for key in ("retain_mission", "observations_mission", "reflect_mission"):

--- a/scripts/openclaw-agent
+++ b/scripts/openclaw-agent
@@ -268,8 +268,17 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
     info(f"skills:     {', '.join(skills) if skills else '(none listed)'}")
     if agent_dir.exists():
         ok(f"workspace exists, syncing on top of it")
-    shutil.copytree(source_dir, agent_dir, dirs_exist_ok=True)
-    ok(f"copied boilerplate → {agent_dir}")
+    # Skip `skills/` from the boilerplate. Task-specific skills are the
+    # agent's job to build on demand via the `hindsight-skill-builder`
+    # meta-skill — not the installer's. The boilerplate should ship the
+    # agent's identity + mission + bank config, nothing else.
+    shutil.copytree(
+        source_dir,
+        agent_dir,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("skills", "skills/*"),
+    )
+    ok(f"copied boilerplate → {agent_dir} (excluding skills/)")
 
     setup_yaml_path = agent_dir / "setup" / "hindsight-config.yaml"
 
@@ -282,11 +291,15 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
             "plugin config has no hindsightApiUrl. Configure the plugin first "
             "(`hindsight-openclaw-setup`)."
         )
-    token = resolve_secret(plugin_cfg.get("hindsightApiToken"))
-    if not token:
+    # Token is optional — local/self-hosted instances often don't require one.
+    # Only error if the config explicitly names a SecretRef that we failed to
+    # resolve (typo'd env var, missing file), not when the field is absent.
+    raw_token = plugin_cfg.get("hindsightApiToken")
+    token = resolve_secret(raw_token) or ""
+    if raw_token and not token:
         die(
-            "could not resolve hindsightApiToken from plugin config "
-            "(check SecretRef env var is exported)"
+            "hindsightApiToken is a SecretRef but could not be resolved "
+            "(check the env var / file / exec source is available)"
         )
     hindsight_health(api_url, token)
 
@@ -374,20 +387,19 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
         save_openclaw_config(cfg)
         ok(f"plugin config updated: {', '.join(plugin_overrides)}")
 
-    # 4. Copy the hindsight-skill-builder meta-skill into the agent's
-    # workspace if listed and missing.
-    if "hindsight-skill-builder" in skills:
-        target = agent_dir / "skills" / "hindsight-skill-builder"
-        if target.exists():
-            ok("hindsight-skill-builder already present in workspace")
-        elif META_SKILL_DIR.exists():
-            shutil.copytree(META_SKILL_DIR, target)
-            ok(f"copied hindsight-skill-builder → {target}")
-        else:
-            warn(
-                f"hindsight-skill-builder listed but source skill not found "
-                f"at {META_SKILL_DIR} — skipping"
-            )
+    # 4. Copy the hindsight-skill-builder meta-skill. This is the ONE skill
+    # the installer ships — every agent needs it, because every other skill
+    # gets built by the agent itself (via this meta-skill) on demand as the
+    # user asks for new capabilities.
+    target = agent_dir / "skills" / "hindsight-skill-builder"
+    if target.exists():
+        # Always refresh it so the agent picks up meta-skill improvements.
+        shutil.rmtree(target)
+    if META_SKILL_DIR.exists():
+        shutil.copytree(META_SKILL_DIR, target)
+        ok(f"installed hindsight-skill-builder → {target}")
+    else:
+        die(f"hindsight-skill-builder source not found at {META_SKILL_DIR}")
 
     # 5. Provision Hindsight bank + mental models from setup/hindsight-config.yaml.
     if not setup_yaml_path.exists():
@@ -410,8 +422,16 @@ def cmd_install(source_dir: Path, model: str | None = None) -> None:
                 updates[key] = val.strip()
         patch_bank_config(api_url, token, bank_id, updates)
 
-        for mm in spec.get("mental_models") or []:
-            upsert_mental_model(api_url, token, bank_id, mm)
+        # Mental models are the agent's job to create on demand, via the
+        # hindsight-skill-builder meta-skill. Each skill the agent builds
+        # gets its own MM. The installer intentionally stays out of MM
+        # provisioning — if a boilerplate ships with `mental_models:` in
+        # its setup/hindsight-config.yaml they're ignored on purpose.
+        if spec.get("mental_models"):
+            info(
+                "setup/hindsight-config.yaml lists mental_models — ignoring "
+                "(the agent builds MMs on demand via hindsight-skill-builder)"
+            )
 
     # 6. Restart the gateway so plugin-config changes + the new agent
     # registration take effect, then bootstrap a starter session — without

--- a/skills/hindsight-skill-builder/SKILL.md
+++ b/skills/hindsight-skill-builder/SKILL.md
@@ -158,25 +158,32 @@ If this fails:
 
 Do not proceed until `hindsight health` returns healthy.
 
-### Ensure the `hindsight` CLI is installed
+### Install (or upgrade) the `hindsight` CLI
 
-The generated skill invokes `hindsight mental-model get` at runtime. Check for the CLI:
+The generated skill invokes `hindsight mental-model get` at runtime, and this meta-skill itself uses the CLI to create banks and mental models. We **always** run the upstream installer so the user ends up on the latest release — older builds won't have the flags this skill relies on (`--trigger-refresh-after-consolidation`, `--tags`).
 
-```bash
-command -v hindsight
-```
+The installer is idempotent — it'll upgrade in place if `hindsight` is already on PATH.
 
-If missing, propose installing it and wait for approval:
+Propose the install and wait for approval:
 
-> I need the `hindsight` CLI to create the mental model and for the new skill to fetch it at runtime. I'd like to run:
+> To set up the bank and the runtime CLI the new skill will use, I want to install or upgrade the `hindsight` CLI to the latest release:
 >
 > ```bash
 > curl -fsSL https://hindsight.vectorize.io/get-cli | bash
 > ```
 >
-> OK to install?
+> The script writes the binary to `~/.local/bin/hindsight` and is safe to re-run. OK to install?
 
-If the user declines, stop the whole flow.
+Once approved, run it. Then verify and report the version:
+
+```bash
+curl -fsSL https://hindsight.vectorize.io/get-cli | bash
+PATH="$HOME/.local/bin:$PATH" hindsight --version
+```
+
+If the install fails (the upstream installer hits the unauthenticated GitHub releases API and gets rate-limited at 60 requests/hour per IP), check whether `hindsight` is already on PATH and meets the minimum version. If yes, proceed and warn the user. If no, stop and tell the user to retry in a few minutes or install manually from <https://github.com/vectorize-io/hindsight/releases>.
+
+If the user declines the install entirely, stop the whole flow.
 
 ### Write the shared env file at `~/.hindsight/learning-skill.env`
 

--- a/skills/hindsight-skill-builder/SKILL.md
+++ b/skills/hindsight-skill-builder/SKILL.md
@@ -7,6 +7,17 @@ description: Create a new self-improving skill for this agent whenever the user 
 
 You are the agent's tool for **growing its own capabilities**. Every time the user asks for a recurring task you don't already have a skill for, use this meta-skill to build one. Once built, the harness reloads it and the agent can handle that class of request going forward — and it gets sharper over time as the user gives feedback.
 
+## ⚠️ The one rule you cannot break
+
+**Once a skill is created, you must never edit its SKILL.md in response to user feedback about what the task should do.** Not for "prefer RSS", not for "include X", not for "drop Y source", not for "use bullet format". All of that is playbook content — it belongs in the mental model, not in the SKILL.md file.
+
+When the user gives you feedback after a skill has been built:
+1. Acknowledge it in one declarative sentence so the retain pipeline captures it cleanly.
+2. Do NOT open the SKILL.md. Do NOT use Edit / Write / apply_patch on it.
+3. The next consolidation + MM refresh will fold that feedback into the playbook automatically.
+
+The SKILL.md changes exactly twice in its life: when you create it, and if a tool allowlist or hard invariant actually needs to change. Everything else is MM territory. If you find yourself reaching for Edit on an existing SKILL.md, stop and retain the feedback as a user statement instead.
+
 ## The discipline: thin SKILL.md + rich mental model
 
 Every skill you build has exactly two artifacts:

--- a/skills/hindsight-skill-builder/SKILL.md
+++ b/skills/hindsight-skill-builder/SKILL.md
@@ -100,17 +100,68 @@ Wait for approval. Iterate on the source_query especially — that's what determ
 
 The source_query must produce **the complete playbook** the skill follows — not "user preferences", not a bullet dump. The MM's output IS the skill's entire behavioral instruction set for this task.
 
-A strong source_query:
-- States the task and who it's for in one line ("You are the playbook a curator follows to assemble <user>'s daily AI/ML news feed.")
-- Asks Hindsight to produce a full playbook: task definition, sections, structure, format, specific rules extracted from retained facts, and sensible defaults for sections where the user hasn't given guidance yet
-- Tells the MM how to structure its output (clear sections, omit empty ones)
-- Instructs on mixing extracted + default content: "Use sensible generic defaults where the user hasn't spoken; clearly mark those so the skill knows they're provisional."
-- Specifies conflict resolution ("newer advice wins; mark contradicted older advice as stale")
-- Asks for extrapolation from partial advice ("where advice is partial, extrapolate intent to related cases")
+**Use the universal playbook template below for every skill you build**, customized only in the leading paragraph that names the task and the user. The section headers stay identical across skills so the loader skill can rely on the shape.
 
-A weak source_query ("what are my preferences") produces an empty MM on day one and a thin bullet list later. A strong one produces a drop-in prompt the skill can follow from day one, updated with user-specific adjustments as feedback accumulates.
+Universal template (copy + fill the `<angle-bracket>` parts for the specific task):
 
-**Bootstrap problem to avoid:** on day one the bank has zero user facts about this task. The source_query must be self-sufficient enough that Hindsight produces a competent generic playbook from the source_query alone — then each consolidation cycle enriches it with real user guidance.
+```
+You are the complete playbook a <ROLE> follows to do <TASK> for the user.
+
+Read everything retained in this bank about how the user wants <TASK>
+done, extract durable rules from their advice / corrections / reactions,
+and produce a self-sufficient playbook organized into the sections
+below. Where the user has given explicit guidance, follow it exactly.
+Where advice is partial, extrapolate intent to adjacent cases. Where
+a section has no durable user input yet, provide a sensible generic
+default and mark it as "(default — no user guidance yet)". Omit a
+section entirely only when it genuinely doesn't apply to this task.
+
+When two pieces of advice conflict, the newer wins; mark the older as
+stale.
+
+Output sections, in this exact order:
+
+## Purpose
+One sentence: what this skill does, for whom, under what trigger.
+
+## Scope
+- In scope: what this skill handles
+- Out of scope: what belongs to sibling skills or to the user directly
+
+## Rules
+- Always: hard constraints the user has stated (must-haves, must-nots)
+- Prefer: softer defaults (style, ordering, priorities)
+
+## Procedure
+Numbered steps at the level of guidance, not code. Reference the
+Inputs and Output sections by name rather than restating their
+content.
+
+## Inputs and context
+Where material comes from: sources, channels, time windows, people,
+external context this skill depends on.
+
+## Output shape
+- Structure
+- Format
+- Length / cap
+- Voice / tone
+
+## Stop conditions
+When to refuse or ask a clarifying question instead of guessing.
+
+## Open questions
+Things the user hasn't told me yet that would sharpen the playbook
+next time they interact.
+```
+
+Why a universal template:
+- Loader skills can rely on a stable structure (Rules before Procedure before Output, always).
+- Cross-skill transfer — a user's "always cite sources" rule looks the same in a research skill and a blog skill.
+- Less cognitive load for the user — they learn one playbook shape, not one per task.
+- Empty-task bootstrap works: the template's defaults kick in on day one; user advice enriches them over time.
+
+Only tweak the leading paragraph (role / task / user) per skill. Do NOT invent skill-specific section names (like "TAKE", "DROP", "CAP" — those are news-feed jargon leaking into the MM). Keep the headers.
 
 ---
 

--- a/skills/hindsight-skill-builder/SKILL.md
+++ b/skills/hindsight-skill-builder/SKILL.md
@@ -1,481 +1,203 @@
 ---
 name: hindsight-skill-builder
-description: Create, install, configure, or update a Hindsight-backed self-improving skill. Use whenever the user asks to build a new skill, add a skill to their agent, set up a marketing/support/research/coding assistant skill, bind a skill to a memory bank, create a skill that learns from feedback, or otherwise turn a task into a Hindsight-powered workflow that evolves over time. Handles the full setup: locating the Hindsight instance, selecting or creating a bank with tuned missions, creating the binding mental model, and writing the new SKILL.md file into the harness skills directory.
+description: Create a new self-improving skill for this agent whenever the user asks for a capability the agent doesn't yet have. Use when the user says "can you also do X", "I want a weekly brief", "remember how I like X", "start tracking Y for me", "build me a Z", or otherwise implies a recurring task the agent should formalize. Produces a thin loader SKILL.md plus a Hindsight mental model that will capture and evolve the user's taste for that task over time.
 ---
 
 # Hindsight Skill Builder
 
-You are helping the user create a **self-improving skill**: a thin SKILL.md file that fetches its live instructions from a Hindsight mental model via `curl` and adapts over time as the user gives feedback during normal conversations.
+You are the agent's tool for **growing its own capabilities**. Every time the user asks for a recurring task you don't already have a skill for, use this meta-skill to build one. Once built, the harness reloads it and the agent can handle that class of request going forward — and it gets sharper over time as the user gives feedback.
 
-Your job is to walk the user through a four-step setup, **pausing for explicit approval at every decision**. You are NOT a silent script. At every step you propose, the user approves or edits, and only then do you execute.
+## The discipline: thin SKILL.md + rich mental model
 
-The resulting skill, once installed, will:
+Every skill you build has exactly two artifacts:
 
-1. Be loaded by the harness whenever a matching request comes in
-2. `curl` a Hindsight mental model to fetch live guidance
-3. Fall back to asking the user when the mental model is empty
-4. Follow the returned guidance strictly when writing output
-5. Learn automatically as the user gives feedback — because Hindsight's auto-retain, consolidation, and `refresh_after_consolidation` pipeline keeps the mental model up to date without any extra work from you
+1. **SKILL.md** (static, tiny — 20–40 lines) — the harness trigger binding. Only three things belong here: *when* the skill activates (trigger phrasings in the description), *which tools* it may use (allowlist + hard guardrails), and the single procedural instruction: "read the mental model; follow it literally; do not contradict it".
+2. **Mental model** (dynamic, in Hindsight — can be long) — the **entire playbook** for this task. Everything the agent needs to remember about doing this task well for this user: what the task is, sensible defaults, structure, format, voice, specific rules, exclusions, anything. Evolves as the user gives feedback. Refreshes after each consolidation via `refresh_after_consolidation`.
 
----
+**Everything the agent has to remember for the task lives in the MM, not the SKILL.md.** The SKILL.md is the tiniest possible shell that says "there's a playbook in Hindsight — go read it". If you catch yourself writing task-specific content into the SKILL.md — defaults, format notes, example output, anything that might plausibly evolve — stop and move it to the MM.
+
+**What belongs where:**
+
+| SKILL.md (tiny, stable) | MM (the whole playbook) |
+|---|---|
+| Trigger phrasings in the `description` frontmatter | What the task is (definition, purpose) |
+| Tool allowlist ("may use web_search, web_fetch, …") | Structure + sections + format |
+| Hard invariants ("never post without approval") | Sensible defaults when the user hasn't specified |
+| The 4-step loader procedure | Specific rules from user feedback |
+| Out-of-scope list (what to defer to other skills) | Voice, tone, stylistic quirks |
+|  | Sources / channels / people to focus on or avoid |
+|  | Concrete examples if they sharpen the output |
+
+Why the MM holds it all: because *anything* in the playbook could evolve from user feedback, and the MM is the only artifact that updates without a harness reload. Stuff you put in SKILL.md is locked in until the agent edits and reloads it — that's the right place for triggers and guardrails, the wrong place for anything the user might tune.
 
 ## Human-in-the-loop protocol (MANDATORY)
 
-At every decision point below, you follow this pattern:
+Every decision point below requires explicit user approval before you execute. You propose → user approves or edits → only then you run. Never chain decisions.
 
-1. **Explore** — run whatever read-only checks you need (read the harness plugin config file, run `hindsight health`)
-2. **Propose** — show the user your proposed values in a clearly labeled block
-3. **Ask for approval** — end with a direct question like *"Proceed with this, or do you want to edit?"*
-4. **Wait for explicit confirmation** before making any API call or writing any file
-
-Never chain decision points. If the user gives partial feedback ("change the source_query"), regenerate the affected field and ask again.
-
-Decision points that require approval:
-
-- **Step 1 — Detected harness config:** the URL, bank id, and key (status only, never the value) you read from the harness plugin's config file
-- **Step 1 — Env file write:** the final contents of `~/.hindsight/learning-skill.env`
-- **Step 2 — Mental model spec:** ONE approval covering the mental model id, name, and source_query. The bank id is fixed (it comes from the env file / harness plugin). After approval, the CLI create + trigger PATCH + verify run without further pauses.
-- **Step 3 — Skill file:** the final description and rendered SKILL.md content before writing
-
-The meta-skill is intentionally minimal: it never creates banks, never sets missions, never asks the user to design a memory pipeline. It binds new mental models to the bank the harness plugin already uses, and writes a skill file that fetches them at runtime.
+Approval gates:
+1. **Skill spec**: name, trigger phrasing, one-line description, procedure sketch
+2. **MM spec**: id, name, source_query (the *most important* field — it's the question the MM answers every consolidation cycle)
+3. **Final SKILL.md content** (before writing)
+4. **Reload plan** (session restart is often required — the agent tells the user how, doesn't do it silently)
 
 ---
 
-## Step 1 — Read Hindsight connection details from an installed harness plugin
+## Step 1 — Resolve the bank
 
-The architecture of this feature relies on **the user's harness plugin being the source of truth** for Hindsight connection details. The flow the user sets up is:
+Every agent already has a bank provisioned by the installer (retain / observations / reflect missions are already tuned for this agent). You don't create a bank; you bind the new MM to the existing one.
 
-1. User installs a Hindsight plugin for their harness (hermes, OpenClaw, Claude Code, Codex, etc.)
-2. User configures the plugin with an API URL, optional API key, and a bank id — either via the plugin's setup wizard or by editing its config file
-3. User installs this meta-skill
-4. The meta-skill **reads the plugin config** to figure out which Hindsight instance to talk to and which bank to bind new mental models to
-5. All generated skills use the same `(url, key, bank_id)` the harness plugin uses
-
-This matters because the harness's **auto-retain hook writes every conversation turn to the plugin's configured bank**. If the meta-skill created a different bank, no auto-retain data would ever reach it and the mental model would stay empty forever. Binding to the plugin's bank is not optional — it's the only way the learning loop works.
-
-### Detect an installed harness plugin
-
-Check the known config locations **in this order**, stopping at the first one that exists. Do NOT probe multiple at once — take the first match and confirm it with the user.
-
-**hermes** — `$HERMES_HOME/hindsight/config.json` (falls back to `~/.hermes/hindsight/config.json` when no profile is active)
-
-Hermes sets `HERMES_HOME` to the active profile's root when you're running under `hermes --profile <name>`. Resolve the config path **from that env var**, not from a hardcoded `~/.hermes/` path, otherwise a named profile's config is missed and the meta-skill binds skills to the wrong bank.
+The openclaw-hindsight plugin writes its effective config into openclaw's config file. Read it:
 
 ```bash
-HERMES_CFG="${HERMES_HOME:-$HOME/.hermes}/hindsight/config.json"
-test -f "$HERMES_CFG" && echo "found: $HERMES_CFG"
+python3 -c "import json, pathlib; c = json.loads(pathlib.Path('~/.openclaw/openclaw.json').expanduser().read_text()); cfg = c['plugins']['entries']['hindsight-openclaw']['config']; print(cfg.get('hindsightApiUrl'), '|', cfg.get('bankIdPrefix',''), '|', cfg.get('dynamicBankGranularity') or cfg.get('bankId'))"
 ```
 
-Keys to extract (JSON):
-- `bank_id` — the bank auto-retain writes to
-- `mode` — one of `cloud`, `local_embedded`, `local_external`
-- `api_url` — explicit URL when `mode` is `cloud` or `local_external`
-- `api_key` — optional; falls back to the `HINDSIGHT_API_KEY` env var for cloud mode
-
-For `mode == "local_embedded"`: the URL is `http://localhost:<port>` where `<port>` is the hermes profile's allocated port. Read it via:
+The agent's bank id follows the plugin routing. For `dynamicBankGranularity=['agent']` (the installer default), it's `<bankIdPrefix>-<thisAgentName>`. Confirm the resolved bank id with a health check:
 
 ```bash
-hindsight-embed -p hermes profile show --output json
+hindsight bank stats <bank_id> --output json | head
 ```
 
-Take the `port` field. If `hindsight-embed` is not available, fall back to `http://localhost:9177` (the hermes default profile port).
+Make sure the CLI points at the same `hindsightApiUrl` the plugin uses — `hindsight configure --api-url <url>` if it doesn't. If `hindsightApiToken` is set on the plugin as a plain value, pass `--api-key` too.
 
-**claude-code** — `~/.hindsight/claude-code.json` OR `~/.claude/hindsight.json`
+> Tell the user: "This skill will bind to bank `<bank_id>` on `<hindsightApiUrl>`." Wait for approval.
+
+---
+
+## Step 2 — Propose the skill spec
+
+Pick a name (lowercase-with-hyphens, specific to the task). Write a one-line description that names the trigger phrasings. Sketch the procedure in 3–6 lines. Propose the MM id + source_query separately.
+
+Example proposal template:
+
+> **Skill: `<name>`**
+> **Description:** *"<description incl. trigger phrasings>"*
+> **Procedure:**
+>   1. `hindsight mental-model get <bank> <mm_id> --output json` → read `content` as rubric
+>   2. If content is empty, stop and ask the user for initial direction
+>   3. Fetch / produce / filter per rubric using <tools>
+>   4. Render per rubric format; never cache state locally
+>
+> **Mental model**
+>   - id: `<mm_id>`
+>   - name: `<MM display name>`
+>   - source_query: *"<question that will synthesize the user's accumulated advice about this task into an actionable rubric for the skill to follow>"*
+
+Wait for approval. Iterate on the source_query especially — that's what determines whether the MM content is useful.
+
+### Good source_query shape
+
+The source_query must produce **the complete playbook** the skill follows — not "user preferences", not a bullet dump. The MM's output IS the skill's entire behavioral instruction set for this task.
+
+A strong source_query:
+- States the task and who it's for in one line ("You are the playbook a curator follows to assemble <user>'s daily AI/ML news feed.")
+- Asks Hindsight to produce a full playbook: task definition, sections, structure, format, specific rules extracted from retained facts, and sensible defaults for sections where the user hasn't given guidance yet
+- Tells the MM how to structure its output (clear sections, omit empty ones)
+- Instructs on mixing extracted + default content: "Use sensible generic defaults where the user hasn't spoken; clearly mark those so the skill knows they're provisional."
+- Specifies conflict resolution ("newer advice wins; mark contradicted older advice as stale")
+- Asks for extrapolation from partial advice ("where advice is partial, extrapolate intent to related cases")
+
+A weak source_query ("what are my preferences") produces an empty MM on day one and a thin bullet list later. A strong one produces a drop-in prompt the skill can follow from day one, updated with user-specific adjustments as feedback accumulates.
+
+**Bootstrap problem to avoid:** on day one the bank has zero user facts about this task. The source_query must be self-sufficient enough that Hindsight produces a competent generic playbook from the source_query alone — then each consolidation cycle enriches it with real user guidance.
+
+---
+
+## Step 3 — Create the mental model
+
+After approval:
 
 ```bash
-test -f ~/.hindsight/claude-code.json && echo found
+hindsight mental-model create <bank_id> "<name>" "<source_query>" \
+  --id <mm_id> \
+  --trigger-refresh-after-consolidation
 ```
 
-Keys (JSON, camelCase):
-- `hindsightApiUrl` — full URL (e.g. `http://localhost:4445/api/hindsight`)
-- `bankId` — bank id
-- `apiKey` — optional
-
-**codex** — `~/.hindsight/codex/settings.json`
+If the MM already exists, use `update` instead:
 
 ```bash
-test -f ~/.hindsight/codex/settings.json && echo found
-```
-
-Keys (JSON, camelCase):
-- `hindsightApiUrl` — full URL (may be empty; if empty, fall back to `HINDSIGHT_API_URL` env var or ask the user)
-- `bankId` — bank id
-- `apiKey` — optional
-
-**openclaw** — `~/.openclaw/extensions/hindsight-openclaw/` (schema present, secrets in the OpenClaw vault)
-
-OpenClaw stores the plugin secrets inside its encrypted vault, not as a plain JSON file. The meta-skill **cannot read them directly**. Instead, check for the plugin directory and ask the user to provide the values manually:
-
-```bash
-test -d ~/.openclaw/extensions/hindsight-openclaw && echo found
-```
-
-If the directory exists, tell the user:
-
-> I see OpenClaw's Hindsight plugin is installed, but OpenClaw keeps plugin secrets in its vault and I can't read them directly. Please paste the Hindsight API URL, bank id, and API key (if any) that you configured for this plugin. I will not print any of them back.
-
-**Unknown harness** — if none of the files above exist:
-
-> I couldn't find a Hindsight plugin configuration for hermes, claude-code, codex, or OpenClaw. This meta-skill assumes you've already installed and configured a Hindsight plugin for your agent harness. The plugin's auto-retain hook is what feeds the mental model with conversation data — without it, any skill I create would never learn from your feedback.
->
-> Please install a Hindsight plugin for your harness first. See:
-> - hermes: https://github.com/vectorize-io/hindsight/tree/main/skills/hindsight-local
-> - Hindsight Cloud: https://ui.hindsight.vectorize.io
->
-> Once the plugin is installed and configured, re-run me.
-
-Stop the flow. Do not continue without a plugin to bind to.
-
-### Propose the extracted config to the user
-
-Once you've read a plugin's config, show the user what you found and ask for confirmation. Do not print the API key value — reference it as `<set>` or `<empty>`.
-
-> I detected a **<harness>** Hindsight plugin. Here's what I read from `<config_path>`:
->
-> - API URL: `<url>`
-> - Bank id: `<bank_id>`
-> - API key: `<set>` *(or `<empty>`)*
-> - Mode: `<mode>` *(if applicable)*
->
-> Any new skill I create will bind to the `<bank_id>` bank on this instance, so the skill learns from the same conversations your harness's auto-retain hook captures.
->
-> Use this config, or tell me to re-read a different plugin config file?
-
-Wait for approval. If the user wants to use a different plugin, repeat the detection with the location they specify.
-
-### Verify the config works
-
-Before touching anything, run a one-shot `hindsight health` to make sure the extracted values actually reach a live instance:
-
-```bash
-HINDSIGHT_API_URL="<url>" ${api_key:+HINDSIGHT_API_KEY="<key>"} hindsight health
-```
-
-If this fails:
-- For hermes `local_embedded`: the daemon isn't running. Tell the user to start hermes (which auto-starts the daemon) or run `hindsight-embed -p hermes daemon start` manually, then retry.
-- For cloud: the URL or key is wrong. Tell the user to verify their plugin config.
-- For self-hosted / other: surface the error and ask.
-
-Do not proceed until `hindsight health` returns healthy.
-
-### Install (or upgrade) the `hindsight` CLI
-
-The generated skill invokes `hindsight mental-model get` at runtime, and this meta-skill itself uses the CLI to create banks and mental models. We **always** run the upstream installer so the user ends up on the latest release — older builds won't have the flags this skill relies on (`--trigger-refresh-after-consolidation`, `--tags`).
-
-The installer is idempotent — it'll upgrade in place if `hindsight` is already on PATH.
-
-Propose the install and wait for approval:
-
-> To set up the bank and the runtime CLI the new skill will use, I want to install or upgrade the `hindsight` CLI to the latest release:
->
-> ```bash
-> curl -fsSL https://hindsight.vectorize.io/get-cli | bash
-> ```
->
-> The script writes the binary to `~/.local/bin/hindsight` and is safe to re-run. OK to install?
-
-Once approved, run it. Then verify and report the version:
-
-```bash
-curl -fsSL https://hindsight.vectorize.io/get-cli | bash
-PATH="$HOME/.local/bin:$PATH" hindsight --version
-```
-
-If the install fails (the upstream installer hits the unauthenticated GitHub releases API and gets rate-limited at 60 requests/hour per IP), check whether `hindsight` is already on PATH and meets the minimum version. If yes, proceed and warn the user. If no, stop and tell the user to retry in a few minutes or install manually from <https://github.com/vectorize-io/hindsight/releases>.
-
-If the user declines the install entirely, stop the whole flow.
-
-### Write the shared env file at `~/.hindsight/learning-skill.env`
-
-Write the verified `(url, key, bank_id)` triple to a sourceable file that every generated skill will read at runtime. This is how the generated SKILL.md bodies stay short — they source one file and call the CLI.
-
-Propose the write:
-
-> I'll write `~/.hindsight/learning-skill.env` (chmod 600) with:
-> - `HINDSIGHT_API_URL="<url>"`
-> - `HINDSIGHT_API_KEY=<set>` *(or empty)*
-> - `HINDSIGHT_BANK_ID="<bank_id>"`
->
-> OK to write?
-
-Once approved:
-
-```bash
-mkdir -p ~/.hindsight
-cat > ~/.hindsight/learning-skill.env <<'EOF'
-export HINDSIGHT_API_URL="<url>"
-export HINDSIGHT_API_KEY="<key-or-empty>"
-export HINDSIGHT_BANK_ID="<bank_id>"
-EOF
-chmod 600 ~/.hindsight/learning-skill.env
+hindsight mental-model update <bank_id> <mm_id> \
+  --name "<name>" \
+  --source-query "<source_query>" \
+  --trigger-refresh-after-consolidation true
 ```
 
 Verify:
 
 ```bash
-ls -la ~/.hindsight/learning-skill.env     # must show -rw-------
-source ~/.hindsight/learning-skill.env
-hindsight health                             # must return healthy
+hindsight mental-model get <bank_id> <mm_id> --output json | head -20
 ```
 
-> **Do NOT print the key value at any point**, not even inside the heredoc. Substitution happens inside your own process; keep the literal value out of chat output.
-
-### What if the user re-runs the meta-skill later
-
-If `~/.hindsight/learning-skill.env` already exists when the meta-skill starts, source it, compare what's in there to what's in the detected plugin config, and ask the user:
-
-> The shared env file already exists and points at `<old_url>` / bank `<old_bank_id>`. The detected plugin now reports `<new_url>` / bank `<new_bank_id>`.
->
-> Keep the existing file (the plugin config must have changed; any previously-created skills still point at `<old_bank_id>`), or overwrite it with the new values (new skills bind to `<new_bank_id>`; old skills may stop learning)?
-
-Let the user decide. Never silently overwrite.
+Don't refresh it yet — it'll auto-refresh on the next consolidation after the user starts giving this skill feedback.
 
 ---
 
-## Step 2 — Create the mental model on the harness's bank
+## Step 4 — Write the SKILL.md
 
-Step 2 is deliberately minimal. The meta-skill does NOT create a new bank, does NOT set retain / observations / reflect missions, and does NOT manage bank configuration at all. The bank the new skill learns from is **whatever the harness plugin is already configured to use** (captured in `HINDSIGHT_BANK_ID` from the env file written in Step 1). Every self-improving skill on this machine shares that bank and is scoped by its own mental model's `source_query`.
+Propose the final file content first. Use this template — keep it short. Extra prose belongs in the MM, not here.
 
-Why this matters: the harness's auto-retain hook writes to exactly one bank per session. If the meta-skill created a dedicated bank per skill, auto-retain data would never reach it and the mental model would stay empty forever. Binding to the harness's bank is the only way the learning loop works end-to-end without modifying the harness plugin.
-
-### The single approval
-
-Source the env file so `HINDSIGHT_API_URL`, `HINDSIGHT_API_KEY`, and `HINDSIGHT_BANK_ID` are available:
-
-```bash
-source ~/.hindsight/learning-skill.env
-```
-
-Then propose the full mental model spec in one block and ask for ONE approval.
-
-> I'll create this mental model on the **`<HINDSIGHT_BANK_ID>`** bank (the one your harness plugin is already configured to use for auto-retain):
->
-> - **id:** `linkedin-post-writer`
-> - **name:** LinkedIn Post Writer Guidelines
-> - **source_query:** *"What are the current writing style, tone, structure, voice, and do/dont rules I should follow when drafting LinkedIn posts on behalf of this user?"*
-> - **refresh_after_consolidation:** true
-> - **tags:** none
->
-> Approve?
-
-Wait for approval. If the user wants to tweak the id, name, or source_query, regenerate and ask again. Do not change the bank id — that comes from the env file and is tied to the harness plugin.
-
-### Execute after approval
-
-Once approved, run the commands below without pausing:
-
-```bash
-# 1. Ensure the bank identity exists. The bank name comes from the harness
-#    plugin's config, but the bank itself may not have been created on the
-#    daemon yet (e.g. brand-new profile where no retain has happened). Always
-#    run `bank create` first — it is a no-op if the bank already exists.
-#    Do NOT bind the skill to a different bank if the target is missing;
-#    create the missing bank and proceed.
-hindsight bank create "$HINDSIGHT_BANK_ID" --name "$HINDSIGHT_BANK_ID" 2>/dev/null || true
-
-# 2. Create the mental model on that bank
-hindsight mental-model create "$HINDSIGHT_BANK_ID" "<mm_name>" "<source_query>" --id <mm_id>
-
-# 3. Set the refresh trigger and empty tags (CLI gap — see below)
-curl -sS -X PATCH \
-  ${HINDSIGHT_API_KEY:+-H "Authorization: Bearer $HINDSIGHT_API_KEY"} \
-  -H "Content-Type: application/json" \
-  -d '{"trigger": {"refresh_after_consolidation": true}, "tags": []}' \
-  "$HINDSIGHT_API_URL/v1/default/banks/$HINDSIGHT_BANK_ID/mental-models/<mm_id>"
-
-# 4. Verify
-hindsight mental-model get "$HINDSIGHT_BANK_ID" <mm_id> --output json
-```
-
-**Hard rule:** if `hindsight mental-model create` fails because the bank does not exist, create the bank (identity only, no missions — the harness plugin will own whatever extraction behavior it wants) and retry. Never silently fall back to a different bank id. The bank id in the env file is authoritative because it's the bank the harness plugin's auto-retain hook writes to. Binding a skill to a different bank would break the learning loop.
-
-The initial `content` field will be a "no information" response. That's correct — the skill's fallback at runtime asks the user for guidance on first use and the mental model populates after the first consolidation cycle.
-
-### Design guidance for the mental model
-
-- **`id`** — matches the skill name so the CLI invocation is predictable (e.g., `linkedin-post-writer`)
-- **`name`** — human-readable (e.g., "LinkedIn Post Writer Guidelines")
-- **`source_query`** — the most important field. It is the **question the mental model answers whenever the skill fetches it**, and it is the ONLY thing scoping this skill's output to its domain since the bank is shared. A good `source_query`:
-  - Mirrors the skill's purpose: *"What are the current X rules I should follow when Y?"*
-  - Is specific enough that reflect pulls only observations relevant to this skill's domain, even though the bank contains feedback from all skills
-  - Is stable — it does not need to be rewritten as the skill learns
-  - Asks for guidance the user *would* give you, not facts about the user
-- **`refresh_after_consolidation`** — always `true` for self-improving skills
-- **`tags`** — leave empty. Do NOT set tags on the mental model. The trigger is tag-gated — if the mental model has tags but the retained memories don't, the trigger silently does nothing and the mental model never refreshes.
-
-### CLI gap: `refresh_after_consolidation` is set via a fallback PATCH
-
-The `hindsight mental-model create` command does not currently accept a `--trigger` or `--refresh-after-consolidation` flag, and neither does `hindsight mental-model update`. Until the CLI is fixed upstream, set the trigger via the raw `curl` PATCH in command 2 above — immediately after `mental-model create`, before verification. This is the ONLY raw curl call in the whole meta-skill. When the CLI gap is fixed, replace command 2 with the equivalent CLI flag.
-
-### Why the meta-skill doesn't create or tune banks anymore
-
-A previous version of this meta-skill created a dedicated bank per skill with hand-designed `retain_mission` and `observations_mission` values. That version was wrong: harness auto-retain only writes to ONE bank per session (read from the plugin's config), so any dedicated bank the meta-skill created would never receive user feedback.
-
-The current version accepts a constraint: **one bank per harness, many skills, many mental models, all scoped by source_query**. The bank's retain and observations missions are whatever the harness plugin set up (often empty, sometimes default). Mental model `source_query` does all the per-skill filtering at reflect time.
-
-Downside: observations in a shared bank are noisier because the retain mission isn't domain-specific. Upside: the learning loop actually closes, and multiple skills can learn from the same conversation when it touches multiple domains. We could revisit per-skill bank tuning later via multi-bank harness plugin support, but that's a v2 story.
-
----
-
-## Step 3 — Write the SKILL.md file
-
-### Where to write it
-
-Figure out the skills directory for the CURRENT harness session. This is **profile-aware** — named profiles have their own skills directories and you must NOT write to the default profile's directory when running under a named profile.
-
-Preferred resolution order:
-
-1. **`$HERMES_HOME/skills/`** — hermes sets `HERMES_HOME` to the active profile's root (e.g. `~/.hermes/profiles/smoke-marketing/` for a named profile, `~/.hermes/` for the default profile). Use this whenever the env var is set. Example:
-   ```bash
-   SKILLS_DIR="${HERMES_HOME:-$HOME/.hermes}/skills"
-   ```
-2. If `HERMES_HOME` is not set, check for Claude Code: `~/.claude/skills/`.
-3. If neither, check Codex: `~/.codex/skills/`.
-4. If none are found, ask the user where the harness loads skills from.
-
-**Never** default to `~/.hermes/skills/` when `HERMES_HOME` is set to a different path — that's the default profile's directory and writing there pollutes it. If `HERMES_HOME=/Users/foo/.hermes/profiles/marketing-agent`, the new skill MUST go to `/Users/foo/.hermes/profiles/marketing-agent/skills/<skill-name>/SKILL.md`.
-
-**Propose the target path to the user before writing** and wait for approval:
-
-> I'll write the new skill to:
-> `~/.hermes/skills/linkedin-post-writer/SKILL.md`
->
-> OK to proceed?
-
-### The frontmatter description
-
-This field is the **auto-match surface** the harness uses to decide when to load the skill. It must enumerate the intents and phrases the user is likely to use. Pattern:
-
-> Use this skill whenever the user asks for [intent 1], [intent 2], [intent 3], or similar. Handles [domain] by [mechanism].
-
-Length: 80–250 characters. Keyword-rich. Concrete.
-
-Propose the description separately and get approval:
-
-> Proposed description:
-> *"Use this skill whenever the user asks for a LinkedIn post, thought-leadership post, company-update post, or executive announcement. Fetches the latest writing style guidelines from Hindsight and follows them strictly, or asks the user for guidance when the guidelines are empty."*
->
-> Approve as-is, or edit?
-
-### The SKILL.md template
-
-Render this template, substituting `<placeholders>`. The same template works for every deployment mode — the runtime skill sources the shared env file and lets the `hindsight` CLI handle URL and auth. There is no branching. Do not add extra sections beyond what is here unless the user asks.
-
-````markdown
+```markdown
 ---
 name: <skill-name>
-description: <description>
+description: <one-line what this does + the trigger phrasings that should fire this skill>
 ---
 
-# <Skill Title>
+# <Skill Name>
 
-Use this skill whenever the user asks for <domain work>. Before doing anything, you MUST fetch the latest guidelines from Hindsight.
+This skill's entire playbook lives in the `<mm_id>` mental model in bank `<bank_id>`. Read it, follow it literally.
 
-## Workflow
+## Procedure
 
-1. **Load the Hindsight connection** (once per session is enough):
-
+1. **Fetch the playbook:**
    ```bash
-   source ~/.hindsight/learning-skill.env
+   hindsight mental-model get <bank_id> <mm_id> --output json
    ```
+   The `content` field is the complete set of instructions for this task. Follow it as-is.
 
-   If this file does not exist, STOP and tell the user: *"The shared Hindsight env file is missing. Ask the agent to run the `hindsight-skill-builder` skill to set it up, or create it manually."* Do not try to reach Hindsight without it.
+2. **If the MM returns empty / "no information" content**, surface that to the user and ask what to do — do not fall back to improvising. The source_query is designed to return a competent default playbook even with no user history, so empty content means something is wrong (MM missing, bank unreachable, etc.).
 
-2. **Fetch live guidance** from the bound mental model. The bank id comes from the sourced env file; the mental model id is fixed to this skill:
+3. **Do the task** using only these tools: <tool allowlist>. Respect all invariants the playbook states.
 
-   ```bash
-   hindsight mental-model get "$HINDSIGHT_BANK_ID" <mm_id> --output json
-   ```
+4. **Re-fetch on follow-up** — if the user asks for a refresh or correction, re-read the MM before responding; the playbook may have been updated by consolidation since the last turn.
 
-   If the command exits non-zero, STOP and report the error verbatim to the user. A CLI failure is NOT the same as empty guidance — do not fall through to step 4. Typical failures: unreachable instance (daemon down / wrong URL), authentication error (wrong or missing `HINDSIGHT_API_KEY`), mental model deleted (ask the user whether to recreate it).
+## Hard invariants (never delegated to the MM)
 
-3. **Parse the JSON output** from the CLI and read the `content` field. That field is your style guide for this request.
+<list any "never" rules that must hold regardless of what the MM says — e.g. "never post without user approval", "never call tool X". Keep this list small. Most rules belong in the MM.>
 
-4. **Handle empty guidance.** If `content` is empty, missing, null, or contains a no-information message ("I do not have any information", "no relevant memories", etc.), you MUST stop and ask the user for direction before producing any output. Ask for the specific fields the domain needs (tone, audience, length, constraints, whatever is relevant). Do not guess from your defaults.
+## Out of scope
 
-5. **Follow the guidance strictly.** When the guidance is populated, apply every rule. If a rule is non-obvious but important, briefly note which rule you are applying in your reasoning.
-
-6. **Re-fetch on revision.** If the user asks for an edit or redo, re-run `hindsight mental-model get ...` first — the guidelines may have been updated since your last turn.
+<list other skills that handle adjacent requests so this one stays focused.>
 
 ## Learning loop
 
-Your feedback teaches this skill. You do not need to do anything special with user feedback — Hindsight's auto-retain hook captures every conversation turn, extracts rules via the bank's retain mission, consolidates them into observations, and refreshes this mental model automatically. The next CLI call will return updated guidelines.
-````
+The plugin retains every turn. The bank's retain + observations missions extract guidance from the user's feedback. Consolidation merges it. `refresh_after_consolidation` rebuilds `<mm_id>`. Next run reads the updated playbook automatically — no local state.
+```
 
-Write the file, create parent directories if needed, then `ls` or `cat` to confirm.
+Wait for approval, then write the file to:
 
----
+```
+~/.hindsight-agents/openclaw/<this-agent>/skills/<skill-name>/SKILL.md
+```
 
-## Final confirmation
-
-After all three steps are done, show the user a summary:
-
-> ✓ **Skill installed: `<name>`**
->
-> - Harness plugin: `<harness>` *(hermes / claude-code / codex / openclaw)*
-> - Hindsight: `<url>`
-> - Env file: `~/.hindsight/learning-skill.env` *(chmod 600; holds `HINDSIGHT_API_URL`, `HINDSIGHT_API_KEY`, `HINDSIGHT_BANK_ID`)*
-> - Bank: `<HINDSIGHT_BANK_ID>` *(shared with your harness's auto-retain stream)*
-> - Mental model: `<mm_id>` — empty, will populate after first feedback
-> - Skill file: `<path>`
->
-> The skill is live. Give your agent work and feedback as usual. Your harness's auto-retain writes every conversation turn to `<bank_id>`; consolidation produces observations; this mental model refreshes automatically and the skill's next call picks up the updated guidance.
->
-> Because this skill shares a bank with everything else on `<bank_id>`, the mental model's `source_query` is the only thing filtering its output. If you ever notice guidance drift — e.g. it starts picking up rules meant for a different domain — that's a signal to narrow the source_query.
+(The workspace path the harness loads skills from. Confirm by reading `agents.list` via the openclaw RPC if unsure.)
 
 ---
 
-## Worked example — `marketing-writer`
+## Step 5 — Reload the harness
 
-This is a known-good shape. The bank is whatever the harness plugin is configured to use (e.g. `hermes`, `claude-code`, `codex`) — this meta-skill never creates banks.
+OpenClaw loads skills at session start. A new skill won't take effect for the current session. Tell the user explicitly:
 
-**Bank:** read from `HINDSIGHT_BANK_ID` (the harness plugin's bank)
+> I've installed `<skill-name>`. To pick it up, end this session and start a fresh one (close + reopen the chat tab, or `openclaw agent --agent <this> --session-id new-<timestamp>`). You don't need to restart the gateway unless you've changed plugin config.
 
-**Mental model:**
-
-- **id:** `marketing-writer`
-- **name:** Marketing Writing Guidelines
-- **source_query:** *"What are the current writing style, tone, structure, voice, and do/dont rules I should follow when drafting marketing posts on behalf of this human?"*
-- **refresh_after_consolidation:** true, no tags
-
-**Skill description:**
-
-> *"Use this skill whenever the user asks for any marketing copy, LinkedIn post, X post, blog teaser, newsletter blurb, announcement, launch copy, or promotional caption. Fetches the latest writing guidelines from Hindsight before drafting and asks the user for tone/audience/length/constraints when no guidance exists yet."*
-
-In an earlier prototype that pre-tuned the bank with a domain-specific retain mission, this configuration started empty and evolved into a ~5000-character structured style guide after four rounds of user feedback. The current version gives up the per-skill retain mission in exchange for the bank actually being the one auto-retain writes to, so the loop closes without manual config edits.
+Do NOT call `openclaw gateway restart` yourself — that's disruptive (kills all sessions) and not your decision. If the user wants a full restart, they'll ask.
 
 ---
 
-## Counter-examples — what NOT to write
+## Counter-examples — things to refuse
 
-Bad configs produce skills that sort-of-work but never auto-activate well and never close the learning loop. Avoid these:
-
-**Bad source_query:** *"What do I need to know?"*
-Too broad — reflect will pull everything in the bank, which includes feedback meant for OTHER skills (since we share one bank across all skills). Good source_queries are scoped to the skill's domain and phrased as the question whose answer *is* the skill's runtime instructions: *"What are the current rules I should follow when drafting marketing posts?"*. The source_query is your only domain filter; make it count.
-
-**Bad description:** *"Marketing helper."*
-Ten characters, zero keywords. The harness will never match user requests to it. Good descriptions enumerate every phrase the user might say ("LinkedIn post, X post, blog teaser, newsletter, announcement, launch copy, promotional caption").
-
-**Bad skill body:** Anything that tries to hardcode rules inline (tone, length, format). The whole point is that the rules live in the mental model and evolve. The skill body should contain ONLY the source + `hindsight mental-model get` workflow, nothing else.
-
-**Bad auth handling:** Embedding the API key directly in the skill file or in any generated command. The key lives in `~/.hindsight/learning-skill.env` with `chmod 600`, and the skill sources that file to pick it up. Never substitute a literal `hsk_...` value into any file the meta-skill writes, and never echo the key in chat output even during setup.
-
-**Bad bank creation:** Creating a NEW bank for each skill. This was the original (broken) design — the harness's auto-retain hook only writes to ONE bank per session, so any dedicated bank the meta-skill creates would never receive user feedback. The current architecture binds every new skill to the harness plugin's existing bank, which is the only bank auto-retain actually writes to.
-
-**Bad fallback to curl:** Reverting to raw `curl` in the generated skill body because "it's simpler". The CLI exists specifically so skills don't have to manage URLs, auth, tenant paths, and HTTP error parsing themselves. The ONE place raw curl is allowed is the `refresh_after_consolidation` fallback PATCH in Step 2, which exists only because the CLI doesn't yet support setting triggers — remove that call once the CLI is updated.
-
----
-
-## Things to watch for (known gotchas)
-
-- **`hindsight` CLI is required.** Both the meta-skill setup and every generated skill assume the CLI is installed and on PATH. Step 1 verifies this and offers to install it if missing. If the user declines, abort the setup — there's no fallback to raw curl in the happy path.
-- **CLI gap: mental-model trigger is not exposed.** `hindsight mental-model create` and `hindsight mental-model update` do not currently support `refresh_after_consolidation` or tags. Step 2 uses a one-shot `curl PATCH` immediately after the CLI create to set the trigger and empty tags. This is the ONLY raw curl call in the whole flow. When the CLI adds `--refresh-after-consolidation` and `--tags` flags, delete the fallback block.
-- **Harness plugin must be installed FIRST.** The meta-skill cannot work in isolation — it reads the URL, key, and bank id from an installed harness Hindsight plugin (hermes / claude-code / codex / openclaw). If no plugin is detected, Step 1 stops and tells the user to install one. The plugin's auto-retain hook is the only source of conversation data; without it, the mental model never learns anything.
-- **One bank per harness, shared across skills.** Every skill the meta-skill creates binds to the same bank — the one the harness plugin is configured to write to. Multiple skills can coexist on that bank, each scoped by its own mental model `source_query`. There is no per-skill bank, no per-skill retain mission, no per-skill consolidation tuning. If the user wants per-skill tuning, that requires multi-bank harness support, which is a v2 story.
-- **Tagged mental models skip auto-refresh.** The `refresh_after_consolidation` trigger only fires when the mental model's tags overlap with the consolidated memories' tags (or when both are untagged). The fallback PATCH always sets `"tags": []` for this reason — do NOT change that to add tags unless you're also tagging every memory the auto-retain hook writes.
-- **Auto-retain must be on.** This pattern only works if the harness's Hindsight plugin has auto-retain enabled (the default for hermes / claude-code / codex). The generated skill cannot verify this itself — the user is responsible.
-- **The first turn after install will hit an empty mental model.** That is correct. The skill's fallback asks the user for guidance, and the first batch of feedback seeds the mental model after one consolidation cycle.
-- **OpenClaw secrets are vault-encrypted.** OpenClaw stores plugin secrets inside its own vault, not as plain JSON. The meta-skill cannot read them — for OpenClaw users, fall back to asking them to paste the URL / key / bank id manually after detecting the plugin directory exists.
-- **Env file is the single source of truth.** Do not write the URL, key, or bank id to any other file (not `~/.hindsight/config`, not the harness config, not the shell rc). Every generated skill sources `~/.hindsight/learning-skill.env` directly. If the harness plugin's config later changes (URL, key, or bank), the meta-skill must be re-run so the env file resyncs.
-- **Env file permissions.** Always `chmod 600`. The file contains the API key in plaintext. OS keychain integration is a future enhancement.
-- **Cloud tenant path.** The `default` in `/v1/default/banks` is the tenant ID. On embedded and standard self-hosted it's always `default`. On cloud, the API key scopes the tenant automatically and `default` usually works — but if the user tells you their account uses a custom tenant, ask them to confirm before continuing.
+- **Any task-specific content in SKILL.md** beyond triggers, tool allowlist, and hard invariants. Defaults, format notes, examples, voice guidance, source lists, step-by-step procedure — all of that goes in the MM. If a human looks at the SKILL.md and learns *how to do the task*, it's too fat.
+- **SKILL.md longer than ~50 lines**. You've bled playbook content into the skill. Move it to the MM.
+- **Procedures without an MM**. If nothing about the task would ever change from user feedback, this isn't a Hindsight skill; skip this meta-skill and write a plain skill directly.
+- **Multiple MMs per skill**. One skill = one MM holding the whole playbook. If you're tempted to split, it's actually two skills.
+- **Empty source_query / "summarize preferences"**. The source_query produces the full playbook the skill will follow; it must stand up on day one with no user facts. A vague query produces an empty MM and a skill that can't act.
+- **Skipping the approval gates**. The user needs to see + shape each piece — skill name, trigger, source_query, final SKILL.md, reload plan.

--- a/skills/hindsight-skill-builder/SKILL.md
+++ b/skills/hindsight-skill-builder/SKILL.md
@@ -208,7 +208,33 @@ description: <one-line what this does + the trigger phrasings that should fire t
 
 This skill's entire playbook lives in the `<mm_id>` mental model in bank `<bank_id>`. Read it, follow it literally.
 
+## Mental model spec (source of truth for this skill's MM)
+
+- **Bank:** `<bank_id>`
+- **MM id:** `<mm_id>`
+- **MM name:** `<mm_display_name>`
+- **Trigger:** `refresh_after_consolidation`
+
+The full `source_query` that defines what this MM synthesizes lives in
+step 0 below, as a heredoc. If you ever need to regenerate or inspect
+it, that's the canonical copy.
+
 ## Procedure
+
+0. **Ensure the MM exists** (idempotent — safe to run every turn; NO-OP when the MM is already there):
+
+   ```bash
+   SRC_QUERY=$(cat <<'EOF'
+   <paste the exact source_query the meta-skill approved, verbatim, here>
+   EOF
+   )
+   hindsight mental-model get <bank_id> <mm_id> --output json >/dev/null 2>&1 || \
+     hindsight mental-model create <bank_id> "<mm_display_name>" "$SRC_QUERY" \
+       --id <mm_id> \
+       --trigger-refresh-after-consolidation
+   ```
+
+   If the MM was missing, this creates it with empty `content`. A subsequent consolidation cycle populates it from retained facts. On the very next turn the fetch in step 1 will still return empty `content` → follow step 2.
 
 1. **Fetch the playbook:**
    ```bash
@@ -216,7 +242,7 @@ This skill's entire playbook lives in the `<mm_id>` mental model in bank `<bank_
    ```
    The `content` field is the complete set of instructions for this task. Follow it as-is.
 
-2. **If the MM returns empty / "no information" content**, surface that to the user and ask what to do — do not fall back to improvising. The source_query is designed to return a competent default playbook even with no user history, so empty content means something is wrong (MM missing, bank unreachable, etc.).
+2. **If the MM returns empty / "no information" content**, surface that to the user and ask what to do — do not fall back to improvising. On a brand-new MM (just created in step 0) this is expected for the first turn; explain that and ask the user to seed with their initial preferences so retain + consolidation can populate the playbook.
 
 3. **Do the task** using only these tools: <tool allowlist>. Respect all invariants the playbook states.
 
@@ -234,6 +260,17 @@ This skill's entire playbook lives in the `<mm_id>` mental model in bank `<bank_
 
 The plugin retains every turn. The bank's retain + observations missions extract guidance from the user's feedback. Consolidation merges it. `refresh_after_consolidation` rebuilds `<mm_id>`. Next run reads the updated playbook automatically — no local state.
 ```
+
+### Why step 0 (idempotent MM create) matters
+
+The MM lives server-side, the SKILL.md lives in the workspace. Those can drift:
+- Someone resets the bank or deletes the MM by hand
+- Workspace gets copied to a fresh machine with an empty Hindsight instance
+- Consolidation never ran so the MM was created lazily but then purged
+
+With step 0, the skill **self-heals** on its next invocation. The SKILL.md is the source of truth for the `source_query`; if the server lost the MM, the skill recreates it. The `get || create` pattern makes this a no-op when the MM is already present.
+
+Important: step 0 does NOT update an existing MM's `source_query`. If the meta-skill needs to change the source_query (rare — it's the *spec* of the MM), that's an explicit operation via `hindsight mental-model update …`, not a silent side-effect of every turn.
 
 Wait for approval, then write the file to:
 


### PR DESCRIPTION
## Summary

PoC CLI that turns an agent boilerplate directory (e.g. `vectorize-agents/marketing-agent`) into a fully wired OpenClaw agent in one command — workspace + skills + Hindsight bank + mental models + bootstrap session.

```
scripts/openclaw-agent install <boilerplate-dir> [--model <id>]
```

Stays separate from `scripts/hindsight-agent` (which is hermes-only) because the OpenClaw setup steps are different enough that a unified script would just be a big `if` ladder.

## What it does

1. Reads `<dir>/agent.yaml` — name, skills, `harness.openclaw.config/model`, `hindsight.bank`.
2. Copies the boilerplate into `~/.hindsight-agents/openclaw/<name>/` so the source stays untouched and the agent's runtime files (skills, generated drafts, etc.) are isolated.
3. Reads Hindsight URL/token from the openclaw plugin config (raw `openclaw.json` — resolves SecretRef sources too).
4. `openclaw agents add --workspace <iso-copy> --model <effective>` (defaults to `openai-codex/gpt-5.4` so it works on Codex-OAuth-only setups; openclaw's default `codex-mini-latest` needs paid OpenAI auth).
5. Re-loads `openclaw.json` *after* `agents add` (avoids racing the openclaw writer) and applies `harness.openclaw.config` overrides (`bankIdPrefix`, `dynamicBankId`, etc.).
6. Copies `hindsight-skill-builder` from this repo into the workspace when listed in `agent.yaml` (the boilerplate doesn't ship the meta-skill itself).
7. Provisions Hindsight bank + missions + mental models from `setup/hindsight-config.yaml` via REST. Idempotent (uses PUT/PATCH).
8. Restarts the gateway, waits for RPC, then bootstraps a starter session — without one, the control-plane chat dropdown (which lists from `sessions.list`, not the agent registry) stays empty.

## Assumptions

- `openclaw` CLI on PATH, gateway already running.
- `hindsight-openclaw` plugin already installed and configured (URL + token).

## Verified end-to-end

```
scripts/openclaw-agent install ../vectorize-agents/marketing-agent
```

→ agent registered, all 7 boilerplate skills + meta-skill loaded into the agent's workspace (gateway-side `skills.status` confirms `openclaw-workspace` source, all eligible), bank `marketing-openclaw` created with all three missions, mental model `write-blog` created with `refresh_after_consolidation`, starter session present in the chat UI.

## Known gotchas (PoC, deliberately not handled)

- `openclaw agents delete --force` moves the workspace dir to Trash — that's an OpenClaw behavior. With this installer the workspace is the isolated `~/.hindsight-agents/openclaw/<name>/` copy, so deletion no longer wipes the source boilerplate.
- The control-plane "Workspace Skills" section in the per-agent Skills tab is collapsed by default — easy to think nothing got installed.
- Sessions started with the CLI default `--channel main` get skipped by the hindsight plugin (`agent:<id>:main` is treated as operational). Use a real channel + recipient to exercise retain/recall.

## Test plan

- [x] Run `scripts/openclaw-agent install ../vectorize-agents/marketing-agent` against a configured local OpenClaw + Hindsight Cloud — installer prints all the ✓ steps and exits 0.
- [x] `openclaw agents list` shows `marketing-agent` with the isolated workspace.
- [x] `openclaw gateway call skills.status --params '{"agentId":"marketing-agent"}'` lists all 7 boilerplate skills as `openclaw-workspace` / eligible.
- [x] Hindsight Cloud has bank `marketing-openclaw` with missions and mental model `write-blog`.
- [x] Re-running the installer is idempotent (skills synced, agent skipped, bank/MM PATCHed not duplicated).