### PR TITLE
docs(opencode): drop npm install step, document Hindsight Cloud

### DIFF
--- a/hindsight-docs/docs-integrations/opencode.md
+++ b/hindsight-docs/docs-integrations/opencode.md
@@ -10,28 +10,46 @@ Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hi
 
 ## Quick Start
 
-```bash
-# 1. Install the plugin
-npm install @vectorize-io/opencode-hindsight
-```
-
-Add to your `opencode.json`:
+Add to your `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):
 
 ```json
 {
+  "$schema": "https://opencode.ai/config.json",
   "plugin": ["@vectorize-io/opencode-hindsight"]
 }
 ```
 
+OpenCode auto-installs plugins in the `"plugin"` array on startup — no `npm install` required.
+
+Point the plugin at your Hindsight server and start OpenCode:
+
 ```bash
-# 2. Configure your Hindsight server
 export HINDSIGHT_API_URL="http://localhost:8888"
-
-# Optional: API key for Hindsight Cloud
-export HINDSIGHT_API_TOKEN="your-api-key"
-
-# 3. Start OpenCode — the plugin activates automatically
 opencode
+```
+
+### Using Hindsight Cloud
+
+Get an API key at [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect):
+
+```bash
+export HINDSIGHT_API_URL="https://api.hindsight.vectorize.io"
+export HINDSIGHT_API_TOKEN="your-api-key"
+opencode
+```
+
+Or configure inline via plugin options in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    ["@vectorize-io/opencode-hindsight", {
+      "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+      "hindsightApiToken": "your-api-key"
+    }]
+  ]
+}
 ```
 
 ## Features

--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -11,33 +11,50 @@ Hindsight memory plugin for [OpenCode](https://opencode.ai) — give your AI cod
 
 ## Quick Start
 
-### 1. Install
+### 1. Enable the plugin
 
-```bash
-npm install @vectorize-io/opencode-hindsight
-```
-
-### 2. Configure
-
-Add to your `opencode.json`:
+Add to your `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):
 
 ```json
 {
+  "$schema": "https://opencode.ai/config.json",
   "plugin": ["@vectorize-io/opencode-hindsight"]
 }
 ```
 
-### 3. Set Environment Variables
+OpenCode auto-installs plugins listed here on startup — no `npm install` required.
+
+### 2. Point to your Hindsight server
 
 ```bash
-# Required: Hindsight API URL
+# Self-hosted
 export HINDSIGHT_API_URL="http://localhost:8888"
 
-# Optional: API key for Hindsight Cloud
-export HINDSIGHT_API_TOKEN="your-api-key"
-
-# Optional: Override the memory bank ID
+# Optional: override the memory bank ID
 export HINDSIGHT_BANK_ID="my-project"
+```
+
+### Using Hindsight Cloud
+
+Get an API key at [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect), then either export env vars:
+
+```bash
+export HINDSIGHT_API_URL="https://api.hindsight.vectorize.io"
+export HINDSIGHT_API_TOKEN="your-api-key"
+```
+
+Or configure inline in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    ["@vectorize-io/opencode-hindsight", {
+      "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+      "hindsightApiToken": "your-api-key"
+    }]
+  ]
+}
 ```
 
 ## Configuration

--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import type { Plugin, PluginModule } from '@opencode-ai/plugin';
+import type { Plugin } from '@opencode-ai/plugin';
 import { HindsightClient } from '@vectorize-io/hindsight-client';
 import { loadConfig } from './config.js';
 import { deriveBankId } from './bank.js';
@@ -67,13 +67,9 @@ const HindsightPlugin: Plugin = async (input, options) => {
 // Named export for direct import
 export { HindsightPlugin };
 
-// Default export as PluginModule for OpenCode plugin loader
-const module: PluginModule = {
-    id: 'hindsight',
-    server: HindsightPlugin,
-};
-
-export default module;
+// Default export is the Plugin function itself — OpenCode's loader calls the
+// default export directly.
+export default HindsightPlugin;
 
 // Re-export types for consumers
 export type { HindsightConfig } from './config.js';

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -127,11 +127,14 @@ describe('HindsightPlugin state sharing', () => {
     });
 });
 
-describe('PluginModule default export', () => {
-    it('exports correct module shape', async () => {
+describe('plugin default export', () => {
+    it('default-exports the Plugin function itself', async () => {
         const mod = await import('./index.js');
-        expect(mod.default).toBeDefined();
-        expect(mod.default.id).toBe('hindsight');
-        expect(typeof mod.default.server).toBe('function');
+        expect(typeof mod.default).toBe('function');
+        // OpenCode iterates Object.entries(mod) and calls every export as a
+        // Plugin factory, deduping by reference. The default export must be
+        // the same reference as the named HindsightPlugin export to avoid
+        // running the factory twice.
+        expect(mod.default).toBe(mod.HindsightPlugin);
     });
 });


### PR DESCRIPTION
## Summary
- Remove misleading \`npm install @vectorize-io/opencode-hindsight\` step — OpenCode auto-installs plugins listed in the \`"plugin"\` array at startup via Bun (per https://opencode.ai/docs/plugins/).
- Add a dedicated **Using Hindsight Cloud** section with the managed API URL (\`https://api.hindsight.vectorize.io\`) and token guidance in both the integration README and the docs site page.

## Test plan
- [ ] Verify rendered docs page reads correctly
- [ ] Confirm a fresh install using only the documented \`opencode.json\` snippet works (plugin auto-installs on first \`opencode\` run)