### PR TITLE
feat(claude-code): recall from additional banks alongside primary

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -32,6 +32,7 @@ DEFAULTS = {
     "retainContext": "claude-code",
     "retainTags": [],
     "retainMetadata": {},
+    "recallAdditionalBanks": [],
     # Connection
     "hindsightApiUrl": None,
     "hindsightApiToken": None,

--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -157,6 +157,26 @@ def main():
         return
 
     results = response.get("results", [])
+
+    # Also recall from any additional banks (e.g. shared user profile bank)
+    additional_banks = config.get("recallAdditionalBanks", [])
+    for extra_bank_id in additional_banks:
+        try:
+            extra_response = client.recall(
+                bank_id=extra_bank_id,
+                query=query,
+                max_tokens=config.get("recallMaxTokens", 1024),
+                budget=config.get("recallBudget", "mid"),
+                types=config.get("recallTypes"),
+                timeout=10,
+            )
+            extra_results = extra_response.get("results", [])
+            if extra_results:
+                debug_log(config, f"Got {len(extra_results)} memories from additional bank '{extra_bank_id}'")
+                results = results + extra_results
+        except Exception as e:
+            debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
+
     if not results:
         debug_log(config, "No memories found")
         return


### PR DESCRIPTION
## Summary

Adds a `recallAdditionalBanks` config option to the Claude Code plugin so that on every `UserPromptSubmit` the hook recalls memories from the primary bank **and** from a list of additional banks, merging the results before injection.

## Motivation

Users often want to separate identity/profile memory from per-agent working memory. Today the plugin is hard-wired to a single `bankId`, so if you keep a shared `ulysses` (user profile) bank plus a per-tool `claude` bank, the agent only sees one of them.

Example `~/.hindsight/claude-code.json`:

```json
{
  "bankId": "claude",
  "recallAdditionalBanks": ["ulysses"],
  "autoRecall": true
}
```

Now the Claude Code hook injects memories from both `claude` (working memory) and `ulysses` (user profile) on each turn.

## Changes

- `scripts/lib/config.py`: add `recallAdditionalBanks: []` to DEFAULTS.
- `scripts/recall.py`: after the primary recall succeeds, iterate over `recallAdditionalBanks`, call `client.recall()` for each with the same query/budget/max_tokens/types, and append results. Failures on an individual extra bank are logged and skipped — they never block the primary recall.

Default is an empty list, so behavior is unchanged for users who don't set it.

## Test plan

- [x] Verified in a live Claude Code session: with `recallAdditionalBanks: ["ulysses"]`, debug logs show `Got N memories from additional bank 'ulysses'` and those memories appear in the injected context block alongside `claude` bank results.
- [x] Verified that an invalid bank name in the list logs an error and does not break the primary recall.
- [ ] Default config (no `recallAdditionalBanks` key) produces identical behavior to prior versions.