### PR TITLE
fix(config): reduce default LLM max retries from 10 to 3

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -449,7 +449,7 @@ DEFAULT_LLAMACPP_NO_GRAMMAR = False  # True = disable JSON grammar enforcement (
 DEFAULT_LLAMACPP_EXTRA_ARGS = None  # Space-separated extra CLI args for llama.cpp server
 
 DEFAULT_LLM_MAX_CONCURRENT = 32
-DEFAULT_LLM_MAX_RETRIES = 10  # Max retry attempts for LLM API calls
+DEFAULT_LLM_MAX_RETRIES = 3  # Max retry attempts for LLM API calls
 DEFAULT_LLM_INITIAL_BACKOFF = 1.0  # Initial backoff in seconds for retry exponential backoff
 DEFAULT_LLM_MAX_BACKOFF = 60.0  # Max backoff cap in seconds for retry exponential backoff
 DEFAULT_LLM_TIMEOUT = 120.0  # seconds


### PR DESCRIPTION
## Summary
- Reduces `DEFAULT_LLM_MAX_RETRIES` from 10 to 3
- 10 retries caused excessive delays on persistent LLM errors; 3 is sufficient for transient failures while failing fast on real issues
- Per-operation overrides (`retain_llm_max_retries`, `reflect_llm_max_retries`, `consolidation_llm_max_retries`) remain available for fine-tuning

## Test plan
- [ ] Verify API starts with new default
- [ ] Confirm retry behavior on transient LLM errors (should retry up to 3 times)
- [ ] Confirm per-operation overrides still work via env vars