### PR TITLE
fix(openclaw): resolve full symlink chain in isDirectExecution()

### DIFF
--- a/hindsight-integrations/openclaw/src/backfill.ts
+++ b/hindsight-integrations/openclaw/src/backfill.ts
@@ -630,13 +630,26 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
   console.log(args.json ? JSON.stringify(summary, null, 2) : JSON.stringify(summary));
 }
 
+function resolveSymlinks(path: string): string {
+  const seen = new Set<string>();
+  let current = path;
+  while (true) {
+    if (seen.has(current)) return current;
+    seen.add(current);
+    let target: string;
+    try {
+      target = realpathSync(current);
+    } catch {
+      return current;
+    }
+    if (target === current) return current;
+    current = target;
+  }
+}
+
 function canonicalizeExecutionPath(path: string): string {
   const resolved = resolve(path);
-  try {
-    return realpathSync(resolved);
-  } catch {
-    return resolved;
-  }
+  return resolveSymlinks(resolved);
 }
 
 export function isDirectExecution(


### PR DESCRIPTION
## Fix: isDirectExecution() misdetects symlinked bin path

**Issue:** #1033

### Root Cause

When a bin symlink points to a CLI wrapper (not directly to the module), process.argv[1] contains the wrapper path after ealpathSync resolution, while import.meta.url points to the actual module file. The original canonicalizeExecutionPath only called ealpathSync once, which is insufficient for chained symlinks.

### Solution

Replace the single-call ealpathSync with an iterative symlink-following function that handles arbitrary-length symlink chains:

\	ypescript
function resolveSymlinks(path: string): string {
  const seen = new Set<string>();
  let current = path;
  while (true) {
    if (seen.has(current)) return current;
    seen.add(current);
    let target: string;
    try { target = realpathSync(current); } catch { return current; }
    if (target === current) return current;
    current = target;
  }
}
\\n
This fix is especially important for environments like OpenClaw where CLI wrappers are common.