### PR TITLE
fix: wire consolidation retry budget to LLM call site

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -339,6 +339,7 @@ ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS = "HINDSIGHT_API_CONSOLIDATION_SOURCE_
 ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
     "HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION"
 )
+ENV_CONSOLIDATION_MAX_ATTEMPTS = "HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS"
 ENV_OBSERVATIONS_MISSION = "HINDSIGHT_API_OBSERVATIONS_MISSION"
 ENV_MAX_OBSERVATIONS_PER_SCOPE = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE"
 ENV_ENABLE_OBSERVATION_HISTORY = "HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY"
@@ -554,6 +555,7 @@ DEFAULT_FILE_DELETE_AFTER_RETAIN = True  # Delete file bytes after retain (saves
 DEFAULT_ENABLE_OBSERVATIONS = True  # Observations enabled by default
 DEFAULT_ENABLE_OBSERVATION_HISTORY = True  # Observation history tracking enabled by default
 DEFAULT_ENABLE_MENTAL_MODEL_HISTORY = True  # Mental model history tracking enabled by default
+DEFAULT_CONSOLIDATION_MAX_ATTEMPTS = 3  # Outer retry attempts for consolidation LLM batch calls
 DEFAULT_CONSOLIDATION_BATCH_SIZE = 50  # Memories to load per batch (internal memory optimization)
 DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 8  # Facts per LLM call (1 = no batching; >1 = batch mode)
 DEFAULT_CONSOLIDATION_MAX_TOKENS = 512  # Max tokens for recall when finding related observations
@@ -917,6 +919,7 @@ class HindsightConfig:
     consolidation_max_tokens: int
     consolidation_source_facts_max_tokens: int
     consolidation_source_facts_max_tokens_per_observation: int
+    consolidation_max_attempts: int
     observations_mission: str | None
     max_observations_per_scope: int
 
@@ -1503,6 +1506,9 @@ class HindsightConfig:
                     ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION,
                     str(DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION),
                 )
+            ),
+            consolidation_max_attempts=int(
+                os.getenv(ENV_CONSOLIDATION_MAX_ATTEMPTS, str(DEFAULT_CONSOLIDATION_MAX_ATTEMPTS))
             ),
             observations_mission=os.getenv(ENV_OBSERVATIONS_MISSION) or DEFAULT_OBSERVATIONS_MISSION,
             max_observations_per_scope=int(

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1182,15 +1182,19 @@ async def _consolidate_batch_with_llm(
     # Use a constrained response model when observation limit is active
     response_model = _build_response_model(max_creates=remaining_observation_slots)
 
-    max_attempts = 3
+    max_attempts = getattr(config, "consolidation_max_attempts", None) or 3
+    inner_max_retries = getattr(config, "consolidation_llm_max_retries", None)
     last_exc: Exception | None = None
     for attempt in range(1, max_attempts + 1):
         try:
-            response: _ConsolidationBatchResponse = await llm_config.call(
-                messages=[{"role": "user", "content": prompt}],
-                response_format=response_model,
-                scope="consolidation",
-            )
+            call_kwargs: dict[str, Any] = {
+                "messages": [{"role": "user", "content": prompt}],
+                "response_format": response_model,
+                "scope": "consolidation",
+            }
+            if inner_max_retries is not None:
+                call_kwargs["max_retries"] = inner_max_retries
+            response: _ConsolidationBatchResponse = await llm_config.call(**call_kwargs)
             # Defensive truncation: some LLM providers may not enforce JSON schema max_length
             creates = response.creates
             if remaining_observation_slots is not None and remaining_observation_slots >= 0:

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -1,0 +1,104 @@
+"""Tests for consolidation retry budget configurability (issue #1042)."""
+
+import pytest
+
+from unittest.mock import AsyncMock, MagicMock
+
+from hindsight_api.engine.consolidation.consolidator import _consolidate_batch_with_llm
+
+
+@pytest.fixture
+def mock_llm_config():
+    llm = AsyncMock()
+    response = MagicMock()
+    response.creates = []
+    response.updates = []
+    response.deletes = []
+    llm.call.return_value = response
+    return llm
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    config.observations_mission = None
+    config.consolidation_max_attempts = 3
+    config.consolidation_llm_max_retries = None
+    return config
+
+
+class TestConsolidationRetryBudget:
+    @pytest.mark.asyncio
+    async def test_default_max_attempts_without_config(self, mock_llm_config):
+        """When config is None, max_attempts defaults to 3."""
+        mock_llm_config.call.side_effect = RuntimeError("fail")
+        result = await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=None,
+        )
+        assert result.failed
+        assert mock_llm_config.call.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_configurable_max_attempts(self, mock_llm_config, mock_config):
+        """consolidation_max_attempts controls the outer retry loop."""
+        mock_config.consolidation_max_attempts = 5
+        mock_llm_config.call.side_effect = RuntimeError("fail")
+        result = await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        assert result.failed
+        assert mock_llm_config.call.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_max_retries_threaded_to_call(self, mock_llm_config, mock_config):
+        """consolidation_llm_max_retries is passed to llm_config.call()."""
+        mock_config.consolidation_llm_max_retries = 3
+        await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        call_kwargs = mock_llm_config.call.call_args
+        assert call_kwargs.kwargs.get("max_retries") == 3 or call_kwargs[1].get("max_retries") == 3
+
+    @pytest.mark.asyncio
+    async def test_max_retries_not_passed_when_none(self, mock_llm_config, mock_config):
+        """When consolidation_llm_max_retries is None, max_retries is not passed."""
+        mock_config.consolidation_llm_max_retries = None
+        await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        call_kwargs = mock_llm_config.call.call_args
+        assert "max_retries" not in (call_kwargs.kwargs if call_kwargs.kwargs else {})
+
+    @pytest.mark.asyncio
+    async def test_reduced_budget_limits_total_calls(self, mock_llm_config, mock_config):
+        """Setting both to low values caps total failure attempts."""
+        mock_config.consolidation_max_attempts = 2
+        mock_config.consolidation_llm_max_retries = 2
+        mock_llm_config.call.side_effect = RuntimeError("upstream 503")
+        result = await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        assert result.failed
+        assert mock_llm_config.call.call_count == 2
+        for call_args in mock_llm_config.call.call_args_list:
+            assert call_args.kwargs.get("max_retries") == 2 or call_args[1].get("max_retries") == 2

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -992,6 +992,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 |----------|-------------|---------|
 | `HINDSIGHT_API_ENABLE_OBSERVATIONS` | Enable observation consolidation | `true` |
 | `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY` | Track history of changes to each observation (previous content + timestamp). Disable to reduce storage if audit trails are not needed. | `true` |
+| `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS` | Outer retry attempts for the consolidation LLM batch call. Each attempt uses the inner retry budget (`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`). Worst-case API calls per batch = `MAX_ATTEMPTS × (LLM_MAX_RETRIES + 1)`. | `3` |
 | `HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE` | Memories to load per batch (internal optimization) | `50` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS` | Max tokens for recall when finding related observations during consolidation | `1024` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` | Number of facts sent to the LLM in a single consolidation call. Higher values reduce LLM calls and improve throughput at the cost of larger prompts. Set to `1` to disable batching. Configurable per bank. | `8` |


### PR DESCRIPTION
## Summary

Fixes #1042.

`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES` was defined in config, loaded from env, and documented — but never actually threaded to the `llm_config.call()` in the consolidation code path. Operators had no way to limit inner retries during upstream outages, leading to up to 33 API calls per batch (3 outer × 11 inner).

**Changes:**

- **Wire existing `consolidation_llm_max_retries`** from config to `llm_config.call(max_retries=...)` in `_consolidate_batch_with_llm()` — makes the documented env var actually work
- **Add `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS`** (default `3`, preserving current behavior) to make the outer retry loop configurable
- **Add 5 unit tests** covering: default fallback, configurable attempts, max_retries threading, None passthrough, and reduced budget cap
- **Update docs** with the new env var and worst-case formula

Defaults are preserved — no behavior change for existing deployments.

## Test plan

- [x] New unit tests: `test_consolidation_retry_budget.py` (5 tests)
- [x] Verified backward compatibility: `config=None` falls back to `max_attempts=3`, `max_retries` not passed

AI-assisted (Claude Code).