### PR TITLE
feat(worker): add opt-in stale foreign task recovery

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2587,6 +2587,8 @@ def create_app(
                 tenant_extension=memory._tenant_extension,
                 max_slots=config.worker_max_slots,
                 consolidation_max_slots=config.worker_consolidation_max_slots,
+                reclaim_stale_tasks_enabled=config.worker_reclaim_stale_tasks_enabled,
+                reclaim_stale_tasks_after_seconds=config.worker_reclaim_stale_tasks_after_seconds,
             )
             poller_task = asyncio.create_task(poller.run())
             logging.info(f"Worker poller started (worker_id={worker_id})")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -382,6 +382,8 @@ ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
 ENV_WORKER_CONSOLIDATION_MAX_SLOTS = "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS"
+ENV_WORKER_RECLAIM_STALE_TASKS_ENABLED = "HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_ENABLED"
+ENV_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS = "HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS"
 ENV_RETAIN_MAX_CONCURRENT = "HINDSIGHT_API_RETAIN_MAX_CONCURRENT"
 
 # Reflect agent settings
@@ -599,6 +601,8 @@ DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_WORKER_CONSOLIDATION_MAX_SLOTS = 2  # Max concurrent consolidation tasks per worker
+DEFAULT_WORKER_RECLAIM_STALE_TASKS_ENABLED = False  # Opt-in recovery for tasks owned by dead/foreign workers.
+DEFAULT_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS = 1800  # Only reclaim foreign processing tasks older than 30 minutes.
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
 
 # Reflect agent settings
@@ -1037,6 +1041,8 @@ class HindsightConfig:
     worker_http_port: int
     worker_max_slots: int
     worker_consolidation_max_slots: int
+    worker_reclaim_stale_tasks_enabled: bool
+    worker_reclaim_stale_tasks_after_seconds: int
     retain_max_concurrent: int
 
     # Reflect agent settings
@@ -1618,6 +1624,16 @@ class HindsightConfig:
             worker_max_slots=int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS))),
             worker_consolidation_max_slots=int(
                 os.getenv(ENV_WORKER_CONSOLIDATION_MAX_SLOTS, str(DEFAULT_WORKER_CONSOLIDATION_MAX_SLOTS))
+            ),
+            worker_reclaim_stale_tasks_enabled=os.getenv(
+                ENV_WORKER_RECLAIM_STALE_TASKS_ENABLED, str(DEFAULT_WORKER_RECLAIM_STALE_TASKS_ENABLED)
+            ).lower()
+            == "true",
+            worker_reclaim_stale_tasks_after_seconds=int(
+                os.getenv(
+                    ENV_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS,
+                    str(DEFAULT_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS),
+                )
             ),
             retain_max_concurrent=int(os.getenv(ENV_RETAIN_MAX_CONCURRENT, str(DEFAULT_RETAIN_MAX_CONCURRENT))),
             # Reflect agent settings

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -223,6 +223,8 @@ def main():
             tenant_extension=tenant_extension,
             max_slots=config.worker_max_slots,
             consolidation_max_slots=config.worker_consolidation_max_slots,
+            reclaim_stale_tasks_enabled=config.worker_reclaim_stale_tasks_enabled,
+            reclaim_stale_tasks_after_seconds=config.worker_reclaim_stale_tasks_after_seconds,
         )
 
         # Create the HTTP app for metrics/health

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -90,6 +90,8 @@ class WorkerPoller:
         tenant_extension: "TenantExtension | None" = None,
         max_slots: int = 10,
         consolidation_max_slots: int = 2,
+        reclaim_stale_tasks_enabled: bool = False,
+        reclaim_stale_tasks_after_seconds: int = 1800,
     ):
         """
         Initialize the worker poller.
@@ -104,6 +106,10 @@ class WorkerPoller:
                             DefaultTenantExtension with the configured schema.
             max_slots: Maximum concurrent tasks per worker
             consolidation_max_slots: Maximum concurrent consolidation tasks per worker
+            reclaim_stale_tasks_enabled: Opt-in startup recovery for stale tasks owned by
+                dead or foreign workers
+            reclaim_stale_tasks_after_seconds: Minimum age before a foreign processing task is
+                considered reclaimable
         """
         self._pool = pool
         self._worker_id = worker_id
@@ -120,6 +126,8 @@ class WorkerPoller:
         self._tenant_extension = tenant_extension
         self._max_slots = max_slots
         self._consolidation_max_slots = consolidation_max_slots
+        self._reclaim_stale_tasks_enabled = reclaim_stale_tasks_enabled
+        self._reclaim_stale_tasks_after_seconds = max(1, reclaim_stale_tasks_after_seconds)
         self._shutdown = asyncio.Event()
         self._current_tasks: set[asyncio.Task] = set()
         self._in_flight_count = 0
@@ -667,6 +675,58 @@ class WorkerPoller:
             logger.info(f"Worker {self._worker_id} recovered {total_count} stale tasks from previous run")
         return total_count
 
+    async def recover_stale_foreign_tasks(self) -> int:
+        """
+        Optionally recover stale tasks owned by dead or foreign workers.
+
+        This is intentionally opt-in and age-gated because reclaiming another
+        worker's in-flight tasks can be disruptive if worker identity is managed
+        outside the process. Only non-batch tasks are reclaimed here.
+
+        Returns:
+            Number of tasks recovered
+        """
+        if not self._reclaim_stale_tasks_enabled:
+            return 0
+
+        schemas = await self._get_schemas()
+        total_count = 0
+
+        for schema in schemas:
+            try:
+                table = fq_table("async_operations", schema)
+                result = await self._pool.execute(
+                    f"""
+                    UPDATE {table}
+                    SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                    WHERE status = 'processing'
+                      AND worker_id IS NOT NULL
+                      AND worker_id <> $1
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at < now() - ($2::int * interval '1 second')
+                      AND COALESCE(result_metadata->>'batch_id', '') = ''
+                    """,
+                    self._worker_id,
+                    self._reclaim_stale_tasks_after_seconds,
+                )
+
+                count = int(result.split()[-1]) if result else 0
+                total_count += count
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else str(schema)
+                logger.warning(
+                    f"Worker {self._worker_id} failed to recover stale foreign tasks for schema {schema_display}: {e}"
+                )
+
+        if total_count > 0:
+            logger.info(
+                "Worker %s reclaimed %s stale foreign task(s) older than %ss",
+                self._worker_id,
+                total_count,
+                self._reclaim_stale_tasks_after_seconds,
+            )
+        return total_count
+
     async def _recover_batch_operations(self, schema: str | None) -> int:
         """
         Recover batch API operations that were in-flight when worker crashed.
@@ -749,6 +809,7 @@ class WorkerPoller:
         and immediately continues polling (up to slot limits).
         """
         await self.recover_own_tasks()
+        await self.recover_stale_foreign_tasks()
 
         logger.info(
             f"Worker {self._worker_id} starting polling loop "

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -944,6 +944,128 @@ class TestWorkerRecovery:
         recovered_count = await poller.recover_own_tasks()
         assert recovered_count == 0
 
+    @pytest.mark.asyncio
+    async def test_recover_stale_foreign_tasks_is_opt_in(self, pool, clean_operations):
+        """Foreign worker tasks should not be reclaimed unless the knob is enabled."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'worker-2', now() - interval '2 hours')
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+
+        poller = WorkerPoller(pool=pool, worker_id="worker-1", executor=lambda x: None)
+        recovered_count = await poller.recover_stale_foreign_tasks()
+        assert recovered_count == 0
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "worker-2"
+
+    @pytest.mark.asyncio
+    async def test_recover_stale_foreign_tasks_reclaims_old_tasks_when_enabled(self, pool, clean_operations):
+        """Opt-in foreign task recovery should release sufficiently old processing tasks."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'worker-2', now() - interval '2 hours')
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="worker-1",
+            executor=lambda x: None,
+            reclaim_stale_tasks_enabled=True,
+            reclaim_stale_tasks_after_seconds=300,
+        )
+        recovered_count = await poller.recover_stale_foreign_tasks()
+        assert recovered_count == 1
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id, claimed_at FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending"
+        assert row["worker_id"] is None
+        assert row["claimed_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_recover_stale_foreign_tasks_respects_age_gate_and_batch_operations(self, pool, clean_operations):
+        """Recent tasks and batch-backed operations should be left alone."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        recent_op_id = uuid.uuid4()
+        batch_op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'worker-2', now() - interval '30 seconds')
+            """,
+            recent_op_id,
+            bank_id,
+            payload,
+        )
+        await pool.execute(
+            """
+            INSERT INTO async_operations (
+                operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, result_metadata
+            )
+            VALUES (
+                $1, $2, 'retain', 'processing', $3::jsonb, 'worker-3', now() - interval '2 hours',
+                '{"batch_id": "batch-123"}'::jsonb
+            )
+            """,
+            batch_op_id,
+            bank_id,
+            payload,
+        )
+
+        poller = WorkerPoller(
+            pool=pool,
+            worker_id="worker-1",
+            executor=lambda x: None,
+            reclaim_stale_tasks_enabled=True,
+            reclaim_stale_tasks_after_seconds=300,
+        )
+        recovered_count = await poller.recover_stale_foreign_tasks()
+        assert recovered_count == 0
+
+        rows = await pool.fetch(
+            "SELECT operation_id, status, worker_id FROM async_operations WHERE operation_id = ANY($1::uuid[])",
+            [recent_op_id, batch_op_id],
+        )
+        by_id = {row["operation_id"]: row for row in rows}
+        assert by_id[recent_op_id]["status"] == "processing"
+        assert by_id[recent_op_id]["worker_id"] == "worker-2"
+        assert by_id[batch_op_id]["status"] == "processing"
+        assert by_id[batch_op_id]["worker_id"] == "worker-3"
+
 
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1161,9 +1161,15 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Slots reserved for consolidation tasks within `WORKER_MAX_SLOTS` | `2` |
+| `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_ENABLED` | Opt-in startup recovery for stale tasks owned by dead or foreign workers | `false` |
+| `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS` | Minimum task age before stale foreign tasks are eligible for reclamation | `1800` |
 
 :::note Slot reservation
 `WORKER_CONSOLIDATION_MAX_SLOTS` is a **reservation within** `WORKER_MAX_SLOTS`, not an additive pool. With the defaults (`MAX_SLOTS=10`, `CONSOLIDATION_MAX_SLOTS=2`), retain and other non-consolidation tasks may use at most `10 - 2 = 8` concurrent slots, leaving 2 always available for consolidation. This prevents consolidation from being starved when retain throughput continuously saturates the queue. Set `CONSOLIDATION_MAX_SLOTS=0` to give all slots to non-consolidation work.
+:::
+
+:::note Opt-in stale task reclamation
+`WORKER_RECLAIM_STALE_TASKS_ENABLED` is intentionally off by default. When enabled, a worker will, on startup, release foreign `processing` tasks older than `WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS`, excluding batch-backed operations. This is meant for orchestrated environments where worker identities are ephemeral and stale claims can block progress.
 :::
 
 ### Performance Optimization

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1160,9 +1160,15 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Slots reserved for consolidation tasks within `WORKER_MAX_SLOTS` | `2` |
+| `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_ENABLED` | Opt-in startup recovery for stale tasks owned by dead or foreign workers | `false` |
+| `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS` | Minimum task age before stale foreign tasks are eligible for reclamation | `1800` |
 
 :::note Slot reservation
 `WORKER_CONSOLIDATION_MAX_SLOTS` is a **reservation within** `WORKER_MAX_SLOTS`, not an additive pool. With the defaults (`MAX_SLOTS=10`, `CONSOLIDATION_MAX_SLOTS=2`), retain and other non-consolidation tasks may use at most `10 - 2 = 8` concurrent slots, leaving 2 always available for consolidation. This prevents consolidation from being starved when retain throughput continuously saturates the queue. Set `CONSOLIDATION_MAX_SLOTS=0` to give all slots to non-consolidation work.
+:::
+
+:::note Opt-in stale task reclamation
+`WORKER_RECLAIM_STALE_TASKS_ENABLED` is intentionally off by default. When enabled, a worker will, on startup, release foreign `processing` tasks older than `WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS`, excluding batch-backed operations. This is meant for orchestrated environments where worker identities are ephemeral and stale claims can block progress.
 :::
 
 ### Performance Optimization


### PR DESCRIPTION
## Summary

This adds an opt-in fallback for reclaiming stale `processing` tasks owned by dead or foreign workers.

It is aimed at environments where worker identities are ephemeral, especially orchestrated systems like Kubernetes, where tying correctness to static worker IDs is often not a good operational fit.

This is intentionally additive and off by default. It does not change or interfere with the current static-worker-ID approach for deployments that prefer it.

Fixes #1107.

## What this changes

Two new worker settings are introduced:

- `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_ENABLED=false`
- `HINDSIGHT_API_WORKER_RECLAIM_STALE_TASKS_AFTER_SECONDS=1800`

When enabled, a worker will, on startup, release foreign `processing` tasks back to `pending` when all of the following are true:

- the task is owned by a different worker
- `claimed_at` is older than the configured threshold
- the task is not part of a batch-backed operation

The existing `recover_own_tasks()` path remains unchanged.

## Why this helps

In orchestrated environments, worker names and identities are frequently derived from pod identity and can change across restarts or rescheduling. In that world, requiring static worker IDs as the main recovery strategy is brittle.

This change provides a conservative fallback for those deployments without taking anything away from users who want explicitly stable worker IDs.

## Safety / scope

This change is intentionally narrow:

- off by default
- startup-only behavior
- age-gated
- excludes batch-backed operations
- leaves the current static-ID workflow intact

## Tests and docs

This PR adds tests for:

- opt-in behavior being disabled by default
- reclaiming old foreign tasks when enabled
- respecting the age threshold
- excluding batch-backed operations

It also documents the new worker settings.

## Longer-term direction

I think a more durable long-term solution would be to improve the worker identity / lease model itself, so recovery does not depend on static IDs or manual decommissioning in ephemeral environments. This PR is meant as a pragmatic fallback, not the final word on worker ownership semantics.
