### PR TITLE
fix(claude-code): retain on SessionEnd even when retainEveryNTurns > 1

### DIFF
--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -69,21 +69,14 @@ def read_transcript(transcript_path: str) -> list:
     return messages
 
 
-def main():
+def run_retain(hook_input: dict, force: bool = False) -> None:
     config = load_config()
 
     if not config.get("autoRetain"):
         debug_log(config, "Auto-retain disabled, exiting")
         return
 
-    # Read hook input from stdin
-    try:
-        hook_input = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        print("[Hindsight] Failed to read hook input", file=sys.stderr)
-        return
-
-    debug_log(config, f"Stop hook input keys: {list(hook_input.keys())}")
+    debug_log(config, f"Retain hook_input keys: {list(hook_input.keys())} force={force}")
 
     session_id = hook_input.get("session_id", "unknown")
     transcript_path = hook_input.get("transcript_path", "")
@@ -102,8 +95,8 @@ def main():
     retain_full_window = False
     messages_to_retain = all_messages
 
-    # Respect retainEveryNTurns in both modes
-    if retain_every_n > 1:
+    # Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
+    if retain_every_n > 1 and not force:
         turn_count = increment_turn_count(session_id)
         if turn_count % retain_every_n != 0:
             next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
@@ -210,6 +203,15 @@ def main():
         debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
     except Exception as e:
         print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        print("[Hindsight] Failed to read hook input", file=sys.stderr)
+        return
+    run_retain(hook_input, force=False)
 
 
 if __name__ == "__main__":

--- a/hindsight-integrations/claude-code/scripts/session_end.py
+++ b/hindsight-integrations/claude-code/scripts/session_end.py
@@ -28,6 +28,15 @@ def main():
 
     debug_log(config, f"SessionEnd hook, reason: {hook_input.get('reason', 'unknown')}")
 
+    # Force a final retain before stopping the daemon — guarantees short sessions
+    # (fewer turns than retainEveryNTurns) still land on disk.
+    if config.get("autoRetain") and hook_input.get("transcript_path"):
+        try:
+            from retain import run_retain
+            run_retain(hook_input, force=True)
+        except Exception as e:
+            print(f"[Hindsight] SessionEnd final retain error: {e}", file=sys.stderr)
+
     # Stop daemon if we started it
     def _dbg(*a):
         debug_log(config, *a)


### PR DESCRIPTION
## Summary

Short Claude Code sessions are silently dropped when `retainEveryNTurns > 1`. SessionEnd previously only stopped the daemon; if a session ended before reaching a retain boundary, its transcript never landed on disk. Next session started with no memory of the previous one.

## Repro

Set (or leave at default) `"retainEveryNTurns": 10` and run a 3-turn session. `turns.json` increments to 3, no POST to `/v1/default/banks/{bank}/memories` is ever made, bank stays empty of the session's content.

## Fix

Refactor `scripts/retain.py`:
- Split `main()` into:
  - `main()`: reads stdin, delegates to `run_retain(hook_input, force=False)`.
  - `run_retain(hook_input, force=False)`: retain body; `force=True` bypasses the `retainEveryNTurns` turn-counter skip.

Patch `scripts/session_end.py` to call `run_retain(hook_input, force=True)` before `stop_daemon()` when `autoRetain` is enabled and a transcript path is present.

## Behavior changes

- With `retainEveryNTurns: 1` (recommended): no behavior change beyond an extra no-op-equivalent final retain at SessionEnd (writes a version of the same transcript — upsert on `session_id` document).
- With `retainEveryNTurns: N > 1`: previously-lost short sessions now retain. Long sessions retain at every Nth turn plus once more on end. The final-flush payload uses `session_id` as `document_id`, so the API upserts rather than duplicates.

## Verification

Tested end-to-end against an external Hindsight API: simulated Stop + SessionEnd hooks each posted successfully, the extractor pulled out a unique canary token as a `world` fact, and recall returned it on the next query.

## Test plan
- [x] Existing Stop path unchanged at `retainEveryNTurns: 1`
- [x] `retainEveryNTurns: 10` short session (< 10 turns) now retains via SessionEnd
- [ ] Add a unit test covering `run_retain(..., force=True)` skipping `increment_turn_count`