### PR TITLE
docs(sdk): add document CRUD methods to TypeScript client reference

### DIFF
--- a/hindsight-docs/docs/sdks/nodejs.md
+++ b/hindsight-docs/docs/sdks/nodejs.md
@@ -137,3 +137,37 @@ const response = await client.listMemories('my-bank', {
 });
 console.log(response)
 ```
+## Document Management
+
+### Get Document
+
+```typescript
+const doc = await client.getDocument('my-bank', 'conversation_001');
+if (doc) {
+    console.log(doc);  // null when document not found
+}
+```
+
+### List Documents
+
+```typescript
+const response = await client.listDocuments('my-bank', {
+    limit: 50,
+    offset: 0,
+});
+console.log(response);
+```
+
+### Update Document
+
+```typescript
+await client.updateDocument('my-bank', 'conversation_001', {
+    tags: ['important', 'meeting-notes'],
+});
+```
+
+### Delete Document
+
+```typescript
+await client.deleteDocument('my-bank', 'conversation_001');
+```

--- a/skills/hindsight-docs/references/sdks/nodejs.md
+++ b/skills/hindsight-docs/references/sdks/nodejs.md
@@ -137,3 +137,37 @@ const response = await client.listMemories('my-bank', {
 });
 console.log(response)
 ```
+## Document Management
+
+### Get Document
+
+```typescript
+const doc = await client.getDocument('my-bank', 'conversation_001');
+if (doc) {
+    console.log(doc);  // null when document not found
+}
+```
+
+### List Documents
+
+```typescript
+const response = await client.listDocuments('my-bank', {
+    limit: 50,
+    offset: 0,
+});
+console.log(response);
+```
+
+### Update Document
+
+```typescript
+await client.updateDocument('my-bank', 'conversation_001', {
+    tags: ['important', 'meeting-notes'],
+});
+```
+
+### Delete Document
+
+```typescript
+await client.deleteDocument('my-bank', 'conversation_001');
+```


### PR DESCRIPTION
## Summary

PR #1118 added `getDocument`, `listDocuments`, `deleteDocument`, and `updateDocument` to the TypeScript `HindsightClient` class (aligning with `hindsight-client@0.5.2`), but the [TypeScript SDK docs page](https://hindsight.vectorize.io/sdks/nodejs) was not updated.

This adds a **Document Management** section documenting all four methods with usage examples, following the same style as the existing Core Operations and Bank Management sections.

Closes #1131

## Changes

- `hindsight-docs/docs/sdks/nodejs.md` — added Document Management section with `getDocument`, `listDocuments`, `updateDocument`, `deleteDocument` examples

## Test plan

- [ ] Docs build passes
- [ ] New section renders correctly on the docs site