### PR TITLE
feat(docs): split template manifests into per-file manifest_file refe…

### DIFF
--- a/hindsight-docs/scripts/check-templates.mjs
+++ b/hindsight-docs/scripts/check-templates.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Validates that every manifest in templates.json conforms to the
- * bank template JSON Schema (static/bank-template-schema.json).
+ * Validates that every manifest referenced from templates.json conforms
+ * to the bank template JSON Schema (static/bank-template-schema.json).
+ * Each catalog entry's manifest_file is loaded off disk.
  *
  * Run: node scripts/check-templates.mjs
  */
@@ -13,9 +14,10 @@ import Ajv from 'ajv';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsRoot = join(__dirname, '..');
+const dataRoot = join(docsRoot, 'src/data');
 
-const templates = JSON.parse(
-  readFileSync(join(docsRoot, 'src/data/templates.json'), 'utf-8'),
+const catalog = JSON.parse(
+  readFileSync(join(dataRoot, 'templates.json'), 'utf-8'),
 );
 const schema = JSON.parse(
   readFileSync(join(docsRoot, 'static/bank-template-schema.json'), 'utf-8'),
@@ -26,11 +28,14 @@ const validate = ajv.compile(schema);
 
 let failed = 0;
 
-for (const template of templates.templates) {
-  const valid = validate(template.manifest);
+for (const entry of catalog.templates) {
+  const manifest = JSON.parse(
+    readFileSync(join(dataRoot, entry.manifest_file), 'utf-8'),
+  );
+  const valid = validate(manifest);
   if (!valid) {
     failed++;
-    console.error(`\x1b[31m✗\x1b[0m Template "${template.id}" has invalid manifest:`);
+    console.error(`\x1b[31m✗\x1b[0m Template "${entry.id}" (${entry.manifest_file}) has invalid manifest:`);
     // Filter out noisy anyOf wrapper errors, keep only leaf errors with paths
     const meaningful = validate.errors.filter(
       (e) => e.keyword !== 'anyOf' && e.keyword !== 'if' && e.keyword !== 'then',
@@ -41,7 +46,7 @@ for (const template of templates.templates) {
       console.error(`    ${path}: ${err.message} ${err.params ? JSON.stringify(err.params) : ''}`);
     }
   } else {
-    console.log(`\x1b[32m✓\x1b[0m Template "${template.id}" — valid`);
+    console.log(`\x1b[32m✓\x1b[0m Template "${entry.id}" — valid`);
   }
 }
 
@@ -49,5 +54,5 @@ if (failed > 0) {
   console.error(`\n\x1b[31m${failed} template(s) failed schema validation.\x1b[0m`);
   process.exit(1);
 } else {
-  console.log(`\n\x1b[32mAll ${templates.templates.length} templates are valid.\x1b[0m`);
+  console.log(`\n\x1b[32mAll ${catalog.templates.length} templates are valid.\x1b[0m`);
 }

--- a/hindsight-docs/src/data/templates.json
+++ b/hindsight-docs/src/data/templates.json
@@ -19,34 +19,7 @@
         "local-mcp",
         "skills"
       ],
-      "manifest": {
-        "version": "1",
-        "bank": {
-          "retain_mission": "Extract user preferences, stated facts about themselves, requests they've made, topics they care about, and any commitments or follow-ups. Ignore small talk and filler.",
-          "enable_observations": true,
-          "observations_mission": "Track stable user preferences, communication style, recurring topics, and how the user's needs evolve over time."
-        },
-        "mental_models": [
-          {
-            "id": "user-profile",
-            "name": "User Profile",
-            "source_query": "What do we know about this user? What are their preferences, background, and how do they like to interact?",
-            "max_tokens": 2048,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          },
-          {
-            "id": "open-threads",
-            "name": "Open Threads",
-            "source_query": "What topics, tasks, or follow-ups are still open or unresolved from past conversations?",
-            "max_tokens": 1024,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          }
-        ]
-      }
+      "manifest_file": "templates/conversation.json"
     },
     {
       "id": "coding-agent",
@@ -57,34 +30,7 @@
         "claude-code",
         "codex"
       ],
-      "manifest": {
-        "version": "1",
-        "bank": {
-          "retain_mission": "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, and recurring issues. Ignore transient debugging output and boilerplate.",
-          "enable_observations": true,
-          "observations_mission": "Track stable project facts: tech stack, team conventions, architecture patterns, and how the codebase evolves over time."
-        },
-        "mental_models": [
-          {
-            "id": "project-context",
-            "name": "Project Context",
-            "source_query": "What is the project's tech stack, architecture, and key conventions? What are the main components and how do they fit together?",
-            "max_tokens": 2048,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          },
-          {
-            "id": "developer-preferences",
-            "name": "Developer Preferences",
-            "source_query": "What are the developer's preferences for tools, libraries, coding style, and workflow? How do they like code to be written and reviewed?",
-            "max_tokens": 1024,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          }
-        ]
-      }
+      "manifest_file": "templates/coding-agent.json"
     },
     {
       "id": "personal-assistant",
@@ -97,34 +43,7 @@
         "nemoclaw",
         "hindclaw"
       ],
-      "manifest": {
-        "version": "1",
-        "bank": {
-          "retain_mission": "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
-          "enable_observations": true,
-          "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time."
-        },
-        "mental_models": [
-          {
-            "id": "user-profile",
-            "name": "User Profile",
-            "source_query": "What do we know about this user? What are their preferences, routines, important people, and how do they like to be helped?",
-            "max_tokens": 2048,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          },
-          {
-            "id": "active-tasks",
-            "name": "Active Tasks & Commitments",
-            "source_query": "What tasks, commitments, or follow-ups is the user currently tracking? What deadlines or promises have been made?",
-            "max_tokens": 1024,
-            "trigger": {
-              "refresh_after_consolidation": true
-            }
-          }
-        ]
-      }
+      "manifest_file": "templates/personal-assistant.json"
     }
   ]
 }

--- a/hindsight-docs/src/data/templates/coding-agent.json
+++ b/hindsight-docs/src/data/templates/coding-agent.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, and recurring issues. Ignore transient debugging output and boilerplate.",
+    "enable_observations": true,
+    "observations_mission": "Track stable project facts: tech stack, team conventions, architecture patterns, and how the codebase evolves over time."
+  },
+  "mental_models": [
+    {
+      "id": "project-context",
+      "name": "Project Context",
+      "source_query": "What is the project's tech stack, architecture, and key conventions? What are the main components and how do they fit together?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "developer-preferences",
+      "name": "Developer Preferences",
+      "source_query": "What are the developer's preferences for tools, libraries, coding style, and workflow? How do they like code to be written and reviewed?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-docs/src/data/templates/conversation.json
+++ b/hindsight-docs/src/data/templates/conversation.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract user preferences, stated facts about themselves, requests they've made, topics they care about, and any commitments or follow-ups. Ignore small talk and filler.",
+    "enable_observations": true,
+    "observations_mission": "Track stable user preferences, communication style, recurring topics, and how the user's needs evolve over time."
+  },
+  "mental_models": [
+    {
+      "id": "user-profile",
+      "name": "User Profile",
+      "source_query": "What do we know about this user? What are their preferences, background, and how do they like to interact?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "open-threads",
+      "name": "Open Threads",
+      "source_query": "What topics, tasks, or follow-ups are still open or unresolved from past conversations?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-docs/src/data/templates/personal-assistant.json
+++ b/hindsight-docs/src/data/templates/personal-assistant.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
+    "enable_observations": true,
+    "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time."
+  },
+  "mental_models": [
+    {
+      "id": "user-profile",
+      "name": "User Profile",
+      "source_query": "What do we know about this user? What are their preferences, routines, important people, and how do they like to be helped?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "active-tasks",
+      "name": "Active Tasks & Commitments",
+      "source_query": "What tasks, commitments, or follow-ups is the user currently tracking? What deadlines or promises have been made?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-docs/src/pages/templates/index.module.css
+++ b/hindsight-docs/src/pages/templates/index.module.css
@@ -564,6 +564,24 @@
 .submitBannerText {
   font-size: 0.9rem;
   color: var(--ifm-color-emphasis-600);
-  margin-bottom: 0;
+  margin-bottom: 1.25rem;
   line-height: 1.6;
+}
+
+.submitButton {
+  display: inline-block;
+  padding: 0.55rem 1.4rem;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #0074d9, #009296);
+  color: #fff !important;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.submitButton:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+  color: #fff !important;
 }

--- a/hindsight-docs/src/pages/templates/index.tsx
+++ b/hindsight-docs/src/pages/templates/index.tsx
@@ -1,9 +1,45 @@
 import React, {useMemo, useState, useCallback} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
-import templatesData from '@site/src/data/templates.json';
+import catalog from '@site/src/data/templates.json';
 import integrationsData from '@site/src/data/integrations.json';
 import styles from './index.module.css';
+
+const TEMPLATES_JSON_URL =
+  'https://github.com/vectorize-io/hindsight/edit/main/hindsight-docs/src/data/templates.json';
+
+// Webpack's require.context eagerly bundles every .json file under
+// src/data/templates/, so adding a template only requires creating
+// the manifest file and adding a catalog entry — no code change here.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const manifestContext = (require as any).context('@site/src/data/templates', false, /\.json$/);
+
+interface Template {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  integrations?: string[];
+  manifest: Record<string, unknown>;
+}
+
+const templatesData: Template[] = catalog.templates.map((entry) => {
+  // catalog's manifest_file is 'templates/<id>.json'; require.context keys are './<id>.json'
+  const key = './' + entry.manifest_file.replace(/^templates\//, '');
+  const manifest = manifestContext(key);
+  if (!manifest) {
+    throw new Error(`No manifest found for ${entry.manifest_file}`);
+  }
+  return {
+    id: entry.id,
+    name: entry.name,
+    description: entry.description,
+    category: entry.category,
+    integrations: entry.integrations,
+    manifest,
+  };
+});
 
 const CATEGORIES = ['all', 'chat', 'coding', 'assistant'] as const;
 type Category = (typeof CATEGORIES)[number];
@@ -19,15 +55,6 @@ const CATEGORY_LABELS: Record<Category, string> = {
 const INTEGRATION_MAP = Object.fromEntries(
   integrationsData.integrations.map((i) => [i.id, {icon: i.icon, name: i.name}]),
 );
-
-interface Template {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  integrations?: string[];
-  manifest: Record<string, unknown>;
-}
 
 function IntegrationIcons({ids}: {ids: string[]}) {
   return (
@@ -117,7 +144,7 @@ export default function TemplateGallery(): React.ReactElement {
   const [selectedCategory, setSelectedCategory] = useState<Category>('all');
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
 
-  const templates = templatesData.templates as Template[];
+  const templates = templatesData;
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim();
@@ -207,8 +234,15 @@ export default function TemplateGallery(): React.ReactElement {
           <div className={styles.submitBannerContent}>
             <h3 className={styles.submitBannerTitle}>Have a template to share?</h3>
             <p className={styles.submitBannerText}>
-              Add your template to the gallery by editing templates.json on GitHub.
+              Contribute it to the community. Open a pull request and add your entry to the bank templates.
             </p>
+            <Link
+              href={TEMPLATES_JSON_URL}
+              className={styles.submitButton}
+              target="_blank"
+              rel="noopener noreferrer">
+              Submit a template →
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

`hindsight-docs/src/data/templates.json` mixes two unrelated concerns: presentation metadata for the gallery card (name, description, category, integrations) and the `BankTemplateManifest` body that gets POSTed to `/v1/default/banks/{id}/import`. A contributor who only tweaks `retain_mission` on one template has to touch a 130-line file full of metadata they did not mean to edit, and review diffs mix card-level and manifest-level changes in the same hunk.

This PR moves each manifest into its own file under `hindsight-docs/src/data/templates/`. The catalog entry in `templates.json` keeps the presentation fields and replaces the inline `manifest` field with a `manifest_file` path pointing at the per-template file. Each file is now a pure `BankTemplateManifest` and can be POSTed directly to `/v1/default/banks/{bank_id}/import` without any extraction step.

The renderer in `src/pages/templates/index.tsx` uses webpack's `require.context` to eagerly bundle every `.json` file under `src/data/templates/` at build time. This keeps the contributor flow to **two files total**: create the manifest under `src/data/templates/`, add a catalog entry to `templates.json`. No code change needed to register the new file — webpack picks it up automatically on the next build.

The validator `scripts/check-templates.mjs` is updated to follow `manifest_file` references off disk instead of reading inline manifests from the catalog.

I also added a `Submit a template →` CTA button to the gallery banner, matching the existing pattern on the integrations page (same `Link` component, same `submitButton` styling copied verbatim from `hindsight-docs/src/pages/integrations/index.module.css`). The button opens `templates.json` in GitHub's web editor in a new tab, so contributors get a one-click contribution path.

**Zero runtime/visual change for existing templates.** The rendered Template Hub page is byte-identical: same gallery cards, same category filters, same search, same modal, same "Copy JSON" output. `require.context` inlines every manifest into the compiled JS bundle at build time, so there is no runtime fetch, no deployed asset change, and no UX delta for anyone browsing the page.

## Test plan

- [x] `node hindsight-docs/scripts/check-templates.mjs` — all 3 bundled templates (Conversation, Coding Agent, Personal Assistant) validate against `static/bank-template-schema.json`.
- [x] `npm run build --workspace=hindsight-docs` — full Docusaurus build succeeds. Only pre-existing broken-anchor warnings (same as clean `main`, unrelated to this PR).
- [x] Rendered `build/templates.html` contains all 3 template names (`Conversation`, `Coding Agent`, `Personal Assistant`) and the new banner text/CTA button.
- [x] Bundled JS chunk contains the full manifest content (`retain_mission`, `refresh_after_consolidation`, `user-profile`, etc.) — proves `require.context` is bundling each manifest file correctly.
- [x] `./scripts/hooks/lint.sh` — all lints pass (ruff, ty, eslint, prettier).
- [ ] CI `build-docs` job passes.

## Notes for reviewers

- `require.context` is typed via a single `(require as any).context(...)` cast with an `eslint-disable-next-line` comment. If you'd prefer a small `.d.ts` declaration for it instead, happy to swap.
- The `.submitButton` CSS rules copied from `integrations/index.module.css` are byte-identical (I diff'd them) and the `.submitBannerText { margin-bottom }` bump from `0` to `1.25rem` mirrors the spacing integrations already uses so the button has room to breathe under the text.
- Adding a new template going forward: create `src/data/templates/<id>.json` with the manifest, add a catalog entry to `templates.json` with `manifest_file: "templates/<id>.json"`, open a PR. No other files to touch. The gallery rebuilds automatically.
