### PR TITLE
fix(alembic): merge divergent heads for v0.5.3

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/8c6fa6f7230b_merge_v053_divergent_heads.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/8c6fa6f7230b_merge_v053_divergent_heads.py
@@ -1,0 +1,40 @@
+"""Merge divergent migration heads for v0.5.3
+
+v0.5.3 shipped with two migration heads that were never unified:
+
+  * ``c4x5y6z7a8b9`` — delta-refresh chain
+    (``add_last_refreshed_source_query`` ->
+     ``add_structured_content_to_mental_models`` ->
+     ``backsweep_orphan_observations_v2``)
+
+  * ``h3i4j5k6l7m8`` — per-bank vector indexes / audit log chain
+    (the ``merge_heads_and_add_unit_entities_index`` subtree)
+
+Both fork from ``z1u2v3w4x5y6``. Upgrades from v0.5.2 still succeed — the
+walker applies the three c4x5 revisions and leaves the database stamped at
+both heads — but the result is a split DAG: ``alembic upgrade head``
+(singular) is ambiguous, and any future migration has to pick one head as
+its parent, orphaning the other.
+
+This revision linearises the DAG into a single head. It has no schema
+effect.
+
+Revision ID: 8c6fa6f7230b
+Revises: c4x5y6z7a8b9, h3i4j5k6l7m8
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+revision: str = "8c6fa6f7230b"
+down_revision: str | Sequence[str] | None = ("c4x5y6z7a8b9", "h3i4j5k6l7m8")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/hindsight-api-slim/tests/test_alembic_dag.py
+++ b/hindsight-api-slim/tests/test_alembic_dag.py
@@ -1,0 +1,47 @@
+"""Graph-level sanity checks for the Alembic migration DAG.
+
+These tests do not touch a database; they only parse the revision files on
+disk, so they are cheap to run in CI and catch DAG accidents (divergent
+heads, unreachable revisions) at merge time instead of at deploy time.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _script_directory() -> ScriptDirectory:
+    cfg = Config()
+    script_location = Path(__file__).parent.parent / "hindsight_api" / "alembic"
+    cfg.set_main_option("script_location", str(script_location))
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_head() -> None:
+    """The DAG must have exactly one head.
+
+    A second head means a branch was added without a merge revision, which
+    makes ``alembic upgrade head`` (singular) ambiguous and forces the next
+    migration author to orphan whichever head they don't pick as parent.
+    v0.5.3 shipped in exactly that state; this test would have caught it.
+
+    Fix for a new head: ``alembic merge heads -m "<reason>"``.
+    """
+    script = _script_directory()
+    heads = script.get_heads()
+    assert len(heads) == 1, (
+        f"Alembic has {len(heads)} heads ({heads}); expected exactly 1. "
+        "Unify them with ``alembic merge heads -m '<reason>'``."
+    )
+
+
+def test_single_base() -> None:
+    """The DAG must have exactly one base (the initial schema).
+
+    Multiple bases mean disconnected migration trees, which can only happen
+    through manual file edits.
+    """
+    script = _script_directory()
+    bases = script.get_bases()
+    assert len(bases) == 1, f"Alembic has {len(bases)} bases ({bases}); expected exactly 1."

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -749,7 +749,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 
-> **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
+> **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](api/memory-banks.md#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](retain.md#entity-labels) for details.
 
 #### Customizing retain: when to use what
 


### PR DESCRIPTION
## Summary

v0.5.3 shipped with two divergent migration heads that were never unified. This is a structural DAG bug — independent of any specific upgrade path — with three consequences:

1. **`alembic upgrade head` (singular) is ambiguous for every v0.5.3 install.** Hindsight's startup code uses `heads` (plural), so the auto-startup path works around this, but any dev/ops tooling using the singular form errors with `Multiple head revisions are present for given argument 'head'`.

2. **No future migration can chain cleanly.** Whoever writes the next migration has to pick one of the two heads as its parent, orphaning the other branch until a separate merge is written.

3. **Upgrades from v0.5.2 leave `alembic_version` in a split state.** The walker applies the three `c4x5` revisions cleanly, leaving two rows stamped (one per head). The database operates normally, but the split state trips alembic's walker in some corner cases (e.g. databases carrying stale multi-head `alembic_version` rows from a pre-v0.5.0 era will see `CommandError: Requested revision X overlaps with other requested revisions Y` at startup).

## The two heads

- **`c4x5y6z7a8b9`** — delta-refresh chain
  (`add_last_refreshed_source_query` → `add_structured_content_to_mental_models` → `backsweep_orphan_observations_v2`)
- **`h3i4j5k6l7m8`** — per-bank vector indexes / audit log chain

Both fork from `z1u2v3w4x5y6`.

## Fix

1. **New merge revision `8c6fa6f7230b`** — empty `upgrade()` / `downgrade()`, linearises the DAG into a single head. No schema effect.
2. **New graph-level regression test (`tests/test_alembic_dag.py`)** — asserts `ScriptDirectory.get_heads()` returns exactly one head and `get_bases()` returns exactly one base. Parses revision files on disk (no database needed), runs fast in CI, and would have caught v0.5.3's split DAG before release.

## Reproduction (pre-fix)

```
$ alembic heads
c4x5y6z7a8b9 (head)
h3i4j5k6l7m8 (head)

$ alembic upgrade head
alembic.util.exc.CommandError: Multiple head revisions are present for given
argument 'head'; specify a specific target revision, '<branchname>@head' to
narrow to a specific head, or 'heads' for all heads
```

After:
```
$ alembic upgrade head
$ alembic current
8c6fa6f7230b (head) (mergepoint)
```

## Test plan
- [x] `uvx ruff check` — clean
- [x] `uvx ruff format --check` — clean
- [x] `uvx ty check` — clean
- [x] New regression test passes with the merge revision in place
- [x] New regression test **fails as intended** when the merge revision is removed (`AssertionError: Alembic has 2 heads (['c4x5y6z7a8b9', 'h3i4j5k6l7m8'])`) — verified locally
- [x] Local scratch database: restored a v0.5.2-era backup → `alembic upgrade heads` walked cleanly to `8c6fa6f7230b (head) (mergepoint)` with schema intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)