### PR TITLE
fix(clients): identifying User-Agent headers (#1041)

### DIFF
--- a/hindsight-clients/go/hindsight_client.go
+++ b/hindsight-clients/go/hindsight_client.go
@@ -2,8 +2,30 @@ package hindsight
 
 import (
 	"net/http"
+	"runtime/debug"
 	"time"
 )
+
+// defaultUserAgent returns the User-Agent string sent on every request unless
+// the caller overrides cfg.UserAgent. The version is read from build info so
+// it stays in sync with the module version automatically; falls back to
+// "devel" when running from an unpinned local checkout.
+func defaultUserAgent() string {
+	version := "devel"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/vectorize-io/hindsight/hindsight-clients/go" {
+				version = dep.Version
+				break
+			}
+		}
+	}
+	return "hindsight-client-go/" + version
+}
+
+// DefaultUserAgent is the User-Agent string sent on every request unless the
+// caller overrides cfg.UserAgent (e.g. for integrations identifying themselves).
+var DefaultUserAgent = defaultUserAgent()
 
 // NewAPIClientWithToken creates a new API client configured with a base URL and API token.
 // The token is sent as a Bearer token in the Authorization header for all requests.
@@ -16,6 +38,7 @@ import (
 //	resp, _, err := client.MemoryAPI.RetainMemories(ctx, bankID).RetainRequest(req).Execute()
 func NewAPIClientWithToken(baseURL, token string) *APIClient {
 	cfg := NewConfiguration()
+	cfg.UserAgent = DefaultUserAgent
 	cfg.Servers = ServerConfigurations{
 		{URL: baseURL},
 	}
@@ -32,6 +55,7 @@ func NewAPIClientWithToken(baseURL, token string) *APIClient {
 //	resp, _, err := client.MemoryAPI.RetainMemories(ctx, bankID).RetainRequest(req).Execute()
 func NewAPIClientWithTimeout(baseURL, token string, timeout time.Duration) *APIClient {
 	cfg := NewConfiguration()
+	cfg.UserAgent = DefaultUserAgent
 	cfg.Servers = ServerConfigurations{
 		{URL: baseURL},
 	}

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -8,10 +8,18 @@ easy-to-use interface on top of the auto-generated OpenAPI client.
 import asyncio
 import json
 from datetime import datetime
+from importlib import metadata
 from pathlib import Path
 from typing import Any, Literal
 
 import hindsight_client_api
+
+try:
+    _CLIENT_VERSION = metadata.version("hindsight-client")
+except metadata.PackageNotFoundError:
+    _CLIENT_VERSION = "0.0.0"
+
+DEFAULT_USER_AGENT = f"hindsight-client-python/{_CLIENT_VERSION}"
 from hindsight_client_api.api import (
     banks_api,
     directives_api,
@@ -119,7 +127,13 @@ class Hindsight:
         - ``client.monitoring``: Health/version checks (MonitoringApi)
     """
 
-    def __init__(self, base_url: str, api_key: str | None = None, timeout: float = 300.0):
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout: float = 300.0,
+        user_agent: str | None = None,
+    ):
         """
         Initialize the Hindsight client.
 
@@ -127,9 +141,14 @@ class Hindsight:
             base_url: The base URL of the Hindsight API server
             api_key: Optional API key for authentication (sent as Bearer token)
             timeout: Request timeout in seconds (default: 300.0)
+            user_agent: Override the default ``User-Agent`` header. Integrations
+                should set this to identify themselves (e.g.
+                ``"hindsight-crewai/1.2.0"``). Defaults to
+                ``hindsight-client-python/<version>``.
         """
         config = hindsight_client_api.Configuration(host=base_url, access_token=api_key)
         self._api_client = hindsight_client_api.ApiClient(config)
+        self._api_client.user_agent = user_agent or DEFAULT_USER_AGENT
         self._timeout = timeout
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key

--- a/hindsight-clients/rust/src/lib.rs
+++ b/hindsight-clients/rust/src/lib.rs
@@ -22,6 +22,45 @@
 // Include the generated client code (which already exports Error and ResponseValue)
 include!(concat!(env!("OUT_DIR"), "/hindsight_client_generated.rs"));
 
+/// Semantic version of this Rust client, kept in sync with the other language
+/// wrappers when a coordinated release is cut.
+pub const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Default `User-Agent` header sent on every request unless overridden.
+pub const DEFAULT_USER_AGENT: &str = concat!("hindsight-client-rust/", env!("CARGO_PKG_VERSION"));
+
+/// Build a [`reqwest::Client`] with the given `User-Agent` header.
+///
+/// Integrations should use this to identify themselves (e.g.
+/// `"hindsight-cli/0.6.2"`) so self-hosted deployments behind Cloudflare or
+/// other UA-based filters accept the traffic. Pass the resulting client to
+/// [`Client::new_with_client`].
+pub fn reqwest_client_with_user_agent(
+    user_agent: impl Into<String>,
+) -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder().user_agent(user_agent.into()).build()
+}
+
+/// Construct a [`Client`] with a custom `User-Agent` header.
+///
+/// Equivalent to [`Client::new`] but sets the UA string. Use this instead of
+/// the bare `Client::new` when pointing at a hosted Hindsight deployment.
+pub fn client_with_user_agent(
+    base_url: &str,
+    user_agent: impl Into<String>,
+) -> Result<Client, reqwest::Error> {
+    let http = reqwest_client_with_user_agent(user_agent)?;
+    Ok(Client::new_with_client(base_url, http))
+}
+
+/// Construct a [`Client`] with the default Hindsight `User-Agent`.
+///
+/// Prefer this over `Client::new` — the bare `Client::new` uses reqwest's
+/// default UA which is blocked by some reverse proxies (e.g. Cloudflare).
+pub fn default_client(base_url: &str) -> Result<Client, reqwest::Error> {
+    client_with_user_agent(base_url, DEFAULT_USER_AGENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -44,12 +44,22 @@ import type {
     Budget,
 } from '../generated/types.gen';
 
+export const CLIENT_VERSION = '0.5.1';
+export const DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;
+
 export interface HindsightClientOptions {
     baseUrl: string;
     /**
      * Optional API key for authentication (sent as Bearer token in Authorization header)
      */
     apiKey?: string;
+    /**
+     * Override the default `User-Agent` header. Integrations should set this to
+     * identify themselves (e.g. `"hindsight-ai-sdk/1.2.0"`). Browsers ignore
+     * attempts to set `User-Agent`; this only takes effect in Node.js / Bun /
+     * Deno runtimes. Defaults to `hindsight-client-typescript/<version>`.
+     */
+    userAgent?: string;
 }
 
 /**
@@ -90,12 +100,16 @@ export class HindsightClient {
     private client: Client;
 
     constructor(options: HindsightClientOptions) {
+        const headers: Record<string, string> = {
+            'User-Agent': options.userAgent ?? DEFAULT_USER_AGENT,
+        };
+        if (options.apiKey) {
+            headers.Authorization = `Bearer ${options.apiKey}`;
+        }
         this.client = createClient(
             createConfig({
                 baseUrl: options.baseUrl,
-                headers: options.apiKey
-                    ? { Authorization: `Bearer ${options.apiKey}` }
-                    : undefined,
+                headers,
             })
         );
     }

--- a/hindsight-integrations/ag2/hindsight_ag2/_client.py
+++ b/hindsight-integrations/ag2/hindsight_ag2/_client.py
@@ -1,11 +1,18 @@
 """Shared Hindsight client resolution logic."""
 
+from importlib import metadata
 from typing import Any, Optional
 
 from hindsight_client import Hindsight
 
 from .config import get_config
 from .errors import HindsightError
+
+try:
+    _VERSION = metadata.version("hindsight-ag2")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-ag2/{_VERSION}"
 
 
 def resolve_client(
@@ -26,7 +33,7 @@ def resolve_client(
             "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/ag2/tests/test_tools.py
+++ b/hindsight-integrations/ag2/tests/test_tools.py
@@ -135,9 +135,9 @@ class TestCreateHindsightTools:
             mock_cls.return_value = _mock_client()
             tools = create_hindsight_tools(bank_id="test")
             assert len(tools) == 3
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://localhost:8888"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
     def test_explicit_url_overrides_config(self):
         configure(hindsight_api_url="http://config:8888")
@@ -146,9 +146,9 @@ class TestCreateHindsightTools:
             create_hindsight_tools(
                 bank_id="test", hindsight_api_url="http://explicit:9999"
             )
-            mock_cls.assert_called_once_with(
-                base_url="http://explicit:9999", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://explicit:9999"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
 
 class TestRetainTool:

--- a/hindsight-integrations/agno/hindsight_agno/tools.py
+++ b/hindsight-integrations/agno/hindsight_agno/tools.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from importlib import metadata
 from typing import Any
 
 from agno.run.base import RunContext
@@ -18,6 +19,12 @@ from .config import get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
+
+try:
+    _VERSION = metadata.version("hindsight-agno")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-agno/{_VERSION}"
 
 _TOOL_INSTRUCTIONS = """\
 You have access to long-term memory via Hindsight tools.
@@ -52,7 +59,7 @@ def _resolve_client(
             "Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/autogen/hindsight_autogen/_client.py
+++ b/hindsight-integrations/autogen/hindsight_autogen/_client.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from importlib import metadata
 from typing import Any
 
 from hindsight_client import Hindsight
 
 from .config import get_config
 from .errors import HindsightError
+
+try:
+    _VERSION = metadata.version("hindsight-autogen")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-autogen/{_VERSION}"
 
 
 def resolve_client(
@@ -28,7 +35,7 @@ def resolve_client(
             "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -8,11 +8,27 @@ import json
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 DEFAULT_TIMEOUT = 15  # seconds
 HEALTH_CHECK_RETRIES = 3
 HEALTH_CHECK_DELAY = 2  # seconds
+
+
+def _plugin_version() -> str:
+    """Read the plugin version from plugin.json (single source of truth)."""
+    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
+    try:
+        return json.loads(manifest.read_text()).get("version", "0.0.0")
+    except (OSError, ValueError):
+        return "0.0.0"
+
+
+# Sent on every request so self-hosted deployments behind Cloudflare (or any
+# reverse proxy with UA-based bot filtering) don't block the stdlib default
+# "Python-urllib/X.Y", which trips Cloudflare error 1010.
+USER_AGENT = f"hindsight-claude-code/{_plugin_version()}"
 
 
 def _validate_api_url(url: str) -> str:
@@ -33,7 +49,10 @@ class HindsightClient:
         self.api_token = api_token
 
     def _headers(self) -> dict:
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        }
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers

--- a/hindsight-integrations/claude-code/scripts/lib/daemon.py
+++ b/hindsight-integrations/claude-code/scripts/lib/daemon.py
@@ -20,6 +20,7 @@ import time
 import urllib.error
 import urllib.request
 
+from .client import USER_AGENT
 from .llm import detect_llm_config, get_llm_env_vars
 from .state import read_state, write_state
 
@@ -74,7 +75,7 @@ def _check_health(base_url: str, timeout: int = 2) -> bool:
     """Quick health check against a Hindsight server."""
     try:
         url = f"{base_url.rstrip('/')}/health"
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status == 200
     except Exception:

--- a/hindsight-integrations/claude-code/tests/test_client.py
+++ b/hindsight-integrations/claude-code/tests/test_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lib.client import HindsightClient, _validate_api_url
+from lib.client import USER_AGENT, HindsightClient, _validate_api_url
 
 
 class TestValidateApiUrl:
@@ -105,6 +105,22 @@ class TestHindsightClientRecall:
             c.recall("bank", "query")
 
         assert "Authorization" not in captured["headers"]
+
+    def test_sends_user_agent_header(self):
+        # Regression test for #1041: the stdlib default "Python-urllib/X.Y" UA
+        # is blocked by Cloudflare with error 1010, so we must always send our own.
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["ua"] = req.get_header("User-agent")
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert captured["ua"] == USER_AGENT
+        assert captured["ua"].startswith("hindsight-claude-code/")
 
     def test_http_error_raises_runtime_error(self):
         c = HindsightClient("http://localhost:9077")

--- a/hindsight-integrations/codex/scripts/lib/client.py
+++ b/hindsight-integrations/codex/scripts/lib/client.py
@@ -8,11 +8,27 @@ import json
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 DEFAULT_TIMEOUT = 15  # seconds
 HEALTH_CHECK_RETRIES = 3
 HEALTH_CHECK_DELAY = 2  # seconds
+
+
+def _plugin_version() -> str:
+    """Read the plugin version from settings.json (single source of truth)."""
+    manifest = Path(__file__).resolve().parents[2] / "settings.json"
+    try:
+        return json.loads(manifest.read_text()).get("version", "0.0.0")
+    except (OSError, ValueError):
+        return "0.0.0"
+
+
+# Sent on every request so self-hosted deployments behind Cloudflare (or any
+# reverse proxy with UA-based bot filtering) don't block the stdlib default
+# "Python-urllib/X.Y", which trips Cloudflare error 1010.
+USER_AGENT = f"hindsight-codex/{_plugin_version()}"
 
 
 def _validate_api_url(url: str) -> str:
@@ -33,7 +49,10 @@ class HindsightClient:
         self.api_token = api_token
 
     def _headers(self) -> dict:
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        }
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers

--- a/hindsight-integrations/codex/scripts/lib/daemon.py
+++ b/hindsight-integrations/codex/scripts/lib/daemon.py
@@ -15,6 +15,7 @@ import time
 import urllib.error
 import urllib.request
 
+from .client import USER_AGENT
 from .llm import detect_llm_config, get_llm_env_vars
 from .state import read_state, write_state
 
@@ -62,7 +63,7 @@ def _check_health(base_url: str, timeout: int = 2) -> bool:
     """Quick health check against a Hindsight server."""
     try:
         url = f"{base_url.rstrip('/')}/health"
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status == 200
     except Exception:

--- a/hindsight-integrations/codex/tests/test_client.py
+++ b/hindsight-integrations/codex/tests/test_client.py
@@ -1,0 +1,42 @@
+"""Tests for lib/client.py — Hindsight REST API client."""
+
+from unittest.mock import patch
+
+from conftest import FakeHTTPResponse
+
+from lib.client import USER_AGENT, HindsightClient
+
+
+class TestUserAgentHeader:
+    """Regression tests for #1041.
+
+    The stdlib default ``Python-urllib/X.Y`` UA is blocked by Cloudflare with
+    error 1010, so every request must carry our identifying UA.
+    """
+
+    def test_recall_sends_user_agent(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["ua"] = req.get_header("User-agent")
+            return FakeHTTPResponse({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert captured["ua"] == USER_AGENT
+        assert captured["ua"].startswith("hindsight-codex/")
+
+    def test_health_check_sends_user_agent(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["ua"] = req.get_header("User-agent")
+            return FakeHTTPResponse({}, status=200)
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.health_check(timeout=1)
+
+        assert captured["ua"] == USER_AGENT

--- a/hindsight-integrations/crewai/hindsight_crewai/storage.py
+++ b/hindsight-integrations/crewai/hindsight_crewai/storage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from importlib import metadata
 from typing import Any, Callable
 
 from crewai.memory.storage.interface import Storage
@@ -17,6 +18,12 @@ from .config import get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
+
+try:
+    _VERSION = metadata.version("hindsight-crewai")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-crewai/{_VERSION}"
 
 
 class HindsightStorage(Storage):
@@ -110,6 +117,7 @@ class HindsightStorage(Storage):
                 base_url=self._api_url,
                 api_key=self._api_key,
                 timeout=30.0,
+                user_agent=_USER_AGENT,
             )
             self._local.client = client
         return client

--- a/hindsight-integrations/crewai/hindsight_crewai/tools.py
+++ b/hindsight-integrations/crewai/hindsight_crewai/tools.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from importlib import metadata
 from typing import Any
 
 from crewai.tools import BaseTool
@@ -18,6 +19,12 @@ from .config import get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
+
+try:
+    _VERSION = metadata.version("hindsight-crewai")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-crewai/{_VERSION}"
 
 
 class HindsightReflectTool(BaseTool):
@@ -80,6 +87,7 @@ class HindsightReflectTool(BaseTool):
                 base_url=api_url,
                 api_key=api_key,
                 timeout=30.0,
+                user_agent=_USER_AGENT,
             )
             self._local.client = client
         return client

--- a/hindsight-integrations/langgraph/hindsight_langgraph/_client.py
+++ b/hindsight-integrations/langgraph/hindsight_langgraph/_client.py
@@ -1,11 +1,18 @@
 """Shared Hindsight client resolution logic."""
 
+from importlib import metadata
 from typing import Any, Optional
 
 from hindsight_client import Hindsight
 
 from .config import get_config
 from .errors import HindsightError
+
+try:
+    _VERSION = metadata.version("hindsight-langgraph")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-langgraph/{_VERSION}"
 
 
 def resolve_client(
@@ -26,7 +33,7 @@ def resolve_client(
             "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/litellm/hindsight_litellm/__init__.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/__init__.py
@@ -108,6 +108,7 @@ import logging
 import litellm
 
 from .config import (
+    USER_AGENT,
     configure,
     set_defaults,
     get_config,
@@ -855,6 +856,7 @@ def _get_existing_document_content(
             host=config.hindsight_api_url, access_token=config.api_key
         )
         api_client = hindsight_client_api.ApiClient(api_config)
+        api_client.user_agent = USER_AGENT
         if config.api_key:
             api_client.set_default_header("Authorization", f"Bearer {config.api_key}")
         docs_api = documents_api.DocumentsApi(api_client)

--- a/hindsight-integrations/litellm/hindsight_litellm/config.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/config.py
@@ -17,7 +17,14 @@ This module provides a clean API for configuring Hindsight integration:
 import os
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
+from importlib import metadata
 from typing import Any, Dict, List, Optional
+
+try:
+    _VERSION = metadata.version("hindsight-litellm")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+USER_AGENT = f"hindsight-litellm/{_VERSION}"
 
 # Default Hindsight API URL (production)
 DEFAULT_HINDSIGHT_API_URL = "https://api.hindsight.vectorize.io"
@@ -508,7 +515,7 @@ def _create_or_update_bank(
     try:
         from hindsight_client import Hindsight
 
-        client = Hindsight(base_url=hindsight_api_url, api_key=api_key)
+        client = Hindsight(base_url=hindsight_api_url, api_key=api_key, user_agent=USER_AGENT)
         client.create_bank(
             bank_id=bank_id,
             name=name,

--- a/hindsight-integrations/litellm/hindsight_litellm/wrappers.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/wrappers.py
@@ -18,6 +18,7 @@ from .config import (
     DEFAULT_BANK_ID,
     DEFAULT_HINDSIGHT_API_URL,
     HINDSIGHT_API_KEY_ENV,
+    USER_AGENT,
     HindsightCallSettings,
     _merge_call_settings as _merge_settings,
     get_config,
@@ -40,7 +41,7 @@ def _get_client(api_url: str, api_key: Optional[str] = None):
     """
     from hindsight_client import Hindsight
 
-    return Hindsight(base_url=api_url, api_key=api_key, timeout=30.0)
+    return Hindsight(base_url=api_url, api_key=api_key, timeout=30.0, user_agent=USER_AGENT)
 
 
 def _close_client():
@@ -897,6 +898,7 @@ class HindsightOpenAI:
                 base_url=self._api_url,
                 api_key=self._api_key,
                 timeout=30.0,
+                user_agent=USER_AGENT,
             )
         return self._hindsight_client
 
@@ -1326,6 +1328,7 @@ class HindsightAnthropic:
                 base_url=self._api_url,
                 api_key=self._api_key,
                 timeout=30.0,
+                user_agent=USER_AGENT,
             )
         return self._hindsight_client
 
@@ -1744,7 +1747,7 @@ def wrap_openai(
         try:
             from hindsight_client import Hindsight
 
-            hs_client = Hindsight(base_url=resolved_api_url, api_key=resolved_api_key)
+            hs_client = Hindsight(base_url=resolved_api_url, api_key=resolved_api_key, user_agent=USER_AGENT)
             hs_client.create_bank(
                 bank_id=settings_kwargs["bank_id"],
                 name=bank_name,
@@ -1846,7 +1849,7 @@ def wrap_anthropic(
         try:
             from hindsight_client import Hindsight
 
-            hs_client = Hindsight(base_url=resolved_api_url, api_key=resolved_api_key)
+            hs_client = Hindsight(base_url=resolved_api_url, api_key=resolved_api_key, user_agent=USER_AGENT)
             hs_client.create_bank(
                 bank_id=settings_kwargs["bank_id"],
                 name=bank_name,

--- a/hindsight-integrations/llamaindex/hindsight_llamaindex/_client.py
+++ b/hindsight-integrations/llamaindex/hindsight_llamaindex/_client.py
@@ -1,11 +1,18 @@
 """Shared Hindsight client resolution logic."""
 
+from importlib import metadata
 from typing import Any, Optional
 
 from hindsight_client import Hindsight
 
 from .config import get_config
 from .errors import HindsightError
+
+try:
+    _VERSION = metadata.version("hindsight-llamaindex")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-llamaindex/{_VERSION}"
 
 # Per-operation timeouts (seconds)
 TIMEOUT_RETAIN = 15.0
@@ -33,7 +40,7 @@ def resolve_client(
             "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": TIMEOUT_DEFAULT}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": TIMEOUT_DEFAULT, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/llamaindex/tests/test_tools.py
+++ b/hindsight-integrations/llamaindex/tests/test_tools.py
@@ -140,9 +140,9 @@ class TestCreateHindsightTools:
             mock_cls.return_value = _mock_client()
             tools = create_hindsight_tools(bank_id="test")
             assert len(tools) == 3
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://localhost:8888"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
     def test_explicit_url_overrides_config(self):
         configure(hindsight_api_url="http://config:8888")
@@ -151,9 +151,9 @@ class TestCreateHindsightTools:
             create_hindsight_tools(
                 bank_id="test", hindsight_api_url="http://explicit:9999"
             )
-            mock_cls.assert_called_once_with(
-                base_url="http://explicit:9999", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://explicit:9999"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
 
 class TestRetainTool:

--- a/hindsight-integrations/openclaw/src/backfill.ts
+++ b/hindsight-integrations/openclaw/src/backfill.ts
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
-import { existsSync, realpathSync } from 'fs';
-import { join, resolve } from 'path';
+import { existsSync, readFileSync, realpathSync } from 'fs';
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { HindsightServer } from '@vectorize-io/hindsight-all';
 import { HindsightClient } from '@vectorize-io/hindsight-client';
+
+function loadPackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const USER_AGENT = `hindsight-openclaw/${loadPackageVersion()}`;
 import { detectExternalApi, detectLLMConfig } from './index.js';
 import type { BankStats, PluginConfig } from './types.js';
 import {
@@ -181,9 +193,11 @@ function inferApiSettings(pluginConfig: PluginConfig, explicitApiUrl?: string, e
 
 async function checkHealth(apiUrl: string, apiToken?: string): Promise<boolean> {
   try {
+    const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+    if (apiToken) headers.Authorization = `Bearer ${apiToken}`;
     const response = await fetch(`${apiUrl.replace(/\/$/, '')}/health`, {
       method: 'GET',
-      headers: apiToken ? { Authorization: `Bearer ${apiToken}` } : undefined,
+      headers,
       signal: AbortSignal.timeout(5000),
     });
     return response.ok;
@@ -323,7 +337,7 @@ export async function createBackfillRuntime(
  * doesn't yet wrap this endpoint, so we go direct — it's one call.
  */
 async function fetchBankStats(baseUrl: string, apiToken: string | undefined, bankId: string): Promise<BankStats> {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
   if (apiToken) headers.Authorization = `Bearer ${apiToken}`;
   const res = await fetch(`${baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}/stats`, { headers });
   if (!res.ok) {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -8,8 +8,20 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import * as log from './logger.js';
 import { configureLogger, setApiLogger, stopLogger } from './logger.js';
-import { mkdirSync } from 'fs';
+import { mkdirSync, readFileSync } from 'fs';
 import { homedir } from 'os';
+
+function loadPackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const USER_AGENT = `hindsight-openclaw/${loadPackageVersion()}`;
 
 // Logger adapter that routes the embed wrapper's output through openclaw's
 // batched structured logger so messages share the same prefix and respect
@@ -991,7 +1003,7 @@ async function checkExternalApiHealth(apiUrl: string, apiToken?: string | null):
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       debug(`[Hindsight] Checking external API health at ${healthUrl}... (attempt ${attempt}/${maxRetries})`);
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
       if (apiToken) {
         headers['Authorization'] = `Bearer ${apiToken}`;
       }

--- a/hindsight-integrations/paperclip/src/client.ts
+++ b/hindsight-integrations/paperclip/src/client.ts
@@ -4,7 +4,24 @@
  * Uses native fetch (Node 20+). No external dependencies.
  */
 
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import type { PaperclipMemoryConfig } from './config.js';
+
+function loadPackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+// Sent on every request so self-hosted deployments behind Cloudflare (or any
+// reverse proxy with UA-based bot filtering) accept the traffic.
+const USER_AGENT = `hindsight-paperclip/${loadPackageVersion()}`;
 
 export interface Memory {
   text: string;
@@ -35,7 +52,10 @@ export class HindsightClient {
   }
 
   private headers(): Record<string, string> {
-    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    const h: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': USER_AGENT,
+    };
     if (this.token) h['Authorization'] = `Bearer ${this.token}`;
     return h;
   }

--- a/hindsight-integrations/pydantic-ai/hindsight_pydantic_ai/tools.py
+++ b/hindsight-integrations/pydantic-ai/hindsight_pydantic_ai/tools.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from importlib import metadata
 from typing import Any
 
 from hindsight_client import Hindsight
@@ -17,6 +18,12 @@ from .config import get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
+
+try:
+    _VERSION = metadata.version("hindsight-pydantic-ai")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-pydantic-ai/{_VERSION}"
 
 
 def _resolve_client(
@@ -38,7 +45,7 @@ def _resolve_client(
             "Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)

--- a/hindsight-integrations/pydantic-ai/tests/test_tools.py
+++ b/hindsight-integrations/pydantic-ai/tests/test_tools.py
@@ -119,9 +119,9 @@ class TestCreateHindsightTools:
             mock_cls.return_value = _mock_client()
             tools = create_hindsight_tools(bank_id="test")
             assert len(tools) == 3
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://localhost:8888"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
     def test_explicit_url_overrides_config(self):
         configure(hindsight_api_url="http://config:8888")
@@ -130,9 +130,9 @@ class TestCreateHindsightTools:
             create_hindsight_tools(
                 bank_id="test", hindsight_api_url="http://explicit:9999"
             )
-            mock_cls.assert_called_once_with(
-                base_url="http://explicit:9999", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://explicit:9999"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
 
 class TestRetainTool:

--- a/hindsight-integrations/strands/hindsight_strands/tools.py
+++ b/hindsight-integrations/strands/hindsight_strands/tools.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+from importlib import metadata
 from typing import Any
+
+try:
+    _VERSION = metadata.version("hindsight-strands")
+except metadata.PackageNotFoundError:
+    _VERSION = "0.0.0"
+_USER_AGENT = f"hindsight-strands/{_VERSION}"
 
 _executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
 
@@ -52,7 +59,7 @@ def _resolve_client(
             "Pass client= or hindsight_api_url=, or call configure() first."
         )
 
-    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
+    kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
     return Hindsight(**kwargs)


### PR DESCRIPTION
## Summary
- Fixes #1041 — Cloudflare (and other UA-filtering proxies) were blocking Hindsight traffic with error 1010 because Python stdlib and some generated clients sent generic default UAs (`Python-urllib/X.Y`, `reqwest/…`, `OpenAPI-Generator/…`).
- All generated-client wrappers (Python / TypeScript / Rust / Go) now send `hindsight-client-<lang>/<version>` by default and expose a `user_agent` / `userAgent` / builder override.
- Every integration now identifies itself as `hindsight-<integration>/<version>` — both the ones using the wrapper (crewai, langgraph, autogen, ag2, llamaindex, agno, strands, pydantic-ai, litellm, opencode, openclaw) and the ones using raw urllib/fetch (claude-code, codex, paperclip). The raw-urllib ones are what directly fixes the reported Cloudflare 1010.

## Test plan
- [ ] CI passes (Python ruff + tests, TS tests including updated opencode plugin.test.ts assertions)
- [ ] Manual: hit a Cloudflare-fronted Hindsight from the claude-code plugin and confirm retain/recall no longer 403
- [ ] Spot-check server logs show integration-specific UAs (`hindsight-crewai/…`, `hindsight-claude-code/…`, etc.)