### PR TITLE
fix(bank-template): align BankTemplateConfig with _CONFIGURABLE_FIELDS

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1673,6 +1673,36 @@ class BankTemplateConfig(BaseModel):
     entities_allow_free_form: bool | None = Field(
         default=None, description="Allow entities outside the label vocabulary"
     )
+    retain_default_strategy: str | None = Field(
+        default=None, description="Name of the default retain strategy (key into retain_strategies map)"
+    )
+    retain_strategies: dict | None = Field(
+        default=None, description="Map of retain strategy name to per-strategy config dict"
+    )
+    retain_chunk_batch_size: int | None = Field(
+        default=None, description="Max chunks per streaming batch (0 disables batching)"
+    )
+    mcp_enabled_tools: list[str] | None = Field(
+        default=None, description="MCP tool allowlist for this bank (None = all tools)"
+    )
+    consolidation_llm_batch_size: int | None = Field(
+        default=None, description="LLM batch size for observation consolidation"
+    )
+    consolidation_source_facts_max_tokens: int | None = Field(
+        default=None, description="Max tokens of source facts per consolidation batch"
+    )
+    consolidation_source_facts_max_tokens_per_observation: int | None = Field(
+        default=None, description="Max tokens of source facts per observation"
+    )
+    max_observations_per_scope: int | None = Field(
+        default=None, description="Max observations to retain per consolidation scope"
+    )
+    reflect_source_facts_max_tokens: int | None = Field(
+        default=None, description="Max tokens of source facts per reflect call"
+    )
+    llm_gemini_safety_settings: list | None = Field(
+        default=None, description="Per-bank Gemini/VertexAI safety filter settings"
+    )
 
     def get_config_updates(self) -> dict[str, Any]:
         """Return only the fields that were explicitly set (non-None)."""

--- a/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
+++ b/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
@@ -1,0 +1,106 @@
+"""Verify that BankTemplateConfig exposes every hierarchical field that
+_CONFIGURABLE_FIELDS already accepts at the engine layer.
+
+This test guards the fix for the gap described in the upstream PR title
+"fix(bank-template): align BankTemplateConfig with _CONFIGURABLE_FIELDS".
+Each new field is POSTed through /v1/default/banks/{id}/import and then
+read back via the bank-config endpoint; assertion is that the applied
+value round-trips through the engine.
+
+Runs via: uv run pytest tests/test_bank_template_configurable_fields.py -v
+
+The api_client fixture (shared with tests/test_bank_templates.py) wraps
+create_app(memory, initialize_memory=False) in an httpx.ASGITransport
+with base_url http://test — in-process, no network, no tenant extension.
+Copy the fixture inline here so the test file does not depend on a
+conftest we do not ship in the patch.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+from hindsight_api.api.http import BankTemplateConfig
+
+# Each tuple is (field_name, applied_value). Values chosen to differ
+# visibly from defaults so round-trip bugs surface.
+NEW_FIELDS: list[tuple[str, object]] = [
+    ("retain_default_strategy", "strategy-a"),
+    ("retain_strategies", {"strategy-a": {"mode": "concise", "max_tokens": 512}}),
+    ("retain_chunk_batch_size", 7),
+    ("mcp_enabled_tools", ["list_banks", "get_bank_profile"]),
+    ("consolidation_llm_batch_size", 11),
+    ("consolidation_source_facts_max_tokens", 2048),
+    ("consolidation_source_facts_max_tokens_per_observation", 256),
+    ("max_observations_per_scope", 13),
+    ("reflect_source_facts_max_tokens", 4096),
+    ("llm_gemini_safety_settings", [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]),
+]
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    """Matches the fixture in tests/test_bank_templates.py — in-process
+    ASGI test client, no tenant extension, no auth."""
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+def bank_id():
+    return f"tmpl_config_{datetime.now().timestamp()}"
+
+
+def test_bank_template_config_declares_every_configurable_field():
+    """Pydantic-level guard: every field in NEW_FIELDS must be a declared
+    attribute of BankTemplateConfig so get_config_updates() picks it up."""
+    declared = set(BankTemplateConfig.model_fields.keys())
+    missing = [name for name, _ in NEW_FIELDS if name not in declared]
+    assert not missing, f"BankTemplateConfig missing fields: {missing}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field_name,applied_value", NEW_FIELDS, ids=[n for n, _ in NEW_FIELDS])
+async def test_new_field_round_trips_through_import(
+    api_client: httpx.AsyncClient,
+    bank_id: str,
+    field_name: str,
+    applied_value: object,
+):
+    """POST a minimal manifest with one new field set, then read bank
+    config back and assert the value made it through.
+
+    Bank config response shape per upstream's test_import_applies_config:
+    top-level keys are resolved hierarchical config; per-bank overrides
+    live under config["overrides"][<field>]. Assert on the override slot.
+    """
+    unique_bank_id = f"{bank_id}_{field_name}"
+    manifest = {
+        "version": "1",
+        "bank": {field_name: applied_value},
+    }
+
+    resp = await api_client.post(
+        f"/v1/default/banks/{unique_bank_id}/import",
+        json=manifest,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Read bank config back — field must reflect the applied value
+    # under the "overrides" slot, matching upstream's own test shape.
+    read = await api_client.get(f"/v1/default/banks/{unique_bank_id}/config")
+    assert read.status_code == 200, read.text
+    config = read.json()
+    overrides = config.get("overrides", {})
+    assert overrides.get(field_name) == applied_value, (
+        f"round-trip mismatch for {field_name}: "
+        f"sent {applied_value!r}, got {overrides.get(field_name)!r} "
+        f"(full overrides: {overrides!r})"
+    )

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3576,6 +3576,39 @@ components:
         entities_allow_free_form:
           nullable: true
           type: boolean
+        retain_default_strategy:
+          nullable: true
+          type: string
+        retain_strategies:
+          additionalProperties: {}
+          nullable: true
+        retain_chunk_batch_size:
+          nullable: true
+          type: integer
+        mcp_enabled_tools:
+          items:
+            type: string
+          nullable: true
+          type: array
+        consolidation_llm_batch_size:
+          nullable: true
+          type: integer
+        consolidation_source_facts_max_tokens:
+          nullable: true
+          type: integer
+        consolidation_source_facts_max_tokens_per_observation:
+          nullable: true
+          type: integer
+        max_observations_per_scope:
+          nullable: true
+          type: integer
+        reflect_source_facts_max_tokens:
+          nullable: true
+          type: integer
+        llm_gemini_safety_settings:
+          items: {}
+          nullable: true
+          type: array
       title: BankTemplateConfig
     BankTemplateDirective:
       description: |-

--- a/hindsight-clients/go/model_bank_template_config.go
+++ b/hindsight-clients/go/model_bank_template_config.go
@@ -31,6 +31,16 @@ type BankTemplateConfig struct {
 	DispositionEmpathy NullableInt32 `json:"disposition_empathy,omitempty"`
 	EntityLabels []map[string]interface{} `json:"entity_labels,omitempty"`
 	EntitiesAllowFreeForm NullableBool `json:"entities_allow_free_form,omitempty"`
+	RetainDefaultStrategy NullableString `json:"retain_default_strategy,omitempty"`
+	RetainStrategies map[string]interface{} `json:"retain_strategies,omitempty"`
+	RetainChunkBatchSize NullableInt32 `json:"retain_chunk_batch_size,omitempty"`
+	McpEnabledTools []string `json:"mcp_enabled_tools,omitempty"`
+	ConsolidationLlmBatchSize NullableInt32 `json:"consolidation_llm_batch_size,omitempty"`
+	ConsolidationSourceFactsMaxTokens NullableInt32 `json:"consolidation_source_facts_max_tokens,omitempty"`
+	ConsolidationSourceFactsMaxTokensPerObservation NullableInt32 `json:"consolidation_source_facts_max_tokens_per_observation,omitempty"`
+	MaxObservationsPerScope NullableInt32 `json:"max_observations_per_scope,omitempty"`
+	ReflectSourceFactsMaxTokens NullableInt32 `json:"reflect_source_facts_max_tokens,omitempty"`
+	LlmGeminiSafetySettings []interface{} `json:"llm_gemini_safety_settings,omitempty"`
 }
 
 // NewBankTemplateConfig instantiates a new BankTemplateConfig object
@@ -545,6 +555,399 @@ func (o *BankTemplateConfig) UnsetEntitiesAllowFreeForm() {
 	o.EntitiesAllowFreeForm.Unset()
 }
 
+// GetRetainDefaultStrategy returns the RetainDefaultStrategy field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRetainDefaultStrategy() string {
+	if o == nil || IsNil(o.RetainDefaultStrategy.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.RetainDefaultStrategy.Get()
+}
+
+// GetRetainDefaultStrategyOk returns a tuple with the RetainDefaultStrategy field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRetainDefaultStrategyOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RetainDefaultStrategy.Get(), o.RetainDefaultStrategy.IsSet()
+}
+
+// HasRetainDefaultStrategy returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRetainDefaultStrategy() bool {
+	if o != nil && o.RetainDefaultStrategy.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRetainDefaultStrategy gets a reference to the given NullableString and assigns it to the RetainDefaultStrategy field.
+func (o *BankTemplateConfig) SetRetainDefaultStrategy(v string) {
+	o.RetainDefaultStrategy.Set(&v)
+}
+// SetRetainDefaultStrategyNil sets the value for RetainDefaultStrategy to be an explicit nil
+func (o *BankTemplateConfig) SetRetainDefaultStrategyNil() {
+	o.RetainDefaultStrategy.Set(nil)
+}
+
+// UnsetRetainDefaultStrategy ensures that no value is present for RetainDefaultStrategy, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRetainDefaultStrategy() {
+	o.RetainDefaultStrategy.Unset()
+}
+
+// GetRetainStrategies returns the RetainStrategies field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRetainStrategies() map[string]interface{} {
+	if o == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return o.RetainStrategies
+}
+
+// GetRetainStrategiesOk returns a tuple with the RetainStrategies field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRetainStrategiesOk() (map[string]interface{}, bool) {
+	if o == nil || IsNil(o.RetainStrategies) {
+		return map[string]interface{}{}, false
+	}
+	return o.RetainStrategies, true
+}
+
+// HasRetainStrategies returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRetainStrategies() bool {
+	if o != nil && !IsNil(o.RetainStrategies) {
+		return true
+	}
+
+	return false
+}
+
+// SetRetainStrategies gets a reference to the given map[string]interface{} and assigns it to the RetainStrategies field.
+func (o *BankTemplateConfig) SetRetainStrategies(v map[string]interface{}) {
+	o.RetainStrategies = v
+}
+
+// GetRetainChunkBatchSize returns the RetainChunkBatchSize field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRetainChunkBatchSize() int32 {
+	if o == nil || IsNil(o.RetainChunkBatchSize.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RetainChunkBatchSize.Get()
+}
+
+// GetRetainChunkBatchSizeOk returns a tuple with the RetainChunkBatchSize field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRetainChunkBatchSizeOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RetainChunkBatchSize.Get(), o.RetainChunkBatchSize.IsSet()
+}
+
+// HasRetainChunkBatchSize returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRetainChunkBatchSize() bool {
+	if o != nil && o.RetainChunkBatchSize.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRetainChunkBatchSize gets a reference to the given NullableInt32 and assigns it to the RetainChunkBatchSize field.
+func (o *BankTemplateConfig) SetRetainChunkBatchSize(v int32) {
+	o.RetainChunkBatchSize.Set(&v)
+}
+// SetRetainChunkBatchSizeNil sets the value for RetainChunkBatchSize to be an explicit nil
+func (o *BankTemplateConfig) SetRetainChunkBatchSizeNil() {
+	o.RetainChunkBatchSize.Set(nil)
+}
+
+// UnsetRetainChunkBatchSize ensures that no value is present for RetainChunkBatchSize, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRetainChunkBatchSize() {
+	o.RetainChunkBatchSize.Unset()
+}
+
+// GetMcpEnabledTools returns the McpEnabledTools field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetMcpEnabledTools() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+	return o.McpEnabledTools
+}
+
+// GetMcpEnabledToolsOk returns a tuple with the McpEnabledTools field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetMcpEnabledToolsOk() ([]string, bool) {
+	if o == nil || IsNil(o.McpEnabledTools) {
+		return nil, false
+	}
+	return o.McpEnabledTools, true
+}
+
+// HasMcpEnabledTools returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasMcpEnabledTools() bool {
+	if o != nil && !IsNil(o.McpEnabledTools) {
+		return true
+	}
+
+	return false
+}
+
+// SetMcpEnabledTools gets a reference to the given []string and assigns it to the McpEnabledTools field.
+func (o *BankTemplateConfig) SetMcpEnabledTools(v []string) {
+	o.McpEnabledTools = v
+}
+
+// GetConsolidationLlmBatchSize returns the ConsolidationLlmBatchSize field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetConsolidationLlmBatchSize() int32 {
+	if o == nil || IsNil(o.ConsolidationLlmBatchSize.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ConsolidationLlmBatchSize.Get()
+}
+
+// GetConsolidationLlmBatchSizeOk returns a tuple with the ConsolidationLlmBatchSize field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetConsolidationLlmBatchSizeOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ConsolidationLlmBatchSize.Get(), o.ConsolidationLlmBatchSize.IsSet()
+}
+
+// HasConsolidationLlmBatchSize returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasConsolidationLlmBatchSize() bool {
+	if o != nil && o.ConsolidationLlmBatchSize.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetConsolidationLlmBatchSize gets a reference to the given NullableInt32 and assigns it to the ConsolidationLlmBatchSize field.
+func (o *BankTemplateConfig) SetConsolidationLlmBatchSize(v int32) {
+	o.ConsolidationLlmBatchSize.Set(&v)
+}
+// SetConsolidationLlmBatchSizeNil sets the value for ConsolidationLlmBatchSize to be an explicit nil
+func (o *BankTemplateConfig) SetConsolidationLlmBatchSizeNil() {
+	o.ConsolidationLlmBatchSize.Set(nil)
+}
+
+// UnsetConsolidationLlmBatchSize ensures that no value is present for ConsolidationLlmBatchSize, not even an explicit nil
+func (o *BankTemplateConfig) UnsetConsolidationLlmBatchSize() {
+	o.ConsolidationLlmBatchSize.Unset()
+}
+
+// GetConsolidationSourceFactsMaxTokens returns the ConsolidationSourceFactsMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetConsolidationSourceFactsMaxTokens() int32 {
+	if o == nil || IsNil(o.ConsolidationSourceFactsMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ConsolidationSourceFactsMaxTokens.Get()
+}
+
+// GetConsolidationSourceFactsMaxTokensOk returns a tuple with the ConsolidationSourceFactsMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetConsolidationSourceFactsMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ConsolidationSourceFactsMaxTokens.Get(), o.ConsolidationSourceFactsMaxTokens.IsSet()
+}
+
+// HasConsolidationSourceFactsMaxTokens returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasConsolidationSourceFactsMaxTokens() bool {
+	if o != nil && o.ConsolidationSourceFactsMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetConsolidationSourceFactsMaxTokens gets a reference to the given NullableInt32 and assigns it to the ConsolidationSourceFactsMaxTokens field.
+func (o *BankTemplateConfig) SetConsolidationSourceFactsMaxTokens(v int32) {
+	o.ConsolidationSourceFactsMaxTokens.Set(&v)
+}
+// SetConsolidationSourceFactsMaxTokensNil sets the value for ConsolidationSourceFactsMaxTokens to be an explicit nil
+func (o *BankTemplateConfig) SetConsolidationSourceFactsMaxTokensNil() {
+	o.ConsolidationSourceFactsMaxTokens.Set(nil)
+}
+
+// UnsetConsolidationSourceFactsMaxTokens ensures that no value is present for ConsolidationSourceFactsMaxTokens, not even an explicit nil
+func (o *BankTemplateConfig) UnsetConsolidationSourceFactsMaxTokens() {
+	o.ConsolidationSourceFactsMaxTokens.Unset()
+}
+
+// GetConsolidationSourceFactsMaxTokensPerObservation returns the ConsolidationSourceFactsMaxTokensPerObservation field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetConsolidationSourceFactsMaxTokensPerObservation() int32 {
+	if o == nil || IsNil(o.ConsolidationSourceFactsMaxTokensPerObservation.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ConsolidationSourceFactsMaxTokensPerObservation.Get()
+}
+
+// GetConsolidationSourceFactsMaxTokensPerObservationOk returns a tuple with the ConsolidationSourceFactsMaxTokensPerObservation field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetConsolidationSourceFactsMaxTokensPerObservationOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ConsolidationSourceFactsMaxTokensPerObservation.Get(), o.ConsolidationSourceFactsMaxTokensPerObservation.IsSet()
+}
+
+// HasConsolidationSourceFactsMaxTokensPerObservation returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasConsolidationSourceFactsMaxTokensPerObservation() bool {
+	if o != nil && o.ConsolidationSourceFactsMaxTokensPerObservation.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetConsolidationSourceFactsMaxTokensPerObservation gets a reference to the given NullableInt32 and assigns it to the ConsolidationSourceFactsMaxTokensPerObservation field.
+func (o *BankTemplateConfig) SetConsolidationSourceFactsMaxTokensPerObservation(v int32) {
+	o.ConsolidationSourceFactsMaxTokensPerObservation.Set(&v)
+}
+// SetConsolidationSourceFactsMaxTokensPerObservationNil sets the value for ConsolidationSourceFactsMaxTokensPerObservation to be an explicit nil
+func (o *BankTemplateConfig) SetConsolidationSourceFactsMaxTokensPerObservationNil() {
+	o.ConsolidationSourceFactsMaxTokensPerObservation.Set(nil)
+}
+
+// UnsetConsolidationSourceFactsMaxTokensPerObservation ensures that no value is present for ConsolidationSourceFactsMaxTokensPerObservation, not even an explicit nil
+func (o *BankTemplateConfig) UnsetConsolidationSourceFactsMaxTokensPerObservation() {
+	o.ConsolidationSourceFactsMaxTokensPerObservation.Unset()
+}
+
+// GetMaxObservationsPerScope returns the MaxObservationsPerScope field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetMaxObservationsPerScope() int32 {
+	if o == nil || IsNil(o.MaxObservationsPerScope.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.MaxObservationsPerScope.Get()
+}
+
+// GetMaxObservationsPerScopeOk returns a tuple with the MaxObservationsPerScope field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetMaxObservationsPerScopeOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxObservationsPerScope.Get(), o.MaxObservationsPerScope.IsSet()
+}
+
+// HasMaxObservationsPerScope returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasMaxObservationsPerScope() bool {
+	if o != nil && o.MaxObservationsPerScope.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxObservationsPerScope gets a reference to the given NullableInt32 and assigns it to the MaxObservationsPerScope field.
+func (o *BankTemplateConfig) SetMaxObservationsPerScope(v int32) {
+	o.MaxObservationsPerScope.Set(&v)
+}
+// SetMaxObservationsPerScopeNil sets the value for MaxObservationsPerScope to be an explicit nil
+func (o *BankTemplateConfig) SetMaxObservationsPerScopeNil() {
+	o.MaxObservationsPerScope.Set(nil)
+}
+
+// UnsetMaxObservationsPerScope ensures that no value is present for MaxObservationsPerScope, not even an explicit nil
+func (o *BankTemplateConfig) UnsetMaxObservationsPerScope() {
+	o.MaxObservationsPerScope.Unset()
+}
+
+// GetReflectSourceFactsMaxTokens returns the ReflectSourceFactsMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetReflectSourceFactsMaxTokens() int32 {
+	if o == nil || IsNil(o.ReflectSourceFactsMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.ReflectSourceFactsMaxTokens.Get()
+}
+
+// GetReflectSourceFactsMaxTokensOk returns a tuple with the ReflectSourceFactsMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetReflectSourceFactsMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ReflectSourceFactsMaxTokens.Get(), o.ReflectSourceFactsMaxTokens.IsSet()
+}
+
+// HasReflectSourceFactsMaxTokens returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasReflectSourceFactsMaxTokens() bool {
+	if o != nil && o.ReflectSourceFactsMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetReflectSourceFactsMaxTokens gets a reference to the given NullableInt32 and assigns it to the ReflectSourceFactsMaxTokens field.
+func (o *BankTemplateConfig) SetReflectSourceFactsMaxTokens(v int32) {
+	o.ReflectSourceFactsMaxTokens.Set(&v)
+}
+// SetReflectSourceFactsMaxTokensNil sets the value for ReflectSourceFactsMaxTokens to be an explicit nil
+func (o *BankTemplateConfig) SetReflectSourceFactsMaxTokensNil() {
+	o.ReflectSourceFactsMaxTokens.Set(nil)
+}
+
+// UnsetReflectSourceFactsMaxTokens ensures that no value is present for ReflectSourceFactsMaxTokens, not even an explicit nil
+func (o *BankTemplateConfig) UnsetReflectSourceFactsMaxTokens() {
+	o.ReflectSourceFactsMaxTokens.Unset()
+}
+
+// GetLlmGeminiSafetySettings returns the LlmGeminiSafetySettings field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetLlmGeminiSafetySettings() []interface{} {
+	if o == nil {
+		var ret []interface{}
+		return ret
+	}
+	return o.LlmGeminiSafetySettings
+}
+
+// GetLlmGeminiSafetySettingsOk returns a tuple with the LlmGeminiSafetySettings field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetLlmGeminiSafetySettingsOk() ([]interface{}, bool) {
+	if o == nil || IsNil(o.LlmGeminiSafetySettings) {
+		return nil, false
+	}
+	return o.LlmGeminiSafetySettings, true
+}
+
+// HasLlmGeminiSafetySettings returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasLlmGeminiSafetySettings() bool {
+	if o != nil && !IsNil(o.LlmGeminiSafetySettings) {
+		return true
+	}
+
+	return false
+}
+
+// SetLlmGeminiSafetySettings gets a reference to the given []interface{} and assigns it to the LlmGeminiSafetySettings field.
+func (o *BankTemplateConfig) SetLlmGeminiSafetySettings(v []interface{}) {
+	o.LlmGeminiSafetySettings = v
+}
+
 func (o BankTemplateConfig) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -590,6 +993,36 @@ func (o BankTemplateConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if o.EntitiesAllowFreeForm.IsSet() {
 		toSerialize["entities_allow_free_form"] = o.EntitiesAllowFreeForm.Get()
+	}
+	if o.RetainDefaultStrategy.IsSet() {
+		toSerialize["retain_default_strategy"] = o.RetainDefaultStrategy.Get()
+	}
+	if o.RetainStrategies != nil {
+		toSerialize["retain_strategies"] = o.RetainStrategies
+	}
+	if o.RetainChunkBatchSize.IsSet() {
+		toSerialize["retain_chunk_batch_size"] = o.RetainChunkBatchSize.Get()
+	}
+	if o.McpEnabledTools != nil {
+		toSerialize["mcp_enabled_tools"] = o.McpEnabledTools
+	}
+	if o.ConsolidationLlmBatchSize.IsSet() {
+		toSerialize["consolidation_llm_batch_size"] = o.ConsolidationLlmBatchSize.Get()
+	}
+	if o.ConsolidationSourceFactsMaxTokens.IsSet() {
+		toSerialize["consolidation_source_facts_max_tokens"] = o.ConsolidationSourceFactsMaxTokens.Get()
+	}
+	if o.ConsolidationSourceFactsMaxTokensPerObservation.IsSet() {
+		toSerialize["consolidation_source_facts_max_tokens_per_observation"] = o.ConsolidationSourceFactsMaxTokensPerObservation.Get()
+	}
+	if o.MaxObservationsPerScope.IsSet() {
+		toSerialize["max_observations_per_scope"] = o.MaxObservationsPerScope.Get()
+	}
+	if o.ReflectSourceFactsMaxTokens.IsSet() {
+		toSerialize["reflect_source_facts_max_tokens"] = o.ReflectSourceFactsMaxTokens.Get()
+	}
+	if o.LlmGeminiSafetySettings != nil {
+		toSerialize["llm_gemini_safety_settings"] = o.LlmGeminiSafetySettings
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
@@ -39,7 +39,17 @@ class BankTemplateConfig(BaseModel):
     disposition_empathy: Optional[Annotated[int, Field(le=5, strict=True, ge=1)]] = None
     entity_labels: Optional[List[Dict[str, Any]]] = None
     entities_allow_free_form: Optional[StrictBool] = None
-    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form"]
+    retain_default_strategy: Optional[StrictStr] = None
+    retain_strategies: Optional[Dict[str, Any]] = None
+    retain_chunk_batch_size: Optional[StrictInt] = None
+    mcp_enabled_tools: Optional[List[StrictStr]] = None
+    consolidation_llm_batch_size: Optional[StrictInt] = None
+    consolidation_source_facts_max_tokens: Optional[StrictInt] = None
+    consolidation_source_facts_max_tokens_per_observation: Optional[StrictInt] = None
+    max_observations_per_scope: Optional[StrictInt] = None
+    reflect_source_facts_max_tokens: Optional[StrictInt] = None
+    llm_gemini_safety_settings: Optional[List[Any]] = None
+    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -140,6 +150,56 @@ class BankTemplateConfig(BaseModel):
         if self.entities_allow_free_form is None and "entities_allow_free_form" in self.model_fields_set:
             _dict['entities_allow_free_form'] = None
 
+        # set to None if retain_default_strategy (nullable) is None
+        # and model_fields_set contains the field
+        if self.retain_default_strategy is None and "retain_default_strategy" in self.model_fields_set:
+            _dict['retain_default_strategy'] = None
+
+        # set to None if retain_strategies (nullable) is None
+        # and model_fields_set contains the field
+        if self.retain_strategies is None and "retain_strategies" in self.model_fields_set:
+            _dict['retain_strategies'] = None
+
+        # set to None if retain_chunk_batch_size (nullable) is None
+        # and model_fields_set contains the field
+        if self.retain_chunk_batch_size is None and "retain_chunk_batch_size" in self.model_fields_set:
+            _dict['retain_chunk_batch_size'] = None
+
+        # set to None if mcp_enabled_tools (nullable) is None
+        # and model_fields_set contains the field
+        if self.mcp_enabled_tools is None and "mcp_enabled_tools" in self.model_fields_set:
+            _dict['mcp_enabled_tools'] = None
+
+        # set to None if consolidation_llm_batch_size (nullable) is None
+        # and model_fields_set contains the field
+        if self.consolidation_llm_batch_size is None and "consolidation_llm_batch_size" in self.model_fields_set:
+            _dict['consolidation_llm_batch_size'] = None
+
+        # set to None if consolidation_source_facts_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.consolidation_source_facts_max_tokens is None and "consolidation_source_facts_max_tokens" in self.model_fields_set:
+            _dict['consolidation_source_facts_max_tokens'] = None
+
+        # set to None if consolidation_source_facts_max_tokens_per_observation (nullable) is None
+        # and model_fields_set contains the field
+        if self.consolidation_source_facts_max_tokens_per_observation is None and "consolidation_source_facts_max_tokens_per_observation" in self.model_fields_set:
+            _dict['consolidation_source_facts_max_tokens_per_observation'] = None
+
+        # set to None if max_observations_per_scope (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_observations_per_scope is None and "max_observations_per_scope" in self.model_fields_set:
+            _dict['max_observations_per_scope'] = None
+
+        # set to None if reflect_source_facts_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.reflect_source_facts_max_tokens is None and "reflect_source_facts_max_tokens" in self.model_fields_set:
+            _dict['reflect_source_facts_max_tokens'] = None
+
+        # set to None if llm_gemini_safety_settings (nullable) is None
+        # and model_fields_set contains the field
+        if self.llm_gemini_safety_settings is None and "llm_gemini_safety_settings" in self.model_fields_set:
+            _dict['llm_gemini_safety_settings'] = None
+
         return _dict
 
     @classmethod
@@ -163,7 +223,17 @@ class BankTemplateConfig(BaseModel):
             "disposition_literalism": obj.get("disposition_literalism"),
             "disposition_empathy": obj.get("disposition_empathy"),
             "entity_labels": obj.get("entity_labels"),
-            "entities_allow_free_form": obj.get("entities_allow_free_form")
+            "entities_allow_free_form": obj.get("entities_allow_free_form"),
+            "retain_default_strategy": obj.get("retain_default_strategy"),
+            "retain_strategies": obj.get("retain_strategies"),
+            "retain_chunk_batch_size": obj.get("retain_chunk_batch_size"),
+            "mcp_enabled_tools": obj.get("mcp_enabled_tools"),
+            "consolidation_llm_batch_size": obj.get("consolidation_llm_batch_size"),
+            "consolidation_source_facts_max_tokens": obj.get("consolidation_source_facts_max_tokens"),
+            "consolidation_source_facts_max_tokens_per_observation": obj.get("consolidation_source_facts_max_tokens_per_observation"),
+            "max_observations_per_scope": obj.get("max_observations_per_scope"),
+            "reflect_source_facts_max_tokens": obj.get("reflect_source_facts_max_tokens"),
+            "llm_gemini_safety_settings": obj.get("llm_gemini_safety_settings")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -468,6 +468,68 @@ export type BankTemplateConfig = {
    * Allow entities outside the label vocabulary
    */
   entities_allow_free_form?: boolean | null;
+  /**
+   * Retain Default Strategy
+   *
+   * Name of the default retain strategy (key into retain_strategies map)
+   */
+  retain_default_strategy?: string | null;
+  /**
+   * Retain Strategies
+   *
+   * Map of retain strategy name to per-strategy config dict
+   */
+  retain_strategies?: {
+    [key: string]: unknown;
+  } | null;
+  /**
+   * Retain Chunk Batch Size
+   *
+   * Max chunks per streaming batch (0 disables batching)
+   */
+  retain_chunk_batch_size?: number | null;
+  /**
+   * Mcp Enabled Tools
+   *
+   * MCP tool allowlist for this bank (None = all tools)
+   */
+  mcp_enabled_tools?: Array<string> | null;
+  /**
+   * Consolidation Llm Batch Size
+   *
+   * LLM batch size for observation consolidation
+   */
+  consolidation_llm_batch_size?: number | null;
+  /**
+   * Consolidation Source Facts Max Tokens
+   *
+   * Max tokens of source facts per consolidation batch
+   */
+  consolidation_source_facts_max_tokens?: number | null;
+  /**
+   * Consolidation Source Facts Max Tokens Per Observation
+   *
+   * Max tokens of source facts per observation
+   */
+  consolidation_source_facts_max_tokens_per_observation?: number | null;
+  /**
+   * Max Observations Per Scope
+   *
+   * Max observations to retain per consolidation scope
+   */
+  max_observations_per_scope?: number | null;
+  /**
+   * Reflect Source Facts Max Tokens
+   *
+   * Max tokens of source facts per reflect call
+   */
+  reflect_source_facts_max_tokens?: number | null;
+  /**
+   * Llm Gemini Safety Settings
+   *
+   * Per-bank Gemini/VertexAI safety filter settings
+   */
+  llm_gemini_safety_settings?: Array<unknown> | null;
 };
 
 /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -5298,6 +5298,131 @@
             ],
             "title": "Entities Allow Free Form",
             "description": "Allow entities outside the label vocabulary"
+          },
+          "retain_default_strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Default Strategy",
+            "description": "Name of the default retain strategy (key into retain_strategies map)"
+          },
+          "retain_strategies": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Strategies",
+            "description": "Map of retain strategy name to per-strategy config dict"
+          },
+          "retain_chunk_batch_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Chunk Batch Size",
+            "description": "Max chunks per streaming batch (0 disables batching)"
+          },
+          "mcp_enabled_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Enabled Tools",
+            "description": "MCP tool allowlist for this bank (None = all tools)"
+          },
+          "consolidation_llm_batch_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Llm Batch Size",
+            "description": "LLM batch size for observation consolidation"
+          },
+          "consolidation_source_facts_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Source Facts Max Tokens",
+            "description": "Max tokens of source facts per consolidation batch"
+          },
+          "consolidation_source_facts_max_tokens_per_observation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Source Facts Max Tokens Per Observation",
+            "description": "Max tokens of source facts per observation"
+          },
+          "max_observations_per_scope": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Observations Per Scope",
+            "description": "Max observations to retain per consolidation scope"
+          },
+          "reflect_source_facts_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reflect Source Facts Max Tokens",
+            "description": "Max tokens of source facts per reflect call"
+          },
+          "llm_gemini_safety_settings": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Gemini Safety Settings",
+            "description": "Per-bank Gemini/VertexAI safety filter settings"
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -5298,6 +5298,131 @@
             ],
             "title": "Entities Allow Free Form",
             "description": "Allow entities outside the label vocabulary"
+          },
+          "retain_default_strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Default Strategy",
+            "description": "Name of the default retain strategy (key into retain_strategies map)"
+          },
+          "retain_strategies": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Strategies",
+            "description": "Map of retain strategy name to per-strategy config dict"
+          },
+          "retain_chunk_batch_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retain Chunk Batch Size",
+            "description": "Max chunks per streaming batch (0 disables batching)"
+          },
+          "mcp_enabled_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Enabled Tools",
+            "description": "MCP tool allowlist for this bank (None = all tools)"
+          },
+          "consolidation_llm_batch_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Llm Batch Size",
+            "description": "LLM batch size for observation consolidation"
+          },
+          "consolidation_source_facts_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Source Facts Max Tokens",
+            "description": "Max tokens of source facts per consolidation batch"
+          },
+          "consolidation_source_facts_max_tokens_per_observation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consolidation Source Facts Max Tokens Per Observation",
+            "description": "Max tokens of source facts per observation"
+          },
+          "max_observations_per_scope": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Observations Per Scope",
+            "description": "Max observations to retain per consolidation scope"
+          },
+          "reflect_source_facts_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reflect Source Facts Max Tokens",
+            "description": "Max tokens of source facts per reflect call"
+          },
+          "llm_gemini_safety_settings": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Gemini Safety Settings",
+            "description": "Per-bank Gemini/VertexAI safety filter settings"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

`_CONFIGURABLE_FIELDS` on `HindsightConfig` defines the contract for what can be overridden per bank — currently 22 fields. `BankTemplateConfig` is the manifest-side representation of that same contract, but it only declares 12. The other ten exist on `HindsightConfig` and `config_resolver.update_bank_config()` accepts them through the bank config API directly, but the template import path at `POST /v1/default/banks/{id}/import` cannot deliver them: the manifest handler resolves overrides via `BankTemplateConfig.get_config_updates()`, which is a `model_dump()` filter, so any field not declared on the model is silently dropped before reaching `update_bank_config()`.

The result is two paths to the same per-bank knob that disagree. The bank config API works for all 22 fields; the template import path silently no-ops on ten of them.

This PR aligns `BankTemplateConfig` with the existing `_CONFIGURABLE_FIELDS` allowlist by declaring the missing ten:

- `retain_default_strategy`
- `retain_strategies`
- `retain_chunk_batch_size`
- `mcp_enabled_tools`
- `consolidation_llm_batch_size`
- `consolidation_source_facts_max_tokens`
- `consolidation_source_facts_max_tokens_per_observation`
- `max_observations_per_scope`
- `reflect_source_facts_max_tokens`
- `llm_gemini_safety_settings`

Field types match the existing declarations on `HindsightConfig` (`dict | None` and `list | None` for the two untyped-generic fields, `int | None` for the integer override slots — same `| None` override convention every other field in `BankTemplateConfig` already uses).

Non-breaking. Existing templates continue to parse and apply unchanged. The new fields are additive — present on the model, default to `None`, ignored when not set. No engine changes; `config_resolver.update_bank_config()` already validates these fields correctly through `_CONFIGURABLE_FIELDS`.

## Test plan

- [x] New parametrized test `tests/test_bank_template_configurable_fields.py`. Each field is POSTed through `/v1/default/banks/{id}/import` with a value chosen to differ visibly from the default, then read back via `GET /v1/default/banks/{id}/config` and asserted under `config["overrides"]`. Fixture shape matches `test_import_applies_config` in `tests/test_bank_templates.py`.
- [x] Pydantic-level guard `test_bank_template_config_declares_every_configurable_field` checks every field in the parametrize list is declared on the model — catches a future rename or removal on either side.
- [ ] CI green (will validate the new test, ruff, and ty in the upstream pipeline).
