### PR TITLE
fix(integrations): add encoding="utf-8" to transcript file reads

### DIFF
--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -53,7 +53,7 @@ def read_transcript_messages(transcript_path: str) -> list:
         return []
     messages = []
     try:
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -47,7 +47,7 @@ def read_transcript(transcript_path: str) -> list:
         return []
     messages = []
     try:
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:

--- a/hindsight-integrations/codex/scripts/lib/content.py
+++ b/hindsight-integrations/codex/scripts/lib/content.py
@@ -93,7 +93,7 @@ def _read_transcript_text(transcript_path: str) -> list:
     """Legacy text-only transcript reader."""
     messages = []
     try:
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -148,7 +148,7 @@ def _read_transcript_rich(transcript_path: str) -> list:
             assistant_blocks = []
 
     try:
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:


### PR DESCRIPTION
On Windows, open() defaults to the system locale encoding (cp1252) instead of UTF-8. Claude Code and Codex transcript JSONL files contain UTF-8 bytes (e.g. 0x9d) that are invalid in cp1252, causing UnicodeDecodeError in the auto-retain and auto-recall hooks. This silently prevented all transcript processing on Windows.

Affected files:
- claude-code/scripts/retain.py (read_transcript)
- claude-code/scripts/recall.py (read_transcript_messages)
- codex/scripts/lib/content.py (_read_transcript_text, _read_transcript_rich)