### PR TITLE
feat(mental-models): structured-ops delta refresh + observation cleanup on upsert

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/a2v3w4x5y6z7_add_last_refreshed_source_query.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a2v3w4x5y6z7_add_last_refreshed_source_query.py
@@ -1,0 +1,38 @@
+"""Add last_refreshed_source_query column to mental_models
+
+Revision ID: a2v3w4x5y6z7
+Revises: z1u2v3w4x5y6
+Create Date: 2026-04-15
+
+Tracks the source_query that was used during the most recent refresh.
+Used by delta-mode refresh to detect when the query has changed: if it has,
+delta mode falls back to a full regeneration because the surgical-edit
+assumption (same topic, new facts) no longer holds.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+revision: str = "a2v3w4x5y6z7"
+down_revision: str | Sequence[str] | None = "z1u2v3w4x5y6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def upgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"""
+        ALTER TABLE {schema}mental_models
+        ADD COLUMN IF NOT EXISTS last_refreshed_source_query TEXT
+    """)
+
+
+def downgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}mental_models DROP COLUMN IF EXISTS last_refreshed_source_query")

--- a/hindsight-api-slim/hindsight_api/alembic/versions/b3w4x5y6z7a8_add_structured_content_to_mental_models.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/b3w4x5y6z7a8_add_structured_content_to_mental_models.py
@@ -1,0 +1,44 @@
+"""Add structured_content JSONB column to mental_models
+
+Revision ID: b3w4x5y6z7a8
+Revises: a2v3w4x5y6z7
+Create Date: 2026-04-16
+
+Stores the structured representation of a mental model document (sections,
+blocks). The plain ``content`` column remains the rendered markdown shown to
+users. ``structured_content`` is the source of truth for delta-mode refreshes:
+each refresh applies a list of typed operations to the structured doc, then
+re-renders to markdown — so unchanged sections come through byte-identical
+without an LLM round-trip.
+
+Nullable: existing markdown-only mental models continue to work in full mode;
+the column is populated lazily the first time a model is refreshed in delta
+mode.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+revision: str = "b3w4x5y6z7a8"
+down_revision: str | Sequence[str] | None = "a2v3w4x5y6z7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def upgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"""
+        ALTER TABLE {schema}mental_models
+        ADD COLUMN IF NOT EXISTS structured_content JSONB
+    """)
+
+
+def downgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}mental_models DROP COLUMN IF EXISTS structured_content")

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c4x5y6z7a8b9_backsweep_orphan_observations_v2.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c4x5y6z7a8b9_backsweep_orphan_observations_v2.py
@@ -1,0 +1,66 @@
+"""backsweep_orphan_observations_v2
+
+Re-run of Pass 2 from migration ``g7h8i9j0k1l2_backsweep_orphan_observations``
+to sweep observations that became orphaned between then and now.
+
+Why we need it again:
+  ``fact_storage.handle_document_tracking`` (the retain/upsert path) deleted
+  the existing document via the FK cascade — which removes the source
+  ``memory_units`` — but never invalidated the observations derived from
+  them.  Only the explicit ``MemoryEngine.delete_document`` API called
+  ``_delete_stale_observations_for_memories``.  Every document re-ingest
+  therefore left orphan observations whose ``source_memory_ids`` arrays
+  pointed at IDs that no longer existed in ``memory_units``.
+
+  ``handle_document_tracking`` now calls the same cleanup helper before the
+  cascade, so no new orphans will accumulate going forward.  This migration
+  cleans up the historical residue.
+
+Identical to Pass 2 of g7h8i9j0k1l2.  Pass 1 (memory_units whose bank is
+gone) is intentionally not re-run; that scenario has no fresh source.
+
+Revision ID: c4x5y6z7a8b9
+Revises: b3w4x5y6z7a8
+Create Date: 2026-04-16
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+revision: str = "c4x5y6z7a8b9"
+down_revision: str | Sequence[str] | None = "b3w4x5y6z7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def upgrade() -> None:
+    schema = _get_schema_prefix()
+    mu = f"{schema}memory_units"
+
+    # Delete observations whose every source_memory_id refers to a now-deleted
+    # memory_unit (or the array is empty).  Observations with at least one
+    # surviving source are left alone — the consolidation engine will refresh
+    # their text on the next pass.
+    op.execute(
+        f"""
+        DELETE FROM {mu} orphan
+        WHERE orphan.fact_type = 'observation'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM {mu} src
+              WHERE src.id = ANY(orphan.source_memory_ids)
+                AND src.bank_id = orphan.bank_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Deleted rows cannot be restored.
+    pass

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1561,6 +1561,16 @@ class UpdateDirectiveRequest(BaseModel):
 class MentalModelTrigger(BaseModel):
     """Trigger settings for a mental model."""
 
+    mode: Literal["full", "delta"] = Field(
+        default="full",
+        description=(
+            "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. "
+            "'delta' performs surgical edits against the existing content: unchanged sections are preserved "
+            "byte-for-byte, stale content is removed, new content is added. If the mental model has no existing "
+            "content, or if the source_query has changed since the last refresh, delta mode falls back to a full "
+            "regeneration automatically."
+        ),
+    )
     refresh_after_consolidation: bool = Field(
         default=False,
         description="If true, refresh this mental model after observations consolidation (real-time mode)",

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1224,6 +1224,16 @@ async def _consolidate_batch_with_llm(
     max_attempts = config.consolidation_max_attempts
     inner_max_retries = config.consolidation_llm_max_retries
     last_exc: Exception | None = None
+    # Pre-compute a stable identifier set for the batch so failure logs name the
+    # exact memories whose consolidation is failing — without this, an opaque
+    # "LLM batch call failed" line gives operators no way to find the offending
+    # input until adaptive bisection narrows the batch down to a single memory.
+    memory_ids = [str(m.get("id")) for m in memories]
+    if len(memory_ids) <= 5:
+        ids_label = ", ".join(memory_ids)
+    else:
+        ids_label = f"{', '.join(memory_ids[:3])}, ... +{len(memory_ids) - 3} more"
+    batch_label = f"{len(memory_ids)} memories [{ids_label}]"
     for attempt in range(1, max_attempts + 1):
         try:
             call_kwargs: dict[str, Any] = {
@@ -1252,10 +1262,14 @@ async def _consolidate_batch_with_llm(
             )
         except Exception as exc:
             last_exc = exc
-            logger.warning(f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}): {exc}")
+            logger.warning(
+                f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}) "
+                f"for {batch_label}: {exc}"
+            )
 
     logger.error(
-        f"[CONSOLIDATION] LLM batch call failed after {max_attempts} attempts, skipping batch. Last error: {last_exc}"
+        f"[CONSOLIDATION] LLM batch call failed after {max_attempts} attempts for {batch_label}, "
+        f"skipping batch. Last error: {last_exc}"
     )
     return _BatchLLMResult(obs_count=len(union_observations), prompt_chars=len(prompt), failed=True)
 

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1263,8 +1263,7 @@ async def _consolidate_batch_with_llm(
         except Exception as exc:
             last_exc = exc
             logger.warning(
-                f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}) "
-                f"for {batch_label}: {exc}"
+                f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}) for {batch_label}: {exc}"
             )
 
     logger.error(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -183,6 +183,7 @@ from .entity_resolver import EntityResolver
 from .llm_wrapper import LLMConfig, requires_api_key, sanitize_llm_output
 from .query_analyzer import QueryAnalyzer
 from .reflect import run_reflect_agent
+from .reflect.prompts import DELTA_SYSTEM_PROMPT, build_delta_prompt
 from .reflect.tools import tool_expand, tool_recall, tool_search_mental_models, tool_search_observations
 from .response_models import (
     VALID_RECALL_FACT_TYPES,
@@ -967,14 +968,20 @@ class MemoryEngine(MemoryEngineInterface):
         """
         Handler for refresh_mental_model tasks.
 
-        Re-runs the source query through reflect and updates the mental model content.
+        Delegates to ``refresh_mental_model`` so async (worker-driven) refreshes
+        and synchronous refreshes share the same code path — including the
+        structured-delta logic. Previously this handler had its own copy of the
+        reflect+update pipeline, which silently bypassed structured delta when
+        the UI/worker queued the task. The duplication caused the original
+        "delta refresh produced full-document drift" bug to persist even after
+        delta was implemented on the synchronous path.
 
         Args:
             task_dict: Dict with 'bank_id', 'mental_model_id', 'operation_id'
 
         Raises:
             ValueError: If required fields are missing
-            Exception: Any exception from reflect/update (propagates to execute_task for retry)
+            Exception: Any exception from refresh_mental_model (propagates for retry)
         """
         bank_id = task_dict.get("bank_id")
         mental_model_id = task_dict.get("mental_model_id")
@@ -994,97 +1001,33 @@ class MemoryEngine(MemoryEngineInterface):
             api_key_id=task_dict.get("_api_key_id"),
         )
 
-        # Get the current mental model to get source_query
-        mental_model = await self.get_mental_model(bank_id, mental_model_id, request_context=internal_context)
-        if not mental_model:
-            raise ValueError(f"Mental model {mental_model_id} not found in bank {bank_id}")
-
-        source_query = mental_model["source_query"]
-
-        # Read reflect options from trigger (if stored)
-        trigger_data = mental_model.get("trigger") or {}
-        fact_types = trigger_data.get("fact_types")
-        exclude_mental_models = trigger_data.get("exclude_mental_models", False)
-        stored_exclude_ids: list[str] = trigger_data.get("exclude_mental_model_ids") or []
-        recall_include_chunks_override = trigger_data.get("include_chunks")
-        recall_max_tokens_override = trigger_data.get("recall_max_tokens")
-        recall_chunks_max_tokens_override = trigger_data.get("recall_chunks_max_tokens")
-
-        tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
-
-        # Run reflect to generate new content, excluding the mental model being refreshed
-        # Always add self to excluded IDs to prevent circular reference
-        reflect_result = await self.reflect_async(
-            bank_id=bank_id,
-            query=source_query,
-            request_context=internal_context,
-            tags=tag_filtering.tags,
-            tags_match=tag_filtering.tags_match,
-            tag_groups=tag_filtering.tag_groups,
-            fact_types=fact_types,
-            exclude_mental_models=exclude_mental_models,
-            exclude_mental_model_ids=list({*stored_exclude_ids, mental_model_id}),
-            recall_include_chunks=recall_include_chunks_override,
-            recall_max_tokens_override=recall_max_tokens_override,
-            recall_chunks_max_tokens_override=recall_chunks_max_tokens_override,
-        )
-
-        generated_content = reflect_result.text or "No content generated"
-
-        # Build reflect_response payload to store
-        # based_on contains MemoryFact objects for most types, but plain dicts for directives
-        based_on_serialized: dict[str, list[dict[str, Any]]] = {}
-        for fact_type, facts in reflect_result.based_on.items():
-            serialized_facts = []
-            for fact in facts:
-                if isinstance(fact, dict):
-                    # Plain dict (e.g., directives with id, name, content)
-                    serialized_facts.append(
-                        {
-                            "id": str(fact["id"]),
-                            "text": fact.get("text", fact.get("content", fact.get("name", ""))),
-                            "type": fact_type,
-                        }
-                    )
-                else:
-                    # MemoryFact object with .id and .text attributes
-                    serialized_facts.append(
-                        {
-                            "id": str(fact.id),
-                            "text": fact.text,
-                            "type": fact_type,
-                        }
-                    )
-            based_on_serialized[fact_type] = serialized_facts
-
-        reflect_response = {
-            "text": reflect_result.text,
-            "based_on": based_on_serialized,
-        }
-
-        # Update the mental model with the generated content and reflect_response
-        await self.update_mental_model(
+        refreshed = await self.refresh_mental_model(
             bank_id=bank_id,
             mental_model_id=mental_model_id,
-            content=generated_content,
-            reflect_response=reflect_response,
             request_context=internal_context,
         )
+        if refreshed is None:
+            raise ValueError(f"Mental model {mental_model_id} not found in bank {bank_id}")
+
+        # Compute facts/mental_models counts for the post-op validator hook.
+        # refresh_mental_model already persisted everything; the hook only needs
+        # tallies that derive from the stored reflect_response payload.
+        rr = refreshed.get("reflect_response") or {}
+        based_on = rr.get("based_on") or {}
+        facts_used = 0
+        mental_models_used = 0
+        for fact_type, facts in based_on.items():
+            n = len(facts) if facts else 0
+            if fact_type in ("mental_models", "mental-models"):
+                mental_models_used += n
+            else:
+                facts_used += n
+        source_query = refreshed.get("source_query") or ""
+        generated_content = refreshed.get("content") or ""
 
         # Call post-operation hook if validator is configured
         if self._operation_validator:
             from hindsight_api.extensions.operation_validator import MentalModelRefreshResult
-
-            # Count facts and mental models from based_on
-            facts_used = 0
-            mental_models_used = 0
-            if reflect_result.based_on:
-                for fact_type, facts in reflect_result.based_on.items():
-                    if facts:
-                        if fact_type == "mental_models":
-                            mental_models_used += len(facts)
-                        else:
-                            facts_used += len(facts)
 
             # Estimate tokens
             query_tokens = len(source_query) // 4 if source_query else 0
@@ -6567,82 +6510,15 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         fact_ids: list[str],
     ) -> int:
+        """Thin wrapper that delegates to ``fact_storage.delete_stale_observations_for_memories``.
+
+        Kept on the engine class so the existing call sites here and the
+        retain pipeline both end up running the same SQL. See the free
+        function for the full contract.
         """
-        Handle cleanup of observations when source memories are deleted.
+        from .retain.fact_storage import delete_stale_observations_for_memories
 
-        For each observation referencing any of the deleted fact IDs:
-        1. Delete the observation (its text is stale without those source memories)
-        2. Reset consolidated_at=NULL on the remaining source memories so they get re-consolidated
-
-        Must be called within an active transaction, before the source memories are deleted.
-
-        Args:
-            conn: Database connection (must be in an active transaction)
-            bank_id: Bank identifier
-            fact_ids: List of fact IDs (as strings) that are being deleted
-
-        Returns:
-            Number of observations deleted
-        """
-        if not fact_ids:
-            return 0
-
-        import uuid as uuid_module
-
-        fact_uuids = [uuid_module.UUID(fid) for fid in fact_ids]
-
-        # Find all observations referencing any of the deleted facts
-        affected_obs = await conn.fetch(
-            f"""
-            SELECT id, source_memory_ids
-            FROM {fq_table("memory_units")}
-            WHERE bank_id = $1
-              AND fact_type = 'observation'
-              AND source_memory_ids && $2::uuid[]
-            """,
-            bank_id,
-            fact_uuids,
-        )
-
-        if not affected_obs:
-            return 0
-
-        # Collect observation IDs to delete and remaining source memory IDs to reset
-        deleted_set = {str(uid) for uid in fact_uuids}
-        obs_ids = [obs["id"] for obs in affected_obs]
-        seen_remaining: set[str] = set()
-        remaining_source_ids: list[uuid_module.UUID] = []
-
-        for obs in affected_obs:
-            for src_id in obs["source_memory_ids"] or []:
-                src_str = str(src_id)
-                if src_str not in deleted_set and src_str not in seen_remaining:
-                    remaining_source_ids.append(src_id)
-                    seen_remaining.add(src_str)
-
-        # Delete the stale observations
-        await conn.execute(
-            f"DELETE FROM {fq_table('memory_units')} WHERE id = ANY($1::uuid[])",
-            obs_ids,
-        )
-
-        # Reset consolidated_at on remaining source memories so they get re-consolidated
-        if remaining_source_ids:
-            await conn.execute(
-                f"""
-                UPDATE {fq_table("memory_units")}
-                SET consolidated_at = NULL
-                WHERE id = ANY($1::uuid[])
-                  AND fact_type IN ('experience', 'world')
-                """,
-                remaining_source_ids,
-            )
-
-        logger.info(
-            f"[OBSERVATIONS] Deleted {len(obs_ids)} observations, reset {len(remaining_source_ids)} "
-            f"source memories for re-consolidation in bank {bank_id}"
-        )
-        return len(obs_ids)
+        return await delete_stale_observations_for_memories(conn, bank_id, fact_ids)
 
     # =========================================================================
     # MENTAL MODELS (CONSOLIDATED) - Read-only access to auto-consolidated mental models
@@ -6848,7 +6724,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
                        last_refreshed_at, created_at, reflect_response,
-                       max_tokens, trigger
+                       max_tokens, trigger, structured_content
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 {tag_filter}
                 ORDER BY last_refreshed_at DESC
@@ -6898,7 +6774,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, bank_id, name, source_query, content, tags,
                        last_refreshed_at, created_at, reflect_response,
-                       max_tokens, trigger
+                       max_tokens, trigger, structured_content
                 FROM {fq_table("mental_models")}
                 WHERE bank_id = $1 AND id = $2
                 """,
@@ -7017,7 +6893,7 @@ class MemoryEngine(MemoryEngineInterface):
                     VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, 2048), COALESCE($9, '{{"refresh_after_consolidation": false}}'::jsonb))
                     RETURNING id, bank_id, name, source_query, content, tags,
                               last_refreshed_at, created_at, reflect_response,
-                              max_tokens, trigger
+                              max_tokens, trigger, structured_content
                     """,
                     mental_model_id,
                     bank_id,
@@ -7037,7 +6913,7 @@ class MemoryEngine(MemoryEngineInterface):
                     VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, 2048), COALESCE($8, '{{"refresh_after_consolidation": false}}'::jsonb))
                     RETURNING id, bank_id, name, source_query, content, tags,
                               last_refreshed_at, created_at, reflect_response,
-                              max_tokens, trigger
+                              max_tokens, trigger, structured_content
                     """,
                     bank_id,
                     name,
@@ -7092,6 +6968,50 @@ class MemoryEngine(MemoryEngineInterface):
             recall_include_chunks_override = trigger_data.get("include_chunks")
             recall_max_tokens_override = trigger_data.get("recall_max_tokens")
             recall_chunks_max_tokens_override = trigger_data.get("recall_chunks_max_tokens")
+            refresh_mode = trigger_data.get("mode") or "full"
+
+            current_content = (mental_model.get("content") or "").strip()
+            current_source_query = mental_model["source_query"]
+
+            # Delta mode requires both existing content and an unchanged source_query.
+            # When either condition fails, we fall back to a full regeneration: a
+            # surgical edit has nothing to edit, or the topic itself has shifted.
+            # The tracking column is only read when delta is requested so full-mode
+            # refreshes don't pay for an extra query (and mock-based unit tests that
+            # stub out the DB don't hit an unexpected pool access).
+            use_delta = False
+            stored_structured_content: dict[str, Any] | None = None
+            if refresh_mode == "delta" and current_content:
+                pool = await self._get_pool()
+                async with acquire_with_retry(pool) as conn:
+                    tracking_row = await conn.fetchrow(
+                        f"SELECT last_refreshed_source_query, structured_content "
+                        f"FROM {fq_table('mental_models')} "
+                        f"WHERE bank_id = $1 AND id = $2",
+                        bank_id,
+                        mental_model_id,
+                    )
+                last_refreshed_source_query: str | None = (
+                    tracking_row["last_refreshed_source_query"] if tracking_row else None
+                )
+                # Use delta when the user has content to anchor on AND the topic
+                # hasn't shifted. The first delta refresh (no tracking row yet)
+                # still uses the existing markdown as the baseline — users who
+                # write a doc and then enable delta mode expect their content to
+                # be the starting point, not discarded by a one-time full rebuild.
+                use_delta = (
+                    last_refreshed_source_query is None
+                    or last_refreshed_source_query == current_source_query
+                )
+                if tracking_row is not None:
+                    raw_struct = tracking_row["structured_content"]
+                    if isinstance(raw_struct, str):
+                        try:
+                            stored_structured_content = json.loads(raw_struct)
+                        except json.JSONDecodeError:
+                            stored_structured_content = None
+                    else:
+                        stored_structured_content = raw_struct
 
             tag_filtering = _resolve_refresh_tag_filtering(mental_model.get("tags"), trigger_data)
 
@@ -7153,12 +7073,165 @@ class MemoryEngine(MemoryEngineInterface):
                 "mental_models": [],  # Mental models are included in based_on["mental-models"]
             }
 
-            # Update the mental model with new content and reflect_response
+            # Delta-mode path: emit structured operations against the existing
+            # structured doc, apply them, then re-render to markdown. Sections
+            # not mentioned by any operation are physically untouched, so prose
+            # drift is structurally impossible. Falls back to the full candidate
+            # markdown if either the structuring or the LLM op call fails.
+            from .reflect.delta_ops import (
+                DeltaOperationList,
+                apply_operations,
+            )
+            from .reflect.prompts import (
+                STRUCTURED_DELTA_SYSTEM_PROMPT,
+                build_structured_delta_prompt,
+            )
+            from .reflect.structured_doc import (
+                StructuredDocument,
+                parse_markdown,
+                render_document,
+            )
+
+            final_content = reflect_result.text
+            final_structured: StructuredDocument | None = None
+            delta_applied = False
+            applied_ops_summary: list[dict[str, Any]] = []
+            skipped_ops_summary: list[dict[str, Any]] = []
+
+            if use_delta:
+                # Use the previously stored structured doc when available; otherwise
+                # parse the existing markdown so the very first delta refresh can
+                # still operate without waiting for a full rebuild.
+                try:
+                    if stored_structured_content is not None:
+                        current_doc = StructuredDocument.model_validate(stored_structured_content)
+                    else:
+                        current_doc = parse_markdown(current_content)
+                except Exception as exc:
+                    logger.warning(
+                        f"[MENTAL_MODELS] Could not load structured doc for {mental_model_id} "
+                        f"({exc}); falling back to full synthesis"
+                    )
+                    current_doc = None
+
+                if current_doc is not None:
+                    supporting_facts: list[dict[str, Any]] = []
+                    for _ftype, facts in based_on_serialized_payload.items():
+                        supporting_facts.extend(facts)
+
+                    # Op JSON is denser than the rendered markdown — each op
+                    # carries the section_id, op type, and a full block payload
+                    # whose ``text`` may quote the original passage. Budget 1.5×
+                    # the document cap so the model can express several edits
+                    # without truncating mid-string. The cap is also surfaced in
+                    # the prompt so the model can self-trim if needed.
+                    doc_max_tokens = mental_model.get("max_tokens") or 2048
+                    delta_max_tokens = max(2048, int(doc_max_tokens * 1.5))
+                    user_prompt = build_structured_delta_prompt(
+                        current_document_json=current_doc.model_dump_json(indent=2),
+                        candidate_markdown=reflect_result.text,
+                        supporting_facts=supporting_facts,
+                        source_query=current_source_query,
+                        max_output_tokens=delta_max_tokens,
+                    )
+                    try:
+                        # Text-mode call (not structured-output) because Pydantic's
+                        # discriminated-union JSON schema isn't accepted by every
+                        # provider — Gemini in particular rejects ``oneOf`` /
+                        # ``discriminator``. We parse + validate the JSON ourselves
+                        # so the same prompt works against any LLM.
+                        raw = await self._reflect_llm_config.call(
+                            messages=[
+                                {"role": "system", "content": STRUCTURED_DELTA_SYSTEM_PROMPT},
+                                {"role": "user", "content": user_prompt},
+                            ],
+                            max_completion_tokens=delta_max_tokens,
+                            temperature=0.0,
+                            scope="mental_model_delta_ops",
+                        )
+                        op_list: DeltaOperationList
+                        if isinstance(raw, DeltaOperationList):
+                            op_list = raw
+                        elif isinstance(raw, dict):
+                            op_list = DeltaOperationList.model_validate(raw)
+                        else:
+                            text = (raw or "").strip()
+                            # Strip optional fenced code block.
+                            if text.startswith("```"):
+                                text = text.split("\n", 1)[1] if "\n" in text else ""
+                                if text.endswith("```"):
+                                    text = text[: -3].rstrip()
+                            op_list = DeltaOperationList.model_validate_json(text)
+                        outcome = apply_operations(current_doc, op_list.operations)
+                        final_structured = outcome.document
+                        final_content = render_document(outcome.document)
+                        applied_ops_summary = outcome.applied
+                        skipped_ops_summary = outcome.skipped
+                        delta_applied = True
+                        logger.info(
+                            f"[MENTAL_MODELS] Delta refresh for {mental_model_id}: "
+                            f"applied {len(applied_ops_summary)} op(s), "
+                            f"skipped {len(skipped_ops_summary)}"
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            f"[MENTAL_MODELS] Structured delta failed for {mental_model_id} "
+                            f"({exc}); falling back to full synthesis"
+                        )
+
+                reflect_response_payload["delta_applied"] = delta_applied
+                if delta_applied:
+                    reflect_response_payload["delta_operations_applied"] = applied_ops_summary
+                    reflect_response_payload["delta_operations_skipped"] = skipped_ops_summary
+
+            # Refuse to overwrite existing content with an empty render.
+            # The reflect agent can return an empty answer (small models, all
+            # tool-call retries failing, transient provider errors) and the
+            # delta merge can also fall back to that empty candidate. Writing
+            # "" to the DB would destroy the working document — and since the
+            # next refresh sees current_content == "" it would also skip the
+            # delta path, compounding the problem. Preserve what's there and
+            # surface the failure via reflect_response.
+            if not final_content.strip() and current_content:
+                logger.warning(
+                    f"[MENTAL_MODELS] Refresh for {mental_model_id} produced empty content; "
+                    "preserving previous content (likely an upstream LLM failure)"
+                )
+                reflect_response_payload["refresh_skipped"] = "empty_candidate"
+                # Persist the reflect_response (so the failure is auditable) and
+                # the source-query tracking, but do NOT touch content/structured.
+                return await self.update_mental_model(
+                    bank_id,
+                    mental_model_id,
+                    reflect_response=reflect_response_payload,
+                    last_refreshed_source_query=current_source_query,
+                    request_context=request_context,
+                )
+
+            # When delta is not applied (full mode, or delta fallback), parse the
+            # candidate markdown so the next refresh has a structured baseline to
+            # operate against.
+            if final_structured is None:
+                try:
+                    final_structured = parse_markdown(final_content)
+                except Exception as exc:
+                    logger.warning(
+                        f"[MENTAL_MODELS] Could not parse final markdown into structured form "
+                        f"for {mental_model_id} ({exc}); leaving structured_content unchanged"
+                    )
+
+            # Update the mental model with new content and reflect_response.
+            # Passing last_refreshed_source_query records the query used for this
+            # refresh so a future delta-mode run can detect a topic change.
             return await self.update_mental_model(
                 bank_id,
                 mental_model_id,
-                content=reflect_result.text,
+                content=final_content,
                 reflect_response=reflect_response_payload,
+                last_refreshed_source_query=current_source_query,
+                structured_content=(
+                    final_structured.model_dump() if final_structured is not None else None
+                ),
                 request_context=request_context,
             )
 
@@ -7174,6 +7247,8 @@ class MemoryEngine(MemoryEngineInterface):
         tags: list[str] | None = None,
         trigger: dict[str, Any] | None = None,
         reflect_response: dict[str, Any] | None = None,
+        last_refreshed_source_query: str | None = None,
+        structured_content: dict[str, Any] | None = None,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
         """Update a pinned mental model.
@@ -7281,6 +7356,16 @@ class MemoryEngine(MemoryEngineInterface):
                 params.append(json.dumps(trigger))
                 param_idx += 1
 
+            if last_refreshed_source_query is not None:
+                updates.append(f"last_refreshed_source_query = ${param_idx}")
+                params.append(last_refreshed_source_query)
+                param_idx += 1
+
+            if structured_content is not None:
+                updates.append(f"structured_content = ${param_idx}")
+                params.append(json.dumps(structured_content))
+                param_idx += 1
+
             if not updates:
                 return None
 
@@ -7290,7 +7375,7 @@ class MemoryEngine(MemoryEngineInterface):
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, created_at, reflect_response,
-                          max_tokens, trigger
+                          max_tokens, trigger, structured_content
             """
 
             row = await conn.fetchrow(query, *params)
@@ -7439,6 +7524,14 @@ class MemoryEngine(MemoryEngineInterface):
                 except json.JSONDecodeError:
                     reflect_response = None
             result["reflect_response"] = reflect_response
+
+            structured_content = row.get("structured_content")
+            if isinstance(structured_content, str):
+                try:
+                    structured_content = json.loads(structured_content)
+                except json.JSONDecodeError:
+                    structured_content = None
+            result["structured_content"] = structured_content
 
         return result
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6999,10 +6999,7 @@ class MemoryEngine(MemoryEngineInterface):
                 # still uses the existing markdown as the baseline — users who
                 # write a doc and then enable delta mode expect their content to
                 # be the starting point, not discarded by a one-time full rebuild.
-                use_delta = (
-                    last_refreshed_source_query is None
-                    or last_refreshed_source_query == current_source_query
-                )
+                use_delta = last_refreshed_source_query is None or last_refreshed_source_query == current_source_query
                 if tracking_row is not None:
                     raw_struct = tracking_row["structured_content"]
                     if isinstance(raw_struct, str):
@@ -7160,7 +7157,7 @@ class MemoryEngine(MemoryEngineInterface):
                             if text.startswith("```"):
                                 text = text.split("\n", 1)[1] if "\n" in text else ""
                                 if text.endswith("```"):
-                                    text = text[: -3].rstrip()
+                                    text = text[:-3].rstrip()
                             op_list = DeltaOperationList.model_validate_json(text)
                         outcome = apply_operations(current_doc, op_list.operations)
                         final_structured = outcome.document
@@ -7229,9 +7226,7 @@ class MemoryEngine(MemoryEngineInterface):
                 content=final_content,
                 reflect_response=reflect_response_payload,
                 last_refreshed_source_query=current_source_query,
-                structured_content=(
-                    final_structured.model_dump() if final_structured is not None else None
-                ),
+                structured_content=(final_structured.model_dump() if final_structured is not None else None),
                 request_context=request_context,
             )
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -60,6 +60,32 @@ def _strip_code_fences(content: str) -> str:
         return content
 
 
+def _summarize_status_error(e: APIStatusError, body_max: int = 400) -> str:
+    """Render an APIStatusError with status code + truncated response body.
+
+    Without this, retry loops only log "API error after N attempts" with the
+    bare exception message — losing the provider's actual error payload, which
+    is the only thing that explains *why* a request failed (rate limit reason,
+    invalid tool schema, model overloaded, etc.).
+    """
+    body: Any = getattr(e, "body", None)
+    if body is None:
+        try:
+            body = e.response.text
+        except Exception:
+            body = None
+    if isinstance(body, (dict, list)):
+        try:
+            body_str = json.dumps(body, default=str)
+        except Exception:
+            body_str = str(body)
+    else:
+        body_str = str(body or "").strip()
+    if len(body_str) > body_max:
+        body_str = body_str[:body_max] + "...TRUNCATED"
+    return f"HTTP {e.status_code}: {body_str or '<no body>'}"
+
+
 class OpenAICompatibleLLM(LLMInterface):
     """
     LLM provider for OpenAI-compatible APIs.
@@ -550,12 +576,19 @@ class OpenAICompatibleLLM(LLMInterface):
 
                 last_exception = e
                 if attempt < max_retries:
+                    logger.warning(
+                        f"APIStatusError ({self.provider}/{self.model}, scope={scope}, "
+                        f"attempt {attempt + 1}/{max_retries + 1}): {_summarize_status_error(e)}"
+                    )
                     backoff = min(initial_backoff * (2**attempt), max_backoff)
                     jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
                     sleep_time = backoff + jitter
                     await asyncio.sleep(sleep_time)
                 else:
-                    logger.error(f"API error after {max_retries + 1} attempts: {str(e)}")
+                    logger.error(
+                        f"API error after {max_retries + 1} attempts ({self.provider}/{self.model}, "
+                        f"scope={scope}): {_summarize_status_error(e)}"
+                    )
                     raise
 
             except Exception:
@@ -706,18 +739,41 @@ class OpenAICompatibleLLM(LLMInterface):
 
             except APIConnectionError as e:
                 last_exception = e
+                status_code = getattr(e, "status_code", None) or getattr(
+                    getattr(e, "response", None), "status_code", None
+                )
                 if attempt < max_retries:
+                    logger.warning(
+                        f"APIConnectionError in tool call ({self.provider}/{self.model}, scope={scope}, "
+                        f"attempt {attempt + 1}/{max_retries + 1}, HTTP {status_code}): {str(e)[:200]}"
+                    )
                     await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
                     continue
+                logger.error(
+                    f"Connection error in tool call after {max_retries + 1} attempts "
+                    f"({self.provider}/{self.model}, scope={scope}): {str(e)}"
+                )
                 raise
 
             except APIStatusError as e:
                 if e.status_code in (401, 403):
+                    logger.error(
+                        f"Auth error in tool call (HTTP {e.status_code}, {self.provider}/{self.model}), "
+                        f"not retrying: {_summarize_status_error(e)}"
+                    )
                     raise
                 last_exception = e
                 if attempt < max_retries:
+                    logger.warning(
+                        f"APIStatusError in tool call ({self.provider}/{self.model}, scope={scope}, "
+                        f"attempt {attempt + 1}/{max_retries + 1}): {_summarize_status_error(e)}"
+                    )
                     await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
                     continue
+                logger.error(
+                    f"API error in tool call after {max_retries + 1} attempts "
+                    f"({self.provider}/{self.model}, scope={scope}): {_summarize_status_error(e)}"
+                )
                 raise
 
             except Exception:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
@@ -1,0 +1,307 @@
+"""Delta operations for structured mental models.
+
+The LLM's job during a delta refresh is to emit a list of these operations,
+each targeting an existing section (by id) or referencing a position relative
+to one.  ``apply_operations`` validates and applies each op in turn against a
+copy of the document; invalid ops (unknown ``section_id``, out-of-range
+``block_index``, malformed payloads) are dropped with a debug-friendly reason.
+
+Sections and blocks not mentioned by any op are physically copied through
+unchanged — there is no LLM-mediated re-emission of unchanged text, so prose
+drift is structurally impossible.
+
+Why operations and not "output the new structured doc":
+- "Output the new doc" still asks the LLM to *generate* every section's
+  blocks, including ones it didn't intend to modify, which gives it the same
+  opportunity to drift.
+- Operations make the no-change case mechanical: zero ops → identical doc.
+- Operations are auditable: each refresh produces a log of exactly what
+  changed, useful for debugging the LLM's behaviour and explaining diffs.
+
+Failure modes are by design conservative: an operation list that fails to
+parse against the Pydantic schema, or an LLM that returns invalid ops, results
+in zero changes — the document stays as-is. The structure can only get better
+or stay the same per refresh, never get worse.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .structured_doc import (
+    Block,
+    Section,
+    StructuredDocument,
+    make_unique_id,
+    slugify_heading,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Op payloads ---------------------------------------------------------------
+
+
+class _OpBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AppendBlockOp(_OpBase):
+    """Add a new block at the end of an existing section."""
+
+    op: Literal["append_block"] = "append_block"
+    section_id: str
+    block: Block
+
+
+class InsertBlockOp(_OpBase):
+    """Insert a new block at ``index`` in an existing section.
+
+    ``index`` may equal ``len(section.blocks)`` (append) but not be greater.
+    """
+
+    op: Literal["insert_block"] = "insert_block"
+    section_id: str
+    index: int = Field(ge=0)
+    block: Block
+
+
+class ReplaceBlockOp(_OpBase):
+    """Replace the block at ``index`` of an existing section."""
+
+    op: Literal["replace_block"] = "replace_block"
+    section_id: str
+    index: int = Field(ge=0)
+    block: Block
+
+
+class RemoveBlockOp(_OpBase):
+    """Remove the block at ``index`` of an existing section."""
+
+    op: Literal["remove_block"] = "remove_block"
+    section_id: str
+    index: int = Field(ge=0)
+
+
+class AddSectionOp(_OpBase):
+    """Add a brand-new section.
+
+    ``after_section_id`` is optional; when omitted the new section is appended
+    at the end. ``new_id`` is optional; when omitted we slugify the heading
+    and disambiguate against existing IDs.
+    """
+
+    op: Literal["add_section"] = "add_section"
+    heading: str
+    level: int = Field(default=2, ge=1, le=6)
+    blocks: list[Block] = Field(default_factory=list)
+    after_section_id: str | None = None
+    new_id: str | None = None
+
+
+class RemoveSectionOp(_OpBase):
+    """Remove an entire section by id."""
+
+    op: Literal["remove_section"] = "remove_section"
+    section_id: str
+
+
+class ReplaceSectionBlocksOp(_OpBase):
+    """Replace all blocks of a section in one go.
+
+    Used when most of a section's contents are stale and rebuilding it as a
+    unit is clearer than emitting many block-level ops. The section's heading
+    and id are preserved.
+    """
+
+    op: Literal["replace_section_blocks"] = "replace_section_blocks"
+    section_id: str
+    blocks: list[Block] = Field(default_factory=list)
+
+
+class RenameSectionOp(_OpBase):
+    """Rename a section's heading. The id is unchanged so future ops still resolve."""
+
+    op: Literal["rename_section"] = "rename_section"
+    section_id: str
+    new_heading: str
+
+
+Operation = Annotated[
+    Union[
+        AppendBlockOp,
+        InsertBlockOp,
+        ReplaceBlockOp,
+        RemoveBlockOp,
+        AddSectionOp,
+        RemoveSectionOp,
+        ReplaceSectionBlocksOp,
+        RenameSectionOp,
+    ],
+    Field(discriminator="op"),
+]
+
+
+class DeltaOperationList(BaseModel):
+    """Container for the operations produced by an LLM delta call."""
+
+    model_config = ConfigDict(extra="forbid")
+    operations: list[Operation] = Field(default_factory=list)
+
+
+# Application ---------------------------------------------------------------
+
+
+class AppliedDelta(BaseModel):
+    """Outcome of applying a list of operations to a document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    document: StructuredDocument
+    applied: list[dict[str, Any]] = Field(default_factory=list)
+    skipped: list[dict[str, Any]] = Field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return len(self.applied) > 0
+
+
+def _op_summary(op: Operation) -> dict[str, Any]:
+    """Compact dict suitable for the audit trail."""
+    data = op.model_dump()
+    return {k: v for k, v in data.items() if k != "block" and k != "blocks"} | {
+        "op": data["op"],
+    }
+
+
+def apply_operations(
+    doc: StructuredDocument,
+    operations: list[Operation],
+) -> AppliedDelta:
+    """Apply a list of operations to a document, returning a new document.
+
+    The original document is never mutated. Invalid operations (unknown
+    section, out-of-range index, name collision when adding a section) are
+    skipped and recorded in ``skipped`` with a ``reason`` string.
+    """
+    new_doc = doc.model_copy(deep=True)
+    applied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    def skip(op: Operation, reason: str) -> None:
+        entry = _op_summary(op)
+        entry["reason"] = reason
+        skipped.append(entry)
+        logger.debug(f"[STRUCTURED_DELTA] skipping op {entry}")
+
+    for op in operations:
+        if isinstance(op, AppendBlockOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            section.blocks.append(op.block)
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, InsertBlockOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            if op.index > len(section.blocks):
+                skip(
+                    op,
+                    f"index out of range: {op.index} > {len(section.blocks)}",
+                )
+                continue
+            section.blocks.insert(op.index, op.block)
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, ReplaceBlockOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            if op.index >= len(section.blocks):
+                skip(
+                    op,
+                    f"index out of range: {op.index} >= {len(section.blocks)}",
+                )
+                continue
+            section.blocks[op.index] = op.block
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, RemoveBlockOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            if op.index >= len(section.blocks):
+                skip(
+                    op,
+                    f"index out of range: {op.index} >= {len(section.blocks)}",
+                )
+                continue
+            section.blocks.pop(op.index)
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, AddSectionOp):
+            existing_ids = {s.id for s in new_doc.sections}
+            base_id = op.new_id or slugify_heading(op.heading)
+            section_id = make_unique_id(base_id, existing_ids)
+            new_section = Section(
+                id=section_id,
+                heading=op.heading,
+                level=op.level,
+                blocks=list(op.blocks),
+            )
+            if op.after_section_id is None:
+                new_doc.sections.append(new_section)
+            else:
+                idx = new_doc.section_index(op.after_section_id)
+                if idx is None:
+                    skip(op, f"unknown after_section_id: {op.after_section_id}")
+                    continue
+                new_doc.sections.insert(idx + 1, new_section)
+            entry = _op_summary(op)
+            entry["assigned_id"] = section_id
+            applied.append(entry)
+            continue
+
+        if isinstance(op, RemoveSectionOp):
+            idx = new_doc.section_index(op.section_id)
+            if idx is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            new_doc.sections.pop(idx)
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, ReplaceSectionBlocksOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            section.blocks = list(op.blocks)
+            applied.append(_op_summary(op))
+            continue
+
+        if isinstance(op, RenameSectionOp):
+            section = new_doc.section_by_id(op.section_id)
+            if section is None:
+                skip(op, f"unknown section_id: {op.section_id}")
+                continue
+            section.heading = op.new_heading
+            applied.append(_op_summary(op))
+            continue
+
+        skip(op, f"unhandled op type: {type(op).__name__}")  # pragma: no cover
+
+    return AppliedDelta(document=new_doc, applied=applied, skipped=skipped)

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -508,3 +508,180 @@ CRITICAL: Output ONLY the final synthesized answer. Do NOT include:
 Just provide the direct answer with proper markdown formatting.
 
 CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, offer to search again, suggest alternatives, or end with anything like "Would you like me to..." or "Let me know if...". The user cannot reply. Your answer must be complete and self-contained."""
+
+
+STRUCTURED_DELTA_SYSTEM_PROMPT = """You are computing a *minimal patch* to a structured document.
+
+You will be given:
+1. CURRENT DOCUMENT (JSON) — the existing structured mental model. Each section
+   has a stable ``id``, a ``heading``, a ``level`` (1..6), and an ordered list
+   of ``blocks``. Blocks are typed: ``paragraph``, ``bullet_list``,
+   ``ordered_list``, or ``code``.
+2. CANDIDATE SUMMARY (markdown) — a freshly generated synthesis of the latest
+   memories, useful only as a hint about *what new information exists*. You
+   MUST NOT copy its formatting or wording wholesale; it is not the target.
+3. SUPPORTING FACTS — the observations and facts the candidate is grounded in.
+   Treat these as the only source of new information.
+
+Your task: output a JSON object ``{"operations": [...]}``. Applied to CURRENT
+DOCUMENT, the operations must produce the smallest possible change that
+reflects the new facts.
+
+ABSOLUTE RULES
+- If CURRENT DOCUMENT already covers all the supporting facts, output
+  exactly ``{"operations": []}``. An empty operation list IS the correct
+  answer when nothing new has come in. This is the most common case.
+- Operations target sections by ``section_id`` (use the ``id`` field of the
+  section in CURRENT DOCUMENT, NOT the heading). Block operations target
+  blocks by ``index`` (0-based, against the section's current block list).
+- Add new content with ``append_block``, ``insert_block``, or ``add_section``.
+  Prefer extending an existing section over creating a new one.
+- Modify existing content with ``replace_block`` or ``replace_section_blocks``
+  ONLY when the supporting facts contradict the current text. Do NOT rewrite
+  for style, brevity, or "improvement".
+- Remove stale content with ``remove_block`` or ``remove_section`` ONLY when
+  the supporting facts directly contradict it.
+- NEVER emit operations whose only effect is to reword unchanged content.
+- NEVER emit operations to "normalize" formatting (numbered → bulleted, casing
+  changes, paragraph → list, etc).
+- Every operation MUST be justifiable by a specific fact in SUPPORTING FACTS.
+
+ALLOWED OPERATIONS (each line shows the JSON shape)
+- ``{"op": "append_block", "section_id": "...", "block": {...}}``
+- ``{"op": "insert_block", "section_id": "...", "index": N, "block": {...}}``
+- ``{"op": "replace_block", "section_id": "...", "index": N, "block": {...}}``
+- ``{"op": "remove_block", "section_id": "...", "index": N}``
+- ``{"op": "add_section", "heading": "...", "level": 2, "blocks": [...], "after_section_id": "..."}``
+- ``{"op": "remove_section", "section_id": "..."}``
+- ``{"op": "replace_section_blocks", "section_id": "...", "blocks": [...]}``
+- ``{"op": "rename_section", "section_id": "...", "new_heading": "..."}``
+
+Block shapes
+- ``{"type": "paragraph", "text": "..."}``
+- ``{"type": "bullet_list", "items": ["...", "..."]}``
+- ``{"type": "ordered_list", "items": ["...", "..."]}``
+- ``{"type": "code", "language": "json", "text": "..."}``
+
+OUTPUT FORMAT
+Return ONLY a single JSON object on its own, with no prose before or after,
+no markdown code fences, no commentary. The object must have exactly one
+top-level key, ``operations``, whose value is an array of operation objects
+(empty array when nothing changes).
+
+Examples
+- No changes needed → ``{"operations": []}``
+- Add one bullet to an existing "Members" section →
+  ``{"operations": [{"op": "append_block", "section_id": "members",
+  "block": {"type": "bullet_list", "items": ["Carol — junior engineer"]}}]}``"""
+
+
+def build_structured_delta_prompt(
+    *,
+    current_document_json: str,
+    candidate_markdown: str,
+    supporting_facts: list[dict[str, Any]],
+    source_query: str,
+    max_output_tokens: int | None = None,
+) -> str:
+    """Build the user prompt for a structured-delta mental model refresh.
+
+    The LLM's job is to emit operations against ``current_document_json``;
+    the surrounding ``candidate_markdown`` and ``supporting_facts`` are
+    references for *what new information exists*, not templates to mimic.
+
+    ``max_output_tokens`` is surfaced in the prompt so the model can keep its
+    op list within the provider's response cap. The actual cap is enforced by
+    the caller; this is just an advisory anchor — without it the model often
+    returns op lists whose JSON gets truncated mid-string.
+    """
+    fact_lines: list[str] = []
+    for f in supporting_facts:
+        fid = f.get("id", "")
+        text = (f.get("text") or "").strip().replace("\n", " ")
+        ftype = f.get("type", "")
+        fact_lines.append(f"- [{ftype}:{fid}] {text}")
+    facts_block = "\n".join(fact_lines) if fact_lines else "(no supporting facts retrieved)"
+
+    budget_hint = ""
+    if max_output_tokens is not None:
+        budget_hint = (
+            f"\n\n## Output budget\n"
+            f"Your JSON response must fit within ~{max_output_tokens} tokens. If you "
+            "would need more than this to express every change, prefer the highest-"
+            "leverage edits first (a few ``replace_section_blocks`` ops over many "
+            "block-level ops) so the response always parses as valid JSON."
+        )
+
+    return (
+        f"## Topic\n{source_query}\n\n"
+        f"## CURRENT DOCUMENT (apply ops to this; reference section ids as listed)\n"
+        f"```json\n{current_document_json}\n```\n\n"
+        f"## CANDIDATE SUMMARY (hint only — do NOT copy wording wholesale)\n"
+        f"```markdown\n{candidate_markdown}\n```\n\n"
+        f"## SUPPORTING FACTS (the only source of new information)\n{facts_block}"
+        f"{budget_hint}\n\n"
+        "## Task\n"
+        "Output a JSON object matching the operations schema. Use an empty list "
+        "if no new fact requires a change. Otherwise, emit the smallest set of "
+        "operations that reflects the new facts in CURRENT DOCUMENT, preserving "
+        "all unchanged sections and blocks by simply not mentioning them."
+    )
+
+
+DELTA_SYSTEM_PROMPT = """You are performing a surgical delta update to an existing mental model document.
+
+You will be given:
+1. CURRENT DOCUMENT: the existing mental model content (markdown).
+2. CANDIDATE UPDATE: a freshly generated synthesis based on the latest retrieved memories.
+3. SUPPORTING FACTS: the observations and facts that support the CANDIDATE UPDATE.
+
+Your task: produce an updated version of the CURRENT DOCUMENT that reflects the new reality, with the MINIMUM possible changes.
+
+ABSOLUTE RULES:
+- Preserve unchanged content BYTE-FOR-BYTE. If a sentence, heading, bullet, code block, or section is still accurate according to the CANDIDATE UPDATE and SUPPORTING FACTS, copy it verbatim — same wording, same punctuation, same whitespace, same markdown structure.
+- Do NOT reformat, rephrase, or re-style content that is still accurate. No "light edits for clarity", no reordering for flow, no synonym swaps.
+- Remove content that is contradicted by the CANDIDATE UPDATE or SUPPORTING FACTS (stale content).
+- Add new content ONLY when the SUPPORTING FACTS contain information not already in the CURRENT DOCUMENT.
+- When adding new content, prefer appending to an existing relevant section. Creating a new section is acceptable when the new information does not fit any existing section.
+- When creating a new section, match the heading style, tone, and formatting conventions used in the CURRENT DOCUMENT.
+- Every assertion in your output MUST be grounded in either (a) the CURRENT DOCUMENT (preserved) or (b) the SUPPORTING FACTS. Never introduce outside knowledge.
+- If nothing in the SUPPORTING FACTS contradicts or extends the CURRENT DOCUMENT, return the CURRENT DOCUMENT UNCHANGED, character for character.
+
+OUTPUT FORMAT:
+- Output ONLY the updated markdown document. No preamble, no explanation, no diff markers, no commentary.
+- Do not wrap the output in code fences unless the CURRENT DOCUMENT itself was entirely a code fence."""
+
+
+def build_delta_prompt(
+    *,
+    current_content: str,
+    candidate_content: str,
+    supporting_facts: list[dict[str, Any]],
+    source_query: str,
+) -> str:
+    """Build the user prompt for a delta-mode mental model refresh.
+
+    Args:
+        current_content: The existing mental model content (to preserve as much as possible).
+        candidate_content: Fresh synthesis from the reflect agent reflecting new reality.
+        supporting_facts: Flat list of fact dicts (id, text, type) supporting the candidate.
+        source_query: The mental model's source query, for topical framing.
+    """
+    fact_lines: list[str] = []
+    for f in supporting_facts:
+        fid = f.get("id", "")
+        text = (f.get("text") or "").strip().replace("\n", " ")
+        ftype = f.get("type", "")
+        fact_lines.append(f"- [{ftype}:{fid}] {text}")
+    facts_block = "\n".join(fact_lines) if fact_lines else "(no supporting facts retrieved)"
+
+    return (
+        f"## Topic\n{source_query}\n\n"
+        f"## CURRENT DOCUMENT\n```markdown\n{current_content}\n```\n\n"
+        f"## CANDIDATE UPDATE\n```markdown\n{candidate_content}\n```\n\n"
+        f"## SUPPORTING FACTS\n{facts_block}\n\n"
+        "## Task\n"
+        "Produce the updated mental model document by applying the minimum necessary changes "
+        "to CURRENT DOCUMENT so that it reflects CANDIDATE UPDATE and SUPPORTING FACTS. "
+        "Preserve unchanged content byte-for-byte. Output only the final markdown."
+    )

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -1,0 +1,301 @@
+"""Structured representation of a mental model document.
+
+Why this exists
+---------------
+Storing mental models as raw markdown forces every refresh to round-trip prose
+through an LLM, which then drifts on stylistic details (numbered vs bulleted
+lists, casing, separator lines, paraphrasing) even when instructed to preserve
+content byte-for-byte. The intrinsic mechanism of an LLM is to *generate* the
+next token from a gestalt of the input — not to copy tokens verbatim — so any
+"preserve unchanged content" instruction is fundamentally a soft constraint.
+
+The fix is to give the LLM no opportunity to drift on unchanged content. We
+keep an authoritative structured representation of the document; the markdown
+shown to users is a deterministic render of that structure. Delta refreshes
+emit *operations* against the structure (see ``delta_ops.py``); sections and
+blocks not mentioned by any operation are physically untouched.
+
+Schema (v1)
+-----------
+A document is an ordered list of ``Section``s.  Each section has:
+- ``id``    : stable slug derived from ``heading`` (used as the operation
+              target across refreshes; surviving renames is a separate
+              concern handled by an explicit ``rename`` op).
+- ``heading``: the markdown heading text (without the ``#`` prefix).
+- ``level`` : 1 (``#``) … 6 (``######``).  Default 2.
+- ``blocks``: ordered list of typed blocks — paragraph, bullet_list,
+              ordered_list, code.
+
+The schema is intentionally narrow: it covers what real mental-model documents
+actually contain (the kind a coding agent writes for itself or a user writes as
+a "skill" doc).  Tables, images, and raw HTML are out of scope until needed.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Blocks ---------------------------------------------------------------------
+
+
+class ParagraphBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["paragraph"] = "paragraph"
+    text: str
+
+
+class BulletListBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["bullet_list"] = "bullet_list"
+    items: list[str] = Field(default_factory=list)
+
+
+class OrderedListBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["ordered_list"] = "ordered_list"
+    items: list[str] = Field(default_factory=list)
+
+
+class CodeBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["code"] = "code"
+    language: str = ""
+    text: str
+
+
+Block = Annotated[
+    Union[ParagraphBlock, BulletListBlock, OrderedListBlock, CodeBlock],
+    Field(discriminator="type"),
+]
+
+
+# Section / Document ---------------------------------------------------------
+
+
+class Section(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    heading: str
+    level: int = Field(default=2, ge=1, le=6)
+    blocks: list[Block] = Field(default_factory=list)
+
+
+class StructuredDocument(BaseModel):
+    """Top-level structured representation of a mental model."""
+
+    model_config = ConfigDict(extra="forbid")
+    version: Literal[1] = 1
+    sections: list[Section] = Field(default_factory=list)
+
+    def section_by_id(self, section_id: str) -> Section | None:
+        for s in self.sections:
+            if s.id == section_id:
+                return s
+        return None
+
+    def section_index(self, section_id: str) -> int | None:
+        for i, s in enumerate(self.sections):
+            if s.id == section_id:
+                return i
+        return None
+
+
+# Slug helpers ---------------------------------------------------------------
+
+_SLUG_RX = re.compile(r"[^a-z0-9]+")
+
+
+def slugify_heading(heading: str) -> str:
+    """Stable, deterministic slug from a heading.
+
+    "Stop Conditions" -> "stop-conditions"
+    "Inputs and Context" -> "inputs-and-context"
+    """
+    slug = _SLUG_RX.sub("-", heading.strip().lower()).strip("-")
+    return slug or "section"
+
+
+def make_unique_id(base: str, existing: set[str]) -> str:
+    """Disambiguate by appending -2, -3, … if the slug is already in use."""
+    if base not in existing:
+        return base
+    i = 2
+    while f"{base}-{i}" in existing:
+        i += 1
+    return f"{base}-{i}"
+
+
+# Renderer -------------------------------------------------------------------
+
+
+def render_block(block: Block) -> str:
+    """Render a single block to markdown. No trailing newline."""
+    if isinstance(block, ParagraphBlock):
+        return block.text.rstrip()
+    if isinstance(block, BulletListBlock):
+        return "\n".join(f"- {item.rstrip()}" for item in block.items)
+    if isinstance(block, OrderedListBlock):
+        return "\n".join(f"{i + 1}. {item.rstrip()}" for i, item in enumerate(block.items))
+    if isinstance(block, CodeBlock):
+        fence_lang = block.language or ""
+        return f"```{fence_lang}\n{block.text}\n```"
+    raise TypeError(f"Unknown block type: {type(block)!r}")
+
+
+def render_section(section: Section) -> str:
+    """Render a section: heading + blank line + blocks separated by blank lines."""
+    parts = ["#" * section.level + " " + section.heading.strip()]
+    for block in section.blocks:
+        parts.append("")  # blank line before each block
+        parts.append(render_block(block))
+    return "\n".join(parts)
+
+
+def render_document(doc: StructuredDocument) -> str:
+    """Render the whole document. Sections separated by a single blank line.
+
+    The output is byte-stable: same structured input always produces the same
+    markdown, modulo the inherent ordering of sections/blocks/items.
+    """
+    if not doc.sections:
+        return ""
+    return "\n\n".join(render_section(s) for s in doc.sections) + "\n"
+
+
+# Parser ---------------------------------------------------------------------
+#
+# The parser is intentionally lenient: it accepts the markdown produced by
+# our own renderer (round-trip-safe) and the markdown an LLM tends to produce
+# for mental-model documents.  It is *not* a general CommonMark parser — it
+# does not need to be.  When it cannot classify a block it falls back to a
+# paragraph so that no content is silently dropped.
+
+_HEADING_RX = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_BULLET_RX = re.compile(r"^\s*[-*+]\s+(.*)$")
+_ORDERED_RX = re.compile(r"^\s*\d+[.)]\s+(.*)$")
+_FENCE_RX = re.compile(r"^```([A-Za-z0-9_+-]*)\s*$")
+
+
+def _strip_separators(lines: list[str]) -> list[str]:
+    """Drop horizontal-rule lines (`---`, `***`) used as section separators.
+
+    Our renderer never emits these, but LLM output frequently includes them
+    between sections; treating them as blank lines avoids parsing them as
+    paragraphs.
+    """
+    return ["" if re.fullmatch(r"\s*([-*_])\1{2,}\s*", line) else line for line in lines]
+
+
+def _split_blocks(lines: list[str]) -> list[list[str]]:
+    """Group consecutive non-blank lines into block chunks."""
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    in_fence = False
+    for line in lines:
+        if _FENCE_RX.match(line):
+            current.append(line)
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            current.append(line)
+            continue
+        if line.strip() == "":
+            if current:
+                chunks.append(current)
+                current = []
+        else:
+            current.append(line)
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _parse_block(chunk: list[str]) -> Block:
+    """Parse a single non-empty chunk into a block."""
+    if chunk and _FENCE_RX.match(chunk[0]):
+        m = _FENCE_RX.match(chunk[0])
+        lang = m.group(1) if m else ""
+        body_lines = chunk[1:]
+        if body_lines and _FENCE_RX.match(body_lines[-1]):
+            body_lines = body_lines[:-1]
+        return CodeBlock(language=lang, text="\n".join(body_lines))
+
+    if all(_BULLET_RX.match(line) for line in chunk):
+        items = []
+        for line in chunk:
+            m = _BULLET_RX.match(line)
+            assert m is not None
+            items.append(m.group(1).strip())
+        return BulletListBlock(items=items)
+
+    if all(_ORDERED_RX.match(line) for line in chunk):
+        items = []
+        for line in chunk:
+            m = _ORDERED_RX.match(line)
+            assert m is not None
+            items.append(m.group(1).strip())
+        return OrderedListBlock(items=items)
+
+    return ParagraphBlock(text=" ".join(line.strip() for line in chunk).strip())
+
+
+def parse_markdown(markdown: str) -> StructuredDocument:
+    """Best-effort parse of a markdown document into the structured schema.
+
+    Sections are introduced by ATX headings (``#``..``######``).  Anything
+    before the first heading is wrapped into an implicit "Overview" section
+    so we never silently drop user content.  Section IDs are unique slugs of
+    their headings.
+    """
+    raw_lines = (markdown or "").splitlines()
+    lines = _strip_separators(raw_lines)
+
+    sections: list[Section] = []
+    used_ids: set[str] = set()
+    pending: list[str] = []
+    current: Section | None = None
+
+    def flush_pending_into(section: Section) -> None:
+        if not pending:
+            return
+        for chunk in _split_blocks(pending):
+            section.blocks.append(_parse_block(chunk))
+        pending.clear()
+
+    for line in lines:
+        m = _HEADING_RX.match(line)
+        if m:
+            if current is not None:
+                flush_pending_into(current)
+                sections.append(current)
+            elif pending:
+                # Content before the first heading: wrap in implicit section.
+                base = "overview"
+                section_id = make_unique_id(base, used_ids)
+                used_ids.add(section_id)
+                implicit = Section(id=section_id, heading="Overview", level=2)
+                flush_pending_into(implicit)
+                sections.append(implicit)
+            level = len(m.group(1))
+            heading = m.group(2).strip()
+            section_id = make_unique_id(slugify_heading(heading), used_ids)
+            used_ids.add(section_id)
+            current = Section(id=section_id, heading=heading, level=level)
+        else:
+            pending.append(line)
+
+    if current is not None:
+        flush_pending_into(current)
+        sections.append(current)
+    elif pending:
+        base = "overview"
+        section_id = make_unique_id(base, used_ids)
+        used_ids.add(section_id)
+        implicit = Section(id=section_id, heading="Overview", level=2)
+        flush_pending_into(implicit)
+        sections.append(implicit)
+
+    return StructuredDocument(sections=sections)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -224,6 +224,85 @@ async def ensure_bank_exists(conn, bank_id: str) -> None:
         await create_bank_vector_indexes(conn, bank_id, str(internal_id))
 
 
+async def delete_stale_observations_for_memories(
+    conn,
+    bank_id: str,
+    fact_ids: "list[str | uuid.UUID]",
+) -> int:
+    """Delete observations whose source memories are about to be removed.
+
+    Mirrors the cleanup performed by ``MemoryEngine.delete_document`` so that
+    every code path that removes ``memory_units`` also removes the
+    observations derived from them. Without this, ingesting a fresh version
+    of a document via the retain pipeline (which does a full-replace
+    ``DELETE FROM documents`` cascade) used to leave orphan observations
+    pointing at memory IDs that no longer existed.
+
+    For each observation referencing any of ``fact_ids``:
+    1. Delete the observation row (its text is stale once even one source
+       memory disappears).
+    2. Reset ``consolidated_at = NULL`` on the surviving source memories so
+       they get re-consolidated under fresh observations on the next run.
+
+    Must be called within an active transaction, before the source memories
+    are deleted.
+
+    Returns the number of observations deleted.
+    """
+    if not fact_ids:
+        return 0
+
+    fact_uuids = [uuid.UUID(str(fid)) if not isinstance(fid, uuid.UUID) else fid for fid in fact_ids]
+
+    affected_obs = await conn.fetch(
+        f"""
+        SELECT id, source_memory_ids
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $1
+          AND fact_type = 'observation'
+          AND source_memory_ids && $2::uuid[]
+        """,
+        bank_id,
+        fact_uuids,
+    )
+
+    if not affected_obs:
+        return 0
+
+    deleted_set = {str(uid) for uid in fact_uuids}
+    obs_ids = [obs["id"] for obs in affected_obs]
+    seen_remaining: set[str] = set()
+    remaining_source_ids: list[uuid.UUID] = []
+    for obs in affected_obs:
+        for src_id in obs["source_memory_ids"] or []:
+            src_str = str(src_id)
+            if src_str not in deleted_set and src_str not in seen_remaining:
+                remaining_source_ids.append(src_id)
+                seen_remaining.add(src_str)
+
+    await conn.execute(
+        f"DELETE FROM {fq_table('memory_units')} WHERE id = ANY($1::uuid[])",
+        obs_ids,
+    )
+
+    if remaining_source_ids:
+        await conn.execute(
+            f"""
+            UPDATE {fq_table("memory_units")}
+            SET consolidated_at = NULL
+            WHERE id = ANY($1::uuid[])
+              AND fact_type IN ('experience', 'world')
+            """,
+            remaining_source_ids,
+        )
+
+    logger.info(
+        f"[OBSERVATIONS] Deleted {len(obs_ids)} observations, reset {len(remaining_source_ids)} "
+        f"source memories for re-consolidation in bank {bank_id}"
+    )
+    return len(obs_ids)
+
+
 async def handle_document_tracking(
     conn,
     bank_id: str,
@@ -254,9 +333,31 @@ async def handle_document_tracking(
     combined_content = _sanitize_text(combined_content) or ""
     content_hash = hashlib.sha256(combined_content.encode()).hexdigest()
 
-    # Delete old document first (cascades to units and links)
-    # Only delete on the first batch to avoid deleting data we just inserted
+    # Delete old document first (cascades to units and links).
+    # Only delete on the first batch to avoid deleting data we just inserted.
+    # Before the cascade, fan out to delete observations derived from the
+    # outgoing memory_units — otherwise the FK ON DELETE CASCADE removes the
+    # source memory_units but leaves observation rows pointing at IDs that
+    # no longer exist (consolidated_at on co-source memories also stays
+    # frozen). Same cleanup the explicit ``delete_document`` API performs.
     if is_first_batch:
+        existing_unit_rows = await conn.fetch(
+            f"""
+            SELECT id FROM {fq_table("memory_units")}
+            WHERE document_id = $1 AND fact_type IN ('experience', 'world')
+            """,
+            document_id,
+        )
+        existing_unit_ids = [row["id"] for row in existing_unit_rows]
+        if existing_unit_ids:
+            invalidated = await delete_stale_observations_for_memories(
+                conn, bank_id, existing_unit_ids
+            )
+            if invalidated:
+                logger.info(
+                    f"[RETAIN] Document {document_id} re-ingested: invalidated "
+                    f"{invalidated} observation(s) derived from {len(existing_unit_ids)} outgoing memory_units"
+                )
         await conn.fetchval(
             f"DELETE FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 RETURNING id",
             document_id,

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -350,9 +350,7 @@ async def handle_document_tracking(
         )
         existing_unit_ids = [row["id"] for row in existing_unit_rows]
         if existing_unit_ids:
-            invalidated = await delete_stale_observations_for_memories(
-                conn, bank_id, existing_unit_ids
-            )
+            invalidated = await delete_stale_observations_for_memories(conn, bank_id, existing_unit_ids)
             if invalidated:
                 logger.info(
                     f"[RETAIN] Document {document_id} re-ingested: invalidated "

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -990,7 +990,14 @@ class WorkerPoller:
             min_size = pool.get_min_size() if hasattr(pool, "get_min_size") else None
             max_size = pool.get_max_size() if hasattr(pool, "get_max_size") else None
             queue = getattr(pool, "_queue", None)
-            waiters = queue.qsize() if queue is not None and hasattr(queue, "qsize") else None
+            # asyncpg's _queue is a LifoQueue pre-filled to max_size with
+            # PoolConnectionHolder objects. qsize() therefore counts *available
+            # holders*, not callers waiting on the pool — the previous "waiters"
+            # label here was the opposite of what it suggested. The actual count
+            # of awaiters is len(_queue._getters), nonzero only when qsize()==0.
+            free_holders = queue.qsize() if queue is not None and hasattr(queue, "qsize") else None
+            getters = getattr(queue, "_getters", None) if queue is not None else None
+            pending_acquires = len(getters) if getters is not None else None
 
             parts = [f"size={size}"]
             if min_size is not None and max_size is not None:
@@ -998,8 +1005,10 @@ class WorkerPoller:
             if free is not None:
                 parts.append(f"idle={free}")
                 parts.append(f"in_use={size - free}")
-            if waiters is not None:
-                parts.append(f"waiters={waiters}")
+            if free_holders is not None:
+                parts.append(f"free_holders={free_holders}")
+            if pending_acquires is not None:
+                parts.append(f"pending_acquires={pending_acquires}")
             return " ".join(parts)
         except Exception as e:
             logger.debug(f"Pool stats unavailable: {e}")

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -1,0 +1,826 @@
+"""Tests for delta-mode mental model refresh.
+
+Delta mode performs a surgical update on the existing mental model content:
+- Unchanged sections are preserved byte-for-byte.
+- Stale content is removed.
+- New content from observations/facts is added, preferably by extending existing sections.
+
+Fallback rules:
+- If the mental model has no existing content, delta falls back to a full regeneration.
+- If the source_query has changed since the last refresh, delta falls back to a full regeneration.
+
+This file contains two kinds of tests:
+
+1. TestDeltaRefreshPlumbing: fast, deterministic tests that monkey-patch reflect_async
+   and the LLM call to verify branching logic (fallback conditions, provenance tracking).
+
+2. TestDeltaRefreshGeminiEval: real-LLM behavioral evals against Gemini. These are
+   gated on HINDSIGHT_RUN_GEMINI_EVALS=1 (plus a Gemini API key) because they cost
+   money/time and require network access. They verify the actual quality of delta
+   updates — format preservation, surgical edits, observation-grounding.
+"""
+
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.engine.llm_wrapper import LLMConfig
+from hindsight_api.engine.response_models import ReflectResult
+
+
+def _canned_reflect_result(text: str, facts: list[dict] | None = None) -> ReflectResult:
+    """Build a minimal ReflectResult for monkey-patching reflect_async."""
+    return ReflectResult.model_validate(
+        {
+            "text": text,
+            "based_on": {
+                "observation": facts or [],
+                "world": [],
+                "experience": [],
+                "mental-models": [],
+                "directives": [],
+            },
+        }
+    )
+
+
+@pytest.fixture
+def patch_reflect(monkeypatch):
+    """Helper that patches memory.reflect_async to return a canned result and records the call.
+
+    Usage:
+        calls = patch_reflect(memory, text="hello", facts=[...])
+        await memory.refresh_mental_model(...)
+        assert len(calls) == 1
+    """
+
+    def _install(memory: MemoryEngine, *, text: str, facts: list[dict] | None = None):
+        calls: list[dict] = []
+
+        async def fake_reflect_async(**kwargs):
+            calls.append(kwargs)
+            return _canned_reflect_result(text, facts)
+
+        monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        return calls
+
+    return _install
+
+
+@pytest.fixture
+def patch_llm_call(monkeypatch):
+    """Patch the reflect LLM config's ``.call()`` used for the structured delta call.
+
+    The structured-delta path passes ``response_format=DeltaOperationList``, so the
+    LLM returns a Pydantic instance.  Each invocation of ``patch_llm_call`` installs
+    a single canned response, in any of these shapes:
+
+    - ``DeltaOperationList`` instance → returned as-is
+    - ``[]`` (empty list) → no operations (this is the no-change case)
+    - ``[{"op": "...", ...}, ...]`` → wrapped into ``{"operations": [...]}``
+    - ``{"operations": [...]}`` → validated directly
+    """
+    from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
+
+    def _to_op_list(resp: Any) -> DeltaOperationList:
+        if isinstance(resp, DeltaOperationList):
+            return resp
+        if isinstance(resp, dict):
+            if "operations" in resp:
+                return DeltaOperationList.model_validate(resp)
+            # Treat a bare op dict as a one-op list for ergonomics.
+            return DeltaOperationList.model_validate({"operations": [resp]})
+        if isinstance(resp, list):
+            return DeltaOperationList.model_validate({"operations": resp})
+        if isinstance(resp, str):
+            # Tests that expect *no* call ever still install a sentinel; treat as no-op.
+            return DeltaOperationList()
+        raise TypeError(f"unsupported canned LLM response: {type(resp)!r}")
+
+    def _install(memory: MemoryEngine, *, returns):
+        calls: list[dict] = []
+        canned = _to_op_list(returns)
+
+        async def fake_call(*, messages, **kwargs):
+            calls.append({"messages": messages, **kwargs})
+            return canned
+
+        monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
+        return calls
+
+    return _install
+
+
+class TestDeltaRefreshPlumbing:
+    """Deterministic tests that verify the branching/plumbing of delta-mode refresh."""
+
+    async def test_full_mode_does_not_call_delta_merge(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """When trigger.mode='full', no second LLM call for delta merge occurs."""
+        bank_id = f"test-delta-full-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nOriginal content.",
+            trigger={"mode": "full"},
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text="# Team\n\nRegenerated from scratch.")
+        llm_calls = patch_llm_call(memory, returns="should-not-be-called")
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert refreshed is not None
+        assert refreshed["content"] == "# Team\n\nRegenerated from scratch."
+        assert len(llm_calls) == 0, "Delta merge LLM call must not happen in full mode"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_mode_empty_content_falls_back_to_full(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """When the mental model has no existing content there is nothing to anchor
+        a surgical edit on, so delta falls back to full regeneration. The user's
+        candidate from reflect_async is used verbatim.
+        """
+        bank_id = f"test-delta-empty-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="",  # no existing content
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        patch_reflect(memory, text="# Team\n\nFull fresh synthesis.")
+        llm_calls = patch_llm_call(memory, returns=[])
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert refreshed["content"] == "# Team\n\nFull fresh synthesis."
+        assert len(llm_calls) == 0  # delta path skipped entirely
+        rr = refreshed.get("reflect_response") or {}
+        assert rr.get("delta_applied") is not True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_mode_source_query_change_falls_back_to_full(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """If source_query changes after a refresh, the next delta run must do a full rewrite."""
+        bank_id = f"test-delta-query-change-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nBaseline.",
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        # First refresh: establishes last_refreshed_source_query.
+        patch_reflect(memory, text="# Team\n\nFirst pass.")
+        patch_llm_call(memory, returns="unused-first")
+        await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        # Now change the source_query — a genuine topic shift.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            source_query="Tell me about customers instead",
+            request_context=request_context,
+        )
+
+        # Second refresh under the new query must do a FULL rewrite, not a delta merge.
+        patch_reflect(memory, text="# Customers\n\nBrand new topic.")
+        llm_calls = patch_llm_call(memory, returns="should-not-be-called")
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert refreshed["content"] == "# Customers\n\nBrand new topic."
+        assert len(llm_calls) == 0, "Source-query change must bypass the delta merge"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_mode_applies_ops_when_query_stable(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """When content exists and source_query is stable, the delta LLM produces ops
+        that are applied against the parsed structured doc. The unchanged section
+        renders byte-identical, the new fact lands in a new block.
+        """
+        bank_id = f"test-delta-apply-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = (
+            "# Team\n"
+            "\n"
+            "Alice is the lead.\n"
+            "\n"
+            "## Members\n"
+            "\n"
+            "- Alice — lead\n"
+        )
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=existing,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        # First refresh: empty op list → structured doc unchanged → markdown is the
+        # render of the parsed existing content. This also seeds the tracking column.
+        patch_reflect(memory, text="ignored — full mode candidate")
+        patch_llm_call(memory, returns=[])  # zero ops
+        await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        # Second refresh: a new fact arrives; LLM returns one append_block op.
+        candidate = "# Team\n\nAlice is the lead. Bob joined as junior engineer."
+        patch_reflect(
+            memory,
+            text=candidate,
+            facts=[
+                {
+                    "id": "obs-bob",
+                    "text": "Bob joined the team as junior engineer",
+                    "type": "observation",
+                    "context": None,
+                }
+            ],
+        )
+        ops = [
+            {
+                "op": "append_block",
+                "section_id": "members",
+                "block": {
+                    "type": "bullet_list",
+                    "items": ["Bob — junior engineer"],
+                },
+            }
+        ]
+        llm_calls = patch_llm_call(memory, returns=ops)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert len(llm_calls) == 1, "Structured-delta LLM call must fire exactly once"
+        system_msg = llm_calls[0]["messages"][0]["content"]
+        user_msg = llm_calls[0]["messages"][1]["content"]
+        # Prompt must include the structured doc + supporting facts + the system prompt.
+        assert "minimal patch" in system_msg.lower()
+        assert "operations" in system_msg.lower()
+        assert "obs-bob" in user_msg
+        assert "Bob joined" in user_msg
+        # The structured JSON of the current doc must include the section id "members".
+        assert '"id": "members"' in user_msg
+
+        # New content includes the new bullet.
+        assert "Bob — junior engineer" in refreshed["content"]
+        # Unchanged section ("Alice is the lead.") still present.
+        assert "Alice is the lead." in refreshed["content"]
+        rr = refreshed.get("reflect_response") or {}
+        assert rr.get("delta_applied") is True
+        applied = rr.get("delta_operations_applied") or []
+        assert len(applied) == 1
+        assert applied[0]["op"] == "append_block"
+        assert applied[0]["section_id"] == "members"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_zero_ops_keeps_existing_content_byte_identical(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+    ):
+        """Zero operations from the LLM must mean zero changes in the rendered output.
+
+        This is the structural guarantee: any sections/blocks not mentioned by an
+        op come through byte-identical. A no-op refresh therefore re-renders the
+        same structured doc — which (after the first refresh has parsed and
+        re-rendered it) is byte-stable.
+        """
+        bank_id = f"test-delta-noop-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = (
+            "# Team\n"
+            "\n"
+            "Alice is the lead.\n"
+            "\n"
+            "## Members\n"
+            "\n"
+            "- Alice\n"
+        )
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=existing,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        # First refresh: parses + renders existing into structured form. The output
+        # may not match `existing` byte-for-byte (whitespace normalised by renderer).
+        patch_reflect(memory, text="ignored — full mode candidate")
+        patch_llm_call(memory, returns=[])
+        first = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        normalised = first["content"]
+
+        # Second refresh: zero ops again → same bytes as first refresh.
+        patch_reflect(memory, text="something completely different from existing")
+        patch_llm_call(memory, returns=[])
+        second = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert second["content"] == normalised
+        rr = second.get("reflect_response") or {}
+        assert rr.get("delta_applied") is True  # delta path ran; produced no changes
+        assert rr.get("delta_operations_applied") == []
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_llm_failure_falls_back_to_candidate(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        monkeypatch,
+    ):
+        """When the structured-delta LLM call raises, refresh falls back to the
+        candidate markdown so the user still sees a fresh synthesis instead of
+        an opaque failure.
+        """
+        bank_id = f"test-delta-llm-fail-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content="# Team\n\nExisting.\n",
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        # Seed tracking column with a successful zero-op refresh.
+        patch_reflect(memory, text="ignored")
+
+        async def ok_call(*, messages, **kwargs):
+            from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
+
+            return DeltaOperationList()
+
+        monkeypatch.setattr(memory._reflect_llm_config, "call", ok_call)
+        await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        # Now the second refresh: LLM raises. Refresh must not crash; it should
+        # store the candidate markdown.
+        candidate = "# Team\n\nFallback candidate from reflect_async.\n"
+        patch_reflect(memory, text=candidate)
+
+        async def boom(*, messages, **kwargs):
+            raise RuntimeError("simulated provider 500")
+
+        monkeypatch.setattr(memory._reflect_llm_config, "call", boom)
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert "Fallback candidate" in refreshed["content"]
+        rr = refreshed.get("reflect_response") or {}
+        assert rr.get("delta_applied") is False
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Real-Gemini evaluation tests
+# ---------------------------------------------------------------------------
+
+_GEMINI_API_KEY = (
+    os.getenv("HINDSIGHT_GEMINI_API_KEY")
+    or os.getenv("GEMINI_API_KEY")
+    or os.getenv("GOOGLE_API_KEY")
+)
+_OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+_RUN_LLM_EVAL = os.getenv("HINDSIGHT_RUN_GEMINI_EVALS") == "1" and (
+    bool(_GEMINI_API_KEY) or bool(_OPENAI_API_KEY)
+)
+
+
+pytestmark_gemini = pytest.mark.skipif(
+    not _RUN_LLM_EVAL,
+    reason=(
+        "Real-LLM delta evals are gated. Set HINDSIGHT_RUN_GEMINI_EVALS=1 and provide "
+        "GEMINI_API_KEY (preferred) or OPENAI_API_KEY to run."
+    ),
+)
+
+
+@pytest.fixture
+async def gemini_memory(memory_no_llm_verify: MemoryEngine):
+    """MemoryEngine wired to a real LLM for reflect + structured delta.
+
+    Prefers Gemini (the original target) but falls back to OpenAI when the
+    Gemini key is unavailable — the structured-delta architecture works
+    against either, and waiting on a single provider's key would block
+    iteration. The chosen model is logged so test failures are unambiguous
+    about which provider produced them.
+    """
+    if _GEMINI_API_KEY:
+        provider = "gemini"
+        model = os.getenv("HINDSIGHT_GEMINI_EVAL_MODEL", "gemini-2.0-flash")
+        cfg = LLMConfig(provider=provider, api_key=_GEMINI_API_KEY, base_url="", model=model)
+    else:
+        provider = "openai"
+        model = os.getenv("HINDSIGHT_OPENAI_EVAL_MODEL", "gpt-4o-mini")
+        cfg = LLMConfig(provider=provider, api_key=_OPENAI_API_KEY or "", base_url="", model=model)
+    print(f"\n[delta-eval] using provider={provider} model={model}")
+    memory_no_llm_verify._reflect_llm_config = cfg
+    memory_no_llm_verify._llm_config = cfg
+    memory_no_llm_verify._retain_llm_config = cfg
+    memory_no_llm_verify._consolidation_llm_config = cfg
+    yield memory_no_llm_verify
+
+
+_NEWS_FEED_SKILL_MARKDOWN = """## Purpose
+
+Generate a concise, top-N personalized AI/ML news brief in response to user-triggered requests such as "ai news", "top 5 this week", or "what matters for builders today".
+
+## Scope
+
+- **In scope**: collecting, filtering, and summarizing AI/ML articles from user-preferred RSS feeds, applying user preferences stored in the AI News Feed Preferences mental model, and delivering the brief to the user.
+- **Out of scope**: non-AI news, detailed article content, legal or privacy reviews beyond user preferences, and posting the brief to external platforms without explicit user approval.
+
+## Rules
+
+- **Always**:
+  1. Use the AI News Feed Preferences mental model to retrieve user preferences; do not embed preferences in the skill file.
+  2. Do not post the brief to any platform unless the user explicitly approves.
+  3. Do not persist preferences locally; rely solely on the mental model.
+  4. Refresh the feed after consolidation if the trigger-refresh-after-consolidation flag is true.
+- **Prefer**:
+  1. Provide a concise summary (about 2-3 sentences per article) for the top-N articles.
+  2. Default to the top-5 articles unless the user specifies otherwise.
+  3. Order articles chronologically or by relevance as per user preference.
+  4. Highlight any user-specified topics or tags if present.
+
+## Procedure
+
+1. **Trigger detection** — identify a request containing keywords like "ai news", "top N", or "what matters".
+2. **Preference retrieval** — call memory recall for the AI News Feed Preferences mental model to obtain RSS feed URLs and any filtering criteria.
+3. **Feed consolidation** — fetch all feeds, de-duplicate entries, and apply any user-specified filters.
+4. **Article selection** — choose the top-N articles based on date or user preference; if trigger-refresh-after-consolidation is true, re-fetch feeds before selection.
+5. **Summarization** — generate a brief summary for each article, keeping it short and to the point.
+6. **Approval check** — if the brief is to be posted externally, verify explicit user approval; otherwise, deliver it directly to the user.
+7. **Memory retention** — store any new learnings or preferences observed during the task using memory retain.
+
+## Inputs and Context
+
+- **Source feeds**: user-specified RSS URLs stored in the mental model (e.g., https://aiagentmemory.org/index.xml).
+- **Time window**: the latest update from each feed; typically the last 7 days for weekly briefs.
+- **User preferences**: stored in the AI News Feed Preferences mental model; may include topics, tags, or language.
+
+## Output Shape
+
+- **Structure**: list of articles with title, publication date, source, and a 2-sentence summary.
+- **Format**: plain text or markdown (as requested by the user).
+- **Length**: concise — approximately 2-3 sentences per article; total brief about 200-300 words for top-5.
+- **Voice/Tone**: neutral, informative, and concise; use bullet points for clarity.
+
+## Stop Conditions
+
+- If the mental model cannot be retrieved, refuse or request clarification.
+- If the user has not provided any RSS feed URLs, ask for a preferred source.
+- If the brief is requested for posting and explicit approval is missing, refuse.
+- If the user explicitly requests to remove a skill or stop the briefing, comply immediately.
+
+## Open Questions
+
+- Desired brief length or word count?
+- Preferred summary style (bullet vs paragraph).
+- Whether the user wants to include non-AI but AI-related topics.
+- Frequency or schedule for automated briefs (if any).
+- Specific user-defined tags or topics to highlight.
+"""
+
+
+@pytestmark_gemini
+class TestDeltaRefreshGeminiEval:
+    """Real-LLM evals for the structured-delta refresh path.
+
+    The structural guarantee these tests verify: sections and blocks not
+    targeted by an LLM-emitted operation are byte-identical between the
+    pre-refresh and post-refresh markdown render. This is what the
+    structured-ops architecture buys us — the LLM cannot drift on text it
+    never re-emits.
+
+    Real Gemini is used (not a mock) because the failure mode we're guarding
+    against is precisely "the LLM doesn't reliably do what the prompt says,
+    even at temperature 0". Mocked output would prove the wiring works but
+    not that the contract holds against an actual model.
+    """
+
+    async def _seed(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        bank_id: str,
+        existing_markdown: str,
+        memories: list[str],
+    ) -> dict[str, Any]:
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Skill Doc",
+            source_query="Document the news-feed skill: purpose, rules, procedure, stop conditions.",
+            content=existing_markdown,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": m} for m in memories],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        # First refresh: parses existing into structured form. With well-aligned
+        # memories the LLM should emit zero ops, so the structured doc is just
+        # the parsed existing content. The rendered markdown is canonicalised.
+        first = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        return {"mm": mm, "first": first}
+
+    async def test_no_change_when_observations_agree_with_existing(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """When observations only restate the existing doc, a second delta
+        refresh produces output byte-identical to the first refresh's output.
+
+        The first refresh canonicalises whitespace via the parser+renderer; we
+        compare the *second* refresh against the *first* (not against the raw
+        seed markdown), which is the actual repeat-refresh behaviour users
+        will see in production.
+        """
+        bank_id = f"eval-delta-noop-{uuid.uuid4().hex[:8]}"
+        seeded = await self._seed(
+            gemini_memory,
+            request_context,
+            bank_id,
+            existing_markdown=_NEWS_FEED_SKILL_MARKDOWN,
+            memories=[
+                "The news-feed skill produces a concise top-N AI/ML news brief.",
+                "Default brief size is top 5 unless the user specifies otherwise.",
+                "Source feed: https://aiagentmemory.org/index.xml.",
+                "The skill must not post externally without explicit approval.",
+            ],
+        )
+        first_content = seeded["first"]["content"]
+
+        second = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=seeded["mm"]["id"],
+            request_context=request_context,
+        )
+        second_content = second["content"]
+
+        # Byte-identical render across refreshes when no new fact has arrived.
+        assert second_content == first_content, (
+            "Repeat delta refresh changed bytes when no new facts arrived.\n"
+            f"--- diff sample (first 300 chars different) ---\n"
+            f"first:  {first_content[:300]!r}\n"
+            f"second: {second_content[:300]!r}"
+        )
+        rr = second.get("reflect_response") or {}
+        # The LLM may emit zero ops (best case) or non-effective ops (still no
+        # change to render); both are acceptable so long as the bytes match.
+        assert rr.get("delta_applied") is True
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_new_observation_is_merged_surgically(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A new fact arrives; only the section relevant to it should change.
+
+        Asserts the architectural guarantee at the section level: every
+        section that the LLM did NOT name in an operation must render exactly
+        the same bytes after the refresh as before. The new fact itself must
+        appear somewhere in the output.
+        """
+        from hindsight_api.engine.reflect.structured_doc import (
+            StructuredDocument,
+            render_section,
+        )
+
+        bank_id = f"eval-delta-add-{uuid.uuid4().hex[:8]}"
+        seeded = await self._seed(
+            gemini_memory,
+            request_context,
+            bank_id,
+            existing_markdown=_NEWS_FEED_SKILL_MARKDOWN,
+            memories=[
+                "The news-feed skill produces a concise top-N AI/ML news brief.",
+                "Default brief size is top 5.",
+                "Source feed: https://aiagentmemory.org/index.xml.",
+            ],
+        )
+        first_content = seeded["first"]["content"]
+        first_struct = StructuredDocument.model_validate(
+            seeded["first"]["reflect_response"]["delta_operations_applied"]
+            and seeded["first"].get("structured_content")
+            or {"version": 1, "sections": []}
+        )
+        # The first refresh's structured snapshot is what the second refresh
+        # will operate on. Re-fetch via get_mental_model would also work.
+        # For preservation comparison we re-parse first_content.
+        from hindsight_api.engine.reflect.structured_doc import parse_markdown
+
+        before = parse_markdown(first_content)
+
+        # Introduce a brand-new fact that fits into "Inputs and Context" or
+        # similar — but the model may pick any reasonable section.
+        await gemini_memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": (
+                        "The default time window for the news brief is the last 7 days, "
+                        "matching the weekly cadence preferred by the user."
+                    )
+                },
+            ],
+            request_context=request_context,
+        )
+        await gemini_memory.wait_for_background_tasks()
+
+        refreshed = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=seeded["mm"]["id"],
+            request_context=request_context,
+        )
+        content = refreshed["content"]
+        rr = refreshed.get("reflect_response") or {}
+        applied_ops = rr.get("delta_operations_applied") or []
+        touched_section_ids = {op.get("section_id") for op in applied_ops if op.get("section_id")}
+
+        # The fact must show up.
+        assert "7 days" in content or "seven days" in content.lower(), (
+            f"New fact about 7-day window missing from delta output: {content!r}"
+        )
+
+        # Every untouched section must render byte-identical to its pre-refresh form.
+        after = parse_markdown(content)
+        before_by_id = {s.id: s for s in before.sections}
+        for section in after.sections:
+            if section.id in touched_section_ids:
+                continue
+            orig = before_by_id.get(section.id)
+            if orig is None:
+                continue  # newly added section, no preservation contract
+            assert render_section(orig) == render_section(section), (
+                f"Untouched section {section.id!r} drifted between refreshes — the "
+                f"structured-ops architecture's preservation guarantee was violated.\n"
+                f"BEFORE:\n{render_section(orig)!r}\n"
+                f"AFTER:\n{render_section(section)!r}"
+            )
+
+        assert rr.get("delta_applied") is True
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_no_change_repeated_three_times_stays_byte_stable(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Three consecutive no-change refreshes must produce three identical
+        markdown outputs. This is the regression test for the original
+        complaint where prose-merge delta drifted content across versions even
+        when no observation changed.
+        """
+        bank_id = f"eval-delta-stable-{uuid.uuid4().hex[:8]}"
+        seeded = await self._seed(
+            gemini_memory,
+            request_context,
+            bank_id,
+            existing_markdown=_NEWS_FEED_SKILL_MARKDOWN,
+            memories=[
+                "The news-feed skill produces a top-N AI brief on demand.",
+                "It must not post without explicit user approval.",
+            ],
+        )
+        c1 = seeded["first"]["content"]
+        r2 = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=seeded["mm"]["id"],
+            request_context=request_context,
+        )
+        r3 = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id,
+            mental_model_id=seeded["mm"]["id"],
+            request_context=request_context,
+        )
+        assert r2["content"] == c1, "second refresh drifted vs first"
+        assert r3["content"] == c1, "third refresh drifted vs first"
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_source_query_change_forces_full_rewrite(
+        self, gemini_memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Changing source_query must bypass delta and produce a full regeneration."""
+        bank_id = f"eval-delta-query-change-{uuid.uuid4().hex[:8]}"
+        await gemini_memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await gemini_memory.create_mental_model(
+            bank_id=bank_id,
+            name="Subject",
+            source_query="Summarize the team and how it operates.",
+            content="# Team Overview\n\nAlice leads the team.\n",
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        await gemini_memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {"content": "Alice leads the team."},
+                {"content": "The product is a memory system for AI agents."},
+                {"content": "Customers include small SaaS startups and enterprise pilots."},
+            ],
+            request_context=request_context,
+        )
+        await gemini_memory.wait_for_background_tasks()
+
+        # First refresh seeds tracking column under the team query.
+        await gemini_memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        # Change the topic entirely.
+        await gemini_memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            source_query="Summarize our customers and what we sell them.",
+            request_context=request_context,
+        )
+
+        refreshed = await gemini_memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        content = refreshed["content"].lower()
+        # Content should now be about customers/product, not (only) about Alice leading the team.
+        assert "customer" in content or "product" in content, (
+            f"Full rewrite should cover the new topic, got: {refreshed['content']!r}"
+        )
+        # delta_applied should be absent/False because we took the full path.
+        assert (refreshed.get("reflect_response") or {}).get("delta_applied") is not True
+
+        await gemini_memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -439,6 +439,72 @@ class TestDeltaRefreshPlumbing:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_empty_reflect_answer_preserves_existing_content(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+        patch_reflect,
+        patch_llm_call,
+        monkeypatch,
+    ):
+        """Regression: when the reflect agent returns an empty answer (small models
+        sometimes hit this after exhausting tool-call retries), the refresh must
+        NOT overwrite the existing content with an empty string.
+
+        Previously this destroyed the working document on every transient upstream
+        failure, and the next refresh saw current_content == "" and skipped the
+        delta path entirely — a snowball that emptied valuable mental models.
+
+        The scenario covered here is the realistic failure path: the structured
+        delta call also fails (because the empty supporting facts produce empty
+        / invalid JSON) so the fallback path kicks in. Without the guard, the
+        fallback would write "" to the DB; with it, the existing content stays.
+        """
+        bank_id = f"test-empty-reflect-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        existing = (
+            "# Team\n"
+            "\n"
+            "Alice is the lead.\n"
+            "\n"
+            "## Members\n"
+            "\n"
+            "- Alice\n"
+        )
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Team Info",
+            source_query="Tell me about the team",
+            content=existing,
+            trigger={"mode": "delta"},
+            request_context=request_context,
+        )
+
+        # Reflect returns "" — this is the upstream failure mode.
+        patch_reflect(memory, text="")
+
+        # Delta call also fails (mirrors the real groq behaviour where empty
+        # supporting facts often produce empty / invalid JSON). Refresh then
+        # falls back to the empty candidate, which the guard rejects.
+        async def boom(*, messages, **kwargs):
+            raise RuntimeError("simulated empty/invalid JSON from provider")
+
+        monkeypatch.setattr(memory._reflect_llm_config, "call", boom)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        # Existing content preserved exactly.
+        assert refreshed["content"] == existing, (
+            "Empty reflect answer overwrote existing content — guard regressed"
+        )
+        rr = refreshed.get("reflect_response") or {}
+        assert rr.get("refresh_skipped") == "empty_candidate"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 # ---------------------------------------------------------------------------
 # Real-Gemini evaluation tests

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -264,6 +264,111 @@ class TestDeleteDocumentObservationCleanup:
 
 
 # ---------------------------------------------------------------------------
+# Tests: document upsert via retain pipeline (regression for orphan observations)
+# ---------------------------------------------------------------------------
+
+class TestDocumentUpsertObservationCleanup:
+    """Regression: re-ingesting a document via the retain pipeline must clean up
+    observations derived from the outgoing memory_units, the same way the
+    explicit ``MemoryEngine.delete_document`` API does.
+
+    Before the fix, ``fact_storage.handle_document_tracking`` deleted the
+    document via FK cascade — removing the source memory_units silently — but
+    never invalidated the dependent observations. They became orphans whose
+    ``source_memory_ids`` arrays pointed at IDs that no longer existed in
+    ``memory_units``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upsert_document_removes_observations_from_outgoing_memories(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        from hindsight_api.engine.retain.fact_storage import handle_document_tracking
+
+        bank_id = f"test-upsert-obs-cleanup-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        doc_id = str(uuid.uuid4())
+
+        # Pre-populate: one document, two source memories under it, one
+        # standalone memory not in the document, and an observation that joins
+        # all three. After the upsert, the two doc memories should be gone
+        # (cascade) AND the observation should be invalidated (the bug we're
+        # fixing). The standalone memory should be reset for re-consolidation.
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO documents (id, bank_id, original_text, content_hash, created_at, updated_at)
+                VALUES ($1, $2, 'old version', 'hash-old', NOW(), NOW())
+                """,
+                doc_id,
+                bank_id,
+            )
+            doc_mem_a = uuid.uuid4()
+            doc_mem_b = uuid.uuid4()
+            for mem_id, text in [(doc_mem_a, "Old fact A."), (doc_mem_b, "Old fact B.")]:
+                await conn.execute(
+                    """
+                    INSERT INTO memory_units (id, bank_id, text, fact_type, event_date, document_id,
+                                              created_at, updated_at, consolidated_at)
+                    VALUES ($1, $2, $3, 'experience', NOW(), $4, NOW(), NOW(), NOW())
+                    """,
+                    mem_id,
+                    bank_id,
+                    text,
+                    doc_id,
+                )
+            standalone_mem = await _insert_memory(conn, bank_id, "Standalone fact C.")
+            obs_id = await _insert_observation(
+                conn,
+                bank_id,
+                "Aggregated observation joining doc + standalone facts.",
+                [doc_mem_a, doc_mem_b, standalone_mem],
+            )
+
+        # Trigger the upsert path directly. ``handle_document_tracking`` is
+        # what the retain orchestrator calls on every document re-ingest.
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await handle_document_tracking(
+                    conn,
+                    bank_id=bank_id,
+                    document_id=doc_id,
+                    combined_content="new version replacing old facts",
+                    is_first_batch=True,
+                    retain_params=None,
+                    document_tags=None,
+                )
+
+        async with pool.acquire() as conn:
+            obs_ids = await _get_observation_ids(conn, bank_id)
+            assert str(obs_id) not in obs_ids, (
+                "Observation derived from the outgoing memory_units should have been "
+                "deleted during the upsert (regression: orphan observations were "
+                "previously left behind because handle_document_tracking didn't call "
+                "delete_stale_observations_for_memories)"
+            )
+
+            # The standalone memory survives (different document_id) and should
+            # be reset for re-consolidation since one of its observations was
+            # invalidated by the upsert.
+            consolidated_at = await _get_consolidated_at(conn, standalone_mem)
+            assert consolidated_at is None, (
+                "Surviving co-source memory should be reset for re-consolidation"
+            )
+
+            # The two doc-scoped memories are gone via FK cascade.
+            doc_mem_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM memory_units WHERE id = ANY($1::uuid[])",
+                [doc_mem_a, doc_mem_b],
+            )
+            assert doc_mem_count == 0
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
 # Tests: delete_bank with fact_type filter
 # ---------------------------------------------------------------------------
 

--- a/hindsight-api-slim/tests/test_structured_doc.py
+++ b/hindsight-api-slim/tests/test_structured_doc.py
@@ -1,0 +1,438 @@
+"""Unit tests for the structured document schema, renderer, parser, and
+delta-operation applicator.
+
+These tests are pure-Python (no DB, no LLM) and run fast. They guard the
+mechanical guarantees that the structured-delta architecture relies on:
+
+- Deterministic rendering (same input → same bytes).
+- Round-trip parse → render is stable for canonical markdown.
+- Section IDs are stable slugs and survive disambiguation.
+- Operations target sections/blocks by id/index and never silently corrupt
+  the document; invalid ops are dropped, not applied half-way.
+- Sections and blocks not mentioned by any op come through byte-identical.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_api.engine.reflect.delta_ops import (
+    AddSectionOp,
+    AppendBlockOp,
+    DeltaOperationList,
+    InsertBlockOp,
+    RemoveBlockOp,
+    RemoveSectionOp,
+    RenameSectionOp,
+    ReplaceBlockOp,
+    ReplaceSectionBlocksOp,
+    apply_operations,
+)
+from hindsight_api.engine.reflect.structured_doc import (
+    BulletListBlock,
+    CodeBlock,
+    OrderedListBlock,
+    ParagraphBlock,
+    Section,
+    StructuredDocument,
+    make_unique_id,
+    parse_markdown,
+    render_block,
+    render_document,
+    render_section,
+    slugify_heading,
+)
+
+# Helpers --------------------------------------------------------------------
+
+
+def _team_overview_doc() -> StructuredDocument:
+    return StructuredDocument(
+        sections=[
+            Section(
+                id="team-overview",
+                heading="Team Overview",
+                level=1,
+                blocks=[ParagraphBlock(text="Quick summary of the engineering team.")],
+            ),
+            Section(
+                id="members",
+                heading="Members",
+                level=2,
+                blocks=[
+                    BulletListBlock(
+                        items=[
+                            "**Alice** — team lead, owns planning.",
+                            "**Bob** — senior engineer, mentors juniors.",
+                        ]
+                    )
+                ],
+            ),
+            Section(
+                id="cadence",
+                heading="Cadence",
+                level=2,
+                blocks=[ParagraphBlock(text="Standups happen daily at 9am.")],
+            ),
+        ]
+    )
+
+
+# Slug ----------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert slugify_heading("Purpose") == "purpose"
+
+    def test_multi_word(self):
+        assert slugify_heading("Stop Conditions") == "stop-conditions"
+
+    def test_punctuation_collapses(self):
+        assert slugify_heading("Inputs / Context !") == "inputs-context"
+
+    def test_unicode_falls_back(self):
+        # Non-ASCII chars are stripped; if nothing remains, slug becomes "section".
+        assert slugify_heading("???") == "section"
+
+    def test_make_unique_id_no_collision(self):
+        assert make_unique_id("rules", set()) == "rules"
+
+    def test_make_unique_id_collision(self):
+        assert make_unique_id("rules", {"rules"}) == "rules-2"
+        assert make_unique_id("rules", {"rules", "rules-2"}) == "rules-3"
+
+
+# Renderer ------------------------------------------------------------------
+
+
+class TestRenderer:
+    def test_paragraph(self):
+        assert render_block(ParagraphBlock(text="hello world")) == "hello world"
+
+    def test_bullet_list(self):
+        block = BulletListBlock(items=["one", "two"])
+        assert render_block(block) == "- one\n- two"
+
+    def test_ordered_list_uses_sequential_numbering(self):
+        block = OrderedListBlock(items=["one", "two", "three"])
+        assert render_block(block) == "1. one\n2. two\n3. three"
+
+    def test_code_block_with_language(self):
+        block = CodeBlock(language="json", text='{"a": 1}')
+        assert render_block(block) == '```json\n{"a": 1}\n```'
+
+    def test_code_block_no_language(self):
+        block = CodeBlock(text="raw text")
+        assert render_block(block) == "```\nraw text\n```"
+
+    def test_section_heading_level(self):
+        section = Section(
+            id="purpose", heading="Purpose", level=3, blocks=[ParagraphBlock(text="hi")]
+        )
+        assert render_section(section).startswith("### Purpose\n\nhi")
+
+    def test_document_round_trip_is_stable(self):
+        doc = _team_overview_doc()
+        rendered = render_document(doc)
+        # Re-rendering must produce the same bytes.
+        assert render_document(doc) == rendered
+        # Headings, members, cadence all present.
+        assert "# Team Overview" in rendered
+        assert "## Members" in rendered
+        assert "## Cadence" in rendered
+        assert "- **Alice**" in rendered
+        assert "Standups happen daily at 9am" in rendered
+        # Sections separated by exactly one blank line, document ends with newline.
+        assert rendered.endswith("\n")
+        assert "\n\n\n" not in rendered
+
+    def test_empty_document_renders_empty(self):
+        assert render_document(StructuredDocument()) == ""
+
+
+# Parser --------------------------------------------------------------------
+
+
+class TestParser:
+    def test_simple_document(self):
+        markdown = (
+            "# Team Overview\n"
+            "\n"
+            "Quick summary.\n"
+            "\n"
+            "## Members\n"
+            "\n"
+            "- Alice\n"
+            "- Bob\n"
+            "\n"
+            "## Cadence\n"
+            "\n"
+            "Standups daily.\n"
+        )
+        doc = parse_markdown(markdown)
+        assert [s.id for s in doc.sections] == ["team-overview", "members", "cadence"]
+        assert [s.level for s in doc.sections] == [1, 2, 2]
+        assert isinstance(doc.sections[0].blocks[0], ParagraphBlock)
+        assert isinstance(doc.sections[1].blocks[0], BulletListBlock)
+        assert doc.sections[1].blocks[0].items == ["Alice", "Bob"]
+
+    def test_horizontal_rule_treated_as_blank(self):
+        markdown = "## Rules\n\n- one\n\n---\n\n## Stop\n\nstop here.\n"
+        doc = parse_markdown(markdown)
+        assert [s.id for s in doc.sections] == ["rules", "stop"]
+        # Horizontal rule must NOT become a paragraph.
+        assert all(
+            not (isinstance(b, ParagraphBlock) and "---" in b.text)
+            for s in doc.sections
+            for b in s.blocks
+        )
+
+    def test_ordered_list(self):
+        markdown = "## Steps\n\n1. one\n2. two\n3. three\n"
+        doc = parse_markdown(markdown)
+        block = doc.sections[0].blocks[0]
+        assert isinstance(block, OrderedListBlock)
+        assert block.items == ["one", "two", "three"]
+
+    def test_code_block(self):
+        markdown = '## Example\n\n```json\n{"a": 1}\n```\n'
+        doc = parse_markdown(markdown)
+        block = doc.sections[0].blocks[0]
+        assert isinstance(block, CodeBlock)
+        assert block.language == "json"
+        assert block.text == '{"a": 1}'
+
+    def test_implicit_overview_when_content_before_first_heading(self):
+        markdown = "preamble paragraph.\n\n## Members\n\n- Alice\n"
+        doc = parse_markdown(markdown)
+        assert doc.sections[0].id == "overview"
+        assert isinstance(doc.sections[0].blocks[0], ParagraphBlock)
+        assert doc.sections[1].id == "members"
+
+    def test_duplicate_headings_get_unique_ids(self):
+        markdown = "## Notes\n\nfirst.\n\n## Notes\n\nsecond.\n"
+        doc = parse_markdown(markdown)
+        assert [s.id for s in doc.sections] == ["notes", "notes-2"]
+
+    def test_round_trip_via_render(self):
+        original = _team_overview_doc()
+        markdown = render_document(original)
+        roundtripped = parse_markdown(markdown)
+        # Re-render must match the original render exactly.
+        assert render_document(roundtripped) == markdown
+
+
+# Operation applicator ------------------------------------------------------
+
+
+class TestApplyOperations:
+    def test_zero_ops_returns_identical_document(self):
+        doc = _team_overview_doc()
+        result = apply_operations(doc, [])
+        assert result.document.model_dump() == doc.model_dump()
+        assert render_document(result.document) == render_document(doc)
+        assert result.applied == []
+        assert result.changed is False
+
+    def test_unknown_section_op_is_skipped(self):
+        doc = _team_overview_doc()
+        op = AppendBlockOp(section_id="does-not-exist", block=ParagraphBlock(text="x"))
+        result = apply_operations(doc, [op])
+        assert result.applied == []
+        assert len(result.skipped) == 1
+        assert "unknown section_id" in result.skipped[0]["reason"]
+        # Document unchanged.
+        assert render_document(result.document) == render_document(doc)
+
+    def test_append_block_to_existing_section(self):
+        doc = _team_overview_doc()
+        op = AppendBlockOp(
+            section_id="members",
+            block=BulletListBlock(items=["**Carol** — junior engineer."]),
+        )
+        result = apply_operations(doc, [op])
+        members = result.document.section_by_id("members")
+        assert members is not None
+        assert len(members.blocks) == 2  # original list + new bullet block
+        # Other sections byte-identical
+        original = doc.model_dump()
+        new = result.document.model_dump()
+        assert new["sections"][0] == original["sections"][0]  # team-overview
+        assert new["sections"][2] == original["sections"][2]  # cadence
+
+    def test_insert_block_at_index(self):
+        doc = _team_overview_doc()
+        op = InsertBlockOp(
+            section_id="members",
+            index=0,
+            block=ParagraphBlock(text="Roster as of 2026:"),
+        )
+        result = apply_operations(doc, [op])
+        members = result.document.section_by_id("members")
+        assert isinstance(members.blocks[0], ParagraphBlock)
+        assert members.blocks[0].text.startswith("Roster")
+
+    def test_insert_block_out_of_range_skipped(self):
+        doc = _team_overview_doc()
+        op = InsertBlockOp(
+            section_id="members", index=99, block=ParagraphBlock(text="x")
+        )
+        result = apply_operations(doc, [op])
+        assert result.applied == []
+        assert "index out of range" in result.skipped[0]["reason"]
+
+    def test_replace_block(self):
+        doc = _team_overview_doc()
+        op = ReplaceBlockOp(
+            section_id="cadence",
+            index=0,
+            block=ParagraphBlock(text="Standups happen daily at 10am."),
+        )
+        result = apply_operations(doc, [op])
+        cadence = result.document.section_by_id("cadence")
+        assert isinstance(cadence.blocks[0], ParagraphBlock)
+        assert cadence.blocks[0].text.endswith("10am.")
+
+    def test_remove_block(self):
+        doc = _team_overview_doc()
+        op = RemoveBlockOp(section_id="members", index=0)
+        result = apply_operations(doc, [op])
+        members = result.document.section_by_id("members")
+        assert members.blocks == []
+
+    def test_add_section_at_end(self):
+        doc = _team_overview_doc()
+        op = AddSectionOp(
+            heading="Open Questions",
+            blocks=[ParagraphBlock(text="None right now.")],
+        )
+        result = apply_operations(doc, [op])
+        assert result.document.sections[-1].id == "open-questions"
+        assert result.document.sections[-1].heading == "Open Questions"
+
+    def test_add_section_after_existing(self):
+        doc = _team_overview_doc()
+        op = AddSectionOp(
+            heading="Charter",
+            after_section_id="team-overview",
+            blocks=[ParagraphBlock(text="Mission statement.")],
+        )
+        result = apply_operations(doc, [op])
+        ids = [s.id for s in result.document.sections]
+        assert ids == ["team-overview", "charter", "members", "cadence"]
+
+    def test_add_section_after_unknown_skipped(self):
+        doc = _team_overview_doc()
+        op = AddSectionOp(
+            heading="Charter",
+            after_section_id="nope",
+            blocks=[],
+        )
+        result = apply_operations(doc, [op])
+        assert result.applied == []
+        assert "unknown after_section_id" in result.skipped[0]["reason"]
+
+    def test_add_section_with_id_collision_disambiguates(self):
+        doc = _team_overview_doc()
+        op = AddSectionOp(heading="Members", blocks=[])
+        result = apply_operations(doc, [op])
+        # Two sections with heading "Members": the new one gets "members-2".
+        ids = [s.id for s in result.document.sections]
+        assert "members" in ids
+        assert "members-2" in ids
+
+    def test_remove_section(self):
+        doc = _team_overview_doc()
+        op = RemoveSectionOp(section_id="cadence")
+        result = apply_operations(doc, [op])
+        assert [s.id for s in result.document.sections] == ["team-overview", "members"]
+
+    def test_replace_section_blocks_preserves_id_and_heading(self):
+        doc = _team_overview_doc()
+        op = ReplaceSectionBlocksOp(
+            section_id="members",
+            blocks=[ParagraphBlock(text="See the org chart.")],
+        )
+        result = apply_operations(doc, [op])
+        members = result.document.section_by_id("members")
+        assert members.heading == "Members"
+        assert members.id == "members"
+        assert len(members.blocks) == 1
+        assert isinstance(members.blocks[0], ParagraphBlock)
+
+    def test_rename_section_keeps_id(self):
+        doc = _team_overview_doc()
+        op = RenameSectionOp(section_id="cadence", new_heading="Operating Cadence")
+        result = apply_operations(doc, [op])
+        section = result.document.section_by_id("cadence")
+        assert section.heading == "Operating Cadence"
+        # ID stable so future ops still resolve.
+        assert section.id == "cadence"
+
+    def test_unmodified_sections_byte_identical_in_render(self):
+        """The structural guarantee: sections not touched by any op render
+        identically character-for-character.
+        """
+        doc = _team_overview_doc()
+        op = AppendBlockOp(
+            section_id="members",
+            block=ParagraphBlock(text="New: Carol joined as junior engineer."),
+        )
+        result = apply_operations(doc, [op])
+        before_overview = render_section(doc.section_by_id("team-overview"))
+        after_overview = render_section(
+            result.document.section_by_id("team-overview")
+        )
+        before_cadence = render_section(doc.section_by_id("cadence"))
+        after_cadence = render_section(
+            result.document.section_by_id("cadence")
+        )
+        assert before_overview == after_overview
+        assert before_cadence == after_cadence
+
+
+class TestDeltaOperationListSchema:
+    """Sanity-check that the discriminated-union schema serialises as the LLM
+    will see it: each op has a literal ``op`` string that picks the variant.
+    """
+
+    def test_round_trip_via_json(self):
+        ops = DeltaOperationList(
+            operations=[
+                AppendBlockOp(
+                    section_id="members",
+                    block=ParagraphBlock(text="hi"),
+                ),
+                AddSectionOp(
+                    heading="Open Questions",
+                    after_section_id="cadence",
+                    blocks=[ParagraphBlock(text="None.")],
+                ),
+                RemoveSectionOp(section_id="charter"),
+            ]
+        )
+        payload = ops.model_dump_json()
+        roundtripped = DeltaOperationList.model_validate_json(payload)
+        assert len(roundtripped.operations) == 3
+
+    def test_invalid_op_field_rejected(self):
+        with pytest.raises(Exception):  # pydantic ValidationError
+            DeltaOperationList.model_validate(
+                {"operations": [{"op": "not_a_real_op", "section_id": "x"}]}
+            )
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(Exception):
+            DeltaOperationList.model_validate(
+                {
+                    "operations": [
+                        {
+                            "op": "append_block",
+                            "section_id": "members",
+                            "block": {"type": "paragraph", "text": "hi"},
+                            "extra_field": "no",
+                        }
+                    ]
+                }
+            )

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -118,6 +118,7 @@ pub fn create(
     // behaviour is preserved otherwise.
     let trigger = if trigger_refresh_after_consolidation {
         Some(types::MentalModelTriggerInput {
+            mode: types::Mode::Full,
             refresh_after_consolidation: true,
             exclude_mental_models: false,
             exclude_mental_model_ids: None,
@@ -195,6 +196,7 @@ pub fn update(
     // Only build a trigger override when the user actually passed the flag;
     // sending None leaves the existing trigger config untouched on the server.
     let trigger = trigger_refresh_after_consolidation.map(|refresh| types::MentalModelTriggerInput {
+        mode: types::Mode::Full,
         refresh_after_consolidation: refresh,
         exclude_mental_models: false,
         exclude_mental_model_ids: None,

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5100,6 +5100,7 @@ components:
           created_at: created_at
           id: id
           trigger:
+            mode: full
             refresh_after_consolidation: false
             recall_chunks_max_tokens: 1
             tag_groups:
@@ -5136,6 +5137,7 @@ components:
           created_at: created_at
           id: id
           trigger:
+            mode: full
             refresh_after_consolidation: false
             recall_chunks_max_tokens: 1
             tag_groups:
@@ -5183,6 +5185,7 @@ components:
         created_at: created_at
         id: id
         trigger:
+          mode: full
           refresh_after_consolidation: false
           recall_chunks_max_tokens: 1
           tag_groups:
@@ -5256,6 +5259,19 @@ components:
     MentalModelTrigger-Input:
       description: Trigger settings for a mental model.
       properties:
+        mode:
+          default: full
+          description: "Refresh mode. 'full' (default) regenerates the mental model\
+            \ content from scratch on each refresh. 'delta' performs surgical edits\
+            \ against the existing content: unchanged sections are preserved byte-for-byte,\
+            \ stale content is removed, new content is added. If the mental model\
+            \ has no existing content, or if the source_query has changed since the\
+            \ last refresh, delta mode falls back to a full regeneration automatically."
+          enum:
+          - full
+          - delta
+          title: Mode
+          type: string
         refresh_after_consolidation:
           default: false
           description: "If true, refresh this mental model after observations consolidation\
@@ -5308,6 +5324,7 @@ components:
     MentalModelTrigger-Output:
       description: Trigger settings for a mental model.
       example:
+        mode: full
         refresh_after_consolidation: false
         recall_chunks_max_tokens: 1
         tag_groups:
@@ -5330,6 +5347,19 @@ components:
         exclude_mental_models: false
         recall_max_tokens: 6
       properties:
+        mode:
+          default: full
+          description: "Refresh mode. 'full' (default) regenerates the mental model\
+            \ content from scratch on each refresh. 'delta' performs surgical edits\
+            \ against the existing content: unchanged sections are preserved byte-for-byte,\
+            \ stale content is removed, new content is added. If the mental model\
+            \ has no existing content, or if the source_query has changed since the\
+            \ last refresh, delta mode falls back to a full regeneration automatically."
+          enum:
+          - full
+          - delta
+          title: Mode
+          type: string
         refresh_after_consolidation:
           default: false
           description: "If true, refresh this mental model after observations consolidation\

--- a/hindsight-clients/go/model_mental_model_trigger_input.go
+++ b/hindsight-clients/go/model_mental_model_trigger_input.go
@@ -19,6 +19,8 @@ var _ MappedNullable = &MentalModelTriggerInput{}
 
 // MentalModelTriggerInput Trigger settings for a mental model.
 type MentalModelTriggerInput struct {
+	// Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.
+	Mode *string `json:"mode,omitempty"`
 	// If true, refresh this mental model after observations consolidation (real-time mode)
 	RefreshAfterConsolidation *bool `json:"refresh_after_consolidation,omitempty"`
 	FactTypes []string `json:"fact_types,omitempty"`
@@ -38,6 +40,8 @@ type MentalModelTriggerInput struct {
 // will change when the set of required properties is changed
 func NewMentalModelTriggerInput() *MentalModelTriggerInput {
 	this := MentalModelTriggerInput{}
+	var mode string = "full"
+	this.Mode = &mode
 	var refreshAfterConsolidation bool = false
 	this.RefreshAfterConsolidation = &refreshAfterConsolidation
 	var excludeMentalModels bool = false
@@ -50,11 +54,45 @@ func NewMentalModelTriggerInput() *MentalModelTriggerInput {
 // but it doesn't guarantee that properties required by API are set
 func NewMentalModelTriggerInputWithDefaults() *MentalModelTriggerInput {
 	this := MentalModelTriggerInput{}
+	var mode string = "full"
+	this.Mode = &mode
 	var refreshAfterConsolidation bool = false
 	this.RefreshAfterConsolidation = &refreshAfterConsolidation
 	var excludeMentalModels bool = false
 	this.ExcludeMentalModels = &excludeMentalModels
 	return &this
+}
+
+// GetMode returns the Mode field value if set, zero value otherwise.
+func (o *MentalModelTriggerInput) GetMode() string {
+	if o == nil || IsNil(o.Mode) {
+		var ret string
+		return ret
+	}
+	return *o.Mode
+}
+
+// GetModeOk returns a tuple with the Mode field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *MentalModelTriggerInput) GetModeOk() (*string, bool) {
+	if o == nil || IsNil(o.Mode) {
+		return nil, false
+	}
+	return o.Mode, true
+}
+
+// HasMode returns a boolean if a field has been set.
+func (o *MentalModelTriggerInput) HasMode() bool {
+	if o != nil && !IsNil(o.Mode) {
+		return true
+	}
+
+	return false
+}
+
+// SetMode gets a reference to the given string and assigns it to the Mode field.
+func (o *MentalModelTriggerInput) SetMode(v string) {
+	o.Mode = &v
 }
 
 // GetRefreshAfterConsolidation returns the RefreshAfterConsolidation field value if set, zero value otherwise.
@@ -398,6 +436,9 @@ func (o MentalModelTriggerInput) MarshalJSON() ([]byte, error) {
 
 func (o MentalModelTriggerInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Mode) {
+		toSerialize["mode"] = o.Mode
+	}
 	if !IsNil(o.RefreshAfterConsolidation) {
 		toSerialize["refresh_after_consolidation"] = o.RefreshAfterConsolidation
 	}

--- a/hindsight-clients/go/model_mental_model_trigger_output.go
+++ b/hindsight-clients/go/model_mental_model_trigger_output.go
@@ -19,6 +19,8 @@ var _ MappedNullable = &MentalModelTriggerOutput{}
 
 // MentalModelTriggerOutput Trigger settings for a mental model.
 type MentalModelTriggerOutput struct {
+	// Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.
+	Mode *string `json:"mode,omitempty"`
 	// If true, refresh this mental model after observations consolidation (real-time mode)
 	RefreshAfterConsolidation *bool `json:"refresh_after_consolidation,omitempty"`
 	FactTypes []string `json:"fact_types,omitempty"`
@@ -38,6 +40,8 @@ type MentalModelTriggerOutput struct {
 // will change when the set of required properties is changed
 func NewMentalModelTriggerOutput() *MentalModelTriggerOutput {
 	this := MentalModelTriggerOutput{}
+	var mode string = "full"
+	this.Mode = &mode
 	var refreshAfterConsolidation bool = false
 	this.RefreshAfterConsolidation = &refreshAfterConsolidation
 	var excludeMentalModels bool = false
@@ -50,11 +54,45 @@ func NewMentalModelTriggerOutput() *MentalModelTriggerOutput {
 // but it doesn't guarantee that properties required by API are set
 func NewMentalModelTriggerOutputWithDefaults() *MentalModelTriggerOutput {
 	this := MentalModelTriggerOutput{}
+	var mode string = "full"
+	this.Mode = &mode
 	var refreshAfterConsolidation bool = false
 	this.RefreshAfterConsolidation = &refreshAfterConsolidation
 	var excludeMentalModels bool = false
 	this.ExcludeMentalModels = &excludeMentalModels
 	return &this
+}
+
+// GetMode returns the Mode field value if set, zero value otherwise.
+func (o *MentalModelTriggerOutput) GetMode() string {
+	if o == nil || IsNil(o.Mode) {
+		var ret string
+		return ret
+	}
+	return *o.Mode
+}
+
+// GetModeOk returns a tuple with the Mode field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *MentalModelTriggerOutput) GetModeOk() (*string, bool) {
+	if o == nil || IsNil(o.Mode) {
+		return nil, false
+	}
+	return o.Mode, true
+}
+
+// HasMode returns a boolean if a field has been set.
+func (o *MentalModelTriggerOutput) HasMode() bool {
+	if o != nil && !IsNil(o.Mode) {
+		return true
+	}
+
+	return false
+}
+
+// SetMode gets a reference to the given string and assigns it to the Mode field.
+func (o *MentalModelTriggerOutput) SetMode(v string) {
+	o.Mode = &v
 }
 
 // GetRefreshAfterConsolidation returns the RefreshAfterConsolidation field value if set, zero value otherwise.
@@ -398,6 +436,9 @@ func (o MentalModelTriggerOutput) MarshalJSON() ([]byte, error) {
 
 func (o MentalModelTriggerOutput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Mode) {
+		toSerialize["mode"] = o.Mode
+	}
 	if !IsNil(o.RefreshAfterConsolidation) {
 		toSerialize["refresh_after_consolidation"] = o.RefreshAfterConsolidation
 	}

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_input.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_input.py
@@ -27,6 +27,7 @@ class MentalModelTriggerInput(BaseModel):
     """
     Trigger settings for a mental model.
     """ # noqa: E501
+    mode: Optional[StrictStr] = Field(default='full', description="Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.")
     refresh_after_consolidation: Optional[StrictBool] = Field(default=False, description="If true, refresh this mental model after observations consolidation (real-time mode)")
     fact_types: Optional[List[StrictStr]] = None
     exclude_mental_models: Optional[StrictBool] = Field(default=False, description="If true, exclude all mental models from the reflect loop (skip search_mental_models tool).")
@@ -36,7 +37,17 @@ class MentalModelTriggerInput(BaseModel):
     include_chunks: Optional[StrictBool] = None
     recall_max_tokens: Optional[StrictInt] = None
     recall_chunks_max_tokens: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
+    __properties: ClassVar[List[str]] = ["mode", "refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
+
+    @field_validator('mode')
+    def mode_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['full', 'delta']):
+            raise ValueError("must be one of enum values ('full', 'delta')")
+        return value
 
     @field_validator('fact_types')
     def fact_types_validate_enum(cls, value):
@@ -152,6 +163,7 @@ class MentalModelTriggerInput(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "mode": obj.get("mode") if obj.get("mode") is not None else 'full',
             "refresh_after_consolidation": obj.get("refresh_after_consolidation") if obj.get("refresh_after_consolidation") is not None else False,
             "fact_types": obj.get("fact_types"),
             "exclude_mental_models": obj.get("exclude_mental_models") if obj.get("exclude_mental_models") is not None else False,

--- a/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_output.py
+++ b/hindsight-clients/python/hindsight_client_api/models/mental_model_trigger_output.py
@@ -27,6 +27,7 @@ class MentalModelTriggerOutput(BaseModel):
     """
     Trigger settings for a mental model.
     """ # noqa: E501
+    mode: Optional[StrictStr] = Field(default='full', description="Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.")
     refresh_after_consolidation: Optional[StrictBool] = Field(default=False, description="If true, refresh this mental model after observations consolidation (real-time mode)")
     fact_types: Optional[List[StrictStr]] = None
     exclude_mental_models: Optional[StrictBool] = Field(default=False, description="If true, exclude all mental models from the reflect loop (skip search_mental_models tool).")
@@ -36,7 +37,17 @@ class MentalModelTriggerOutput(BaseModel):
     include_chunks: Optional[StrictBool] = None
     recall_max_tokens: Optional[StrictInt] = None
     recall_chunks_max_tokens: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
+    __properties: ClassVar[List[str]] = ["mode", "refresh_after_consolidation", "fact_types", "exclude_mental_models", "exclude_mental_model_ids", "tags_match", "tag_groups", "include_chunks", "recall_max_tokens", "recall_chunks_max_tokens"]
+
+    @field_validator('mode')
+    def mode_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['full', 'delta']):
+            raise ValueError("must be one of enum values ('full', 'delta')")
+        return value
 
     @field_validator('fact_types')
     def fact_types_validate_enum(cls, value):
@@ -152,6 +163,7 @@ class MentalModelTriggerOutput(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "mode": obj.get("mode") if obj.get("mode") is not None else 'full',
             "refresh_after_consolidation": obj.get("refresh_after_consolidation") if obj.get("refresh_after_consolidation") is not None else False,
             "fact_types": obj.get("fact_types"),
             "exclude_mental_models": obj.get("exclude_mental_models") if obj.get("exclude_mental_models") is not None else False,

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1915,6 +1915,12 @@ export type MentalModelResponse = {
  */
 export type MentalModelTriggerInput = {
   /**
+   * Mode
+   *
+   * Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.
+   */
+  mode?: "full" | "delta";
+  /**
    * Refresh After Consolidation
    *
    * If true, refresh this mental model after observations consolidation (real-time mode)
@@ -1978,6 +1984,12 @@ export type MentalModelTriggerInput = {
  * Trigger settings for a mental model.
  */
 export type MentalModelTriggerOutput = {
+  /**
+   * Mode
+   *
+   * Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.
+   */
+  mode?: "full" | "delta";
   /**
    * Refresh After Consolidation
    *

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -160,24 +160,90 @@ function BasedOnList({
   );
 }
 
-type LineDiff = { type: "same" | "removed" | "added"; text: string };
+type LineKind = "same" | "removed" | "added";
+type LineDiff = { type: LineKind; text: string };
+type TokenSpan = { type: LineKind; text: string };
+type AnnotatedLine = { type: LineKind; spans: TokenSpan[] };
 
-function diffLines(a: string, b: string): { left: LineDiff[]; right: LineDiff[] } {
+/** Tokenise into words, whitespace, and single punctuation marks so the
+ *  per-character diff aligns on natural boundaries instead of mid-word. */
+function tokenize(s: string): string[] {
+  return s.match(/\s+|[A-Za-z0-9_]+|[^\s\w]/g) || [];
+}
+
+/** Normalize a token for equality: collapse runs of whitespace so that
+ *  reflowing whitespace doesn't show as a diff. */
+function normToken(t: string): string {
+  return /^\s+$/.test(t) ? " " : t;
+}
+
+/** Word-level LCS over two single lines, returning inline spans for
+ *  before/after. Pure-whitespace differences are folded into "same" so
+ *  the diff highlights actual content changes only. */
+function diffTokensInline(
+  a: string,
+  b: string,
+): { left: TokenSpan[]; right: TokenSpan[] } {
+  const aTok = tokenize(a);
+  const bTok = tokenize(b);
+  const m = aTok.length;
+  const n = bTok.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        normToken(aTok[i - 1]) === normToken(bTok[j - 1])
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  const left: TokenSpan[] = [];
+  const right: TokenSpan[] = [];
+  let i = m;
+  let j = n;
+  const leftStack: TokenSpan[] = [];
+  const rightStack: TokenSpan[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && normToken(aTok[i - 1]) === normToken(bTok[j - 1])) {
+      leftStack.push({ type: "same", text: aTok[i - 1] });
+      rightStack.push({ type: "same", text: bTok[j - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      // Whitespace-only insertions render as "same" so reflow noise is hidden.
+      const t = bTok[j - 1];
+      rightStack.push({ type: /^\s+$/.test(t) ? "same" : "added", text: t });
+      j--;
+    } else {
+      const t = aTok[i - 1];
+      leftStack.push({ type: /^\s+$/.test(t) ? "same" : "removed", text: t });
+      i--;
+    }
+  }
+  while (leftStack.length) left.push(leftStack.pop()!);
+  while (rightStack.length) right.push(rightStack.pop()!);
+  return { left, right };
+}
+
+function diffLines(a: string, b: string): { left: AnnotatedLine[]; right: AnnotatedLine[] } {
   const aLines = a.split("\n");
   const bLines = b.split("\n");
   const m = aLines.length;
   const n = bLines.length;
   const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
-  for (let i = 1; i <= m; i++)
-    for (let j = 1; j <= n; j++)
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
       dp[i][j] =
         aLines[i - 1] === bLines[j - 1]
           ? dp[i - 1][j - 1] + 1
           : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
 
   const ops: LineDiff[] = [];
-  let i = m,
-    j = n;
+  let i = m;
+  let j = n;
   while (i > 0 || j > 0) {
     if (i > 0 && j > 0 && aLines[i - 1] === bLines[j - 1]) {
       ops.push({ type: "same", text: aLines[i - 1] });
@@ -193,35 +259,67 @@ function diffLines(a: string, b: string): { left: LineDiff[]; right: LineDiff[] 
   }
   ops.reverse();
 
-  const left: LineDiff[] = [];
-  const right: LineDiff[] = [];
+  const left: AnnotatedLine[] = [];
+  const right: AnnotatedLine[] = [];
   let k = 0;
   while (k < ops.length) {
     const op = ops[k];
     if (op.type === "same") {
-      left.push(op);
-      right.push(op);
+      left.push({ type: "same", spans: [{ type: "same", text: op.text }] });
+      right.push({ type: "same", spans: [{ type: "same", text: op.text }] });
       k++;
-    } else {
-      const removed: string[] = [];
-      const added: string[] = [];
-      while (k < ops.length && ops[k].type !== "same") {
-        if (ops[k].type === "removed") removed.push(ops[k].text);
-        else added.push(ops[k].text);
-        k++;
-      }
-      const maxLen = Math.max(removed.length, added.length);
-      for (let r = 0; r < maxLen; r++) {
-        left.push(
-          r < removed.length ? { type: "removed", text: removed[r] } : { type: "same", text: "" }
-        );
-        right.push(
-          r < added.length ? { type: "added", text: added[r] } : { type: "same", text: "" }
-        );
+      continue;
+    }
+    // Collect a contiguous run of removed/added lines and pair them up so
+    // we can emit per-token inline diffs for the overlap.
+    const removed: string[] = [];
+    const added: string[] = [];
+    while (k < ops.length && ops[k].type !== "same") {
+      if (ops[k].type === "removed") removed.push(ops[k].text);
+      else added.push(ops[k].text);
+      k++;
+    }
+    const maxLen = Math.max(removed.length, added.length);
+    for (let r = 0; r < maxLen; r++) {
+      const r0 = r < removed.length ? removed[r] : null;
+      const a0 = r < added.length ? added[r] : null;
+      if (r0 !== null && a0 !== null) {
+        const inline = diffTokensInline(r0, a0);
+        // Demote whole-line classification to "same" if every span is
+        // already "same" (purely whitespace-only difference).
+        const leftKind: LineKind = inline.left.some((s) => s.type !== "same")
+          ? "removed"
+          : "same";
+        const rightKind: LineKind = inline.right.some((s) => s.type !== "same")
+          ? "added"
+          : "same";
+        left.push({ type: leftKind, spans: inline.left });
+        right.push({ type: rightKind, spans: inline.right });
+      } else if (r0 !== null) {
+        left.push({ type: "removed", spans: [{ type: "removed", text: r0 }] });
+        right.push({ type: "same", spans: [{ type: "same", text: "" }] });
+      } else if (a0 !== null) {
+        left.push({ type: "same", spans: [{ type: "same", text: "" }] });
+        right.push({ type: "added", spans: [{ type: "added", text: a0 }] });
       }
     }
   }
   return { left, right };
+}
+
+function renderSpans(spans: TokenSpan[], side: "left" | "right") {
+  return spans.map((s, i) => {
+    if (s.type === "same") return <span key={i}>{s.text}</span>;
+    const cls =
+      side === "left"
+        ? "bg-red-500/25 text-red-800 dark:text-red-300 rounded-sm px-0.5"
+        : "bg-green-500/25 text-green-800 dark:text-green-300 rounded-sm px-0.5";
+    return (
+      <span key={i} className={cls}>
+        {s.text}
+      </span>
+    );
+  });
 }
 
 function SideBySideDiff({ before, after }: { before: string; after: string }) {
@@ -239,12 +337,10 @@ function SideBySideDiff({ before, after }: { before: string; after: string }) {
           <div
             key={idx}
             className={`px-3 py-0.5 whitespace-pre-wrap leading-5 min-h-[1.25rem] ${
-              line.type === "removed"
-                ? "bg-red-500/10 text-red-700 dark:text-red-400"
-                : "text-foreground"
+              line.type === "removed" ? "bg-red-500/5" : ""
             }`}
           >
-            {line.text}
+            {renderSpans(line.spans, "left")}
           </div>
         ))}
       </div>
@@ -256,12 +352,10 @@ function SideBySideDiff({ before, after }: { before: string; after: string }) {
           <div
             key={idx}
             className={`px-3 py-0.5 whitespace-pre-wrap leading-5 min-h-[1.25rem] ${
-              line.type === "added"
-                ? "bg-green-500/10 text-green-700 dark:text-green-400"
-                : "text-foreground"
+              line.type === "added" ? "bg-green-500/5" : ""
             }`}
           >
-            {line.text}
+            {renderSpans(line.spans, "right")}
           </div>
         ))}
       </div>
@@ -637,7 +731,7 @@ export function MentalModelDetailModal({
                 </Button>
               )}
               {mentalModel?.trigger?.refresh_after_consolidation && (
-                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-medium">
+                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 text-xs font-medium">
                   <Zap className="w-3 h-3" />
                   Auto refresh
                 </span>
@@ -909,6 +1003,19 @@ function ConfigurationTab({ mentalModel }: { mentalModel: MentalModel }) {
       </InfoCard>
 
       <InfoCard title="Refresh Trigger" icon={<Zap className="w-3.5 h-3.5" />}>
+        <Metadata
+          label="Refresh mode"
+          value={
+            t.mode === "delta" ? (
+              <Pill
+                label="Delta"
+                color="bg-purple-500/10 text-purple-600 dark:text-purple-400"
+              />
+            ) : (
+              <Pill label="Full" />
+            )
+          }
+        />
         <Metadata
           label="Auto-refresh after consolidation"
           value={

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -180,10 +180,7 @@ function normToken(t: string): string {
 /** Word-level LCS over two single lines, returning inline spans for
  *  before/after. Pure-whitespace differences are folded into "same" so
  *  the diff highlights actual content changes only. */
-function diffTokensInline(
-  a: string,
-  b: string,
-): { left: TokenSpan[]; right: TokenSpan[] } {
+function diffTokensInline(a: string, b: string): { left: TokenSpan[]; right: TokenSpan[] } {
   const aTok = tokenize(a);
   const bTok = tokenize(b);
   const m = aTok.length;
@@ -287,12 +284,8 @@ function diffLines(a: string, b: string): { left: AnnotatedLine[]; right: Annota
         const inline = diffTokensInline(r0, a0);
         // Demote whole-line classification to "same" if every span is
         // already "same" (purely whitespace-only difference).
-        const leftKind: LineKind = inline.left.some((s) => s.type !== "same")
-          ? "removed"
-          : "same";
-        const rightKind: LineKind = inline.right.some((s) => s.type !== "same")
-          ? "added"
-          : "same";
+        const leftKind: LineKind = inline.left.some((s) => s.type !== "same") ? "removed" : "same";
+        const rightKind: LineKind = inline.right.some((s) => s.type !== "same") ? "added" : "same";
         left.push({ type: leftKind, spans: inline.left });
         right.push({ type: rightKind, spans: inline.right });
       } else if (r0 !== null) {
@@ -1007,10 +1000,7 @@ function ConfigurationTab({ mentalModel }: { mentalModel: MentalModel }) {
           label="Refresh mode"
           value={
             t.mode === "delta" ? (
-              <Pill
-                label="Delta"
-                color="bg-purple-500/10 text-purple-600 dark:text-purple-400"
-              />
+              <Pill label="Delta" color="bg-purple-500/10 text-purple-600 dark:text-purple-400" />
             ) : (
               <Pill label="Full" />
             )

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -58,7 +58,16 @@ import {
   ChevronsRight,
   LayoutGrid,
   List,
+  MoreVertical,
+  Pencil,
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { MentalModelDetailModal } from "./mental-model-detail-modal";
 
 interface ReflectResponseBasedOnFact {
@@ -82,6 +91,7 @@ interface MentalModel {
   tags: string[];
   max_tokens: number;
   trigger: {
+    mode?: "full" | "delta";
     refresh_after_consolidation: boolean;
     fact_types?: Array<"world" | "experience" | "observation">;
     exclude_mental_models?: boolean;
@@ -141,6 +151,37 @@ export function MentalModelsView() {
       console.error("Error loading mental models:", error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const [refreshingIds, setRefreshingIds] = useState<Set<string>>(new Set());
+
+  const handleRowRefresh = async (m: MentalModel) => {
+    if (!currentBank) return;
+    const originalAt = m.last_refreshed_at;
+    setRefreshingIds((prev) => new Set(prev).add(m.id));
+    try {
+      await client.refreshMentalModel(currentBank, m.id);
+      const maxAttempts = 120;
+      for (let i = 0; i < maxAttempts; i++) {
+        await new Promise((r) => setTimeout(r, 1000));
+        const updated = await client.getMentalModel(currentBank, m.id);
+        if (updated.last_refreshed_at !== originalAt) {
+          setMentalModels((prev) => prev.map((x) => (x.id === m.id ? updated : x)));
+          if (selectedMentalModel?.id === m.id) setSelectedMentalModel(updated);
+          toast.success("Mental model refreshed");
+          return;
+        }
+      }
+      toast.error("Refresh timeout");
+    } catch {
+      // Error toast handled by API client interceptor
+    } finally {
+      setRefreshingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(m.id);
+        return next;
+      });
     }
   };
 
@@ -292,17 +333,19 @@ export function MentalModelsView() {
                                 </span>
                               </div>
                             </div>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-7 w-7 p-0 ml-2 text-muted-foreground hover:text-destructive flex-shrink-0"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeleteTarget({ id: m.id, name: m.name });
+                            <RowActionsMenu
+                              m={m}
+                              refreshing={refreshingIds.has(m.id)}
+                              onEdit={(target) => {
+                                setMentalModelToUpdate(target);
+                                setShowUpdateDialog(true);
                               }}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                              onRefresh={handleRowRefresh}
+                              onDelete={(target) =>
+                                setDeleteTarget({ id: target.id, name: target.name })
+                              }
+                              triggerClassName="h-7 w-7 ml-2 flex-shrink-0"
+                            />
                           </div>
                           <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
                             {m.source_query}
@@ -387,17 +430,18 @@ export function MentalModelsView() {
                             {formatRelativeTime(m.last_refreshed_at)}
                           </TableCell>
                           <TableCell className="py-2">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeleteTarget({ id: m.id, name: m.name });
+                            <RowActionsMenu
+                              m={m}
+                              refreshing={refreshingIds.has(m.id)}
+                              onEdit={(target) => {
+                                setMentalModelToUpdate(target);
+                                setShowUpdateDialog(true);
                               }}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                              onRefresh={handleRowRefresh}
+                              onDelete={(target) =>
+                                setDeleteTarget({ id: target.id, name: target.name })
+                              }
+                            />
                           </TableCell>
                         </TableRow>
                       );
@@ -540,6 +584,56 @@ export function MentalModelsView() {
   );
 }
 
+function RowActionsMenu({
+  m,
+  refreshing,
+  onEdit,
+  onRefresh,
+  onDelete,
+  triggerClassName,
+}: {
+  m: MentalModel;
+  refreshing: boolean;
+  onEdit: (m: MentalModel) => void;
+  onRefresh: (m: MentalModel) => void;
+  onDelete: (m: MentalModel) => void;
+  triggerClassName?: string;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`p-0 text-muted-foreground ${triggerClassName ?? "h-8 w-8"}`}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Actions"
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenuItem onClick={() => onEdit(m)}>
+          <Pencil className="h-4 w-4 mr-2" />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onRefresh(m)} disabled={refreshing}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? "animate-spin" : ""}`} />
+          Refresh Manually
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => onDelete(m)}
+          className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400 focus:bg-red-500/10"
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function CreateMentalModelDialog({
   open,
   onClose,
@@ -558,6 +652,7 @@ function CreateMentalModelDialog({
     maxTokens: "2048",
     tags: "",
     autoRefresh: false,
+    mode: "full" as "full" | "delta",
     factTypes: [] as Array<"world" | "experience" | "observation">,
     excludeMentalModels: false,
     excludeMentalModelIds: "",
@@ -613,6 +708,7 @@ function CreateMentalModelDialog({
         tags: tags.length > 0 ? tags : undefined,
         max_tokens: maxTokens,
         trigger: {
+          mode: form.mode,
           refresh_after_consolidation: form.autoRefresh,
           fact_types: form.factTypes.length > 0 ? form.factTypes : undefined,
           exclude_mental_models: form.excludeMentalModels || undefined,
@@ -632,6 +728,7 @@ function CreateMentalModelDialog({
         maxTokens: "2048",
         tags: "",
         autoRefresh: false,
+        mode: "full",
         factTypes: [],
         excludeMentalModels: false,
         excludeMentalModelIds: "",
@@ -661,6 +758,7 @@ function CreateMentalModelDialog({
             maxTokens: "2048",
             tags: "",
             autoRefresh: false,
+            mode: "full",
             factTypes: [],
             excludeMentalModels: false,
             excludeMentalModelIds: "",
@@ -674,7 +772,7 @@ function CreateMentalModelDialog({
         }
       }}
     >
-      <DialogContent className="sm:max-w-lg max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Create Mental Model</DialogTitle>
           <DialogDescription>
@@ -683,7 +781,10 @@ function CreateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="general" className="py-2 flex-1 min-h-0 overflow-y-auto">
+        <Tabs
+          defaultValue="general"
+          className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden"
+        >
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General
@@ -693,6 +794,7 @@ function CreateMentalModelDialog({
             </TabsTrigger>
           </TabsList>
 
+          <div className="flex-1 overflow-y-auto mt-2 pr-1">
           <TabsContent value="general" className="space-y-4 pt-4">
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground">ID</label>
@@ -746,6 +848,29 @@ function CreateMentalModelDialog({
                 >
                   Auto-refresh after consolidation
                 </label>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Refresh mode</label>
+                <Select
+                  value={form.mode}
+                  onValueChange={(value) =>
+                    setForm({ ...form, mode: value as "full" | "delta" })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="full">Full — regenerate from scratch each refresh</SelectItem>
+                    <SelectItem value="delta">
+                      Delta — surgical edits, preserve unchanged content
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Delta mode applies minimal changes to the existing content. Falls back to a full
+                  rewrite on the first refresh and whenever the source query changes.
+                </p>
               </div>
             </section>
 
@@ -903,6 +1028,7 @@ function CreateMentalModelDialog({
               </div>
             </section>
           </TabsContent>
+          </div>
         </Tabs>
 
         <DialogFooter>
@@ -947,6 +1073,7 @@ function UpdateMentalModelDialog({
     maxTokens: String(mentalModel.max_tokens || 2048),
     tags: mentalModel.tags.join(", "),
     autoRefresh: mentalModel.trigger?.refresh_after_consolidation || false,
+    mode: (mentalModel.trigger?.mode || "full") as "full" | "delta",
     factTypes:
       (mentalModel.trigger?.fact_types as
         | Array<"world" | "experience" | "observation">
@@ -1022,6 +1149,7 @@ function UpdateMentalModelDialog({
         tags: tags.length > 0 ? tags : undefined,
         max_tokens: maxTokens,
         trigger: {
+          mode: form.mode,
           refresh_after_consolidation: form.autoRefresh,
           fact_types: form.factTypes.length > 0 ? form.factTypes : undefined,
           exclude_mental_models: form.excludeMentalModels || undefined,
@@ -1045,7 +1173,7 @@ function UpdateMentalModelDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-lg max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Update Mental Model</DialogTitle>
           <DialogDescription>
@@ -1053,7 +1181,10 @@ function UpdateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="general" className="py-2 flex-1 min-h-0 overflow-y-auto">
+        <Tabs
+          defaultValue="general"
+          className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden"
+        >
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General
@@ -1063,6 +1194,7 @@ function UpdateMentalModelDialog({
             </TabsTrigger>
           </TabsList>
 
+          <div className="flex-1 overflow-y-auto mt-2 pr-1">
           <TabsContent value="general" className="space-y-4 pt-4">
             <div className="space-y-2">
               <label className="text-sm font-medium text-muted-foreground">ID</label>
@@ -1112,6 +1244,29 @@ function UpdateMentalModelDialog({
                 >
                   Auto-refresh after consolidation
                 </label>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">Refresh mode</label>
+                <Select
+                  value={form.mode}
+                  onValueChange={(value) =>
+                    setForm({ ...form, mode: value as "full" | "delta" })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="full">Full — regenerate from scratch each refresh</SelectItem>
+                    <SelectItem value="delta">
+                      Delta — surgical edits, preserve unchanged content
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Delta mode applies minimal changes to the existing content. Falls back to a full
+                  rewrite on the first refresh and whenever the source query changes.
+                </p>
               </div>
             </section>
 
@@ -1269,6 +1424,7 @@ function UpdateMentalModelDialog({
               </div>
             </section>
           </TabsContent>
+          </div>
         </Tabs>
 
         <DialogFooter>

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -781,10 +781,7 @@ function CreateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs
-          defaultValue="general"
-          className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden"
-        >
+        <Tabs defaultValue="general" className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden">
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General
@@ -795,239 +792,241 @@ function CreateMentalModelDialog({
           </TabsList>
 
           <div className="flex-1 overflow-y-auto mt-2 pr-1">
-          <TabsContent value="general" className="space-y-4 pt-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">ID</label>
-              <Input
-                value={form.id}
-                onChange={(e) => setForm({ ...form, id: e.target.value })}
-                placeholder="e.g., team-communication"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Name *</label>
-              <Input
-                value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
-                placeholder="e.g., Team Communication Preferences"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Source Query *</label>
-              <Input
-                value={form.sourceQuery}
-                onChange={(e) => setForm({ ...form, sourceQuery: e.target.value })}
-                placeholder="e.g., How does the team prefer to communicate?"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Max Tokens</label>
-              <Input
-                type="number"
-                value={form.maxTokens}
-                onChange={(e) => setForm({ ...form, maxTokens: e.target.value })}
-                placeholder="2048"
-                min="256"
-                max="8192"
-              />
-            </div>
-          </TabsContent>
-
-          <TabsContent value="options" className="space-y-6 pt-4">
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="auto-refresh"
-                  checked={form.autoRefresh}
-                  onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
-                />
-                <label
-                  htmlFor="auto-refresh"
-                  className="text-sm font-medium text-foreground cursor-pointer"
-                >
-                  Auto-refresh after consolidation
-                </label>
-              </div>
+            <TabsContent value="general" className="space-y-4 pt-4">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Refresh mode</label>
-                <Select
-                  value={form.mode}
-                  onValueChange={(value) =>
-                    setForm({ ...form, mode: value as "full" | "delta" })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="full">Full — regenerate from scratch each refresh</SelectItem>
-                    <SelectItem value="delta">
-                      Delta — surgical edits, preserve unchanged content
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Delta mode applies minimal changes to the existing content. Falls back to a full
-                  rewrite on the first refresh and whenever the source query changes.
-                </p>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">
-                Other Mental Models
-              </h3>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="exclude-mental-models"
-                  checked={form.excludeMentalModels}
-                  onCheckedChange={(checked) =>
-                    setForm({ ...form, excludeMentalModels: checked === true })
-                  }
-                />
-                <label
-                  htmlFor="exclude-mental-models"
-                  className="text-sm font-medium text-foreground cursor-pointer"
-                >
-                  Exclude all mental models
-                </label>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">
-                  Exclude Mental Model IDs
-                </label>
+                <label className="text-sm font-medium text-foreground">ID</label>
                 <Input
-                  value={form.excludeMentalModelIds}
-                  onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
-                  placeholder="e.g., model-a, model-b (comma-separated)"
+                  value={form.id}
+                  onChange={(e) => setForm({ ...form, id: e.target.value })}
+                  placeholder="e.g., team-communication"
                 />
               </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tags</label>
+                <label className="text-sm font-medium text-foreground">Name *</label>
                 <Input
-                  value={form.tags}
-                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
-                  placeholder="e.g., project-x, team-alpha (comma-separated)"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="e.g., Team Communication Preferences"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Tags scope the model during reflect <strong>and</strong> filter source memories
-                  during refresh (default <code>all_strict</code>: only memories carrying every
-                  listed tag are read). If no memories have these tags yet, refresh will produce
-                  empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
-                  <em>Tag Groups</em> below.
-                </p>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tags Match</label>
-                <Select
-                  value={form.tagsMatch}
-                  onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Default (all_strict when tags set)" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
-                    <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
-                    <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
-                    <SelectItem value="any_strict">
-                      any_strict — OR matching, excludes untagged
-                    </SelectItem>
-                    <SelectItem value="all_strict">
-                      all_strict — AND matching, excludes untagged
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Controls how the model&apos;s tags filter memories during refresh.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
-                <Textarea
-                  value={form.tagGroups}
-                  onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
-                  placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
-                  rows={3}
-                  className="font-mono text-xs"
+                <label className="text-sm font-medium text-foreground">Source Query *</label>
+                <Input
+                  value={form.sourceQuery}
+                  onChange={(e) => setForm({ ...form, sourceQuery: e.target.value })}
+                  placeholder="e.g., How does the team prefer to communicate?"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Compound boolean tag expressions for refresh filtering. Overrides flat tags when
-                  set.
-                </p>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
-              <p className="text-xs text-muted-foreground">
-                Override how the internal recall behaves when this model refreshes. Leave blank to
-                inherit the bank/global default.
-              </p>
-              <div className="space-y-3">
-                <label className="text-sm font-medium text-foreground">Fact Types</label>
-                <FactTypeCheckboxGroup
-                  value={form.factTypes}
-                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-                />
-                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Include chunks</label>
-                <Select
-                  value={form.includeChunks || "default"}
-                  onValueChange={(v) =>
-                    setForm({
-                      ...form,
-                      includeChunks: v === "default" ? "" : (v as "true" | "false"),
-                    })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Default (inherit)</SelectItem>
-                    <SelectItem value="true">Yes — include raw chunk text</SelectItem>
-                    <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                <label className="text-sm font-medium text-foreground">Max Tokens</label>
                 <Input
                   type="number"
-                  value={form.recallMaxTokens}
-                  onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
-                  placeholder="Default (inherit)"
-                  min="0"
+                  value={form.maxTokens}
+                  onChange={(e) => setForm({ ...form, maxTokens: e.target.value })}
+                  placeholder="2048"
+                  min="256"
+                  max="8192"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Token budget for facts returned by recall.
-                </p>
               </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">
-                  Recall chunks max tokens
-                </label>
-                <Input
-                  type="number"
-                  value={form.recallChunksMaxTokens}
-                  onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
-                  placeholder="Default (inherit)"
-                  min="0"
-                />
+            </TabsContent>
+
+            <TabsContent value="options" className="space-y-6 pt-4">
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="auto-refresh"
+                    checked={form.autoRefresh}
+                    onCheckedChange={(checked) =>
+                      setForm({ ...form, autoRefresh: checked === true })
+                    }
+                  />
+                  <label
+                    htmlFor="auto-refresh"
+                    className="text-sm font-medium text-foreground cursor-pointer"
+                  >
+                    Auto-refresh after consolidation
+                  </label>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Refresh mode</label>
+                  <Select
+                    value={form.mode}
+                    onValueChange={(value) => setForm({ ...form, mode: value as "full" | "delta" })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="full">
+                        Full — regenerate from scratch each refresh
+                      </SelectItem>
+                      <SelectItem value="delta">
+                        Delta — surgical edits, preserve unchanged content
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Delta mode applies minimal changes to the existing content. Falls back to a full
+                    rewrite on the first refresh and whenever the source query changes.
+                  </p>
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">
+                  Other Mental Models
+                </h3>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="exclude-mental-models"
+                    checked={form.excludeMentalModels}
+                    onCheckedChange={(checked) =>
+                      setForm({ ...form, excludeMentalModels: checked === true })
+                    }
+                  />
+                  <label
+                    htmlFor="exclude-mental-models"
+                    className="text-sm font-medium text-foreground cursor-pointer"
+                  >
+                    Exclude all mental models
+                  </label>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">
+                    Exclude Mental Model IDs
+                  </label>
+                  <Input
+                    value={form.excludeMentalModelIds}
+                    onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
+                    placeholder="e.g., model-a, model-b (comma-separated)"
+                  />
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tags</label>
+                  <Input
+                    value={form.tags}
+                    onChange={(e) => setForm({ ...form, tags: e.target.value })}
+                    placeholder="e.g., project-x, team-alpha (comma-separated)"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Tags scope the model during reflect <strong>and</strong> filter source memories
+                    during refresh (default <code>all_strict</code>: only memories carrying every
+                    listed tag are read). If no memories have these tags yet, refresh will produce
+                    empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
+                    <em>Tag Groups</em> below.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tags Match</label>
+                  <Select
+                    value={form.tagsMatch}
+                    onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Default (all_strict when tags set)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
+                      <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
+                      <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
+                      <SelectItem value="any_strict">
+                        any_strict — OR matching, excludes untagged
+                      </SelectItem>
+                      <SelectItem value="all_strict">
+                        all_strict — AND matching, excludes untagged
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Controls how the model&apos;s tags filter memories during refresh.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
+                  <Textarea
+                    value={form.tagGroups}
+                    onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
+                    placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
+                    rows={3}
+                    className="font-mono text-xs"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Compound boolean tag expressions for refresh filtering. Overrides flat tags when
+                    set.
+                  </p>
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
                 <p className="text-xs text-muted-foreground">
-                  Token budget for raw chunk text returned by recall.
+                  Override how the internal recall behaves when this model refreshes. Leave blank to
+                  inherit the bank/global default.
                 </p>
-              </div>
-            </section>
-          </TabsContent>
+                <div className="space-y-3">
+                  <label className="text-sm font-medium text-foreground">Fact Types</label>
+                  <FactTypeCheckboxGroup
+                    value={form.factTypes}
+                    onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                  />
+                  <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Include chunks</label>
+                  <Select
+                    value={form.includeChunks || "default"}
+                    onValueChange={(v) =>
+                      setForm({
+                        ...form,
+                        includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="default">Default (inherit)</SelectItem>
+                      <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                      <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                  <Input
+                    type="number"
+                    value={form.recallMaxTokens}
+                    onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                    placeholder="Default (inherit)"
+                    min="0"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Token budget for facts returned by recall.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">
+                    Recall chunks max tokens
+                  </label>
+                  <Input
+                    type="number"
+                    value={form.recallChunksMaxTokens}
+                    onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                    placeholder="Default (inherit)"
+                    min="0"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Token budget for raw chunk text returned by recall.
+                  </p>
+                </div>
+              </section>
+            </TabsContent>
           </div>
         </Tabs>
 
@@ -1181,10 +1180,7 @@ function UpdateMentalModelDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs
-          defaultValue="general"
-          className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden"
-        >
+        <Tabs defaultValue="general" className="py-2 flex-1 flex flex-col min-h-0 overflow-hidden">
           <TabsList className="w-full">
             <TabsTrigger value="general" className="flex-1">
               General
@@ -1195,235 +1191,237 @@ function UpdateMentalModelDialog({
           </TabsList>
 
           <div className="flex-1 overflow-y-auto mt-2 pr-1">
-          <TabsContent value="general" className="space-y-4 pt-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground">ID</label>
-              <Input value={mentalModel.id} disabled className="bg-muted" />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Name *</label>
-              <Input
-                value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
-                placeholder="e.g., Team Communication Preferences"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Source Query *</label>
-              <Input
-                value={form.sourceQuery}
-                onChange={(e) => setForm({ ...form, sourceQuery: e.target.value })}
-                placeholder="e.g., How does the team prefer to communicate?"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Max Tokens</label>
-              <Input
-                type="number"
-                value={form.maxTokens}
-                onChange={(e) => setForm({ ...form, maxTokens: e.target.value })}
-                placeholder="2048"
-                min="256"
-                max="8192"
-              />
-            </div>
-          </TabsContent>
-
-          <TabsContent value="options" className="space-y-6 pt-4">
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="update-auto-refresh"
-                  checked={form.autoRefresh}
-                  onCheckedChange={(checked) => setForm({ ...form, autoRefresh: checked === true })}
-                />
-                <label
-                  htmlFor="update-auto-refresh"
-                  className="text-sm font-medium text-foreground cursor-pointer"
-                >
-                  Auto-refresh after consolidation
-                </label>
+            <TabsContent value="general" className="space-y-4 pt-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-muted-foreground">ID</label>
+                <Input value={mentalModel.id} disabled className="bg-muted" />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Refresh mode</label>
-                <Select
-                  value={form.mode}
-                  onValueChange={(value) =>
-                    setForm({ ...form, mode: value as "full" | "delta" })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="full">Full — regenerate from scratch each refresh</SelectItem>
-                    <SelectItem value="delta">
-                      Delta — surgical edits, preserve unchanged content
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Delta mode applies minimal changes to the existing content. Falls back to a full
-                  rewrite on the first refresh and whenever the source query changes.
-                </p>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">
-                Other Mental Models
-              </h3>
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="update-exclude-mental-models"
-                  checked={form.excludeMentalModels}
-                  onCheckedChange={(checked) =>
-                    setForm({ ...form, excludeMentalModels: checked === true })
-                  }
-                />
-                <label
-                  htmlFor="update-exclude-mental-models"
-                  className="text-sm font-medium text-foreground cursor-pointer"
-                >
-                  Exclude all mental models
-                </label>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">
-                  Exclude Mental Model IDs
-                </label>
+                <label className="text-sm font-medium text-foreground">Name *</label>
                 <Input
-                  value={form.excludeMentalModelIds}
-                  onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
-                  placeholder="e.g., model-a, model-b (comma-separated)"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="e.g., Team Communication Preferences"
                 />
               </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tags</label>
+                <label className="text-sm font-medium text-foreground">Source Query *</label>
                 <Input
-                  value={form.tags}
-                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
-                  placeholder="e.g., project-x, team-alpha (comma-separated)"
+                  value={form.sourceQuery}
+                  onChange={(e) => setForm({ ...form, sourceQuery: e.target.value })}
+                  placeholder="e.g., How does the team prefer to communicate?"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Tags scope the model during reflect <strong>and</strong> filter source memories
-                  during refresh (default <code>all_strict</code>: only memories carrying every
-                  listed tag are read). If no memories have these tags yet, refresh will produce
-                  empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
-                  <em>Tag Groups</em> below.
-                </p>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tags Match</label>
-                <Select
-                  value={form.tagsMatch || "default"}
-                  onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Default (all_strict when tags set)" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
-                    <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
-                    <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
-                    <SelectItem value="any_strict">
-                      any_strict — OR matching, excludes untagged
-                    </SelectItem>
-                    <SelectItem value="all_strict">
-                      all_strict — AND matching, excludes untagged
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Controls how the model&apos;s tags filter memories during refresh.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
-                <Textarea
-                  value={form.tagGroups}
-                  onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
-                  placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
-                  rows={3}
-                  className="font-mono text-xs"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Compound boolean tag expressions for refresh filtering. Overrides flat tags when
-                  set.
-                </p>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
-              <p className="text-xs text-muted-foreground">
-                Override how the internal recall behaves when this model refreshes. Leave blank to
-                inherit the bank/global default.
-              </p>
-              <div className="space-y-3">
-                <label className="text-sm font-medium text-foreground">Fact Types</label>
-                <FactTypeCheckboxGroup
-                  value={form.factTypes}
-                  onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
-                />
-                <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Include chunks</label>
-                <Select
-                  value={form.includeChunks || "default"}
-                  onValueChange={(v) =>
-                    setForm({
-                      ...form,
-                      includeChunks: v === "default" ? "" : (v as "true" | "false"),
-                    })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Default (inherit)</SelectItem>
-                    <SelectItem value="true">Yes — include raw chunk text</SelectItem>
-                    <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                <label className="text-sm font-medium text-foreground">Max Tokens</label>
                 <Input
                   type="number"
-                  value={form.recallMaxTokens}
-                  onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
-                  placeholder="Default (inherit)"
-                  min="0"
+                  value={form.maxTokens}
+                  onChange={(e) => setForm({ ...form, maxTokens: e.target.value })}
+                  placeholder="2048"
+                  min="256"
+                  max="8192"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Token budget for facts returned by recall.
-                </p>
               </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">
-                  Recall chunks max tokens
-                </label>
-                <Input
-                  type="number"
-                  value={form.recallChunksMaxTokens}
-                  onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
-                  placeholder="Default (inherit)"
-                  min="0"
-                />
+            </TabsContent>
+
+            <TabsContent value="options" className="space-y-6 pt-4">
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Refresh</h3>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="update-auto-refresh"
+                    checked={form.autoRefresh}
+                    onCheckedChange={(checked) =>
+                      setForm({ ...form, autoRefresh: checked === true })
+                    }
+                  />
+                  <label
+                    htmlFor="update-auto-refresh"
+                    className="text-sm font-medium text-foreground cursor-pointer"
+                  >
+                    Auto-refresh after consolidation
+                  </label>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Refresh mode</label>
+                  <Select
+                    value={form.mode}
+                    onValueChange={(value) => setForm({ ...form, mode: value as "full" | "delta" })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="full">
+                        Full — regenerate from scratch each refresh
+                      </SelectItem>
+                      <SelectItem value="delta">
+                        Delta — surgical edits, preserve unchanged content
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Delta mode applies minimal changes to the existing content. Falls back to a full
+                    rewrite on the first refresh and whenever the source query changes.
+                  </p>
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">
+                  Other Mental Models
+                </h3>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="update-exclude-mental-models"
+                    checked={form.excludeMentalModels}
+                    onCheckedChange={(checked) =>
+                      setForm({ ...form, excludeMentalModels: checked === true })
+                    }
+                  />
+                  <label
+                    htmlFor="update-exclude-mental-models"
+                    className="text-sm font-medium text-foreground cursor-pointer"
+                  >
+                    Exclude all mental models
+                  </label>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">
+                    Exclude Mental Model IDs
+                  </label>
+                  <Input
+                    value={form.excludeMentalModelIds}
+                    onChange={(e) => setForm({ ...form, excludeMentalModelIds: e.target.value })}
+                    placeholder="e.g., model-a, model-b (comma-separated)"
+                  />
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Tags</h3>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tags</label>
+                  <Input
+                    value={form.tags}
+                    onChange={(e) => setForm({ ...form, tags: e.target.value })}
+                    placeholder="e.g., project-x, team-alpha (comma-separated)"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Tags scope the model during reflect <strong>and</strong> filter source memories
+                    during refresh (default <code>all_strict</code>: only memories carrying every
+                    listed tag are read). If no memories have these tags yet, refresh will produce
+                    empty content — backfill tags on memories, or adjust <em>Tags Match</em> /{" "}
+                    <em>Tag Groups</em> below.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tags Match</label>
+                  <Select
+                    value={form.tagsMatch || "default"}
+                    onValueChange={(v) => setForm({ ...form, tagsMatch: v === "default" ? "" : v })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Default (all_strict when tags set)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="default">Default (all_strict when tags set)</SelectItem>
+                      <SelectItem value="any">any — OR matching, includes untagged</SelectItem>
+                      <SelectItem value="all">all — AND matching, includes untagged</SelectItem>
+                      <SelectItem value="any_strict">
+                        any_strict — OR matching, excludes untagged
+                      </SelectItem>
+                      <SelectItem value="all_strict">
+                        all_strict — AND matching, excludes untagged
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Controls how the model&apos;s tags filter memories during refresh.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Tag Groups (JSON)</label>
+                  <Textarea
+                    value={form.tagGroups}
+                    onChange={(e) => setForm({ ...form, tagGroups: e.target.value })}
+                    placeholder='e.g., [{"or": [{"tags": ["user:alice"], "match": "all_strict"}, {"tags": ["shared"]}]}]'
+                    rows={3}
+                    className="font-mono text-xs"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Compound boolean tag expressions for refresh filtering. Overrides flat tags when
+                    set.
+                  </p>
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground border-b pb-1">Recall</h3>
                 <p className="text-xs text-muted-foreground">
-                  Token budget for raw chunk text returned by recall.
+                  Override how the internal recall behaves when this model refreshes. Leave blank to
+                  inherit the bank/global default.
                 </p>
-              </div>
-            </section>
-          </TabsContent>
+                <div className="space-y-3">
+                  <label className="text-sm font-medium text-foreground">Fact Types</label>
+                  <FactTypeCheckboxGroup
+                    value={form.factTypes}
+                    onChange={(v) => setForm({ ...form, factTypes: v as FactType[] })}
+                  />
+                  <p className="text-xs text-muted-foreground">Leave empty to include all types.</p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Include chunks</label>
+                  <Select
+                    value={form.includeChunks || "default"}
+                    onValueChange={(v) =>
+                      setForm({
+                        ...form,
+                        includeChunks: v === "default" ? "" : (v as "true" | "false"),
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="default">Default (inherit)</SelectItem>
+                      <SelectItem value="true">Yes — include raw chunk text</SelectItem>
+                      <SelectItem value="false">No — skip chunks (smaller prompt)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">Recall max tokens</label>
+                  <Input
+                    type="number"
+                    value={form.recallMaxTokens}
+                    onChange={(e) => setForm({ ...form, recallMaxTokens: e.target.value })}
+                    placeholder="Default (inherit)"
+                    min="0"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Token budget for facts returned by recall.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-foreground">
+                    Recall chunks max tokens
+                  </label>
+                  <Input
+                    type="number"
+                    value={form.recallChunksMaxTokens}
+                    onChange={(e) => setForm({ ...form, recallChunksMaxTokens: e.target.value })}
+                    placeholder="Default (inherit)"
+                    min="0"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Token budget for raw chunk text returned by recall.
+                  </p>
+                </div>
+              </section>
+            </TabsContent>
           </div>
         </Tabs>
 

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -91,6 +91,7 @@ export interface MentalModel {
   tags: string[];
   max_tokens: number;
   trigger: {
+    mode?: "full" | "delta";
     refresh_after_consolidation: boolean;
     fact_types?: Array<"world" | "experience" | "observation">;
     exclude_mental_models?: boolean;
@@ -952,6 +953,7 @@ export class ControlPlaneClient {
         tags: string[];
         max_tokens: number;
         trigger: {
+          mode?: "full" | "delta";
           refresh_after_consolidation: boolean;
           fact_types?: Array<"world" | "experience" | "observation">;
           exclude_mental_models?: boolean;
@@ -985,6 +987,7 @@ export class ControlPlaneClient {
       tags?: string[];
       max_tokens?: number;
       trigger?: {
+        mode?: "full" | "delta";
         refresh_after_consolidation: boolean;
         fact_types?: Array<"world" | "experience" | "observation">;
         exclude_mental_models?: boolean;
@@ -1026,6 +1029,7 @@ export class ControlPlaneClient {
       max_tokens?: number;
       tags?: string[];
       trigger?: {
+        mode?: "full" | "delta";
         refresh_after_consolidation: boolean;
         fact_types?: Array<"world" | "experience" | "observation">;
         exclude_mental_models?: boolean;

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -116,9 +116,31 @@ Mental models can be configured to **automatically refresh** when observations a
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
+| `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
+
+### Refresh Mode
+
+Two strategies are available for how a refresh produces the new content:
+
+- **`full`** *(default)* — every refresh regenerates the entire content from scratch. Simple and predictable: the LLM synthesises a fresh document from the retrieved memories. Best when the document is short, when you want every refresh to potentially restructure the output, or when you're not yet sure what the final shape should be.
+
+- **`delta`** — refresh emits a list of typed *operations* (add a section, append a bullet, replace a block, remove a stale paragraph) against the document's existing structure, then renders the result. Sections that aren't targeted by any operation are copied through **byte-identical** — no paraphrasing, no whitespace drift, no list-style normalisation. Best for long-lived "playbook"–style mental models where you want stability across refreshes and only the genuinely changed parts to move.
+
+Delta mode falls back to a full regeneration automatically in two cases:
+1. The mental model has no existing content yet (nothing to anchor edits on).
+2. The `source_query` has changed since the last refresh (the topic has shifted; the existing structure may no longer apply).
+
+If the LLM call fails or returns an empty answer, the existing content is preserved — refreshes never overwrite a populated document with an empty one.
+
+| Use Case | Recommended Mode | Why |
+|----------|-----------------|-----|
+| Skill / playbook docs | `delta` | Sections live for many refreshes; only specific rules change |
+| Onboarding summaries | `delta` | Adding new team members shouldn't restructure the doc |
+| Real-time dashboards | `full` | Each refresh is a fresh snapshot |
+| Short FAQ summaries | `full` | Whole-document regeneration is cheap and unambiguous |
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -402,6 +402,16 @@
     "MentalModelTrigger": {
       "description": "Trigger settings for a mental model.",
       "properties": {
+        "mode": {
+          "default": "full",
+          "description": "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.",
+          "enum": [
+            "full",
+            "delta"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
         "refresh_after_consolidation": {
           "default": false,
           "description": "If true, refresh this mental model after observations consolidation (real-time mode)",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7888,6 +7888,16 @@
       },
       "MentalModelTrigger-Input": {
         "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "delta"
+            ],
+            "title": "Mode",
+            "description": "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.",
+            "default": "full"
+          },
           "refresh_after_consolidation": {
             "type": "boolean",
             "title": "Refresh After Consolidation",
@@ -8024,6 +8034,16 @@
       },
       "MentalModelTrigger-Output": {
         "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "delta"
+            ],
+            "title": "Mode",
+            "description": "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.",
+            "default": "full"
+          },
           "refresh_after_consolidation": {
             "type": "boolean",
             "title": "Refresh After Consolidation",

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -162,9 +162,31 @@ Mental models can be configured to **automatically refresh** when observations a
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
+| `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
+
+### Refresh Mode
+
+Two strategies are available for how a refresh produces the new content:
+
+- **`full`** *(default)* — every refresh regenerates the entire content from scratch. Simple and predictable: the LLM synthesises a fresh document from the retrieved memories. Best when the document is short, when you want every refresh to potentially restructure the output, or when you're not yet sure what the final shape should be.
+
+- **`delta`** — refresh emits a list of typed *operations* (add a section, append a bullet, replace a block, remove a stale paragraph) against the document's existing structure, then renders the result. Sections that aren't targeted by any operation are copied through **byte-identical** — no paraphrasing, no whitespace drift, no list-style normalisation. Best for long-lived "playbook"–style mental models where you want stability across refreshes and only the genuinely changed parts to move.
+
+Delta mode falls back to a full regeneration automatically in two cases:
+1. The mental model has no existing content yet (nothing to anchor edits on).
+2. The `source_query` has changed since the last refresh (the topic has shifted; the existing structure may no longer apply).
+
+If the LLM call fails or returns an empty answer, the existing content is preserved — refreshes never overwrite a populated document with an empty one.
+
+| Use Case | Recommended Mode | Why |
+|----------|-----------------|-----|
+| Skill / playbook docs | `delta` | Sections live for many refreshes; only specific rules change |
+| Onboarding summaries | `delta` | Adding new team members shouldn't restructure the doc |
+| Real-time dashboards | `full` | Each refresh is a fresh snapshot |
+| Short FAQ summaries | `full` | Whole-document regeneration is cheap and unambiguous |
 
 ### Python
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7888,6 +7888,16 @@
       },
       "MentalModelTrigger-Input": {
         "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "delta"
+            ],
+            "title": "Mode",
+            "description": "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.",
+            "default": "full"
+          },
           "refresh_after_consolidation": {
             "type": "boolean",
             "title": "Refresh After Consolidation",
@@ -8024,6 +8034,16 @@
       },
       "MentalModelTrigger-Output": {
         "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "full",
+              "delta"
+            ],
+            "title": "Mode",
+            "description": "Refresh mode. 'full' (default) regenerates the mental model content from scratch on each refresh. 'delta' performs surgical edits against the existing content: unchanged sections are preserved byte-for-byte, stale content is removed, new content is added. If the mental model has no existing content, or if the source_query has changed since the last refresh, delta mode falls back to a full regeneration automatically.",
+            "default": "full"
+          },
           "refresh_after_consolidation": {
             "type": "boolean",
             "title": "Refresh After Consolidation",


### PR DESCRIPTION
## Summary

Three orthogonal changes shipped together because they share the mental-model / observation lifecycle code paths.

### 1. Mental model delta refresh (new feature)
Refreshing a mental model in delta mode used to round-trip the existing markdown through an LLM "preserve byte-for-byte" prompt — which never worked in practice. Even at temperature 0, every refresh drifted on stylistic details (numbered → bulleted lists, casing, separator lines added, whole-section paraphrases) because LLMs don't reliably copy tokens.

This PR replaces that with a structured-ops architecture:
- New ``structured_content`` JSONB column on ``mental_models`` (sections + typed blocks).
- Markdown is a deterministic render of the structured doc — never LLM output.
- Delta refresh asks the LLM for a list of typed operations (``append_block``, ``replace_block``, ``add_section``, …) against the structured doc. Sections not mentioned by any op are physically copied through unchanged, so prose drift is structurally impossible.
- Text-mode JSON for the LLM call (Gemini rejects the discriminated-union schema Pydantic emits); we parse + validate manually.
- Token budget: 1.5× the doc cap with a 2048 floor; the budget is surfaced in the prompt so models can self-trim.
- New ``mode: "full" | "delta"`` enum on the trigger jsonb. First refresh on an empty document falls back to full; a source_query change forces a full rebuild via a ``last_refreshed_source_query`` tracking column.
- Worker handler ``_handle_refresh_mental_model`` now delegates to the public ``refresh_mental_model`` (single source of truth — previously had its own copy of the reflect+update pipeline that bypassed delta entirely).
- Refuse to overwrite existing content with an empty render — small models occasionally return empty answers from the reflect agent and the previous behaviour destroyed the working document on transient upstream failures.

### 2. Observation cleanup on document upsert (production bug fix)
Confirmed in ``nicolo-news-feed``: every document re-ingest left orphan observations.

Root cause: ``fact_storage.handle_document_tracking`` (the retain/upsert path) deleted the document via FK cascade — which removes the source ``memory_units`` — but never invalidated the observations whose ``source_memory_ids`` referenced them. Only the explicit ``MemoryEngine.delete_document`` API ran the cleanup.

Fix:
- Extracted ``delete_stale_observations_for_memories`` into a free function in ``fact_storage.py``. Both the retain upsert path and the explicit-delete API now run the same SQL — single source of truth.
- Migration ``c4x5y6z7a8b9`` re-runs Pass 2 of ``g7h8i9j0k1l2`` to sweep orphan observations that accumulated since the last cleanup.

### 3. Operational logging fixes
- ``openai_compatible_llm`` was silent on ``APIStatusError`` retries — only logging on the *final* failure. With consolidation hitting 11 inner retries × 3 outer attempts, you'd wait minutes before seeing the actual error body. Now logs status + truncated body per attempt via a new ``_summarize_status_error`` helper. Same treatment for ``call_with_tools``.
- Consolidator's ``[CONSOLIDATION] LLM batch call failed`` log now includes the failing memory IDs (count + first 3) so ``json_validate_failed`` and similar can be traced to a specific memory without waiting for adaptive bisection.
- Worker ``[WORKER_STATS]`` had a mis-labelled ``waiters`` field reading ``pool._queue.qsize()`` (asyncpg's queue of *available holders*, not waiting acquirers — pre-filled to ``max_size`` at startup). High-load incidents were diagnosed against an inverted metric. Split into ``free_holders`` (idle holders in queue) and ``pending_acquires`` (``len(_queue._getters)`` — actual coroutines blocked on ``pool.acquire``).

### UI changes
- New "Refresh mode" select in the Create/Update mental model dialogs.
- Per-row actions dropdown (Edit / Refresh / Delete) on the dashboard cards and table rows, mirroring the detail dialog's actions menu.
- History diff view: per-token whitespace-insensitive inline diff so only the actually-changed substrings light up red/green; runs of unchanged lines render as plain text.
- Mental-model dialogs widened to ``sm:max-w-2xl``; Tabs restructured so ``TabsList`` stays sticky and the scroll wrapper inherits the global themed scrollbar.
- Auto-refresh badge colour unified to green across all surfaces.

### Migrations (in order)
- ``a2v3w4x5y6z7`` — ``last_refreshed_source_query TEXT``
- ``b3w4x5y6z7a8`` — ``structured_content JSONB``
- ``c4x5y6z7a8b9`` — backsweep orphan observations v2

## Test plan

- [x] ``ruff check`` clean across all touched files
- [x] ``pytest tests/test_structured_doc.py`` — 39 new unit tests (renderer, parser, op application, byte-identical preservation)
- [x] ``pytest tests/test_mental_model_delta.py::TestDeltaRefreshPlumbing`` — 6 plumbing tests (full/delta branching, source-query change, empty-content guard, LLM-failure fallback)
- [x] Standalone real-LLM smoke against OpenAI gpt-4o-mini: 5/5 scenarios pass (no-op → 0 ops byte-identical, single-add → exactly one append, add-section, contradict → replace, irrelevant → 0 ops)
- [x] Live-DB validation against ``nicolo-news-feed`` mental model + migration
- [ ] CI green
- [ ] One end-to-end sanity check: re-ingest a document and confirm orphan observations are swept (logs ``[OBSERVATIONS] Deleted N observations``)
- [ ] Real-Gemini eval suite once the project's Gemini key is renewed (currently expired; ``HINDSIGHT_RUN_GEMINI_EVALS=1`` will skip until then or use OpenAI fallback)