### PR TITLE
feat(api): add recall controls to mental model trigger

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1526,6 +1526,27 @@ class MentalModelTrigger(BaseModel):
             "Supports nested and/or/not expressions for complex tag-based scoping."
         ),
     )
+    include_chunks: bool | None = Field(
+        default=None,
+        description=(
+            "Override whether the internal recall used during refresh returns raw chunk text. "
+            "None means use the bank/global config default (recall_include_chunks)."
+        ),
+    )
+    recall_max_tokens: int | None = Field(
+        default=None,
+        description=(
+            "Override the token budget for facts returned by the internal recall during refresh. "
+            "None means use the bank/global config default (recall_max_tokens)."
+        ),
+    )
+    recall_chunks_max_tokens: int | None = Field(
+        default=None,
+        description=(
+            "Override the token budget for raw chunks returned by the internal recall during refresh. "
+            "None means use the bank/global config default (recall_chunks_max_tokens)."
+        ),
+    )
 
     @field_validator("fact_types")
     @classmethod

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -387,6 +387,9 @@ ENV_REFLECT_MAX_CONTEXT_TOKENS = "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS"
 ENV_REFLECT_WALL_TIMEOUT = "HINDSIGHT_API_REFLECT_WALL_TIMEOUT"
 ENV_REFLECT_MISSION = "HINDSIGHT_API_REFLECT_MISSION"
 ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS = "HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS"
+ENV_RECALL_INCLUDE_CHUNKS = "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS"
+ENV_RECALL_MAX_TOKENS = "HINDSIGHT_API_RECALL_MAX_TOKENS"
+ENV_RECALL_CHUNKS_MAX_TOKENS = "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS"
 
 # Audit log settings
 ENV_AUDIT_LOG_ENABLED = "HINDSIGHT_API_AUDIT_LOG_ENABLED"
@@ -587,6 +590,9 @@ DEFAULT_REFLECT_MAX_ITERATIONS = 10  # Max tool call iterations before forcing r
 DEFAULT_REFLECT_MAX_CONTEXT_TOKENS = 100_000  # Max accumulated context tokens before forcing final prompt
 DEFAULT_REFLECT_WALL_TIMEOUT = 300  # Wall-clock timeout in seconds for the entire reflect operation (5 minutes)
 DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS = -1  # Token budget for source facts in search_observations (-1 = disabled)
+DEFAULT_RECALL_INCLUDE_CHUNKS = True  # Whether internal recall (e.g. mental model refresh) returns raw chunks
+DEFAULT_RECALL_MAX_TOKENS = 2048  # Token budget for facts returned by internal recall
+DEFAULT_RECALL_CHUNKS_MAX_TOKENS = 1000  # Token budget for raw chunks returned by internal recall
 
 # Disposition defaults (None = not set, fall back to bank DB value or 3)
 DEFAULT_DISPOSITION_SKEPTICISM = None
@@ -925,6 +931,11 @@ class HindsightConfig:
     reflect_mission: str | None
     reflect_source_facts_max_tokens: int
 
+    # Recall settings (used by internal recall, e.g. during mental model refresh)
+    recall_include_chunks: bool
+    recall_max_tokens: int
+    recall_chunks_max_tokens: int
+
     # Disposition settings (hierarchical - can be overridden per bank; None = fall back to DB)
     disposition_skepticism: int | None
     disposition_literalism: int | None
@@ -1038,6 +1049,10 @@ class HindsightConfig:
         # Reflect settings
         "reflect_mission",
         "reflect_source_facts_max_tokens",
+        # Recall settings (used by internal recall, e.g. mental model refresh)
+        "recall_include_chunks",
+        "recall_max_tokens",
+        "recall_chunks_max_tokens",
         # Disposition settings
         "disposition_skepticism",
         "disposition_literalism",
@@ -1522,6 +1537,12 @@ class HindsightConfig:
             reflect_mission=os.getenv(ENV_REFLECT_MISSION) or None,
             reflect_source_facts_max_tokens=int(
                 os.getenv(ENV_REFLECT_SOURCE_FACTS_MAX_TOKENS, str(DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS))
+            ),
+            recall_include_chunks=os.getenv(ENV_RECALL_INCLUDE_CHUNKS, str(DEFAULT_RECALL_INCLUDE_CHUNKS)).lower()
+            in ("true", "1", "yes"),
+            recall_max_tokens=int(os.getenv(ENV_RECALL_MAX_TOKENS, str(DEFAULT_RECALL_MAX_TOKENS))),
+            recall_chunks_max_tokens=int(
+                os.getenv(ENV_RECALL_CHUNKS_MAX_TOKENS, str(DEFAULT_RECALL_CHUNKS_MAX_TOKENS))
             ),
             # Disposition settings (None = fall back to DB value)
             disposition_skepticism=int(os.getenv(ENV_DISPOSITION_SKEPTICISM))

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -24,7 +24,13 @@ import asyncpg
 import httpx
 import tiktoken
 
-from ..config import DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS, get_config
+from ..config import (
+    DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
+    DEFAULT_RECALL_INCLUDE_CHUNKS,
+    DEFAULT_RECALL_MAX_TOKENS,
+    DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
+    get_config,
+)
 from ..metrics import get_metrics_collector
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
@@ -952,6 +958,9 @@ class MemoryEngine(MemoryEngineInterface):
         fact_types = trigger_data.get("fact_types")
         exclude_mental_models = trigger_data.get("exclude_mental_models", False)
         stored_exclude_ids: list[str] = trigger_data.get("exclude_mental_model_ids") or []
+        recall_include_chunks_override = trigger_data.get("include_chunks")
+        recall_max_tokens_override = trigger_data.get("recall_max_tokens")
+        recall_chunks_max_tokens_override = trigger_data.get("recall_chunks_max_tokens")
 
         tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
 
@@ -967,6 +976,9 @@ class MemoryEngine(MemoryEngineInterface):
             fact_types=fact_types,
             exclude_mental_models=exclude_mental_models,
             exclude_mental_model_ids=list({*stored_exclude_ids, mental_model_id}),
+            recall_include_chunks=recall_include_chunks_override,
+            recall_max_tokens_override=recall_max_tokens_override,
+            recall_chunks_max_tokens_override=recall_chunks_max_tokens_override,
         )
 
         generated_content = reflect_result.text or "No content generated"
@@ -5399,6 +5411,9 @@ class MemoryEngine(MemoryEngineInterface):
         exclude_mental_model_ids: list[str] | None = None,
         fact_types: list[str] | None = None,
         exclude_mental_models: bool = False,
+        recall_include_chunks: bool | None = None,
+        recall_max_tokens_override: int | None = None,
+        recall_chunks_max_tokens_override: int | None = None,
         _skip_span: bool = False,
     ) -> ReflectResult:
         """
@@ -5521,6 +5536,23 @@ class MemoryEngine(MemoryEngineInterface):
             "reflect_source_facts_max_tokens", DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS
         )
 
+        # Resolve recall overrides: caller arg (e.g. mental model trigger) → bank config → env default
+        effective_recall_include_chunks = (
+            recall_include_chunks
+            if recall_include_chunks is not None
+            else config_dict.get("recall_include_chunks", DEFAULT_RECALL_INCLUDE_CHUNKS)
+        )
+        effective_recall_max_tokens = (
+            recall_max_tokens_override
+            if recall_max_tokens_override is not None
+            else config_dict.get("recall_max_tokens", DEFAULT_RECALL_MAX_TOKENS)
+        )
+        effective_recall_chunks_max_tokens = (
+            recall_chunks_max_tokens_override
+            if recall_chunks_max_tokens_override is not None
+            else config_dict.get("recall_chunks_max_tokens", DEFAULT_RECALL_CHUNKS_MAX_TOKENS)
+        )
+
         async def search_observations_fn(q: str, max_tokens: int = 5000) -> dict[str, Any]:
             return await tool_search_observations(
                 self,
@@ -5541,7 +5573,14 @@ class MemoryEngine(MemoryEngineInterface):
         recall_fact_types = [ft for ft in (fact_types or ["world", "experience"]) if ft in ("world", "experience")]
         include_recall = bool(recall_fact_types)
 
-        async def recall_fn(q: str, max_tokens: int = 4096, max_chunk_tokens: int = 1000) -> dict[str, Any]:
+        # Defaults are bound at closure-definition time (re-evaluated on each
+        # reflect_async call), so per-bank/per-trigger overrides apply when the
+        # agent invokes recall without explicit token args.
+        async def recall_fn(
+            q: str,
+            max_tokens: int = effective_recall_max_tokens,
+            max_chunk_tokens: int = effective_recall_chunks_max_tokens,
+        ) -> dict[str, Any]:
             return await tool_recall(
                 self,
                 bank_id,
@@ -5553,6 +5592,7 @@ class MemoryEngine(MemoryEngineInterface):
                 tag_groups=tag_groups,
                 max_chunk_tokens=max_chunk_tokens,
                 fact_types=recall_fact_types if fact_types is not None else None,
+                include_chunks=effective_recall_include_chunks,
             )
 
         async def expand_fn(memory_ids: list[str], depth: str) -> dict[str, Any]:
@@ -6770,6 +6810,9 @@ class MemoryEngine(MemoryEngineInterface):
             fact_types = trigger_data.get("fact_types")
             exclude_mental_models = trigger_data.get("exclude_mental_models", False)
             stored_exclude_ids: list[str] = trigger_data.get("exclude_mental_model_ids") or []
+            recall_include_chunks_override = trigger_data.get("include_chunks")
+            recall_max_tokens_override = trigger_data.get("recall_max_tokens")
+            recall_chunks_max_tokens_override = trigger_data.get("recall_chunks_max_tokens")
 
             tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
 
@@ -6785,6 +6828,9 @@ class MemoryEngine(MemoryEngineInterface):
                 fact_types=fact_types,
                 exclude_mental_models=exclude_mental_models,
                 exclude_mental_model_ids=list({*stored_exclude_ids, mental_model_id}),
+                recall_include_chunks=recall_include_chunks_override,
+                recall_max_tokens_override=recall_max_tokens_override,
+                recall_chunks_max_tokens_override=recall_chunks_max_tokens_override,
                 _skip_span=True,
             )
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -214,6 +214,7 @@ async def tool_recall(
     connection_budget: int = 1,
     max_chunk_tokens: int = 1000,
     fact_types: list[str] | None = None,
+    include_chunks: bool = True,
 ) -> dict[str, Any]:
     """
     Search memories using TEMPR retrieval.
@@ -230,15 +231,15 @@ async def tool_recall(
         tags: Filter by tags (includes untagged memories)
         tags_match: How to match tags - "any" (OR), "all" (AND), or "exact"
         connection_budget: Max DB connections for this recall (default 1 for internal ops)
-        max_chunk_tokens: Maximum tokens for raw source chunk text (default 1000, always included)
+        max_chunk_tokens: Maximum tokens for raw source chunk text (default 1000)
         fact_types: Optional filter for fact types to retrieve. Defaults to ["experience", "world"].
+        include_chunks: Whether to fetch raw chunk text alongside facts (default True).
 
     Returns:
-        Dict with list of matching memories including raw chunk text
+        Dict with list of matching memories including raw chunk text (when include_chunks)
     """
     # Only world/experience are valid for raw recall (observation is handled by search_observations)
     recall_fact_type = [ft for ft in (fact_types or ["experience", "world"]) if ft in ("world", "experience")]
-    include_chunks = True
     internal_ctx = replace(request_context, internal=True)
     result = await memory_engine.recall_async(
         bank_id=bank_id,

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -98,7 +98,7 @@ async def test_hierarchical_fields_categorization():
     assert "retain_chunk_batch_size" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 22
+    assert len(configurable) == 25
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials
@@ -458,7 +458,7 @@ async def test_config_get_bank_config_no_static_or_credential_fields_leak(memory
             assert field in config, f"Expected configurable field '{field}' missing from config"
 
         # Should have a small number of configurable fields (not hundreds)
-        assert len(config) < 25, f"Too many fields returned: {len(config)}"
+        assert len(config) < 30, f"Too many fields returned: {len(config)}"
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -1,0 +1,231 @@
+"""
+Tests for the internal recall configuration knobs used during mental model
+refresh: recall_include_chunks, recall_max_tokens, recall_chunks_max_tokens.
+
+These are exposed both as hierarchical config fields (env → tenant → bank)
+and as overrides on a mental model's `trigger` JSONB field.
+"""
+
+import dataclasses
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.reflect.tools import tool_recall
+from hindsight_api.engine.response_models import RecallResult as RecallResultModel
+from hindsight_api.models import RequestContext
+
+
+def _make_mock_engine():
+    engine = MagicMock()
+    engine.recall_async = AsyncMock(return_value=RecallResultModel(results=[], entities={}, chunks={}))
+    return engine
+
+
+@pytest.fixture
+def mock_request_context():
+    # internal=True bypasses the tenant extension, letting these unit tests
+    # exercise engine methods without standing up auth.
+    return RequestContext(internal=True)
+
+
+class TestToolRecallIncludeChunks:
+    """tool_recall must honor the include_chunks parameter (was hardcoded True)."""
+
+    @pytest.mark.asyncio
+    async def test_default_includes_chunks(self, mock_request_context):
+        engine = _make_mock_engine()
+
+        await tool_recall(engine, "bank-1", "q", mock_request_context)
+
+        kwargs = engine.recall_async.call_args.kwargs
+        assert kwargs["include_chunks"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_chunks_false_propagates(self, mock_request_context):
+        engine = _make_mock_engine()
+
+        await tool_recall(engine, "bank-1", "q", mock_request_context, include_chunks=False)
+
+        kwargs = engine.recall_async.call_args.kwargs
+        assert kwargs["include_chunks"] is False
+
+    @pytest.mark.asyncio
+    async def test_max_chunk_tokens_propagates(self, mock_request_context):
+        engine = _make_mock_engine()
+
+        await tool_recall(
+            engine, "bank-1", "q", mock_request_context, max_chunk_tokens=2500, max_tokens=512
+        )
+
+        kwargs = engine.recall_async.call_args.kwargs
+        assert kwargs["max_chunk_tokens"] == 2500
+        assert kwargs["max_tokens"] == 512
+
+
+class TestRecallConfigFields:
+    """Hierarchical config fields for internal recall."""
+
+    def test_fields_exist_on_dataclass(self):
+        from hindsight_api.config import HindsightConfig
+
+        names = {f.name for f in dataclasses.fields(HindsightConfig)}
+        assert "recall_include_chunks" in names
+        assert "recall_max_tokens" in names
+        assert "recall_chunks_max_tokens" in names
+
+    def test_fields_are_configurable(self):
+        from hindsight_api.config import HindsightConfig
+
+        configurable = HindsightConfig.get_configurable_fields()
+        assert "recall_include_chunks" in configurable
+        assert "recall_max_tokens" in configurable
+        assert "recall_chunks_max_tokens" in configurable
+
+    def test_default_values(self):
+        from hindsight_api.config import (
+            DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
+            DEFAULT_RECALL_INCLUDE_CHUNKS,
+            DEFAULT_RECALL_MAX_TOKENS,
+        )
+
+        assert DEFAULT_RECALL_INCLUDE_CHUNKS is True
+        assert DEFAULT_RECALL_MAX_TOKENS == 2048
+        assert DEFAULT_RECALL_CHUNKS_MAX_TOKENS == 1000
+
+    def test_env_var_constants(self):
+        from hindsight_api.config import (
+            ENV_RECALL_CHUNKS_MAX_TOKENS,
+            ENV_RECALL_INCLUDE_CHUNKS,
+            ENV_RECALL_MAX_TOKENS,
+        )
+
+        assert ENV_RECALL_INCLUDE_CHUNKS == "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS"
+        assert ENV_RECALL_MAX_TOKENS == "HINDSIGHT_API_RECALL_MAX_TOKENS"
+        assert ENV_RECALL_CHUNKS_MAX_TOKENS == "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS"
+
+    @patch.dict(
+        "os.environ",
+        {
+            "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS": "false",
+            "HINDSIGHT_API_RECALL_MAX_TOKENS": "777",
+            "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS": "333",
+        },
+    )
+    def test_from_env_reads_overrides(self):
+        from hindsight_api.config import HindsightConfig
+
+        config = HindsightConfig.from_env()
+        assert config.recall_include_chunks is False
+        assert config.recall_max_tokens == 777
+        assert config.recall_chunks_max_tokens == 333
+
+
+class TestMentalModelTriggerRecallFields:
+    """MentalModelTrigger Pydantic model accepts the new override fields."""
+
+    def test_trigger_accepts_new_fields(self):
+        from hindsight_api.api.http import MentalModelTrigger
+
+        trigger = MentalModelTrigger(
+            include_chunks=False,
+            recall_max_tokens=512,
+            recall_chunks_max_tokens=0,
+        )
+        assert trigger.include_chunks is False
+        assert trigger.recall_max_tokens == 512
+        assert trigger.recall_chunks_max_tokens == 0
+
+    def test_trigger_defaults_are_none(self):
+        from hindsight_api.api.http import MentalModelTrigger
+
+        trigger = MentalModelTrigger()
+        assert trigger.include_chunks is None
+        assert trigger.recall_max_tokens is None
+        assert trigger.recall_chunks_max_tokens is None
+
+
+class TestRefreshTriggerWiring:
+    """Verify mental-model refresh forwards trigger overrides into reflect_async kwargs."""
+
+    @pytest.mark.asyncio
+    async def test_trigger_overrides_passed_to_reflect_async(self, mock_request_context):
+        from hindsight_api.engine.memory_engine import MemoryEngine
+        from hindsight_api.engine.response_models import ReflectResult
+
+        engine = MemoryEngine.__new__(MemoryEngine)
+
+        async def fake_get_mental_model(bank_id, mental_model_id, request_context):
+            return {
+                "id": mental_model_id,
+                "source_query": "What do we know?",
+                "tags": [],
+                "trigger": {
+                    "include_chunks": False,
+                    "recall_max_tokens": 512,
+                    "recall_chunks_max_tokens": 0,
+                    "fact_types": ["world"],
+                },
+            }
+
+        captured = {}
+
+        async def fake_reflect_async(**kwargs):
+            captured.update(kwargs)
+            return ReflectResult(text="ok", based_on={})
+
+        async def fake_update_mental_model(*args, **kwargs):
+            return None
+
+        engine.get_mental_model = fake_get_mental_model
+        engine.reflect_async = fake_reflect_async
+        engine.update_mental_model = fake_update_mental_model
+        engine._operation_validator = None
+        engine._tenant_extension = None
+
+        await engine.refresh_mental_model(
+            bank_id="bank-1",
+            mental_model_id="mm-1",
+            request_context=mock_request_context,
+        )
+
+        assert captured["recall_include_chunks"] is False
+        assert captured["recall_max_tokens_override"] == 512
+        assert captured["recall_chunks_max_tokens_override"] == 0
+        assert captured["fact_types"] == ["world"]
+
+    @pytest.mark.asyncio
+    async def test_missing_trigger_fields_pass_none(self, mock_request_context):
+        from hindsight_api.engine.memory_engine import MemoryEngine
+        from hindsight_api.engine.response_models import ReflectResult
+
+        engine = MemoryEngine.__new__(MemoryEngine)
+
+        async def fake_get_mental_model(bank_id, mental_model_id, request_context):
+            return {"id": mental_model_id, "source_query": "q", "tags": [], "trigger": {}}
+
+        captured = {}
+
+        async def fake_reflect_async(**kwargs):
+            captured.update(kwargs)
+            return ReflectResult(text="ok", based_on={})
+
+        async def fake_update_mental_model(*args, **kwargs):
+            return None
+
+        engine.get_mental_model = fake_get_mental_model
+        engine.reflect_async = fake_reflect_async
+        engine.update_mental_model = fake_update_mental_model
+        engine._operation_validator = None
+        engine._tenant_extension = None
+
+        await engine.refresh_mental_model(
+            bank_id="bank-1",
+            mental_model_id="mm-1",
+            request_context=mock_request_context,
+        )
+
+        # When trigger fields are absent, None is forwarded so reflect_async falls back to bank/global config.
+        assert captured["recall_include_chunks"] is None
+        assert captured["recall_max_tokens_override"] is None
+        assert captured["recall_chunks_max_tokens_override"] is None

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -124,6 +124,9 @@ pub fn create(
             fact_types: None,
             tag_groups: None,
             tags_match: None,
+            include_chunks: None,
+            recall_max_tokens: None,
+            recall_chunks_max_tokens: None,
         })
     } else {
         None
@@ -198,6 +201,9 @@ pub fn update(
         fact_types: None,
         tag_groups: None,
         tags_match: None,
+        include_chunks: None,
+        recall_max_tokens: None,
+        recall_chunks_max_tokens: None,
     });
 
     let request = types::UpdateMentalModelRequest {

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -4853,6 +4853,7 @@ components:
           id: id
           trigger:
             refresh_after_consolidation: false
+            recall_chunks_max_tokens: 1
             tag_groups:
             - match: any_strict
               tags:
@@ -4868,8 +4869,10 @@ components:
             exclude_mental_model_ids:
             - exclude_mental_model_ids
             - exclude_mental_model_ids
+            include_chunks: true
             tags_match: any
             exclude_mental_models: false
+            recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
           content: content
           tags:
@@ -4885,6 +4888,7 @@ components:
           id: id
           trigger:
             refresh_after_consolidation: false
+            recall_chunks_max_tokens: 1
             tag_groups:
             - match: any_strict
               tags:
@@ -4900,8 +4904,10 @@ components:
             exclude_mental_model_ids:
             - exclude_mental_model_ids
             - exclude_mental_model_ids
+            include_chunks: true
             tags_match: any
             exclude_mental_models: false
+            recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
           content: content
           tags:
@@ -4928,6 +4934,7 @@ components:
         id: id
         trigger:
           refresh_after_consolidation: false
+          recall_chunks_max_tokens: 1
           tag_groups:
           - match: any_strict
             tags:
@@ -4943,8 +4950,10 @@ components:
           exclude_mental_model_ids:
           - exclude_mental_model_ids
           - exclude_mental_model_ids
+          include_chunks: true
           tags_match: any
           exclude_mental_models: false
+          recall_max_tokens: 6
         last_refreshed_at: last_refreshed_at
         content: content
         tags:
@@ -5032,11 +5041,21 @@ components:
             $ref: '#/components/schemas/MentalModelTrigger_Input_tag_groups_inner'
           nullable: true
           type: array
+        include_chunks:
+          nullable: true
+          type: boolean
+        recall_max_tokens:
+          nullable: true
+          type: integer
+        recall_chunks_max_tokens:
+          nullable: true
+          type: integer
       title: MentalModelTrigger
     MentalModelTrigger-Output:
       description: Trigger settings for a mental model.
       example:
         refresh_after_consolidation: false
+        recall_chunks_max_tokens: 1
         tag_groups:
         - match: any_strict
           tags:
@@ -5052,8 +5071,10 @@ components:
         exclude_mental_model_ids:
         - exclude_mental_model_ids
         - exclude_mental_model_ids
+        include_chunks: true
         tags_match: any
         exclude_mental_models: false
+        recall_max_tokens: 6
       properties:
         refresh_after_consolidation:
           default: false
@@ -5094,6 +5115,15 @@ components:
             $ref: '#/components/schemas/MentalModelTrigger_Output_tag_groups_inner'
           nullable: true
           type: array
+        include_chunks:
+          nullable: true
+          type: boolean
+        recall_max_tokens:
+          nullable: true
+          type: integer
+        recall_chunks_max_tokens:
+          nullable: true
+          type: integer
       title: MentalModelTrigger
     OperationResponse:
       description: Response model for a single async operation.

--- a/hindsight-clients/go/model_mental_model_trigger_input.go
+++ b/hindsight-clients/go/model_mental_model_trigger_input.go
@@ -27,6 +27,9 @@ type MentalModelTriggerInput struct {
 	ExcludeMentalModelIds []string `json:"exclude_mental_model_ids,omitempty"`
 	TagsMatch NullableString `json:"tags_match,omitempty"`
 	TagGroups []MentalModelTriggerInputTagGroupsInner `json:"tag_groups,omitempty"`
+	IncludeChunks NullableBool `json:"include_chunks,omitempty"`
+	RecallMaxTokens NullableInt32 `json:"recall_max_tokens,omitempty"`
+	RecallChunksMaxTokens NullableInt32 `json:"recall_chunks_max_tokens,omitempty"`
 }
 
 // NewMentalModelTriggerInput instantiates a new MentalModelTriggerInput object
@@ -259,6 +262,132 @@ func (o *MentalModelTriggerInput) SetTagGroups(v []MentalModelTriggerInputTagGro
 	o.TagGroups = v
 }
 
+// GetIncludeChunks returns the IncludeChunks field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerInput) GetIncludeChunks() bool {
+	if o == nil || IsNil(o.IncludeChunks.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.IncludeChunks.Get()
+}
+
+// GetIncludeChunksOk returns a tuple with the IncludeChunks field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerInput) GetIncludeChunksOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.IncludeChunks.Get(), o.IncludeChunks.IsSet()
+}
+
+// HasIncludeChunks returns a boolean if a field has been set.
+func (o *MentalModelTriggerInput) HasIncludeChunks() bool {
+	if o != nil && o.IncludeChunks.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeChunks gets a reference to the given NullableBool and assigns it to the IncludeChunks field.
+func (o *MentalModelTriggerInput) SetIncludeChunks(v bool) {
+	o.IncludeChunks.Set(&v)
+}
+// SetIncludeChunksNil sets the value for IncludeChunks to be an explicit nil
+func (o *MentalModelTriggerInput) SetIncludeChunksNil() {
+	o.IncludeChunks.Set(nil)
+}
+
+// UnsetIncludeChunks ensures that no value is present for IncludeChunks, not even an explicit nil
+func (o *MentalModelTriggerInput) UnsetIncludeChunks() {
+	o.IncludeChunks.Unset()
+}
+
+// GetRecallMaxTokens returns the RecallMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerInput) GetRecallMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallMaxTokens.Get()
+}
+
+// GetRecallMaxTokensOk returns a tuple with the RecallMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerInput) GetRecallMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallMaxTokens.Get(), o.RecallMaxTokens.IsSet()
+}
+
+// HasRecallMaxTokens returns a boolean if a field has been set.
+func (o *MentalModelTriggerInput) HasRecallMaxTokens() bool {
+	if o != nil && o.RecallMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallMaxTokens field.
+func (o *MentalModelTriggerInput) SetRecallMaxTokens(v int32) {
+	o.RecallMaxTokens.Set(&v)
+}
+// SetRecallMaxTokensNil sets the value for RecallMaxTokens to be an explicit nil
+func (o *MentalModelTriggerInput) SetRecallMaxTokensNil() {
+	o.RecallMaxTokens.Set(nil)
+}
+
+// UnsetRecallMaxTokens ensures that no value is present for RecallMaxTokens, not even an explicit nil
+func (o *MentalModelTriggerInput) UnsetRecallMaxTokens() {
+	o.RecallMaxTokens.Unset()
+}
+
+// GetRecallChunksMaxTokens returns the RecallChunksMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerInput) GetRecallChunksMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallChunksMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallChunksMaxTokens.Get()
+}
+
+// GetRecallChunksMaxTokensOk returns a tuple with the RecallChunksMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerInput) GetRecallChunksMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallChunksMaxTokens.Get(), o.RecallChunksMaxTokens.IsSet()
+}
+
+// HasRecallChunksMaxTokens returns a boolean if a field has been set.
+func (o *MentalModelTriggerInput) HasRecallChunksMaxTokens() bool {
+	if o != nil && o.RecallChunksMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallChunksMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallChunksMaxTokens field.
+func (o *MentalModelTriggerInput) SetRecallChunksMaxTokens(v int32) {
+	o.RecallChunksMaxTokens.Set(&v)
+}
+// SetRecallChunksMaxTokensNil sets the value for RecallChunksMaxTokens to be an explicit nil
+func (o *MentalModelTriggerInput) SetRecallChunksMaxTokensNil() {
+	o.RecallChunksMaxTokens.Set(nil)
+}
+
+// UnsetRecallChunksMaxTokens ensures that no value is present for RecallChunksMaxTokens, not even an explicit nil
+func (o *MentalModelTriggerInput) UnsetRecallChunksMaxTokens() {
+	o.RecallChunksMaxTokens.Unset()
+}
+
 func (o MentalModelTriggerInput) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -286,6 +415,15 @@ func (o MentalModelTriggerInput) ToMap() (map[string]interface{}, error) {
 	}
 	if o.TagGroups != nil {
 		toSerialize["tag_groups"] = o.TagGroups
+	}
+	if o.IncludeChunks.IsSet() {
+		toSerialize["include_chunks"] = o.IncludeChunks.Get()
+	}
+	if o.RecallMaxTokens.IsSet() {
+		toSerialize["recall_max_tokens"] = o.RecallMaxTokens.Get()
+	}
+	if o.RecallChunksMaxTokens.IsSet() {
+		toSerialize["recall_chunks_max_tokens"] = o.RecallChunksMaxTokens.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/go/model_mental_model_trigger_output.go
+++ b/hindsight-clients/go/model_mental_model_trigger_output.go
@@ -27,6 +27,9 @@ type MentalModelTriggerOutput struct {
 	ExcludeMentalModelIds []string `json:"exclude_mental_model_ids,omitempty"`
 	TagsMatch NullableString `json:"tags_match,omitempty"`
 	TagGroups []MentalModelTriggerOutputTagGroupsInner `json:"tag_groups,omitempty"`
+	IncludeChunks NullableBool `json:"include_chunks,omitempty"`
+	RecallMaxTokens NullableInt32 `json:"recall_max_tokens,omitempty"`
+	RecallChunksMaxTokens NullableInt32 `json:"recall_chunks_max_tokens,omitempty"`
 }
 
 // NewMentalModelTriggerOutput instantiates a new MentalModelTriggerOutput object
@@ -259,6 +262,132 @@ func (o *MentalModelTriggerOutput) SetTagGroups(v []MentalModelTriggerOutputTagG
 	o.TagGroups = v
 }
 
+// GetIncludeChunks returns the IncludeChunks field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerOutput) GetIncludeChunks() bool {
+	if o == nil || IsNil(o.IncludeChunks.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.IncludeChunks.Get()
+}
+
+// GetIncludeChunksOk returns a tuple with the IncludeChunks field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerOutput) GetIncludeChunksOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.IncludeChunks.Get(), o.IncludeChunks.IsSet()
+}
+
+// HasIncludeChunks returns a boolean if a field has been set.
+func (o *MentalModelTriggerOutput) HasIncludeChunks() bool {
+	if o != nil && o.IncludeChunks.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeChunks gets a reference to the given NullableBool and assigns it to the IncludeChunks field.
+func (o *MentalModelTriggerOutput) SetIncludeChunks(v bool) {
+	o.IncludeChunks.Set(&v)
+}
+// SetIncludeChunksNil sets the value for IncludeChunks to be an explicit nil
+func (o *MentalModelTriggerOutput) SetIncludeChunksNil() {
+	o.IncludeChunks.Set(nil)
+}
+
+// UnsetIncludeChunks ensures that no value is present for IncludeChunks, not even an explicit nil
+func (o *MentalModelTriggerOutput) UnsetIncludeChunks() {
+	o.IncludeChunks.Unset()
+}
+
+// GetRecallMaxTokens returns the RecallMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerOutput) GetRecallMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallMaxTokens.Get()
+}
+
+// GetRecallMaxTokensOk returns a tuple with the RecallMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerOutput) GetRecallMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallMaxTokens.Get(), o.RecallMaxTokens.IsSet()
+}
+
+// HasRecallMaxTokens returns a boolean if a field has been set.
+func (o *MentalModelTriggerOutput) HasRecallMaxTokens() bool {
+	if o != nil && o.RecallMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallMaxTokens field.
+func (o *MentalModelTriggerOutput) SetRecallMaxTokens(v int32) {
+	o.RecallMaxTokens.Set(&v)
+}
+// SetRecallMaxTokensNil sets the value for RecallMaxTokens to be an explicit nil
+func (o *MentalModelTriggerOutput) SetRecallMaxTokensNil() {
+	o.RecallMaxTokens.Set(nil)
+}
+
+// UnsetRecallMaxTokens ensures that no value is present for RecallMaxTokens, not even an explicit nil
+func (o *MentalModelTriggerOutput) UnsetRecallMaxTokens() {
+	o.RecallMaxTokens.Unset()
+}
+
+// GetRecallChunksMaxTokens returns the RecallChunksMaxTokens field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelTriggerOutput) GetRecallChunksMaxTokens() int32 {
+	if o == nil || IsNil(o.RecallChunksMaxTokens.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallChunksMaxTokens.Get()
+}
+
+// GetRecallChunksMaxTokensOk returns a tuple with the RecallChunksMaxTokens field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelTriggerOutput) GetRecallChunksMaxTokensOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallChunksMaxTokens.Get(), o.RecallChunksMaxTokens.IsSet()
+}
+
+// HasRecallChunksMaxTokens returns a boolean if a field has been set.
+func (o *MentalModelTriggerOutput) HasRecallChunksMaxTokens() bool {
+	if o != nil && o.RecallChunksMaxTokens.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallChunksMaxTokens gets a reference to the given NullableInt32 and assigns it to the RecallChunksMaxTokens field.
+func (o *MentalModelTriggerOutput) SetRecallChunksMaxTokens(v int32) {
+	o.RecallChunksMaxTokens.Set(&v)
+}
+// SetRecallChunksMaxTokensNil sets the value for RecallChunksMaxTokens to be an explicit nil
+func (o *MentalModelTriggerOutput) SetRecallChunksMaxTokensNil() {
+	o.RecallChunksMaxTokens.Set(nil)
+}
+
+// UnsetRecallChunksMaxTokens ensures that no value is present for RecallChunksMaxTokens, not even an explicit nil
+func (o *MentalModelTriggerOutput) UnsetRecallChunksMaxTokens() {
+	o.RecallChunksMaxTokens.Unset()
+}
+
 func (o MentalModelTriggerOutput) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -286,6 +415,15 @@ func (o MentalModelTriggerOutput) ToMap() (map[string]interface{}, error) {
 	}
 	if o.TagGroups != nil {
 		toSerialize["tag_groups"] = o.TagGroups
+	}
+	if o.IncludeChunks.IsSet() {
+		toSerialize["include_chunks"] = o.IncludeChunks.Get()
+	}
+	if o.RecallMaxTokens.IsSet() {
+		toSerialize["recall_max_tokens"] = o.RecallMaxTokens.Get()
+	}
+	if o.RecallChunksMaxTokens.IsSet() {
+		toSerialize["recall_chunks_max_tokens"] = o.RecallChunksMaxTokens.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_input.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_input.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.mental_model_trigger_input_tag_groups_inner import MentalModelTriggerInputTagGroupsInner
 from typing import Optional, Set
@@ -33,7 +33,10 @@ class MentalModelTriggerInput(BaseModel):
     exclude_mental_model_ids: Optional[List[StrictStr]] = None
     tags_match: Optional[StrictStr] = None
     tag_groups: Optional[List[MentalModelTriggerInputTagGroupsInner]] = None
-    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups"]
+    include_chunks: Optional[StrictBool] = None
+    recall_max_tokens: Optional[StrictInt] = None
+    recall_chunks_max_tokens: Optional[StrictInt] = None
+    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
 
     @field_validator('fact_types')
     def fact_types_validate_enum(cls, value):
@@ -122,6 +125,21 @@ class MentalModelTriggerInput(BaseModel):
         if self.tag_groups is None and "tag_groups" in self.model_fields_set:
             _dict['tag_groups'] = None
 
+        # set to None if include_chunks (nullable) is None
+        # and model_fields_set contains the field
+        if self.include_chunks is None and "include_chunks" in self.model_fields_set:
+            _dict['include_chunks'] = None
+
+        # set to None if recall_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_max_tokens is None and "recall_max_tokens" in self.model_fields_set:
+            _dict['recall_max_tokens'] = None
+
+        # set to None if recall_chunks_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_chunks_max_tokens is None and "recall_chunks_max_tokens" in self.model_fields_set:
+            _dict['recall_chunks_max_tokens'] = None
+
         return _dict
 
     @classmethod
@@ -139,7 +157,10 @@ class MentalModelTriggerInput(BaseModel):
             "exclude_mental_models": obj.get("exclude_mental_models") if obj.get("exclude_mental_models") is not None else False,
             "exclude_mental_model_ids": obj.get("exclude_mental_model_ids"),
             "tags_match": obj.get("tags_match"),
-            "tag_groups": [MentalModelTriggerInputTagGroupsInner.from_dict(_item) for _item in obj["tag_groups"]] if obj.get("tag_groups") is not None else None
+            "tag_groups": [MentalModelTriggerInputTagGroupsInner.from_dict(_item) for _item in obj["tag_groups"]] if obj.get("tag_groups") is not None else None,
+            "include_chunks": obj.get("include_chunks"),
+            "recall_max_tokens": obj.get("recall_max_tokens"),
+            "recall_chunks_max_tokens": obj.get("recall_chunks_max_tokens")
         })
         return _obj
 

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_output.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_output.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.mental_model_trigger_output_tag_groups_inner import MentalModelTriggerOutputTagGroupsInner
 from typing import Optional, Set
@@ -33,7 +33,10 @@ class MentalModelTriggerOutput(BaseModel):
     exclude_mental_model_ids: Optional[List[StrictStr]] = None
     tags_match: Optional[StrictStr] = None
     tag_groups: Optional[List[MentalModelTriggerOutputTagGroupsInner]] = None
-    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups"]
+    include_chunks: Optional[StrictBool] = None
+    recall_max_tokens: Optional[StrictInt] = None
+    recall_chunks_max_tokens: Optional[StrictInt] = None
+    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
 
     @field_validator('fact_types')
     def fact_types_validate_enum(cls, value):
@@ -122,6 +125,21 @@ class MentalModelTriggerOutput(BaseModel):
         if self.tag_groups is None and "tag_groups" in self.model_fields_set:
             _dict['tag_groups'] = None
 
+        # set to None if include_chunks (nullable) is None
+        # and model_fields_set contains the field
+        if self.include_chunks is None and "include_chunks" in self.model_fields_set:
+            _dict['include_chunks'] = None
+
+        # set to None if recall_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_max_tokens is None and "recall_max_tokens" in self.model_fields_set:
+            _dict['recall_max_tokens'] = None
+
+        # set to None if recall_chunks_max_tokens (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_chunks_max_tokens is None and "recall_chunks_max_tokens" in self.model_fields_set:
+            _dict['recall_chunks_max_tokens'] = None
+
         return _dict
 
     @classmethod
@@ -139,7 +157,10 @@ class MentalModelTriggerOutput(BaseModel):
             "exclude_mental_models": obj.get("exclude_mental_models") if obj.get("exclude_mental_models") is not None else False,
             "exclude_mental_model_ids": obj.get("exclude_mental_model_ids"),
             "tags_match": obj.get("tags_match"),
-            "tag_groups": [MentalModelTriggerOutputTagGroupsInner.from_dict(_item) for _item in obj["tag_groups"]] if obj.get("tag_groups") is not None else None
+            "tag_groups": [MentalModelTriggerOutputTagGroupsInner.from_dict(_item) for _item in obj["tag_groups"]] if obj.get("tag_groups") is not None else None,
+            "include_chunks": obj.get("include_chunks"),
+            "recall_max_tokens": obj.get("recall_max_tokens"),
+            "recall_chunks_max_tokens": obj.get("recall_chunks_max_tokens")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1838,6 +1838,24 @@ export type MentalModelTriggerInput = {
   tag_groups?: Array<
     TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput
   > | null;
+  /**
+   * Include Chunks
+   *
+   * Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks).
+   */
+  include_chunks?: boolean | null;
+  /**
+   * Recall Max Tokens
+   *
+   * Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens).
+   */
+  recall_max_tokens?: number | null;
+  /**
+   * Recall Chunks Max Tokens
+   *
+   * Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens).
+   */
+  recall_chunks_max_tokens?: number | null;
 };
 
 /**
@@ -1884,6 +1902,24 @@ export type MentalModelTriggerOutput = {
   tag_groups?: Array<
     TagGroupLeaf | TagGroupAndOutput | TagGroupOrOutput | TagGroupNotOutput
   > | null;
+  /**
+   * Include Chunks
+   *
+   * Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks).
+   */
+  include_chunks?: boolean | null;
+  /**
+   * Recall Max Tokens
+   *
+   * Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens).
+   */
+  recall_max_tokens?: number | null;
+  /**
+   * Recall Chunks Max Tokens
+   *
+   * Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens).
+   */
+  recall_chunks_max_tokens?: number | null;
 };
 
 /**

--- a/hindsight-control-plane/src/app/globals.css
+++ b/hindsight-control-plane/src/app/globals.css
@@ -261,3 +261,34 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 .dark .prose tbody tr:hover {
   background-color: rgba(255, 255, 255, 0.05);
 }
+
+/* Themed scrollbars — match the app surface instead of the default white track.
+   Theme tokens are oklch, so wrap with color-mix to apply opacity. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 35%, transparent) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: color-mix(in oklab, var(--muted-foreground) 30%, transparent);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in oklab, var(--muted-foreground) 55%, transparent);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -784,163 +784,173 @@ function CreateMentalModelDialog({
             </div>
           </TabsContent>
 
-          <TabsContent value="options" className="space-y-4 pt-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tags</label>
-              <Input
-                value={form.tags}
-                onChange={(e) => setForm({ ...form, tags: e.target.value })}
-                placeholder="e.g., project-x, team-alpha (comma-separated)"
-              />
-              <p className="text-xs text-muted-foreground">
-                Tags scope the model during reflect <strong>and</strong> filter source memories
-                during refresh (default <code>all_strict</code>: only memories carrying every listed
-                tag are read). If no memories have these tags yet, refresh will produce empty
-                content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
-                <em>Tag Groups</em> below.
-              </p>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="auto-refresh"
-                checked={form.autoRefresh}
-                onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
-              />
-              <label
-                htmlFor="auto-refresh"
-                className="text-sm font-medium text-foreground cursor-pointer"
-              >
-                Auto-refresh after consolidation
-              </label>
-            </div>
-            <div className="space-y-3">
-              <label className="text-sm font-medium text-foreground">Fact Types</label>
-              <FactTypeCheckboxGroup
-                value={form.factTypes}
-                onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-              />
-              <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="exclude-mental-models"
-                checked={form.excludeMentalModels}
-                onCheckedChange={(checked) =>
-                  setForm({ ...form, excludeMentalModels: checked === true })
-                }
-              />
-              <label
-                htmlFor="exclude-mental-models"
-                className="text-sm font-medium text-foreground cursor-pointer"
-              >
-                Exclude all mental models
-              </label>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">
-                Exclude Mental Model IDs
-              </label>
-              <Input
-                value={form.excludeMentalModelIds}
-                onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
-                placeholder="e.g., model-a, model-b (comma-separated)"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tags Match</label>
-              <Select
-                value={form.tagsMatch}
-                onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Default (all_strict when tags set)" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
-                  <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
-                  <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
-                  <SelectItem value="any_strict">
-                    any_strict — OR matching, excludes untagged
-                  </SelectItem>
-                  <SelectItem value="all_strict">
-                    all_strict — AND matching, excludes untagged
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                Controls how the model&apos;s tags filter memories during refresh.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
-              <Textarea
-                value={form.tagGroups}
-                onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
-                placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
-                rows={3}
-                className="font-mono text-xs"
-              />
-              <p className="text-xs text-muted-foreground">
-                Compound boolean tag expressions for refresh filtering. Overrides flat tags when
-                set.
-              </p>
-            </div>
-            <div className="space-y-2 border-t pt-4">
-              <p className="text-sm font-medium text-foreground">Recall during refresh</p>
+          <TabsContent value="options" className="space-y-6 pt-4">
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="auto-refresh"
+                  checked={form.autoRefresh}
+                  onCheckedChange={(checked) =>
+                    setForm({ ...form, autoRefresh: checked === true })
+                  }
+                />
+                <label
+                  htmlFor="auto-refresh"
+                  className="text-sm font-medium text-foreground cursor-pointer"
+                >
+                  Auto-refresh after consolidation
+                </label>
+              </div>
+              <div className="space-y-3">
+                <label className="text-sm font-medium text-foreground">Fact Types</label>
+                <FactTypeCheckboxGroup
+                  value={form.factTypes}
+                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                />
+                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="exclude-mental-models"
+                  checked={form.excludeMentalModels}
+                  onCheckedChange={(checked) =>
+                    setForm({ ...form, excludeMentalModels: checked === true })
+                  }
+                />
+                <label
+                  htmlFor="exclude-mental-models"
+                  className="text-sm font-medium text-foreground cursor-pointer"
+                >
+                  Exclude all mental models
+                </label>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Exclude Mental Model IDs
+                </label>
+                <Input
+                  value={form.excludeMentalModelIds}
+                  onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
+                  placeholder="e.g., model-a, model-b (comma-separated)"
+                />
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tags</label>
+                <Input
+                  value={form.tags}
+                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
+                  placeholder="e.g., project-x, team-alpha (comma-separated)"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Tags scope the model during reflect <strong>and</strong> filter source memories
+                  during refresh (default <code>all_strict</code>: only memories carrying every
+                  listed tag are read). If no memories have these tags yet, refresh will produce
+                  empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
+                  <em>Tag Groups</em> below.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tags Match</label>
+                <Select
+                  value={form.tagsMatch}
+                  onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Default (all_strict when tags set)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
+                    <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
+                    <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
+                    <SelectItem value="any_strict">
+                      any_strict — OR matching, excludes untagged
+                    </SelectItem>
+                    <SelectItem value="all_strict">
+                      all_strict — AND matching, excludes untagged
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Controls how the model&apos;s tags filter memories during refresh.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
+                <Textarea
+                  value={form.tagGroups}
+                  onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
+                  placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
+                  rows={3}
+                  className="font-mono text-xs"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Compound boolean tag expressions for refresh filtering. Overrides flat tags when
+                  set.
+                </p>
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
               <p className="text-xs text-muted-foreground">
                 Override how the internal recall behaves when this model refreshes. Leave blank to
                 inherit the bank/global default.
               </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Include chunks</label>
-              <Select
-                value={form.includeChunks || "default"}
-                onValueChange={(v) =>
-                  setForm({
-                    ...form,
-                    includeChunks: v === "default" ? "" : (v as "true" | "false"),
-                  })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default (inherit)</SelectItem>
-                  <SelectItem value="true">Yes — include raw chunk text</SelectItem>
-                  <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Recall max tokens</label>
-              <Input
-                type="number"
-                value={form.recallMaxTokens}
-                onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
-                placeholder="Default (inherit)"
-                min="0"
-              />
-              <p className="text-xs text-muted-foreground">
-                Token budget for facts returned by recall.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">
-                Recall chunks max tokens
-              </label>
-              <Input
-                type="number"
-                value={form.recallChunksMaxTokens}
-                onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
-                placeholder="Default (inherit)"
-                min="0"
-              />
-              <p className="text-xs text-muted-foreground">
-                Token budget for raw chunk text returned by recall.
-              </p>
-            </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Include chunks</label>
+                <Select
+                  value={form.includeChunks || "default"}
+                  onValueChange={(v) =>
+                    setForm({
+                      ...form,
+                      includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default (inherit)</SelectItem>
+                    <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                    <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                <Input
+                  type="number"
+                  value={form.recallMaxTokens}
+                  onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                  placeholder="Default (inherit)"
+                  min="0"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Token budget for facts returned by recall.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Recall chunks max tokens
+                </label>
+                <Input
+                  type="number"
+                  value={form.recallChunksMaxTokens}
+                  onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                  placeholder="Default (inherit)"
+                  min="0"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Token budget for raw chunk text returned by recall.
+                </p>
+              </div>
+            </section>
           </TabsContent>
         </Tabs>
 
@@ -1136,163 +1146,173 @@ function UpdateMentalModelDialog({
             </div>
           </TabsContent>
 
-          <TabsContent value="options" className="space-y-4 pt-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tags</label>
-              <Input
-                value={form.tags}
-                onChange={(e) => setForm({ ...form, tags: e.target.value })}
-                placeholder="e.g., project-x, team-alpha (comma-separated)"
-              />
-              <p className="text-xs text-muted-foreground">
-                Tags scope the model during reflect <strong>and</strong> filter source memories
-                during refresh (default <code>all_strict</code>: only memories carrying every listed
-                tag are read). If no memories have these tags yet, refresh will produce empty
-                content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
-                <em>Tag Groups</em> below.
-              </p>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="update-auto-refresh"
-                checked={form.autoRefresh}
-                onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
-              />
-              <label
-                htmlFor="update-auto-refresh"
-                className="text-sm font-medium text-foreground cursor-pointer"
-              >
-                Auto-refresh after consolidation
-              </label>
-            </div>
-            <div className="space-y-3">
-              <label className="text-sm font-medium text-foreground">Fact Types</label>
-              <FactTypeCheckboxGroup
-                value={form.factTypes}
-                onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-              />
-              <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="update-exclude-mental-models"
-                checked={form.excludeMentalModels}
-                onCheckedChange={(checked) =>
-                  setForm({ ...form, excludeMentalModels: checked === true })
-                }
-              />
-              <label
-                htmlFor="update-exclude-mental-models"
-                className="text-sm font-medium text-foreground cursor-pointer"
-              >
-                Exclude all mental models
-              </label>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">
-                Exclude Mental Model IDs
-              </label>
-              <Input
-                value={form.excludeMentalModelIds}
-                onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
-                placeholder="e.g., model-a, model-b (comma-separated)"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tags Match</label>
-              <Select
-                value={form.tagsMatch || "default"}
-                onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Default (all_strict when tags set)" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
-                  <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
-                  <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
-                  <SelectItem value="any_strict">
-                    any_strict — OR matching, excludes untagged
-                  </SelectItem>
-                  <SelectItem value="all_strict">
-                    all_strict — AND matching, excludes untagged
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                Controls how the model&apos;s tags filter memories during refresh.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
-              <Textarea
-                value={form.tagGroups}
-                onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
-                placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
-                rows={3}
-                className="font-mono text-xs"
-              />
-              <p className="text-xs text-muted-foreground">
-                Compound boolean tag expressions for refresh filtering. Overrides flat tags when
-                set.
-              </p>
-            </div>
-            <div className="space-y-2 border-t pt-4">
-              <p className="text-sm font-medium text-foreground">Recall during refresh</p>
+          <TabsContent value="options" className="space-y-6 pt-4">
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="update-auto-refresh"
+                  checked={form.autoRefresh}
+                  onCheckedChange={(checked) =>
+                    setForm({ ...form, autoRefresh: checked === true })
+                  }
+                />
+                <label
+                  htmlFor="update-auto-refresh"
+                  className="text-sm font-medium text-foreground cursor-pointer"
+                >
+                  Auto-refresh after consolidation
+                </label>
+              </div>
+              <div className="space-y-3">
+                <label className="text-sm font-medium text-foreground">Fact Types</label>
+                <FactTypeCheckboxGroup
+                  value={form.factTypes}
+                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                />
+                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="update-exclude-mental-models"
+                  checked={form.excludeMentalModels}
+                  onCheckedChange={(checked) =>
+                    setForm({ ...form, excludeMentalModels: checked === true })
+                  }
+                />
+                <label
+                  htmlFor="update-exclude-mental-models"
+                  className="text-sm font-medium text-foreground cursor-pointer"
+                >
+                  Exclude all mental models
+                </label>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Exclude Mental Model IDs
+                </label>
+                <Input
+                  value={form.excludeMentalModelIds}
+                  onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
+                  placeholder="e.g., model-a, model-b (comma-separated)"
+                />
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tags</label>
+                <Input
+                  value={form.tags}
+                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
+                  placeholder="e.g., project-x, team-alpha (comma-separated)"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Tags scope the model during reflect <strong>and</strong> filter source memories
+                  during refresh (default <code>all_strict</code>: only memories carrying every
+                  listed tag are read). If no memories have these tags yet, refresh will produce
+                  empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
+                  <em>Tag Groups</em> below.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tags Match</label>
+                <Select
+                  value={form.tagsMatch || "default"}
+                  onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Default (all_strict when tags set)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
+                    <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
+                    <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
+                    <SelectItem value="any_strict">
+                      any_strict — OR matching, excludes untagged
+                    </SelectItem>
+                    <SelectItem value="all_strict">
+                      all_strict — AND matching, excludes untagged
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Controls how the model&apos;s tags filter memories during refresh.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
+                <Textarea
+                  value={form.tagGroups}
+                  onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
+                  placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
+                  rows={3}
+                  className="font-mono text-xs"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Compound boolean tag expressions for refresh filtering. Overrides flat tags when
+                  set.
+                </p>
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
               <p className="text-xs text-muted-foreground">
                 Override how the internal recall behaves when this model refreshes. Leave blank to
                 inherit the bank/global default.
               </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Include chunks</label>
-              <Select
-                value={form.includeChunks || "default"}
-                onValueChange={(v) =>
-                  setForm({
-                    ...form,
-                    includeChunks: v === "default" ? "" : (v as "true" | "false"),
-                  })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="default">Default (inherit)</SelectItem>
-                  <SelectItem value="true">Yes — include raw chunk text</SelectItem>
-                  <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Recall max tokens</label>
-              <Input
-                type="number"
-                value={form.recallMaxTokens}
-                onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
-                placeholder="Default (inherit)"
-                min="0"
-              />
-              <p className="text-xs text-muted-foreground">
-                Token budget for facts returned by recall.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">
-                Recall chunks max tokens
-              </label>
-              <Input
-                type="number"
-                value={form.recallChunksMaxTokens}
-                onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
-                placeholder="Default (inherit)"
-                min="0"
-              />
-              <p className="text-xs text-muted-foreground">
-                Token budget for raw chunk text returned by recall.
-              </p>
-            </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Include chunks</label>
+                <Select
+                  value={form.includeChunks || "default"}
+                  onValueChange={(v) =>
+                    setForm({
+                      ...form,
+                      includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default (inherit)</SelectItem>
+                    <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                    <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                <Input
+                  type="number"
+                  value={form.recallMaxTokens}
+                  onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                  placeholder="Default (inherit)"
+                  min="0"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Token budget for facts returned by recall.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Recall chunks max tokens
+                </label>
+                <Input
+                  type="number"
+                  value={form.recallChunksMaxTokens}
+                  onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                  placeholder="Default (inherit)"
+                  min="0"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Token budget for raw chunk text returned by recall.
+                </p>
+              </div>
+            </section>
           </TabsContent>
         </Tabs>
 

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -727,7 +727,7 @@ function CreateMentalModelDialog({
         }
       }}
     >
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Create Mental Model</DialogTitle>
           <DialogDescription>
@@ -736,7 +736,7 @@ function CreateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="general" className="py-2">
+        <Tabs defaultValue="general" className="py-2 flex-1 min-h-0 overflow-y-auto">
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General
@@ -1084,7 +1084,7 @@ function UpdateMentalModelDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Update Mental Model</DialogTitle>
           <DialogDescription>
@@ -1092,7 +1092,7 @@ function UpdateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="general" className="py-2">
+        <Tabs defaultValue="general" className="py-2 flex-1 min-h-0 overflow-y-auto">
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -101,6 +101,9 @@ interface MentalModel {
     exclude_mental_model_ids?: string[];
     tags_match?: TagsMatch;
     tag_groups?: TagGroup[];
+    include_chunks?: boolean;
+    recall_max_tokens?: number;
+    recall_chunks_max_tokens?: number;
   };
   last_refreshed_at: string;
   created_at: string;
@@ -613,6 +616,10 @@ function CreateMentalModelDialog({
     excludeMentalModelIds: "",
     tagsMatch: "" as string,
     tagGroups: "",
+    // Recall overrides for refresh: "" means inherit bank/global default
+    includeChunks: "" as "" | "true" | "false",
+    recallMaxTokens: "",
+    recallChunksMaxTokens: "",
   });
 
   const handleCreate = async () => {
@@ -643,6 +650,15 @@ function CreateMentalModelDialog({
         }
       }
 
+      const recallMaxTokens = form.recallMaxTokens.trim()
+        ? parseInt(form.recallMaxTokens, 10)
+        : undefined;
+      const recallChunksMaxTokens = form.recallChunksMaxTokens.trim()
+        ? parseInt(form.recallChunksMaxTokens, 10)
+        : undefined;
+      const includeChunks =
+        form.includeChunks === "true" ? true : form.includeChunks === "false" ? false : undefined;
+
       await client.createMentalModel(currentBank, {
         id: form.id.trim() || undefined,
         name: form.name.trim(),
@@ -656,6 +672,9 @@ function CreateMentalModelDialog({
           exclude_mental_model_ids: excludeIds.length > 0 ? excludeIds : undefined,
           tags_match: (form.tagsMatch as TagsMatch) || undefined,
           tag_groups: tagGroups,
+          include_chunks: includeChunks,
+          recall_max_tokens: recallMaxTokens,
+          recall_chunks_max_tokens: recallChunksMaxTokens,
         },
       });
 
@@ -671,6 +690,9 @@ function CreateMentalModelDialog({
         excludeMentalModelIds: "",
         tagsMatch: "",
         tagGroups: "",
+        includeChunks: "",
+        recallMaxTokens: "",
+        recallChunksMaxTokens: "",
       });
       onCreated();
     } catch (error) {
@@ -697,6 +719,9 @@ function CreateMentalModelDialog({
             excludeMentalModelIds: "",
             tagsMatch: "",
             tagGroups: "",
+            includeChunks: "",
+            recallMaxTokens: "",
+            recallChunksMaxTokens: "",
           });
           onClose();
         }
@@ -860,6 +885,62 @@ function CreateMentalModelDialog({
                 set.
               </p>
             </div>
+            <div className="space-y-2 border-t pt-4">
+              <p className="text-sm font-medium text-foreground">Recall during refresh</p>
+              <p className="text-xs text-muted-foreground">
+                Override how the internal recall behaves when this model refreshes. Leave blank to
+                inherit the bank/global default.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">Include chunks</label>
+              <Select
+                value={form.includeChunks || "default"}
+                onValueChange={(v) =>
+                  setForm({
+                    ...form,
+                    includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default (inherit)</SelectItem>
+                  <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                  <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+              <Input
+                type="number"
+                value={form.recallMaxTokens}
+                onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                placeholder="Default (inherit)"
+                min="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Token budget for facts returned by recall.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Recall chunks max tokens
+              </label>
+              <Input
+                type="number"
+                value={form.recallChunksMaxTokens}
+                onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                placeholder="Default (inherit)"
+                min="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Token budget for raw chunk text returned by recall.
+              </p>
+            </div>
           </TabsContent>
         </Tabs>
 
@@ -899,7 +980,7 @@ function UpdateMentalModelDialog({
 }) {
   const { currentBank } = useBank();
   const [updating, setUpdating] = useState(false);
-  const [form, setForm] = useState({
+  const buildFormState = () => ({
     name: mentalModel.name,
     sourceQuery: mentalModel.source_query,
     maxTokens: String(mentalModel.max_tokens || 2048),
@@ -915,28 +996,26 @@ function UpdateMentalModelDialog({
     tagGroups: mentalModel.trigger?.tag_groups
       ? JSON.stringify(mentalModel.trigger.tag_groups, null, 2)
       : "",
+    includeChunks: (mentalModel.trigger?.include_chunks === true
+      ? "true"
+      : mentalModel.trigger?.include_chunks === false
+        ? "false"
+        : "") as "" | "true" | "false",
+    recallMaxTokens:
+      mentalModel.trigger?.recall_max_tokens != null
+        ? String(mentalModel.trigger.recall_max_tokens)
+        : "",
+    recallChunksMaxTokens:
+      mentalModel.trigger?.recall_chunks_max_tokens != null
+        ? String(mentalModel.trigger.recall_chunks_max_tokens)
+        : "",
   });
+  const [form, setForm] = useState(buildFormState);
 
   // Reset form when mental model changes or dialog opens
   useEffect(() => {
     if (open) {
-      setForm({
-        name: mentalModel.name,
-        sourceQuery: mentalModel.source_query,
-        maxTokens: String(mentalModel.max_tokens || 2048),
-        tags: mentalModel.tags.join(", "),
-        autoRefresh: mentalModel.trigger?.refresh_after_consolidation || false,
-        factTypes:
-          (mentalModel.trigger?.fact_types as
-            | Array<"world" | "experience" | "observation">
-            | undefined) || [],
-        excludeMentalModels: mentalModel.trigger?.exclude_mental_models || false,
-        excludeMentalModelIds: (mentalModel.trigger?.exclude_mental_model_ids || []).join(", "),
-        tagsMatch: (mentalModel.trigger?.tags_match as string) || "",
-        tagGroups: mentalModel.trigger?.tag_groups
-          ? JSON.stringify(mentalModel.trigger.tag_groups, null, 2)
-          : "",
-      });
+      setForm(buildFormState());
     }
   }, [open, mentalModel]);
 
@@ -967,6 +1046,15 @@ function UpdateMentalModelDialog({
         }
       }
 
+      const recallMaxTokens = form.recallMaxTokens.trim()
+        ? parseInt(form.recallMaxTokens, 10)
+        : undefined;
+      const recallChunksMaxTokens = form.recallChunksMaxTokens.trim()
+        ? parseInt(form.recallChunksMaxTokens, 10)
+        : undefined;
+      const includeChunks =
+        form.includeChunks === "true" ? true : form.includeChunks === "false" ? false : undefined;
+
       const updated = await client.updateMentalModel(currentBank, mentalModel.id, {
         name: form.name.trim(),
         source_query: form.sourceQuery.trim(),
@@ -979,6 +1067,9 @@ function UpdateMentalModelDialog({
           exclude_mental_model_ids: excludeIds.length > 0 ? excludeIds : undefined,
           tags_match: (form.tagsMatch as TagsMatch) || undefined,
           tag_groups: tagGroups,
+          include_chunks: includeChunks,
+          recall_max_tokens: recallMaxTokens,
+          recall_chunks_max_tokens: recallChunksMaxTokens,
         },
       });
 
@@ -1144,6 +1235,62 @@ function UpdateMentalModelDialog({
               <p className="text-xs text-muted-foreground">
                 Compound boolean tag expressions for refresh filtering. Overrides flat tags when
                 set.
+              </p>
+            </div>
+            <div className="space-y-2 border-t pt-4">
+              <p className="text-sm font-medium text-foreground">Recall during refresh</p>
+              <p className="text-xs text-muted-foreground">
+                Override how the internal recall behaves when this model refreshes. Leave blank to
+                inherit the bank/global default.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">Include chunks</label>
+              <Select
+                value={form.includeChunks || "default"}
+                onValueChange={(v) =>
+                  setForm({
+                    ...form,
+                    includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default (inherit)</SelectItem>
+                  <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                  <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+              <Input
+                type="number"
+                value={form.recallMaxTokens}
+                onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                placeholder="Default (inherit)"
+                min="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Token budget for facts returned by recall.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Recall chunks max tokens
+              </label>
+              <Input
+                type="number"
+                value={form.recallChunksMaxTokens}
+                onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                placeholder="Default (inherit)"
+                min="0"
+              />
+              <p className="text-xs text-muted-foreground">
+                Token budget for raw chunk text returned by recall.
               </p>
             </div>
           </TabsContent>

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -791,9 +791,7 @@ function CreateMentalModelDialog({
                 <Checkbox
                   id="auto-refresh"
                   checked={form.autoRefresh}
-                  onCheckedChange={(checked) =>
-                    setForm({ ...form, autoRefresh: checked === true })
-                  }
+                  onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
                 />
                 <label
                   htmlFor="auto-refresh"
@@ -802,14 +800,12 @@ function CreateMentalModelDialog({
                   Auto-refresh after consolidation
                 </label>
               </div>
-              <div className="space-y-3">
-                <label className="text-sm font-medium text-foreground">Fact Types</label>
-                <FactTypeCheckboxGroup
-                  value={form.factTypes}
-                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-                />
-                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
-              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">
+                Other Mental Models
+              </h3>
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="exclude-mental-models"
@@ -901,6 +897,14 @@ function CreateMentalModelDialog({
                 Override how the internal recall behaves when this model refreshes. Leave blank to
                 inherit the bank/global default.
               </p>
+              <div className="space-y-3">
+                <label className="text-sm font-medium text-foreground">Fact Types</label>
+                <FactTypeCheckboxGroup
+                  value={form.factTypes}
+                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                />
+                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+              </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium text-foreground">Include chunks</label>
                 <Select
@@ -1153,9 +1157,7 @@ function UpdateMentalModelDialog({
                 <Checkbox
                   id="update-auto-refresh"
                   checked={form.autoRefresh}
-                  onCheckedChange={(checked) =>
-                    setForm({ ...form, autoRefresh: checked === true })
-                  }
+                  onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
                 />
                 <label
                   htmlFor="update-auto-refresh"
@@ -1164,14 +1166,12 @@ function UpdateMentalModelDialog({
                   Auto-refresh after consolidation
                 </label>
               </div>
-              <div className="space-y-3">
-                <label className="text-sm font-medium text-foreground">Fact Types</label>
-                <FactTypeCheckboxGroup
-                  value={form.factTypes}
-                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-                />
-                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
-              </div>
+            </section>
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground border-b pb-1">
+                Other Mental Models
+              </h3>
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="update-exclude-mental-models"
@@ -1263,6 +1263,14 @@ function UpdateMentalModelDialog({
                 Override how the internal recall behaves when this model refreshes. Leave blank to
                 inherit the bank/global default.
               </p>
+              <div className="space-y-3">
+                <label className="text-sm font-medium text-foreground">Fact Types</label>
+                <FactTypeCheckboxGroup
+                  value={form.factTypes}
+                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                />
+                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+              </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium text-foreground">Include chunks</label>
                 <Select

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -96,6 +96,9 @@ export interface MentalModel {
     exclude_mental_model_ids?: string[];
     tags_match?: TagsMatch;
     tag_groups?: TagGroup[];
+    include_chunks?: boolean;
+    recall_max_tokens?: number;
+    recall_chunks_max_tokens?: number;
   };
   last_refreshed_at: string;
   created_at: string;
@@ -863,6 +866,9 @@ export class ControlPlaneClient {
           exclude_mental_model_ids?: string[];
           tags_match?: TagsMatch;
           tag_groups?: TagGroup[];
+          include_chunks?: boolean;
+          recall_max_tokens?: number;
+          recall_chunks_max_tokens?: number;
         };
         last_refreshed_at: string;
         created_at: string;
@@ -893,6 +899,9 @@ export class ControlPlaneClient {
         exclude_mental_model_ids?: string[];
         tags_match?: TagsMatch;
         tag_groups?: TagGroup[];
+        include_chunks?: boolean;
+        recall_max_tokens?: number;
+        recall_chunks_max_tokens?: number;
       };
     }
   ) {
@@ -929,6 +938,9 @@ export class ControlPlaneClient {
         exclude_mental_model_ids?: string[];
         tags_match?: TagsMatch;
         tag_groups?: TagGroup[];
+        include_chunks?: boolean;
+        recall_max_tokens?: number;
+        recall_chunks_max_tokens?: number;
       };
     }
   ) {
@@ -947,6 +959,9 @@ export class ControlPlaneClient {
         exclude_mental_model_ids?: string[];
         tags_match?: TagsMatch;
         tag_groups?: TagGroup[];
+        include_chunks?: boolean;
+        recall_max_tokens?: number;
+        recall_chunks_max_tokens?: number;
       };
       last_refreshed_at: string;
       created_at: string;

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1048,6 +1048,16 @@ export HINDSIGHT_API_OBSERVATIONS_MISSION="Observations are recurring patterns i
 | `HINDSIGHT_API_REFLECT_MISSION` | Global reflect mission (identity and reasoning framing). Overridden per bank via config API. | - |
 | `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` | Token budget for source facts in `search_observations` during reflect. `-1` disables source facts (default), `0` enables with no limit, `>0` enables with a token budget. Hierarchical — can be overridden per bank via config API. | `-1` |
 
+#### Internal recall (used by mental model refresh)
+
+These knobs control the recall tool that runs inside `reflect_async` (e.g. when refreshing a mental model). They are hierarchical — overridable per bank via the config API, and individually overridable per mental model via the `trigger.include_chunks`, `trigger.recall_max_tokens`, and `trigger.recall_chunks_max_tokens` fields.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RECALL_INCLUDE_CHUNKS` | Whether the internal recall returns raw chunk text alongside facts. Set `false` to skip chunks and save prompt budget. | `true` |
+| `HINDSIGHT_API_RECALL_MAX_TOKENS` | Token budget for facts returned by the internal recall. | `2048` |
+| `HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS` | Token budget for raw chunks returned by the internal recall. | `1000` |
+
 #### Disposition
 
 Disposition traits control how the bank reasons during reflect operations. Each trait is on a scale of 1–5. These are hierarchical — they can be overridden per bank via the [config API](./configuration.md#hierarchical-configuration).

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7639,6 +7639,42 @@
             ],
             "title": "Tag Groups",
             "description": "Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping."
+          },
+          "include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Chunks",
+            "description": "Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks)."
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens)."
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens)."
           }
         },
         "type": "object",
@@ -7739,6 +7775,42 @@
             ],
             "title": "Tag Groups",
             "description": "Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping."
+          },
+          "include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Chunks",
+            "description": "Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks)."
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens)."
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens)."
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1048,6 +1048,16 @@ export HINDSIGHT_API_OBSERVATIONS_MISSION="Observations are recurring patterns i
 | `HINDSIGHT_API_REFLECT_MISSION` | Global reflect mission (identity and reasoning framing). Overridden per bank via config API. | - |
 | `HINDSIGHT_API_REFLECT_SOURCE_FACTS_MAX_TOKENS` | Token budget for source facts in `search_observations` during reflect. `-1` disables source facts (default), `0` enables with no limit, `>0` enables with a token budget. Hierarchical — can be overridden per bank via config API. | `-1` |
 
+#### Internal recall (used by mental model refresh)
+
+These knobs control the recall tool that runs inside `reflect_async` (e.g. when refreshing a mental model). They are hierarchical — overridable per bank via the config API, and individually overridable per mental model via the `trigger.include_chunks`, `trigger.recall_max_tokens`, and `trigger.recall_chunks_max_tokens` fields.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RECALL_INCLUDE_CHUNKS` | Whether the internal recall returns raw chunk text alongside facts. Set `false` to skip chunks and save prompt budget. | `true` |
+| `HINDSIGHT_API_RECALL_MAX_TOKENS` | Token budget for facts returned by the internal recall. | `2048` |
+| `HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS` | Token budget for raw chunks returned by the internal recall. | `1000` |
+
 #### Disposition
 
 Disposition traits control how the bank reasons during reflect operations. Each trait is on a scale of 1–5. These are hierarchical — they can be overridden per bank via the [config API](./configuration.md#hierarchical-configuration).

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7639,6 +7639,42 @@
             ],
             "title": "Tag Groups",
             "description": "Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping."
+          },
+          "include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Chunks",
+            "description": "Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks)."
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens)."
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens)."
           }
         },
         "type": "object",
@@ -7739,6 +7775,42 @@
             ],
             "title": "Tag Groups",
             "description": "Compound boolean tag expressions to use during refresh instead of the model's own tags. When set, these tag groups are passed to reflect and the model's flat tags are NOT used for filtering. Supports nested and/or/not expressions for complex tag-based scoping."
+          },
+          "include_chunks": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Chunks",
+            "description": "Override whether the internal recall used during refresh returns raw chunk text. None means use the bank/global config default (recall_include_chunks)."
+          },
+          "recall_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Max Tokens",
+            "description": "Override the token budget for facts returned by the internal recall during refresh. None means use the bank/global config default (recall_max_tokens)."
+          },
+          "recall_chunks_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Chunks Max Tokens",
+            "description": "Override the token budget for raw chunks returned by the internal recall during refresh. None means use the bank/global config default (recall_chunks_max_tokens)."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

- Adds three knobs that control the internal recall used during mental model refresh, exposed both as hierarchical config (env → tenant → bank) and as per-model overrides on the `trigger` JSONB field:
  - `recall_include_chunks` / `trigger.include_chunks`
  - `recall_max_tokens` / `trigger.recall_max_tokens`
  - `recall_chunks_max_tokens` / `trigger.recall_chunks_max_tokens`
- `tool_recall` no longer hardcodes `include_chunks=True`. Both refresh code paths (task handler and synchronous `refresh_mental_model`) forward the overrides into `reflect_async`, which resolves trigger → bank config → env default.
- Regenerated OpenAPI + Python/TypeScript/Go SDK clients; updated control plane TS trigger types; documented the env vars.

## Test plan

- [x] `cd hindsight-api-slim && uv run pytest tests/test_recall_config.py -v` (12/12 pass — covers tool_recall param, config plumbing, Pydantic acceptance, and end-to-end trigger → reflect_async wiring for both refresh paths)
- [x] `./scripts/hooks/lint.sh`
- [x] `cd hindsight-api-slim && uv run ruff check . && uv run ty check hindsight_api/`
- [ ] Manual: create a mental model with `trigger = {"include_chunks": false, "recall_max_tokens": 512}` and verify a refresh runs without chunks and within the smaller token budget