### PR TITLE
fix(opencode): replace unconditional console.error with debugLog

### DIFF
--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -127,14 +127,13 @@ export function createHooks(
     /** Extract plain-text messages from an OpenCode session */
     async function getSessionMessages(sessionId: string): Promise<Message[]> {
         try {
-            console.error(`[Hindsight] getSessionMessages: calling session.messages with path.id=${sessionId}`);
+            debugLog(config, `getSessionMessages: fetching messages for session ${sessionId}`);
             const response = await opencodeClient.session.messages({
                 path: { id: sessionId },
             });
             if (response.error) {
-                console.error(`[Hindsight] getSessionMessages: error=${JSON.stringify(response.error)?.substring(0, 500)}`);
+                debugLog(config, `getSessionMessages: error=${JSON.stringify(response.error)?.substring(0, 500)}`);
             }
-            console.error(`[Hindsight] getSessionMessages: response keys=${Object.keys(response).join(',')}, type=${typeof response.data}, isArray=${Array.isArray(response.data)}, data=${JSON.stringify(response.data)?.substring(0, 200)}`);
             const rawMessages = response.data || [];
             const messages: Message[] = [];
             for (const msg of rawMessages) {
@@ -147,10 +146,10 @@ export function createHooks(
                     messages.push({ role, content: textParts.join('\n') });
                 }
             }
-            console.error(`[Hindsight] getSessionMessages: raw=${rawMessages.length}, parsed=${messages.length}`);
+            debugLog(config, `getSessionMessages: raw=${rawMessages.length}, parsed=${messages.length}`);
             return messages;
         } catch (e) {
-            console.error('[Hindsight] Failed to get session messages:', e);
+            debugLog(config, 'Failed to get session messages:', e);
             return [];
         }
     }
@@ -193,20 +192,16 @@ export function createHooks(
 
     /** Auto-retain conversation transcript */
     async function handleSessionIdle(sessionId: string): Promise<void> {
-        console.error(`[Hindsight] handleSessionIdle called for session ${sessionId}`);
-        if (!config.autoRetain) {
-            console.error('[Hindsight] handleSessionIdle: autoRetain is false, skipping');
-            return;
-        }
+        debugLog(config, `handleSessionIdle called for session ${sessionId}`);
+        if (!config.autoRetain) return;
 
         const messages = await getSessionMessages(sessionId);
-        console.error(`[Hindsight] handleSessionIdle: got ${messages.length} messages`);
         if (!messages.length) return;
 
         // Count user turns
         const userTurns = messages.filter((m) => m.role === 'user').length;
         const lastRetained = state.lastRetainedTurn.get(sessionId) || 0;
-        console.error(`[Hindsight] handleSessionIdle: userTurns=${userTurns}, lastRetained=${lastRetained}, retainEveryNTurns=${config.retainEveryNTurns}`);
+        debugLog(config, `handleSessionIdle: userTurns=${userTurns}, lastRetained=${lastRetained}, retainEveryNTurns=${config.retainEveryNTurns}`);
 
         // Only retain if enough new turns since last retain
         if (userTurns - lastRetained < config.retainEveryNTurns) return;
@@ -214,20 +209,19 @@ export function createHooks(
         try {
             await retainSession(sessionId, messages);
             state.lastRetainedTurn.set(sessionId, userTurns);
-            console.error(`[Hindsight] Auto-retained ${messages.length} messages for session ${sessionId}`);
+            debugLog(config, `Auto-retained ${messages.length} messages for session ${sessionId}`);
         } catch (e) {
-            console.error('[Hindsight] Auto-retain failed:', e);
+            debugLog(config, 'Auto-retain failed:', e);
         }
     }
 
     const event = async (input: EventInput): Promise<void> => {
         try {
             const { event: evt } = input;
-            console.error(`[Hindsight] event hook fired: type=${evt.type}`);
+            debugLog(config, `event hook fired: type=${evt.type}`);
 
             if (evt.type === 'session.idle') {
                 const sessionId = (evt.properties as { sessionID?: string }).sessionID;
-                console.error(`[Hindsight] session.idle event: sessionId=${sessionId}`);
                 if (sessionId) {
                     await handleSessionIdle(sessionId);
                 }


### PR DESCRIPTION
## Summary

- Replace 13 hardcoded `console.error` calls in `hooks.ts` with `debugLog(config, ...)` so they only appear when `debug: true` is set in plugin options
- PR #993 added these for debugging the message parsing fix, but they were left unconditional, spamming every user's TUI with red error text on every event, message parse, and retain cycle

## Test plan

- [x] All 91 opencode plugin tests pass
- [x] Verified in live OpenCode session — no TUI spam with `debug: false`, logs appear with `debug: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)