### PR TITLE
fix(retain): prevent IndexError on embeddings/facts length mismatch (#1037)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -47,6 +47,16 @@ async def generate_embeddings_batch(embeddings_backend, texts: list[str]) -> lis
             embeddings_backend.encode,
             texts,
         )
-        return embeddings
     except Exception as e:
         raise Exception(f"Failed to generate batch embeddings: {str(e)}")
+
+    # Guarantee 1:1 alignment with input texts. A silent length mismatch here
+    # propagates downstream as zip() drops items, eventually surfacing as an
+    # IndexError in retain mapping (see issue #1037).
+    if len(embeddings) != len(texts):
+        raise RuntimeError(
+            f"Embeddings backend returned {len(embeddings)} vectors for {len(texts)} input texts; "
+            "expected exact 1:1 alignment"
+        )
+
+    return embeddings

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -72,7 +72,6 @@ from . import (
 from .types import (
     ChunkMetadata,
     EntityResolutionResult,
-    ExtractedFact,
     Phase1Result,
     Phase3Context,
     ProcessedFact,
@@ -302,8 +301,11 @@ async def _insert_facts_and_links(
         causal_link_count = await link_creation.create_causal_links_batch(conn, bank_id, unit_ids, processed_facts)
         log_buffer.append(f"  Causal links: {causal_link_count} links in {time.time() - step_start:.3f}s")
 
-    # Map results back to original content items
-    result_unit_ids = _map_results_to_contents(contents, extracted_facts, unit_ids if unit_ids else [])
+    # Map results back to original content items. Use processed_facts (not
+    # extracted_facts) because unit_ids has 1:1 alignment with processed_facts —
+    # any upstream drop between extraction and processing would otherwise cause
+    # an IndexError (see issue #1037).
+    result_unit_ids = _map_results_to_contents(contents, processed_facts, unit_ids if unit_ids else [])
 
     if outbox_callback:
         await outbox_callback(conn)
@@ -1550,12 +1552,19 @@ def _build_delta_contents(
 
 def _map_results_to_contents(
     contents: list[RetainContent],
-    extracted_facts: list[ExtractedFact],
+    processed_facts: list[ProcessedFact],
     unit_ids: list[str],
 ) -> list[list[str]]:
-    """Map created unit IDs back to original content items."""
+    """Map created unit IDs back to original content items.
+
+    `processed_facts` and `unit_ids` must have the same length: each unit_id
+    corresponds to the processed_fact at the same index.
+    """
+    if len(processed_facts) != len(unit_ids):
+        raise ValueError(f"processed_facts ({len(processed_facts)}) and unit_ids ({len(unit_ids)}) length mismatch")
+
     facts_by_content: dict[int, list[int]] = {i: [] for i in range(len(contents))}
-    for i, fact in enumerate(extracted_facts):
+    for i, fact in enumerate(processed_facts):
         # Normalize content_index: some LLM providers return 1-indexed values.
         # Clamp to valid range to prevent KeyError.
         idx = fact.content_index
@@ -1564,12 +1573,8 @@ def _map_results_to_contents(
         facts_by_content[idx].append(i)
 
     result_unit_ids = []
-    unit_idx = 0
     for content_index in range(len(contents)):
-        content_unit_ids = []
-        for _ in facts_by_content[content_index]:
-            content_unit_ids.append(unit_ids[unit_idx])
-            unit_idx += 1
+        content_unit_ids = [unit_ids[i] for i in facts_by_content[content_index]]
         result_unit_ids.append(content_unit_ids)
 
     return result_unit_ids

--- a/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
+++ b/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
@@ -1,0 +1,117 @@
+"""Unit tests for retain orchestrator mapping and embeddings length guarantee.
+
+Regression coverage for issue #1037: a silent length mismatch between the
+extracted facts and the generated embeddings caused
+`_map_results_to_contents` to raise IndexError during batch_retain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api.engine.retain import embedding_utils
+from hindsight_api.engine.retain.orchestrator import _map_results_to_contents
+from hindsight_api.engine.retain.types import ProcessedFact, RetainContent
+
+
+def _make_processed_fact(content_index: int, text: str = "fact") -> ProcessedFact:
+    return ProcessedFact(
+        fact_text=text,
+        fact_type="world",
+        embedding=[0.0, 0.0, 0.0],
+        occurred_start=None,
+        occurred_end=None,
+        mentioned_at=datetime(2026, 1, 1),
+        context="",
+        metadata={},
+        content_index=content_index,
+    )
+
+
+def _make_content(text: str = "x") -> RetainContent:
+    return RetainContent(content=text)
+
+
+class TestMapResultsToContents:
+    def test_groups_unit_ids_by_content_index(self):
+        contents = [_make_content("a"), _make_content("b"), _make_content("c")]
+        processed = [
+            _make_processed_fact(0, "a1"),
+            _make_processed_fact(0, "a2"),
+            _make_processed_fact(2, "c1"),
+        ]
+        unit_ids = ["u-a1", "u-a2", "u-c1"]
+
+        result = _map_results_to_contents(contents, processed, unit_ids)
+
+        assert result == [["u-a1", "u-a2"], [], ["u-c1"]]
+
+    def test_handles_out_of_range_content_index(self):
+        contents = [_make_content("a"), _make_content("b")]
+        processed = [
+            _make_processed_fact(-1, "f1"),
+            _make_processed_fact(99, "f2"),
+        ]
+        unit_ids = ["u1", "u2"]
+
+        result = _map_results_to_contents(contents, processed, unit_ids)
+
+        assert result == [["u1"], ["u2"]]
+
+    def test_empty_inputs(self):
+        assert _map_results_to_contents([], [], []) == []
+
+    def test_length_mismatch_raises(self):
+        # Regression for #1037: previously the function silently overran unit_ids.
+        contents = [_make_content("a")]
+        processed = [_make_processed_fact(0), _make_processed_fact(0)]
+        unit_ids = ["u1"]  # one fewer than processed_facts
+
+        with pytest.raises(ValueError, match="length mismatch"):
+            _map_results_to_contents(contents, processed, unit_ids)
+
+    def test_unit_ids_assigned_by_processed_fact_position(self):
+        # Even if processed_facts are interleaved across contents, each unit_id
+        # must follow its corresponding processed_fact (positional alignment).
+        contents = [_make_content("a"), _make_content("b")]
+        processed = [
+            _make_processed_fact(1, "b1"),
+            _make_processed_fact(0, "a1"),
+            _make_processed_fact(1, "b2"),
+        ]
+        unit_ids = ["u-b1", "u-a1", "u-b2"]
+
+        result = _map_results_to_contents(contents, processed, unit_ids)
+
+        assert result == [["u-a1"], ["u-b1", "u-b2"]]
+
+
+class TestEmbeddingsBatchLengthGuarantee:
+    def test_raises_when_backend_returns_fewer_embeddings(self):
+        # Regression for #1037: backends that silently truncate must not pass
+        # through — `zip(extracted_facts, embeddings)` would otherwise drop
+        # facts and break unit_id alignment downstream.
+        backend = MagicMock()
+        backend.encode.return_value = [[0.1, 0.2]]  # only 1 vector for 3 inputs
+
+        with pytest.raises(RuntimeError, match="returned 1 vectors for 3 input texts"):
+            asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b", "c"]))
+
+    def test_raises_when_backend_returns_more_embeddings(self):
+        backend = MagicMock()
+        backend.encode.return_value = [[0.1], [0.2], [0.3]]
+
+        with pytest.raises(RuntimeError, match="returned 3 vectors for 2 input texts"):
+            asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))
+
+    def test_passes_through_aligned_embeddings(self):
+        backend = MagicMock()
+        backend.encode.return_value = [[0.1], [0.2]]
+
+        result = asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))
+
+        assert result == [[0.1], [0.2]]


### PR DESCRIPTION
## Summary

Fixes #1037 — `batch_retain` crashed with `IndexError: list index out of range` in `_map_results_to_contents` when the embeddings backend returned fewer vectors than extracted facts.

Root cause: in `orchestrator.py`, `processed_facts = [ProcessedFact.from_extracted_fact(ef, emb) for ef, emb in zip(extracted_facts, embeddings)]` silently dropped facts when `len(embeddings) < len(extracted_facts)`. The downstream `unit_ids` then had `len == len(processed_facts)`, but `_map_results_to_contents` walked all `extracted_facts` and ran past the end of `unit_ids`.

## Changes

- **`embedding_utils.generate_embeddings_batch`** — raises `RuntimeError` when the backend returns a different number of vectors than input texts, instead of allowing silent truncation. This is the real root cause guard.
- **`orchestrator._map_results_to_contents`** — now takes `processed_facts` (1:1 with `unit_ids` by construction) instead of `extracted_facts`, and asserts the length invariant explicitly. Defense-in-depth.
- **`tests/test_retain_orchestrator_mapping.py`** — unit tests covering both fixes, including a regression test for the original IndexError scenario.

## Test plan

- [x] `uv run pytest tests/test_retain_orchestrator_mapping.py -v` — 8/8 pass
- [x] `./scripts/hooks/lint.sh` — clean
- [ ] Verify `hindsight-openclaw-backfill` no longer raises on large batches in the original reporter's environment