### PR TITLE
fix(alembic): backfill banks.config from legacy per-column overrides (fixes #1157)

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/8c6fa6f7230b_merge_v053_divergent_heads.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/8c6fa6f7230b_merge_v053_divergent_heads.py
@@ -1,0 +1,40 @@
+"""Merge divergent migration heads for v0.5.3
+
+v0.5.3 shipped with two migration heads that were never unified:
+
+  * ``c4x5y6z7a8b9`` — delta-refresh chain
+    (``add_last_refreshed_source_query`` ->
+     ``add_structured_content_to_mental_models`` ->
+     ``backsweep_orphan_observations_v2``)
+
+  * ``h3i4j5k6l7m8`` — per-bank vector indexes / audit log chain
+    (the ``merge_heads_and_add_unit_entities_index`` subtree)
+
+Both fork from ``z1u2v3w4x5y6``. Upgrades from v0.5.2 still succeed — the
+walker applies the three c4x5 revisions and leaves the database stamped at
+both heads — but the result is a split DAG: ``alembic upgrade head``
+(singular) is ambiguous, and any future migration has to pick one head as
+its parent, orphaning the other.
+
+This revision linearises the DAG into a single head. It has no schema
+effect.
+
+Revision ID: 8c6fa6f7230b
+Revises: c4x5y6z7a8b9, h3i4j5k6l7m8
+Create Date: 2026-04-18
+"""
+
+from collections.abc import Sequence
+
+revision: str = "8c6fa6f7230b"
+down_revision: str | Sequence[str] | None = ("c4x5y6z7a8b9", "h3i4j5k6l7m8")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a0b1c2d3e4f5_backfill_bank_config_from_legacy.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a0b1c2d3e4f5_backfill_bank_config_from_legacy.py
@@ -1,0 +1,172 @@
+"""Backfill banks.config from legacy per-column bank config fields
+
+Revision ID: a0b1c2d3e4f5
+Revises: 8c6fa6f7230b
+Create Date: 2026-04-19
+
+Closes: #1157
+
+`x9s0t1u2v3w4_add_bank_config_column.py` (2026-02-09) introduced
+`banks.config JSONB DEFAULT '{}'::jsonb` as the new per-bank override
+store, but did not copy existing per-column values into it. Any user
+who had bank config set before Feb 2026 and upgraded past
+`x9s0t1u2v3w4` silently lost their `retain_mission`,
+`observations_mission`, `disposition_*`, and other override values.
+
+This migration is idempotent and defensive:
+
+  * For each legacy override field (the full list from
+    `hindsight_api/config.py::BankConfigOverride`), it checks whether
+    the corresponding legacy column still exists on `banks`.
+  * If the column exists AND the row has a non-null value AND the
+    new `banks.config` JSONB does not already carry that key, the
+    legacy value is copied into `banks.config`.
+  * Downgrade is intentionally a no-op: removing backfilled keys
+    from `config` would destroy the only remaining copy of the data.
+
+This migration cannot recover users whose legacy columns were
+subsequently dropped after `x9s0t1u2v3w4` shipped. Those users must
+restore from a pre-upgrade dump; see issue #1157 for recovery notes.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import context, op
+
+# revision identifiers, used by Alembic.
+revision: str = "a0b1c2d3e4f5"
+down_revision: str | Sequence[str] | None = "8c6fa6f7230b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Fields previously stored as individual columns on `banks` that now
+# live as keys under `banks.config` (JSONB). Sourced from
+# `hindsight_api/config.py::BankConfigOverride`.
+LEGACY_FIELDS: tuple[str, ...] = (
+    "llm_gemini_safety_settings",
+    "consolidation_llm_provider",
+    "consolidation_llm_api_key",
+    "consolidation_llm_model",
+    "consolidation_llm_base_url",
+    "consolidation_llm_max_concurrent",
+    "consolidation_llm_max_retries",
+    "consolidation_llm_initial_backoff",
+    "consolidation_llm_max_backoff",
+    "consolidation_llm_timeout",
+    "mcp_enabled_tools",
+    "recall_max_concurrent",
+    "recall_connection_budget",
+    "recall_max_query_tokens",
+    "retain_chunk_size",
+    "retain_extraction_mode",
+    "retain_mission",
+    "retain_custom_instructions",
+    "retain_default_strategy",
+    "retain_strategies",
+    "retain_chunk_batch_size",
+    "enable_observations",
+    "consolidation_batch_size",
+    "consolidation_max_memories_per_round",
+    "consolidation_llm_batch_size",
+    "consolidation_max_tokens",
+    "consolidation_source_facts_max_tokens",
+    "consolidation_source_facts_max_tokens_per_observation",
+    "consolidation_max_attempts",
+    "observations_mission",
+    "max_observations_per_scope",
+    "entity_labels",
+    "entities_allow_free_form",
+    "reflect_mission",
+    "reflect_source_facts_max_tokens",
+    "recall_include_chunks",
+    "recall_max_tokens",
+    "recall_chunks_max_tokens",
+    "recall_budget_function",
+    "recall_budget_fixed_low",
+    "recall_budget_fixed_mid",
+    "recall_budget_fixed_high",
+    "recall_budget_adaptive_low",
+    "recall_budget_adaptive_mid",
+    "recall_budget_adaptive_high",
+    "recall_budget_min",
+    "recall_budget_max",
+    "disposition_skepticism",
+    "disposition_literalism",
+    "disposition_empathy",
+)
+
+
+def _get_schema_prefix() -> str:
+    """Get schema prefix for table names (e.g., 'tenant_x.' or '' for public)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _get_target_schema() -> str:
+    """Get the target schema name (tenant schema or 'public')."""
+    schema = context.config.get_main_option("target_schema")
+    return schema if schema else "public"
+
+
+def upgrade() -> None:
+    """Backfill banks.config from any surviving legacy override columns."""
+    conn = op.get_bind()
+    schema_prefix = _get_schema_prefix()
+    schema_name = _get_target_schema()
+
+    # Confirm the `banks.config` column exists (added by x9s0t1u2v3w4).
+    # If it doesn't, we're running on a pre-x9s0t1u2v3w4 schema — nothing
+    # to backfill into.
+    config_col_exists = conn.execute(
+        sa.text(
+            """
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = :schema
+              AND table_name = 'banks'
+              AND column_name = 'config'
+            """
+        ),
+        {"schema": schema_name},
+    ).fetchone()
+    if not config_col_exists:
+        return
+
+    for field in LEGACY_FIELDS:
+        legacy_col_exists = conn.execute(
+            sa.text(
+                """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = :schema
+                  AND table_name = 'banks'
+                  AND column_name = :col
+                """
+            ),
+            {"schema": schema_name, "col": field},
+        ).fetchone()
+        if not legacy_col_exists:
+            # Column was dropped or never existed on this install.
+            continue
+
+        # Idempotent copy: only set config[field] when legacy column has
+        # a value AND the JSONB key is not already present. `to_jsonb`
+        # handles any column type (text, int, float, bool, jsonb, array).
+        conn.execute(
+            sa.text(
+                f"""
+                UPDATE {schema_prefix}banks
+                SET config = config || jsonb_build_object(:key, to_jsonb({field}))
+                WHERE {field} IS NOT NULL
+                  AND NOT (config ? :key)
+                """
+            ),
+            {"key": field},
+        )
+
+
+def downgrade() -> None:
+    """No-op: removing backfilled keys would destroy the only remaining copy."""
+    # Intentionally blank. If you need to undo this migration, do so by
+    # restoring from a pre-upgrade database dump.
+    pass

--- a/hindsight-api-slim/tests/test_alembic_dag.py
+++ b/hindsight-api-slim/tests/test_alembic_dag.py
@@ -1,0 +1,47 @@
+"""Graph-level sanity checks for the Alembic migration DAG.
+
+These tests do not touch a database; they only parse the revision files on
+disk, so they are cheap to run in CI and catch DAG accidents (divergent
+heads, unreachable revisions) at merge time instead of at deploy time.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _script_directory() -> ScriptDirectory:
+    cfg = Config()
+    script_location = Path(__file__).parent.parent / "hindsight_api" / "alembic"
+    cfg.set_main_option("script_location", str(script_location))
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_head() -> None:
+    """The DAG must have exactly one head.
+
+    A second head means a branch was added without a merge revision, which
+    makes ``alembic upgrade head`` (singular) ambiguous and forces the next
+    migration author to orphan whichever head they don't pick as parent.
+    v0.5.3 shipped in exactly that state; this test would have caught it.
+
+    Fix for a new head: ``alembic merge heads -m "<reason>"``.
+    """
+    script = _script_directory()
+    heads = script.get_heads()
+    assert len(heads) == 1, (
+        f"Alembic has {len(heads)} heads ({heads}); expected exactly 1. "
+        "Unify them with ``alembic merge heads -m '<reason>'``."
+    )
+
+
+def test_single_base() -> None:
+    """The DAG must have exactly one base (the initial schema).
+
+    Multiple bases mean disconnected migration trees, which can only happen
+    through manual file edits.
+    """
+    script = _script_directory()
+    bases = script.get_bases()
+    assert len(bases) == 1, f"Alembic has {len(bases)} bases ({bases}); expected exactly 1."

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -749,7 +749,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 
-> **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
+> **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](api/memory-banks.md#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](retain.md#entity-labels) for details.
 
 #### Customizing retain: when to use what
 


### PR DESCRIPTION
## Summary

- Fixes silent bank-config data loss introduced by `x9s0t1u2v3w4_add_bank_config_column.py` (2026-02-09) — closes #1157.
- Adds a new idempotent migration `a0b1c2d3e4f5_backfill_bank_config_from_legacy.py` that copies surviving legacy per-column override values into `banks.config` JSONB.
- No-op downgrade; intentionally destructive-safe.

## Context

`x9s0t1u2v3w4` introduced `banks.config JSONB DEFAULT '{}'::jsonb` as the new per-bank override store but never copied the pre-existing per-column values into it. Users who had `retain_mission`, `observations_mission`, `disposition_*`, or any other override field set before Feb 2026 silently lost them on upgrade. Full reproduction and impact analysis in #1157.

I have a concrete affected-user case: my April 9, 2026 JSON dump shows `retain_mission`, `observations_mission`, and all three `disposition_*` fields populated. Post-upgrade: all `null` in `banks.config`. No intervening manual change.

## What this PR does

Walks every field in `hindsight_api.config.BankConfigOverride`. For each field:

1. Checks whether the corresponding legacy column still exists on `banks` (multi-tenant safe via `target_schema`).
2. If it exists AND the row has a non-null value AND `banks.config` does not already carry that key, copies the value over using `jsonb_build_object(:key, to_jsonb(<column>))`.

Result: idempotent — safe to run on installs that already migrated cleanly, on installs that dropped the legacy columns, and on fresh installs (all branches no-op). `to_jsonb()` handles every existing column type (text, int, float, bool, jsonb, array).

## What this PR does NOT do

Can't recover users whose legacy columns were **subsequently dropped** by any migration after `x9s0t1u2v3w4`. Those users must restore from a pre-upgrade dump. Recovery path discussion is in #1157.

## Chaining

`down_revision = "8c6fa6f7230b"` — the alembic merge node from #1149. This PR is built on top of that branch so the DAG stays single-headed. **Depends on #1149 merging first.** If the maintainers prefer a different base, happy to rebase.

## Test plan

- [ ] Fresh install — migration runs, all legacy-column checks fail, no-op. `banks.config` for a new bank is `{}`.
- [ ] Install with legacy columns present and values set — migration copies values into `banks.config`. Re-run is idempotent (no duplicate keys, no overwrites).
- [ ] Install with legacy columns present but `config` already populated with the same key — existing JSONB value wins (idempotent guarantee from the `NOT (config ? :key)` predicate).
- [ ] Install where legacy columns were dropped — per-column existence check skips them, no errors.
- [ ] Multi-tenant: migration respects `target_schema` for both column-existence check and UPDATE.
- [ ] Downgrade — no-op, confirmed by comment + empty `downgrade()` body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)