### PR TITLE
feat(recall): make budget mapping configurable per bank

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1800,6 +1800,31 @@ class BankTemplateConfig(BaseModel):
     llm_gemini_safety_settings: list | None = Field(
         default=None, description="Per-bank Gemini/VertexAI safety filter settings"
     )
+    recall_budget_function: str | None = Field(
+        default=None, description="Recall budget mapping function: 'fixed' or 'adaptive'"
+    )
+    recall_budget_fixed_low: int | None = Field(
+        default=None, description="Fixed thinking_budget for budget=low (function='fixed')"
+    )
+    recall_budget_fixed_mid: int | None = Field(
+        default=None, description="Fixed thinking_budget for budget=mid (function='fixed')"
+    )
+    recall_budget_fixed_high: int | None = Field(
+        default=None, description="Fixed thinking_budget for budget=high (function='fixed')"
+    )
+    recall_budget_adaptive_low: float | None = Field(
+        default=None, description="Ratio of max_tokens for budget=low (function='adaptive')"
+    )
+    recall_budget_adaptive_mid: float | None = Field(
+        default=None, description="Ratio of max_tokens for budget=mid (function='adaptive')"
+    )
+    recall_budget_adaptive_high: float | None = Field(
+        default=None, description="Ratio of max_tokens for budget=high (function='adaptive')"
+    )
+    recall_budget_min: int | None = Field(default=None, description="Floor for the adaptive function (after clamping)")
+    recall_budget_max: int | None = Field(
+        default=None, description="Ceiling for the adaptive function (after clamping)"
+    )
 
     def get_config_updates(self) -> dict[str, Any]:
         """Return only the fields that were explicitly set (non-None)."""

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -393,6 +393,17 @@ ENV_RECALL_INCLUDE_CHUNKS = "HINDSIGHT_API_RECALL_INCLUDE_CHUNKS"
 ENV_RECALL_MAX_TOKENS = "HINDSIGHT_API_RECALL_MAX_TOKENS"
 ENV_RECALL_CHUNKS_MAX_TOKENS = "HINDSIGHT_API_RECALL_CHUNKS_MAX_TOKENS"
 
+# Recall budget mapping (budget enum -> thinking_budget integer)
+ENV_RECALL_BUDGET_FUNCTION = "HINDSIGHT_API_RECALL_BUDGET_FUNCTION"
+ENV_RECALL_BUDGET_FIXED_LOW = "HINDSIGHT_API_RECALL_BUDGET_FIXED_LOW"
+ENV_RECALL_BUDGET_FIXED_MID = "HINDSIGHT_API_RECALL_BUDGET_FIXED_MID"
+ENV_RECALL_BUDGET_FIXED_HIGH = "HINDSIGHT_API_RECALL_BUDGET_FIXED_HIGH"
+ENV_RECALL_BUDGET_ADAPTIVE_LOW = "HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_LOW"
+ENV_RECALL_BUDGET_ADAPTIVE_MID = "HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_MID"
+ENV_RECALL_BUDGET_ADAPTIVE_HIGH = "HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_HIGH"
+ENV_RECALL_BUDGET_MIN = "HINDSIGHT_API_RECALL_BUDGET_MIN"
+ENV_RECALL_BUDGET_MAX = "HINDSIGHT_API_RECALL_BUDGET_MAX"
+
 # Audit log settings
 ENV_AUDIT_LOG_ENABLED = "HINDSIGHT_API_AUDIT_LOG_ENABLED"
 ENV_AUDIT_LOG_ACTIONS = "HINDSIGHT_API_AUDIT_LOG_ACTIONS"
@@ -597,6 +608,22 @@ DEFAULT_RECALL_INCLUDE_CHUNKS = True  # Whether internal recall (e.g. mental mod
 DEFAULT_RECALL_MAX_TOKENS = 2048  # Token budget for facts returned by internal recall
 DEFAULT_RECALL_CHUNKS_MAX_TOKENS = 1000  # Token budget for raw chunks returned by internal recall
 
+# Recall budget mapping
+# "fixed": thinking_budget = recall_budget_fixed_<level> (preserves legacy behavior)
+# "adaptive": thinking_budget = round(max_tokens * recall_budget_adaptive_<level>),
+#             clamped to [recall_budget_min, recall_budget_max]
+RECALL_BUDGET_FUNCTIONS = ("fixed", "adaptive")
+DEFAULT_RECALL_BUDGET_FUNCTION = "fixed"
+DEFAULT_RECALL_BUDGET_FIXED_LOW = 100
+DEFAULT_RECALL_BUDGET_FIXED_MID = 300
+DEFAULT_RECALL_BUDGET_FIXED_HIGH = 1000
+# Adaptive defaults chosen to roughly match fixed defaults at max_tokens=4096
+DEFAULT_RECALL_BUDGET_ADAPTIVE_LOW = 0.025
+DEFAULT_RECALL_BUDGET_ADAPTIVE_MID = 0.075
+DEFAULT_RECALL_BUDGET_ADAPTIVE_HIGH = 0.25
+DEFAULT_RECALL_BUDGET_MIN = 20  # Floor for the adaptive function
+DEFAULT_RECALL_BUDGET_MAX = 2000  # Ceiling for the adaptive function
+
 # Disposition defaults (None = not set, fall back to bank DB value or 3)
 DEFAULT_DISPOSITION_SKEPTICISM = None
 DEFAULT_DISPOSITION_LITERALISM = None
@@ -702,6 +729,18 @@ def _validate_extraction_mode(mode: str) -> str:
         )
         return DEFAULT_RETAIN_EXTRACTION_MODE
     return mode_lower
+
+
+def _validate_recall_budget_function(function: str) -> str:
+    """Validate and normalize recall budget function."""
+    function_lower = function.lower()
+    if function_lower not in RECALL_BUDGET_FUNCTIONS:
+        logger.warning(
+            f"Invalid recall budget function '{function}', must be one of {RECALL_BUDGET_FUNCTIONS}. "
+            f"Defaulting to '{DEFAULT_RECALL_BUDGET_FUNCTION}'."
+        )
+        return DEFAULT_RECALL_BUDGET_FUNCTION
+    return function_lower
 
 
 def _get_default_model_for_provider(provider: str) -> str:
@@ -955,6 +994,20 @@ class HindsightConfig:
     recall_max_tokens: int
     recall_chunks_max_tokens: int
 
+    # Recall budget mapping: how the Budget enum (LOW/MID/HIGH) maps to thinking_budget integer.
+    # function="fixed": use the recall_budget_fixed_* values directly (legacy behavior).
+    # function="adaptive": compute round(max_tokens * recall_budget_adaptive_*),
+    #                      clamped to [recall_budget_min, recall_budget_max].
+    recall_budget_function: str
+    recall_budget_fixed_low: int
+    recall_budget_fixed_mid: int
+    recall_budget_fixed_high: int
+    recall_budget_adaptive_low: float
+    recall_budget_adaptive_mid: float
+    recall_budget_adaptive_high: float
+    recall_budget_min: int
+    recall_budget_max: int
+
     # Disposition settings (hierarchical - can be overridden per bank; None = fall back to DB)
     disposition_skepticism: int | None
     disposition_literalism: int | None
@@ -1072,6 +1125,16 @@ class HindsightConfig:
         "recall_include_chunks",
         "recall_max_tokens",
         "recall_chunks_max_tokens",
+        # Recall budget mapping (Budget enum -> thinking_budget integer)
+        "recall_budget_function",
+        "recall_budget_fixed_low",
+        "recall_budget_fixed_mid",
+        "recall_budget_fixed_high",
+        "recall_budget_adaptive_low",
+        "recall_budget_adaptive_mid",
+        "recall_budget_adaptive_high",
+        "recall_budget_min",
+        "recall_budget_max",
         # Disposition settings
         "disposition_skepticism",
         "disposition_literalism",
@@ -1567,6 +1630,25 @@ class HindsightConfig:
             recall_chunks_max_tokens=int(
                 os.getenv(ENV_RECALL_CHUNKS_MAX_TOKENS, str(DEFAULT_RECALL_CHUNKS_MAX_TOKENS))
             ),
+            recall_budget_function=_validate_recall_budget_function(
+                os.getenv(ENV_RECALL_BUDGET_FUNCTION, DEFAULT_RECALL_BUDGET_FUNCTION)
+            ),
+            recall_budget_fixed_low=int(os.getenv(ENV_RECALL_BUDGET_FIXED_LOW, str(DEFAULT_RECALL_BUDGET_FIXED_LOW))),
+            recall_budget_fixed_mid=int(os.getenv(ENV_RECALL_BUDGET_FIXED_MID, str(DEFAULT_RECALL_BUDGET_FIXED_MID))),
+            recall_budget_fixed_high=int(
+                os.getenv(ENV_RECALL_BUDGET_FIXED_HIGH, str(DEFAULT_RECALL_BUDGET_FIXED_HIGH))
+            ),
+            recall_budget_adaptive_low=float(
+                os.getenv(ENV_RECALL_BUDGET_ADAPTIVE_LOW, str(DEFAULT_RECALL_BUDGET_ADAPTIVE_LOW))
+            ),
+            recall_budget_adaptive_mid=float(
+                os.getenv(ENV_RECALL_BUDGET_ADAPTIVE_MID, str(DEFAULT_RECALL_BUDGET_ADAPTIVE_MID))
+            ),
+            recall_budget_adaptive_high=float(
+                os.getenv(ENV_RECALL_BUDGET_ADAPTIVE_HIGH, str(DEFAULT_RECALL_BUDGET_ADAPTIVE_HIGH))
+            ),
+            recall_budget_min=int(os.getenv(ENV_RECALL_BUDGET_MIN, str(DEFAULT_RECALL_BUDGET_MIN))),
+            recall_budget_max=int(os.getenv(ENV_RECALL_BUDGET_MAX, str(DEFAULT_RECALL_BUDGET_MAX))),
             # Disposition settings (None = fall back to DB value)
             disposition_skepticism=int(os.getenv(ENV_DISPOSITION_SKEPTICISM))
             if os.getenv(ENV_DISPOSITION_SKEPTICISM)

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -15,7 +15,12 @@ from typing import Any
 
 import asyncpg
 
-from hindsight_api.config import HindsightConfig, _get_raw_config, normalize_config_dict
+from hindsight_api.config import (
+    RECALL_BUDGET_FUNCTIONS,
+    HindsightConfig,
+    _get_raw_config,
+    normalize_config_dict,
+)
 from hindsight_api.engine.memory_engine import fq_table
 from hindsight_api.extensions.tenant import TenantExtension
 from hindsight_api.models import RequestContext
@@ -256,6 +261,9 @@ class ConfigResolver:
                     "Strategy names must not be empty strings. Remove entries with empty names before saving."
                 )
 
+        # Validate recall budget fields
+        _validate_recall_budget_updates(normalized_updates)
+
         # Merge with existing config (JSONB || operator)
         async with self.pool.acquire() as conn:
             await conn.execute(
@@ -290,6 +298,53 @@ class ConfigResolver:
             )
 
         logger.info(f"Reset bank config for {bank_id} to defaults")
+
+
+_RECALL_BUDGET_FIXED_KEYS = (
+    "recall_budget_fixed_low",
+    "recall_budget_fixed_mid",
+    "recall_budget_fixed_high",
+)
+_RECALL_BUDGET_ADAPTIVE_KEYS = (
+    "recall_budget_adaptive_low",
+    "recall_budget_adaptive_mid",
+    "recall_budget_adaptive_high",
+)
+
+
+def _validate_recall_budget_updates(updates: dict[str, Any]) -> None:
+    """Validate recall budget config updates. Raises ValueError on invalid input."""
+    if "recall_budget_function" in updates:
+        function = updates["recall_budget_function"]
+        if not isinstance(function, str) or function.lower() not in RECALL_BUDGET_FUNCTIONS:
+            raise ValueError(
+                f"recall_budget_function must be one of {sorted(RECALL_BUDGET_FUNCTIONS)}, got {function!r}"
+            )
+
+    for key in _RECALL_BUDGET_FIXED_KEYS:
+        if key in updates:
+            value = updates[key]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{key} must be a positive integer, got {value!r}")
+
+    for key in _RECALL_BUDGET_ADAPTIVE_KEYS:
+        if key in updates:
+            value = updates[key]
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+                raise ValueError(f"{key} must be a positive number, got {value!r}")
+
+    for key in ("recall_budget_min", "recall_budget_max"):
+        if key in updates:
+            value = updates[key]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{key} must be a positive integer, got {value!r}")
+
+    if "recall_budget_min" in updates and "recall_budget_max" in updates:
+        if updates["recall_budget_min"] > updates["recall_budget_max"]:
+            raise ValueError(
+                f"recall_budget_min ({updates['recall_budget_min']}) must be <= "
+                f"recall_budget_max ({updates['recall_budget_max']})"
+            )
 
 
 def apply_strategy(config: HindsightConfig, strategy_name: str) -> HindsightConfig:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -212,6 +212,39 @@ class Budget(str, Enum):
     HIGH = "high"
 
 
+def _resolve_thinking_budget(config_dict: dict, budget: "Budget | None", max_tokens: int) -> int:
+    """
+    Map a Budget enum level to the integer thinking_budget passed to retrieval.
+
+    Reads the bank-resolved config to decide between two functions:
+    - "fixed": returns recall_budget_fixed_<level> directly (legacy default).
+    - "adaptive": returns round(max_tokens * recall_budget_adaptive_<level>),
+                  clamped to [recall_budget_min, recall_budget_max].
+
+    A None budget falls back to MID (preserves legacy default).
+    """
+    effective_budget = budget if budget is not None else Budget.MID
+    function = config_dict.get("recall_budget_function", "fixed")
+
+    if function == "adaptive":
+        ratios = {
+            Budget.LOW: config_dict.get("recall_budget_adaptive_low", 0.025),
+            Budget.MID: config_dict.get("recall_budget_adaptive_mid", 0.075),
+            Budget.HIGH: config_dict.get("recall_budget_adaptive_high", 0.25),
+        }
+        raw = round(max_tokens * float(ratios[effective_budget]))
+        floor = int(config_dict.get("recall_budget_min", 20))
+        ceiling = int(config_dict.get("recall_budget_max", 2000))
+        return max(floor, min(ceiling, raw))
+
+    fixed = {
+        Budget.LOW: config_dict.get("recall_budget_fixed_low", 100),
+        Budget.MID: config_dict.get("recall_budget_fixed_mid", 300),
+        Budget.HIGH: config_dict.get("recall_budget_fixed_high", 1000),
+    }
+    return int(fixed[effective_budget])
+
+
 def utcnow():
     """Get current UTC time with timezone info."""
     return datetime.now(UTC)
@@ -2604,10 +2637,11 @@ class MemoryEngine(MemoryEngineInterface):
                 if result.tag_groups is not None:
                     tag_groups = result.tag_groups
 
-        # Map budget enum to thinking_budget number (default to MID if None)
-        budget_mapping = {Budget.LOW: 100, Budget.MID: 300, Budget.HIGH: 1000}
-        effective_budget = budget if budget is not None else Budget.MID
-        thinking_budget = budget_mapping[effective_budget]
+        # Map budget enum to thinking_budget number using bank-resolved config.
+        # Function "fixed" preserves legacy {LOW: 100, MID: 300, HIGH: 1000}; function "adaptive"
+        # derives from max_tokens and clamps to [recall_budget_min, recall_budget_max].
+        budget_config_dict = await self._config_resolver.get_bank_config(bank_id, request_context)
+        thinking_budget = _resolve_thinking_budget(budget_config_dict, budget, max_tokens)
 
         # Log recall start with tags if present (skip if quiet mode for internal operations)
         if not _quiet:

--- a/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
+++ b/hindsight-api-slim/tests/test_bank_template_configurable_fields.py
@@ -40,6 +40,15 @@ NEW_FIELDS: list[tuple[str, object]] = [
     ("max_observations_per_scope", 13),
     ("reflect_source_facts_max_tokens", 4096),
     ("llm_gemini_safety_settings", [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]),
+    ("recall_budget_function", "adaptive"),
+    ("recall_budget_fixed_low", 50),
+    ("recall_budget_fixed_mid", 250),
+    ("recall_budget_fixed_high", 800),
+    ("recall_budget_adaptive_low", 0.05),
+    ("recall_budget_adaptive_mid", 0.1),
+    ("recall_budget_adaptive_high", 0.4),
+    ("recall_budget_min", 30),
+    ("recall_budget_max", 1500),
 ]
 
 

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -98,7 +98,7 @@ async def test_hierarchical_fields_categorization():
     assert "retain_chunk_batch_size" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 25
+    assert len(configurable) == 34
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -458,7 +458,7 @@ async def test_config_get_bank_config_no_static_or_credential_fields_leak(memory
             assert field in config, f"Expected configurable field '{field}' missing from config"
 
         # Should have a small number of configurable fields (not hundreds)
-        assert len(config) < 30, f"Too many fields returned: {len(config)}"
+        assert len(config) < 50, f"Too many fields returned: {len(config)}"
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_recall_budget_config.py
+++ b/hindsight-api-slim/tests/test_recall_budget_config.py
@@ -1,0 +1,254 @@
+"""
+Tests for the configurable recall-budget mapping (Budget enum -> thinking_budget int).
+
+Two functions are supported:
+- "fixed": returns the recall_budget_fixed_<level> integer directly (legacy default).
+- "adaptive": returns round(max_tokens * recall_budget_adaptive_<level>),
+              clamped to [recall_budget_min, recall_budget_max].
+
+Both the function selector and the per-level numbers are hierarchical config
+fields (global env -> tenant -> bank), so they can be overridden per bank.
+"""
+
+import dataclasses
+
+import pytest
+
+from hindsight_api.config import (
+    DEFAULT_RECALL_BUDGET_ADAPTIVE_HIGH,
+    DEFAULT_RECALL_BUDGET_ADAPTIVE_LOW,
+    DEFAULT_RECALL_BUDGET_ADAPTIVE_MID,
+    DEFAULT_RECALL_BUDGET_FIXED_HIGH,
+    DEFAULT_RECALL_BUDGET_FIXED_LOW,
+    DEFAULT_RECALL_BUDGET_FIXED_MID,
+    DEFAULT_RECALL_BUDGET_MAX,
+    DEFAULT_RECALL_BUDGET_MIN,
+    DEFAULT_RECALL_BUDGET_FUNCTION,
+    ENV_RECALL_BUDGET_ADAPTIVE_LOW,
+    ENV_RECALL_BUDGET_ADAPTIVE_MID,
+    ENV_RECALL_BUDGET_FIXED_HIGH,
+    ENV_RECALL_BUDGET_FIXED_LOW,
+    ENV_RECALL_BUDGET_FIXED_MID,
+    ENV_RECALL_BUDGET_MAX,
+    ENV_RECALL_BUDGET_MIN,
+    ENV_RECALL_BUDGET_FUNCTION,
+    RECALL_BUDGET_FUNCTIONS,
+    HindsightConfig,
+)
+from hindsight_api.config_resolver import _validate_recall_budget_updates
+from hindsight_api.engine.memory_engine import Budget, _resolve_thinking_budget
+
+
+_BUDGET_FIELD_NAMES = (
+    "recall_budget_function",
+    "recall_budget_fixed_low",
+    "recall_budget_fixed_mid",
+    "recall_budget_fixed_high",
+    "recall_budget_adaptive_low",
+    "recall_budget_adaptive_mid",
+    "recall_budget_adaptive_high",
+    "recall_budget_min",
+    "recall_budget_max",
+)
+
+
+class TestBudgetConfigFields:
+    def test_fields_exist_on_dataclass(self):
+        names = {f.name for f in dataclasses.fields(HindsightConfig)}
+        for field_name in _BUDGET_FIELD_NAMES:
+            assert field_name in names, f"Missing dataclass field: {field_name}"
+
+    def test_fields_are_configurable(self):
+        configurable = HindsightConfig.get_configurable_fields()
+        for field_name in _BUDGET_FIELD_NAMES:
+            assert field_name in configurable, f"Field not in _CONFIGURABLE_FIELDS: {field_name}"
+
+    def test_default_function_is_fixed_for_backwards_compat(self):
+        # The whole point of function="fixed" being default is to preserve legacy behavior.
+        assert DEFAULT_RECALL_BUDGET_FUNCTION == "fixed"
+        assert "fixed" in RECALL_BUDGET_FUNCTIONS
+        assert "adaptive" in RECALL_BUDGET_FUNCTIONS
+
+    def test_default_fixed_values_match_legacy_hardcoded_mapping(self):
+        # These are the values that used to live in the hardcoded budget_mapping dict.
+        assert DEFAULT_RECALL_BUDGET_FIXED_LOW == 100
+        assert DEFAULT_RECALL_BUDGET_FIXED_MID == 300
+        assert DEFAULT_RECALL_BUDGET_FIXED_HIGH == 1000
+
+    def test_default_adaptive_clamps_are_sane(self):
+        assert DEFAULT_RECALL_BUDGET_MIN >= 1
+        assert DEFAULT_RECALL_BUDGET_MAX > DEFAULT_RECALL_BUDGET_MIN
+
+    def test_env_var_constants(self):
+        assert ENV_RECALL_BUDGET_FUNCTION == "HINDSIGHT_API_RECALL_BUDGET_FUNCTION"
+        assert ENV_RECALL_BUDGET_FIXED_LOW == "HINDSIGHT_API_RECALL_BUDGET_FIXED_LOW"
+        assert ENV_RECALL_BUDGET_FIXED_MID == "HINDSIGHT_API_RECALL_BUDGET_FIXED_MID"
+        assert ENV_RECALL_BUDGET_FIXED_HIGH == "HINDSIGHT_API_RECALL_BUDGET_FIXED_HIGH"
+        assert ENV_RECALL_BUDGET_ADAPTIVE_LOW == "HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_LOW"
+        assert ENV_RECALL_BUDGET_ADAPTIVE_MID == "HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_MID"
+        assert ENV_RECALL_BUDGET_MIN == "HINDSIGHT_API_RECALL_BUDGET_MIN"
+        assert ENV_RECALL_BUDGET_MAX == "HINDSIGHT_API_RECALL_BUDGET_MAX"
+
+    def test_from_env_reads_overrides(self, monkeypatch):
+        monkeypatch.setenv(ENV_RECALL_BUDGET_FUNCTION, "adaptive")
+        monkeypatch.setenv(ENV_RECALL_BUDGET_FIXED_MID, "777")
+        monkeypatch.setenv(ENV_RECALL_BUDGET_ADAPTIVE_MID, "0.5")
+        monkeypatch.setenv(ENV_RECALL_BUDGET_MIN, "5")
+        monkeypatch.setenv(ENV_RECALL_BUDGET_MAX, "9999")
+
+        config = HindsightConfig.from_env()
+        assert config.recall_budget_function == "adaptive"
+        assert config.recall_budget_fixed_mid == 777
+        assert config.recall_budget_adaptive_mid == 0.5
+        assert config.recall_budget_min == 5
+        assert config.recall_budget_max == 9999
+
+    def test_from_env_invalid_function_falls_back_to_default(self, monkeypatch):
+        # Defensive parsing: an invalid env value logs a warning and falls back.
+        monkeypatch.setenv(ENV_RECALL_BUDGET_FUNCTION, "garbage")
+        config = HindsightConfig.from_env()
+        assert config.recall_budget_function == DEFAULT_RECALL_BUDGET_FUNCTION
+
+
+class TestResolveThinkingBudgetFixedFunction:
+    @pytest.fixture
+    def fixed_config(self):
+        return {
+            "recall_budget_function": "fixed",
+            "recall_budget_fixed_low": 100,
+            "recall_budget_fixed_mid": 300,
+            "recall_budget_fixed_high": 1000,
+            "recall_budget_adaptive_low": 0.025,
+            "recall_budget_adaptive_mid": 0.075,
+            "recall_budget_adaptive_high": 0.25,
+            "recall_budget_min": 20,
+            "recall_budget_max": 2000,
+        }
+
+    def test_low_mid_high_match_fixed_values(self, fixed_config):
+        assert _resolve_thinking_budget(fixed_config, Budget.LOW, 4096) == 100
+        assert _resolve_thinking_budget(fixed_config, Budget.MID, 4096) == 300
+        assert _resolve_thinking_budget(fixed_config, Budget.HIGH, 4096) == 1000
+
+    def test_none_budget_defaults_to_mid(self, fixed_config):
+        assert _resolve_thinking_budget(fixed_config, None, 4096) == 300
+
+    def test_max_tokens_does_not_affect_fixed_function(self, fixed_config):
+        # Whole point of "fixed": result is independent of max_tokens.
+        assert _resolve_thinking_budget(fixed_config, Budget.MID, 1) == 300
+        assert _resolve_thinking_budget(fixed_config, Budget.MID, 1_000_000) == 300
+
+    def test_per_bank_overrides_take_effect(self, fixed_config):
+        fixed_config["recall_budget_fixed_mid"] = 42
+        assert _resolve_thinking_budget(fixed_config, Budget.MID, 4096) == 42
+
+
+class TestResolveThinkingBudgetAdaptiveFunction:
+    @pytest.fixture
+    def adaptive_config(self):
+        return {
+            "recall_budget_function": "adaptive",
+            "recall_budget_fixed_low": 100,
+            "recall_budget_fixed_mid": 300,
+            "recall_budget_fixed_high": 1000,
+            "recall_budget_adaptive_low": 0.025,
+            "recall_budget_adaptive_mid": 0.075,
+            "recall_budget_adaptive_high": 0.25,
+            "recall_budget_min": 20,
+            "recall_budget_max": 2000,
+        }
+
+    def test_scales_with_max_tokens(self, adaptive_config):
+        # 4096 * 0.075 = 307.2 -> 307
+        assert _resolve_thinking_budget(adaptive_config, Budget.MID, 4096) == 307
+        # 8192 * 0.075 = 614.4 -> 614
+        assert _resolve_thinking_budget(adaptive_config, Budget.MID, 8192) == 614
+
+    def test_clamps_to_floor_when_max_tokens_tiny(self, adaptive_config):
+        # 100 * 0.025 = 2.5 -> 2 -> clamped to floor 20
+        assert _resolve_thinking_budget(adaptive_config, Budget.LOW, 100) == 20
+
+    def test_clamps_to_ceiling_when_max_tokens_huge(self, adaptive_config):
+        # 100_000 * 0.25 = 25_000 -> clamped to ceiling 2000
+        assert _resolve_thinking_budget(adaptive_config, Budget.HIGH, 100_000) == 2000
+
+    def test_none_budget_defaults_to_mid(self, adaptive_config):
+        assert _resolve_thinking_budget(adaptive_config, None, 4096) == 307
+
+    def test_custom_clamps_per_bank(self, adaptive_config):
+        adaptive_config["recall_budget_min"] = 500
+        adaptive_config["recall_budget_max"] = 600
+        # 4096 * 0.075 = 307 -> below floor 500
+        assert _resolve_thinking_budget(adaptive_config, Budget.MID, 4096) == 500
+        # 4096 * 0.25 = 1024 -> above ceiling 600
+        assert _resolve_thinking_budget(adaptive_config, Budget.HIGH, 4096) == 600
+
+
+class TestResolveThinkingBudgetFallbacks:
+    def test_empty_config_uses_legacy_defaults(self):
+        # Resilience: missing keys should not crash; fallback to legacy mapping.
+        assert _resolve_thinking_budget({}, Budget.LOW, 4096) == 100
+        assert _resolve_thinking_budget({}, Budget.MID, 4096) == 300
+        assert _resolve_thinking_budget({}, Budget.HIGH, 4096) == 1000
+
+    def test_unknown_function_falls_back_to_fixed(self):
+        # Defensive: if some bad config slipped past validation, behave like "fixed".
+        assert _resolve_thinking_budget({"recall_budget_function": "garbage"}, Budget.MID, 4096) == 300
+
+
+class TestValidateRecallBudgetUpdates:
+    def test_no_op_passes(self):
+        _validate_recall_budget_updates({})
+        _validate_recall_budget_updates({"unrelated_field": 123})
+
+    def test_valid_function_values(self):
+        _validate_recall_budget_updates({"recall_budget_function": "fixed"})
+        _validate_recall_budget_updates({"recall_budget_function": "adaptive"})
+
+    def test_invalid_function_raises(self):
+        with pytest.raises(ValueError, match="recall_budget_function"):
+            _validate_recall_budget_updates({"recall_budget_function": "wrong"})
+        with pytest.raises(ValueError, match="recall_budget_function"):
+            _validate_recall_budget_updates({"recall_budget_function": 123})
+
+    def test_fixed_must_be_positive_integer(self):
+        for key in ("recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high"):
+            _validate_recall_budget_updates({key: 1})
+            _validate_recall_budget_updates({key: 100_000})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: 0})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: -5})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: 1.5})  # float not allowed for fixed
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: True})  # bool sneaks past int check
+
+    def test_adaptive_must_be_positive_number(self):
+        for key in ("recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high"):
+            _validate_recall_budget_updates({key: 0.001})
+            _validate_recall_budget_updates({key: 1.0})
+            _validate_recall_budget_updates({key: 5})  # int is acceptable as a number
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: 0})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: -0.1})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: True})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: "0.5"})
+
+    def test_min_must_be_le_max_when_both_set(self):
+        _validate_recall_budget_updates({"recall_budget_min": 10, "recall_budget_max": 1000})
+        _validate_recall_budget_updates({"recall_budget_min": 100, "recall_budget_max": 100})
+        with pytest.raises(ValueError, match="recall_budget_min"):
+            _validate_recall_budget_updates({"recall_budget_min": 5000, "recall_budget_max": 100})
+
+    def test_min_max_must_be_positive_integers(self):
+        for key in ("recall_budget_min", "recall_budget_max"):
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: 0})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: -1})
+            with pytest.raises(ValueError, match=key):
+                _validate_recall_budget_updates({key: 1.5})

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3750,6 +3750,33 @@ components:
           items: {}
           nullable: true
           type: array
+        recall_budget_function:
+          nullable: true
+          type: string
+        recall_budget_fixed_low:
+          nullable: true
+          type: integer
+        recall_budget_fixed_mid:
+          nullable: true
+          type: integer
+        recall_budget_fixed_high:
+          nullable: true
+          type: integer
+        recall_budget_adaptive_low:
+          nullable: true
+          type: number
+        recall_budget_adaptive_mid:
+          nullable: true
+          type: number
+        recall_budget_adaptive_high:
+          nullable: true
+          type: number
+        recall_budget_min:
+          nullable: true
+          type: integer
+        recall_budget_max:
+          nullable: true
+          type: integer
       title: BankTemplateConfig
     BankTemplateDirective:
       description: |-

--- a/hindsight-clients/go/model_bank_template_config.go
+++ b/hindsight-clients/go/model_bank_template_config.go
@@ -41,6 +41,15 @@ type BankTemplateConfig struct {
 	MaxObservationsPerScope NullableInt32 `json:"max_observations_per_scope,omitempty"`
 	ReflectSourceFactsMaxTokens NullableInt32 `json:"reflect_source_facts_max_tokens,omitempty"`
 	LlmGeminiSafetySettings []interface{} `json:"llm_gemini_safety_settings,omitempty"`
+	RecallBudgetFunction NullableString `json:"recall_budget_function,omitempty"`
+	RecallBudgetFixedLow NullableInt32 `json:"recall_budget_fixed_low,omitempty"`
+	RecallBudgetFixedMid NullableInt32 `json:"recall_budget_fixed_mid,omitempty"`
+	RecallBudgetFixedHigh NullableInt32 `json:"recall_budget_fixed_high,omitempty"`
+	RecallBudgetAdaptiveLow NullableFloat32 `json:"recall_budget_adaptive_low,omitempty"`
+	RecallBudgetAdaptiveMid NullableFloat32 `json:"recall_budget_adaptive_mid,omitempty"`
+	RecallBudgetAdaptiveHigh NullableFloat32 `json:"recall_budget_adaptive_high,omitempty"`
+	RecallBudgetMin NullableInt32 `json:"recall_budget_min,omitempty"`
+	RecallBudgetMax NullableInt32 `json:"recall_budget_max,omitempty"`
 }
 
 // NewBankTemplateConfig instantiates a new BankTemplateConfig object
@@ -948,6 +957,384 @@ func (o *BankTemplateConfig) SetLlmGeminiSafetySettings(v []interface{}) {
 	o.LlmGeminiSafetySettings = v
 }
 
+// GetRecallBudgetFunction returns the RecallBudgetFunction field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetFunction() string {
+	if o == nil || IsNil(o.RecallBudgetFunction.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.RecallBudgetFunction.Get()
+}
+
+// GetRecallBudgetFunctionOk returns a tuple with the RecallBudgetFunction field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetFunctionOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetFunction.Get(), o.RecallBudgetFunction.IsSet()
+}
+
+// HasRecallBudgetFunction returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetFunction() bool {
+	if o != nil && o.RecallBudgetFunction.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetFunction gets a reference to the given NullableString and assigns it to the RecallBudgetFunction field.
+func (o *BankTemplateConfig) SetRecallBudgetFunction(v string) {
+	o.RecallBudgetFunction.Set(&v)
+}
+// SetRecallBudgetFunctionNil sets the value for RecallBudgetFunction to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetFunctionNil() {
+	o.RecallBudgetFunction.Set(nil)
+}
+
+// UnsetRecallBudgetFunction ensures that no value is present for RecallBudgetFunction, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetFunction() {
+	o.RecallBudgetFunction.Unset()
+}
+
+// GetRecallBudgetFixedLow returns the RecallBudgetFixedLow field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetFixedLow() int32 {
+	if o == nil || IsNil(o.RecallBudgetFixedLow.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallBudgetFixedLow.Get()
+}
+
+// GetRecallBudgetFixedLowOk returns a tuple with the RecallBudgetFixedLow field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetFixedLowOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetFixedLow.Get(), o.RecallBudgetFixedLow.IsSet()
+}
+
+// HasRecallBudgetFixedLow returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetFixedLow() bool {
+	if o != nil && o.RecallBudgetFixedLow.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetFixedLow gets a reference to the given NullableInt32 and assigns it to the RecallBudgetFixedLow field.
+func (o *BankTemplateConfig) SetRecallBudgetFixedLow(v int32) {
+	o.RecallBudgetFixedLow.Set(&v)
+}
+// SetRecallBudgetFixedLowNil sets the value for RecallBudgetFixedLow to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetFixedLowNil() {
+	o.RecallBudgetFixedLow.Set(nil)
+}
+
+// UnsetRecallBudgetFixedLow ensures that no value is present for RecallBudgetFixedLow, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetFixedLow() {
+	o.RecallBudgetFixedLow.Unset()
+}
+
+// GetRecallBudgetFixedMid returns the RecallBudgetFixedMid field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetFixedMid() int32 {
+	if o == nil || IsNil(o.RecallBudgetFixedMid.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallBudgetFixedMid.Get()
+}
+
+// GetRecallBudgetFixedMidOk returns a tuple with the RecallBudgetFixedMid field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetFixedMidOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetFixedMid.Get(), o.RecallBudgetFixedMid.IsSet()
+}
+
+// HasRecallBudgetFixedMid returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetFixedMid() bool {
+	if o != nil && o.RecallBudgetFixedMid.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetFixedMid gets a reference to the given NullableInt32 and assigns it to the RecallBudgetFixedMid field.
+func (o *BankTemplateConfig) SetRecallBudgetFixedMid(v int32) {
+	o.RecallBudgetFixedMid.Set(&v)
+}
+// SetRecallBudgetFixedMidNil sets the value for RecallBudgetFixedMid to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetFixedMidNil() {
+	o.RecallBudgetFixedMid.Set(nil)
+}
+
+// UnsetRecallBudgetFixedMid ensures that no value is present for RecallBudgetFixedMid, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetFixedMid() {
+	o.RecallBudgetFixedMid.Unset()
+}
+
+// GetRecallBudgetFixedHigh returns the RecallBudgetFixedHigh field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetFixedHigh() int32 {
+	if o == nil || IsNil(o.RecallBudgetFixedHigh.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallBudgetFixedHigh.Get()
+}
+
+// GetRecallBudgetFixedHighOk returns a tuple with the RecallBudgetFixedHigh field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetFixedHighOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetFixedHigh.Get(), o.RecallBudgetFixedHigh.IsSet()
+}
+
+// HasRecallBudgetFixedHigh returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetFixedHigh() bool {
+	if o != nil && o.RecallBudgetFixedHigh.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetFixedHigh gets a reference to the given NullableInt32 and assigns it to the RecallBudgetFixedHigh field.
+func (o *BankTemplateConfig) SetRecallBudgetFixedHigh(v int32) {
+	o.RecallBudgetFixedHigh.Set(&v)
+}
+// SetRecallBudgetFixedHighNil sets the value for RecallBudgetFixedHigh to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetFixedHighNil() {
+	o.RecallBudgetFixedHigh.Set(nil)
+}
+
+// UnsetRecallBudgetFixedHigh ensures that no value is present for RecallBudgetFixedHigh, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetFixedHigh() {
+	o.RecallBudgetFixedHigh.Unset()
+}
+
+// GetRecallBudgetAdaptiveLow returns the RecallBudgetAdaptiveLow field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveLow() float32 {
+	if o == nil || IsNil(o.RecallBudgetAdaptiveLow.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.RecallBudgetAdaptiveLow.Get()
+}
+
+// GetRecallBudgetAdaptiveLowOk returns a tuple with the RecallBudgetAdaptiveLow field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveLowOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetAdaptiveLow.Get(), o.RecallBudgetAdaptiveLow.IsSet()
+}
+
+// HasRecallBudgetAdaptiveLow returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetAdaptiveLow() bool {
+	if o != nil && o.RecallBudgetAdaptiveLow.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetAdaptiveLow gets a reference to the given NullableFloat32 and assigns it to the RecallBudgetAdaptiveLow field.
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveLow(v float32) {
+	o.RecallBudgetAdaptiveLow.Set(&v)
+}
+// SetRecallBudgetAdaptiveLowNil sets the value for RecallBudgetAdaptiveLow to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveLowNil() {
+	o.RecallBudgetAdaptiveLow.Set(nil)
+}
+
+// UnsetRecallBudgetAdaptiveLow ensures that no value is present for RecallBudgetAdaptiveLow, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetAdaptiveLow() {
+	o.RecallBudgetAdaptiveLow.Unset()
+}
+
+// GetRecallBudgetAdaptiveMid returns the RecallBudgetAdaptiveMid field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveMid() float32 {
+	if o == nil || IsNil(o.RecallBudgetAdaptiveMid.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.RecallBudgetAdaptiveMid.Get()
+}
+
+// GetRecallBudgetAdaptiveMidOk returns a tuple with the RecallBudgetAdaptiveMid field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveMidOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetAdaptiveMid.Get(), o.RecallBudgetAdaptiveMid.IsSet()
+}
+
+// HasRecallBudgetAdaptiveMid returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetAdaptiveMid() bool {
+	if o != nil && o.RecallBudgetAdaptiveMid.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetAdaptiveMid gets a reference to the given NullableFloat32 and assigns it to the RecallBudgetAdaptiveMid field.
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveMid(v float32) {
+	o.RecallBudgetAdaptiveMid.Set(&v)
+}
+// SetRecallBudgetAdaptiveMidNil sets the value for RecallBudgetAdaptiveMid to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveMidNil() {
+	o.RecallBudgetAdaptiveMid.Set(nil)
+}
+
+// UnsetRecallBudgetAdaptiveMid ensures that no value is present for RecallBudgetAdaptiveMid, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetAdaptiveMid() {
+	o.RecallBudgetAdaptiveMid.Unset()
+}
+
+// GetRecallBudgetAdaptiveHigh returns the RecallBudgetAdaptiveHigh field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveHigh() float32 {
+	if o == nil || IsNil(o.RecallBudgetAdaptiveHigh.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.RecallBudgetAdaptiveHigh.Get()
+}
+
+// GetRecallBudgetAdaptiveHighOk returns a tuple with the RecallBudgetAdaptiveHigh field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetAdaptiveHighOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetAdaptiveHigh.Get(), o.RecallBudgetAdaptiveHigh.IsSet()
+}
+
+// HasRecallBudgetAdaptiveHigh returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetAdaptiveHigh() bool {
+	if o != nil && o.RecallBudgetAdaptiveHigh.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetAdaptiveHigh gets a reference to the given NullableFloat32 and assigns it to the RecallBudgetAdaptiveHigh field.
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveHigh(v float32) {
+	o.RecallBudgetAdaptiveHigh.Set(&v)
+}
+// SetRecallBudgetAdaptiveHighNil sets the value for RecallBudgetAdaptiveHigh to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetAdaptiveHighNil() {
+	o.RecallBudgetAdaptiveHigh.Set(nil)
+}
+
+// UnsetRecallBudgetAdaptiveHigh ensures that no value is present for RecallBudgetAdaptiveHigh, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetAdaptiveHigh() {
+	o.RecallBudgetAdaptiveHigh.Unset()
+}
+
+// GetRecallBudgetMin returns the RecallBudgetMin field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetMin() int32 {
+	if o == nil || IsNil(o.RecallBudgetMin.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallBudgetMin.Get()
+}
+
+// GetRecallBudgetMinOk returns a tuple with the RecallBudgetMin field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetMinOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetMin.Get(), o.RecallBudgetMin.IsSet()
+}
+
+// HasRecallBudgetMin returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetMin() bool {
+	if o != nil && o.RecallBudgetMin.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetMin gets a reference to the given NullableInt32 and assigns it to the RecallBudgetMin field.
+func (o *BankTemplateConfig) SetRecallBudgetMin(v int32) {
+	o.RecallBudgetMin.Set(&v)
+}
+// SetRecallBudgetMinNil sets the value for RecallBudgetMin to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetMinNil() {
+	o.RecallBudgetMin.Set(nil)
+}
+
+// UnsetRecallBudgetMin ensures that no value is present for RecallBudgetMin, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetMin() {
+	o.RecallBudgetMin.Unset()
+}
+
+// GetRecallBudgetMax returns the RecallBudgetMax field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankTemplateConfig) GetRecallBudgetMax() int32 {
+	if o == nil || IsNil(o.RecallBudgetMax.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RecallBudgetMax.Get()
+}
+
+// GetRecallBudgetMaxOk returns a tuple with the RecallBudgetMax field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankTemplateConfig) GetRecallBudgetMaxOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RecallBudgetMax.Get(), o.RecallBudgetMax.IsSet()
+}
+
+// HasRecallBudgetMax returns a boolean if a field has been set.
+func (o *BankTemplateConfig) HasRecallBudgetMax() bool {
+	if o != nil && o.RecallBudgetMax.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRecallBudgetMax gets a reference to the given NullableInt32 and assigns it to the RecallBudgetMax field.
+func (o *BankTemplateConfig) SetRecallBudgetMax(v int32) {
+	o.RecallBudgetMax.Set(&v)
+}
+// SetRecallBudgetMaxNil sets the value for RecallBudgetMax to be an explicit nil
+func (o *BankTemplateConfig) SetRecallBudgetMaxNil() {
+	o.RecallBudgetMax.Set(nil)
+}
+
+// UnsetRecallBudgetMax ensures that no value is present for RecallBudgetMax, not even an explicit nil
+func (o *BankTemplateConfig) UnsetRecallBudgetMax() {
+	o.RecallBudgetMax.Unset()
+}
+
 func (o BankTemplateConfig) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -1023,6 +1410,33 @@ func (o BankTemplateConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if o.LlmGeminiSafetySettings != nil {
 		toSerialize["llm_gemini_safety_settings"] = o.LlmGeminiSafetySettings
+	}
+	if o.RecallBudgetFunction.IsSet() {
+		toSerialize["recall_budget_function"] = o.RecallBudgetFunction.Get()
+	}
+	if o.RecallBudgetFixedLow.IsSet() {
+		toSerialize["recall_budget_fixed_low"] = o.RecallBudgetFixedLow.Get()
+	}
+	if o.RecallBudgetFixedMid.IsSet() {
+		toSerialize["recall_budget_fixed_mid"] = o.RecallBudgetFixedMid.Get()
+	}
+	if o.RecallBudgetFixedHigh.IsSet() {
+		toSerialize["recall_budget_fixed_high"] = o.RecallBudgetFixedHigh.Get()
+	}
+	if o.RecallBudgetAdaptiveLow.IsSet() {
+		toSerialize["recall_budget_adaptive_low"] = o.RecallBudgetAdaptiveLow.Get()
+	}
+	if o.RecallBudgetAdaptiveMid.IsSet() {
+		toSerialize["recall_budget_adaptive_mid"] = o.RecallBudgetAdaptiveMid.Get()
+	}
+	if o.RecallBudgetAdaptiveHigh.IsSet() {
+		toSerialize["recall_budget_adaptive_high"] = o.RecallBudgetAdaptiveHigh.Get()
+	}
+	if o.RecallBudgetMin.IsSet() {
+		toSerialize["recall_budget_min"] = o.RecallBudgetMin.Get()
+	}
+	if o.RecallBudgetMax.IsSet() {
+		toSerialize["recall_budget_max"] = o.RecallBudgetMax.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_template_config.py
@@ -17,8 +17,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
@@ -49,7 +49,16 @@ class BankTemplateConfig(BaseModel):
     max_observations_per_scope: Optional[StrictInt] = None
     reflect_source_facts_max_tokens: Optional[StrictInt] = None
     llm_gemini_safety_settings: Optional[List[Any]] = None
-    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings"]
+    recall_budget_function: Optional[StrictStr] = None
+    recall_budget_fixed_low: Optional[StrictInt] = None
+    recall_budget_fixed_mid: Optional[StrictInt] = None
+    recall_budget_fixed_high: Optional[StrictInt] = None
+    recall_budget_adaptive_low: Optional[Union[StrictFloat, StrictInt]] = None
+    recall_budget_adaptive_mid: Optional[Union[StrictFloat, StrictInt]] = None
+    recall_budget_adaptive_high: Optional[Union[StrictFloat, StrictInt]] = None
+    recall_budget_min: Optional[StrictInt] = None
+    recall_budget_max: Optional[StrictInt] = None
+    __properties: ClassVar[List[str]] = ["reflect_mission", "retain_mission", "retain_extraction_mode", "retain_custom_instructions", "retain_chunk_size", "enable_observations", "observations_mission", "disposition_skepticism", "disposition_literalism", "disposition_empathy", "entity_labels", "entities_allow_free_form", "retain_default_strategy", "retain_strategies", "retain_chunk_batch_size", "mcp_enabled_tools", "consolidation_llm_batch_size", "consolidation_source_facts_max_tokens", "consolidation_source_facts_max_tokens_per_observation", "max_observations_per_scope", "reflect_source_facts_max_tokens", "llm_gemini_safety_settings", "recall_budget_function", "recall_budget_fixed_low", "recall_budget_fixed_mid", "recall_budget_fixed_high", "recall_budget_adaptive_low", "recall_budget_adaptive_mid", "recall_budget_adaptive_high", "recall_budget_min", "recall_budget_max"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -200,6 +209,51 @@ class BankTemplateConfig(BaseModel):
         if self.llm_gemini_safety_settings is None and "llm_gemini_safety_settings" in self.model_fields_set:
             _dict['llm_gemini_safety_settings'] = None
 
+        # set to None if recall_budget_function (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_function is None and "recall_budget_function" in self.model_fields_set:
+            _dict['recall_budget_function'] = None
+
+        # set to None if recall_budget_fixed_low (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_fixed_low is None and "recall_budget_fixed_low" in self.model_fields_set:
+            _dict['recall_budget_fixed_low'] = None
+
+        # set to None if recall_budget_fixed_mid (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_fixed_mid is None and "recall_budget_fixed_mid" in self.model_fields_set:
+            _dict['recall_budget_fixed_mid'] = None
+
+        # set to None if recall_budget_fixed_high (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_fixed_high is None and "recall_budget_fixed_high" in self.model_fields_set:
+            _dict['recall_budget_fixed_high'] = None
+
+        # set to None if recall_budget_adaptive_low (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_adaptive_low is None and "recall_budget_adaptive_low" in self.model_fields_set:
+            _dict['recall_budget_adaptive_low'] = None
+
+        # set to None if recall_budget_adaptive_mid (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_adaptive_mid is None and "recall_budget_adaptive_mid" in self.model_fields_set:
+            _dict['recall_budget_adaptive_mid'] = None
+
+        # set to None if recall_budget_adaptive_high (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_adaptive_high is None and "recall_budget_adaptive_high" in self.model_fields_set:
+            _dict['recall_budget_adaptive_high'] = None
+
+        # set to None if recall_budget_min (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_min is None and "recall_budget_min" in self.model_fields_set:
+            _dict['recall_budget_min'] = None
+
+        # set to None if recall_budget_max (nullable) is None
+        # and model_fields_set contains the field
+        if self.recall_budget_max is None and "recall_budget_max" in self.model_fields_set:
+            _dict['recall_budget_max'] = None
+
         return _dict
 
     @classmethod
@@ -233,7 +287,16 @@ class BankTemplateConfig(BaseModel):
             "consolidation_source_facts_max_tokens_per_observation": obj.get("consolidation_source_facts_max_tokens_per_observation"),
             "max_observations_per_scope": obj.get("max_observations_per_scope"),
             "reflect_source_facts_max_tokens": obj.get("reflect_source_facts_max_tokens"),
-            "llm_gemini_safety_settings": obj.get("llm_gemini_safety_settings")
+            "llm_gemini_safety_settings": obj.get("llm_gemini_safety_settings"),
+            "recall_budget_function": obj.get("recall_budget_function"),
+            "recall_budget_fixed_low": obj.get("recall_budget_fixed_low"),
+            "recall_budget_fixed_mid": obj.get("recall_budget_fixed_mid"),
+            "recall_budget_fixed_high": obj.get("recall_budget_fixed_high"),
+            "recall_budget_adaptive_low": obj.get("recall_budget_adaptive_low"),
+            "recall_budget_adaptive_mid": obj.get("recall_budget_adaptive_mid"),
+            "recall_budget_adaptive_high": obj.get("recall_budget_adaptive_high"),
+            "recall_budget_min": obj.get("recall_budget_min"),
+            "recall_budget_max": obj.get("recall_budget_max")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -544,6 +544,60 @@ export type BankTemplateConfig = {
    * Per-bank Gemini/VertexAI safety filter settings
    */
   llm_gemini_safety_settings?: Array<unknown> | null;
+  /**
+   * Recall Budget Function
+   *
+   * Recall budget mapping function: 'fixed' or 'adaptive'
+   */
+  recall_budget_function?: string | null;
+  /**
+   * Recall Budget Fixed Low
+   *
+   * Fixed thinking_budget for budget=low (function='fixed')
+   */
+  recall_budget_fixed_low?: number | null;
+  /**
+   * Recall Budget Fixed Mid
+   *
+   * Fixed thinking_budget for budget=mid (function='fixed')
+   */
+  recall_budget_fixed_mid?: number | null;
+  /**
+   * Recall Budget Fixed High
+   *
+   * Fixed thinking_budget for budget=high (function='fixed')
+   */
+  recall_budget_fixed_high?: number | null;
+  /**
+   * Recall Budget Adaptive Low
+   *
+   * Ratio of max_tokens for budget=low (function='adaptive')
+   */
+  recall_budget_adaptive_low?: number | null;
+  /**
+   * Recall Budget Adaptive Mid
+   *
+   * Ratio of max_tokens for budget=mid (function='adaptive')
+   */
+  recall_budget_adaptive_mid?: number | null;
+  /**
+   * Recall Budget Adaptive High
+   *
+   * Ratio of max_tokens for budget=high (function='adaptive')
+   */
+  recall_budget_adaptive_high?: number | null;
+  /**
+   * Recall Budget Min
+   *
+   * Floor for the adaptive function (after clamping)
+   */
+  recall_budget_min?: number | null;
+  /**
+   * Recall Budget Max
+   *
+   * Ceiling for the adaptive function (after clamping)
+   */
+  recall_budget_max?: number | null;
 };
 
 /**

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -269,6 +269,40 @@ Controls content filtering thresholds for Gemini and VertexAI providers. Accepts
 
 Only applies when `HINDSIGHT_API_LLM_PROVIDER` is `gemini` or `vertexai`.
 
+### recall_budget_function {#recall-budget-configuration}
+
+Selects how the [`recall` request's `budget` parameter](./recall) (`low` / `mid` / `high`) maps to the internal `thinking_budget` integer used by every retrieval method (semantic, BM25, graph, temporal). Two functions are supported:
+
+| Function | Behaviour |
+|----------|-----------|
+| `fixed` *(default)* | `thinking_budget = recall_budget_fixed_<level>` — independent of `max_tokens`. Preserves legacy behavior. |
+| `adaptive` | `thinking_budget = round(max_tokens * recall_budget_adaptive_<level>)`, clamped to `[recall_budget_min, recall_budget_max]`. Retrieval breadth scales with the requested output size. |
+
+```json
+{
+  "recall_budget_function": "adaptive",
+  "recall_budget_adaptive_low": 0.05,
+  "recall_budget_adaptive_mid": 0.1,
+  "recall_budget_adaptive_high": 0.3,
+  "recall_budget_min": 30,
+  "recall_budget_max": 1500
+}
+```
+
+### recall_budget_fixed_low / recall_budget_fixed_mid / recall_budget_fixed_high
+
+When `recall_budget_function` is `fixed` (the default), these positive integers are used directly as the per-method retrieval limit for each `budget` level. Defaults: `100` / `300` / `1000` — exactly matching the legacy hardcoded mapping.
+
+### recall_budget_adaptive_low / recall_budget_adaptive_mid / recall_budget_adaptive_high
+
+When `recall_budget_function` is `adaptive`, these positive ratios multiply the request's `max_tokens` to derive the per-method retrieval limit. Defaults: `0.025` / `0.075` / `0.25` — chosen to roughly match the fixed defaults at `max_tokens = 4096`.
+
+### recall_budget_min / recall_budget_max
+
+Floor and ceiling applied to the result of the adaptive function (after the ratio multiplication). Both must be positive integers and `min ≤ max`. Defaults: `20` / `2000`.
+
+See [Recall budget mapping](/developer/configuration#recall-budget-mapping) for environment variable names and full defaults.
+
 ---
 
 ## Updating Configuration

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -707,6 +707,27 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 
 - **`link_expansion`** (default): Fast graph expansion from semantic seeds via entity co-occurrence, semantic kNN, and causal links. Target latency under 100ms.
 
+#### Recall budget mapping
+
+The recall request takes a `budget` parameter (`low` / `mid` / `high`, default `mid`) that maps to an integer `thinking_budget` used by every retrieval method (semantic, BM25, graph, temporal). These knobs control that mapping. They are hierarchical — overridable per bank via the [config API](#hierarchical-configuration).
+
+Two functions are available:
+
+- **`fixed`** (default — preserves legacy behavior): `thinking_budget = recall_budget_fixed_<level>` (independent of `max_tokens`).
+- **`adaptive`**: `thinking_budget = round(max_tokens * recall_budget_adaptive_<level>)`, clamped to `[recall_budget_min, recall_budget_max]`. Useful when callers vary `max_tokens` and you want retrieval breadth to scale with the requested output size.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RECALL_BUDGET_FUNCTION` | Mapping function: `fixed` or `adaptive`. | `fixed` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_LOW` | Items per retrieval method per fact type when `budget=low` and function is `fixed`. | `100` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_MID` | Items per retrieval method per fact type when `budget=mid` and function is `fixed`. | `300` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_HIGH` | Items per retrieval method per fact type when `budget=high` and function is `fixed`. | `1000` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_LOW` | Ratio of request `max_tokens` used when `budget=low` and function is `adaptive`. | `0.025` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_MID` | Ratio of request `max_tokens` used when `budget=mid` and function is `adaptive`. | `0.075` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_HIGH` | Ratio of request `max_tokens` used when `budget=high` and function is `adaptive`. | `0.25` |
+| `HINDSIGHT_API_RECALL_BUDGET_MIN` | Floor for the adaptive function (after clamping). | `20` |
+| `HINDSIGHT_API_RECALL_BUDGET_MAX` | Ceiling for the adaptive function (after clamping). | `2000` |
+
 ### Retain
 
 Controls the retain (memory ingestion) pipeline.

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -303,6 +303,123 @@
           "default": null,
           "description": "Per-bank Gemini/VertexAI safety filter settings",
           "title": "Llm Gemini Safety Settings"
+        },
+        "recall_budget_function": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recall budget mapping function: 'fixed' or 'adaptive'",
+          "title": "Recall Budget Function"
+        },
+        "recall_budget_fixed_low": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Fixed thinking_budget for budget=low (function='fixed')",
+          "title": "Recall Budget Fixed Low"
+        },
+        "recall_budget_fixed_mid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Fixed thinking_budget for budget=mid (function='fixed')",
+          "title": "Recall Budget Fixed Mid"
+        },
+        "recall_budget_fixed_high": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Fixed thinking_budget for budget=high (function='fixed')",
+          "title": "Recall Budget Fixed High"
+        },
+        "recall_budget_adaptive_low": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ratio of max_tokens for budget=low (function='adaptive')",
+          "title": "Recall Budget Adaptive Low"
+        },
+        "recall_budget_adaptive_mid": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ratio of max_tokens for budget=mid (function='adaptive')",
+          "title": "Recall Budget Adaptive Mid"
+        },
+        "recall_budget_adaptive_high": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ratio of max_tokens for budget=high (function='adaptive')",
+          "title": "Recall Budget Adaptive High"
+        },
+        "recall_budget_min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Floor for the adaptive function (after clamping)",
+          "title": "Recall Budget Min"
+        },
+        "recall_budget_max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ceiling for the adaptive function (after clamping)",
+          "title": "Recall Budget Max"
         }
       },
       "title": "BankTemplateConfig",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -5618,6 +5618,114 @@
             ],
             "title": "Llm Gemini Safety Settings",
             "description": "Per-bank Gemini/VertexAI safety filter settings"
+          },
+          "recall_budget_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Function",
+            "description": "Recall budget mapping function: 'fixed' or 'adaptive'"
+          },
+          "recall_budget_fixed_low": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed Low",
+            "description": "Fixed thinking_budget for budget=low (function='fixed')"
+          },
+          "recall_budget_fixed_mid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed Mid",
+            "description": "Fixed thinking_budget for budget=mid (function='fixed')"
+          },
+          "recall_budget_fixed_high": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed High",
+            "description": "Fixed thinking_budget for budget=high (function='fixed')"
+          },
+          "recall_budget_adaptive_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive Low",
+            "description": "Ratio of max_tokens for budget=low (function='adaptive')"
+          },
+          "recall_budget_adaptive_mid": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive Mid",
+            "description": "Ratio of max_tokens for budget=mid (function='adaptive')"
+          },
+          "recall_budget_adaptive_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive High",
+            "description": "Ratio of max_tokens for budget=high (function='adaptive')"
+          },
+          "recall_budget_min": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Min",
+            "description": "Floor for the adaptive function (after clamping)"
+          },
+          "recall_budget_max": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Max",
+            "description": "Ceiling for the adaptive function (after clamping)"
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -287,6 +287,40 @@ Controls content filtering thresholds for Gemini and VertexAI providers. Accepts
 
 Only applies when `HINDSIGHT_API_LLM_PROVIDER` is `gemini` or `vertexai`.
 
+### recall_budget_function {#recall-budget-configuration}
+
+Selects how the [`recall` request's `budget` parameter](./recall) (`low` / `mid` / `high`) maps to the internal `thinking_budget` integer used by every retrieval method (semantic, BM25, graph, temporal). Two functions are supported:
+
+| Function | Behaviour |
+|----------|-----------|
+| `fixed` *(default)* | `thinking_budget = recall_budget_fixed_<level>` — independent of `max_tokens`. Preserves legacy behavior. |
+| `adaptive` | `thinking_budget = round(max_tokens * recall_budget_adaptive_<level>)`, clamped to `[recall_budget_min, recall_budget_max]`. Retrieval breadth scales with the requested output size. |
+
+```json
+{
+  "recall_budget_function": "adaptive",
+  "recall_budget_adaptive_low": 0.05,
+  "recall_budget_adaptive_mid": 0.1,
+  "recall_budget_adaptive_high": 0.3,
+  "recall_budget_min": 30,
+  "recall_budget_max": 1500
+}
+```
+
+### recall_budget_fixed_low / recall_budget_fixed_mid / recall_budget_fixed_high
+
+When `recall_budget_function` is `fixed` (the default), these positive integers are used directly as the per-method retrieval limit for each `budget` level. Defaults: `100` / `300` / `1000` — exactly matching the legacy hardcoded mapping.
+
+### recall_budget_adaptive_low / recall_budget_adaptive_mid / recall_budget_adaptive_high
+
+When `recall_budget_function` is `adaptive`, these positive ratios multiply the request's `max_tokens` to derive the per-method retrieval limit. Defaults: `0.025` / `0.075` / `0.25` — chosen to roughly match the fixed defaults at `max_tokens = 4096`.
+
+### recall_budget_min / recall_budget_max
+
+Floor and ceiling applied to the result of the adaptive function (after the ratio multiplication). Both must be positive integers and `min ≤ max`. Defaults: `20` / `2000`.
+
+See [Recall budget mapping](../configuration.md#recall-budget-mapping) for environment variable names and full defaults.
+
 ---
 
 ## Updating Configuration

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -707,6 +707,27 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 
 - **`link_expansion`** (default): Fast graph expansion from semantic seeds via entity co-occurrence, semantic kNN, and causal links. Target latency under 100ms.
 
+#### Recall budget mapping
+
+The recall request takes a `budget` parameter (`low` / `mid` / `high`, default `mid`) that maps to an integer `thinking_budget` used by every retrieval method (semantic, BM25, graph, temporal). These knobs control that mapping. They are hierarchical — overridable per bank via the [config API](#hierarchical-configuration).
+
+Two functions are available:
+
+- **`fixed`** (default — preserves legacy behavior): `thinking_budget = recall_budget_fixed_<level>` (independent of `max_tokens`).
+- **`adaptive`**: `thinking_budget = round(max_tokens * recall_budget_adaptive_<level>)`, clamped to `[recall_budget_min, recall_budget_max]`. Useful when callers vary `max_tokens` and you want retrieval breadth to scale with the requested output size.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_RECALL_BUDGET_FUNCTION` | Mapping function: `fixed` or `adaptive`. | `fixed` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_LOW` | Items per retrieval method per fact type when `budget=low` and function is `fixed`. | `100` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_MID` | Items per retrieval method per fact type when `budget=mid` and function is `fixed`. | `300` |
+| `HINDSIGHT_API_RECALL_BUDGET_FIXED_HIGH` | Items per retrieval method per fact type when `budget=high` and function is `fixed`. | `1000` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_LOW` | Ratio of request `max_tokens` used when `budget=low` and function is `adaptive`. | `0.025` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_MID` | Ratio of request `max_tokens` used when `budget=mid` and function is `adaptive`. | `0.075` |
+| `HINDSIGHT_API_RECALL_BUDGET_ADAPTIVE_HIGH` | Ratio of request `max_tokens` used when `budget=high` and function is `adaptive`. | `0.25` |
+| `HINDSIGHT_API_RECALL_BUDGET_MIN` | Floor for the adaptive function (after clamping). | `20` |
+| `HINDSIGHT_API_RECALL_BUDGET_MAX` | Ceiling for the adaptive function (after clamping). | `2000` |
+
 ### Retain
 
 Controls the retain (memory ingestion) pipeline.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -5618,6 +5618,114 @@
             ],
             "title": "Llm Gemini Safety Settings",
             "description": "Per-bank Gemini/VertexAI safety filter settings"
+          },
+          "recall_budget_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Function",
+            "description": "Recall budget mapping function: 'fixed' or 'adaptive'"
+          },
+          "recall_budget_fixed_low": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed Low",
+            "description": "Fixed thinking_budget for budget=low (function='fixed')"
+          },
+          "recall_budget_fixed_mid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed Mid",
+            "description": "Fixed thinking_budget for budget=mid (function='fixed')"
+          },
+          "recall_budget_fixed_high": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Fixed High",
+            "description": "Fixed thinking_budget for budget=high (function='fixed')"
+          },
+          "recall_budget_adaptive_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive Low",
+            "description": "Ratio of max_tokens for budget=low (function='adaptive')"
+          },
+          "recall_budget_adaptive_mid": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive Mid",
+            "description": "Ratio of max_tokens for budget=mid (function='adaptive')"
+          },
+          "recall_budget_adaptive_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Adaptive High",
+            "description": "Ratio of max_tokens for budget=high (function='adaptive')"
+          },
+          "recall_budget_min": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Min",
+            "description": "Floor for the adaptive function (after clamping)"
+          },
+          "recall_budget_max": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recall Budget Max",
+            "description": "Ceiling for the adaptive function (after clamping)"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

The recall `Budget` enum (`low` / `mid` / `high`) used to map to hardcoded `thinking_budget` values (`100` / `300` / `1000`) regardless of the request's `max_tokens`. This PR makes the mapping a configurable function with two implementations, both overridable per bank.

- **`fixed`** (default — preserves legacy behavior): per-level integer read from `recall_budget_fixed_<level>`.
- **`adaptive`**: `round(max_tokens * recall_budget_adaptive_<level>)`, clamped to `[recall_budget_min, recall_budget_max]` so retrieval breadth scales with the requested output size.

All 9 knobs are hierarchical config fields — set via env (`HINDSIGHT_API_RECALL_BUDGET_*`) and overridable per bank through the existing bank-config API.

| Field | Default |
|-------|---------|
| `recall_budget_function` | `fixed` |
| `recall_budget_fixed_low` / `mid` / `high` | `100` / `300` / `1000` |
| `recall_budget_adaptive_low` / `mid` / `high` | `0.025` / `0.075` / `0.25` |
| `recall_budget_min` / `max` | `20` / `2000` |

`ConfigResolver.update_bank_config` rejects unknown functions, non-positive values, and `min > max`.

## Test plan

- [x] 26 new unit tests in `tests/test_recall_budget_config.py` covering: field existence + configurability, env-var parsing, both functions across LOW/MID/HIGH, `None` budget falls back to MID, clamping at floor/ceiling, per-bank overrides, fallback when keys are missing, and the validator's error cases.
- [x] Updated `tests/test_hierarchical_config.py:101` configurable-field count (25 → 34).
- [x] `./scripts/hooks/lint.sh` passes.
- [ ] Manual smoke: PATCH `/v1/default/banks/{bank_id}/config` with `{"recall_budget_function": "adaptive", ...}` and verify `thinking_budget` in recall span attributes scales with `max_tokens`.

## Notes

- 100% backwards compatible — defaults exactly reproduce the legacy `{LOW:100, MID:300, HIGH:1000}` mapping at any `max_tokens`.
- One extra DB query per recall (`get_bank_config`) to read the resolved function. Could be threaded through later if it shows up in profiling.