### PR TITLE
fix(ai-sdk): align ReflectBasedOn types with OpenAPI spec

### DIFF
--- a/hindsight-integrations/ai-sdk/src/tools/index.ts
+++ b/hindsight-integrations/ai-sdk/src/tools/index.ts
@@ -76,8 +76,8 @@ export interface ReflectFact {
  */
 export interface ReflectBasedOn {
   memories?: ReflectFact[];
-  mental_models?: Array<{ id: string; name: string; content?: string | null }>;
-  directives?: Array<{ id: string; content: string }>;
+  mental_models?: Array<{ id: string; text: string; context?: string | null }>;
+  directives?: Array<{ id: string; name: string; content: string }>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes `ReflectBasedOn.mental_models` inline type from `{id, name, content?}` to `{id, text, context?}` to match `ReflectMentalModel` in the OpenAPI spec and `@vectorize-io/hindsight-client`
- Adds missing `name` field to `ReflectBasedOn.directives` to match `ReflectDirective` in the OpenAPI spec

This eliminates the need for `as unknown as HindsightClient` cast when calling `createHindsightTools()`, and fixes runtime `undefined` when consumers access `mental_models[].text`.

Fixes #1133

## Test plan

- [x] `npm run build` passes in `hindsight-integrations/ai-sdk`
- [x] Lint passes
- [ ] Verify `createHindsightTools({ client })` compiles without cast when `client` is a `HindsightClient` from `@vectorize-io/hindsight-client`