### PR TITLE
test: stabilize flaky retain and load batch tests

### DIFF
--- a/hindsight-api-slim/tests/test_load_large_batch.py
+++ b/hindsight-api-slim/tests/test_load_large_batch.py
@@ -25,6 +25,8 @@ from hindsight_api.engine.llm_wrapper import TokenUsage
 
 logger = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.xdist_group("load_batch_tests")
+
 
 def generate_content(char_count: int) -> str:
     """Generate realistic content of approximately char_count characters."""
@@ -117,9 +119,18 @@ class TestLargeBatchRetain:
         except Exception:
             pass
 
+    @pytest.fixture
+    def disable_observations(self):
+        from hindsight_api.config import _get_raw_config
+        config = _get_raw_config()
+        original = config.enable_observations
+        config.enable_observations = False
+        yield
+        config.enable_observations = original
+
     @pytest.mark.asyncio
     @pytest.mark.timeout(300)  # 5 minute timeout
-    async def test_large_batch_500k_chars_20_items(self, memory_with_mock_llm, request_context):
+    async def test_large_batch_500k_chars_20_items(self, memory_with_mock_llm, request_context, disable_observations):
         """
         Test retaining a batch of 20 content items totaling ~500k chars.
 
@@ -283,7 +294,7 @@ class TestLargeBatchRetain:
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(60)
-    async def test_db_connection_pool_under_load(self, memory_with_mock_llm, request_context):
+    async def test_db_connection_pool_under_load(self, memory_with_mock_llm, request_context, disable_observations):
         """
         Test that DB connection pool handles concurrent operations.
 

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -378,6 +378,7 @@ async def test_mentioned_at_vs_occurred(memory, request_context):
             content="Alice graduated from MIT in March 2020.",
             context="education history",
             event_date=conversation_date,  # When this conversation happened
+            fact_type_override="world",
             request_context=request_context,
         )
 
@@ -1149,6 +1150,7 @@ async def test_chunk_fact_mapping(memory, request_context):
             content=content,
             context="technical documentation",
             document_id=document_id,
+            fact_type_override="world",
             request_context=request_context,
         )
 


### PR DESCRIPTION
## Summary
Fixes four tests that were consistently failing/flaking on CI.

### `test_retain.py::test_mentioned_at_vs_occurred` and `test_chunk_fact_mapping`
Both retained content and then recalled with `fact_type=["world"]`. The LLM was free to classify facts as `experience` vs `world`, so recall returned 0 results whenever classification landed on `experience`. Fix: pass `fact_type_override="world"` on retain so the classification is deterministic.

### `test_load_large_batch.py::test_db_connection_pool_under_load`
Was timing out at 60s (3/3 runs locally). Root cause: `enable_observations=True` (default) triggers inline consolidation via `SyncTaskBackend` after each retain. The mock `LLMProvider.call` in this test wasn't special-casing `scope="consolidation"`, so consolidation received a fact-extraction-shaped response and stalled. With 10 concurrent retains, this compounded into timeouts. Fix: add a `disable_observations` fixture that sets `config.enable_observations = False` for the test's duration. Post-fix: 3/3 runs pass in <1s call time.

### `test_load_large_batch.py::test_large_batch_500k_chars_20_items`
Applied the same `disable_observations` fixture (it was also spending time in inline consolidation, and the fixture is the cleaner pattern now that it exists for the file).

### `test_load_large_batch.py` xdist grouping
The file is also marked with `pytest.mark.xdist_group("load_batch_tests")` so the heavy load tests don't run simultaneously with each other or with the rest of the suite under `-n 8`. One of the runs was crashing under worker contention; grouping serializes them and eliminates the crash.

## Test plan
- [x] `pytest tests/test_retain.py::test_mentioned_at_vs_occurred tests/test_retain.py::test_chunk_fact_mapping` — 3/3 green
- [x] `pytest tests/test_load_large_batch.py::TestLargeBatchRetain::test_db_connection_pool_under_load` — 3/3 green (was 3/3 failing before)
- [x] `pytest tests/test_load_large_batch.py` — all 3 tests pass together in ~68s