### PR TITLE
fix(migrations): restore broken chain for v0.4.22 to v0.5.x upgrades

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/2eee35aa3cfc_case_insensitive_entities_trgm_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/2eee35aa3cfc_case_insensitive_entities_trgm_index.py
@@ -4,8 +4,8 @@ The previous GIN trigram index on canonical_name was case-sensitive, causing
 "Alice" and "alice" to have different trigram sets. This recreates it on
 LOWER(canonical_name) so the % operator matches case-insensitively.
 
-Revision ID: d6e7f8a9b0c1
-Revises: c5d6e7f8a9b0
+Revision ID: 2eee35aa3cfc
+Revises: d6e7f8a9b0c1
 Create Date: 2026-03-31
 """
 
@@ -13,8 +13,8 @@ from collections.abc import Sequence
 
 from alembic import context, op
 
-revision: str = "d6e7f8a9b0c1"
-down_revision: str | Sequence[str] | None = "c5d6e7f8a9b0"
+revision: str = "2eee35aa3cfc"
+down_revision: str | Sequence[str] | None = "d6e7f8a9b0c1"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
@@ -1,7 +1,7 @@
 """Fix per-bank vector indexes to match configured extension
 
 Revision ID: a4b5c6d7e8f9
-Revises: d6e7f8a9b0c1
+Revises: 2eee35aa3cfc
 Create Date: 2026-04-01
 
 Migration d5e6f7a8b9c0 hardcoded HNSW when creating per-bank partial vector
@@ -21,7 +21,7 @@ from alembic import context, op
 from sqlalchemy import text
 
 revision: str = "a4b5c6d7e8f9"
-down_revision: str | Sequence[str] | None = "d6e7f8a9b0c1"
+down_revision: str | Sequence[str] | None = "2eee35aa3cfc"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/d6e7f8a9b0c1_drop_documents_metadata_column.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d6e7f8a9b0c1_drop_documents_metadata_column.py
@@ -37,4 +37,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     schema = _get_schema_prefix()
     op.execute(f"ALTER TABLE {schema}documents ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{{}}'")
-

--- a/hindsight-api-slim/hindsight_api/alembic/versions/d6e7f8a9b0c1_drop_documents_metadata_column.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d6e7f8a9b0c1_drop_documents_metadata_column.py
@@ -1,0 +1,40 @@
+"""Drop unused metadata column from documents table
+
+Revision ID: d6e7f8a9b0c1
+Revises: c2d3e4f5g6h7, c5d6e7f8a9b0
+Create Date: 2026-03-30
+
+The metadata column on documents was always stored as an empty dict {}.
+Actual document metadata is stored inside retain_params.metadata.
+
+This migration was originally shipped in v0.4.22, then its file was deleted
+in v0.5.0 (and its revision ID accidentally reused by 2eee35aa3cfc).
+Restoring the file so that databases stamped at this revision can upgrade
+cleanly to v0.5.x+.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+revision: str = "d6e7f8a9b0c1"
+down_revision: str | Sequence[str] | None = ("c2d3e4f5g6h7", "c5d6e7f8a9b0")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    """Get schema prefix for table names (required for multi-tenant support)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def upgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}documents DROP COLUMN IF EXISTS metadata")
+
+
+def downgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}documents ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{{}}'")
+

--- a/hindsight-api-slim/hindsight_api/alembic/versions/h3i4j5k6l7m8_merge_heads_and_add_unit_entities_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/h3i4j5k6l7m8_merge_heads_and_add_unit_entities_index.py
@@ -1,7 +1,7 @@
 """Merge 3 migration heads and add unit_entities composite index
 
 Revision ID: h3i4j5k6l7m8
-Revises: a4b5c6d7e8f9, c2d3e4f5g6h7, g2h3i4j5k6l7
+Revises: a4b5c6d7e8f9, g2h3i4j5k6l7
 Create Date: 2026-04-07
 
 Merges three unmerged migration heads into one, and adds a composite index
@@ -14,7 +14,7 @@ from collections.abc import Sequence
 from alembic import context, op
 
 revision: str = "h3i4j5k6l7m8"
-down_revision: str | Sequence[str] | None = ("a4b5c6d7e8f9", "c2d3e4f5g6h7", "g2h3i4j5k6l7")
+down_revision: str | Sequence[str] | None = ("a4b5c6d7e8f9", "g2h3i4j5k6l7")
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -62,7 +62,6 @@ class Document(Base):
     bank_id: Mapped[str] = mapped_column(Text, primary_key=True)
     original_text: Mapped[str | None] = mapped_column(Text)
     content_hash: Mapped[str | None] = mapped_column(Text)
-    doc_metadata: Mapped[dict] = mapped_column("metadata", JSONB, server_default=sql_text("'{}'::jsonb"))
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 

--- a/hindsight-control-plane/src/components/constellation.tsx
+++ b/hindsight-control-plane/src/components/constellation.tsx
@@ -94,21 +94,18 @@ function hexToRgba(hex: string, alpha: number): string {
 }
 
 /**
- * Map a 0..1 value to a Hindsight brand gradient.
- * 0 = few links (teal #009296), 1 = hub (blue #0074d9).
- * Passes through a brighter midpoint for contrast.
+ * Map a 0..1 value to a perceptually monotonic cool→warm ramp.
+ * 0 = cool blue (low / older / few links), 1 = warm orange-red (high / newer / many).
+ * Mid passes through a desaturated lavender so brightness stays roughly monotonic
+ * — viewers should read the position on the bar at a glance without consulting
+ * the legend.
  */
 function heatColor(t: number): string {
   const v = Math.max(0, Math.min(1, t));
-
-  // Cool-to-hot ramp with strong contrast between stops so low/high reads at a
-  // glance. Previously a teal→cyan→blue ramp, but all three blues looked alike.
-  // deep indigo → magenta → orange → gold (sunset-style)
   const stops = [
-    [60, 90, 180], // cool indigo
-    [170, 70, 190], // magenta
-    [240, 120, 70], // vivid orange
-    [255, 210, 90], // warm gold
+    [56, 130, 220], // cool blue
+    [170, 130, 200], // muted lavender bridge
+    [240, 100, 60], // warm orange-red
   ];
   const seg = v * (stops.length - 1);
   const i = Math.min(Math.floor(seg), stops.length - 2);
@@ -562,40 +559,48 @@ export function Constellation({
     ctx.font = FONT_BOLD;
     ctx.fillStyle = isDark ? "#a1a1aa" : "#52525b";
     ctx.fillText((heatLegendLabel || "LINKS").toUpperCase(), 12, 36);
-    const gradW = 80;
+    const [heatLo, heatHi] = heatLegendEndpoints || ["few", "many"];
+    // Size the bar so both endpoint labels fit without overlap (e.g. ISO dates
+    // are wider than "few"/"many"). Min 80px keeps the visual weight stable.
+    ctx.font = MONO;
+    const heatLoW = ctx.measureText(heatLo).width;
+    const heatHiW = ctx.measureText(heatHi).width;
+    const gradW = Math.max(80, heatLoW + heatHiW + 12);
     for (let gx = 0; gx < gradW; gx++) {
       ctx.fillStyle = heatColor(gx / gradW);
       ctx.fillRect(12 + gx, 42, 1, 6);
     }
-    ctx.font = MONO;
     ctx.fillStyle = isDark ? "#a1a1aa" : "#71717a";
-    const [heatLo, heatHi] = heatLegendEndpoints || ["few", "many"];
     ctx.fillText(heatLo, 12, 60);
     ctx.textAlign = "right";
     ctx.fillText(heatHi, 12 + gradW, 60);
 
     // Node-size legend — only shown when the caller maps size to a real dimension.
+    // Layout: "few • • ● many" so the labels bracket the dots without overlap.
     if (sizeLegendLabel) {
       ctx.textAlign = "left";
       ctx.font = FONT_BOLD;
       ctx.fillStyle = isDark ? "#a1a1aa" : "#52525b";
       ctx.fillText(sizeLegendLabel.toUpperCase(), 12, 82);
+      ctx.font = MONO;
+      const labelColor = isDark ? "#a1a1aa" : "#71717a";
+      ctx.fillStyle = labelColor;
+      ctx.fillText("few", 12, 98);
+      const fewW = ctx.measureText("few").width;
+      const dotsStart = 12 + fewW + 8;
       const dotColor = isDark ? "#a1a1aa" : "#52525b";
       ctx.fillStyle = dotColor;
       ctx.beginPath();
-      ctx.arc(16, 94, 2, 0, Math.PI * 2);
+      ctx.arc(dotsStart + 2, 94, 2, 0, Math.PI * 2);
       ctx.fill();
       ctx.beginPath();
-      ctx.arc(28, 94, 4, 0, Math.PI * 2);
+      ctx.arc(dotsStart + 14, 94, 4, 0, Math.PI * 2);
       ctx.fill();
       ctx.beginPath();
-      ctx.arc(44, 94, 6, 0, Math.PI * 2);
+      ctx.arc(dotsStart + 30, 94, 6, 0, Math.PI * 2);
       ctx.fill();
-      ctx.font = MONO;
-      ctx.fillStyle = isDark ? "#a1a1aa" : "#71717a";
-      ctx.fillText("few", 56, 98);
-      ctx.textAlign = "right";
-      ctx.fillText("many", 92, 98);
+      ctx.fillStyle = labelColor;
+      ctx.fillText("many", dotsStart + 42, 98);
     }
 
     // Instructions
@@ -760,10 +765,9 @@ export function Constellation({
         const factType = meta?.fact_type || node.group || "memory";
         const context = meta?.context && meta.context !== "N/A" ? meta.context : null;
         const tags: string[] = Array.isArray(meta?.tags) ? meta.tags : [];
-        const date = meta?.date && meta.date !== "N/A" ? meta.date : null;
         const occurredStart = meta?.occurred_start || null;
         const occurredEnd = meta?.occurred_end || null;
-        const createdAt = meta?.created_at || null;
+        const mentionedAt = meta?.mentioned_at || null;
         const proofCount = meta?.proof_count || null;
         const documentId = meta?.document_id || null;
 
@@ -789,18 +793,19 @@ export function Constellation({
           html += `<div style="${rowStyle}"><span style="${labelStyle}">Context</span><span style="${valStyle}">${context}</span></div>`;
         }
 
-        if (date) {
-          html += `<div style="${rowStyle}"><span style="${labelStyle}">Date</span><span style="${valStyle}">${date}</span></div>`;
-        } else if (occurredStart) {
-          const timeRange =
-            occurredEnd && occurredEnd !== occurredStart
-              ? `${occurredStart.slice(0, 10)} → ${occurredEnd.slice(0, 10)}`
-              : occurredStart.slice(0, 10);
-          html += `<div style="${rowStyle}"><span style="${labelStyle}">Occurred</span><span style="${valStyle}">${timeRange}</span></div>`;
+        // Format ISO timestamp as "YYYY-MM-DD HH:MM" — keeps the row compact
+        // while still surfacing the time-of-day the user asked for.
+        const fmtTs = (iso: string) => iso.slice(0, 16).replace("T", " ");
+
+        if (occurredStart) {
+          const start = fmtTs(occurredStart);
+          const end = occurredEnd ? fmtTs(occurredEnd) : null;
+          const occurredDisplay = end && end !== start ? `${start} → ${end}` : start;
+          html += `<div style="${rowStyle}"><span style="${labelStyle}">Occurred</span><span style="${valStyle}">${occurredDisplay}</span></div>`;
         }
 
-        if (createdAt) {
-          html += `<div style="${rowStyle}"><span style="${labelStyle}">Created</span><span style="${valStyle}">${createdAt.slice(0, 16).replace("T", " ")}</span></div>`;
+        if (mentionedAt) {
+          html += `<div style="${rowStyle}"><span style="${labelStyle}">Mentioned</span><span style="${valStyle}">${fmtTs(mentionedAt)}</span></div>`;
         }
 
         if (proofCount && proofCount > 1) {

--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -36,6 +36,13 @@ import {
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { MemoryDetailPanel } from "./memory-detail-panel";
 import { MemoryDetailModal } from "./memory-detail-modal";
 import { Graph2D, convertHindsightGraphData, GraphNode } from "./graph-2d";
@@ -64,6 +71,15 @@ export function DataView({ factType }: DataViewProps) {
 
   // Fetch limit state - how many memories to load from the API
   const [fetchLimit, setFetchLimit] = useState(1000);
+
+  // Which timestamp drives the constellation recency color
+  type RecencyBasis = "mentioned_at" | "occurred_start" | "occurred_end";
+  const RECENCY_BASIS_LABEL: Record<RecencyBasis, string> = {
+    mentioned_at: "mentioned",
+    occurred_start: "occurred (start)",
+    occurred_end: "occurred (end)",
+  };
+  const [recencyBasis, setRecencyBasis] = useState<RecencyBasis>("mentioned_at");
 
   // Consolidation status for mental models
   const [consolidationStatus, setConsolidationStatus] = useState<{
@@ -227,21 +243,22 @@ export function DataView({ factType }: DataViewProps) {
     return { counts, max };
   }, [factType, data]);
 
-  // Recency heat — map each memory's most-recent timestamp to 0..1 (oldest → newest).
-  // Uses mentioned_at when available, else created_at. Sqrt gives mid-age memories
-  // a visible warmth instead of piling everything at the cool end.
+  // Recency heat — map each memory's chosen timestamp to 0..1 (oldest → newest).
+  // Linear so the position on the gradient bar reflects the actual time fraction
+  // between the oldest and newest memory in view.
   const recencyLookup = useMemo(() => {
     if (!data?.table_rows?.length) return null;
     type Row = {
       id: string;
       mentioned_at?: string | null;
-      created_at?: string | null;
+      occurred_start?: string | null;
+      occurred_end?: string | null;
     };
     const times = new Map<string, number>();
     let minT = Infinity;
     let maxT = -Infinity;
     for (const row of data.table_rows as Row[]) {
-      const ts = row.mentioned_at || row.created_at;
+      const ts = row[recencyBasis];
       if (!ts) continue;
       const t = Date.parse(ts);
       if (Number.isNaN(t)) continue;
@@ -253,14 +270,14 @@ export function DataView({ factType }: DataViewProps) {
       return null;
     }
     return { times, minT, maxT };
-  }, [data]);
+  }, [data, recencyBasis]);
 
   const recencyHeatFn = useCallback(
     (node: GraphNode) => {
       if (!recencyLookup) return 0.5;
       const t = recencyLookup.times.get(node.id);
       if (t === undefined) return 0;
-      return Math.sqrt((t - recencyLookup.minT) / (recencyLookup.maxT - recencyLookup.minT));
+      return (t - recencyLookup.minT) / (recencyLookup.maxT - recencyLookup.minT);
     },
     [recencyLookup]
   );
@@ -785,8 +802,17 @@ export function DataView({ factType }: DataViewProps) {
                   nodeSizeFn={factType === "observation" ? observationNodeSizeFn : undefined}
                   sizeLegendLabel={factType === "observation" ? "source facts" : undefined}
                   nodeHeatFn={recencyLookup ? recencyHeatFn : undefined}
-                  heatLegendLabel={recencyLookup ? "recency" : undefined}
-                  heatLegendEndpoints={recencyLookup ? ["older", "newer"] : undefined}
+                  heatLegendLabel={
+                    recencyLookup ? `recency · ${RECENCY_BASIS_LABEL[recencyBasis]}` : undefined
+                  }
+                  heatLegendEndpoints={
+                    recencyLookup
+                      ? [
+                          new Date(recencyLookup.minT).toISOString().slice(0, 10),
+                          new Date(recencyLookup.maxT).toISOString().slice(0, 10),
+                        ]
+                      : undefined
+                  }
                 />
               </div>
 
@@ -821,6 +847,22 @@ export function DataView({ factType }: DataViewProps) {
                         drag to pan, hover to explore entity connections. Click a memory to view
                         details.
                       </p>
+                      <div className="space-y-2 pt-2">
+                        <h4 className="text-xs font-medium text-muted-foreground">Color by</h4>
+                        <Select
+                          value={recencyBasis}
+                          onValueChange={(v) => setRecencyBasis(v as RecencyBasis)}
+                        >
+                          <SelectTrigger className="h-8 w-full text-xs">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="mentioned_at">Mentioned</SelectItem>
+                            <SelectItem value="occurred_start">Occurred (start)</SelectItem>
+                            <SelectItem value="occurred_end">Occurred (end)</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
                       <div className="space-y-2 pt-2">
                         <h4 className="text-xs font-medium text-muted-foreground">Link types</h4>
                         {Object.entries({

--- a/hindsight-control-plane/src/components/entities-view.tsx
+++ b/hindsight-control-plane/src/components/entities-view.tsx
@@ -192,7 +192,7 @@ export function EntitiesView() {
       if (!recencyLookup) return 0.5;
       const t = recencyLookup.times.get(node.id);
       if (t === undefined) return 0;
-      return Math.sqrt((t - recencyLookup.minT) / (recencyLookup.maxT - recencyLookup.minT));
+      return (t - recencyLookup.minT) / (recencyLookup.maxT - recencyLookup.minT);
     },
     [recencyLookup]
   );
@@ -255,8 +255,15 @@ export function EntitiesView() {
               onNodeClick={handleConstellationNodeClick}
               nodeSizeFn={nodeSizeFn}
               nodeHeatFn={recencyLookup ? nodeHeatFn : undefined}
-              heatLegendLabel={recencyLookup ? "recency" : undefined}
-              heatLegendEndpoints={recencyLookup ? ["older", "newer"] : undefined}
+              heatLegendLabel={recencyLookup ? "recency · last co-occurrence" : undefined}
+              heatLegendEndpoints={
+                recencyLookup
+                  ? [
+                      new Date(recencyLookup.minT).toISOString().slice(0, 10),
+                      new Date(recencyLookup.maxT).toISOString().slice(0, 10),
+                    ]
+                  : undefined
+              }
               sizeLegendLabel="co-occurrences"
               compactLabels
             />

--- a/skills/hindsight-docs/references/developer/extensions.md
+++ b/skills/hindsight-docs/references/developer/extensions.md
@@ -211,6 +211,41 @@ class MyValidator(OperationValidatorExtension):
         pass
 ```
 
+#### Deferring an operation
+
+In addition to `accept` and `reject`, a `validate_*` hook can ask the
+worker to **requeue** the operation for a future time by raising
+`DeferOperation`. Use this for backpressure (rate-limited upstream,
+quota window not yet open, dependency warming up) — unlike a retry, it
+does not increment `retry_count` or write `error_message`. The worker
+sets `next_retry_at` to your `exec_date` and the task is invisible to
+claim queries until that time.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from hindsight_api.extensions import (
+    DeferOperation,
+    OperationValidatorExtension,
+    RetainContext,
+    ValidationResult,
+)
+
+
+class QuotaAwareValidator(OperationValidatorExtension):
+    async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
+        if not await self._quota_available(ctx.bank_id):
+            raise DeferOperation(
+                exec_date=datetime.now(timezone.utc) + timedelta(minutes=5),
+                reason="bank quota window exhausted",
+            )
+        return ValidationResult.accept()
+```
+
+`DeferOperation` is **worker-only**: do not raise it from
+`validate_recall` or `validate_reflect` in synchronous HTTP request
+paths — there is no queue to defer to and it will surface as a 500.
+
 ### Example: Custom MCPExtension
 
 ```python


### PR DESCRIPTION
## Summary

- Fixes crash on startup when upgrading from v0.4.22 to v0.5.x: `Can't locate revision identified by 'd6e7f8a9b0c1'`
- Root cause: migration `d6e7f8a9b0c1` (drop unused `documents.metadata` column) was deleted in v0.5.0 and its revision ID was reused by `2eee35aa3cfc` (case-insensitive trigram index). Any DB stamped at `d6e7f8a9b0c1` from v0.4.22 crashes because alembic resolves the ID to an incompatible migration.
- Restores `d6e7f8a9b0c1` with original DROP COLUMN logic, gives `2eee35aa3cfc` its own revision ID, and fixes the chain: `d6e7f8a9b0c1` → `2eee35aa3cfc` → `a4b5c6d7e8f9` → `h3i4j5k6l7m8`
- Removes dead `doc_metadata` field from `Document` model (never read/written, column is dropped)

## Test plan

- [ ] Fresh install: `alembic upgrade heads` succeeds, `documents` table has no `metadata` column
- [ ] Upgrade from v0.4.22 DB (stamped at `d6e7f8a9b0c1`): startup succeeds, migrations apply cleanly
- [ ] Upgrade from v0.5.0/v0.5.1 DB: startup succeeds (no regression)
- [ ] Verify `alembic heads` shows expected heads with no warnings