### PR TITLE
fix(openai-agents): review followup — docs, tests, polish

### DIFF
--- a/hindsight-docs/docs-integrations/openai-agents.md
+++ b/hindsight-docs/docs-integrations/openai-agents.md
@@ -12,6 +12,7 @@ Persistent long-term memory for [OpenAI Agents SDK](https://github.com/openai/op
 
 - **Memory Tools** — retain, recall, and reflect as OpenAI Agents SDK `FunctionTool` instances compatible with `Agent(tools=[...])`
 - **Async-Native** — Uses `aretain`, `arecall`, `areflect` directly — works seamlessly in the Agents SDK async runtime
+- **Auto-Inject Memories** — Use `memory_instructions()` to automatically inject relevant memories into the agent's system prompt every turn
 - **Selective Tools** — Include only the tools you need with `include_retain/recall/reflect` flags
 - **Tag-Based Scoping** — Partition memories by topic, session, or user with tags
 - **Global Configuration** — Configure once with `configure()`, create tools anywhere
@@ -73,6 +74,30 @@ The agent gets three tools it can call:
 - **`hindsight_retain`** — Store information to long-term memory
 - **`hindsight_recall`** — Search long-term memory for relevant facts
 - **`hindsight_reflect`** — Synthesize a reasoned answer from memories
+
+## Auto-Inject Memories with `memory_instructions()`
+
+Instead of relying on the agent to call `hindsight_recall` explicitly, you can auto-inject relevant memories into the system prompt on every turn:
+
+```python
+from hindsight_openai_agents import create_hindsight_tools, memory_instructions
+
+agent = Agent(
+    name="assistant",
+    instructions=memory_instructions(
+        client=client,
+        bank_id="user-123",
+        base_instructions="You are a helpful assistant with long-term memory.",
+    ),
+    tools=create_hindsight_tools(
+        client=client,
+        bank_id="user-123",
+        include_recall=False,  # recall handled by memory_instructions
+    ),
+)
+```
+
+`memory_instructions()` returns an async callable compatible with `Agent(instructions=...)`. On each turn it recalls relevant memories and appends them to your base instructions. If recall fails or returns nothing, it gracefully falls back to `base_instructions` alone.
 
 ## Selecting Tools
 
@@ -201,6 +226,23 @@ shared_tools = create_hindsight_tools(
 | `include_recall` | `True` | Include the recall (search) tool |
 | `include_reflect` | `True` | Include the reflect (synthesize) tool |
 
+### `memory_instructions()`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `bank_id` | *required* | Hindsight memory bank to recall from |
+| `base_instructions` | `""` | Static instructions prepended before memories |
+| `client` | `None` | Pre-configured Hindsight client |
+| `hindsight_api_url` | `None` | API URL (used if no client provided) |
+| `api_key` | `None` | API key (used if no client provided) |
+| `query` | `"relevant context about the user"` | The recall query to find relevant memories |
+| `budget` | `"mid"` | Recall budget level (low/mid/high) |
+| `max_results` | `5` | Maximum number of memories to include |
+| `max_tokens` | `4096` | Maximum tokens for recall results |
+| `prefix` | `"\n\nRelevant memories:\n"` | Text prepended before the memory list |
+| `tags` | `None` | Tags to filter when searching |
+| `tags_match` | `"any"` | Tag matching mode |
+
 ### `configure()`
 
 | Parameter | Default | Description |
@@ -216,5 +258,5 @@ shared_tools = create_hindsight_tools(
 ## Requirements
 
 - Python >= 3.10
-- openai-agents >= 0.1.0
+- openai-agents >= 0.7.0
 - hindsight-client >= 0.4.0

--- a/hindsight-integrations/openai-agents/README.md
+++ b/hindsight-integrations/openai-agents/README.md
@@ -63,6 +63,30 @@ The agent gets three tools:
 - **`hindsight_recall`** — Search long-term memory for relevant facts
 - **`hindsight_reflect`** — Synthesize a reasoned answer from memories
 
+## Auto-Inject Memories with `memory_instructions()`
+
+Instead of relying on the agent to call `hindsight_recall` explicitly, you can auto-inject relevant memories into the system prompt on every turn:
+
+```python
+from hindsight_openai_agents import create_hindsight_tools, memory_instructions
+
+agent = Agent(
+    name="assistant",
+    instructions=memory_instructions(
+        client=client,
+        bank_id="user-123",
+        base_instructions="You are a helpful assistant with long-term memory.",
+    ),
+    tools=create_hindsight_tools(
+        client=client,
+        bank_id="user-123",
+        include_recall=False,  # recall handled by memory_instructions
+    ),
+)
+```
+
+`memory_instructions()` returns an async callable compatible with `Agent(instructions=...)`. On each turn it recalls relevant memories and appends them to your base instructions. If recall fails or returns nothing, it gracefully falls back to `base_instructions` alone.
+
 ## Selecting Tools
 
 Include only the tools you need:
@@ -142,7 +166,7 @@ tools = create_hindsight_tools(
 ## Requirements
 
 - Python >= 3.10
-- openai-agents >= 0.1.0
+- openai-agents >= 0.7.0
 - hindsight-client >= 0.4.0
 
 ## Documentation

--- a/hindsight-integrations/openai-agents/README.md
+++ b/hindsight-integrations/openai-agents/README.md
@@ -163,6 +163,55 @@ tools = create_hindsight_tools(
 | `include_recall` | `True` | Include the recall (search) tool |
 | `include_reflect` | `True` | Include the reflect (synthesize) tool |
 
+## Production Patterns
+
+### Error Handling
+
+Tools surface errors to the agent as tool error results. The OpenAI Agents SDK catches exceptions from tools automatically and returns them as error strings, allowing the agent to handle failures gracefully:
+
+```python
+from hindsight_openai_agents.errors import HindsightError
+
+# The agent will see error messages and can decide how to proceed
+result = await Runner.run(agent, "What do you remember about me?")
+print(result.final_output)
+```
+
+### Bank Lifecycle
+
+Create banks before first use and clean up when done:
+
+```python
+async def main():
+    client = Hindsight(base_url="http://localhost:8888")
+
+    # Create bank (idempotent)
+    await client.acreate_bank(bank_id="user-123")
+
+    tools = create_hindsight_tools(client=client, bank_id="user-123")
+    # ... use tools ...
+
+    # Optional: delete bank when no longer needed
+    await client.adelete_bank(bank_id="user-123")
+```
+
+### Multi-Agent Workflows
+
+Give each agent its own memory bank, or share a bank across agents:
+
+```python
+# Per-agent memory
+researcher_tools = create_hindsight_tools(client=client, bank_id="researcher-memory")
+writer_tools = create_hindsight_tools(client=client, bank_id="writer-memory")
+
+# Shared memory across agents
+shared_tools = create_hindsight_tools(
+    client=client,
+    bank_id="team-shared",
+    tags=["team:content"],
+)
+```
+
 ## Requirements
 
 - Python >= 3.10

--- a/hindsight-integrations/openai-agents/pyproject.toml
+++ b/hindsight-integrations/openai-agents/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/vectorize-io/hindsight"
-Documentation = "https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/openai-agents"
+Documentation = "https://docs.hindsight.vectorize.io/docs/sdks/integrations/openai-agents"
 Repository = "https://github.com/vectorize-io/hindsight"
 
 [build-system]

--- a/hindsight-integrations/openai-agents/tests/test_config.py
+++ b/hindsight-integrations/openai-agents/tests/test_config.py
@@ -1,0 +1,93 @@
+"""Unit tests for hindsight_openai_agents configuration."""
+
+import os
+from unittest.mock import patch
+
+from hindsight_openai_agents import configure, get_config, reset_config
+from hindsight_openai_agents.config import (
+    DEFAULT_BUDGET,
+    DEFAULT_HINDSIGHT_API_URL,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_RECALL_TAGS_MATCH,
+    HINDSIGHT_API_KEY_ENV,
+)
+
+
+class TestDefaults:
+    def test_default_api_url(self):
+        assert DEFAULT_HINDSIGHT_API_URL == "https://api.hindsight.vectorize.io"
+
+    def test_default_budget(self):
+        assert DEFAULT_BUDGET == "mid"
+
+    def test_default_max_tokens(self):
+        assert DEFAULT_MAX_TOKENS == 4096
+
+    def test_default_recall_tags_match(self):
+        assert DEFAULT_RECALL_TAGS_MATCH == "any"
+
+    def test_env_var_name(self):
+        assert HINDSIGHT_API_KEY_ENV == "HINDSIGHT_API_KEY"
+
+
+class TestConfigure:
+    def setup_method(self):
+        reset_config()
+
+    def teardown_method(self):
+        reset_config()
+
+    def test_configure_with_no_arguments(self):
+        config = configure()
+        assert config.hindsight_api_url == DEFAULT_HINDSIGHT_API_URL
+        assert config.budget == "mid"
+        assert config.max_tokens == 4096
+        assert config.api_key is None
+        assert config.tags is None
+        assert config.recall_tags is None
+        assert config.recall_tags_match == "any"
+
+    def test_configure_reads_api_key_from_env(self):
+        with patch.dict(os.environ, {HINDSIGHT_API_KEY_ENV: "test-key"}):
+            config = configure()
+        assert config.api_key == "test-key"
+
+    def test_configure_explicit_overrides_env(self):
+        with patch.dict(os.environ, {HINDSIGHT_API_KEY_ENV: "env-key"}):
+            config = configure(api_key="explicit-key")
+        assert config.api_key == "explicit-key"
+
+    def test_configure_all_options(self):
+        config = configure(
+            hindsight_api_url="http://custom:8888",
+            api_key="my-key",
+            budget="high",
+            max_tokens=2048,
+            tags=["env:test"],
+            recall_tags=["scope:global"],
+            recall_tags_match="all",
+        )
+        assert config.hindsight_api_url == "http://custom:8888"
+        assert config.api_key == "my-key"
+        assert config.budget == "high"
+        assert config.max_tokens == 2048
+        assert config.tags == ["env:test"]
+        assert config.recall_tags == ["scope:global"]
+        assert config.recall_tags_match == "all"
+
+    def test_get_config_returns_none_without_configure(self):
+        assert get_config() is None
+
+    def test_get_config_returns_config_after_configure(self):
+        configure()
+        assert get_config() is not None
+
+    def test_reset_config(self):
+        configure()
+        assert get_config() is not None
+        reset_config()
+        assert get_config() is None
+
+    def test_configure_returns_config_object(self):
+        config = configure()
+        assert config is get_config()


### PR DESCRIPTION
## Summary

Follow-up fixes from review of #842 (OpenAI Agents SDK integration).

- Fix SDK version requirement in README and docs (`>= 0.1.0` → `>= 0.7.0`) to match pyproject.toml
- Add `memory_instructions()` documentation to README and docs page (was exported but undocumented)
- Add `memory_instructions()` API reference table to docs
- Add Production Patterns section to README (error handling, bank lifecycle, multi-agent workflows)
- Add dedicated `test_config.py` with 13 tests matching pydantic-ai pattern (55 total tests)
- Fix pyproject.toml Documentation URL to point to integration-specific docs page

## Test plan

- [x] All 55 unit tests pass (`uv run pytest tests -v`)
- [x] E2E tested against live Hindsight server with published package
- [x] Full notebook E2E verified with tool call inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)