### PR TITLE
fix(ollama): add think=false to _call_ollama_native payload

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -765,6 +765,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "model": self.model,
             "messages": messages,
             "stream": False,
+            "think": False,  # Disable thinking for reasoning models (qwen3.5, etc.)
         }
 
         # Add schema as format parameter for structured output


### PR DESCRIPTION
## Summary

- Add `"think": False` to the `/api/chat` payload in `_call_ollama_native()` to disable thinking mode for reasoning models

## Problem

Reasoning models (e.g. qwen3.5) route their entire response to the `thinking` field when `think` is not explicitly set to `false`, leaving `message.content` empty. This breaks structured output (fact extraction, etc.) for any Ollama reasoning model used via the native API path.

## Fix

One-line addition to `openai_compatible_llm.py` L764:

```python
payload: dict[str, Any] = {
    "model": self.model,
    "messages": messages,
    "stream": False,
    "think": False,  # Disable thinking for reasoning models (qwen3.5, etc.)
}
```

## Impact

- **Affected**: Ollama provider + structured output (`_call_ollama_native` path)
- **Not affected**: OpenAI-compatible path (`/v1/chat/completions`), other providers
- **Safe for non-reasoning models**: Ollama ignores unknown fields, so gemma3, phi4-mini, etc. are unaffected

## Testing

Verified with qwen3.5:2b via Ollama v0.20.7:
- Without `think: false`: response content is empty (all output goes to thinking field)
- With `think: false`: structured JSON output works correctly, Japanese fact extraction succeeds

Fixes #1098