### PR TITLE
fix: files/retain upload problems and orphaned retains

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -854,26 +854,37 @@ class MemoryEngine(MemoryEngineInterface):
             "file_content_type": task_dict["content_type"],
         }
 
-        # In one transaction: create the retain async operation AND mark this conversion as completed
+        # Include task_payload in the INSERT atomically. Previously this was a
+        # two-step process (INSERT without payload, then UPDATE to set it) which
+        # left null-payload rows when a crash or timeout occurred between the two
+        # statements. The worker claim query filters on `task_payload IS NOT NULL`,
+        # so those orphaned rows became permanently stuck as unclaimed pending tasks.
         retain_operation_id = uuid.uuid4()
+        full_retain_payload = {
+            "type": "batch_retain",
+            "operation_id": str(retain_operation_id),
+            "bank_id": bank_id,
+            **retain_task_payload,
+        }
+        payload_json = json.dumps(full_retain_payload, default=_json_default)
+
         pool = await self._get_pool()
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
-                # Create the retain operation record
                 await conn.execute(
                     f"""
                     INSERT INTO {fq_table("async_operations")}
-                    (operation_id, bank_id, operation_type, result_metadata, status)
-                    VALUES ($1, $2, $3, $4, $5)
+                    (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
                     """,
                     retain_operation_id,
                     bank_id,
                     "retain",
                     json.dumps({}),
                     "pending",
+                    payload_json,
                 )
 
-                # Mark this file_convert_retain operation as completed
                 if operation_id:
                     await conn.execute(
                         f"""
@@ -884,13 +895,8 @@ class MemoryEngine(MemoryEngineInterface):
                         uuid.UUID(operation_id),
                     )
 
-        # Submit the retain task to the task backend (outside the transaction)
-        full_retain_payload = {
-            "type": "batch_retain",
-            "operation_id": str(retain_operation_id),
-            "bank_id": bank_id,
-            **retain_task_payload,
-        }
+        # For SyncTaskBackend: executes the retain task inline.
+        # For BrokerTaskBackend: idempotent UPDATE (payload already set above).
         await self._task_backend.submit_task(full_retain_payload)
 
         logger.info(


### PR DESCRIPTION
### Summary

Closes a race between the file-convert-retain worker task and the async task backend where a crash or timeout could orphan retain operations permanently.

The bug: _handle_file_convert_retain_task inserted an async_operations row without task_payload, then separately called submit_task to set the payload. If a crash or timeout occurred between those two statements, the row was left with task_payload IS NULL. The worker's claim_batch query filters on task_payload IS NOT NULL, so those orphaned rows became permanently stuck as unclaimed pending tasks — file uploads that silently never completed.

Fix: Build full_retain_payload and serialize it to JSON before the transaction, then include task_payload as a column in the atomic INSERT. The row is now born with its payload, so a crash at any point either leaves no row (transaction rolled back) or a fully-claimable row.

memory_engine.py: _handle_file_convert_retain_task now inserts task_payload in the same INSERT statement that creates the async_operations row. submit_task is still called afterwards for the SyncTaskBackend path (inline execution) and is idempotent for BrokerTaskBackend (payload already set).


### Test plan

- [x] uv run pytest tests/test_http_api_integration.py -v -- file/retain integration tests 
- [x] ./scripts/hooks/lint.sh -- all passed
- [ ] CI green