### PR TITLE
fix(control-plane): encode bank ids in URLs end-to-end

### DIFF
--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -13,7 +13,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const { searchParams } = new URL(request.url);
     const query = searchParams.toString();
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/audit-logs${query ? `?${query}` : ""}`;
+    const url = dataplaneBankUrl(bankId, `/audit-logs${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
       headers: getDataplaneHeaders(),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -11,7 +11,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const { searchParams } = new URL(request.url);
     const query = searchParams.toString();
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/audit-logs/stats${query ? `?${query}` : ""}`;
+    const url = dataplaneBankUrl(bankId, `/audit-logs/stats${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
       headers: getDataplaneHeaders(),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: Request,
@@ -13,7 +13,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/directives/${directiveId}`,
+      dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
       { method: "GET", headers: getDataplaneHeaders() }
     );
 
@@ -45,7 +45,7 @@ export async function PATCH(
     const body = await request.json();
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/directives/${directiveId}`,
+      dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
       {
         method: "PATCH",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
@@ -82,7 +82,7 @@ export async function DELETE(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/directives/${directiveId}`,
+      dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
       { method: "DELETE", headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -20,7 +20,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       queryParams.append("tags_match", tagsMatch);
     }
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/directives${queryParams.toString() ? `?${queryParams}` : ""}`;
+    const url = dataplaneBankUrl(
+      bankId,
+      `/directives${queryParams.toString() ? `?${queryParams}` : ""}`
+    );
     const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
 
     if (!response.ok) {
@@ -47,7 +50,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const body = await request.json();
 
-    const response = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/directives`, {
+    const response = await fetch(dataplaneBankUrl(bankId, "/directives"), {
       method: "POST",
       headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -8,7 +8,7 @@ export async function GET(
   try {
     const { bankId } = await params;
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(bankId)}/export`;
+    const url = dataplaneBankUrl(bankId, "/export");
     const response = await fetch(url, {
       headers: getDataplaneHeaders(),
     });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +11,7 @@ export async function POST(
     const dryRun = request.nextUrl.searchParams.get("dry_run") === "true";
 
     // Direct fetch since the SDK doesn't have this operation yet
-    const url = `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(bankId)}/import${dryRun ? "?dry_run=true" : ""}`;
+    const url = dataplaneBankUrl(bankId, `/import${dryRun ? "?dry_run=true" : ""}`);
     const response = await fetch(url, {
       method: "POST",
       headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   _request: Request,
@@ -16,7 +16,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models/${mentalModelId}/history`,
+      dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`),
       { method: "GET", headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function POST(
   request: Request,
@@ -16,7 +16,7 @@ export async function POST(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models/${mentalModelId}/refresh`,
+      dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/refresh`),
       { method: "POST", headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: Request,
@@ -16,7 +16,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models/${mentalModelId}`,
+      dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
       { method: "GET", headers: getDataplaneHeaders() }
     );
 
@@ -54,7 +54,7 @@ export async function PATCH(
     const body = await request.json();
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models/${mentalModelId}`,
+      dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
       {
         method: "PATCH",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
@@ -94,7 +94,7 @@ export async function DELETE(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models/${mentalModelId}`,
+      dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
       { method: "DELETE", headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -20,7 +20,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       queryParams.append("tags_match", tagsMatch);
     }
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models${queryParams.toString() ? `?${queryParams}` : ""}`;
+    const url = dataplaneBankUrl(
+      bankId,
+      `/mental-models${queryParams.toString() ? `?${queryParams}` : ""}`
+    );
     const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
 
     if (!response.ok) {
@@ -50,7 +53,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const body = await request.json();
 
-    const response = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/mental-models`, {
+    const response = await fetch(dataplaneBankUrl(bankId, "/mental-models"), {
       method: "POST",
       headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: Request,
@@ -13,7 +13,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/memories/${modelId}`,
+      dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(modelId)}`),
       { method: "GET", headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { sdk, lowLevelClient, DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: Request,
@@ -52,7 +52,7 @@ export async function POST(
       return NextResponse.json({ error: "operation_id is required" }, { status: 400 });
     }
 
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/operations/${operationId}/retry`;
+    const url = dataplaneBankUrl(bankId, `/operations/${encodeURIComponent(operationId)}/retry`);
     const response = await fetch(url, {
       method: "POST",
       headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: Request,
@@ -12,7 +12,7 @@ export async function GET(
   const qs = new URLSearchParams({ limit });
   if (cursor) qs.set("cursor", cursor);
   const res = await fetch(
-    `${DATAPLANE_URL}/v1/default/banks/${bankId}/webhooks/${webhookId}/deliveries?${qs}`,
+    dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}/deliveries?${qs}`),
     {
       headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
     }

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function PATCH(
   request: Request,
@@ -7,7 +7,7 @@ export async function PATCH(
 ) {
   const { bankId, webhookId } = await params;
   const body = await request.json();
-  const res = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/webhooks/${webhookId}`, {
+  const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "PATCH",
     headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify(body),
@@ -22,7 +22,7 @@ export async function DELETE(
   { params }: { params: Promise<{ bankId: string; webhookId: string }> }
 ) {
   const { bankId, webhookId } = await params;
-  const res = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/webhooks/${webhookId}`, {
+  const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "DELETE",
     headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
   });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   const { bankId } = await params;
-  const res = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/webhooks`, {
+  const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
     headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
   });
   const data = await res.json();
@@ -14,7 +14,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
 export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   const { bankId } = await params;
   const body = await request.json();
-  const res = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/webhooks`, {
+  const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
     method: "POST",
     headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify(body),

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sdk, lowLevelClient, DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -41,7 +41,7 @@ export async function PATCH(
 
     const body = await request.json();
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}`,
+      dataplaneBankUrl(bankId, `/documents/${encodeURIComponent(documentId)}`),
       {
         method: "PATCH",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/files/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/files/retain/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Use the shared dataplane URL configuration
-    const url = `${DATAPLANE_URL}/v1/default/banks/${bankId}/files/retain`;
+    const url = dataplaneBankUrl(bankId, "/files/retain");
 
     // Forward the form data to the dataplane
     const response = await fetch(url, {

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -15,7 +15,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/memories/${memoryId}/history`,
+      dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}/history`),
       {
         method: "GET",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -15,7 +15,7 @@ export async function GET(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/memories/${memoryId}`,
+      dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
       {
         method: "GET",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -8,7 +8,10 @@ export async function GET(
   try {
     const { agentId } = await params;
     const period = request.nextUrl.searchParams.get("period") || "7d";
-    const url = `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(agentId)}/stats/memories-timeseries?period=${encodeURIComponent(period)}`;
+    const url = dataplaneBankUrl(
+      agentId,
+      `/stats/memories-timeseries?period=${encodeURIComponent(period)}`
+    );
     const upstream = await fetch(url, { headers: getDataplaneHeaders() });
     const body = await upstream.json();
     return NextResponse.json(body, { status: upstream.status });

--- a/hindsight-control-plane/src/app/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/banks/[bankId]/page.tsx
@@ -19,6 +19,7 @@ import { WebhooksView } from "@/components/webhooks-view";
 import { AuditLogsView } from "@/components/audit-logs-view";
 import { useFeatures } from "@/lib/features-context";
 import { useBank } from "@/lib/bank-context";
+import { bankRoute } from "@/lib/bank-url";
 import { client } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
@@ -68,15 +69,18 @@ export default function BankPage() {
   const [isResettingConfig, setIsResettingConfig] = useState(false);
 
   const handleTabChange = (tab: NavItem) => {
-    router.push(`/banks/${bankId}?view=${tab}`);
+    if (!bankId) return;
+    router.push(bankRoute(bankId, `?view=${tab}`));
   };
 
   const handleDataSubTabChange = (newSubTab: DataSubTab) => {
-    router.push(`/banks/${bankId}?view=data&subTab=${newSubTab}`);
+    if (!bankId) return;
+    router.push(bankRoute(bankId, `?view=data&subTab=${newSubTab}`));
   };
 
   const handleBankConfigTabChange = (newTab: BankConfigTab) => {
-    router.push(`/banks/${bankId}?view=profile&bankConfigTab=${newTab}`);
+    if (!bankId) return;
+    router.push(bankRoute(bankId, `?view=profile&bankConfigTab=${newTab}`));
   };
 
   const handleDeleteBank = async () => {

--- a/hindsight-control-plane/src/app/dashboard/page.tsx
+++ b/hindsight-control-plane/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { BankSelector } from "@/components/bank-selector";
 import { useBank } from "@/lib/bank-context";
+import { bankRoute } from "@/lib/bank-url";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -12,7 +13,7 @@ export default function DashboardPage() {
   // Redirect to bank page if a bank is selected
   useEffect(() => {
     if (currentBank) {
-      router.push(`/banks/${currentBank}?view=data`);
+      router.push(bankRoute(currentBank, "?view=data"));
     }
   }, [currentBank, router]);
 

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useBank } from "@/lib/bank-context";
+import { bankRoute } from "@/lib/bank-url";
 import { client } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
@@ -176,7 +177,7 @@ function BankSelectorInner() {
       setTemplateError(null);
       // Navigate to the new bank
       setCurrentBank(newBankId.trim());
-      router.push(`/banks/${newBankId.trim()}?view=data`);
+      router.push(bankRoute(newBankId.trim(), "?view=data"));
     } catch (error) {
       setCreateError(error instanceof Error ? error.message : "Failed to create bank");
     } finally {
@@ -321,7 +322,7 @@ function BankSelectorInner() {
       setUploadProgress("");
 
       // Navigate to documents view
-      router.push(`/banks/${currentBank}?view=documents`);
+      router.push(bankRoute(currentBank!, "?view=documents"));
     } catch {
       // Error toast is shown automatically by the API client interceptor
     } finally {
@@ -402,7 +403,7 @@ function BankSelectorInner() {
       setDocStrategy("");
 
       // Navigate to documents view to see the new document
-      router.push(`/banks/${currentBank}?view=documents`);
+      router.push(bankRoute(currentBank!, "?view=documents"));
     } catch {
       // Error toast is shown automatically by the API client interceptor
     } finally {
@@ -464,7 +465,7 @@ function BankSelectorInner() {
                         const queryString = subTab
                           ? `?view=${view}&subTab=${subTab}`
                           : `?view=${view}`;
-                        router.push(`/banks/${value}${queryString}`);
+                        router.push(bankRoute(value, queryString));
                       }}
                     >
                       <Check

--- a/hindsight-control-plane/src/components/sidebar.tsx
+++ b/hindsight-control-plane/src/components/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useBank } from "@/lib/bank-context";
+import { bankRoute } from "@/lib/bank-url";
 import { useFeatures } from "@/lib/features-context";
 import {
   Search,
@@ -53,7 +54,7 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
           {navItems.map((item) => {
             const Icon = item.icon;
             const isActive = currentTab === item.id;
-            const href = `/banks/${currentBank}?view=${item.id}`;
+            const href = bankRoute(currentBank, `?view=${item.id}`);
 
             return (
               <li key={item.id}>

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -4,6 +4,7 @@
  */
 
 import { toast } from "sonner";
+import { bankApi, bankStatsApi, documentApi, memoryApi } from "./bank-url";
 
 export interface WebhookHttpConfig {
   method: string;
@@ -212,7 +213,7 @@ export class ControlPlaneClient {
    */
   async importBankTemplate(bankId: string, manifest: Record<string, unknown>, dryRun = false) {
     const params = dryRun ? "?dry_run=true" : "";
-    return this.fetchApi<BankTemplateImportResponse>(`/api/banks/${bankId}/import${params}`, {
+    return this.fetchApi<BankTemplateImportResponse>(bankApi(bankId, `/import${params}`), {
       method: "POST",
       body: JSON.stringify(manifest),
     });
@@ -222,7 +223,7 @@ export class ControlPlaneClient {
    * Export a bank as a template manifest
    */
   async exportBankTemplate(bankId: string) {
-    return this.fetchApi<Record<string, unknown>>(`/api/banks/${bankId}/export`);
+    return this.fetchApi<Record<string, unknown>>(bankApi(bankId, "/export"));
   }
 
   /**
@@ -302,7 +303,7 @@ export class ControlPlaneClient {
    * Get bank statistics
    */
   async getBankStats(bankId: string) {
-    return this.fetchApi(`/api/stats/${bankId}`);
+    return this.fetchApi(bankStatsApi(bankId));
   }
 
   async getMemoriesTimeseries(bankId: string, period: string) {
@@ -316,7 +317,7 @@ export class ControlPlaneClient {
         experience: number;
         observation: number;
       }>;
-    }>(`/api/stats/${bankId}/memories-timeseries?period=${encodeURIComponent(period)}`);
+    }>(bankStatsApi(bankId, `/memories-timeseries?period=${encodeURIComponent(period)}`));
   }
 
   /**
@@ -367,7 +368,7 @@ export class ControlPlaneClient {
         status: string;
         error_message: string | null;
       }>;
-    }>(`/api/operations/${bankId}${query ? `?${query}` : ""}`);
+    }>(`/api/operations/${encodeURIComponent(bankId)}${query ? `?${query}` : ""}`);
   }
 
   /**
@@ -378,9 +379,12 @@ export class ControlPlaneClient {
       success: boolean;
       message: string;
       operation_id: string;
-    }>(`/api/operations/${bankId}?operation_id=${operationId}`, {
-      method: "DELETE",
-    });
+    }>(
+      `/api/operations/${encodeURIComponent(bankId)}?operation_id=${encodeURIComponent(operationId)}`,
+      {
+        method: "DELETE",
+      }
+    );
   }
 
   /**
@@ -391,7 +395,7 @@ export class ControlPlaneClient {
       success: boolean;
       message: string;
       operation_id: string;
-    }>(`/api/banks/${bankId}/operations/${operationId}`, {
+    }>(bankApi(bankId, `/operations/${encodeURIComponent(operationId)}`), {
       method: "POST",
     });
   }
@@ -445,16 +449,21 @@ export class ControlPlaneClient {
    * Get entity details
    */
   async getEntity(entityId: string, bankId: string) {
-    return this.fetchApi(`/api/entities/${entityId}?bank_id=${bankId}`);
+    return this.fetchApi(
+      `/api/entities/${encodeURIComponent(entityId)}?bank_id=${encodeURIComponent(bankId)}`
+    );
   }
 
   /**
    * Regenerate entity observations
    */
   async regenerateEntityObservations(entityId: string, bankId: string) {
-    return this.fetchApi(`/api/entities/${entityId}/regenerate?bank_id=${bankId}`, {
-      method: "POST",
-    });
+    return this.fetchApi(
+      `/api/entities/${encodeURIComponent(entityId)}/regenerate?bank_id=${encodeURIComponent(bankId)}`,
+      {
+        method: "POST",
+      }
+    );
   }
 
   /**
@@ -473,21 +482,18 @@ export class ControlPlaneClient {
    * Get document
    */
   async getDocument(documentId: string, bankId: string) {
-    return this.fetchApi(`/api/documents/${documentId}?bank_id=${bankId}`);
+    return this.fetchApi(documentApi(documentId, bankId));
   }
 
   /**
    * Update tags on a document and its associated memory units
    */
   async updateDocument(documentId: string, bankId: string, tags: string[]) {
-    return this.fetchApi<{ success: boolean }>(
-      `/api/documents/${encodeURIComponent(documentId)}?bank_id=${bankId}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tags }),
-      }
-    );
+    return this.fetchApi<{ success: boolean }>(documentApi(documentId, bankId), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tags }),
+    });
   }
 
   /**
@@ -499,7 +505,7 @@ export class ControlPlaneClient {
       message: string;
       document_id: string;
       memory_units_deleted: number;
-    }>(`/api/documents/${documentId}?bank_id=${bankId}`, {
+    }>(documentApi(documentId, bankId), {
       method: "DELETE",
     });
   }
@@ -512,7 +518,7 @@ export class ControlPlaneClient {
       success: boolean;
       message: string;
       deleted_count: number;
-    }>(`/api/banks/${bankId}`, {
+    }>(bankApi(bankId), {
       method: "DELETE",
     });
   }
@@ -525,7 +531,7 @@ export class ControlPlaneClient {
       success: boolean;
       message: string;
       deleted_count: number;
-    }>(`/api/banks/${bankId}/observations`, {
+    }>(bankApi(bankId, "/observations"), {
       method: "DELETE",
     });
   }
@@ -537,7 +543,7 @@ export class ControlPlaneClient {
     return this.fetchApi<{
       operation_id: string;
       deduplicated: boolean;
-    }>(`/api/banks/${bankId}/consolidate`, {
+    }>(bankApi(bankId, "/consolidate"), {
       method: "POST",
     });
   }
@@ -548,7 +554,7 @@ export class ControlPlaneClient {
   async recoverConsolidation(bankId: string) {
     return this.fetchApi<{
       retried_count: number;
-    }>(`/api/banks/${bankId}/consolidation-recover`, {
+    }>(bankApi(bankId, "/consolidation-recover"), {
       method: "POST",
     });
   }
@@ -587,7 +593,7 @@ export class ControlPlaneClient {
         changed_at: string;
         new_source_memory_ids: string[];
       }[];
-    }>(`/api/memories/${memoryId}?bank_id=${bankId}`);
+    }>(memoryApi(memoryId, bankId));
   }
 
   /**
@@ -611,7 +617,7 @@ export class ControlPlaneClient {
           is_new: boolean;
         }[];
       }[]
-    >(`/api/memories/${memoryId}/history?bank_id=${bankId}`);
+    >(memoryApi(memoryId, bankId, "/history"));
   }
 
   /**
@@ -628,14 +634,14 @@ export class ControlPlaneClient {
       };
       mission: string;
       background?: string; // Deprecated, kept for backwards compatibility
-    }>(`/api/profile/${bankId}`);
+    }>(`/api/profile/${encodeURIComponent(bankId)}`);
   }
 
   /**
    * Set bank mission
    */
   async setBankMission(bankId: string, mission: string) {
-    return this.fetchApi(`/api/banks/${bankId}`, {
+    return this.fetchApi(bankApi(bankId), {
       method: "PATCH",
       body: JSON.stringify({ mission }),
     });
@@ -665,7 +671,7 @@ export class ControlPlaneClient {
         created_at: string;
         updated_at: string;
       }>;
-    }>(`/api/banks/${bankId}/directives${query ? `?${query}` : ""}`);
+    }>(bankApi(bankId, `/directives${query ? `?${query}` : ""}`));
   }
 
   /**
@@ -691,7 +697,7 @@ export class ControlPlaneClient {
       tags: string[];
       created_at: string;
       updated_at: string;
-    }>(`/api/banks/${bankId}/directives`, {
+    }>(bankApi(bankId, "/directives"), {
       method: "POST",
       body: JSON.stringify(params),
     });
@@ -711,14 +717,14 @@ export class ControlPlaneClient {
       tags: string[];
       created_at: string;
       updated_at: string;
-    }>(`/api/banks/${bankId}/directives/${directiveId}`);
+    }>(bankApi(bankId, `/directives/${encodeURIComponent(directiveId)}`));
   }
 
   /**
    * Delete a directive
    */
   async deleteDirective(bankId: string, directiveId: string) {
-    return this.fetchApi(`/api/banks/${bankId}/directives/${directiveId}`, {
+    return this.fetchApi(bankApi(bankId, `/directives/${encodeURIComponent(directiveId)}`), {
       method: "DELETE",
     });
   }
@@ -747,7 +753,7 @@ export class ControlPlaneClient {
       tags: string[];
       created_at: string;
       updated_at: string;
-    }>(`/api/banks/${bankId}/directives/${directiveId}`, {
+    }>(bankApi(bankId, `/directives/${encodeURIComponent(directiveId)}`), {
       method: "PATCH",
       body: JSON.stringify(params),
     });
@@ -785,7 +791,7 @@ export class ControlPlaneClient {
         error_message: string | null;
       }> | null;
       task_payload?: Record<string, unknown> | null;
-    }>(`/api/banks/${bankId}/operations/${operationId}${qs}`);
+    }>(bankApi(bankId, `/operations/${encodeURIComponent(operationId)}${qs}`));
   }
 
   /**
@@ -803,7 +809,7 @@ export class ControlPlaneClient {
       mission?: string;
     }
   ) {
-    return this.fetchApi(`/api/profile/${bankId}`, {
+    return this.fetchApi(`/api/profile/${encodeURIComponent(bankId)}`, {
       method: "PUT",
       body: JSON.stringify(profile),
     });
@@ -847,7 +853,7 @@ export class ControlPlaneClient {
         created_at: string;
         updated_at: string;
       }>;
-    }>(`/api/banks/${bankId}/observations${query ? `?${query}` : ""}`);
+    }>(bankApi(bankId, `/observations${query ? `?${query}` : ""}`));
   }
 
   /**
@@ -876,7 +882,7 @@ export class ControlPlaneClient {
       }>;
       created_at: string;
       updated_at: string;
-    }>(`/api/banks/${bankId}/observations/${observationId}`);
+    }>(bankApi(bankId, `/observations/${encodeURIComponent(observationId)}`));
   }
 
   // ============= MENTAL MODELS (stored reflect responses) =============
@@ -920,7 +926,7 @@ export class ControlPlaneClient {
           based_on: Record<string, Array<{ id: string; text: string; type: string }>>;
         };
       }>;
-    }>(`/api/banks/${bankId}/mental-models${query ? `?${query}` : ""}`);
+    }>(bankApi(bankId, `/mental-models${query ? `?${query}` : ""}`));
   }
 
   /**
@@ -950,7 +956,7 @@ export class ControlPlaneClient {
   ) {
     return this.fetchApi<{
       operation_id: string;
-    }>(`/api/banks/${bankId}/mental-models`, {
+    }>(bankApi(bankId, "/mental-models"), {
       method: "POST",
       body: JSON.stringify(params),
     });
@@ -960,7 +966,9 @@ export class ControlPlaneClient {
    * Get a mental model
    */
   async getMentalModel(bankId: string, mentalModelId: string): Promise<MentalModel> {
-    return this.fetchApi<MentalModel>(`/api/banks/${bankId}/mental-models/${mentalModelId}`);
+    return this.fetchApi<MentalModel>(
+      bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`)
+    );
   }
 
   /**
@@ -1012,7 +1020,7 @@ export class ControlPlaneClient {
         text: string;
         based_on: Record<string, Array<{ id: string; text: string; type: string }>>;
       };
-    }>(`/api/banks/${bankId}/mental-models/${mentalModelId}`, {
+    }>(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`), {
       method: "PATCH",
       body: JSON.stringify(params),
     });
@@ -1022,7 +1030,7 @@ export class ControlPlaneClient {
    * Delete a mental model
    */
   async deleteMentalModel(bankId: string, mentalModelId: string) {
-    return this.fetchApi(`/api/banks/${bankId}/mental-models/${mentalModelId}`, {
+    return this.fetchApi(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`), {
       method: "DELETE",
     });
   }
@@ -1033,7 +1041,7 @@ export class ControlPlaneClient {
   async refreshMentalModel(bankId: string, mentalModelId: string) {
     return this.fetchApi<{
       operation_id: string;
-    }>(`/api/banks/${bankId}/mental-models/${mentalModelId}/refresh`, {
+    }>(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/refresh`), {
       method: "POST",
     });
   }
@@ -1047,7 +1055,7 @@ export class ControlPlaneClient {
         previous_content: string | null;
         changed_at: string;
       }[]
-    >(`/api/banks/${bankId}/mental-models/${mentalModelId}/history`);
+    >(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`));
   }
 
   /**
@@ -1134,7 +1142,7 @@ export class ControlPlaneClient {
       bank_id: string;
       config: Record<string, any>;
       overrides: Record<string, any>;
-    }>(`/api/banks/${bankId}/config`);
+    }>(bankApi(bankId, "/config"));
   }
 
   /**
@@ -1145,7 +1153,7 @@ export class ControlPlaneClient {
       bank_id: string;
       config: Record<string, any>;
       overrides: Record<string, any>;
-    }>(`/api/banks/${bankId}/config`, {
+    }>(bankApi(bankId, "/config"), {
       method: "PATCH",
       body: JSON.stringify({ updates }),
     });
@@ -1159,7 +1167,7 @@ export class ControlPlaneClient {
       bank_id: string;
       config: Record<string, any>;
       overrides: Record<string, any>;
-    }>(`/api/banks/${bankId}/config`, {
+    }>(bankApi(bankId, "/config"), {
       method: "DELETE",
     });
   }
@@ -1168,7 +1176,7 @@ export class ControlPlaneClient {
    * List webhooks for a bank
    */
   async listWebhooks(bankId: string): Promise<{ items: Webhook[] }> {
-    return this.fetchApi<{ items: Webhook[] }>(`/api/banks/${bankId}/webhooks`);
+    return this.fetchApi<{ items: Webhook[] }>(bankApi(bankId, "/webhooks"));
   }
 
   /**
@@ -1184,7 +1192,7 @@ export class ControlPlaneClient {
       http_config?: WebhookHttpConfig;
     }
   ): Promise<Webhook> {
-    return this.fetchApi<Webhook>(`/api/banks/${bankId}/webhooks`, {
+    return this.fetchApi<Webhook>(bankApi(bankId, "/webhooks"), {
       method: "POST",
       body: JSON.stringify(params),
     });
@@ -1204,7 +1212,7 @@ export class ControlPlaneClient {
       http_config?: WebhookHttpConfig;
     }
   ): Promise<Webhook> {
-    return this.fetchApi<Webhook>(`/api/banks/${bankId}/webhooks/${webhookId}`, {
+    return this.fetchApi<Webhook>(bankApi(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
       method: "PATCH",
       body: JSON.stringify(params),
     });
@@ -1214,9 +1222,12 @@ export class ControlPlaneClient {
    * Delete a webhook
    */
   async deleteWebhook(bankId: string, webhookId: string): Promise<{ success: boolean }> {
-    return this.fetchApi<{ success: boolean }>(`/api/banks/${bankId}/webhooks/${webhookId}`, {
-      method: "DELETE",
-    });
+    return this.fetchApi<{ success: boolean }>(
+      bankApi(bankId, `/webhooks/${encodeURIComponent(webhookId)}`),
+      {
+        method: "DELETE",
+      }
+    );
   }
 
   /**
@@ -1233,7 +1244,10 @@ export class ControlPlaneClient {
     if (cursor) params.append("cursor", cursor);
     const query = params.toString();
     return this.fetchApi<{ items: WebhookDelivery[]; next_cursor: string | null }>(
-      `/api/banks/${bankId}/webhooks/${webhookId}/deliveries${query ? `?${query}` : ""}`
+      bankApi(
+        bankId,
+        `/webhooks/${encodeURIComponent(webhookId)}/deliveries${query ? `?${query}` : ""}`
+      )
     );
   }
 
@@ -1260,7 +1274,7 @@ export class ControlPlaneClient {
     if (options?.offset) params.append("offset", options.offset.toString());
     const query = params.toString();
     return this.fetchApi<AuditLogsResponse>(
-      `/api/banks/${bankId}/audit-logs${query ? `?${query}` : ""}`
+      bankApi(bankId, `/audit-logs${query ? `?${query}` : ""}`)
     );
   }
 
@@ -1273,7 +1287,7 @@ export class ControlPlaneClient {
     if (options?.period) params.append("period", options.period);
     const query = params.toString();
     return this.fetchApi<AuditStatsResponse>(
-      `/api/banks/${bankId}/audit-logs/stats${query ? `?${query}` : ""}`
+      bankApi(bankId, `/audit-logs/stats${query ? `?${query}` : ""}`)
     );
   }
 }

--- a/hindsight-control-plane/src/lib/bank-url.ts
+++ b/hindsight-control-plane/src/lib/bank-url.ts
@@ -1,0 +1,39 @@
+/**
+ * Helpers for building URLs that include a bank id.
+ *
+ * Bank ids are user-defined and may contain characters that are not URL-safe
+ * (e.g. openclaw composite ids like `agent-1::channel-2::user-3`, which contain
+ * `:` and may also contain `/`, `%`, spaces, etc.). They must be percent-encoded
+ * before being interpolated into a URL path or query string — both for client
+ * navigation (`/banks/...`) and for calls to the control-plane proxy
+ * (`/api/banks/...`).
+ *
+ * Always use these helpers instead of raw template literals.
+ */
+
+const enc = (value: string): string => encodeURIComponent(value);
+
+/** Page route for a bank in the control plane app router. */
+export function bankRoute(bankId: string, suffix = ""): string {
+  return `/banks/${enc(bankId)}${suffix}`;
+}
+
+/** Control-plane proxy URL under `/api/banks/...` for a bank-scoped endpoint. */
+export function bankApi(bankId: string, suffix = ""): string {
+  return `/api/banks/${enc(bankId)}${suffix}`;
+}
+
+/** Control-plane proxy URL under `/api/stats/...` for bank statistics. */
+export function bankStatsApi(bankId: string, suffix = ""): string {
+  return `/api/stats/${enc(bankId)}${suffix}`;
+}
+
+/** Control-plane proxy URL for memory operations scoped to a bank via query string. */
+export function memoryApi(memoryId: string, bankId: string, suffix = ""): string {
+  return `/api/memories/${enc(memoryId)}${suffix}${suffix.includes("?") ? "&" : "?"}bank_id=${enc(bankId)}`;
+}
+
+/** Control-plane proxy URL for document operations scoped to a bank via query string. */
+export function documentApi(documentId: string, bankId: string): string {
+  return `/api/documents/${enc(documentId)}?bank_id=${enc(bankId)}`;
+}

--- a/hindsight-control-plane/src/lib/hindsight-client.ts
+++ b/hindsight-control-plane/src/lib/hindsight-client.ts
@@ -26,6 +26,15 @@ export function getDataplaneHeaders(extra?: Record<string, string>): Record<stri
 }
 
 /**
+ * Build a dataplane URL for a bank-scoped endpoint with the bank id properly encoded.
+ * Bank ids may contain `:`, `/`, `%`, etc. (e.g. openclaw `agent::channel::user`),
+ * which must be percent-encoded before being interpolated into a URL path.
+ */
+export function dataplaneBankUrl(bankId: string, suffix = ""): string {
+  return `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
+}
+
+/**
  * High-level client with convenience methods
  */
 export const hindsightClient = new HindsightClient({


### PR DESCRIPTION
## Summary

Bank ids can contain URL-unsafe characters (e.g. openclaw composite ids like `agent-1::channel-2::user-3`, or ids with `/`, `%`, spaces). Most control-plane code interpolated them raw into URLs, which broke:

- Next.js client-side navigation (`router.push(`/banks/${bankId}?view=...`)`)
- Control-plane proxy endpoints (`/api/banks/${bankId}/...`)
- Direct fetches to the dataplane (`${DATAPLANE_URL}/v1/default/banks/${bankId}/...`)

Only a handful of routes (export/import/memories-timeseries) encoded correctly, so behavior was inconsistent — some pages/requests worked, others 404'd or routed to the wrong place.

This PR adds helpers and routes every bank-id URL interpolation through them:

- `src/lib/bank-url.ts` — `bankRoute`, `bankApi`, `bankStatsApi`, `memoryApi`, `documentApi` for client-side navigation and the `/api/*` proxy.
- `dataplaneBankUrl` in `src/lib/hindsight-client.ts` for server-side proxy routes.

Migrates ~40 call sites across the control-plane client (`lib/api.ts`), navigation (sidebar, bank selector, dashboard, bank page), and all direct-fetch server routes (directives, webhooks, mental-models, audit-logs, operations, observations, memories, documents, files, stats, export, import). SDK-based routes are unchanged — the SDK already encodes path params.

Refs #1069. This resolves the control-plane half of that issue; the openclaw `::`-separator swap is a separate cosmetic change for DB/log readability.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `./scripts/hooks/lint.sh` passes (verified locally)
- [ ] Manually create a bank with id like `agent::chan::user` and confirm: sidebar links work, bank page loads, recall/reflect/documents/entities views load, config/webhooks/audit-logs tabs load, delete/reset dialogs work, export/import round-trip.