### PR TITLE
fix(openclaw): per-session retain stops overwriting prior turns

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -10,6 +10,7 @@ import {
   composeRecallQuery,
   truncateRecallQuery,
   buildRetainRequest,
+  meetsMinimumVersion,
   parseSessionKey,
   extractTelegramDirectSenderId,
   resolveSessionIdentity,
@@ -323,7 +324,7 @@ describe("inline retain tag helpers", () => {
 });
 
 describe("buildRetainRequest", () => {
-  it("adds configured source metadata and retain tags", () => {
+  it("uses session-scoped doc id + update_mode=append when API supports it", () => {
     const request = buildRetainRequest(
       "hello world",
       2,
@@ -338,7 +339,8 @@ describe("buildRetainRequest", () => {
         retainSource: "openclaw",
         retainTags: ["source_system:openclaw", "agent:agentname"],
       },
-      1700000000000
+      1700000000000,
+      { appendSupported: true }
     );
 
     expect(request).toEqual({
@@ -359,7 +361,42 @@ describe("buildRetainRequest", () => {
         sender_id: "user:456",
       },
       tags: ["source_system:openclaw", "agent:agentname"],
+      updateMode: "append",
     });
+  });
+
+  it("falls back to per-turn doc id when appendSupported is false (older API)", () => {
+    const request = buildRetainRequest(
+      "hello world",
+      2,
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        messageProvider: "discord",
+      },
+      { retainSource: "openclaw" },
+      1700000000000,
+      { turnIndex: 4, appendSupported: false }
+    );
+    expect(request.documentId).toBe("openclaw:agent:main:main:turn:000004");
+    expect(request.updateMode).toBeUndefined();
+  });
+
+  it("defaults to per-turn fallback when appendSupported flag is omitted (conservative)", () => {
+    const request = buildRetainRequest(
+      "hello world",
+      2,
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        messageProvider: "discord",
+      },
+      { retainSource: "openclaw" },
+      1700000000000,
+      { turnIndex: 6 }
+    );
+    expect(request.documentId).toBe("openclaw:agent:main:main:turn:000006");
+    expect(request.updateMode).toBeUndefined();
   });
 
   it("uses per-turn document ids when retainDocumentScope is 'turn'", () => {
@@ -1087,5 +1124,39 @@ describe("waitForReady (CLI mode)", () => {
   it("getClient returns null when service.start not called", () => {
     const hindsight = (global as any).__hindsightClient;
     expect(hindsight.getClient()).toBeNull();
+  });
+});
+
+describe("meetsMinimumVersion", () => {
+  it("treats equal versions as supported", () => {
+    expect(meetsMinimumVersion("0.5.0", "0.5.0")).toBe(true);
+  });
+
+  it("returns true for newer major/minor/patch", () => {
+    expect(meetsMinimumVersion("0.5.1", "0.5.0")).toBe(true);
+    expect(meetsMinimumVersion("0.6.0", "0.5.0")).toBe(true);
+    expect(meetsMinimumVersion("1.0.0", "0.5.0")).toBe(true);
+  });
+
+  it("returns false for older versions", () => {
+    expect(meetsMinimumVersion("0.4.22", "0.5.0")).toBe(false);
+    expect(meetsMinimumVersion("0.4.0", "0.5.0")).toBe(false);
+    expect(meetsMinimumVersion("0.0.1", "0.5.0")).toBe(false);
+  });
+
+  it("ignores pre-release suffixes (treats them as the bare version)", () => {
+    expect(meetsMinimumVersion("0.5.0-beta.1", "0.5.0")).toBe(true);
+    expect(meetsMinimumVersion("0.4.99-rc.1", "0.5.0")).toBe(false);
+  });
+
+  it("treats missing patch / minor as zero", () => {
+    expect(meetsMinimumVersion("0.5", "0.5.0")).toBe(true);
+    expect(meetsMinimumVersion("1", "0.5.0")).toBe(true);
+    expect(meetsMinimumVersion("0.4", "0.5.0")).toBe(false);
+  });
+
+  it("returns false for malformed versions instead of throwing", () => {
+    expect(meetsMinimumVersion("garbage", "0.5.0")).toBe(false);
+    expect(meetsMinimumVersion("", "0.5.0")).toBe(false);
   });
 });

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -58,6 +58,14 @@ let initPromise: Promise<void> | null = null;
 let isInitialized = false;
 let usingExternalApi = false; // Track if using external API (skip daemon management)
 
+// Capability detected once per service.start() against `<apiUrl>/version`.
+// `true` when the Hindsight API supports `update_mode: 'append'` (added in
+// 0.5.0 — see vectorize-io/hindsight#932). When false, retain falls back to a
+// per-turn document id so prior turns aren't silently overwritten.
+let supportsUpdateModeAppend = false;
+let appendCapabilityProbed = false;
+const MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0";
+
 // Store the current plugin config for bank ID derivation
 let currentPluginConfig: PluginConfig | null = null;
 
@@ -99,6 +107,7 @@ function scopeClient(c: HindsightClient, bankId: string): BankScopedClient {
         documentId: req.documentId,
         metadata: toStringMetadata(req.metadata),
         tags: req.tags,
+        updateMode: req.updateMode,
         async: true,
       });
     },
@@ -205,6 +214,7 @@ async function flushRetainQueue(): Promise<void> {
           documentId: item.documentId,
           metadata: toStringMetadata(item.metadata),
           tags: item.tags,
+          updateMode: item.updateMode,
           async: true,
         });
 
@@ -275,6 +285,7 @@ async function lazyReinit(configOverride?: PluginConfig): Promise<void> {
   debug("[Hindsight] Attempting lazy re-initialization...");
   try {
     await checkExternalApiHealth(externalApi.apiUrl, externalApi.apiToken);
+    await detectAppendCapability(externalApi.apiUrl, externalApi.apiToken);
 
     const llmConfig = detectLLMConfig(config);
     clientOptions = buildClientOptions(llmConfig, config, externalApi);
@@ -1126,6 +1137,96 @@ export function buildClientOptions(
  * Health check for external Hindsight API.
  * Retries up to 3 times with 2s delay — container DNS may not be ready on first boot.
  */
+/**
+ * Compare two semver-shaped strings ("0.5.0", "0.4.22"). Returns true when
+ * `actual >= minimum`. Tolerates pre-release suffixes (treats them as the
+ * same major.minor.patch as the bare version — good enough for capability
+ * gating).
+ */
+export function meetsMinimumVersion(actual: string, minimum: string): boolean {
+  const parse = (v: string): number[] =>
+    v
+      .split("-")[0]
+      .split(".")
+      .map((part) => Number.parseInt(part, 10))
+      .map((n) => (Number.isFinite(n) ? n : 0));
+  const a = parse(actual);
+  const m = parse(minimum);
+  for (let i = 0; i < Math.max(a.length, m.length); i++) {
+    const av = a[i] ?? 0;
+    const mv = m[i] ?? 0;
+    if (av > mv) return true;
+    if (av < mv) return false;
+  }
+  return true;
+}
+
+/**
+ * Probe `<apiUrl>/version` once at service.start to learn the running
+ * Hindsight API version. Returns `null` (treated as "no append support") if
+ * the endpoint is unreachable or returns malformed payload — conservative
+ * fallback path is the right call when we can't be sure.
+ */
+async function fetchHindsightApiVersion(
+  apiUrl: string,
+  apiToken?: string | null
+): Promise<string | null> {
+  const versionUrl = `${apiUrl.replace(/\/$/, "")}/version`;
+  try {
+    const headers: Record<string, string> = { "User-Agent": USER_AGENT };
+    if (apiToken) headers["Authorization"] = `Bearer ${apiToken}`;
+    const response = await fetch(versionUrl, {
+      signal: AbortSignal.timeout(5000),
+      headers,
+    });
+    if (!response.ok) {
+      debug(`[Hindsight] /version returned HTTP ${response.status}; assuming legacy`);
+      return null;
+    }
+    const data = (await response.json()) as { api_version?: unknown };
+    const v = typeof data.api_version === "string" ? data.api_version : null;
+    if (!v) {
+      debug(`[Hindsight] /version payload missing api_version; assuming legacy`);
+    }
+    return v;
+  } catch (error) {
+    debug(`[Hindsight] /version probe failed: ${String(error)}; assuming legacy`);
+    return null;
+  }
+}
+
+/**
+ * Probe `/version` and update the module-level `supportsUpdateModeAppend`
+ * capability flag accordingly. Logs a one-time WARN block when the API is
+ * older than 0.5.0 — without `update_mode: 'append'`, every retain on the
+ * same session id silently overwrites prior turns server-side.
+ *
+ * Called from the same code paths as the health check, so capability is
+ * always re-evaluated when the plugin (re)connects to the API.
+ */
+async function detectAppendCapability(apiUrl: string, apiToken?: string | null): Promise<void> {
+  const version = await fetchHindsightApiVersion(apiUrl, apiToken);
+  const supported =
+    version !== null && meetsMinimumVersion(version, MIN_VERSION_FOR_UPDATE_MODE_APPEND);
+  const transitionedToUnsupported = supportsUpdateModeAppend && !supported;
+  const firstProbe = !appendCapabilityProbed;
+  appendCapabilityProbed = true;
+  supportsUpdateModeAppend = supported;
+  if (supported) {
+    debug(`[Hindsight] API version ${version} supports update_mode=append`);
+    return;
+  }
+  // Warn on the first probe when unsupported, and on any transition from
+  // supported -> unsupported. Stay silent on subsequent re-probes that
+  // confirm the same unsupported state.
+  if (!firstProbe && !transitionedToUnsupported) return;
+  log.warn(
+    `[Hindsight] ⚠️  API at ${apiUrl} reports version "${version ?? "unknown"}", which is older than ${MIN_VERSION_FOR_UPDATE_MODE_APPEND}. ` +
+      `Falling back to per-turn document ids — each retain becomes its own document instead of accumulating into one per-session document. ` +
+      `Upgrade Hindsight to ${MIN_VERSION_FOR_UPDATE_MODE_APPEND} or newer to enable session-scoped retention with update_mode=append.`
+  );
+}
+
 async function checkExternalApiHealth(apiUrl: string, apiToken?: string | null): Promise<void> {
   const healthUrl = `${apiUrl.replace(/\/$/, "")}/health`;
   const maxRetries = 3;
@@ -1400,6 +1501,7 @@ export default function (api: MoltbotPluginAPI) {
               // External API mode - check health, skip daemon startup
               debug("[Hindsight] External API mode - skipping local daemon...");
               await checkExternalApiHealth(externalApi.apiUrl, externalApi.apiToken);
+              await detectAppendCapability(externalApi.apiUrl, externalApi.apiToken);
 
               // Initialize client for external API
               debug("[Hindsight] Creating HindsightClient (external API)...");
@@ -1510,6 +1612,7 @@ export default function (api: MoltbotPluginAPI) {
           if (externalApi.apiUrl && isInitialized) {
             try {
               await checkExternalApiHealth(externalApi.apiUrl, externalApi.apiToken);
+              await detectAppendCapability(externalApi.apiUrl, externalApi.apiToken);
               debug("[Hindsight] External API is healthy");
               return;
             } catch (error) {
@@ -1554,6 +1657,7 @@ export default function (api: MoltbotPluginAPI) {
             usingExternalApi = true;
 
             await checkExternalApiHealth(externalApi.apiUrl, externalApi.apiToken);
+            await detectAppendCapability(externalApi.apiUrl, externalApi.apiToken);
 
             clientOptions = buildClientOptions(llmConfig, reinitPluginConfig, externalApi);
             banksWithMissionSet.clear();
@@ -2168,6 +2272,7 @@ ${memoriesFormatted}
               ? (pluginConfig.retainEveryNTurns ?? 1) + (pluginConfig.retainOverlapTurns ?? 0)
               : undefined,
             tags: inlineRetainTags,
+            appendSupported: supportsUpdateModeAppend,
           }
         );
 
@@ -2256,6 +2361,15 @@ export function buildRetainRequest(
     windowTurns?: number;
     turnIndex?: number;
     tags?: string[];
+    /**
+     * Whether the live Hindsight API supports `update_mode: 'append'`. When
+     * true with `retainDocumentScope: 'session'`, the request gets a stable
+     * per-session document id and `updateMode: 'append'` so each retain
+     * concatenates to the existing document. When false, falls back to a
+     * unique per-turn document id so prior turns aren't overwritten.
+     * Defaults to false (conservative).
+     */
+    appendSupported?: boolean;
   }
 ): RetainRequest {
   const resolvedCtx = resolveSessionIdentity(effectiveCtx);
@@ -2265,10 +2379,13 @@ export function buildRetainRequest(
   const documentBase = getSessionDocumentBase(resolvedCtx);
   const documentScope = pluginConfig.retainDocumentScope ?? "session";
   const documentKind = retentionScope === "window" ? "window" : "turn";
-  const documentId =
-    documentScope === "session"
-      ? documentBase
-      : `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, "0")}`;
+  // Session-scope only stays session-scope when the API can append; otherwise
+  // every retain on the same id silently overwrites prior turns (behavior
+  // pre-#932). Force per-turn ids on legacy APIs.
+  const useSessionScopedDoc = documentScope === "session" && options?.appendSupported === true;
+  const documentId = useSessionScopedDoc
+    ? documentBase
+    : `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, "0")}`;
   const provider = effectiveCtx?.messageProvider || parsedSession.provider;
   const channelId = sanitizeChannelId(effectiveCtx?.channelId, provider) || parsedSession.channel;
   const channelType = effectiveCtx?.messageProvider;
@@ -2297,6 +2414,7 @@ export function buildRetainRequest(
       ...(options?.windowTurns !== undefined ? { window_turns: String(options.windowTurns) } : {}),
     },
     tags: mergedTags.length > 0 ? mergedTags : undefined,
+    updateMode: useSessionScopedDoc ? "append" : undefined,
   };
 }
 

--- a/hindsight-integrations/openclaw/src/retain-queue.ts
+++ b/hindsight-integrations/openclaw/src/retain-queue.ts
@@ -24,6 +24,7 @@ export interface QueuedRetainPayload {
   documentId?: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
+  updateMode?: "replace" | "append";
 }
 
 export interface QueuedRetain {
@@ -33,6 +34,7 @@ export interface QueuedRetain {
   documentId: string;
   metadata: Record<string, unknown>;
   tags?: string[];
+  updateMode?: "replace" | "append";
   createdAt: string; // ISO 8601
 }
 
@@ -63,6 +65,7 @@ export class RetainQueue {
       documentId: request.documentId || "conversation",
       metadata: metadata || request.metadata || {},
       tags: request.tags,
+      updateMode: request.updateMode,
       createdAt: new Date().toISOString(),
     };
     appendFileSync(this.filePath, JSON.stringify(item) + "\n", "utf8");

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -133,6 +133,14 @@ export interface RetainRequest {
   documentId?: string;
   metadata?: Record<string, unknown>;
   tags?: string[];
+  /**
+   * `'append'` concatenates this content to the existing document text
+   * (Hindsight ≥ 0.5 only — older versions silently ignore the field and
+   * overwrite). The plugin only sets this when capability detection at
+   * service.start() confirmed support; otherwise it falls back to a
+   * per-turn document id and leaves this unset.
+   */
+  updateMode?: "replace" | "append";
 }
 
 /**


### PR DESCRIPTION
## Summary

Default `retainDocumentScope: 'session'` produces a stable per-session `documentId` for every retain. Without `update_mode: 'append'` (added in #932, shipped in 0.5.0), every retain on the same `documentId` overwrote the document server-side — only the latest retain's slice (last user message + assistant replies) survived. Banks ended up with one document per session containing only the last turn, all earlier history silently lost.

This PR fixes it without bumping the client or `peerDependencies` — the plugin detects the API capability at runtime via `GET /version` and uses one of two paths:

- **Hindsight ≥ 0.5.0**: keep the session-scoped `documentId` AND set `updateMode: 'append'` so each retain concatenates to the existing document.
- **Older Hindsight or `/version` unreachable**: fall back to per-turn `documentId`s (`<base>:turn:<6-digit-idx>`) so prior turns aren't lost. Logs a one-time WARN telling the user to upgrade.

## Implementation

- `types.ts` — `updateMode?: 'replace' | 'append'` on `RetainRequest`
- `retain-queue.ts` — persist + replay `updateMode` through the JSONL retain queue (so `update_mode` survives offline buffering)
- `index.ts`:
  - `meetsMinimumVersion(actual, minimum)` — small semver-shaped helper, tolerates pre-releases, treats malformed as `false`
  - `fetchHindsightApiVersion()` — probes `GET /version`, 5s timeout, returns `null` on any error so we fall through to legacy mode
  - `detectAppendCapability()` — sets the module-level flag, emits a giant one-time `WARN` block when unsupported (also re-emits on supported → unsupported transitions; stays silent on repeated unsupported probes)
  - Wired into all 4 `checkExternalApiHealth` call sites (initial start, lazy reinit, periodic reconnect, late re-init)
  - `buildRetainRequest` takes new `appendSupported` option; emits session-scoped doc + `updateMode: 'append'` only when both `documentScope === 'session'` AND `appendSupported === true`. Default for omitted `appendSupported` is `false` (conservative — prevents data loss when the flag isn't threaded through somewhere new)

## Test plan

- [x] `npm test` — 194/194 passing
  - 6 new `meetsMinimumVersion` cases (equal / newer / older / pre-release / partial / malformed)
  - 3 new `buildRetainRequest` cases (session+append when capable, per-turn fallback when not, per-turn when flag omitted)
- [x] `./scripts/hooks/lint.sh` clean

## Compat

- **No `peerDependencies` bump** — the plugin works against pre-0.5.0 Hindsight, just with a giant warning and per-turn fallback semantics.
- Existing documents in users' banks (pre-fix, with the lossy session-overwrite shape) are not migrated. New retains accumulate properly going forward; old single-document-per-session entries stay as-is unless the user re-runs `hindsight-openclaw-backfill`.