### PR TITLE
test(ollama): regression test for think=false payload flag (#1099)

### DIFF
--- a/hindsight-api-slim/tests/test_ollama_native_think.py
+++ b/hindsight-api-slim/tests/test_ollama_native_think.py
@@ -1,0 +1,97 @@
+"""
+Regression test for PR #1099: Ollama native API must include think=False.
+
+Without this flag, reasoning models (qwen3.5, deepseek-r1, etc.) route their
+entire response to the thinking field, leaving message.content empty and
+breaking structured output (fact extraction, consolidation, etc.).
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+class _SampleOutput(BaseModel):
+    summary: str
+
+
+def _make_ollama_llm(**overrides) -> OpenAICompatibleLLM:
+    defaults = dict(
+        provider="ollama",
+        api_key="",
+        base_url="http://localhost:11434/v1",
+        model="qwen3.5:2b",
+    )
+    defaults.update(overrides)
+    return OpenAICompatibleLLM(**defaults)
+
+
+def _mock_ollama_response(content: dict) -> httpx.Response:
+    body = {
+        "model": "qwen3.5:2b",
+        "message": {"role": "assistant", "content": json.dumps(content)},
+        "done": True,
+    }
+    return httpx.Response(200, json=body)
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_payload_includes_think_false():
+    """think=False must be in every _call_ollama_native payload (PR #1099)."""
+    llm = _make_ollama_llm()
+    captured_payloads: list[dict] = []
+
+    async def _capture_post(url, *, json=None, **kw):
+        captured_payloads.append(json)
+        return _mock_ollama_response({"summary": "test"})
+
+    with patch("httpx.AsyncClient.post", new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post)):
+        await llm._call_ollama_native(
+            messages=[{"role": "user", "content": "hello"}],
+            response_format=_SampleOutput,
+            max_completion_tokens=None,
+            temperature=None,
+            max_retries=0,
+            initial_backoff=1.0,
+            max_backoff=10.0,
+            skip_validation=True,
+        )
+
+    assert len(captured_payloads) == 1
+    payload = captured_payloads[0]
+    assert "think" in payload, "payload must include 'think' key"
+    assert payload["think"] is False, "think must be False to prevent reasoning models routing output to thinking field"
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_think_false_coexists_with_schema():
+    """think=False must be present alongside the format (schema) parameter."""
+    llm = _make_ollama_llm()
+    captured_payloads: list[dict] = []
+
+    async def _capture_post(url, *, json=None, **kw):
+        captured_payloads.append(json)
+        return _mock_ollama_response({"summary": "test"})
+
+    with patch("httpx.AsyncClient.post", new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post)):
+        await llm._call_ollama_native(
+            messages=[{"role": "user", "content": "extract facts"}],
+            response_format=_SampleOutput,
+            max_completion_tokens=512,
+            temperature=0.1,
+            max_retries=0,
+            initial_backoff=1.0,
+            max_backoff=10.0,
+            skip_validation=True,
+        )
+
+    payload = captured_payloads[0]
+    assert payload["think"] is False
+    assert "format" in payload, "schema must be passed as 'format'"
+    assert payload["options"]["num_predict"] == 512
+    assert payload["options"]["temperature"] == 0.1

--- a/hindsight-api-slim/tests/test_ollama_native_think.py
+++ b/hindsight-api-slim/tests/test_ollama_native_think.py
@@ -7,7 +7,7 @@ breaking structured output (fact extraction, consolidation, etc.).
 """
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -40,20 +40,32 @@ def _mock_ollama_response(content: dict) -> httpx.Response:
     return httpx.Response(200, json=body)
 
 
+def _build_mock_client(captured_payloads: list[dict]) -> MagicMock:
+    """Build a mock httpx.AsyncClient that captures post payloads."""
+    mock_post = AsyncMock(side_effect=lambda url, **kw: (
+        captured_payloads.append(kw.get("json")),
+        _mock_ollama_response({"summary": "test"}),
+    )[-1])
+
+    mock_client = AsyncMock()
+    mock_client.post = mock_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
 @pytest.mark.asyncio
-async def test_ollama_native_payload_includes_think_false():
+@pytest.mark.parametrize("response_format", [_SampleOutput, None])
+async def test_ollama_native_payload_includes_think_false(response_format):
     """think=False must be in every _call_ollama_native payload (PR #1099)."""
     llm = _make_ollama_llm()
     captured_payloads: list[dict] = []
+    mock_client = _build_mock_client(captured_payloads)
 
-    async def _capture_post(url, *, json=None, **kw):
-        captured_payloads.append(json)
-        return _mock_ollama_response({"summary": "test"})
-
-    with patch("httpx.AsyncClient.post", new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post)):
+    with patch("httpx.AsyncClient", return_value=mock_client):
         await llm._call_ollama_native(
             messages=[{"role": "user", "content": "hello"}],
-            response_format=_SampleOutput,
+            response_format=response_format,
             max_completion_tokens=None,
             temperature=None,
             max_retries=0,
@@ -69,16 +81,13 @@ async def test_ollama_native_payload_includes_think_false():
 
 
 @pytest.mark.asyncio
-async def test_ollama_native_think_false_coexists_with_schema():
-    """think=False must be present alongside the format (schema) parameter."""
+async def test_ollama_native_think_false_coexists_with_schema_and_options():
+    """think=False must coexist with format, num_predict, and temperature."""
     llm = _make_ollama_llm()
     captured_payloads: list[dict] = []
+    mock_client = _build_mock_client(captured_payloads)
 
-    async def _capture_post(url, *, json=None, **kw):
-        captured_payloads.append(json)
-        return _mock_ollama_response({"summary": "test"})
-
-    with patch("httpx.AsyncClient.post", new_callable=lambda: lambda: AsyncMock(side_effect=_capture_post)):
+    with patch("httpx.AsyncClient", return_value=mock_client):
         await llm._call_ollama_native(
             messages=[{"role": "user", "content": "extract facts"}],
             response_format=_SampleOutput,
@@ -90,6 +99,7 @@ async def test_ollama_native_think_false_coexists_with_schema():
             skip_validation=True,
         )
 
+    assert len(captured_payloads) == 1
     payload = captured_payloads[0]
     assert payload["think"] is False
     assert "format" in payload, "schema must be passed as 'format'"


### PR DESCRIPTION
## Summary

- Add regression tests for PR #1099 (`think: False` in Ollama native API payload)
- Prevents future refactors from silently breaking reasoning model support (qwen3.5, deepseek-r1, etc.)

## What it tests

1. `test_ollama_native_payload_includes_think_false` — parametrized over `response_format=_SampleOutput` and `response_format=None`: asserts `think: False` is present in every `_call_ollama_native()` outbound payload regardless of whether structured output is requested
2. `test_ollama_native_think_false_coexists_with_schema_and_options` — verifies `think: False` coexists correctly with `format` (JSON schema), `num_predict`, and `temperature` options

## Why this matters

Without `think: False`, reasoning models route their entire response to the `thinking` field, leaving `message.content` empty. This silently breaks fact extraction, consolidation, and all structured output for Ollama reasoning models.

## Zero production code changes

Pure test addition (3 tests, ~95 LOC). No behavior change.

Fixes #1111