### PR TITLE
feat(claude-code): add {user_id} retainTags template variable

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `{user_id}` template variable for `retainTags` and `retainMetadata`, resolved
+  from the `HINDSIGHT_USER_ID` env var (empty string if unset). Enables
+  machine-independent per-user memory scoping without hardcoding user ids in
+  `settings.json`.
+
+### Changed
+
+- Tags that resolve to an empty namespace content (e.g. `"user:"` when
+  `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
+  such tags were sent as-is. Tags without `:` are unaffected.
+
 ## [0.1.0] - 2025-03-23
 
 ### Added

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -202,9 +202,34 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |
 | `retainToolCalls` | — | `true` | Whether to include tool calls (function invocations and results) in the retained transcript. Captures structured actions like file reads, searches, and code edits. |
-| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports `{session_id}` placeholder which is replaced with the current session ID at runtime. |
-| `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. |
+| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: `{session_id}`, `{bank_id}`, `{timestamp}`, and `{user_id}` (resolved from `HINDSIGHT_USER_ID` env var; empty string if unset). Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. See [Template variables](#template-variables-for-retaintags-and-retainmetadata) below. |
+| `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. Same template placeholders as `retainTags`. |
 | `retainContext` | — | `"claude-code"` | A label attached to retained memories identifying their source. Useful when multiple integrations write to the same bank. |
+
+#### Template variables for `retainTags` and `retainMetadata`
+
+| Variable | Source |
+|----------|--------|
+| `{session_id}` | Current Claude Code session ID |
+| `{bank_id}` | Resolved bank ID (per `bankGranularity`) |
+| `{timestamp}` | ISO 8601 UTC at retain time |
+| `{user_id}` | Value of `HINDSIGHT_USER_ID` env var (empty string if unset) |
+
+##### Example: per-user memory scoping
+
+```json
+{
+  "retainTags": ["user:{user_id}", "session:{session_id}"]
+}
+```
+
+Set `HINDSIGHT_USER_ID=<opaque-user-id>` in your shell profile (`.zshrc`,
+`.bashrc`, etc.). If the env var is unset, the `user:` tag is dropped from the
+outgoing retain request and the rest of the tags are sent as-is — so the same
+`settings.json` works across machines whether you've set the env var or not.
+
+Downstream, `recall` can filter by `tags=["user:alice"]` to isolate memories
+authored by a specific user from a shared bank.
 
 ---
 

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -165,11 +165,12 @@ def main():
         document_id = session_id
 
     # Resolve template variables in tags and metadata.
-    # Supported variables: {session_id}, {bank_id}, {timestamp}
+    # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}
     template_vars = {
         "session_id": session_id,
         "bank_id": bank_id,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
     }
 
     def _resolve_template(value: str) -> str:
@@ -177,9 +178,22 @@ def main():
             value = value.replace(f"{{{k}}}", v)
         return value
 
-    # Tags from config with template resolution
+    # Tags from config with template resolution.
+    # Drop tags whose resolved form ends in an empty namespace part (e.g. "user:"
+    # when HINDSIGHT_USER_ID is unset). Tags without ':' are preserved as-is.
     raw_tags = config.get("retainTags", [])
-    tags = [_resolve_template(t) for t in raw_tags] if raw_tags else None
+    if raw_tags:
+        tags = []
+        for original in raw_tags:
+            resolved = _resolve_template(original)
+            if ":" in resolved and resolved.split(":", 1)[1] == "":
+                debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
+                continue
+            tags.append(resolved)
+        if not tags:
+            tags = None
+    else:
+        tags = None
 
     # Metadata: merge built-in defaults with user-configured extras
     metadata = {

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -276,6 +276,100 @@ class TestRetainHook:
         item = captured["body"]["items"][0]
         assert item["tags"] == ["sess-tag-test", "claude-code", "custom-tag"]
 
+    def test_retain_tag_resolves_user_id_when_env_set(self, monkeypatch, tmp_path):
+        """retainTags with {user_id} resolves from HINDSIGHT_USER_ID env var."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-user-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_env={"HINDSIGHT_USER_ID": "alice"},
+            extra_settings={"retainTags": ["user:{user_id}", "session:{session_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["user:alice", "session:sess-user-test"]
+
+    def test_retain_tag_dropped_when_user_id_env_unset(self, monkeypatch, tmp_path):
+        """user:{user_id} resolves to 'user:' and is dropped when env is unset; other tags survive."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-drop-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["user:{user_id}", "session:{session_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["session:sess-drop-test"]
+        assert not any(t.startswith("user:") for t in item["tags"])
+
+    def test_retain_tag_without_colon_preserved(self, monkeypatch, tmp_path):
+        """Tags without ':' are never dropped, regardless of env state."""
+        # _run_hook strips all HINDSIGHT_* env vars, so unset state is the default.
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-plain")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["plain-tag", "another"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["plain-tag", "another"]
+
+    def test_retain_tag_all_dropped_yields_no_tags_field(self, monkeypatch, tmp_path):
+        """If all tags resolve to dangling, the outgoing request omits the tags field."""
+        # _run_hook strips all HINDSIGHT_* env vars, so unset state is the default.
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-none")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["user:{user_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        # HindsightClient.retain only sets item["tags"] if tags is truthy (client.py:144).
+        # With all tags dropped, retain.py sets tags=None, so "tags" is absent from item.
+        assert "tags" not in item
+
     def test_retain_custom_metadata(self, monkeypatch, tmp_path):
         """retainMetadata config should be merged with built-in metadata."""
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]


### PR DESCRIPTION
## Summary

- Adds `{user_id}` template variable to `retainTags` / `retainMetadata`, resolved from `HINDSIGHT_USER_ID`.
- After resolution, drops tags of the form `"<ns>:"` (empty post-colon segment). Tags without `:` are untouched.
- Four new tests covering env-set / env-unset-drop / colon-less-preserved / all-dropped-yields-no-field. Full suite: 133 passed.

Fixes #1160.

## What

- `scripts/retain.py`: extend `template_vars` with `"user_id": os.environ.get("HINDSIGHT_USER_ID", "")`, rewrite the tag-resolution loop to drop dangling namespaced tags (logged via `debug_log`).
- `tests/test_hooks.py`: four new cases in `TestRetainHook`. `{user_id}` is injected via `_run_hook`'s `extra_env` (the helper strips real `HINDSIGHT_*` vars by design).
- `README.md`: expanded `retainTags` description, template variables reference table, per-user scoping example.
- `CHANGELOG.md`: `[Unreleased]` Added / Changed entries.

## How

`template_vars["user_id"]` is resolved once and applies to both `retainTags` and `retainMetadata` because `_resolve_template` is shared.

After `_resolve_template`, the loop skips any tag where `":" in resolved and resolved.split(":", 1)[1] == ""`. Colon-less tags never match the guard, so backward compat is preserved by construction. If every tag drops, `tags` is normalized to `None`; `HindsightClient.retain`'s existing field-omission path (`client.py:144` — `if tags: item["tags"] = tags`) then omits the field from the outgoing request.

## Test plan

- [x] [auto] `pytest tests/test_hooks.py -v -k retain_tag` → 5 passed (1 existing + 4 new).
- [x] [auto] `pytest tests/ -v` → 133 passed, no regression.
- [ ] [manual] CI green on this PR.
