### PR TITLE
fix: improve reranker error messages and add configurable TEI timeout

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -238,6 +238,7 @@ ENV_RERANKER_LOCAL_BATCH_SIZE = "HINDSIGHT_API_RERANKER_LOCAL_BATCH_SIZE"
 ENV_RERANKER_TEI_URL = "HINDSIGHT_API_RERANKER_TEI_URL"
 ENV_RERANKER_TEI_BATCH_SIZE = "HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE"
 ENV_RERANKER_TEI_MAX_CONCURRENT = "HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT"
+ENV_RERANKER_TEI_HTTP_TIMEOUT = "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT"
 ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
@@ -482,6 +483,7 @@ DEFAULT_RERANKER_LOCAL_BUCKET_BATCHING = False  # Length-sorted bucket batching:
 DEFAULT_RERANKER_LOCAL_BATCH_SIZE = 32  # Batch size for local reranker predict() calls
 DEFAULT_RERANKER_TEI_BATCH_SIZE = 128
 DEFAULT_RERANKER_TEI_MAX_CONCURRENT = 8
+DEFAULT_RERANKER_TEI_HTTP_TIMEOUT = 30.0  # HTTP timeout for TEI reranker requests (seconds)
 DEFAULT_RERANKER_MAX_CANDIDATES = 300
 DEFAULT_RERANKER_FLASHRANK_MODEL = "ms-marco-MiniLM-L-12-v2"  # Best balance of speed and quality
 DEFAULT_RERANKER_FLASHRANK_CACHE_DIR = None  # Use default cache directory
@@ -882,6 +884,7 @@ class HindsightConfig:
     reranker_tei_url: str | None
     reranker_tei_batch_size: int
     reranker_tei_max_concurrent: int
+    reranker_tei_http_timeout: float
     reranker_max_candidates: int
     reranker_cohere_api_key: str | None
     reranker_cohere_model: str
@@ -1434,6 +1437,9 @@ class HindsightConfig:
             reranker_tei_batch_size=int(os.getenv(ENV_RERANKER_TEI_BATCH_SIZE, str(DEFAULT_RERANKER_TEI_BATCH_SIZE))),
             reranker_tei_max_concurrent=int(
                 os.getenv(ENV_RERANKER_TEI_MAX_CONCURRENT, str(DEFAULT_RERANKER_TEI_MAX_CONCURRENT))
+            ),
+            reranker_tei_http_timeout=float(
+                os.getenv(ENV_RERANKER_TEI_HTTP_TIMEOUT, str(DEFAULT_RERANKER_TEI_HTTP_TIMEOUT))
             ),
             reranker_max_candidates=int(os.getenv(ENV_RERANKER_MAX_CANDIDATES, str(DEFAULT_RERANKER_MAX_CANDIDATES))),
             # Cohere reranker (with backward-compatible fallback to shared API key)

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -33,6 +33,7 @@ from ..config import (
     DEFAULT_RERANKER_SILICONFLOW_BASE_URL,
     DEFAULT_RERANKER_SILICONFLOW_MODEL,
     DEFAULT_RERANKER_TEI_BATCH_SIZE,
+    DEFAULT_RERANKER_TEI_HTTP_TIMEOUT,
     DEFAULT_RERANKER_TEI_MAX_CONCURRENT,
     DEFAULT_RERANKER_ZEROENTROPY_MODEL,
     ENV_RERANKER_COHERE_API_KEY,
@@ -48,6 +49,7 @@ from ..config import (
     ENV_RERANKER_PROVIDER,
     ENV_RERANKER_SILICONFLOW_API_KEY,
     ENV_RERANKER_TEI_BATCH_SIZE,
+    ENV_RERANKER_TEI_HTTP_TIMEOUT,
     ENV_RERANKER_TEI_MAX_CONCURRENT,
     ENV_RERANKER_TEI_URL,
     ENV_RERANKER_ZEROENTROPY_API_KEY,
@@ -1506,6 +1508,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             raise ValueError(f"{ENV_RERANKER_TEI_URL} is required when {ENV_RERANKER_PROVIDER} is 'tei'")
         return RemoteTEICrossEncoder(
             base_url=url,
+            timeout=config.reranker_tei_http_timeout,
             batch_size=config.reranker_tei_batch_size,
             max_concurrent=config.reranker_tei_max_concurrent,
         )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3552,10 +3552,10 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
         except Exception as e:
-            log_buffer.append(f"[RECALL {recall_id}] ERROR after {time.time() - recall_start:.3f}s: {str(e)}")
+            log_buffer.append(f"[RECALL {recall_id}] ERROR after {time.time() - recall_start:.3f}s: {type(e).__name__}: {e}")
             if not quiet:
                 logger.error("\n" + "\n".join(log_buffer))
-            raise Exception(f"Failed to search memories: {str(e)}")
+            raise Exception(f"Failed to search memories: {type(e).__name__}: {e}")
 
     def _filter_by_token_budget(
         self, results: list[dict[str, Any]], max_tokens: int

--- a/hindsight-api-slim/tests/test_tei_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_tei_cross_encoder.py
@@ -549,6 +549,29 @@ class TestRemoteTEICrossEncoderConfig:
 
         clear_config_cache()  # Clear cache after test
 
+    def test_create_from_env_with_custom_timeout(self):
+        """Test that HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT is respected."""
+        import os
+
+        from hindsight_api.config import clear_config_cache
+        from hindsight_api.engine.cross_encoder import create_cross_encoder_from_env
+
+        with patch.dict(
+            os.environ,
+            {
+                "HINDSIGHT_API_RERANKER_PROVIDER": "tei",
+                "HINDSIGHT_API_RERANKER_TEI_URL": "http://test:9000",
+                "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT": "120.0",
+            },
+        ):
+            clear_config_cache()
+            encoder = create_cross_encoder_from_env()
+
+            assert isinstance(encoder, RemoteTEICrossEncoder)
+            assert encoder.timeout == 120.0
+
+        clear_config_cache()
+
 
 # ============================================================================
 # TEI Reranker Performance Benchmark Tests

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -531,6 +531,7 @@ Google's `gemini-embedding-001` produces 3072 dimensions natively but supports c
 | `HINDSIGHT_API_RERANKER_TEI_URL` | TEI server URL | - |
 | `HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE` | Batch size for TEI reranking | `128` |
 | `HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT` | Max concurrent TEI reranking requests | `8` |
+| `HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT` | HTTP request timeout for TEI reranker (seconds). Increase when using a slower CPU-based reranker under load. | `30.0` |
 | `HINDSIGHT_API_RERANKER_OPENROUTER_API_KEY` | OpenRouter API key for reranking (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_RERANKER_OPENROUTER_MODEL` | OpenRouter rerank model | `cohere/rerank-v3.5` |
 | `HINDSIGHT_API_RERANKER_COHERE_API_KEY` | Cohere API key for reranking | - |


### PR DESCRIPTION
Fixes #1081

## Problem

Two issues with the self-hosted TEI reranker under load (reported by users running CPU rerankers like Infinity v2):

1. **Opaque error messages**: When `httpcore.ReadTimeout` (or any exception whose `str()` is empty) propagates through the recall pipeline, the user sees `"Failed to search memories: "` with no indication of what went wrong. This makes debugging extremely difficult.

2. **Hardcoded HTTP timeout**: The TEI reranker's HTTP timeout was hardcoded in `RemoteTEICrossEncoder.__init__` at 30 seconds with no way to configure it. Under consolidation load, CPU-based rerankers can take longer to respond, causing spurious timeout failures.

## Solution

**Fix 1 — Include exception type in error messages**

Changed the recall error handler in `memory_engine.py` to use `type(e).__name__` alongside `str(e)`. This ensures that even when `str(e)` returns an empty string, the exception class name (e.g. `ReadTimeout`) is visible in the log and in the raised exception message.

Before: `"Failed to search memories: "`
After: `"Failed to search memories: ReadTimeout: "`

**Fix 2 — Add `HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT` env var**

Added a new configuration field following the project's standard config pattern:
- `ENV_RERANKER_TEI_HTTP_TIMEOUT = "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT"` in `config.py`
- `DEFAULT_RERANKER_TEI_HTTP_TIMEOUT = 30.0` (preserves existing default)
- `reranker_tei_http_timeout: float` field in `HindsightConfig`
- `create_cross_encoder_from_env()` now passes `timeout=config.reranker_tei_http_timeout` to `RemoteTEICrossEncoder`
- Documentation added to `hindsight-docs/docs/developer/configuration.md`

## Testing

- Verified ruff lint passes on all modified files
- Added `test_create_from_env_with_custom_timeout` test to confirm `HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT` is correctly picked up and passed to the encoder
- Existing `test_default_values` and `test_custom_values` tests continue to verify the timeout field works end-to-end