### PR TITLE
fix: handle 'timestamp' field for file retain API

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -823,16 +823,19 @@ class MemoryEngine(MemoryEngineInterface):
                 logger.warning(f"[FILE_CONVERT_RETAIN] on_file_convert_complete hook failed: {e}")
 
         # Build retain task payload
-        retain_contents = [
-            {
-                "content": markdown_content,
-                "document_id": document_id,
-                "context": task_dict.get("context"),
-                "metadata": task_dict.get("metadata", {}),
-                "tags": task_dict.get("tags", []),
-                "timestamp": task_dict.get("timestamp"),
-            }
-        ]
+        retain_content: dict[str, Any] = {
+            "content": markdown_content,
+            "document_id": document_id,
+            "context": task_dict.get("context"),
+            "metadata": task_dict.get("metadata", {}),
+            "tags": task_dict.get("tags", []),
+        }
+        file_timestamp = task_dict.get("timestamp")
+        if file_timestamp == "unset":
+            retain_content["event_date"] = None
+        elif file_timestamp:
+            retain_content["event_date"] = file_timestamp
+        retain_contents = [retain_content]
         document_tags = task_dict.get("document_tags")
 
         retain_task_payload: dict[str, Any] = {"contents": retain_contents}


### PR DESCRIPTION
## Summary

Fixes the `timestamp` → `event_date` mapping in the **file/retain** path (`_handle_file_convert_retain_task`).

**The bug:** The normal retain API route (`POST /memories/retain`) correctly maps the user-facing `timestamp` field to the internal `event_date` key before passing content to the retain pipeline:

```python
if item.timestamp == "unset":
    content_dict["event_date"] = None
elif item.timestamp:
    content_dict["event_date"] = item.timestamp
```

The retain orchestrator then reads `event_date` from the content dict to set the memory's date:

```python
if "event_date" in item and item["event_date"] is None:
    event_date_value = None
elif item.get("event_date"):
    event_date_value = parse_datetime_flexible(item["event_date"])
else:
    event_date_value = utcnow()
```

However, the **file/retain** path (`POST /files/retain`) skipped this mapping entirely — it passed `"timestamp"` as-is into the retain content dict. Since the orchestrator looks for `"event_date"` (not `"timestamp"`), the timestamp was silently ignored and every file-retained memory defaulted to `utcnow()` regardless of what the caller specified. The `"unset"` sentinel (which explicitly opts out of a date) was also never handled.

**Fix:** Apply the same `timestamp` → `event_date` mapping that the normal retain route uses, including `"unset"` support to explicitly clear the date.

- `memory_engine.py`: `_handle_file_convert_retain_task` now maps `timestamp` to `event_date` before building `retain_contents`, matching the behavior of the HTTP retain route.

## Test plan

- [x] `uv run pytest tests/ -v` — retain integration tests pass
- [x] `./scripts/hooks/lint.sh` — all passed
- [ ] CI green
