### PR TITLE
fix(jina-mlx): serialize Metal GPU ops to prevent SIGSEGV on concurrent reranker calls

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1282,6 +1282,7 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
     def _load_model(self) -> None:
         """Download (if needed) and load the MLX reranker. Runs in a thread."""
         import os
+        import threading
 
         from huggingface_hub import snapshot_download
 
@@ -1297,6 +1298,10 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
             model_path=model_path,
             projector_path=os.path.join(model_path, "projector.safetensors"),
         )
+        # MLX Metal GPU ops are not thread-safe — concurrent calls to
+        # Device::end_encoding() crash with SIGSEGV (NULL deref).
+        # Serialize all reranker inference through this lock.
+        self._mlx_lock = threading.Lock()
         logger.info("Reranker: jina-mlx provider initialized")
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
@@ -1310,13 +1315,14 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
 
         all_scores = [0.0] * len(pairs)
 
-        for query, indexed_docs in query_groups.items():
-            docs = [doc for _, doc in indexed_docs]
-            indices = [idx for idx, _ in indexed_docs]
-            results = self._reranker.rerank(query, docs)
-            for result in results:
-                original_idx = result["index"]
-                all_scores[indices[original_idx]] = result["relevance_score"]
+        with self._mlx_lock:
+            for query, indexed_docs in query_groups.items():
+                docs = [doc for _, doc in indexed_docs]
+                indices = [idx for idx, _ in indexed_docs]
+                results = self._reranker.rerank(query, docs)
+                for result in results:
+                    original_idx = result["index"]
+                    all_scores[indices[original_idx]] = result["relevance_score"]
 
         return all_scores
 


### PR DESCRIPTION
## Summary

- Add a `threading.Lock` to `JinaMLXCrossEncoder._predict_sync()` to serialize MLX Metal GPU operations, preventing SIGSEGV crashes when the reranker is called concurrently from multiple threads.

## Problem

When consolidation and recall trigger the jina-mlx reranker concurrently (both dispatched via `run_in_executor`), two threads race on `mlx::core::metal::Device::end_encoding()`, causing a NULL pointer dereference:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Subtype:         KERN_INVALID_ADDRESS at 0x0000000000000000

Thread 3 (crashed):
  0  libmlx.dylib  mlx::core::metal::Device::end_encoding(int)
  1  libmlx.dylib  mlx::core::gpu::eval(mlx::core::array&)
  ...
```

This is reproducible on Apple Silicon (M5 Pro, macOS 15) when a retain operation triggers consolidation while a recall is in progress — the consolidation worker's observation recall uses the reranker in a separate thread.

## Fix

A single `threading.Lock` (`_mlx_lock`) serializes all calls to `self._reranker.rerank()` inside `_predict_sync()`. This is safe because:

- **No deadlock risk**: single lock, no nesting, no recursive acquisition path (`rerank()` is a pure forward pass that never calls back into `predict()`)
- **No livelock**: `rerank()` is bounded computation; `with` statement guarantees release even on exception
- **Minimal blocking**: reranker calls take ~150-400ms; concurrent calls queue behind the lock. In practice, collisions are rare (consolidation runs periodically, user recalls are sporadic)

## Test plan

- [x] Verified on Apple M5 Pro (macOS 15, Python 3.13, MLX 0.31.1)
- [x] Concurrent retain + recall no longer crashes (previously crashed consistently during consolidation)
- [x] Two parallel consolidation tasks completing without SIGSEGV
- [x] Single-threaded performance unaffected (lock acquisition is ~microsecond when uncontended)