### PR TITLE
fix(worker): per-tenant fair rotation in claim_batch

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -130,6 +130,9 @@ class WorkerPoller:
         self._active_tasks: dict[str, ActiveTaskInfo] = {}
         # Track in-flight tasks by operation type
         self._in_flight_by_type: dict[str, int] = {}
+        # Rotation offset for per-tenant fair claiming. Advances past the last
+        # schema we serviced so a busy tenant can't monopolize the poll order.
+        self._next_schema_idx: int = 0
 
     async def _get_schemas(self) -> list[str | None]:
         """Get list of schemas to poll. Returns [None] for default schema (no prefix)."""
@@ -196,6 +199,15 @@ class WorkerPoller:
 
         Uses FOR UPDATE SKIP LOCKED to ensure no conflicts with other workers.
 
+        Schema iteration is round-robin to prevent one busy tenant from
+        starving others. Each poll starts at ``self._next_schema_idx`` and
+        wraps around the full list. First pass caps at 1 claim per schema
+        so every tenant with pending work gets a fair chance; a second
+        pass backfills remaining slots from any schema when there's spare
+        capacity. After the call, the offset advances past the last
+        schema we serviced (or by 1 if nothing was claimed) so the next
+        poll starts at a different position.
+
         Returns:
             List of ClaimedTask objects containing operation_id, task_dict, and schema
         """
@@ -206,15 +218,29 @@ class WorkerPoller:
             return []
 
         schemas = await self._get_schemas()
+        if not schemas:
+            return []
+
+        # Rotate the schema order so no tenant is always first.
+        start = self._next_schema_idx % len(schemas)
+        rotated = list(enumerate(schemas))
+        rotated = rotated[start:] + rotated[:start]
+
         all_tasks: list[ClaimedTask] = []
         remaining_non_consolidation = non_consolidation_available
         remaining_consolidation = consolidation_available
+        last_serviced_idx: int | None = None
 
-        for schema in schemas:
+        # Pass 1: fairness pass — at most 1 claim per pool per schema,
+        # so every tenant with pending work is considered before we
+        # return to a tenant we already claimed from.
+        for orig_idx, schema in rotated:
             if remaining_non_consolidation <= 0 and remaining_consolidation <= 0:
                 break
 
-            tasks = await self._claim_batch_for_schema(schema, remaining_non_consolidation, remaining_consolidation)
+            nc_limit = min(1, remaining_non_consolidation)
+            c_limit = min(1, remaining_consolidation)
+            tasks = await self._claim_batch_for_schema(schema, nc_limit, c_limit)
 
             for task in tasks:
                 op_type = task.task_dict.get("operation_type", "unknown")
@@ -223,7 +249,40 @@ class WorkerPoller:
                 else:
                     remaining_non_consolidation -= 1
 
+            if tasks:
+                last_serviced_idx = orig_idx
+
             all_tasks.extend(tasks)
+
+        # Pass 2: capacity pass — fill any remaining slots from whichever
+        # schemas still have work. Preserves rotation order so a tenant
+        # earlier in the rotation doesn't monopolize again when only one
+        # tenant has more work.
+        if remaining_non_consolidation > 0 or remaining_consolidation > 0:
+            for orig_idx, schema in rotated:
+                if remaining_non_consolidation <= 0 and remaining_consolidation <= 0:
+                    break
+
+                tasks = await self._claim_batch_for_schema(schema, remaining_non_consolidation, remaining_consolidation)
+
+                for task in tasks:
+                    op_type = task.task_dict.get("operation_type", "unknown")
+                    if op_type == "consolidation":
+                        remaining_consolidation -= 1
+                    else:
+                        remaining_non_consolidation -= 1
+
+                if tasks:
+                    last_serviced_idx = orig_idx
+
+                all_tasks.extend(tasks)
+
+        # Advance offset past the last schema we serviced, or by 1 if
+        # nothing was claimed (so we don't keep re-hitting an empty head).
+        if last_serviced_idx is not None:
+            self._next_schema_idx = (last_serviced_idx + 1) % len(schemas)
+        else:
+            self._next_schema_idx = (start + 1) % len(schemas)
 
         return all_tasks
 

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1836,3 +1836,145 @@ class TestMarkFailedParentPropagation:
             f"Parent batch_retain should be 'failed' after child fails via unhandled exception, "
             f"got '{parent_row['status']}'"
         )
+
+
+class TestClaimBatchRotation:
+    """Tests for round-robin schema rotation in claim_batch.
+
+    These use a mocked _claim_batch_for_schema so the tests are hermetic
+    and exercise rotation logic without needing multiple real tenant schemas.
+    """
+
+    def _make_poller_with_fake_work(self, pool, pending_per_schema, max_slots=1):
+        """Build a poller whose schemas and per-schema claims are scripted.
+
+        ``pending_per_schema`` maps schema name -> current pending count.
+        The fake claim handler decrements the count and returns a ClaimedTask
+        if the schema still has work, else returns an empty list.
+        """
+        from hindsight_api.extensions.tenant import Tenant, TenantExtension
+        from hindsight_api.worker import WorkerPoller
+        from hindsight_api.worker.poller import ClaimedTask
+
+        schemas = list(pending_per_schema.keys())
+
+        class StaticTenantExtension(TenantExtension):
+            def __init__(self):
+                super().__init__(config={})
+
+            async def authenticate(self, context):
+                raise NotImplementedError
+
+            async def list_tenants(self) -> list[Tenant]:
+                return [Tenant(schema=s) for s in schemas]
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="test-rotation",
+            executor=lambda x: None,
+            tenant_extension=StaticTenantExtension(),
+            max_slots=max_slots,
+            # No consolidation reservation — all slots available for non-consolidation
+            # test tasks. Keeps the fair-rotation behavior easy to assert.
+            consolidation_max_slots=0,
+        )
+
+        serviced: list[str] = []
+
+        async def fake_claim(schema, non_consolidation_limit, consolidation_limit):
+            # Tests only exercise non-consolidation ("test") tasks, so we only
+            # consult the non-consolidation limit.
+            remaining = pending_per_schema.get(schema, 0)
+            if remaining <= 0 or non_consolidation_limit <= 0:
+                return []
+            take = min(remaining, non_consolidation_limit)
+            pending_per_schema[schema] = remaining - take
+            out = []
+            for _ in range(take):
+                serviced.append(schema)
+                out.append(
+                    ClaimedTask(
+                        operation_id=str(uuid.uuid4()),
+                        task_dict={"operation_type": "test", "bank_id": schema or "default"},
+                        schema=schema,
+                    )
+                )
+            return out
+
+        poller._claim_batch_for_schema = fake_claim  # type: ignore[method-assign]
+        return poller, serviced
+
+    @pytest.mark.asyncio
+    async def test_rotation_advances_past_serviced_schema(self, pool):
+        """After claiming from schema at offset N, next poll starts at N+1.
+
+        This is the 'crucial detail' that separates working rotation from
+        broken rotation: advancing +1 from the previous offset would cause
+        the first schema with work to always win.
+        """
+        # Only schema "b" has work; "a" and "c" are idle.
+        pending = {"a": 0, "b": 5, "c": 0}
+        poller, serviced = self._make_poller_with_fake_work(pool, pending, max_slots=1)
+
+        await poller.claim_batch()
+        # Found work at index 1 ("b"), so next offset should be 2 ("c").
+        assert poller._next_schema_idx == 2
+        assert serviced == ["b"]
+
+    @pytest.mark.asyncio
+    async def test_rotation_advances_by_one_when_no_work(self, pool):
+        """Empty sweep advances offset by 1 so we don't keep re-hitting the same head."""
+        pending = {"a": 0, "b": 0, "c": 0}
+        poller, serviced = self._make_poller_with_fake_work(pool, pending, max_slots=1)
+
+        poller._next_schema_idx = 0
+        await poller.claim_batch()
+        assert poller._next_schema_idx == 1
+        assert serviced == []
+
+        await poller.claim_batch()
+        assert poller._next_schema_idx == 2
+        assert serviced == []
+
+    @pytest.mark.asyncio
+    async def test_small_tenant_not_starved_by_busy_tenant(self, pool):
+        """Small tenant with 1 pending task gets serviced within bounded polls
+        even when another tenant has a huge backlog. Prevents the regression
+        observed in prod where one tenant's 1000+ retains monopolized workers.
+        """
+        pending = {"friday-main": 1000, "tenant-b": 1}
+        poller, serviced = self._make_poller_with_fake_work(pool, pending, max_slots=1)
+
+        # MAX_SLOTS=1 means one claim per poll. Over ~2 polls the rotation
+        # must reach tenant-b, regardless of which started first.
+        for _ in range(5):
+            await poller.claim_batch()
+            if "tenant-b" in serviced:
+                break
+
+        assert "tenant-b" in serviced, f"tenant-b was starved; serviced={serviced[:20]}"
+
+    @pytest.mark.asyncio
+    async def test_max_slots_greater_than_one_spreads_across_tenants(self, pool):
+        """With MAX_SLOTS>1 the first pass caps at 1 claim per schema so
+        a single poll services multiple tenants rather than draining one.
+        """
+        pending = {"a": 10, "b": 10, "c": 10, "d": 10, "e": 10}
+        poller, serviced = self._make_poller_with_fake_work(pool, pending, max_slots=3)
+
+        await poller.claim_batch()
+        # First pass gives 1 claim each to 3 different schemas — not 3 from the same one.
+        assert len(serviced) == 3
+        assert len(set(serviced)) == 3, f"Expected 3 different tenants, got {serviced}"
+
+    @pytest.mark.asyncio
+    async def test_max_slots_greater_than_one_backfills_when_only_one_tenant_has_work(self, pool):
+        """Second pass fills remaining slots when only one tenant has work,
+        so fairness doesn't sacrifice throughput in the single-tenant case.
+        """
+        pending = {"a": 0, "b": 10, "c": 0}
+        poller, serviced = self._make_poller_with_fake_work(pool, pending, max_slots=3)
+
+        await poller.claim_batch()
+        # Pass 1: 1 from "b" (only one with work). Pass 2: 2 more from "b".
+        assert serviced == ["b", "b", "b"]


### PR DESCRIPTION
## Summary

Prevents a single busy tenant from starving workers away from other tenants in a multi-tenant deployment. When one tenant has a much larger backlog than others, tenants at the front of the `list_tenants()` iteration could monopolize every claim and leave others queued indefinitely.

## The bug

`WorkerPoller.claim_batch()` iterated schemas in the fixed order returned by `tenant_extension.list_tenants()` and claimed until slots filled. A tenant near the front of the list could take every available slot, poll after poll.

## Fix

Round-robin rotation at the schema level:

- `WorkerPoller` now tracks `_next_schema_idx`, which advances **past the last schema we serviced** (not `+1 from previous offset` — that would still let a heavy tenant at the same position win iteration after iteration).
- **Pass 1 (fairness)**: cap at 1 claim per pool per schema, so every tenant with pending work is considered before we return to one we already claimed from.
- **Pass 2 (capacity)**: backfill remaining slots from any schema when the first pass didn't fill them — so single-tenant throughput isn't sacrificed for fairness.

Starvation bound: (time until any worker frees up) + one poll interval. A small tenant's single task is claimed within one rotation cycle.

## Interactions checked

- **`MAX_SLOTS=1`**: rotation alone suffices — pass 2 is a no-op since quota is filled by pass 1.
- **`MAX_SLOTS>1`**: pass 1 spreads claims across tenants, pass 2 backfills when only one tenant has work.
- **Consolidation slot reservation**: non-consolidation and consolidation pools are capped independently per-schema in pass 1, respecting the existing `_get_available_slots()` split.
- **Worker synchronization**: fresh workers start at offset 0. If multiple workers poll at the same time they initially hit the same schema; `SKIP LOCKED` handles the race cleanly. Offsets diverge over subsequent polls.

## Test plan

New `TestClaimBatchRotation` class in `tests/test_worker.py`:
- [x] Rotation advances past serviced schema (the crucial detail)
- [x] Empty sweep advances by 1 so we don't re-hit the head
- [x] Small tenant not starved by heavy tenant (1 vs 1000 pending)
- [x] `MAX_SLOTS>1` spreads pass-1 claims across tenants
- [x] `MAX_SLOTS>1` backfills in pass 2 when only one tenant has work

All tests in `test_worker.py` pass. Lint, format, type check all clean.