### PR TITLE
feat(cli): add named connection profiles (-p/--profile)

### DIFF
--- a/hindsight-cli/src/config.rs
+++ b/hindsight-cli/src/config.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 const DEFAULT_API_URL: &str = "http://localhost:8888";
 const CONFIG_FILE_NAME: &str = "config";
 const CONFIG_DIR_NAME: &str = ".hindsight";
+const PROFILE_DIR_NAME: &str = "cli-profiles";
+const PROFILE_ENV_VAR: &str = "HINDSIGHT_PROFILE";
 
 #[derive(Debug)]
 pub struct Config {
@@ -18,6 +20,7 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConfigSource {
     LocalFile,
+    Profile(String),
     Environment,
     Default,
 }
@@ -26,6 +29,7 @@ impl std::fmt::Display for ConfigSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigSource::LocalFile => write!(f, "config file"),
+            ConfigSource::Profile(name) => write!(f, "profile '{}'", name),
             ConfigSource::Environment => write!(f, "environment variable"),
             ConfigSource::Default => write!(f, "default"),
         }
@@ -33,27 +37,43 @@ impl std::fmt::Display for ConfigSource {
 }
 
 impl Config {
-    /// Load configuration with the following priority:
-    /// 1. Environment variable (HINDSIGHT_API_URL, HINDSIGHT_API_KEY) - highest priority, for overrides
-    /// 2. Local config file (~/.hindsight/config.toml)
-    /// 3. Default (http://localhost:8888)
+    /// Load configuration with no explicit profile. See [`Self::load_with_profile`].
     pub fn load() -> Result<Self> {
-        // Load API key from environment (highest priority)
+        Self::load_with_profile(None)
+    }
+
+    /// Load configuration with the following priority:
+    /// 1. Environment variable (HINDSIGHT_API_URL/HINDSIGHT_API_KEY) - highest priority
+    /// 2. Named profile (from `profile_name` arg, else `$HINDSIGHT_PROFILE`)
+    ///    at `~/.hindsight/cli-profiles/<name>.toml`
+    /// 3. Local config file (`~/.hindsight/config`)
+    /// 4. Default (http://localhost:8888)
+    pub fn load_with_profile(profile_name: Option<&str>) -> Result<Self> {
         let env_api_key = env::var("HINDSIGHT_API_KEY").ok();
 
-        // 1. Environment variable takes highest priority (for overrides)
+        // 1. Environment variable takes highest priority
         if let Ok(api_url) = env::var("HINDSIGHT_API_URL") {
             return Self::validate_and_create(api_url, env_api_key, ConfigSource::Environment);
         }
 
-        // 2. Try local config file
+        // 2. Named profile (explicit flag takes precedence over env var)
+        let resolved_profile: Option<String> = profile_name
+            .map(|s| s.to_string())
+            .or_else(|| env::var(PROFILE_ENV_VAR).ok().filter(|s| !s.is_empty()));
+
+        if let Some(name) = resolved_profile {
+            let (api_url, file_api_key) = Self::load_profile(&name)?;
+            let api_key = env_api_key.or(file_api_key);
+            return Self::validate_and_create(api_url, api_key, ConfigSource::Profile(name));
+        }
+
+        // 3. Local config file
         if let Some((api_url, file_api_key)) = Self::load_from_file()? {
-            // Environment api_key takes precedence over file api_key
             let api_key = env_api_key.or(file_api_key);
             return Self::validate_and_create(api_url, api_key, ConfigSource::LocalFile);
         }
 
-        // 3. Fall back to default
+        // 4. Fall back to default
         Self::validate_and_create(DEFAULT_API_URL.to_string(), env_api_key, ConfigSource::Default)
     }
 
@@ -151,6 +171,173 @@ impl Config {
     pub fn api_url(&self) -> &str {
         &self.api_url
     }
+
+    // ---------- profile support ----------
+
+    pub fn profile_dir() -> Option<PathBuf> {
+        Self::config_dir().map(|dir| dir.join(PROFILE_DIR_NAME))
+    }
+
+    pub fn profile_file_path(name: &str) -> Option<PathBuf> {
+        Self::profile_dir().map(|dir| dir.join(format!("{}.toml", name)))
+    }
+
+    /// Load a named profile. Returns (api_url, api_key) or an error if the profile
+    /// file is missing / malformed.
+    pub fn load_profile(name: &str) -> Result<(String, Option<String>)> {
+        validate_profile_name(name)?;
+        let dir = Self::profile_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        load_profile_from_dir(&dir, name)
+    }
+
+    /// Save a named profile to `~/.hindsight/cli-profiles/<name>.toml`.
+    /// Sets file permissions to 0600 on Unix to protect the API key.
+    pub fn save_profile(name: &str, api_url: &str, api_key: Option<&str>) -> Result<PathBuf> {
+        validate_profile_name(name)?;
+        let dir = Self::profile_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        save_profile_to_dir(&dir, name, api_url, api_key)
+    }
+
+    /// List profile names (without `.toml` extension), sorted alphabetically.
+    pub fn list_profiles() -> Result<Vec<String>> {
+        let dir = match Self::profile_dir() {
+            Some(d) => d,
+            None => return Ok(vec![]),
+        };
+        list_profiles_in_dir(&dir)
+    }
+
+    /// Delete a named profile. Returns Ok(path) on success. Errors if the profile
+    /// does not exist.
+    pub fn delete_profile(name: &str) -> Result<PathBuf> {
+        validate_profile_name(name)?;
+        let path = Self::profile_file_path(name)
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        if !path.exists() {
+            anyhow::bail!("profile '{}' not found at {}", name, path.display());
+        }
+        fs::remove_file(&path)
+            .with_context(|| format!("Failed to delete profile file: {}", path.display()))?;
+        Ok(path)
+    }
+}
+
+fn load_profile_from_dir(dir: &std::path::Path, name: &str) -> Result<(String, Option<String>)> {
+    let path = dir.join(format!("{}.toml", name));
+    if !path.exists() {
+        anyhow::bail!(
+            "profile '{}' not found at {}; create with: hindsight profile create {} --api-url <url>",
+            name,
+            path.display(),
+            name
+        );
+    }
+
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read profile file: {}", path.display()))?;
+
+    let mut api_url: Option<String> = None;
+    let mut api_key: Option<String> = None;
+
+    for line in content.lines() {
+        if let Some(v) = parse_config_value(line, "api_url") {
+            api_url = Some(v);
+        } else if let Some(v) = parse_config_value(line, "api_key") {
+            api_key = Some(v);
+        }
+    }
+
+    let api_url = api_url.ok_or_else(|| {
+        anyhow::anyhow!(
+            "profile '{}' at {} is missing required 'api_url' field",
+            name,
+            path.display()
+        )
+    })?;
+
+    Ok((api_url, api_key))
+}
+
+fn save_profile_to_dir(
+    dir: &std::path::Path,
+    name: &str,
+    api_url: &str,
+    api_key: Option<&str>,
+) -> Result<PathBuf> {
+    if !api_url.starts_with("http://") && !api_url.starts_with("https://") {
+        anyhow::bail!(
+            "Invalid API URL: {}. Must start with http:// or https://",
+            api_url
+        );
+    }
+
+    if !dir.exists() {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create profile directory: {}", dir.display()))?;
+    }
+
+    let path = dir.join(format!("{}.toml", name));
+    let mut content = format!("api_url = \"{}\"\n", api_url);
+    if let Some(key) = api_key {
+        content.push_str(&format!("api_key = \"{}\"\n", key));
+    }
+
+    fs::write(&path, content)
+        .with_context(|| format!("Failed to write profile file: {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&path, perms).with_context(|| {
+            format!("Failed to set permissions on profile file: {}", path.display())
+        })?;
+    }
+
+    Ok(path)
+}
+
+fn list_profiles_in_dir(dir: &std::path::Path) -> Result<Vec<String>> {
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut names: Vec<String> = fs::read_dir(dir)
+        .with_context(|| format!("Failed to read profile directory: {}", dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("toml") {
+                return None;
+            }
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+        })
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+/// Reject empty, path-like, or hidden profile names so they can't escape the
+/// profile directory.
+fn validate_profile_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("profile name cannot be empty");
+    }
+    if name.starts_with('.')
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || name.contains(char::is_whitespace)
+    {
+        anyhow::bail!(
+            "invalid profile name '{}': must not contain path separators, whitespace, or start with '.'",
+            name
+        );
+    }
+    Ok(())
 }
 
 /// Prompt user for API URL interactively
@@ -197,6 +384,104 @@ mod tests {
         assert_eq!(format!("{}", ConfigSource::LocalFile), "config file");
         assert_eq!(format!("{}", ConfigSource::Environment), "environment variable");
         assert_eq!(format!("{}", ConfigSource::Default), "default");
+        assert_eq!(
+            format!("{}", ConfigSource::Profile("prod".to_string())),
+            "profile 'prod'"
+        );
+    }
+
+    fn tempdir() -> PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = std::sync::atomic::AtomicU64::new(0);
+        let n = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("hindsight-cli-test-{}-{}-{}", pid, nanos, n));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_validate_profile_name_ok() {
+        assert!(validate_profile_name("prod").is_ok());
+        assert!(validate_profile_name("staging-1").is_ok());
+        assert!(validate_profile_name("openclaw-plugin").is_ok());
+        assert!(validate_profile_name("a_b_c").is_ok());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_unsafe() {
+        assert!(validate_profile_name("").is_err());
+        assert!(validate_profile_name(".hidden").is_err());
+        assert!(validate_profile_name("a/b").is_err());
+        assert!(validate_profile_name("a\\b").is_err());
+        assert!(validate_profile_name("..").is_err());
+        assert!(validate_profile_name("foo bar").is_err());
+    }
+
+    #[test]
+    fn test_save_and_load_profile_roundtrip() {
+        let dir = tempdir();
+        let path = save_profile_to_dir(&dir, "prod", "https://api.example.com", Some("hsk_abc"))
+            .unwrap();
+        assert!(path.exists());
+
+        let (url, key) = load_profile_from_dir(&dir, "prod").unwrap();
+        assert_eq!(url, "https://api.example.com");
+        assert_eq!(key.as_deref(), Some("hsk_abc"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn test_save_profile_rejects_invalid_url() {
+        let dir = tempdir();
+        let err = save_profile_to_dir(&dir, "foo", "localhost:8888", None).unwrap_err();
+        assert!(err.to_string().contains("Invalid API URL"));
+    }
+
+    #[test]
+    fn test_load_profile_missing_returns_helpful_error() {
+        let dir = tempdir();
+        let err = load_profile_from_dir(&dir, "nope").unwrap_err().to_string();
+        assert!(err.contains("profile 'nope' not found"));
+        assert!(err.contains("hindsight profile create nope"));
+    }
+
+    #[test]
+    fn test_load_profile_missing_api_url_fails() {
+        let dir = tempdir();
+        let path = dir.join("broken.toml");
+        std::fs::write(&path, "api_key = \"x\"\n").unwrap();
+        let err = load_profile_from_dir(&dir, "broken").unwrap_err().to_string();
+        assert!(err.contains("missing required 'api_url'"));
+    }
+
+    #[test]
+    fn test_list_profiles_returns_sorted_names() {
+        let dir = tempdir();
+        save_profile_to_dir(&dir, "prod", "https://prod.example.com", None).unwrap();
+        save_profile_to_dir(&dir, "dev", "https://dev.example.com", None).unwrap();
+        save_profile_to_dir(&dir, "staging", "https://staging.example.com", None).unwrap();
+        // Non-toml files should be ignored.
+        std::fs::write(dir.join("README"), "hi").unwrap();
+
+        let names = list_profiles_in_dir(&dir).unwrap();
+        assert_eq!(names, vec!["dev", "prod", "staging"]);
+    }
+
+    #[test]
+    fn test_list_profiles_missing_dir_is_empty() {
+        let dir = tempdir().join("nonexistent");
+        let names = list_profiles_in_dir(&dir).unwrap();
+        assert!(names.is_empty());
     }
 
     #[test]

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1131,7 +1131,8 @@ enum DirectiveCommands {
 }
 
 fn main() {
-    if let Err(_) = run() {
+    if let Err(e) = run() {
+        ui::print_error(&format!("{:#}", e));
         std::process::exit(1);
     }
 }

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -45,6 +45,12 @@ struct Cli {
     #[arg(short = 'v', long, global = true)]
     verbose: bool,
 
+    /// Named profile to load from ~/.hindsight/cli-profiles/<name>.toml
+    /// (env var HINDSIGHT_PROFILE is used if this flag is omitted).
+    /// Environment variables (HINDSIGHT_API_URL / HINDSIGHT_API_KEY) still override profile values.
+    #[arg(short = 'p', long, global = true, env = "HINDSIGHT_PROFILE")]
+    profile: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -129,7 +135,7 @@ enum Commands {
 
     /// Configure the CLI (API URL, API key, etc.)
     #[command(
-        after_help = "Configuration priority:\n  1. Environment variables (HINDSIGHT_API_URL, HINDSIGHT_API_KEY) - highest priority\n  2. Config file (~/.hindsight/config)\n  3. Default (http://localhost:8888)"
+        after_help = "Configuration priority:\n  1. Environment variables (HINDSIGHT_API_URL, HINDSIGHT_API_KEY) - highest priority\n  2. Named profile (-p / HINDSIGHT_PROFILE, see 'hindsight profile')\n  3. Config file (~/.hindsight/config)\n  4. Default (http://localhost:8888)"
     )]
     Configure {
         /// API URL to connect to (interactive prompt if not provided)
@@ -138,6 +144,40 @@ enum Commands {
         /// API key for authentication (sent as Bearer token)
         #[arg(long)]
         api_key: Option<String>,
+    },
+
+    /// Manage named connection profiles (~/.hindsight/cli-profiles/<name>.toml)
+    #[command(subcommand)]
+    Profile(ProfileCommands),
+}
+
+#[derive(Subcommand)]
+enum ProfileCommands {
+    /// Create or overwrite a profile
+    Create {
+        /// Profile name (used with -p/--profile or $HINDSIGHT_PROFILE)
+        name: String,
+        /// API URL (required)
+        #[arg(long)]
+        api_url: String,
+        /// API key (optional; stored in profile file with 0600 permissions)
+        #[arg(long)]
+        api_key: Option<String>,
+    },
+    /// List all known profiles
+    List,
+    /// Show the contents of a profile
+    Show {
+        /// Profile name
+        name: String,
+    },
+    /// Delete a profile
+    Delete {
+        /// Profile name
+        name: String,
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
 }
 
@@ -1101,19 +1141,25 @@ fn run() -> Result<()> {
 
     let output_format: OutputFormat = cli.output.into();
     let verbose = cli.verbose;
+    let profile = cli.profile.clone();
 
     // Handle configure command before loading full config (it doesn't need API client)
     if let Commands::Configure { api_url, api_key } = cli.command {
         return handle_configure(api_url, api_key, output_format);
     }
 
+    // Handle profile management commands — no API client required.
+    if let Commands::Profile(cmd) = cli.command {
+        return handle_profile(cmd, output_format);
+    }
+
     // Handle ui command - needs config but not API client
     if let Commands::Ui = cli.command {
-        return handle_ui(output_format);
+        return handle_ui(profile.as_deref(), output_format);
     }
 
     // Load configuration
-    let config = Config::from_env().unwrap_or_else(|e| {
+    let config = Config::load_with_profile(profile.as_deref()).unwrap_or_else(|e| {
         ui::print_error(&format!("Configuration error: {}", e));
         errors::print_config_help();
         std::process::exit(1);
@@ -1130,6 +1176,7 @@ fn run() -> Result<()> {
     // Execute command and handle errors
     let result: Result<()> = match cli.command {
         Commands::Configure { .. } => unreachable!(), // Handled above
+        Commands::Profile(_) => unreachable!(),       // Handled above
         Commands::Ui => unreachable!(),               // Handled above
         Commands::Explore => commands::explore::run(&client),
 
@@ -1875,11 +1922,11 @@ fn handle_configure(
     Ok(())
 }
 
-fn handle_ui(output_format: OutputFormat) -> Result<()> {
+fn handle_ui(profile: Option<&str>, output_format: OutputFormat) -> Result<()> {
     use std::process::Command;
 
     // Load configuration to get the API URL
-    let config = Config::load().unwrap_or_else(|e| {
+    let config = Config::load_with_profile(profile).unwrap_or_else(|e| {
         ui::print_error(&format!("Configuration error: {}", e));
         errors::print_config_help();
         std::process::exit(1);
@@ -1920,4 +1967,119 @@ fn handle_ui(output_format: OutputFormat) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 8 {
+        format!("{}...{}", &key[..4], &key[key.len() - 4..])
+    } else {
+        "****".to_string()
+    }
+}
+
+fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<()> {
+    match cmd {
+        ProfileCommands::Create {
+            name,
+            api_url,
+            api_key,
+        } => {
+            let path = Config::save_profile(&name, &api_url, api_key.as_deref())?;
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Profile '{}' saved to {}", name, path.display()));
+                println!();
+                println!("  API URL: {}", api_url);
+                if let Some(ref key) = api_key {
+                    println!("  API Key: {}", mask_api_key(key));
+                }
+                println!();
+                println!(
+                    "Use with: hindsight -p {} <command>  (or export HINDSIGHT_PROFILE={})",
+                    name, name
+                );
+            } else {
+                let result = serde_json::json!({
+                    "name": name,
+                    "api_url": api_url,
+                    "api_key_set": api_key.is_some(),
+                    "path": path.display().to_string(),
+                });
+                output::print_output(&result, output_format)?;
+            }
+            Ok(())
+        }
+        ProfileCommands::List => {
+            let names = Config::list_profiles()?;
+            if output_format == OutputFormat::Pretty {
+                if names.is_empty() {
+                    ui::print_info("No profiles found.");
+                    println!();
+                    println!("Create one with: hindsight profile create <name> --api-url <url>");
+                } else {
+                    ui::print_info("Profiles:");
+                    for name in &names {
+                        println!("  • {}", name);
+                    }
+                }
+            } else {
+                output::print_output(&serde_json::json!({ "profiles": names }), output_format)?;
+            }
+            Ok(())
+        }
+        ProfileCommands::Show { name } => {
+            let (api_url, api_key) = Config::load_profile(&name)?;
+            let path = Config::profile_file_path(&name)
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            if output_format == OutputFormat::Pretty {
+                ui::print_info(&format!("Profile '{}'", name));
+                println!();
+                println!("  Path:    {}", path);
+                println!("  API URL: {}", api_url);
+                if let Some(ref key) = api_key {
+                    println!("  API Key: {}", mask_api_key(key));
+                }
+            } else {
+                let result = serde_json::json!({
+                    "name": name,
+                    "path": path,
+                    "api_url": api_url,
+                    "api_key_set": api_key.is_some(),
+                });
+                output::print_output(&result, output_format)?;
+            }
+            Ok(())
+        }
+        ProfileCommands::Delete { name, yes } => {
+            let path = Config::profile_file_path(&name)
+                .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+            if !path.exists() {
+                anyhow::bail!("profile '{}' not found at {}", name, path.display());
+            }
+            if !yes && output_format == OutputFormat::Pretty {
+                print!("Delete profile '{}' at {}? [y/N]: ", name, path.display());
+                std::io::Write::flush(&mut std::io::stdout())?;
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                if !matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
+                    ui::print_info("Aborted.");
+                    return Ok(());
+                }
+            }
+            let deleted = Config::delete_profile(&name)?;
+            if output_format == OutputFormat::Pretty {
+                ui::print_success(&format!("Deleted profile '{}' ({})", name, deleted.display()));
+            } else {
+                output::print_output(
+                    &serde_json::json!({
+                        "name": name,
+                        "path": deleted.display().to_string(),
+                        "deleted": true,
+                    }),
+                    output_format,
+                )?;
+            }
+            Ok(())
+        }
+    }
 }

--- a/hindsight-cli/tests/cli_profile.rs
+++ b/hindsight-cli/tests/cli_profile.rs
@@ -8,6 +8,15 @@
 //! a deliberately-unreachable URL so we can assert that the profile value
 //! (not the default `http://localhost:8888`) was picked up from the error
 //! message.
+//!
+//! These integration tests are Unix-only because they rely on overriding
+//! `$HOME` to redirect `dirs::home_dir()` at a tempdir. On Windows
+//! `dirs::home_dir()` resolves via `FOLDERID_Profile` (the Win32 shell API)
+//! and ignores the env var, so running these tests there would pollute the
+//! real user profile directory. The Windows runtime path is still exercised
+//! by the `config::tests::*` unit tests, which drive the path-based
+//! `save_profile_to_dir` / `load_profile_from_dir` helpers directly.
+#![cfg(unix)]
 
 use std::path::PathBuf;
 use std::process::{Command, Output};

--- a/hindsight-cli/tests/cli_profile.rs
+++ b/hindsight-cli/tests/cli_profile.rs
@@ -1,0 +1,312 @@
+//! End-to-end tests for the `hindsight profile` CRUD subcommands and the
+//! global `-p/--profile` flag.
+//!
+//! These tests do not require a running Hindsight API server: they exercise
+//! the binary against a temporary HOME directory and assert on the profile
+//! files it reads/writes. The only time a command is expected to contact the
+//! API is the `-p` precedence test, which uses `hindsight version` pointed at
+//! a deliberately-unreachable URL so we can assert that the profile value
+//! (not the default `http://localhost:8888`) was picked up from the error
+//! message.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_tempdir(tag: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("hindsight-profile-test-{}-{}-{}-{}", tag, pid, nanos, n));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn hindsight_binary() -> String {
+    std::env::var("CARGO_BIN_EXE_hindsight").unwrap_or_else(|_| {
+        let debug = "./target/debug/hindsight";
+        let release = "./target/release/hindsight";
+        if std::path::Path::new(debug).exists() {
+            debug.to_string()
+        } else if std::path::Path::new(release).exists() {
+            release.to_string()
+        } else {
+            "hindsight".to_string()
+        }
+    })
+}
+
+fn run_with_home(home: &std::path::Path, args: &[&str]) -> Output {
+    Command::new(hindsight_binary())
+        .env("HOME", home)
+        // Unset anything that would bypass the profile/config-file resolution
+        // we're trying to exercise here.
+        .env_remove("HINDSIGHT_API_URL")
+        .env_remove("HINDSIGHT_API_KEY")
+        .env_remove("HINDSIGHT_PROFILE")
+        .args(args)
+        .output()
+        .expect("failed to spawn hindsight binary")
+}
+
+fn assert_success(out: &Output) {
+    if !out.status.success() {
+        panic!(
+            "command failed: status={:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn profile_create_writes_toml_and_json_output() {
+    let home = unique_tempdir("create");
+    let out = run_with_home(
+        &home,
+        &[
+            "--output",
+            "json",
+            "profile",
+            "create",
+            "prod",
+            "--api-url",
+            "https://api.example.com",
+            "--api-key",
+            "hsk_abcdef1234",
+        ],
+    );
+    assert_success(&out);
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).expect("expected JSON output");
+    assert_eq!(payload["name"], "prod");
+    assert_eq!(payload["api_url"], "https://api.example.com");
+    assert_eq!(payload["api_key_set"], true);
+
+    let path = home.join(".hindsight/cli-profiles/prod.toml");
+    assert!(path.exists(), "profile file was not created at {}", path.display());
+    let body = std::fs::read_to_string(&path).unwrap();
+    assert!(body.contains("api_url = \"https://api.example.com\""));
+    assert!(body.contains("api_key = \"hsk_abcdef1234\""));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "profile file should be mode 0600");
+    }
+}
+
+#[test]
+fn profile_create_rejects_invalid_api_url() {
+    let home = unique_tempdir("invalid-url");
+    let out = run_with_home(
+        &home,
+        &["profile", "create", "foo", "--api-url", "localhost:8888"],
+    );
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("Invalid API URL"));
+}
+
+#[test]
+fn profile_create_rejects_unsafe_names() {
+    let home = unique_tempdir("unsafe-name");
+    for bad in &["..", ".hidden", "a/b", "a b"] {
+        let out = run_with_home(
+            &home,
+            &["profile", "create", bad, "--api-url", "https://example.com"],
+        );
+        assert!(
+            !out.status.success(),
+            "expected failure for profile name {:?}",
+            bad
+        );
+    }
+}
+
+#[test]
+fn profile_list_returns_sorted_names() {
+    let home = unique_tempdir("list");
+    for name in &["prod", "dev", "staging"] {
+        let out = run_with_home(
+            &home,
+            &[
+                "profile",
+                "create",
+                name,
+                "--api-url",
+                &format!("https://{}.example.com", name),
+            ],
+        );
+        assert_success(&out);
+    }
+
+    let out = run_with_home(&home, &["--output", "json", "profile", "list"]);
+    assert_success(&out);
+    let payload: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    let names: Vec<&str> = payload["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["dev", "prod", "staging"]);
+}
+
+#[test]
+fn profile_list_empty_when_no_profiles() {
+    let home = unique_tempdir("list-empty");
+    let out = run_with_home(&home, &["--output", "json", "profile", "list"]);
+    assert_success(&out);
+    let payload: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert!(payload["profiles"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn profile_show_returns_stored_values() {
+    let home = unique_tempdir("show");
+    assert_success(&run_with_home(
+        &home,
+        &[
+            "profile",
+            "create",
+            "prod",
+            "--api-url",
+            "https://api.example.com",
+            "--api-key",
+            "hsk_xyz",
+        ],
+    ));
+
+    let out = run_with_home(&home, &["--output", "json", "profile", "show", "prod"]);
+    assert_success(&out);
+    let payload: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert_eq!(payload["name"], "prod");
+    assert_eq!(payload["api_url"], "https://api.example.com");
+    assert_eq!(payload["api_key_set"], true);
+}
+
+#[test]
+fn profile_show_missing_profile_errors_with_hint() {
+    let home = unique_tempdir("show-missing");
+    let out = run_with_home(&home, &["profile", "show", "nope"]);
+    assert!(!out.status.success());
+    let err = stderr(&out) + &stdout(&out);
+    assert!(err.contains("profile 'nope' not found"));
+    assert!(err.contains("hindsight profile create nope"));
+}
+
+#[test]
+fn profile_delete_removes_file() {
+    let home = unique_tempdir("delete");
+    assert_success(&run_with_home(
+        &home,
+        &[
+            "profile",
+            "create",
+            "prod",
+            "--api-url",
+            "https://api.example.com",
+        ],
+    ));
+    let path = home.join(".hindsight/cli-profiles/prod.toml");
+    assert!(path.exists());
+
+    let out = run_with_home(&home, &["profile", "delete", "prod", "-y"]);
+    assert_success(&out);
+    assert!(!path.exists(), "profile file should have been removed");
+}
+
+#[test]
+fn profile_delete_missing_errors() {
+    let home = unique_tempdir("delete-missing");
+    let out = run_with_home(&home, &["profile", "delete", "nope", "-y"]);
+    assert!(!out.status.success());
+}
+
+#[test]
+fn p_flag_overrides_config_file_api_url() {
+    // Build a HOME that contains BOTH a legacy ~/.hindsight/config pointing
+    // at URL_A and a named profile pointing at URL_B. Running `hindsight -p`
+    // should pick the profile URL, not the config-file URL — we verify by
+    // looking at the connection-error message (no API server needed).
+    let home = unique_tempdir("precedence");
+    let hindsight_dir = home.join(".hindsight");
+    std::fs::create_dir_all(&hindsight_dir).unwrap();
+    std::fs::write(
+        hindsight_dir.join("config"),
+        "api_url = \"http://127.0.0.1:9/from-config\"\n",
+    )
+    .unwrap();
+
+    assert_success(&run_with_home(
+        &home,
+        &[
+            "profile",
+            "create",
+            "prod",
+            "--api-url",
+            "http://127.0.0.1:9/from-profile",
+        ],
+    ));
+
+    // `version` will fail to connect (port 9 is "discard"), but the error
+    // message echoes the API URL actually used.
+    let out = run_with_home(&home, &["-p", "prod", "version"]);
+    assert!(!out.status.success());
+    let err = stderr(&out) + &stdout(&out);
+    assert!(
+        err.contains("from-profile"),
+        "expected profile URL in output, got:\n{}",
+        err
+    );
+    assert!(
+        !err.contains("from-config"),
+        "config-file URL should not have been used:\n{}",
+        err
+    );
+}
+
+#[test]
+fn hindsight_profile_env_var_is_honored() {
+    let home = unique_tempdir("env-var");
+    assert_success(&run_with_home(
+        &home,
+        &[
+            "profile",
+            "create",
+            "staging",
+            "--api-url",
+            "http://127.0.0.1:9/from-env",
+        ],
+    ));
+
+    // Re-run without `-p` but with HINDSIGHT_PROFILE set.
+    let out = Command::new(hindsight_binary())
+        .env("HOME", &home)
+        .env_remove("HINDSIGHT_API_URL")
+        .env_remove("HINDSIGHT_API_KEY")
+        .env("HINDSIGHT_PROFILE", "staging")
+        .args(["version"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr).into_owned()
+        + &String::from_utf8_lossy(&out.stdout);
+    assert!(err.contains("from-env"), "expected profile URL in output:\n{}", err);
+}

--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -31,6 +31,49 @@ export HINDSIGHT_API_URL=http://localhost:8888
 export HINDSIGHT_API_KEY=your-api-key
 ```
 
+### Named Profiles
+
+When you need to switch between multiple Hindsight deployments (e.g. local,
+staging, production) without constantly rewriting `~/.hindsight/config`, use
+named profiles. Each profile is a TOML file at
+`~/.hindsight/cli-profiles/<name>.toml` and is selected per-invocation with
+`-p/--profile` (or by setting `$HINDSIGHT_PROFILE`).
+
+```bash
+# Create (or overwrite) a profile
+hindsight profile create prod \
+  --api-url https://api.hindsight.vectorize.io \
+  --api-key hsk_...
+
+# List and inspect profiles
+hindsight profile list
+hindsight profile show prod
+
+# Use a profile for a single command
+hindsight -p prod bank list
+
+# Or make it sticky for the current shell
+export HINDSIGHT_PROFILE=prod
+hindsight bank list
+
+# Remove a profile
+hindsight profile delete prod -y
+```
+
+Profile files are written with `0600` permissions on Unix so the API key is
+only readable by the owner.
+
+**Configuration precedence** (highest first):
+
+1. Environment variables (`HINDSIGHT_API_URL`, `HINDSIGHT_API_KEY`)
+2. Named profile — explicit `-p <name>`, otherwise `$HINDSIGHT_PROFILE`
+3. Shared config file (`~/.hindsight/config`, written by `hindsight configure`)
+4. Default (`http://localhost:8888`)
+
+`HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` always override profile values, which
+makes it safe to use `-p` in scripts while letting CI inject credentials via
+environment.
+
 ## Core Commands
 
 ### Retain (Store Memory)

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -31,6 +31,49 @@ export HINDSIGHT_API_URL=http://localhost:8888
 export HINDSIGHT_API_KEY=your-api-key
 ```
 
+### Named Profiles
+
+When you need to switch between multiple Hindsight deployments (e.g. local,
+staging, production) without constantly rewriting `~/.hindsight/config`, use
+named profiles. Each profile is a TOML file at
+`~/.hindsight/cli-profiles/<name>.toml` and is selected per-invocation with
+`-p/--profile` (or by setting `$HINDSIGHT_PROFILE`).
+
+```bash
+# Create (or overwrite) a profile
+hindsight profile create prod \
+  --api-url https://api.hindsight.vectorize.io \
+  --api-key hsk_...
+
+# List and inspect profiles
+hindsight profile list
+hindsight profile show prod
+
+# Use a profile for a single command
+hindsight -p prod bank list
+
+# Or make it sticky for the current shell
+export HINDSIGHT_PROFILE=prod
+hindsight bank list
+
+# Remove a profile
+hindsight profile delete prod -y
+```
+
+Profile files are written with `0600` permissions on Unix so the API key is
+only readable by the owner.
+
+**Configuration precedence** (highest first):
+
+1. Environment variables (`HINDSIGHT_API_URL`, `HINDSIGHT_API_KEY`)
+2. Named profile — explicit `-p <name>`, otherwise `$HINDSIGHT_PROFILE`
+3. Shared config file (`~/.hindsight/config`, written by `hindsight configure`)
+4. Default (`http://localhost:8888`)
+
+`HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` always override profile values, which
+makes it safe to use `-p` in scripts while letting CI inject credentials via
+environment.
+
 ## Core Commands
 
 ### Retain (Store Memory)


### PR DESCRIPTION
## Summary
- New `-p/--profile <NAME>` global flag (also reads `\$HINDSIGHT_PROFILE`) that loads `~/.hindsight/cli-profiles/<name>.toml`, so a single `hindsight` binary can target multiple deployments without overwriting the shared `~/.hindsight/config`.
- New `hindsight profile {create,list,show,delete}` subcommands. Profile files are plain TOML (`api_url`, `api_key`) written with `0600` permissions on Unix.
- Config precedence is now: env vars > named profile > `~/.hindsight/config` > default (`http://localhost:8888`). Missing profile produces an actionable error pointing at `hindsight profile create <name> --api-url <url>`.

This is PR A of a two-part plan; PR B will have the openclaw plugin write `~/.hindsight/cli-profiles/openclaw-plugin.toml` on setup so skills can invoke `hindsight -p openclaw-plugin …` without hardcoding URLs.

## Test plan
- [x] `cargo build` (CLI)
- [x] `cargo test config::` — 22 tests pass (10 new)
- [x] Manual lifecycle smoke test: `profile create` → `profile list` → `profile show` → `hindsight -p prod version` (confirmed URL is picked up from profile) → `profile delete -y`
- [x] Manual error path: `hindsight -p missing version` prints the actionable not-found error
- [ ] CI green