### PR TITLE
fix(claude-code): add User-Agent header to prevent Cloudflare 403

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -33,7 +33,10 @@ class HindsightClient:
         self.api_token = api_token
 
     def _headers(self) -> dict:
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "hindsight-claude-code/1.0",
+        }
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers

--- a/hindsight-integrations/claude-code/tests/test_client.py
+++ b/hindsight-integrations/claude-code/tests/test_client.py
@@ -214,3 +214,32 @@ class TestHindsightClientSetBankMission:
         assert "my-bank" in captured["url"]
         assert captured["body"]["updates"]["reflect_mission"] == "I am Claude"
         assert captured["body"]["updates"]["retain_mission"] == "Extract facts"
+
+class TestHindsightClientUserAgent:
+    def test_user_agent_header_always_present(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert "User-agent" in captured["headers"]
+        assert captured["headers"]["User-agent"].startswith("hindsight-claude-code/")
+
+    def test_user_agent_present_with_token(self):
+        c = HindsightClient("http://localhost:9077", api_token="secret")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert "User-agent" in captured["headers"]
+        assert "Authorization" in captured["headers"]


### PR DESCRIPTION
Superseded by #1052 which provides a comprehensive User-Agent fix across all client SDKs (Python/TypeScript/Rust/Go). Closing.