### PR TITLE
refactor(templates): split into hindsight-bank-templates package (v2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2553,6 +2553,9 @@ jobs:
     - name: Run generate-docs-skill
       run: ./scripts/generate-docs-skill.sh
 
+    - name: Run generate-templates
+      run: ./scripts/generate-templates.sh
+
     - name: Run lint
       run: ./scripts/hooks/lint.sh
 
@@ -2568,6 +2571,7 @@ jobs:
           echo "  ./scripts/generate-openapi.sh"
           echo "  ./scripts/generate-clients.sh"
           echo "  ./scripts/generate-docs-skill.sh"
+          echo "  ./scripts/generate-templates.sh"
           echo "  ./scripts/hooks/lint.sh"
           echo ""
           git diff --stat

--- a/hindsight-bank-templates/templates.json
+++ b/hindsight-bank-templates/templates.json
@@ -1,0 +1,49 @@
+{
+  "templates": [
+    {
+      "id": "conversation",
+      "name": "Conversation",
+      "description": "For chat-based agents and assistants. Tracks user preferences, conversation patterns, and builds a profile over time.",
+      "category": "chat",
+      "integrations": [
+        "litellm",
+        "langgraph",
+        "pydantic-ai",
+        "ai-sdk",
+        "chat",
+        "crewai",
+        "ag2",
+        "agno",
+        "strands",
+        "llamaindex",
+        "local-mcp",
+        "skills"
+      ],
+      "manifest_file": "templates/conversation.json"
+    },
+    {
+      "id": "coding-agent",
+      "name": "Coding Agent",
+      "description": "For coding assistants. Remembers project architecture, technical decisions, coding patterns, and user preferences across sessions. High literalism for precise technical recall.",
+      "category": "coding",
+      "integrations": [
+        "claude-code",
+        "codex"
+      ],
+      "manifest_file": "templates/coding-agent.json"
+    },
+    {
+      "id": "personal-assistant",
+      "name": "Personal Assistant",
+      "description": "For always-on personal assistants that manage tasks, remember preferences, and maintain context across daily life. Tracks commitments, routines, and personal context.",
+      "category": "assistant",
+      "integrations": [
+        "openclaw",
+        "hermes",
+        "nemoclaw",
+        "hindclaw"
+      ],
+      "manifest_file": "templates/personal-assistant.json"
+    }
+  ]
+}

--- a/hindsight-bank-templates/templates/coding-agent.json
+++ b/hindsight-bank-templates/templates/coding-agent.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, and recurring issues. Ignore transient debugging output and boilerplate.",
+    "enable_observations": true,
+    "observations_mission": "Track stable project facts: tech stack, team conventions, architecture patterns, and how the codebase evolves over time."
+  },
+  "mental_models": [
+    {
+      "id": "project-context",
+      "name": "Project Context",
+      "source_query": "What is the project's tech stack, architecture, and key conventions? What are the main components and how do they fit together?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "developer-preferences",
+      "name": "Developer Preferences",
+      "source_query": "What are the developer's preferences for tools, libraries, coding style, and workflow? How do they like code to be written and reviewed?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-bank-templates/templates/conversation.json
+++ b/hindsight-bank-templates/templates/conversation.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract user preferences, stated facts about themselves, requests they've made, topics they care about, and any commitments or follow-ups. Ignore small talk and filler.",
+    "enable_observations": true,
+    "observations_mission": "Track stable user preferences, communication style, recurring topics, and how the user's needs evolve over time."
+  },
+  "mental_models": [
+    {
+      "id": "user-profile",
+      "name": "User Profile",
+      "source_query": "What do we know about this user? What are their preferences, background, and how do they like to interact?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "open-threads",
+      "name": "Open Threads",
+      "source_query": "What topics, tasks, or follow-ups are still open or unresolved from past conversations?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-bank-templates/templates/personal-assistant.json
+++ b/hindsight-bank-templates/templates/personal-assistant.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "bank": {
+    "retain_mission": "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
+    "enable_observations": true,
+    "observations_mission": "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time."
+  },
+  "mental_models": [
+    {
+      "id": "user-profile",
+      "name": "User Profile",
+      "source_query": "What do we know about this user? What are their preferences, routines, important people, and how do they like to be helped?",
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    },
+    {
+      "id": "active-tasks",
+      "name": "Active Tasks & Commitments",
+      "source_query": "What tasks, commitments, or follow-ups is the user currently tracking? What deadlines or promises have been made?",
+      "max_tokens": 1024,
+      "trigger": {
+        "refresh_after_consolidation": true
+      }
+    }
+  ]
+}

--- a/hindsight-docs/src/pages/templates/index.module.css
+++ b/hindsight-docs/src/pages/templates/index.module.css
@@ -564,6 +564,24 @@
 .submitBannerText {
   font-size: 0.9rem;
   color: var(--ifm-color-emphasis-600);
-  margin-bottom: 0;
+  margin-bottom: 1.25rem;
   line-height: 1.6;
+}
+
+.submitButton {
+  display: inline-block;
+  padding: 0.55rem 1.4rem;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #0074d9, #009296);
+  color: #fff !important;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.submitButton:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+  color: #fff !important;
 }

--- a/hindsight-docs/src/pages/templates/index.tsx
+++ b/hindsight-docs/src/pages/templates/index.tsx
@@ -1,9 +1,13 @@
 import React, {useMemo, useState, useCallback} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import templatesData from '@site/src/data/templates.json';
 import integrationsData from '@site/src/data/integrations.json';
 import styles from './index.module.css';
+
+const TEMPLATES_SOURCE_URL =
+  'https://github.com/vectorize-io/hindsight/edit/main/hindsight-bank-templates/templates.json';
 
 const CATEGORIES = ['all', 'chat', 'coding', 'assistant'] as const;
 type Category = (typeof CATEGORIES)[number];
@@ -207,8 +211,16 @@ export default function TemplateGallery(): React.ReactElement {
           <div className={styles.submitBannerContent}>
             <h3 className={styles.submitBannerTitle}>Have a template to share?</h3>
             <p className={styles.submitBannerText}>
-              Add your template to the gallery by editing templates.json on GitHub.
+              Contribute it to the community. Open a pull request and add your entry to the
+              bank templates source package.
             </p>
+            <Link
+              href={TEMPLATES_SOURCE_URL}
+              className={styles.submitButton}
+              target="_blank"
+              rel="noopener noreferrer">
+              Submit a template &rarr;
+            </Link>
           </div>
         </div>
       </div>

--- a/scripts/generate-templates.sh
+++ b/scripts/generate-templates.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Generate hindsight-docs/src/data/templates.json from the
+# hindsight-bank-templates package. Flattens the catalog by inlining each
+# manifest file under the `manifest` field so the Templates Hub page can
+# consume a single committed import.
+#
+# Runs as part of the verify-generated-files CI job — re-run locally when
+# editing anything under hindsight-bank-templates/ and commit the regenerated
+# templates.json alongside your source change.
+#
+# Usage: ./scripts/generate-templates.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TPL_ROOT="$REPO_ROOT/hindsight-bank-templates"
+CATALOG="$TPL_ROOT/templates.json"
+OUT="$REPO_ROOT/hindsight-docs/src/data/templates.json"
+
+if [ ! -f "$CATALOG" ]; then
+  echo -e "\033[31m✗\033[0m Source catalog not found: $CATALOG" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo -e "\033[31m✗\033[0m jq is required but not installed" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+LEN=$(jq '.templates | length' "$CATALOG")
+RESULT='{"templates": []}'
+
+for i in $(seq 0 $((LEN - 1))); do
+  ENTRY=$(jq ".templates[$i]" "$CATALOG")
+  MANIFEST_FILE=$(echo "$ENTRY" | jq -r '.manifest_file')
+  MANIFEST_PATH="$TPL_ROOT/$MANIFEST_FILE"
+
+  if [ ! -f "$MANIFEST_PATH" ]; then
+    echo -e "\033[31m✗\033[0m Manifest not found: $MANIFEST_PATH" >&2
+    exit 1
+  fi
+
+  MANIFEST=$(jq '.' "$MANIFEST_PATH")
+  MERGED=$(echo "$ENTRY" | jq --argjson m "$MANIFEST" '. + {manifest: $m} | del(.manifest_file)')
+  RESULT=$(echo "$RESULT" | jq --argjson e "$MERGED" '.templates += [$e]')
+done
+
+echo "$RESULT" > "$OUT"
+COUNT=$(echo "$RESULT" | jq '.templates | length')
+echo -e "\033[32m✓\033[0m Generated $OUT ($COUNT templates)"


### PR DESCRIPTION
Moves the bank template catalog out of hindsight-docs/src/data/templates.json and into a new top-level package at hindsight-bank-templates/, modelled on hindsight-clients/ + scripts/generate-clients.sh. The source package holds per-file manifests plus a small catalog, and a shell script flattens it into hindsight-docs/src/data/templates.json when you run it.

The Templates Hub page and scripts/check-templates.mjs validator still read the committed flat file. The generator produces the same bytes as main.

- hindsight-bank-templates/templates.json: small catalog with manifest_file refs, one entry per template (id, name, description, category, integrations, manifest_file)
- hindsight-bank-templates/templates/{conversation,coding-agent, personal-assistant}.json: full manifest bodies lifted out of the previously inline catalog
- scripts/generate-templates.sh: pure bash + jq, reads the source package and writes hindsight-docs/src/data/templates.json. Matches the style of generate-openapi.sh, generate-clients.sh, generate-docs-skill.sh.
- .github/workflows/test.yml: add a generate-templates step to the existing verify-generated-files job so a PR that forgets to regenerate fails CI. The new script is also listed in the failure-hint command block.
- hindsight-docs/src/pages/templates/index.tsx + index.module.css: add a CTA button on the submit banner that opens the source catalog at hindsight-bank-templates/templates.json, so contributors edit the source instead of the generated output.

Why a top-level package instead of nesting under hindsight-docs/:

- Templates are data, not docs. Putting them at the repo root makes that explicit and opens the door for other consumers (hindsight-cli, SDKs, third-party tooling) to read from the same source without reaching into a docs subtree.
- Down the line this gives hindsight-cli somewhere natural to add a `hindsight template install <id> --bank <name>` subcommand that fetches manifests straight from the package instead of parsing a docs data file.
- Editing a template means touching two focused files (catalog + one manifest) instead of scrolling through a 130-line aggregated JSON to change a single retain_mission.
- The drift check in verify-generated-files catches the case where someone edits a manifest and forgets to rerun the script, the same way generate-clients.sh already catches SDK drift.

v2 of the "per-file manifest_file refs" approach. Same end result, different mechanics: the v1 branch resolves manifest_file at Docusaurus build time via require.context inside the Templates Hub page; this branch resolves it up front via a shell script and commits the flat output, so Docusaurus reads the file the same way it does on main. Pick whichever feels better to maintain.