### PR TITLE
feat(control-plane): surface failed-consolidation count and drilldown

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1454,6 +1454,7 @@ class BankStatsResponse(BaseModel):
                 "failed_operations": 0,
                 "last_consolidated_at": "2024-01-15T10:30:00Z",
                 "pending_consolidation": 0,
+                "failed_consolidation": 0,
                 "total_observations": 45,
             }
         }
@@ -1476,6 +1477,10 @@ class BankStatsResponse(BaseModel):
     # Consolidation stats
     last_consolidated_at: str | None = Field(default=None, description="When consolidation last ran (ISO format)")
     pending_consolidation: int = Field(default=0, description="Number of memories not yet processed into observations")
+    failed_consolidation: int = Field(
+        default=0,
+        description="Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.",
+    )
     total_observations: int = Field(default=0, description="Total number of observations")
 
 
@@ -2893,6 +2898,7 @@ def _register_routes(app: FastAPI):
         bank_id: str,
         type: str | None = None,
         q: str | None = None,
+        consolidation_state: str | None = None,
         limit: int = 100,
         offset: int = 0,
         request_context: RequestContext = Depends(get_request_context),
@@ -2907,6 +2913,8 @@ def _register_routes(app: FastAPI):
             bank_id: Memory Bank ID (from path)
             type: Filter by fact type (world, experience, opinion)
             q: Search query for full-text search (searches text and context)
+            consolidation_state: Filter by consolidation state for source memories
+                (world/experience). One of 'failed', 'pending', or 'done'.
             limit: Maximum number of results (default: 100)
             offset: Offset for pagination (default: 0)
         """
@@ -2915,11 +2923,14 @@ def _register_routes(app: FastAPI):
                 bank_id=bank_id,
                 fact_type=type,
                 search_query=q,
+                consolidation_state=consolidation_state,
                 limit=limit,
                 offset=offset,
                 request_context=request_context,
             )
             return data
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
@@ -3377,6 +3388,7 @@ def _register_routes(app: FastAPI):
                 operations_by_status=ops,
                 last_consolidated_at=stats["last_consolidated_at"],
                 pending_consolidation=stats["pending_consolidation"],
+                failed_consolidation=stats.get("failed_consolidation", 0),
                 total_observations=stats["total_observations"],
             )
         except OperationValidationError as e:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4669,6 +4669,7 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         fact_type: str | None = None,
         search_query: str | None = None,
+        consolidation_state: str | None = None,
         limit: int = 100,
         offset: int = 0,
         request_context: "RequestContext",
@@ -4680,6 +4681,11 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id: Filter by bank ID
             fact_type: Filter by fact type (world, experience)
             search_query: Full-text search query (searches text and context fields)
+            consolidation_state: Optional filter on consolidation state. One of
+                'failed' (consolidation permanently failed and awaiting recovery),
+                'pending' (not yet consolidated, no failure), or
+                'done' (successfully consolidated). Only applies to source memory
+                types (world/experience).
             limit: Maximum number of results to return
             offset: Offset for pagination
             request_context: Request context for authentication.
@@ -4716,6 +4722,24 @@ class MemoryEngine(MemoryEngineInterface):
                 query_conditions.append(f"(text ILIKE ${param_count} OR context ILIKE ${param_count})")
                 query_params.append(f"%{search_query}%")
 
+            if consolidation_state:
+                state = consolidation_state.lower()
+                if state == "failed":
+                    query_conditions.append(
+                        "consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')"
+                    )
+                elif state == "pending":
+                    query_conditions.append(
+                        "consolidated_at IS NULL AND consolidation_failed_at IS NULL "
+                        "AND fact_type IN ('experience', 'world')"
+                    )
+                elif state == "done":
+                    query_conditions.append("consolidated_at IS NOT NULL AND fact_type IN ('experience', 'world')")
+                else:
+                    raise ValueError(
+                        f"Invalid consolidation_state '{consolidation_state}': expected 'failed', 'pending', or 'done'."
+                    )
+
             where_clause = "WHERE " + " AND ".join(query_conditions) if query_conditions else ""
 
             # Get total count
@@ -4738,7 +4762,7 @@ class MemoryEngine(MemoryEngineInterface):
 
             units = await conn.fetch(
                 f"""
-                SELECT id, text, event_date, context, fact_type, mentioned_at, occurred_start, occurred_end, chunk_id, proof_count, tags
+                SELECT id, text, event_date, context, fact_type, mentioned_at, occurred_start, occurred_end, chunk_id, proof_count, tags, consolidated_at, consolidation_failed_at
                 FROM {fq_table("memory_units")}
                 {where_clause}
                 ORDER BY mentioned_at DESC NULLS LAST, created_at DESC
@@ -4792,6 +4816,10 @@ class MemoryEngine(MemoryEngineInterface):
                         "chunk_id": row["chunk_id"] if row["chunk_id"] else None,
                         "proof_count": row["proof_count"] if row["proof_count"] is not None else 1,
                         "tags": list(row["tags"]) if row["tags"] else [],
+                        "consolidated_at": row["consolidated_at"].isoformat() if row["consolidated_at"] else None,
+                        "consolidation_failed_at": (
+                            row["consolidation_failed_at"].isoformat() if row["consolidation_failed_at"] else None
+                        ),
                     }
                 )
 
@@ -6285,7 +6313,8 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT
                     MAX(consolidated_at) as last_consolidated_at,
-                    COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) as pending
+                    COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) as pending,
+                    COUNT(*) FILTER (WHERE consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')) as failed
                 FROM {fq_table("memory_units")}
                 WHERE bank_id = $1
                 """,
@@ -6309,6 +6338,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "total_documents": doc_count_row["count"] if doc_count_row else 0,
                 "last_consolidated_at": last_consolidated_at.isoformat() if last_consolidated_at else None,
                 "pending_consolidation": consolidation_row["pending"] if consolidation_row else 0,
+                "failed_consolidation": consolidation_row["failed"] if consolidation_row else 0,
                 "total_observations": node_counts.get("observation", 0),
             }
 

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -5,6 +5,7 @@ Covers the new fields exposed by GET /v1/default/banks/{bank_id}/stats
 (operations_by_status) and the new endpoint
 GET /v1/default/banks/{bank_id}/stats/memories-timeseries.
 """
+import uuid
 from datetime import datetime
 
 import httpx
@@ -25,6 +26,23 @@ async def api_client(memory):
 @pytest.fixture
 def test_bank_id():
     return f"stats_test_{datetime.now().timestamp()}"
+
+
+async def _insert_memory(memory, bank_id: str, text: str, *, failed: bool = False) -> str:
+    """Insert a single experience memory, optionally marked as consolidation-failed."""
+    mem_id = uuid.uuid4()
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO memory_units (id, bank_id, text, fact_type, created_at, consolidation_failed_at)
+            VALUES ($1, $2, $3, 'experience', now(), CASE WHEN $4 THEN now() ELSE NULL END)
+            """,
+            mem_id,
+            bank_id,
+            text,
+            failed,
+        )
+    return str(mem_id)
 
 
 @pytest.mark.asyncio
@@ -166,5 +184,59 @@ async def test_memories_timeseries_reflects_retained_memories(api_client, test_b
         # Those memories should land in the most-recent bucket.
         latest = body["buckets"][-1]
         assert latest["world"] + latest["experience"] + latest["observation"] >= 2
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_bank_stats_reports_failed_consolidation(api_client, memory, test_bank_id):
+    """/stats must surface the count of memories with consolidation_failed_at set."""
+    try:
+        await _insert_memory(memory, test_bank_id, "Alice failed 1.", failed=True)
+        await _insert_memory(memory, test_bank_id, "Alice failed 2.", failed=True)
+        await _insert_memory(memory, test_bank_id, "Alice pending.", failed=False)
+
+        response = await api_client.get(f"/v1/default/banks/{test_bank_id}/stats")
+        assert response.status_code == 200
+        stats = response.json()
+
+        assert stats["failed_consolidation"] == 2
+        # The two failed memories also count as "not-yet-consolidated".
+        assert stats["pending_consolidation"] >= 3
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_by_consolidation_state_failed(api_client, memory, test_bank_id):
+    """?consolidation_state=failed returns only memories with consolidation_failed_at set."""
+    try:
+        failed_id = await _insert_memory(memory, test_bank_id, "Broken item.", failed=True)
+        await _insert_memory(memory, test_bank_id, "Healthy item.", failed=False)
+
+        response = await api_client.get(
+            f"/v1/default/banks/{test_bank_id}/memories/list",
+            params={"consolidation_state": "failed"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+
+        ids = [item["id"] for item in body["items"]]
+        assert failed_id in ids
+        assert body["total"] == 1
+        assert body["items"][0]["consolidation_failed_at"] is not None
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_by_consolidation_state_rejects_unknown(api_client, test_bank_id):
+    """An invalid consolidation_state value must return a 400 (not 500)."""
+    try:
+        response = await api_client.get(
+            f"/v1/default/banks/{test_bank_id}/memories/list",
+            params={"consolidation_state": "bogus"},
+        )
+        assert response.status_code == 400
     finally:
         await api_client.delete(f"/v1/default/banks/{test_bank_id}")

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -513,7 +513,7 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .list_memories(bank_id, limit, offset, q, type_filter, None)
+                .list_memories(bank_id, None, limit, offset, q, type_filter, None)
                 .await?;
             Ok(response.into_inner())
         })

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -168,6 +168,14 @@ paths:
         style: form
       - explode: true
         in: query
+        name: consolidation_state
+        required: false
+        schema:
+          nullable: true
+          type: string
+        style: form
+      - explode: true
+        in: query
         name: limit
         required: false
         schema:
@@ -3559,6 +3567,7 @@ components:
       description: Response model for bank statistics endpoint.
       example:
         bank_id: user123
+        failed_consolidation: 0
         failed_operations: 0
         last_consolidated_at: 2024-01-15T10:30:00Z
         links_breakdown:
@@ -3633,6 +3642,12 @@ components:
           default: 0
           description: Number of memories not yet processed into observations
           title: Pending Consolidation
+          type: integer
+        failed_consolidation:
+          default: 0
+          description: Number of source memories (world/experience) whose consolidation
+            permanently failed and can be retried via the consolidation recovery endpoint.
+          title: Failed Consolidation
           type: integer
         total_observations:
           default: 0

--- a/hindsight-clients/go/api_memory.go
+++ b/hindsight-clients/go/api_memory.go
@@ -721,6 +721,7 @@ type ApiListMemoriesRequest struct {
 	bankId string
 	type_ *string
 	q *string
+	consolidationState *string
 	limit *int32
 	offset *int32
 	authorization *string
@@ -733,6 +734,11 @@ func (r ApiListMemoriesRequest) Type_(type_ string) ApiListMemoriesRequest {
 
 func (r ApiListMemoriesRequest) Q(q string) ApiListMemoriesRequest {
 	r.q = &q
+	return r
+}
+
+func (r ApiListMemoriesRequest) ConsolidationState(consolidationState string) ApiListMemoriesRequest {
+	r.consolidationState = &consolidationState
 	return r
 }
 
@@ -799,6 +805,9 @@ func (a *MemoryAPIService) ListMemoriesExecute(r ApiListMemoriesRequest) (*ListM
 	}
 	if r.q != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "q", r.q, "form", "")
+	}
+	if r.consolidationState != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "consolidation_state", r.consolidationState, "form", "")
 	}
 	if r.limit != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "limit", r.limit, "form", "")

--- a/hindsight-clients/go/model_bank_stats_response.go
+++ b/hindsight-clients/go/model_bank_stats_response.go
@@ -36,6 +36,8 @@ type BankStatsResponse struct {
 	LastConsolidatedAt NullableString `json:"last_consolidated_at,omitempty"`
 	// Number of memories not yet processed into observations
 	PendingConsolidation *int32 `json:"pending_consolidation,omitempty"`
+	// Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.
+	FailedConsolidation *int32 `json:"failed_consolidation,omitempty"`
 	// Total number of observations
 	TotalObservations *int32 `json:"total_observations,omitempty"`
 }
@@ -60,6 +62,8 @@ func NewBankStatsResponse(bankId string, totalNodes int32, totalLinks int32, tot
 	this.FailedOperations = failedOperations
 	var pendingConsolidation int32 = 0
 	this.PendingConsolidation = &pendingConsolidation
+	var failedConsolidation int32 = 0
+	this.FailedConsolidation = &failedConsolidation
 	var totalObservations int32 = 0
 	this.TotalObservations = &totalObservations
 	return &this
@@ -72,6 +76,8 @@ func NewBankStatsResponseWithDefaults() *BankStatsResponse {
 	this := BankStatsResponse{}
 	var pendingConsolidation int32 = 0
 	this.PendingConsolidation = &pendingConsolidation
+	var failedConsolidation int32 = 0
+	this.FailedConsolidation = &failedConsolidation
 	var totalObservations int32 = 0
 	this.TotalObservations = &totalObservations
 	return &this
@@ -423,6 +429,38 @@ func (o *BankStatsResponse) SetPendingConsolidation(v int32) {
 	o.PendingConsolidation = &v
 }
 
+// GetFailedConsolidation returns the FailedConsolidation field value if set, zero value otherwise.
+func (o *BankStatsResponse) GetFailedConsolidation() int32 {
+	if o == nil || IsNil(o.FailedConsolidation) {
+		var ret int32
+		return ret
+	}
+	return *o.FailedConsolidation
+}
+
+// GetFailedConsolidationOk returns a tuple with the FailedConsolidation field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *BankStatsResponse) GetFailedConsolidationOk() (*int32, bool) {
+	if o == nil || IsNil(o.FailedConsolidation) {
+		return nil, false
+	}
+	return o.FailedConsolidation, true
+}
+
+// HasFailedConsolidation returns a boolean if a field has been set.
+func (o *BankStatsResponse) HasFailedConsolidation() bool {
+	if o != nil && !IsNil(o.FailedConsolidation) {
+		return true
+	}
+
+	return false
+}
+
+// SetFailedConsolidation gets a reference to the given int32 and assigns it to the FailedConsolidation field.
+func (o *BankStatsResponse) SetFailedConsolidation(v int32) {
+	o.FailedConsolidation = &v
+}
+
 // GetTotalObservations returns the TotalObservations field value if set, zero value otherwise.
 func (o *BankStatsResponse) GetTotalObservations() int32 {
 	if o == nil || IsNil(o.TotalObservations) {
@@ -483,6 +521,9 @@ func (o BankStatsResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.PendingConsolidation) {
 		toSerialize["pending_consolidation"] = o.PendingConsolidation
+	}
+	if !IsNil(o.FailedConsolidation) {
+		toSerialize["failed_consolidation"] = o.FailedConsolidation
 	}
 	if !IsNil(o.TotalObservations) {
 		toSerialize["total_observations"] = o.TotalObservations

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -1593,6 +1593,7 @@ class MemoryApi:
         bank_id: StrictStr,
         type: Optional[StrictStr] = None,
         q: Optional[StrictStr] = None,
+        consolidation_state: Optional[StrictStr] = None,
         limit: Optional[StrictInt] = None,
         offset: Optional[StrictInt] = None,
         authorization: Optional[StrictStr] = None,
@@ -1619,6 +1620,8 @@ class MemoryApi:
         :type type: str
         :param q:
         :type q: str
+        :param consolidation_state:
+        :type consolidation_state: str
         :param limit:
         :type limit: int
         :param offset:
@@ -1651,6 +1654,7 @@ class MemoryApi:
             bank_id=bank_id,
             type=type,
             q=q,
+            consolidation_state=consolidation_state,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -1681,6 +1685,7 @@ class MemoryApi:
         bank_id: StrictStr,
         type: Optional[StrictStr] = None,
         q: Optional[StrictStr] = None,
+        consolidation_state: Optional[StrictStr] = None,
         limit: Optional[StrictInt] = None,
         offset: Optional[StrictInt] = None,
         authorization: Optional[StrictStr] = None,
@@ -1707,6 +1712,8 @@ class MemoryApi:
         :type type: str
         :param q:
         :type q: str
+        :param consolidation_state:
+        :type consolidation_state: str
         :param limit:
         :type limit: int
         :param offset:
@@ -1739,6 +1746,7 @@ class MemoryApi:
             bank_id=bank_id,
             type=type,
             q=q,
+            consolidation_state=consolidation_state,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -1769,6 +1777,7 @@ class MemoryApi:
         bank_id: StrictStr,
         type: Optional[StrictStr] = None,
         q: Optional[StrictStr] = None,
+        consolidation_state: Optional[StrictStr] = None,
         limit: Optional[StrictInt] = None,
         offset: Optional[StrictInt] = None,
         authorization: Optional[StrictStr] = None,
@@ -1795,6 +1804,8 @@ class MemoryApi:
         :type type: str
         :param q:
         :type q: str
+        :param consolidation_state:
+        :type consolidation_state: str
         :param limit:
         :type limit: int
         :param offset:
@@ -1827,6 +1838,7 @@ class MemoryApi:
             bank_id=bank_id,
             type=type,
             q=q,
+            consolidation_state=consolidation_state,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -1852,6 +1864,7 @@ class MemoryApi:
         bank_id,
         type,
         q,
+        consolidation_state,
         limit,
         offset,
         authorization,
@@ -1886,6 +1899,10 @@ class MemoryApi:
         if q is not None:
             
             _query_params.append(('q', q))
+            
+        if consolidation_state is not None:
+            
+            _query_params.append(('consolidation_state', consolidation_state))
             
         if limit is not None:
             

--- a/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_stats_response.py
@@ -39,8 +39,9 @@ class BankStatsResponse(BaseModel):
     operations_by_status: Optional[Dict[str, StrictInt]] = Field(default=None, description="Async operations grouped by status (pending, in_progress, completed, failed, cancelled).")
     last_consolidated_at: Optional[StrictStr] = None
     pending_consolidation: Optional[StrictInt] = Field(default=0, description="Number of memories not yet processed into observations")
+    failed_consolidation: Optional[StrictInt] = Field(default=0, description="Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.")
     total_observations: Optional[StrictInt] = Field(default=0, description="Total number of observations")
-    __properties: ClassVar[List[str]] = ["bank_id", "total_nodes", "total_links", "total_documents", "nodes_by_fact_type", "links_by_link_type", "links_by_fact_type", "links_breakdown", "pending_operations", "failed_operations", "operations_by_status", "last_consolidated_at", "pending_consolidation", "total_observations"]
+    __properties: ClassVar[List[str]] = ["bank_id", "total_nodes", "total_links", "total_documents", "nodes_by_fact_type", "links_by_link_type", "links_by_fact_type", "links_breakdown", "pending_operations", "failed_operations", "operations_by_status", "last_consolidated_at", "pending_consolidation", "failed_consolidation", "total_observations"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -111,6 +112,7 @@ class BankStatsResponse(BaseModel):
             "operations_by_status": obj.get("operations_by_status"),
             "last_consolidated_at": obj.get("last_consolidated_at"),
             "pending_consolidation": obj.get("pending_consolidation") if obj.get("pending_consolidation") is not None else 0,
+            "failed_consolidation": obj.get("failed_consolidation") if obj.get("failed_consolidation") is not None else 0,
             "total_observations": obj.get("total_observations") if obj.get("total_observations") is not None else 0
         })
         return _obj

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -386,6 +386,12 @@ export type BankStatsResponse = {
    */
   pending_consolidation?: number;
   /**
+   * Failed Consolidation
+   *
+   * Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.
+   */
+  failed_consolidation?: number;
+  /**
    * Total Observations
    *
    * Total number of observations
@@ -3399,6 +3405,10 @@ export type ListMemoriesData = {
      * Q
      */
     q?: string | null;
+    /**
+     * Consolidation State
+     */
+    consolidation_state?: string | null;
     /**
      * Limit
      */

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -362,7 +362,13 @@ export class HindsightClient {
      */
     async listMemories(
         bankId: string,
-        options?: { limit?: number; offset?: number; type?: string; q?: string }
+        options?: {
+            limit?: number;
+            offset?: number;
+            type?: string;
+            q?: string;
+            consolidationState?: 'failed' | 'pending' | 'done';
+        }
     ): Promise<ListMemoryUnitsResponse> {
         const response = await sdk.listMemories({
             client: this.client,
@@ -372,6 +378,7 @@ export class HindsightClient {
                 offset: options?.offset,
                 type: options?.type,
                 q: options?.q,
+                consolidation_state: options?.consolidationState,
             },
         });
 

--- a/hindsight-control-plane/src/app/api/list/route.ts
+++ b/hindsight-control-plane/src/app/api/list/route.ts
@@ -14,12 +14,21 @@ export async function GET(request: NextRequest) {
     const offset = searchParams.get("offset") ? Number(searchParams.get("offset")) : undefined;
     const type = searchParams.get("type") || searchParams.get("fact_type") || undefined;
     const q = searchParams.get("q") || undefined;
+    const consolidationStateParam =
+      searchParams.get("consolidation_state") || searchParams.get("consolidationState");
+    const consolidationState =
+      consolidationStateParam === "failed" ||
+      consolidationStateParam === "pending" ||
+      consolidationStateParam === "done"
+        ? consolidationStateParam
+        : undefined;
 
     const response = await hindsightClient.listMemories(bankId, {
       limit,
       offset,
       type,
       q,
+      consolidationState,
     });
 
     return NextResponse.json(response, { status: 200 });

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -14,7 +14,27 @@ import {
   Brain,
   CheckCircle2,
   AlertCircle,
+  XCircle,
+  RefreshCw,
+  ExternalLink,
 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import {
   AreaChart,
   Area,
@@ -46,6 +66,7 @@ interface BankStats {
   operations_by_status?: Record<string, number>;
   last_consolidated_at: string | null;
   pending_consolidation: number;
+  failed_consolidation: number;
   total_observations: number;
 }
 
@@ -441,14 +462,19 @@ function OperationsCard({ byStatus }: { byStatus: Record<string, number> }) {
 function ConsolidationCard({
   done,
   pending,
+  failed,
   total,
   lastConsolidatedAt,
 }: {
   done: number;
   pending: number;
+  failed: number;
   total: number;
   lastConsolidatedAt: string | null;
 }) {
+  const [failedOpen, setFailedOpen] = useState(false);
+  const hasFailed = failed > 0;
+
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -456,7 +482,7 @@ function ConsolidationCard({
       </CardHeader>
       <CardContent className="space-y-4">
         <ProgressRow done={done} total={total} doneColor={CHART_COLORS.success} />
-        <div className="grid grid-cols-3 gap-3 pt-1">
+        <div className="grid grid-cols-4 gap-3 pt-1">
           <div className="space-y-0.5">
             <div className="flex items-center gap-1.5">
               <CheckCircle2 className="w-3 h-3 text-emerald-500" />
@@ -481,6 +507,40 @@ function ConsolidationCard({
               className="text-base font-semibold tabular-nums text-foreground block"
             />
           </div>
+          <button
+            type="button"
+            onClick={() => hasFailed && setFailedOpen(true)}
+            disabled={!hasFailed}
+            className={`text-left space-y-0.5 rounded-md -mx-1 px-1 py-0.5 transition-colors ${
+              hasFailed
+                ? "cursor-pointer hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+                : "cursor-default"
+            }`}
+            title={hasFailed ? "View failed memories" : undefined}
+          >
+            <div className="flex items-center gap-1.5">
+              <XCircle
+                className={`w-3 h-3 ${
+                  hasFailed ? "text-red-600 dark:text-red-400" : "text-muted-foreground/50"
+                }`}
+              />
+              <span
+                className={`text-[10px] uppercase tracking-wider font-medium ${
+                  hasFailed ? "text-red-600 dark:text-red-400" : "text-muted-foreground"
+                }`}
+              >
+                Failed
+              </span>
+            </div>
+            <span
+              className={`text-base font-semibold tabular-nums block ${
+                hasFailed ? "text-red-600 dark:text-red-400" : "text-foreground"
+              }`}
+            >
+              <CompactNumber value={failed} />
+              {hasFailed && <ExternalLink className="inline w-3 h-3 ml-1 opacity-70" />}
+            </span>
+          </button>
           <div className="space-y-0.5">
             <div className="flex items-center gap-1.5">
               <Clock className="w-3 h-3 text-muted-foreground" />
@@ -494,7 +554,135 @@ function ConsolidationCard({
           </div>
         </div>
       </CardContent>
+      <FailedConsolidationsDialog open={failedOpen} onOpenChange={setFailedOpen} />
     </Card>
+  );
+}
+
+interface FailedMemoryItem {
+  id: string;
+  text: string;
+  context: string;
+  fact_type: string;
+  consolidation_failed_at: string | null;
+}
+
+function FailedConsolidationsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+}) {
+  const { currentBank } = useBank();
+  const [items, setItems] = useState<FailedMemoryItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [recovering, setRecovering] = useState(false);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    if (!open || !currentBank) return;
+    let cancelled = false;
+    setLoading(true);
+    client
+      .listMemories(currentBank, { consolidationState: "failed", limit: 200 })
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.items as FailedMemoryItem[]);
+        setTotal(res.total);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentBank, refreshTick]);
+
+  const handleRecover = async () => {
+    if (!currentBank) return;
+    setRecovering(true);
+    try {
+      const res = await client.recoverConsolidation(currentBank);
+      // The backend recovery endpoint only clears consolidation_failed_at; it does
+      // not queue a consolidation task. Kick one off here so the reset memories
+      // are actually picked up by the worker instead of sitting in pending state.
+      if (res.retried_count > 0) {
+        await client.triggerConsolidation(currentBank);
+      }
+      toast.success(
+        `Queued ${res.retried_count} memor${res.retried_count === 1 ? "y" : "ies"} for re-consolidation`
+      );
+      setRefreshTick((t) => t + 1);
+    } catch {
+      // toast shown by interceptor
+    } finally {
+      setRecovering(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <XCircle className="w-4 h-4 text-red-600 dark:text-red-400" />
+            Failed consolidations
+          </DialogTitle>
+          <DialogDescription>
+            Source memories whose consolidation permanently failed. Recovery resets them so they are
+            retried on the next consolidation run.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center justify-between gap-2 py-2">
+          <span className="text-sm text-muted-foreground">
+            {loading ? "Loading…" : `${total} failed`}
+          </span>
+          <Button size="sm" onClick={handleRecover} disabled={recovering || loading || total === 0}>
+            <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${recovering ? "animate-spin" : ""}`} />
+            Recover all
+          </Button>
+        </div>
+        <div className="flex-1 min-h-0 overflow-auto border border-border rounded-md">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[140px]">Failed at</TableHead>
+                <TableHead className="w-[100px]">Type</TableHead>
+                <TableHead>Text</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.length === 0 && !loading && (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center text-muted-foreground py-8">
+                    No failed consolidations.
+                  </TableCell>
+                </TableRow>
+              )}
+              {items.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                    {formatRelativeTime(row.consolidation_failed_at)}
+                  </TableCell>
+                  <TableCell className="text-xs capitalize">{row.fact_type}</TableCell>
+                  <TableCell className="text-sm">
+                    <div className="line-clamp-2">{row.text}</div>
+                    {row.context && (
+                      <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                        {row.context}
+                      </div>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -744,6 +932,7 @@ export function BankStatsView() {
           <ConsolidationCard
             done={consolidatedDone}
             pending={stats.pending_consolidation}
+            failed={stats.failed_consolidation ?? 0}
             total={stats.total_nodes}
             lastConsolidatedAt={stats.last_consolidated_at}
           />

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -561,6 +561,48 @@ export class ControlPlaneClient {
   }
 
   /**
+   * List memory units for a bank with optional filters.
+   */
+  async listMemories(
+    bankId: string,
+    options?: {
+      type?: string;
+      q?: string;
+      consolidationState?: "failed" | "pending" | "done";
+      limit?: number;
+      offset?: number;
+    }
+  ) {
+    const params = new URLSearchParams({ bank_id: bankId });
+    if (options?.type) params.set("type", options.type);
+    if (options?.q) params.set("q", options.q);
+    if (options?.consolidationState) params.set("consolidation_state", options.consolidationState);
+    if (options?.limit !== undefined) params.set("limit", String(options.limit));
+    if (options?.offset !== undefined) params.set("offset", String(options.offset));
+    return this.fetchApi<{
+      items: Array<{
+        id: string;
+        text: string;
+        context: string;
+        date: string;
+        fact_type: string;
+        mentioned_at: string | null;
+        occurred_start: string | null;
+        occurred_end: string | null;
+        entities: string;
+        chunk_id: string | null;
+        proof_count: number;
+        tags: string[];
+        consolidated_at: string | null;
+        consolidation_failed_at: string | null;
+      }>;
+      total: number;
+      limit: number;
+      offset: number;
+    }>(`/api/list?${params.toString()}`);
+  }
+
+  /**
    * Get chunk
    */
   async getChunk(chunkId: string) {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -256,6 +256,22 @@
             }
           },
           {
+            "name": "consolidation_state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Consolidation State"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -5259,6 +5275,12 @@
             "description": "Number of memories not yet processed into observations",
             "default": 0
           },
+          "failed_consolidation": {
+            "type": "integer",
+            "title": "Failed Consolidation",
+            "description": "Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.",
+            "default": 0
+          },
           "total_observations": {
             "type": "integer",
             "title": "Total Observations",
@@ -5283,6 +5305,7 @@
         "description": "Response model for bank statistics endpoint.",
         "example": {
           "bank_id": "user123",
+          "failed_consolidation": 0,
           "failed_operations": 0,
           "last_consolidated_at": "2024-01-15T10:30:00Z",
           "links_breakdown": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -256,6 +256,22 @@
             }
           },
           {
+            "name": "consolidation_state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Consolidation State"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -5259,6 +5275,12 @@
             "description": "Number of memories not yet processed into observations",
             "default": 0
           },
+          "failed_consolidation": {
+            "type": "integer",
+            "title": "Failed Consolidation",
+            "description": "Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.",
+            "default": 0
+          },
           "total_observations": {
             "type": "integer",
             "title": "Total Observations",
@@ -5283,6 +5305,7 @@
         "description": "Response model for bank statistics endpoint.",
         "example": {
           "bank_id": "user123",
+          "failed_consolidation": 0,
           "failed_operations": 0,
           "last_consolidated_at": "2024-01-15T10:30:00Z",
           "links_breakdown": {


### PR DESCRIPTION
## Summary
- Add a **Failed** cell to the Consolidation card on the bank General page, counting memories with `consolidation_failed_at` set. When non-zero the cell is clickable and opens a dialog listing the affected memories with a "Recover all" action.
- "Recover all" resets the failed flag **and** queues a consolidation run, so the worker actually retries the recovered memories (previously the recover endpoint only cleared the flag — the memories sat in pending state).
- Backend is additive only: `failed_consolidation` added to `BankStatsResponse`, optional `consolidation_state` filter (`failed` | `pending` | `done`) added to `GET /v1/default/banks/{bank_id}/memories/list`.

## Test plan
- [x] `uv run pytest hindsight-api-slim/tests/test_bank_stats.py` (13 passed, incl. 3 new tests covering the failed count + filter + 400 on bogus state)
- [x] `./scripts/hooks/lint.sh`
- [x] Regenerated OpenAPI + SDKs via `./scripts/generate-openapi.sh` + `./scripts/generate-clients.sh`
- [x] Manual UI check: seeded 3 memories with `consolidation_failed_at`, saw the red "Failed: 3" cell in both light and dark mode, opened drilldown, clicked "Recover all" — worker picked them up and count went to 0.