### PR TITLE
fix(worker): pass DeferOperation through MemoryEngine.execute_task

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -34,7 +34,7 @@ from ..config import (
 from ..metrics import get_metrics_collector
 from ..tracing import create_operation_span
 from ..utils import mask_network_location
-from ..worker.exceptions import RetryTaskAt
+from ..worker.exceptions import DeferOperation, RetryTaskAt
 from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
 from .db_budget import budgeted_operation
@@ -1166,6 +1166,14 @@ class MemoryEngine(MemoryEngineInterface):
 
             except RetryTaskAt:
                 # Task-owned retry: let the poller handle scheduling
+                raise
+            except DeferOperation:
+                # Task-owned defer: let the poller handle re-scheduling without
+                # bumping retry_count or writing error_message. Pairs with the
+                # DeferOperation catch in poller._execute_task_inner (PR #1105);
+                # without this passthrough, the generic-exception branch below
+                # would convert a legitimate defer into a 60-second RetryTaskAt
+                # and lose the "not a failure" semantics entirely.
                 raise
             except Exception as e:
                 logger.error(f"Task execution failed: {task_type}, error: {e}")

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -709,6 +709,82 @@ class TestWorkerPoller:
         assert abs((row["next_retry_at"] - defer_until).total_seconds()) < 1
 
     @pytest.mark.asyncio
+    async def test_memory_engine_execute_task_passes_through_defer_operation(self, memory):
+        """Regression test: MemoryEngine.execute_task must pass DeferOperation
+        through to the worker poller unchanged (same as RetryTaskAt).
+
+        Prior to this fix, the generic ``except Exception`` in execute_task
+        converted any exception — including DeferOperation — into a
+        ``RetryTaskAt(60s)``, which bumps retry_count and writes an
+        error_message. That silently broke the "defer is not a failure"
+        semantics added in #1105: a task scheduled hours out (e.g. by a
+        backpressure-aware extension waiting for a quota window to open)
+        would instead come back in 60 seconds with retry_count bumped.
+
+        Verify by injecting a validator that raises DeferOperation during
+        validate_retain and confirming the outer exception type that
+        escapes execute_task is DeferOperation, not RetryTaskAt.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from hindsight_api.extensions import (
+            DeferOperation,
+            OperationValidatorExtension,
+            RecallContext,
+            ReflectContext,
+            RetainContext,
+            ValidationResult,
+        )
+        from hindsight_api.worker.exceptions import DeferOperation as DeferOpFromExceptions
+        from hindsight_api.worker.exceptions import RetryTaskAt
+
+        defer_until = datetime.now(timezone.utc) + timedelta(hours=6)
+
+        class QuotaDeferringValidator(OperationValidatorExtension):
+            def __init__(self):
+                super().__init__({})
+
+            async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
+                raise DeferOperation(exec_date=defer_until, reason="quota_window_closed")
+
+            async def validate_recall(self, ctx: RecallContext) -> ValidationResult:
+                return ValidationResult.accept()
+
+            async def validate_reflect(self, ctx: ReflectContext) -> ValidationResult:
+                return ValidationResult.accept()
+
+        # Attach the validator to the MemoryEngine so it's invoked from
+        # inside retain_batch_async → _validate_operation.
+        memory._operation_validator = QuotaDeferringValidator()
+
+        # Set up a bank the task handler can address.
+        bank_id = f"test-defer-passthrough-{uuid.uuid4().hex[:8]}"
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
+                bank_id,
+            )
+
+        task_dict = {
+            "type": "batch_retain",
+            "bank_id": bank_id,
+            "contents": [{"content": "x"}],
+            "operation_id": str(uuid.uuid4()),
+            "_tenant_id": "default",
+        }
+
+        # Contract: DeferOperation must escape execute_task intact.
+        # Must NOT be converted to RetryTaskAt. Must NOT be swallowed.
+        with pytest.raises(DeferOpFromExceptions) as exc_info:
+            await memory.execute_task(task_dict)
+
+        assert exc_info.value.reason == "quota_window_closed"
+        assert abs((exc_info.value.exec_date - defer_until).total_seconds()) < 1
+
+        # Defensive: confirm it wasn't a RetryTaskAt masquerading as Defer.
+        assert not isinstance(exc_info.value, RetryTaskAt)
+
+    @pytest.mark.asyncio
     async def test_claim_batch_skips_consolidation_when_same_bank_processing(self, pool, clean_operations):
         """Test that pending consolidation is skipped if same bank has one processing."""
         from hindsight_api.worker import WorkerPoller


### PR DESCRIPTION
## Summary

Follow-up to #1105. The poller catches `DeferOperation` and routes it to
`_defer_operation` (no `retry_count` bump, no `error_message`), but the
outer `MemoryEngine.execute_task` dispatcher has a broad
`except Exception` that converts every exception — including
`DeferOperation` — into a `RetryTaskAt(60s)`.

Net effect: a task deferred hours out (e.g. by a backpressure-aware
validator waiting for a quota window) instead came back in 60 seconds
with `retry_count` bumped. The "defer is not a failure" semantics from
#1105 were silently lost for any exception raised from inside an
executor.

## Fix

One-line addition: `except DeferOperation: raise` alongside the existing
`RetryTaskAt` passthrough. Paired import added.

## Test plan

- [x] New regression test `test_memory_engine_execute_task_passes_through_defer_operation` injects a validator that raises `DeferOperation` from `validate_retain`, submits a `batch_retain` task through `MemoryEngine.execute_task`, and asserts the exception that escapes is `DeferOperation` (not `RetryTaskAt`).
- [x] `./scripts/hooks/lint.sh` clean
- [x] Existing `DeferOperation` tests in `test_worker.py` unaffected (they use a synthetic executor that doesn't exercise the `execute_task` wrapper)