### PR TITLE
feat(mental-models): staleness signal + history reflect snapshot + UI revamp

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1639,6 +1639,14 @@ class MentalModelResponse(BaseModel):
         default=None,
         description="Full reflect API response payload including based_on facts and observations",
     )
+    is_stale: bool | None = Field(
+        default=None,
+        description=(
+            "True when new memories matching this mental model's tag/fact_type scope have been "
+            "ingested since last_refreshed_at, or consolidation has pending items. Only populated "
+            "when detail=full."
+        ),
+    )
 
 
 class MentalModelListResponse(BaseModel):

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -593,17 +593,15 @@ async def _trigger_mental_model_refreshes(
     """
     pool = memory_engine._pool
 
-    # Find mental models with refresh_after_consolidation=true
-    # SECURITY: Control which mental models get refreshed based on tags
+    # Find mental models with refresh_after_consolidation=true that are actually stale.
+    # The tag filter on the SELECT enforces the security boundary (never look outside the
+    # relevant tag scope); compute_mental_model_is_stale then verifies that new memories
+    # in the MM's scope really were ingested since its last refresh.
     async with pool.acquire() as conn:
         if consolidated_tags:
-            # Tagged memories were consolidated - refresh:
-            # 1. Mental models with overlapping tags (security boundary)
-            # 2. Untagged mental models (they're "global" and available to all contexts)
-            # DO NOT refresh mental models with different tags
-            rows = await conn.fetch(
+            candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags
+                SELECT id, name, tags, last_refreshed_at, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
@@ -616,11 +614,9 @@ async def _trigger_mental_model_refreshes(
                 consolidated_tags,
             )
         else:
-            # Untagged memories were consolidated - only refresh untagged mental models
-            # SECURITY: Tagged mental models are NOT refreshed when untagged memories are consolidated
-            rows = await conn.fetch(
+            candidates = await conn.fetch(
                 f"""
-                SELECT id, name, tags
+                SELECT id, name, tags, last_refreshed_at, trigger
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1
                   AND (trigger->>'refresh_after_consolidation')::boolean = true
@@ -628,6 +624,11 @@ async def _trigger_mental_model_refreshes(
                 """,
                 bank_id,
             )
+
+        rows = []
+        for candidate in candidates:
+            if await memory_engine.compute_mental_model_is_stale(conn, bank_id, candidate):
+                rows.append(candidate)
 
     if not rows:
         return 0

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5556,6 +5556,7 @@ class MemoryEngine(MemoryEngineInterface):
             query_embedding = embeddings[0]
             async with pool.acquire() as conn:
                 return await tool_search_mental_models(
+                    self,
                     conn,
                     bank_id,
                     q,
@@ -5565,7 +5566,6 @@ class MemoryEngine(MemoryEngineInterface):
                     tags_match=tags_match,
                     tag_groups=tag_groups,
                     exclude_ids=exclude_mental_model_ids,
-                    pending_consolidation=pending_consolidation,
                 )
 
         # Get reflect source facts config (hierarchical: env → tenant → bank)
@@ -6854,6 +6854,8 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
             result = self._row_to_mental_model(row, detail=detail) if row else None
+            if result is not None and detail == "full":
+                result["is_stale"] = await self.compute_mental_model_is_stale(conn, bank_id, row)
 
         # Post-operation hook (usage recording)
         if result and self._operation_validator:
@@ -7147,16 +7149,22 @@ class MemoryEngine(MemoryEngineInterface):
         pool = await self._get_pool()
 
         async with acquire_with_retry(pool) as conn:
-            # If content is changing, fetch current content first to record history
+            # If content is changing, fetch current content + reflect_response to record history
             previous_content: str | None = None
+            previous_reflect_response: dict[str, Any] | None = None
             if content is not None:
                 current_row = await conn.fetchrow(
-                    f"SELECT content FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    f"SELECT content, reflect_response FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
                     bank_id,
                     mental_model_id,
                 )
                 if current_row:
                     previous_content = current_row["content"]
+                    raw_rr = current_row["reflect_response"]
+                    if isinstance(raw_rr, str):
+                        previous_reflect_response = json.loads(raw_rr) if raw_rr else None
+                    else:
+                        previous_reflect_response = raw_rr
 
             # Build dynamic update
             updates = []
@@ -7176,7 +7184,13 @@ class MemoryEngine(MemoryEngineInterface):
                 # Record history entry with the previous content
                 if get_config().enable_mental_model_history:
                     history_entry = json.dumps(
-                        [{"previous_content": previous_content, "changed_at": datetime.now(timezone.utc).isoformat()}]
+                        [
+                            {
+                                "previous_content": previous_content,
+                                "previous_reflect_response": previous_reflect_response,
+                                "changed_at": datetime.now(timezone.utc).isoformat(),
+                            }
+                        ]
                     )
                     updates.append(f"history = COALESCE(history, '[]'::jsonb) || ${param_idx}::jsonb")
                     params.append(history_entry)
@@ -7263,6 +7277,77 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
         return result == "DELETE 1"
+
+    async def compute_mental_model_is_stale(
+        self,
+        conn,
+        bank_id: str,
+        mm_row: Any,
+    ) -> bool:
+        """Check whether a mental model is out of date.
+
+        A mental model is stale when a memory in its **scope** has been ingested after
+        ``last_refreshed_at``. The scope is defined by the model's ``tags`` +
+        ``trigger.tags_match`` semantics (``any`` / ``all`` / ``any_strict`` /
+        ``all_strict``, matching recall semantics) and its ``trigger.fact_types`` filter
+        when set. Memories still pending consolidation are included because they are
+        already rows in ``memory_units``; no separate ``pending_consolidation`` signal is
+        needed — it would bypass the tag scope and falsely flag unrelated MMs.
+
+        Untagged mental model defaults to ``tags_match="any"`` so it matches any memory
+        ingested in the bank (what a user would expect for a "global" MM).
+        """
+        from hindsight_api.engine.search.tags import _parse_tags_match
+
+        def _get(key: str) -> Any:
+            if isinstance(mm_row, dict):
+                return mm_row.get(key)
+            try:
+                return mm_row[key]
+            except (KeyError, TypeError):
+                return None
+
+        last_refreshed_at = _get("last_refreshed_at")
+        if not last_refreshed_at:
+            return True
+
+        raw_tags = _get("tags")
+        mm_tags: list[str] = list(raw_tags) if raw_tags else []
+
+        trigger = _get("trigger")
+        if isinstance(trigger, str):
+            try:
+                trigger = json.loads(trigger)
+            except json.JSONDecodeError:
+                trigger = None
+        trigger = trigger or {}
+        fact_types: list[str] = list(trigger.get("fact_types") or [])
+        tags_match = trigger.get("tags_match")
+        if not tags_match:
+            tags_match = "any"  # default: untagged MM is "global", tagged MM matches any overlap
+
+        params: list[Any] = [bank_id, last_refreshed_at]
+        where = ["bank_id = $1", "created_at > $2"]
+
+        if mm_tags:
+            operator, include_untagged = _parse_tags_match(tags_match)
+            params.append(mm_tags)
+            tag_idx = len(params)
+            if include_untagged:
+                where.append(f"(tags IS NULL OR tags = '{{}}' OR tags {operator} ${tag_idx}::varchar[])")
+            else:
+                where.append(f"(tags IS NOT NULL AND tags != '{{}}' AND tags {operator} ${tag_idx}::varchar[])")
+        # else: untagged MM → no tag constraint, matches any ingested memory in scope
+
+        if fact_types:
+            params.append(fact_types)
+            where.append(f"fact_type = ANY(${len(params)}::text[])")
+
+        row = await conn.fetchrow(
+            f"SELECT 1 FROM {fq_table('memory_units')} WHERE {' AND '.join(where)} LIMIT 1",
+            *params,
+        )
+        return row is not None
 
     def _row_to_mental_model(self, row, *, detail: str = "full") -> dict[str, Any]:
         """Convert a database row to a mental model dict.

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 async def tool_search_mental_models(
+    memory_engine: "MemoryEngine",
     conn: "Connection",
     bank_id: str,
     query: str,
@@ -32,7 +33,6 @@ async def tool_search_mental_models(
     tags_match: str = "any",
     tag_groups: "list | None" = None,
     exclude_ids: list[str] | None = None,
-    pending_consolidation: int = 0,
 ) -> dict[str, Any]:
     """
     Search user-curated mental models by semantic similarity.
@@ -82,7 +82,7 @@ async def tool_search_mental_models(
         f"""
         SELECT
             id, name, content,
-            tags, created_at, last_refreshed_at,
+            tags, created_at, last_refreshed_at, trigger,
             1 - (embedding <=> $2::vector) as relevance
         FROM {fq_table("mental_models")}
         WHERE bank_id = $1 AND embedding IS NOT NULL {filters}
@@ -99,10 +99,9 @@ async def tool_search_mental_models(
         if last_refreshed_at and last_refreshed_at.tzinfo is None:
             last_refreshed_at = last_refreshed_at.replace(tzinfo=timezone.utc)
 
-        # A mental model is stale when there are memories that haven't been consolidated yet —
-        # the same signal used for observations staleness.
-        is_stale = pending_consolidation > 0
-        staleness_reason = f"{pending_consolidation} memories pending consolidation" if is_stale else None
+        # Per-MM staleness: new in-scope memories since last refresh (includes pending).
+        is_stale = await memory_engine.compute_mental_model_is_stale(conn, bank_id, row)
+        staleness_reason = "new in-scope memories ingested since last refresh" if is_stale else None
 
         mental_models.append(
             {

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -1515,6 +1515,7 @@ class TestHierarchicalRetrieval:
         async with memory._pool.acquire() as conn:
             query_embedding = memory.embeddings.encode(["What does John like?"])[0]
             mental_model_result = await tool_search_mental_models(
+                memory_engine=memory,
                 conn=conn,
                 bank_id=bank_id,
                 query="What does John like?",
@@ -1576,6 +1577,7 @@ class TestHierarchicalRetrieval:
         async with memory._pool.acquire() as conn:
             query_embedding = memory.embeddings.encode(["Where does Sarah work?"])[0]
             mental_model_result = await tool_search_mental_models(
+                memory_engine=memory,
                 conn=conn,
                 bank_id=bank_id,
                 query="Where does Sarah work?",

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -8,7 +8,8 @@ import uuid
 
 import pytest
 
-from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
+from hindsight_api.engine.retain import embedding_utils
 
 
 @pytest.fixture
@@ -688,6 +689,51 @@ class TestMentalModelHistory:
         assert len(history) == 1
         assert history[0]["previous_content"] == "Original content"
         assert "changed_at" in history[0]
+        assert "previous_reflect_response" in history[0]
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_history_snapshots_previous_reflect_response(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Each history entry snapshots the reflect_response that produced previous_content."""
+        bank_id = f"test-mm-history-reflect-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Test Model",
+            source_query="What is the test?",
+            content="v1",
+            request_context=request_context,
+        )
+
+        rr_v1 = {"text": "v1", "based_on": {"observation": [{"id": "o1", "text": "obs1"}]}, "mental_models": []}
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="v2",
+            reflect_response=rr_v1,
+            request_context=request_context,
+        )
+
+        rr_v2 = {"text": "v2", "based_on": {"observation": [{"id": "o2", "text": "obs2"}]}, "mental_models": []}
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="v3",
+            reflect_response=rr_v2,
+            request_context=request_context,
+        )
+
+        history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
+        assert len(history) == 2
+        # Most recent first: replacing v2 snapshotted rr_v1 (the reflect that produced v2).
+        assert history[0]["previous_content"] == "v2"
+        assert history[0]["previous_reflect_response"] == rr_v1
+        # The first update replaced v1, which had no reflect_response stored yet.
+        assert history[1]["previous_content"] == "v1"
+        assert history[1]["previous_reflect_response"] is None
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -759,6 +805,222 @@ class TestMentalModelHistory:
             bank_id, "nonexistent-id", request_context=request_context
         )
         assert result is None
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+class TestMentalModelStaleness:
+    """Tests for compute_mental_model_is_stale scope semantics.
+
+    Memories are inserted directly into ``memory_units`` so the scenarios don't
+    depend on the LLM fact-extraction pipeline.
+    """
+
+    @staticmethod
+    async def _insert_memory(
+        memory: MemoryEngine,
+        bank_id: str,
+        *,
+        tags: list[str] | None = None,
+        fact_type: str = "experience",
+    ) -> str:
+        from datetime import datetime, timezone
+
+        pool = await memory._get_pool()
+        mem_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO {fq_table("memory_units")}
+                    (id, bank_id, text, event_date, fact_type, tags, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6::varchar[], $4)
+                """,
+                mem_id,
+                bank_id,
+                "test memory",
+                now,
+                fact_type,
+                tags if tags is not None else [],
+            )
+        return mem_id
+
+    async def test_fresh_mental_model_is_not_stale(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-mm-stale-fresh-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_untagged_mm_stale_on_any_new_memory(
+        self, memory: MemoryEngine, request_context
+    ):
+        bank_id = f"test-mm-stale-untagged-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id, name="MM", source_query="q", content="c", request_context=request_context
+        )
+        await self._insert_memory(memory, bank_id, tags=["something"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tagged_mm_ignores_out_of_scope_memory(
+        self, memory: MemoryEngine, request_context
+    ):
+        bank_id = f"test-mm-stale-oos-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a"],
+            request_context=request_context,
+        )
+        # Memory tagged with unrelated tag → not in scope, MM should not be stale
+        await self._insert_memory(memory, bank_id, tags=["user_b"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tagged_mm_stale_on_overlapping_memory(
+        self, memory: MemoryEngine, request_context
+    ):
+        bank_id = f"test-mm-stale-overlap-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a"],
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=["user_a", "extra"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tags_match_all_strict_requires_all_tags(
+        self, memory: MemoryEngine, request_context
+    ):
+        """tags_match='all_strict' → memory must contain ALL MM tags (and be tagged)."""
+        bank_id = f"test-mm-stale-all-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a", "proj_x"],
+            trigger={"refresh_after_consolidation": False, "tags_match": "all_strict"},
+            request_context=request_context,
+        )
+        # Memory only has one of the tags → does NOT match all_strict
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False, "all_strict must require ALL MM tags"
+
+        # Now add a memory with both tags → matches
+        await self._insert_memory(memory, bank_id, tags=["user_a", "proj_x"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tags_match_any_strict_excludes_untagged(
+        self, memory: MemoryEngine, request_context
+    ):
+        """tags_match='any_strict' → untagged memory does NOT keep MM in scope."""
+        bank_id = f"test-mm-stale-anystrict-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a"],
+            trigger={"refresh_after_consolidation": False, "tags_match": "any_strict"},
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=None)
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_fact_type_filter_narrows_scope(
+        self, memory: MemoryEngine, request_context
+    ):
+        bank_id = f"test-mm-stale-fact-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            trigger={"refresh_after_consolidation": False, "fact_types": ["world"]},
+            request_context=request_context,
+        )
+        # Out-of-scope fact_type → not stale
+        await self._insert_memory(memory, bank_id, fact_type="experience")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        # Matching fact_type → stale
+        await self._insert_memory(memory, bank_id, fact_type="world")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tool_search_mental_models_returns_is_stale_per_mm(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Regression: tool_search_mental_models must compute is_stale per-MM via scope,
+        not via a bank-wide pending_consolidation short-circuit."""
+        from hindsight_api.engine.reflect.tools import tool_search_mental_models
+
+        bank_id = f"test-mm-stale-tool-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        fresh = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="fresh MM",
+            source_query="q",
+            content="fresh",
+            tags=["user_b"],
+            request_context=request_context,
+        )
+        stale = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="stale MM",
+            source_query="q",
+            content="stale",
+            tags=["user_a"],
+            request_context=request_context,
+        )
+        # Memory only in user_a's scope → only `stale` MM should be flagged.
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            embedding = (
+                await embedding_utils.generate_embeddings_batch(memory.embeddings, ["q"])
+            )[0]
+            result = await tool_search_mental_models(
+                memory, conn, bank_id, "q", embedding, max_results=10
+            )
+        by_id = {m["id"]: m for m in result["mental_models"]}
+        assert by_id[fresh["id"]]["is_stale"] is False
+        assert by_id[stale["id"]]["is_stale"] is True
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5107,6 +5107,7 @@ components:
             exclude_mental_models: false
             recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
+          is_stale: true
           content: content
           tags:
           - tags
@@ -5142,6 +5143,7 @@ components:
             exclude_mental_models: false
             recall_max_tokens: 6
           last_refreshed_at: last_refreshed_at
+          is_stale: true
           content: content
           tags:
           - tags
@@ -5188,6 +5190,7 @@ components:
           exclude_mental_models: false
           recall_max_tokens: 6
         last_refreshed_at: last_refreshed_at
+        is_stale: true
         content: content
         tags:
         - tags
@@ -5227,6 +5230,9 @@ components:
         reflect_response:
           additionalProperties: {}
           nullable: true
+        is_stale:
+          nullable: true
+          type: boolean
       required:
       - bank_id
       - id

--- a/hindsight-clients/go/model_mental_model_response.go
+++ b/hindsight-clients/go/model_mental_model_response.go
@@ -32,6 +32,7 @@ type MentalModelResponse struct {
 	LastRefreshedAt NullableString `json:"last_refreshed_at,omitempty"`
 	CreatedAt NullableString `json:"created_at,omitempty"`
 	ReflectResponse map[string]interface{} `json:"reflect_response,omitempty"`
+	IsStale NullableBool `json:"is_stale,omitempty"`
 }
 
 type _MentalModelResponse MentalModelResponse
@@ -445,6 +446,48 @@ func (o *MentalModelResponse) SetReflectResponse(v map[string]interface{}) {
 	o.ReflectResponse = v
 }
 
+// GetIsStale returns the IsStale field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MentalModelResponse) GetIsStale() bool {
+	if o == nil || IsNil(o.IsStale.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.IsStale.Get()
+}
+
+// GetIsStaleOk returns a tuple with the IsStale field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MentalModelResponse) GetIsStaleOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.IsStale.Get(), o.IsStale.IsSet()
+}
+
+// HasIsStale returns a boolean if a field has been set.
+func (o *MentalModelResponse) HasIsStale() bool {
+	if o != nil && o.IsStale.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetIsStale gets a reference to the given NullableBool and assigns it to the IsStale field.
+func (o *MentalModelResponse) SetIsStale(v bool) {
+	o.IsStale.Set(&v)
+}
+// SetIsStaleNil sets the value for IsStale to be an explicit nil
+func (o *MentalModelResponse) SetIsStaleNil() {
+	o.IsStale.Set(nil)
+}
+
+// UnsetIsStale ensures that no value is present for IsStale, not even an explicit nil
+func (o *MentalModelResponse) UnsetIsStale() {
+	o.IsStale.Unset()
+}
+
 func (o MentalModelResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -481,6 +524,9 @@ func (o MentalModelResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.ReflectResponse != nil {
 		toSerialize["reflect_response"] = o.ReflectResponse
+	}
+	if o.IsStale.IsSet() {
+		toSerialize["is_stale"] = o.IsStale.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.mental_model_trigger_output import MentalModelTriggerOutput
 from typing import Optional, Set
@@ -38,7 +38,8 @@ class MentalModelResponse(BaseModel):
     last_refreshed_at: Optional[StrictStr] = None
     created_at: Optional[StrictStr] = None
     reflect_response: Optional[Dict[str, Any]] = None
-    __properties: ClassVar[List[str]] = ["id", "bank_id", "name", "source_query", "content", "tags", "max_tokens", "trigger", "last_refreshed_at", "created_at", "reflect_response"]
+    is_stale: Optional[StrictBool] = None
+    __properties: ClassVar[List[str]] = ["id", "bank_id", "name", "source_query", "content", "tags", "max_tokens", "trigger", "last_refreshed_at", "created_at", "reflect_response", "is_stale"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -117,6 +118,11 @@ class MentalModelResponse(BaseModel):
         if self.reflect_response is None and "reflect_response" in self.model_fields_set:
             _dict['reflect_response'] = None
 
+        # set to None if is_stale (nullable) is None
+        # and model_fields_set contains the field
+        if self.is_stale is None and "is_stale" in self.model_fields_set:
+            _dict['is_stale'] = None
+
         return _dict
 
     @classmethod
@@ -139,7 +145,8 @@ class MentalModelResponse(BaseModel):
             "trigger": MentalModelTriggerOutput.from_dict(obj["trigger"]) if obj.get("trigger") is not None else None,
             "last_refreshed_at": obj.get("last_refreshed_at"),
             "created_at": obj.get("created_at"),
-            "reflect_response": obj.get("reflect_response")
+            "reflect_response": obj.get("reflect_response"),
+            "is_stale": obj.get("is_stale")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1894,6 +1894,12 @@ export type MentalModelResponse = {
   reflect_response?: {
     [key: string]: unknown;
   } | null;
+  /**
+   * Is Stale
+   *
+   * True when new memories matching this mental model's tag/fact_type scope have been ingested since last_refreshed_at, or consolidation has pending items. Only populated when detail=full.
+   */
+  is_stale?: boolean | null;
 };
 
 /**

--- a/hindsight-control-plane/src/components/compact-markdown.tsx
+++ b/hindsight-control-plane/src/components/compact-markdown.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
+
+export function CompactMarkdown({ children, className }: { children: string; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "text-[13px] leading-6 text-foreground/90 space-y-2 [&>:first-child]:mt-0",
+        className
+      )}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: (props) => (
+            <div
+              className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mt-4 mb-1"
+              {...props}
+            />
+          ),
+          h2: (props) => (
+            <div
+              className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mt-4 mb-1"
+              {...props}
+            />
+          ),
+          h3: (props) => (
+            <div
+              className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mt-3 mb-1"
+              {...props}
+            />
+          ),
+          h4: (props) => (
+            <div
+              className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mt-3 mb-1"
+              {...props}
+            />
+          ),
+          p: (props) => <p className="my-1.5" {...props} />,
+          ul: (props) => <ul className="list-disc pl-5 my-1.5 space-y-0.5" {...props} />,
+          ol: (props) => <ol className="list-decimal pl-5 my-1.5 space-y-0.5" {...props} />,
+          li: (props) => <li className="leading-6" {...props} />,
+          strong: (props) => <strong className="font-semibold text-foreground" {...props} />,
+          code: (props) => (
+            <code className="text-[12px] font-mono bg-muted/70 px-1 py-0.5 rounded" {...props} />
+          ),
+          a: (props) => <a className="text-primary underline" {...props} />,
+          table: (props) => (
+            <div className="overflow-x-auto my-2">
+              <table className="text-[12px] border-collapse" {...props} />
+            </div>
+          ),
+          th: (props) => (
+            <th className="text-left font-semibold px-2 py-1 border-b border-border" {...props} />
+          ),
+          td: (props) => <td className="px-2 py-1 border-b border-border/50" {...props} />,
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -1,108 +1,164 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { client, MentalModel } from "@/lib/api";
 import { useBank } from "@/lib/bank-context";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { Loader2, Zap, FileText, History, ChevronLeft, ChevronRight } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Loader2,
+  Zap,
+  FileText,
+  History as HistoryIcon,
+  Settings,
+  ChevronLeft,
+  ChevronRight,
+  MoreVertical,
+  Pencil,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { CompactMarkdown } from "./compact-markdown";
+import { MemoryDetailModal } from "./memory-detail-modal";
+import { DirectiveDetailModal } from "./directive-detail-modal";
+import { formatAbsoluteDateTime as formatDateTime, formatRelativeTime } from "@/lib/relative-time";
 
-interface MentalModelDetailContentProps {
-  mentalModel: MentalModel;
-}
-
-const formatDateTime = (dateStr: string) => {
-  const date = new Date(dateStr);
-  return `${date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  })} at ${date.toLocaleTimeString("en-US", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  })}`;
+type BasedOnFact = {
+  id: string;
+  text: string;
+  type?: string;
+  context?: string | null;
 };
 
-/**
- * Shared content component for displaying mental model details.
- * Matches the layout of MentalModelDetailPanel for consistency.
- */
-export function MentalModelDetailContent({ mentalModel }: MentalModelDetailContentProps) {
+type ReflectResponseSnapshot = {
+  text?: string;
+  based_on?: Record<string, BasedOnFact[]>;
+  mental_models?: unknown[];
+} | null;
+
+type HistoryEntry = {
+  previous_content: string | null;
+  previous_reflect_response?: ReflectResponseSnapshot;
+  changed_at: string;
+};
+
+function getFactTypeDisplay(factType: string) {
+  if (factType === "directives") {
+    return { label: "directive", color: "bg-purple-500/10 text-purple-600 dark:text-purple-400" };
+  }
+  if (factType === "mental-models") {
+    return {
+      label: "mental model",
+      color: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
+    };
+  }
+  if (factType === "world") {
+    return { label: "world", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400" };
+  }
+  if (factType === "experience") {
+    return { label: "experience", color: "bg-green-500/10 text-green-600 dark:text-green-400" };
+  }
+  if (factType === "observation") {
+    return {
+      label: "observation",
+      color: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    };
+  }
+  return { label: factType, color: "bg-slate-500/10 text-slate-600 dark:text-slate-400" };
+}
+
+const FACT_TYPE_ORDER = ["observation", "experience", "world", "directives", "mental-models"];
+
+function BasedOnList({
+  based_on,
+  onViewMemory,
+  onViewDirective,
+}: {
+  based_on: Record<string, BasedOnFact[]> | undefined;
+  onViewMemory?: (id: string) => void;
+  onViewDirective?: (id: string) => void;
+}) {
+  const groups = useMemo(() => {
+    if (!based_on) return [] as Array<{ factType: string; facts: BasedOnFact[] }>;
+    const all = Object.entries(based_on)
+      .map(([factType, facts]) => ({ factType, facts: facts ?? [] }))
+      .filter((g) => g.facts.length > 0);
+    all.sort((a, b) => {
+      const ai = FACT_TYPE_ORDER.indexOf(a.factType);
+      const bi = FACT_TYPE_ORDER.indexOf(b.factType);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+    return all;
+  }, [based_on]);
+
+  if (groups.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">No based_on data.</p>;
+  }
+
   return (
-    <div className="space-y-6">
-      {/* Header: Name, ID, Source Query */}
-      <div className="pb-5 border-b border-border">
-        <div className="flex items-center gap-2">
-          <h3 className="text-xl font-bold text-foreground">{mentalModel.name}</h3>
-          {mentalModel.trigger?.refresh_after_consolidation && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-medium">
-              <Zap className="w-3 h-3" />
-              Auto refresh
-            </span>
-          )}
-        </div>
-        <code className="text-xs font-mono text-muted-foreground/70">{mentalModel.id}</code>
-        {mentalModel.source_query && (
-          <p className="text-sm text-muted-foreground mt-1">{mentalModel.source_query}</p>
-        )}
-      </div>
-
-      {/* Created / Last Refreshed */}
-      <div className="flex gap-8">
-        <div>
-          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
-            Created
-          </div>
-          <div className="text-sm text-foreground">{formatDateTime(mentalModel.created_at)}</div>
-        </div>
-        <div>
-          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
-            Last Refreshed
-          </div>
-          <div className="text-sm text-foreground">
-            {formatDateTime(mentalModel.last_refreshed_at)}
-          </div>
-        </div>
-      </div>
-
-      {/* Content */}
-      <div>
-        <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-          Content
-        </div>
-        <div className="prose prose-base dark:prose-invert max-w-none">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{mentalModel.content}</ReactMarkdown>
-        </div>
-      </div>
-
-      {/* Tags */}
-      {mentalModel.tags && mentalModel.tags.length > 0 && (
-        <div>
-          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-            Tags
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            {mentalModel.tags.map((tag: string, idx: number) => (
+    <div className="space-y-4">
+      {groups.map((group) => {
+        const display = getFactTypeDisplay(group.factType);
+        return (
+          <div key={group.factType} className="rounded-lg border border-border/60 overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 border-b border-border/60">
               <span
-                key={idx}
-                className="px-2 py-0.5 bg-amber-500/10 text-amber-600 dark:text-amber-400 rounded text-xs"
+                className={`px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${display.color}`}
               >
-                {tag}
+                {display.label}
               </span>
-            ))}
+              <span className="text-xs text-muted-foreground">{group.facts.length}</span>
+            </div>
+            <ul className="divide-y divide-border/50">
+              {group.facts.map((fact, i) => {
+                const canView =
+                  (group.factType === "directives" && !!onViewDirective) ||
+                  (group.factType !== "directives" &&
+                    group.factType !== "mental-models" &&
+                    !!onViewMemory);
+                return (
+                  <li
+                    key={fact.id || i}
+                    className="group flex items-start gap-3 px-3 py-2 hover:bg-muted/30"
+                  >
+                    <p className="text-sm text-foreground leading-relaxed flex-1 min-w-0">
+                      {fact.text}
+                      {fact.context && (
+                        <span className="block text-xs text-muted-foreground italic mt-0.5">
+                          {fact.context}
+                        </span>
+                      )}
+                    </p>
+                    {canView && (
+                      <button
+                        className="text-xs text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+                        onClick={() => {
+                          if (group.factType === "directives") onViewDirective?.(fact.id);
+                          else onViewMemory?.(fact.id);
+                        }}
+                      >
+                        View →
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-        </div>
-      )}
+        );
+      })}
     </div>
   );
 }
-
-type HistoryEntry = { previous_content: string | null; changed_at: string };
 
 type LineDiff = { type: "same" | "removed" | "added"; text: string };
 
@@ -137,7 +193,6 @@ function diffLines(a: string, b: string): { left: LineDiff[]; right: LineDiff[] 
   }
   ops.reverse();
 
-  // Pair removed/added lines side-by-side; same lines appear on both sides
   const left: LineDiff[] = [];
   const right: LineDiff[] = [];
   let k = 0;
@@ -148,7 +203,6 @@ function diffLines(a: string, b: string): { left: LineDiff[]; right: LineDiff[] 
       right.push(op);
       k++;
     } else {
-      // collect a block of removed/added and align them
       const removed: string[] = [];
       const added: string[] = [];
       while (k < ops.length && ops[k].type !== "same") {
@@ -215,24 +269,160 @@ function SideBySideDiff({ before, after }: { before: string; after: string }) {
   );
 }
 
+function BasedOnDiff({
+  before,
+  after,
+  onViewMemory,
+  onViewDirective,
+}: {
+  before: Record<string, BasedOnFact[]> | undefined;
+  after: Record<string, BasedOnFact[]> | undefined;
+  onViewMemory: (id: string) => void;
+  onViewDirective: (id: string) => void;
+}) {
+  const diff = useMemo(() => {
+    const types = new Set<string>([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+    const groups: Array<{
+      factType: string;
+      added: BasedOnFact[];
+      removed: BasedOnFact[];
+      kept: BasedOnFact[];
+    }> = [];
+    for (const factType of types) {
+      const b = (before?.[factType] ?? []).filter(Boolean);
+      const a = (after?.[factType] ?? []).filter(Boolean);
+      const bIds = new Set(b.map((f) => f.id));
+      const aIds = new Set(a.map((f) => f.id));
+      const added = a.filter((f) => !bIds.has(f.id));
+      const removed = b.filter((f) => !aIds.has(f.id));
+      const kept = a.filter((f) => bIds.has(f.id));
+      if (added.length === 0 && removed.length === 0 && kept.length === 0) continue;
+      groups.push({ factType, added, removed, kept });
+    }
+    groups.sort((x, y) => {
+      const xi = FACT_TYPE_ORDER.indexOf(x.factType);
+      const yi = FACT_TYPE_ORDER.indexOf(y.factType);
+      return (xi === -1 ? 999 : xi) - (yi === -1 ? 999 : yi);
+    });
+    return groups;
+  }, [before, after]);
+
+  if (diff.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">No based_on data.</p>;
+  }
+
+  const renderFact = (fact: BasedOnFact, factType: string, mode: "added" | "removed" | "kept") => {
+    const canView =
+      (factType === "directives" && !!onViewDirective) ||
+      (factType !== "directives" && factType !== "mental-models" && !!onViewMemory);
+    const rowCls =
+      mode === "added"
+        ? "bg-green-500/10 border-l-2 border-green-500"
+        : mode === "removed"
+          ? "bg-red-500/10 border-l-2 border-red-500 text-muted-foreground line-through decoration-red-500/50"
+          : "";
+    const marker = mode === "added" ? "+" : mode === "removed" ? "−" : " ";
+    const markerCls =
+      mode === "added"
+        ? "text-green-600 dark:text-green-400"
+        : mode === "removed"
+          ? "text-red-600 dark:text-red-400"
+          : "text-muted-foreground/40";
+    return (
+      <li key={`${mode}-${fact.id}`} className={`group flex items-start gap-2 px-3 py-2 ${rowCls}`}>
+        <span className={`font-mono text-sm shrink-0 ${markerCls}`}>{marker}</span>
+        <p className="text-sm leading-relaxed flex-1 min-w-0">
+          {fact.text}
+          {fact.context && (
+            <span className="block text-xs text-muted-foreground italic mt-0.5 no-underline">
+              {fact.context}
+            </span>
+          )}
+        </p>
+        {canView && mode !== "removed" && (
+          <button
+            className="text-xs text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+            onClick={() => {
+              if (factType === "directives") onViewDirective(fact.id);
+              else onViewMemory(fact.id);
+            }}
+          >
+            View →
+          </button>
+        )}
+      </li>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {diff.map((group) => {
+        const display = getFactTypeDisplay(group.factType);
+        return (
+          <div key={group.factType} className="rounded-lg border border-border/60 overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 border-b border-border/60">
+              <span
+                className={`px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${display.color}`}
+              >
+                {display.label}
+              </span>
+              {group.added.length > 0 && (
+                <span className="text-xs text-green-600 dark:text-green-400">
+                  +{group.added.length}
+                </span>
+              )}
+              {group.removed.length > 0 && (
+                <span className="text-xs text-red-600 dark:text-red-400">
+                  −{group.removed.length}
+                </span>
+              )}
+              {group.kept.length > 0 && (
+                <span className="text-xs text-muted-foreground">{group.kept.length} kept</span>
+              )}
+            </div>
+            <ul className="divide-y divide-border/40">
+              {group.added.map((f) => renderFact(f, group.factType, "added"))}
+              {group.removed.map((f) => renderFact(f, group.factType, "removed"))}
+              {group.kept.map((f) => renderFact(f, group.factType, "kept"))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function MentalModelHistoryView({
   history,
   currentContent,
+  currentBasedOn,
+  onViewMemory,
+  onViewDirective,
 }: {
   history: HistoryEntry[];
   currentContent: string;
+  currentBasedOn: Record<string, BasedOnFact[]> | undefined;
+  onViewMemory: (id: string) => void;
+  onViewDirective: (id: string) => void;
 }) {
   const [idx, setIdx] = useState(0);
   const entry = history[idx];
   const afterContent = idx === 0 ? currentContent : (history[idx - 1].previous_content ?? "");
+  const beforeBasedOn = entry.previous_reflect_response?.based_on;
+  const afterBasedOn =
+    idx === 0 ? currentBasedOn : history[idx - 1].previous_reflect_response?.based_on;
+  const snapshot = entry.previous_reflect_response ?? null;
 
   return (
-    <div className="space-y-3">
-      {/* Navigation header */}
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">
-          Change <span className="font-semibold text-foreground">{history.length - idx}</span> of{" "}
-          {history.length} &middot; {new Date(entry.changed_at).toLocaleString()}
+          <span className="font-semibold text-foreground">v{history.length - idx}</span> →{" "}
+          <span className="font-semibold text-foreground">
+            v{history.length - idx + 1}
+            {idx === 0 ? " (current)" : ""}
+          </span>{" "}
+          &middot; changed {new Date(entry.changed_at).toLocaleString()}
         </span>
         <div className="flex items-center gap-1">
           <Button
@@ -256,16 +446,34 @@ function MentalModelHistoryView({
         </div>
       </div>
 
-      {/* Change card */}
-      {entry.previous_content !== null ? (
-        <SideBySideDiff before={entry.previous_content} after={afterContent} />
-      ) : (
-        <div className="border border-border rounded-lg p-3">
-          <span className="text-sm text-muted-foreground italic">
-            Previous content not available
-          </span>
-        </div>
-      )}
+      <div>
+        <SectionLabel>Content diff</SectionLabel>
+        {entry.previous_content !== null ? (
+          <SideBySideDiff before={entry.previous_content} after={afterContent} />
+        ) : (
+          <div className="border border-border rounded-lg p-3">
+            <span className="text-sm text-muted-foreground italic">
+              Previous content not available
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <SectionLabel>Based on diff</SectionLabel>
+        {snapshot?.based_on ? (
+          <BasedOnDiff
+            before={beforeBasedOn}
+            after={afterBasedOn}
+            onViewMemory={onViewMemory}
+            onViewDirective={onViewDirective}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground italic">
+            Not captured for this version (recorded before reflect snapshots were tracked).
+          </p>
+        )}
+      </div>
     </div>
   );
 }
@@ -273,23 +481,29 @@ function MentalModelHistoryView({
 interface MentalModelDetailModalProps {
   mentalModelId: string | null;
   onClose: () => void;
-  initialTab?: string;
+  onEdit?: (m: MentalModel) => void;
+  onDelete?: (m: MentalModel) => void;
+  onRefreshed?: (m: MentalModel) => void;
+  initialTab?: "content" | "configuration" | "history";
 }
 
-/**
- * Modal wrapper for MentalModelDetailContent.
- * Fetches the mental model by ID and displays it in a dialog.
- */
 export function MentalModelDetailModal({
   mentalModelId,
   onClose,
-  initialTab,
+  onEdit,
+  onDelete,
+  onRefreshed,
+  initialTab = "content",
 }: MentalModelDetailModalProps) {
   const { currentBank } = useBank();
   const [mentalModel, setMentalModel] = useState<MentalModel | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState(initialTab ?? "model");
+  const [activeTab, setActiveTab] = useState<"content" | "configuration" | "history">(initialTab);
+  const [refreshing, setRefreshing] = useState(false);
+  const [reloading, setReloading] = useState(false);
+  const [viewMemoryId, setViewMemoryId] = useState<string | null>(null);
+  const [viewDirectiveId, setViewDirectiveId] = useState<string | null>(null);
 
   const [history, setHistory] = useState<HistoryEntry[] | null>(null);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -297,12 +511,12 @@ export function MentalModelDetailModal({
   useEffect(() => {
     if (!mentalModelId || !currentBank) return;
 
-    const loadMentalModel = async () => {
+    const load = async () => {
       setLoading(true);
       setError(null);
       setMentalModel(null);
       setHistory(null);
-      setActiveTab(initialTab ?? "model");
+      setActiveTab(initialTab);
 
       try {
         const data = await client.getMentalModel(currentBank, mentalModelId);
@@ -315,10 +529,9 @@ export function MentalModelDetailModal({
       }
     };
 
-    loadMentalModel();
-  }, [mentalModelId, currentBank]);
+    load();
+  }, [mentalModelId, currentBank, initialTab]);
 
-  // Load history lazily when history tab is selected
   useEffect(() => {
     if (activeTab !== "history" || !mentalModel || !currentBank || history !== null) return;
 
@@ -338,62 +551,449 @@ export function MentalModelDetailModal({
     loadHistory();
   }, [activeTab, mentalModel, currentBank, history]);
 
+  const handleReload = async () => {
+    if (!currentBank || !mentalModel) return;
+    setReloading(true);
+    try {
+      const updated = await client.getMentalModel(currentBank, mentalModel.id);
+      setMentalModel(updated);
+      setHistory(null);
+    } catch (err) {
+      console.error("Error reloading mental model:", err);
+    } finally {
+      setReloading(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    if (!currentBank || !mentalModel) return;
+    setRefreshing(true);
+    const originalRefreshedAt = mentalModel.last_refreshed_at;
+
+    try {
+      await client.refreshMentalModel(currentBank, mentalModel.id);
+
+      const pollInterval = 1000;
+      const maxAttempts = 120;
+      let attempts = 0;
+
+      const poll = async (): Promise<void> => {
+        attempts++;
+        try {
+          const updated = await client.getMentalModel(currentBank, mentalModel.id);
+          if (updated.last_refreshed_at !== originalRefreshedAt) {
+            setMentalModel(updated);
+            setHistory(null);
+            onRefreshed?.(updated);
+            setRefreshing(false);
+            return;
+          }
+          if (attempts >= maxAttempts) {
+            setRefreshing(false);
+            toast.error("Refresh timeout", {
+              description:
+                "Refresh is taking longer than expected. Check the operations list for status.",
+            });
+            return;
+          }
+          setTimeout(poll, pollInterval);
+        } catch (err) {
+          console.error("Error polling mental model:", err);
+          setRefreshing(false);
+        }
+      };
+      setTimeout(poll, pollInterval);
+    } catch {
+      setRefreshing(false);
+    }
+  };
+
   const isOpen = mentalModelId !== null;
 
+  const basedOn = mentalModel?.reflect_response?.based_on as
+    | Record<string, BasedOnFact[]>
+    | undefined;
+  const basedOnCount = basedOn
+    ? Object.values(basedOn).reduce((acc, facts) => acc + (facts?.length ?? 0), 0)
+    : 0;
+
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col p-6">
-        <VisuallyHidden>
-          <DialogTitle>Mental Model Details</DialogTitle>
-        </VisuallyHidden>
-        {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
-          </div>
-        ) : error ? (
-          <div className="flex items-center justify-center py-20">
-            <div className="text-center text-destructive">
-              <div className="text-sm">Error: {error}</div>
+    <>
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="w-[95vw] max-w-[95vw] h-[92vh] sm:max-w-[95vw] flex flex-col overflow-hidden">
+          <DialogHeader className="pr-10">
+            <DialogTitle className="flex items-center gap-2">
+              <span className="truncate">{mentalModel?.name ?? "Mental Model"}</span>
+              {mentalModel && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 shrink-0"
+                  onClick={handleReload}
+                  disabled={reloading}
+                  title="Reload data"
+                >
+                  <RefreshCw className={`h-3.5 w-3.5 ${reloading ? "animate-spin" : ""}`} />
+                </Button>
+              )}
+              {mentalModel?.trigger?.refresh_after_consolidation && (
+                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-medium">
+                  <Zap className="w-3 h-3" />
+                  Auto refresh
+                </span>
+              )}
+            </DialogTitle>
+          </DialogHeader>
+
+          {loading ? (
+            <div className="flex items-center justify-center flex-1">
+              <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
             </div>
-          </div>
-        ) : mentalModel ? (
-          <Tabs
-            value={activeTab}
-            onValueChange={setActiveTab}
-            className="flex-1 flex flex-col overflow-hidden"
-          >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="model" className="flex items-center gap-1.5">
-                <FileText className="w-3.5 h-3.5" />
-                Mental Model
-              </TabsTrigger>
-              <TabsTrigger value="history" className="flex items-center gap-1.5">
-                <History className="w-3.5 h-3.5" />
-                History
-                {history && history.length > 0 ? ` (${history.length})` : ""}
-              </TabsTrigger>
-            </TabsList>
+          ) : error ? (
+            <div className="flex items-center justify-center flex-1">
+              <div className="text-center text-destructive">
+                <div className="text-sm">Error: {error}</div>
+              </div>
+            </div>
+          ) : mentalModel ? (
+            <Tabs
+              value={activeTab}
+              onValueChange={(v) => setActiveTab(v as "content" | "configuration" | "history")}
+              className="flex-1 flex flex-col overflow-hidden"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <TabsList className="grid grid-cols-3 w-full max-w-md">
+                  <TabsTrigger value="content" className="flex items-center gap-1.5">
+                    <FileText className="w-3.5 h-3.5" />
+                    Content
+                  </TabsTrigger>
+                  <TabsTrigger value="configuration" className="flex items-center gap-1.5">
+                    <Settings className="w-3.5 h-3.5" />
+                    Configuration
+                  </TabsTrigger>
+                  <TabsTrigger value="history" className="flex items-center gap-1.5">
+                    <HistoryIcon className="w-3.5 h-3.5" />
+                    History
+                  </TabsTrigger>
+                </TabsList>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0 shrink-0"
+                      disabled={refreshing}
+                      aria-label="Actions"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {onEdit && (
+                      <DropdownMenuItem onClick={() => onEdit(mentalModel)}>
+                        <Pencil className="h-4 w-4 mr-2" />
+                        Edit
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem onClick={handleRefresh} disabled={refreshing}>
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Refresh Manually
+                    </DropdownMenuItem>
+                    {onDelete && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={() => onDelete(mentalModel)}
+                          className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400 focus:bg-red-500/10"
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
 
-            <div className="flex-1 overflow-y-auto mt-4">
-              <TabsContent value="model" className="mt-0">
-                <MentalModelDetailContent mentalModel={mentalModel} />
-              </TabsContent>
-
-              <TabsContent value="history" className="mt-0">
-                {loadingHistory ? (
-                  <div className="flex items-center justify-center py-12">
-                    <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+              <div className="flex-1 overflow-y-auto mt-4">
+                <TabsContent value="content" className="mt-0 space-y-6">
+                  <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
+                    <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-border bg-muted/50 text-xs text-muted-foreground">
+                      <div className="flex items-center gap-1.5">
+                        <FileText className="w-3.5 h-3.5" />
+                        <span className="font-semibold uppercase tracking-wide">
+                          Stored content
+                        </span>
+                        <span className="text-muted-foreground/70">
+                          &middot; {mentalModel.content.length.toLocaleString()} chars
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {mentalModel.is_stale === true ? (
+                          <span
+                            className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
+                            title="New memories in this mental model's scope have been ingested since it was last refreshed"
+                          >
+                            Stale
+                          </span>
+                        ) : mentalModel.is_stale === false ? (
+                          <span
+                            className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-green-500/15 text-green-700 dark:text-green-400"
+                            title="No new memories in this mental model's scope since it was last refreshed"
+                          >
+                            In sync
+                          </span>
+                        ) : null}
+                        <span
+                          title={formatDateTime(mentalModel.last_refreshed_at)}
+                          className="flex items-center gap-1"
+                        >
+                          <RefreshCw className="w-3 h-3" />
+                          Last refreshed {formatRelativeTime(mentalModel.last_refreshed_at)}
+                        </span>
+                      </div>
+                    </div>
+                    <CompactMarkdown className="p-4">{mentalModel.content}</CompactMarkdown>
                   </div>
-                ) : history && history.length > 0 ? (
-                  <MentalModelHistoryView history={history} currentContent={mentalModel.content} />
-                ) : (
-                  <p className="text-sm text-muted-foreground italic">No history recorded yet.</p>
-                )}
-              </TabsContent>
-            </div>
-          </Tabs>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+                  <div>
+                    <SectionLabel>
+                      Based On{basedOnCount > 0 ? ` (${basedOnCount})` : ""}
+                    </SectionLabel>
+                    {mentalModel.reflect_response ? (
+                      <BasedOnList
+                        based_on={basedOn}
+                        onViewMemory={(id) => setViewMemoryId(id)}
+                        onViewDirective={(id) => setViewDirectiveId(id)}
+                      />
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No source data available. Click &quot;Refresh&quot; to regenerate with
+                        source tracking.
+                      </p>
+                    )}
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="configuration" className="mt-0">
+                  <ConfigurationTab mentalModel={mentalModel} />
+                </TabsContent>
+
+                <TabsContent value="history" className="mt-0">
+                  {loadingHistory ? (
+                    <div className="flex items-center justify-center py-12">
+                      <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : history && history.length > 0 ? (
+                    <MentalModelHistoryView
+                      history={history}
+                      currentContent={mentalModel.content}
+                      currentBasedOn={basedOn}
+                      onViewMemory={(id) => setViewMemoryId(id)}
+                      onViewDirective={(id) => setViewDirectiveId(id)}
+                    />
+                  ) : (
+                    <p className="text-sm text-muted-foreground italic">No history recorded yet.</p>
+                  )}
+                </TabsContent>
+              </div>
+            </Tabs>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      {viewMemoryId && (
+        <MemoryDetailModal memoryId={viewMemoryId} onClose={() => setViewMemoryId(null)} />
+      )}
+      {viewDirectiveId && (
+        <DirectiveDetailModal
+          directiveId={viewDirectiveId}
+          onClose={() => setViewDirectiveId(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function Metadata({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <SectionLabel>{label}</SectionLabel>
+      <div className="text-sm text-foreground">{value}</div>
+    </div>
+  );
+}
+
+function InfoCard({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border bg-muted/40 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {icon}
+        {title}
+      </div>
+      <div className="p-4 space-y-4">{children}</div>
+    </div>
+  );
+}
+
+function Pill({ label, color }: { label: string; color?: string }) {
+  return (
+    <span
+      className={`px-2 py-0.5 rounded text-xs ${
+        color ?? "bg-muted text-foreground border border-border/60"
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ConfigurationTab({ mentalModel }: { mentalModel: MentalModel }) {
+  const t = mentalModel.trigger ?? { refresh_after_consolidation: false };
+  const factTypes = t.fact_types ?? [];
+  const tagGroups = t.tag_groups ?? [];
+  const excludeIds = t.exclude_mental_model_ids ?? [];
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <InfoCard title="Identity" icon={<FileText className="w-3.5 h-3.5" />}>
+        <Metadata
+          label="ID"
+          value={
+            <code className="text-xs font-mono text-muted-foreground break-all">
+              {mentalModel.id}
+            </code>
+          }
+        />
+        <Metadata label="Name" value={mentalModel.name} />
+        {mentalModel.source_query && (
+          <Metadata label="Source Query" value={mentalModel.source_query} />
+        )}
+        <Metadata
+          label="Tags"
+          value={
+            mentalModel.tags?.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {mentalModel.tags.map((tag) => (
+                  <Pill
+                    key={tag}
+                    label={tag}
+                    color="bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                  />
+                ))}
+              </div>
+            ) : (
+              <span className="text-muted-foreground italic text-sm">none</span>
+            )
+          }
+        />
+      </InfoCard>
+
+      <InfoCard title="Timing" icon={<RefreshCw className="w-3.5 h-3.5" />}>
+        <Metadata label="Created" value={formatDateTime(mentalModel.created_at)} />
+        <Metadata
+          label="Last Refreshed"
+          value={
+            <span title={formatDateTime(mentalModel.last_refreshed_at)}>
+              {formatRelativeTime(mentalModel.last_refreshed_at)}
+            </span>
+          }
+        />
+        <Metadata label="Max Tokens" value={mentalModel.max_tokens.toLocaleString()} />
+      </InfoCard>
+
+      <InfoCard title="Refresh Trigger" icon={<Zap className="w-3.5 h-3.5" />}>
+        <Metadata
+          label="Auto-refresh after consolidation"
+          value={
+            t.refresh_after_consolidation ? (
+              <Pill label="Enabled" color="bg-green-500/10 text-green-600 dark:text-green-400" />
+            ) : (
+              <Pill label="Disabled" />
+            )
+          }
+        />
+        <Metadata
+          label="Fact types"
+          value={
+            factTypes.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {factTypes.map((ft) => {
+                  const d = getFactTypeDisplay(ft);
+                  return <Pill key={ft} label={d.label} color={d.color} />;
+                })}
+              </div>
+            ) : (
+              <span className="text-muted-foreground italic text-sm">all</span>
+            )
+          }
+        />
+        <Metadata label="Exclude mental models" value={t.exclude_mental_models ? "Yes" : "No"} />
+        {excludeIds.length > 0 && (
+          <Metadata
+            label="Excluded IDs"
+            value={
+              <div className="flex flex-wrap gap-1.5">
+                {excludeIds.map((id) => (
+                  <code
+                    key={id}
+                    className="text-xs font-mono px-1.5 py-0.5 rounded bg-muted border border-border/60"
+                  >
+                    {id}
+                  </code>
+                ))}
+              </div>
+            }
+          />
+        )}
+      </InfoCard>
+
+      <InfoCard title="Recall Parameters" icon={<Settings className="w-3.5 h-3.5" />}>
+        <Metadata
+          label="Include chunks"
+          value={t.include_chunks == null ? "default" : t.include_chunks ? "Yes" : "No"}
+        />
+        <Metadata
+          label="Recall max tokens"
+          value={t.recall_max_tokens != null ? t.recall_max_tokens.toLocaleString() : "default"}
+        />
+        <Metadata
+          label="Recall chunks max tokens"
+          value={
+            t.recall_chunks_max_tokens != null
+              ? t.recall_chunks_max_tokens.toLocaleString()
+              : "default"
+          }
+        />
+        <Metadata
+          label="Tags match"
+          value={t.tags_match ? <Pill label={t.tags_match} /> : "default"}
+        />
+      </InfoCard>
+
+      {tagGroups.length > 0 && (
+        <div className="md:col-span-2">
+          <InfoCard title="Tag Groups" icon={<Settings className="w-3.5 h-3.5" />}>
+            <pre className="text-xs font-mono bg-muted/40 rounded p-3 overflow-x-auto border border-border/60">
+              {JSON.stringify(tagGroups, null, 2)}
+            </pre>
+          </InfoCard>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+      {children}
+    </div>
   );
 }

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { client, type TagGroup, type TagsMatch } from "@/lib/api";
+import { formatAbsoluteDateTime, formatRelativeTime } from "@/lib/relative-time";
+import { CompactMarkdown } from "./compact-markdown";
 import { useBank } from "@/lib/bank-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -52,26 +52,13 @@ import {
   Loader2,
   Trash2,
   RefreshCw,
-  X,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
-  Pencil,
   LayoutGrid,
   List,
-  History,
-  MoreVertical,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { MemoryDetailModal } from "./memory-detail-modal";
-import { DirectiveDetailModal } from "./directive-detail-modal";
 import { MentalModelDetailModal } from "./mental-model-detail-modal";
 
 interface ReflectResponseBasedOnFact {
@@ -274,18 +261,6 @@ export function MentalModelsView() {
               {viewMode === "dashboard" && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {paginatedMentalModels.map((m) => {
-                    const refreshedDate = new Date(m.last_refreshed_at);
-                    const dateDisplay = refreshedDate.toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    });
-                    const timeDisplay = refreshedDate.toLocaleTimeString("en-US", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      hour12: false,
-                    });
-
                     return (
                       <Card
                         key={m.id}
@@ -332,24 +307,9 @@ export function MentalModelsView() {
                           <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
                             {m.source_query}
                           </p>
-                          <div className="text-sm text-foreground mb-3 border-t border-border pt-3">
-                            {/* Check if content has tables or complex markdown */}
-                            {m.content.includes("|") ||
-                            m.content.includes("```") ||
-                            m.content.includes("\n\n") ? (
-                              // Show plain text preview for complex content
-                              <div className="line-clamp-3 text-muted-foreground italic">
-                                {m.content.substring(0, 150)}...{" "}
-                                <span className="text-primary">Click to view full content</span>
-                              </div>
-                            ) : (
-                              // Render simple markdown with line clamp
-                              <div className="line-clamp-6 prose prose-sm dark:prose-invert max-w-none">
-                                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                                  {m.content}
-                                </ReactMarkdown>
-                              </div>
-                            )}
+                          <div className="relative mb-3 border-t border-border pt-3 max-h-40 overflow-hidden">
+                            <CompactMarkdown>{m.content}</CompactMarkdown>
+                            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-card to-transparent" />
                           </div>
                           <div className="flex items-center justify-between text-xs border-t border-border pt-3">
                             <div className="flex items-center gap-2">
@@ -371,8 +331,11 @@ export function MentalModelsView() {
                                 </div>
                               )}
                             </div>
-                            <div className="text-muted-foreground">
-                              {dateDisplay} {timeDisplay}
+                            <div
+                              className="text-muted-foreground"
+                              title={formatAbsoluteDateTime(m.last_refreshed_at)}
+                            >
+                              {formatRelativeTime(m.last_refreshed_at)}
                             </div>
                           </div>
                         </CardContent>
@@ -396,18 +359,6 @@ export function MentalModelsView() {
                   </TableHeader>
                   <TableBody>
                     {paginatedMentalModels.map((m) => {
-                      const refreshedDate = new Date(m.last_refreshed_at);
-                      const dateDisplay = refreshedDate.toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      });
-                      const timeDisplay = refreshedDate.toLocaleTimeString("en-US", {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                        hour12: false,
-                      });
-
                       return (
                         <TableRow
                           key={m.id}
@@ -429,9 +380,11 @@ export function MentalModelsView() {
                               {m.source_query}
                             </div>
                           </TableCell>
-                          <TableCell className="py-2 text-sm text-foreground">
-                            <div>{dateDisplay}</div>
-                            <div className="text-xs text-muted-foreground">{timeDisplay}</div>
+                          <TableCell
+                            className="py-2 text-sm text-foreground"
+                            title={formatAbsoluteDateTime(m.last_refreshed_at)}
+                          >
+                            {formatRelativeTime(m.last_refreshed_at)}
                           </TableCell>
                           <TableCell className="py-2">
                             <Button
@@ -553,23 +506,19 @@ export function MentalModelsView() {
         </AlertDialogContent>
       </AlertDialog>
 
-      {selectedMentalModel && (
-        <MentalModelDetailPanel
-          mentalModel={selectedMentalModel}
-          onClose={() => setSelectedMentalModel(null)}
-          onDelete={() =>
-            setDeleteTarget({ id: selectedMentalModel.id, name: selectedMentalModel.name })
-          }
-          onEdit={() => {
-            setMentalModelToUpdate(selectedMentalModel);
-            setShowUpdateDialog(true);
-          }}
-          onRefreshed={(updated) => {
-            setMentalModels((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
-            setSelectedMentalModel(updated);
-          }}
-        />
-      )}
+      <MentalModelDetailModal
+        mentalModelId={selectedMentalModel?.id ?? null}
+        onClose={() => setSelectedMentalModel(null)}
+        onDelete={(m) => setDeleteTarget({ id: m.id, name: m.name })}
+        onEdit={(m) => {
+          setMentalModelToUpdate(m);
+          setShowUpdateDialog(true);
+        }}
+        onRefreshed={(updated) => {
+          setMentalModels((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+          setSelectedMentalModel(updated);
+        }}
+      />
 
       {mentalModelToUpdate && (
         <UpdateMentalModelDialog
@@ -1342,361 +1291,5 @@ function UpdateMentalModelDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function MentalModelDetailPanel({
-  mentalModel,
-  onClose,
-  onDelete,
-  onEdit,
-  onRefreshed,
-}: {
-  mentalModel: MentalModel;
-  onClose: () => void;
-  onDelete: () => void;
-  onEdit: () => void;
-  onRefreshed: (m: MentalModel) => void;
-}) {
-  const { currentBank } = useBank();
-  const [refreshing, setRefreshing] = useState(false);
-  const [viewMemoryId, setViewMemoryId] = useState<string | null>(null);
-  const [viewDirectiveId, setViewDirectiveId] = useState<string | null>(null);
-  const [showHistoryModal, setShowHistoryModal] = useState(false);
-
-  const handleRefresh = async () => {
-    if (!currentBank) return;
-
-    setRefreshing(true);
-    const originalRefreshedAt = mentalModel.last_refreshed_at;
-
-    try {
-      // Submit the refresh task
-      await client.refreshMentalModel(currentBank, mentalModel.id);
-
-      // Poll until last_refreshed_at changes
-      const pollInterval = 1000; // 1 second
-      const maxAttempts = 120; // 2 minutes max
-      let attempts = 0;
-
-      const poll = async (): Promise<void> => {
-        attempts++;
-        try {
-          const updated = await client.getMentalModel(currentBank, mentalModel.id);
-          if (updated.last_refreshed_at !== originalRefreshedAt) {
-            // Refresh complete
-            onRefreshed(updated);
-            setRefreshing(false);
-            return;
-          }
-          if (attempts >= maxAttempts) {
-            // Timeout
-            setRefreshing(false);
-            toast.error("Refresh timeout", {
-              description:
-                "Refresh is taking longer than expected. Check the operations list for status.",
-            });
-            return;
-          }
-          // Continue polling
-          setTimeout(poll, pollInterval);
-        } catch (error) {
-          console.error("Error polling mental model:", error);
-          setRefreshing(false);
-        }
-      };
-
-      // Start polling after a short delay
-      setTimeout(poll, pollInterval);
-    } catch (error) {
-      // Error toast is shown automatically by the API client interceptor
-      setRefreshing(false);
-    }
-  };
-
-  const formatDateTime = (dateStr: string) => {
-    const date = new Date(dateStr);
-    return `${date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })} at ${date.toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    })}`;
-  };
-
-  // Extract all memories from based_on (excluding observations which are shown separately)
-  const basedOnFacts = mentalModel.reflect_response?.based_on
-    ? Object.entries(mentalModel.reflect_response.based_on)
-        .filter(([factType]) => factType !== "observation")
-        .flatMap(([factType, facts]) => facts.map((fact) => ({ ...fact, factType })))
-    : [];
-
-  // Helper to determine display label for fact type
-  const getFactTypeDisplay = (fact: any) => {
-    if (fact.factType === "directives") {
-      return {
-        label: "directive",
-        color: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
-      };
-    }
-    if (fact.factType === "mental-models") {
-      return {
-        label: "mental model",
-        color: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
-      };
-    }
-    if (fact.factType === "world") {
-      return { label: "world", color: "bg-blue-500/10 text-blue-600 dark:text-blue-400" };
-    }
-    if (fact.factType === "experience") {
-      return { label: "experience", color: "bg-green-500/10 text-green-600 dark:text-green-400" };
-    }
-    return { label: fact.factType, color: "bg-slate-500/10 text-slate-600 dark:text-slate-400" };
-  };
-
-  // Observations are now in based_on with type=observation
-  const observations = mentalModel.reflect_response?.based_on?.observation || [];
-
-  return (
-    <div className="fixed right-0 top-0 h-screen w-1/2 bg-card border-l shadow-2xl z-50 overflow-y-auto animate-in slide-in-from-right duration-300 ease-out">
-      <div className="p-6">
-        <div className="flex justify-between items-start mb-8 pb-5 border-b border-border">
-          <div className="flex-1 mr-4">
-            <div className="flex items-center gap-2">
-              <h3 className="text-xl font-bold text-foreground">{mentalModel.name}</h3>
-            </div>
-            <p className="text-sm text-muted-foreground mt-1">{mentalModel.source_query}</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-8 px-2 gap-1" disabled={refreshing}>
-                  {refreshing ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <MoreVertical className="h-4 w-4" />
-                  )}
-                  <span className="text-xs">Actions</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={onEdit}>
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleRefresh}>
-                  <RefreshCw className="h-4 w-4 mr-2" />
-                  Refresh
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setShowHistoryModal(true)}>
-                  <History className="h-4 w-4 mr-2" />
-                  View History
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={onDelete}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Button variant="ghost" size="sm" onClick={onClose} className="h-8 w-8 p-0">
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="space-y-6">
-          {/* Metadata Section */}
-          <div className="space-y-4">
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">ID</div>
-              <div className="text-sm text-foreground font-mono">{mentalModel.id}</div>
-            </div>
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">Name</div>
-              <div className="text-sm text-foreground">{mentalModel.name}</div>
-            </div>
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">
-                Source Query
-              </div>
-              <div className="text-sm text-foreground">{mentalModel.source_query}</div>
-            </div>
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">
-                Max Tokens
-              </div>
-              <div className="text-sm text-foreground">{mentalModel.max_tokens}</div>
-            </div>
-            {mentalModel.tags.length > 0 && (
-              <div>
-                <div className="text-xs font-bold text-muted-foreground uppercase mb-2">Tags</div>
-                <div className="flex flex-wrap gap-1.5">
-                  {mentalModel.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="px-2 py-1 rounded text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">
-                Auto-refresh
-              </div>
-              <span
-                className={`inline-block text-xs px-2 py-1 rounded-full font-medium ${
-                  mentalModel.trigger?.refresh_after_consolidation
-                    ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                    : "bg-slate-500/10 text-slate-600 dark:text-slate-400"
-                }`}
-              >
-                {mentalModel.trigger?.refresh_after_consolidation ? "Auto Refresh" : "Manual"}
-              </span>
-            </div>
-            {mentalModel.last_refreshed_at && (
-              <div>
-                <div className="text-xs font-bold text-muted-foreground uppercase mb-2">
-                  Last Refreshed
-                </div>
-                <div className="text-sm text-foreground">
-                  {formatDateTime(mentalModel.last_refreshed_at)}
-                </div>
-              </div>
-            )}
-            <div>
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-2">Created</div>
-              <div className="text-sm text-foreground">
-                {formatDateTime(mentalModel.created_at)}
-              </div>
-            </div>
-          </div>
-
-          <div className="border-t border-border pt-5">
-            <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-              Content
-            </div>
-            <div className="prose prose-base dark:prose-invert max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{mentalModel.content}</ReactMarkdown>
-            </div>
-          </div>
-
-          {/* Based On Facts Section */}
-          {basedOnFacts.length > 0 && (
-            <div className="border-t border-border pt-5">
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-3">
-                Based On ({basedOnFacts.length} {basedOnFacts.length === 1 ? "fact" : "facts"})
-              </div>
-              <div className="space-y-3">
-                {basedOnFacts.map((fact, i) => {
-                  const display = getFactTypeDisplay(fact);
-                  return (
-                    <div
-                      key={fact.id || i}
-                      className="p-4 bg-muted/50 rounded-lg border border-border/50"
-                    >
-                      <div className="flex items-start justify-between gap-2 mb-2">
-                        <span
-                          className={`px-2 py-0.5 rounded text-xs font-medium ${display.color}`}
-                        >
-                          {display.label}
-                        </span>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-6 text-xs"
-                          onClick={() => {
-                            if (fact.factType === "directives") {
-                              setViewDirectiveId(fact.id);
-                            } else {
-                              setViewMemoryId(fact.id);
-                            }
-                          }}
-                        >
-                          View
-                        </Button>
-                      </div>
-                      <p className="text-sm text-foreground leading-relaxed">{fact.text}</p>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Observations Used Section */}
-          {observations.length > 0 && (
-            <div className="border-t border-border pt-5">
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-3">
-                Observations Used ({observations.length})
-              </div>
-              <div className="space-y-3">
-                {observations.map((obs, i) => (
-                  <div
-                    key={obs.id || i}
-                    className="p-4 bg-muted/50 rounded-lg border border-border/50"
-                  >
-                    <div className="flex items-start justify-between gap-2 mb-2">
-                      <span className="px-2 py-0.5 rounded text-xs font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400">
-                        observation
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-6 text-xs"
-                        onClick={() => setViewMemoryId(obs.id)}
-                      >
-                        View
-                      </Button>
-                    </div>
-                    <p className="text-sm text-foreground leading-relaxed">{obs.text}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* No based_on data yet */}
-          {!mentalModel.reflect_response && (
-            <div className="border-t border-border pt-5">
-              <div className="text-xs font-bold text-muted-foreground uppercase mb-3">Based On</div>
-              <p className="text-sm text-muted-foreground">
-                No source data available. Click &quot;Refresh&quot; to regenerate with source
-                tracking.
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Memory Detail Modal */}
-      {viewMemoryId && currentBank && (
-        <MemoryDetailModal memoryId={viewMemoryId} onClose={() => setViewMemoryId(null)} />
-      )}
-
-      {/* Directive Detail Modal */}
-      {viewDirectiveId && currentBank && (
-        <DirectiveDetailModal
-          directiveId={viewDirectiveId}
-          onClose={() => setViewDirectiveId(null)}
-        />
-      )}
-
-      {/* Mental Model History Modal */}
-      <MentalModelDetailModal
-        mentalModelId={showHistoryModal ? mentalModel.id : null}
-        onClose={() => setShowHistoryModal(false)}
-        initialTab="history"
-      />
-    </div>
   );
 }

--- a/hindsight-control-plane/src/components/ui/dialog.tsx
+++ b/hindsight-control-plane/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -104,6 +104,7 @@ export interface MentalModel {
   last_refreshed_at: string;
   created_at: string;
   reflect_response?: any;
+  is_stale?: boolean | null;
 }
 
 export interface BankTemplateImportResponse {
@@ -1053,6 +1054,14 @@ export class ControlPlaneClient {
     return this.fetchApi<
       {
         previous_content: string | null;
+        previous_reflect_response: {
+          text?: string;
+          based_on?: Record<
+            string,
+            { id: string; text: string; type: string; context?: string | null }[]
+          >;
+          mental_models?: unknown[];
+        } | null;
         changed_at: string;
       }[]
     >(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`));

--- a/hindsight-control-plane/src/lib/relative-time.ts
+++ b/hindsight-control-plane/src/lib/relative-time.ts
@@ -1,0 +1,36 @@
+export function formatRelativeTime(dateStr: string): string {
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.round((Date.now() - then) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return diffSec >= 0 ? "just now" : "in a moment";
+  const units: [number, Intl.RelativeTimeFormatUnit][] = [
+    [60, "second"],
+    [60, "minute"],
+    [24, "hour"],
+    [7, "day"],
+    [4.345, "week"],
+    [12, "month"],
+    [Number.POSITIVE_INFINITY, "year"],
+  ];
+  let value = diffSec;
+  let unit: Intl.RelativeTimeFormatUnit = "second";
+  for (const [factor, nextUnit] of units) {
+    if (Math.abs(value) < factor) break;
+    value = value / factor;
+    unit = nextUnit;
+  }
+  return new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-Math.round(value), unit);
+}
+
+export function formatAbsoluteDateTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  return `${date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })} at ${date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })}`;
+}

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7840,6 +7840,18 @@
             ],
             "title": "Reflect Response",
             "description": "Full reflect API response payload including based_on facts and observations"
+          },
+          "is_stale": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Stale",
+            "description": "True when new memories matching this mental model's tag/fact_type scope have been ingested since last_refreshed_at, or consolidation has pending items. Only populated when detail=full."
           }
         },
         "type": "object",

--- a/scripts/check-integration-releases.sh
+++ b/scripts/check-integration-releases.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+ALL_INTEGRATIONS=("litellm" "pydantic-ai" "crewai" "ag2" "ai-sdk" "chat" "openclaw" "langgraph" "llamaindex" "nemoclaw" "strands" "claude-code" "codex" "autogen" "paperclip" "opencode" "cloudflare-oauth-proxy")
+
+usage() {
+    echo "Usage: $0 [integration]"
+    echo ""
+    echo "  integration   Optional. Name (e.g. 'crewai') or path (e.g. 'hindsight-integrations/crewai')."
+    echo "                If omitted, checks all integrations."
+    exit 1
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+fi
+
+if [ -n "$1" ]; then
+    arg="${1%/}"
+    arg="${arg#hindsight-integrations/}"
+    found=false
+    for v in "${ALL_INTEGRATIONS[@]}"; do
+        [ "$v" = "$arg" ] && found=true && break
+    done
+    if [ "$found" = "false" ]; then
+        echo -e "${RED}Unknown integration '$arg'${NC}"
+        echo "Valid: ${ALL_INTEGRATIONS[*]}"
+        exit 1
+    fi
+    INTEGRATIONS=("$arg")
+else
+    INTEGRATIONS=("${ALL_INTEGRATIONS[@]}")
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+check_one() {
+    local name="$1"
+    local dir="hindsight-integrations/$name"
+
+    if [ ! -d "$dir" ]; then
+        echo -e "${RED}[MISSING]${NC} $name (no directory)"
+        return
+    fi
+
+    local last_tag
+    last_tag=$(git tag --list "integrations/$name/v*" --sort=-v:refname | head -1)
+
+    if [ -z "$last_tag" ]; then
+        echo -e "${YELLOW}[NEVER RELEASED]${NC} $name"
+        echo -e "  ${DIM}all commits touching $dir:${NC}"
+        git log --graph --decorate --pretty=format:'%C(yellow)%h%Creset %C(cyan)(%ar)%Creset %C(green)<%an>%Creset %s%C(auto)%d%Creset' -- "$dir" | sed 's/^/    /'
+        echo ""
+        echo ""
+        return
+    fi
+
+    local version="${last_tag#integrations/$name/v}"
+    local count
+    count=$(git log --oneline "$last_tag"..HEAD -- "$dir" | wc -l | tr -d ' ')
+
+    if [ "$count" = "0" ]; then
+        echo -e "${GREEN}[OK]${NC} $name v$version (up to date with $last_tag)"
+        return
+    fi
+
+    echo -e "${BLUE}[UNRELEASED]${NC} $name v$version → $count commit(s) since $last_tag"
+    git log --graph --decorate --pretty=format:'%C(yellow)%h%Creset %C(cyan)(%ar)%Creset %C(green)<%an>%Creset %s%C(auto)%d%Creset' "$last_tag"..HEAD -- "$dir" | sed 's/^/    /'
+    echo ""
+    echo ""
+}
+
+for name in "${INTEGRATIONS[@]}"; do
+    check_one "$name"
+done

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7840,6 +7840,18 @@
             ],
             "title": "Reflect Response",
             "description": "Full reflect API response payload including based_on facts and observations"
+          },
+          "is_stale": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Stale",
+            "description": "True when new memories matching this mental model's tag/fact_type scope have been ingested since last_refreshed_at, or consolidation has pending items. Only populated when detail=full."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary
- Add a scope-aware `is_stale` signal on mental models (tags + `trigger.tags_match` + `fact_types`) and surface it on `GET /mental-models/{id}` (detail=full). Consolidation refresh and `tool_search_mental_models` now use the same helper, so refreshes fire only when an MM's scope actually has new memories.
- History entries now snapshot `previous_reflect_response` alongside `previous_content`, so each version keeps its based_on grounding.
- Revamp the mental model detail UI: replace the side panel with a near-fullscreen dialog (Content / Configuration / History tabs) with In sync / Stale badge, per-version based_on diff, and compact markdown rendering reused by the list cards.

## Test plan
- [x] `uv run pytest tests/test_mental_models.py::TestMentalModelStaleness` (8 tests) — covers untagged scope, out-of-scope tags, `any_strict`, `all_strict`, `fact_types` filter, plus a `tool_search_mental_models` regression.
- [x] `uv run pytest tests/test_mental_models.py::TestMentalModelHistory` — `previous_reflect_response` snapshot.
- [x] `./scripts/hooks/lint.sh`
- [x] Manual UI smoke: detail modal, tabs, stale badge, history diff.
- [ ] Full API test suite in CI.