### PR TITLE
fix(worker): make submit_task idempotent when payload already set

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -899,7 +899,8 @@ class MemoryEngine(MemoryEngineInterface):
                     )
 
         # For SyncTaskBackend: executes the retain task inline.
-        # For BrokerTaskBackend: idempotent UPDATE (payload already set above).
+        # For BrokerTaskBackend: no-op (submit_task's UPDATE skips rows whose
+        # task_payload is already set, which it is after the INSERT above).
         await self._task_backend.submit_task(full_retain_payload)
 
         logger.info(
@@ -8166,8 +8167,9 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
         # For SyncTaskBackend: executes the task immediately.
-        # For BrokerTaskBackend: does an idempotent UPDATE (payload already set above),
-        # kept for symmetry and to support any future notification mechanisms.
+        # For BrokerTaskBackend: no-op (submit_task's UPDATE skips rows whose
+        # task_payload is already set, which it is after the INSERT above). The call
+        # is kept for symmetry and to support any future notification mechanisms.
         await self._task_backend.submit_task(full_payload)
 
         logger.info(f"{operation_type} task queued for bank_id={bank_id}, operation_id={operation_id}")

--- a/hindsight-api-slim/hindsight_api/engine/task_backend.py
+++ b/hindsight-api-slim/hindsight_api/engine/task_backend.py
@@ -193,17 +193,21 @@ class BrokerTaskBackend(TaskBackend):
         table = fq_table("async_operations", schema)
 
         if operation_id:
-            # Update existing operation with task payload
+            # Callers now include task_payload in the same INSERT that creates the
+            # async_operations row (see MemoryEngine._submit_async_operation). The
+            # WHERE clause guards against overwriting that payload — the UPDATE is a
+            # no-op when the row is already claimable, and only fills in a NULL payload
+            # for any legacy caller that still creates the row first.
             await pool.execute(
                 f"""
                 UPDATE {table}
                 SET task_payload = $1::jsonb, updated_at = now()
-                WHERE operation_id = $2
+                WHERE operation_id = $2 AND task_payload IS NULL
                 """,
                 payload_json,
                 operation_id,
             )
-            logger.debug(f"Updated task payload for operation {operation_id}")
+            logger.debug(f"submit_task UPDATE for operation {operation_id} (no-op if payload already set)")
         else:
             # Insert new operation (for tasks without pre-created records)
             # e.g., access_count_update tasks

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -560,3 +560,54 @@ async def test_get_operation_status_include_payload(memory, request_context):
     assert payload.get("bank_id") == bank_id
     assert payload.get("contents")
     assert payload["contents"][0]["content"] == "Payload roundtrip test item."
+
+
+@pytest.mark.asyncio
+async def test_submit_async_operation_leaves_claimable_row_when_submit_task_fails(memory):
+    """Regression for the crash-window orphan bug fixed in #1091.
+
+    Previously, _submit_async_operation INSERTed the async_operations row without
+    task_payload, then called submit_task as a separate step to fill it in. If
+    submit_task failed (crash, timeout, dropped connection) after the INSERT
+    committed, the row was left with task_payload IS NULL and became permanently
+    stuck because the worker claim query filters on task_payload IS NOT NULL.
+
+    With the atomic INSERT, even if submit_task raises afterwards the row is born
+    claimable. This test simulates the crash by forcing submit_task to raise.
+    """
+    bank_id = f"test_orphan_prevention_{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+
+    async def failing_submit_task(_task_dict):
+        raise RuntimeError("Simulated crash between INSERT and submit_task")
+
+    memory._task_backend.submit_task = failing_submit_task  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="Simulated crash"):
+        await memory._submit_async_operation(
+            bank_id=bank_id,
+            operation_type="retain",
+            task_type="batch_retain",
+            task_payload={"contents": [{"content": "hello", "document_id": "d1"}]},
+        )
+
+    rows = await pool.fetch(
+        """
+        SELECT status, task_payload
+        FROM async_operations
+        WHERE bank_id = $1 AND operation_type = 'retain'
+        """,
+        bank_id,
+    )
+    assert len(rows) == 1, f"Expected exactly one retain row for bank_id={bank_id}, got {len(rows)}"
+    row = rows[0]
+    assert row["status"] == "pending"
+    assert row["task_payload"] is not None, (
+        "task_payload must be set atomically by the INSERT — a NULL here means "
+        "the worker claim query (task_payload IS NOT NULL) will never pick this row up"
+    )
+    payload = json.loads(row["task_payload"])
+    assert payload["type"] == "batch_retain"
+    assert payload["bank_id"] == bank_id
+    assert payload["contents"] == [{"content": "hello", "document_id": "d1"}]

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -137,6 +137,55 @@ class TestBrokerTaskBackend:
         payload = json.loads(row["task_payload"])
         assert payload["node_ids"] == ["node1", "node2"]
 
+    @pytest.mark.asyncio
+    async def test_submit_task_preserves_existing_payload(self, pool, clean_operations):
+        """Callers now INSERT task_payload atomically, then call submit_task as a
+        no-op for the BrokerTaskBackend path. submit_task must not overwrite a
+        payload that is already set, otherwise a stale updated_at bump on a
+        possibly-already-processing row reintroduces noise the fix aimed to remove.
+        """
+        operation_id = uuid.uuid4()
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        original_payload = {"type": "test_task", "bank_id": bank_id, "version": "inserted"}
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'test_operation', 'pending', $3::jsonb)
+            """,
+            operation_id,
+            bank_id,
+            json.dumps(original_payload),
+        )
+
+        row_before = await pool.fetchrow(
+            "SELECT updated_at FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+
+        backend = BrokerTaskBackend(pool_getter=lambda: pool)
+        await backend.initialize()
+
+        await backend.submit_task(
+            {
+                "operation_id": str(operation_id),
+                "type": "test_task",
+                "bank_id": bank_id,
+                "version": "resubmitted",
+            }
+        )
+
+        row_after = await pool.fetchrow(
+            "SELECT task_payload, updated_at FROM async_operations WHERE operation_id = $1",
+            operation_id,
+        )
+        payload = json.loads(row_after["task_payload"])
+        assert payload["version"] == "inserted", "submit_task must not overwrite an existing payload"
+        assert row_after["updated_at"] == row_before["updated_at"], (
+            "submit_task must not bump updated_at when payload was already set"
+        )
+
 
 class TestWorkerPoller:
     """Tests for WorkerPoller task claiming and execution."""


### PR DESCRIPTION
## Summary

Follow-up to #1091. That PR made `_submit_async_operation` insert `task_payload` atomically in the same row that creates the async_operations record, closing the crash-window orphan bug. The follow-up call to `_task_backend.submit_task` is still needed so `SyncTaskBackend` can execute the task inline (tests + embedded mode), but for `BrokerTaskBackend` the call was redundantly UPDATE-ing `task_payload` and bumping `updated_at` on a row that was already claimable — and could even touch a row that a worker had already claimed and transitioned to processing/completed.

- Make the UPDATE a no-op when `task_payload` is already set by adding `AND task_payload IS NULL` to the WHERE clause.
- Existing callers that still rely on a two-step INSERT-then-submit pattern continue to work via the legacy fallback path.
- Updated the now-stale "idempotent UPDATE" comments at both call sites in `memory_engine.py`.

## Test plan

- [x] ` tests/test_worker.py::TestBrokerTaskBackend::test_submit_task_preserves_existing_payload` — locks in the idempotent semantics at the backend level (payload not overwritten, `updated_at` not bumped).
- [x] `tests/test_async_batch_retain.py::test_submit_async_operation_leaves_claimable_row_when_submit_task_fails` — regression test for the original #1091 bug. Mocks `submit_task` to raise (simulating a crash between the INSERT commit and the follow-up call) and asserts the row is still born claimable (`status=pending`, `task_payload` populated).
- [x] `./scripts/hooks/lint.sh` passes
- [ ] CI green