### PR TITLE
fix(ts-sdk): re-export BankTemplate types from package root

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -42,6 +42,11 @@ import type {
     BankConfigResponse,
     CreateBankRequest,
     Budget,
+    BankTemplateManifest,
+    BankTemplateConfig,
+    BankTemplateMentalModel,
+    BankTemplateDirective,
+    BankTemplateImportResponse,
 } from '../generated/types.gen';
 
 export const CLIENT_VERSION = '0.5.1';
@@ -824,6 +829,11 @@ export type {
     BankConfigResponse,
     CreateBankRequest,
     Budget,
+    BankTemplateManifest,
+    BankTemplateConfig,
+    BankTemplateMentalModel,
+    BankTemplateDirective,
+    BankTemplateImportResponse,
 };
 
 // Also export low-level SDK functions for advanced usage


### PR DESCRIPTION
## Summary

BankTemplate types were added in #819 and registered in the Python client's `hindsight_client_api.models` top-level export. The TypeScript client's hand-maintained `src/index.ts` re-export block was never updated to match, so downstream TypeScript consumers cannot reach `BankTemplateManifest` or its five related types from the package root. The generated types already exist in `generated/types.gen.ts`, but the package's `exports` field only surfaces the `"."` entry, which means tsc rejects the deep subpath import.

Python and TypeScript have had an asymmetric public type surface since #819 merged. This closes the gap by adding the five types to the existing re-export block, matching what Python already does.

- Add `BankTemplateManifest`, `BankTemplateConfig`, `BankTemplateMentalModel`, `BankTemplateDirective`, `BankTemplateImportResponse` to the `import type` pull-in and the `export type` re-export block in `hindsight-clients/typescript/src/index.ts`

Non-breaking. Existing exports unchanged. No client regeneration needed. Per `CONTRIBUTING.md`, `src/index.ts` is hand-maintained and clients are only regenerated at release time. This commit only widens the package's public surface.

## Tested

Verified end-to-end against v0.5.1 with the patch applied locally: