### PR TITLE
feat(openclaw): session-scoped document_id and structured per-message timestamp

### DIFF
--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -150,7 +150,7 @@ Glob syntax:
 
 ## Retention details
 
-Retained documents use stable session-scoped IDs like `openclaw:agent:agentname:discord:channel:123:turn:000001` (or `...:window:000002` for chunked retention), and include richer metadata such as `session_key`, `agent_id`, `provider`, `channel_id`, `thread_id`, `sender_id`, `turn_index`, and `retention_scope`.
+Retained documents use stable session-scoped IDs derived from the OpenClaw `sessionKey`. By default (`retainDocumentScope: 'session'`) every retain in a session shares one document id like `openclaw:agent:agentname:discord:channel:123`, so all turns of the conversation accumulate under a single Hindsight document. Set `retainDocumentScope: 'turn'` to fall back to the per-retain ids (`...:turn:000001`, `...:window:000002` for chunked retention). Either way, retained documents include richer metadata such as `session_key`, `agent_id`, `provider`, `channel_id`, `thread_id`, `sender_id`, `turn_index`, and `retention_scope`. Each message in the retained JSON also carries a structured `timestamp` field (ISO 8601) lifted from OpenClaw's per-message time, so facts are not polluted by inline weekday/date prefixes.
 
 ## Documentation
 

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeRetainTags,
   extractInlineRetainTags,
   stripInlineRetainTags,
+  stripInlineTimestampPrefix,
 } from "./index.js";
 import type { PluginConfig, MemoryResult } from "./types.js";
 
@@ -342,7 +343,7 @@ describe("buildRetainRequest", () => {
 
     expect(request).toEqual({
       content: "hello world",
-      documentId: "openclaw:agent:main:main:turn:000001",
+      documentId: "openclaw:agent:main:main",
       metadata: {
         retained_at: expect.any(String),
         message_count: "2",
@@ -361,6 +362,28 @@ describe("buildRetainRequest", () => {
     });
   });
 
+  it("uses per-turn document ids when retainDocumentScope is 'turn'", () => {
+    const request = buildRetainRequest(
+      "hello world",
+      2,
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        messageProvider: "discord",
+        channelId: "channel:123",
+        senderId: "user:456",
+      },
+      {
+        retainSource: "openclaw",
+        retainDocumentScope: "turn",
+      },
+      1700000000000,
+      { turnIndex: 7 }
+    );
+
+    expect(request.documentId).toBe("openclaw:agent:main:main:turn:000007");
+  });
+
   it("uses window ids and metadata for chunked retention", () => {
     const request = buildRetainRequest(
       "hello world",
@@ -373,6 +396,7 @@ describe("buildRetainRequest", () => {
       },
       {
         retainSource: "openclaw",
+        retainDocumentScope: "turn",
       },
       1700000000000,
       {
@@ -444,6 +468,19 @@ describe("buildRetainRequest", () => {
   });
 });
 
+describe("stripInlineTimestampPrefix", () => {
+  it("strips weekday/date/time/GMT offset prefixes", () => {
+    expect(stripInlineTimestampPrefix("[Wed 2026-04-15 10:44 GMT+2] hello")).toBe("hello");
+    expect(stripInlineTimestampPrefix("[Mon 2026-01-05 9:07 GMT-5] x")).toBe("x");
+    expect(stripInlineTimestampPrefix("[Sun 2025-12-07 23:59:30 UTC] y")).toBe("y");
+  });
+
+  it("leaves unrelated content untouched", () => {
+    expect(stripInlineTimestampPrefix("just text")).toBe("just text");
+    expect(stripInlineTimestampPrefix("[Random] not a timestamp")).toBe("[Random] not a timestamp");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // prepareRetentionTranscript
 // ---------------------------------------------------------------------------
@@ -453,6 +490,53 @@ describe("prepareRetentionTranscript", () => {
     dynamicBankId: true,
     retainRoles: ["user", "assistant"],
   };
+
+  it("lifts message timestamps into a structured field and strips inline prefix (json+toolcalls)", () => {
+    const messages = [
+      {
+        role: "user",
+        timestamp: 1776246240000,
+        content: [{ type: "text", text: "[Wed 2026-04-15 10:44 GMT+2] just pick some news" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 1776246243000,
+        content: [{ type: "text", text: "Got it." }],
+      },
+    ];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.transcript);
+    expect(parsed).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "just pick some news" }],
+        timestamp: "2026-04-15T09:44:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Got it." }],
+        timestamp: "2026-04-15T09:44:03.000Z",
+      },
+    ]);
+  });
+
+  it("lifts message timestamps into a structured field (json without toolcalls)", () => {
+    const config: PluginConfig = { ...baseConfig, retainToolCalls: false };
+    const messages = [
+      {
+        role: "user",
+        timestamp: 1776246240000,
+        content: "[Wed 2026-04-15 10:44 GMT+2] hi there",
+      },
+    ];
+    const result = prepareRetentionTranscript(messages, config);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.transcript);
+    expect(parsed).toEqual([
+      { role: "user", content: "hi there", timestamp: "2026-04-15T09:44:00.000Z" },
+    ]);
+  });
 
   it("returns null if no user message found (turn boundary)", () => {
     const messages = [

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -453,6 +453,20 @@ export function stripInlineRetainTags(content: string): string {
 }
 
 /**
+ * Strip OpenClaw's inline timestamp prefix (e.g. "[Wed 2026-04-15 10:44 GMT+2] ")
+ * from the start of user-facing text. We lift this into a structured `timestamp`
+ * field on the retained message instead, so facts aren't polluted by a weekday
+ * prefix that varies per message.
+ */
+const INLINE_TIMESTAMP_PREFIX_RE =
+  /^\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{1,2}:\d{2}(?::\d{2})?\s+(?:GMT|UTC)(?:[+\-]\d{1,2}(?::\d{2})?)?\]\s*/;
+
+export function stripInlineTimestampPrefix(content: string): string {
+  if (!content) return content;
+  return content.replace(INLINE_TIMESTAMP_PREFIX_RE, "");
+}
+
+/**
  * Extract sender_id from OpenClaw's injected inbound metadata blocks.
  * Checks both "Conversation info (untrusted metadata)" and "Sender (untrusted metadata)" blocks.
  * Returns the first sender_id / id string found, or undefined if none.
@@ -2249,8 +2263,12 @@ export function buildRetainRequest(
   const turnIndex = options?.turnIndex ?? nextDocumentSequence(resolvedCtx);
   const retentionScope = options?.retentionScope || "turn";
   const documentBase = getSessionDocumentBase(resolvedCtx);
+  const documentScope = pluginConfig.retainDocumentScope ?? "session";
   const documentKind = retentionScope === "window" ? "window" : "turn";
-  const documentId = `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, "0")}`;
+  const documentId =
+    documentScope === "session"
+      ? documentBase
+      : `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, "0")}`;
   const provider = effectiveCtx?.messageProvider || parsedSession.provider;
   const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const channelType = effectiveCtx?.messageProvider;
@@ -2329,7 +2347,7 @@ export function prepareRetentionTranscript(
     return null; // No messages to retain
   }
 
-  const normalized: Array<{ role: string; content: string }> = [];
+  const normalized: Array<{ role: string; content: string; timestamp?: string }> = [];
   for (const msg of filteredMessages) {
     const role = msg.role || "unknown";
     let content = "";
@@ -2346,9 +2364,11 @@ export function prepareRetentionTranscript(
     content = stripMemoryTags(content);
     content = stripInlineRetainTags(content);
     content = stripMetadataEnvelopes(content);
+    content = stripInlineTimestampPrefix(content);
 
     if (content.trim()) {
-      normalized.push({ role, content });
+      const timestamp = normalizeMessageTimestamp(msg);
+      normalized.push(timestamp ? { role, content, timestamp } : { role, content });
     }
   }
 
@@ -2388,9 +2408,9 @@ const TOOL_RESULT_MAX_CHARS = 2000;
 function buildAnthropicStructuredMessages(
   messages: any[],
   pluginConfig: PluginConfig
-): Array<{ role: string; content: any[] }> {
+): Array<{ role: string; content: any[]; timestamp?: string }> {
   const allowedRoles = new Set(pluginConfig.retainRoles || ["user", "assistant"]);
-  const out: Array<{ role: string; content: any[] }> = [];
+  const out: Array<{ role: string; content: any[]; timestamp?: string }> = [];
 
   for (const msg of messages) {
     const rawRole = msg?.role;
@@ -2417,16 +2437,32 @@ function buildAnthropicStructuredMessages(
 
     const blocks = extractStructuredBlocks(msg.content, rawRole);
     if (blocks.length > 0) {
-      out.push({ role: rawRole, content: blocks });
+      const timestamp = normalizeMessageTimestamp(msg);
+      out.push(
+        timestamp
+          ? { role: rawRole, content: blocks, timestamp }
+          : { role: rawRole, content: blocks }
+      );
     }
   }
 
   return out;
 }
 
+function normalizeMessageTimestamp(msg: any): string | undefined {
+  const raw = msg?.timestamp;
+  if (raw === undefined || raw === null) return undefined;
+  const date =
+    typeof raw === "number" ? new Date(raw) : typeof raw === "string" ? new Date(raw) : undefined;
+  if (!date || Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
 function extractStructuredBlocks(content: any, role: string): any[] {
   if (typeof content === "string") {
-    const cleaned = stripMetadataEnvelopes(stripInlineRetainTags(stripMemoryTags(content))).trim();
+    const cleaned = stripInlineTimestampPrefix(
+      stripMetadataEnvelopes(stripInlineRetainTags(stripMemoryTags(content)))
+    ).trim();
     return cleaned ? [{ type: "text", text: cleaned }] : [];
   }
   if (!Array.isArray(content)) return [];
@@ -2437,8 +2473,8 @@ function extractStructuredBlocks(content: any, role: string): any[] {
     const blockType = block.type;
 
     if (blockType === "text") {
-      const cleaned = stripMetadataEnvelopes(
-        stripInlineRetainTags(stripMemoryTags(block.text ?? ""))
+      const cleaned = stripInlineTimestampPrefix(
+        stripMetadataEnvelopes(stripInlineRetainTags(stripMemoryTags(block.text ?? "")))
       ).trim();
       if (cleaned) blocks.push({ type: "text", text: cleaned });
     } else if (blockType === "toolCall" && role === "assistant") {

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -81,6 +81,7 @@ export interface PluginConfig {
   recallMaxTokens?: number; // Max tokens for recall response. Default: 1024
   recallTypes?: Array<"world" | "experience" | "observation">; // Memory types to recall. Default: ['world', 'experience']
   recallRoles?: Array<"user" | "assistant" | "system" | "tool">; // Roles to include when composing contextual recall query. Default: ['user', 'assistant']
+  retainDocumentScope?: "session" | "turn"; // Granularity of the retained document_id. 'session' (default) groups all retains under a single document per OpenClaw session (`openclaw:{sessionKey}`). 'turn' produces a new document per retain (`openclaw:{sessionKey}:turn:NNNNNN` / `:window:NNNNNN`).
   retainEveryNTurns?: number; // Retain every Nth turn (1 = every turn, default: 1). Values > 1 enable chunked retention.
   retainOverlapTurns?: number; // Extra prior turns included when chunked retention fires (default: 0). Window = retainEveryNTurns + retainOverlapTurns.
   recallTopK?: number; // Max number of memories to inject. Default: unlimited


### PR DESCRIPTION
## Summary

- **Session-scoped document ids.** New `retainDocumentScope` plugin config (default `'session'`) so every retain within an OpenClaw session shares one Hindsight document id (`openclaw:{sessionKey}`). Set `retainDocumentScope: 'turn'` to keep the legacy per-retain ids (`...:turn:NNNNNN`, `...:window:NNNNNN`). Fixes the bug where each turn minted a brand-new document and an in-memory counter meant post-restart turns could even collide as `turn:000001`.
- **Structured per-message `timestamp` field.** Each message in the retained JSON now carries an ISO-8601 `timestamp` lifted from OpenClaw's `msg.timestamp`, and the inline `[Www YYYY-MM-DD HH:MM GMT±N]` prefix OpenClaw injects into user text is stripped. Facts extracted from retained content are no longer contaminated by weekday/date prefixes that vary per turn.

Sample retained message payload:

\`\`\`json
[
  {
    "role": "user",
    "content": [{"type": "text", "text": "just pick some news"}],
    "timestamp": "2026-04-15T09:44:00.000Z"
  }
]
\`\`\`

## Test plan

- [x] `npm run build` clean
- [x] `npm test -- --run src/index.test.ts` — 186/186 passing, with new coverage for both `retainDocumentScope: 'turn'` and the timestamp-lift path (json-with-toolcalls and json-without-toolcalls).
- [x] `./scripts/hooks/lint.sh` — all lints passing
- [x] Smoke-tested against the installed plugin locally: `prepareRetentionTranscript` emits `timestamp` field and stripped text; `buildRetainRequest` produces `openclaw:agent:news-feed:main` as document_id by default.
- [ ] Reviewer: spot-check the README copy in `Retention details`.