### PR TITLE
fix(api): populate items_count in list_operations

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7946,11 +7946,13 @@ class MemoryEngine(MemoryEngineInterface):
                 db_status = row["status"]
                 api_status = "pending" if db_status in ("pending", "processing") else db_status
 
+                result_metadata = json.loads(row["result_metadata"]) if row["result_metadata"] else {}
+
                 operation_list.append(
                     {
                         "id": str(row["operation_id"]),
                         "task_type": row["operation_type"],
-                        "items_count": 0,
+                        "items_count": result_metadata.get("items_count", 0),
                         "document_id": None,
                         "created_at": row["created_at"].isoformat(),
                         "status": api_status,


### PR DESCRIPTION
## Summary
- `list_operations` was hardcoding `items_count: 0` for every operation instead of reading it from `result_metadata`, which is already fetched by the query and correctly populated during retain/batch_retain submission
- Now parses `result_metadata` and extracts `items_count`, falling back to `0` for operation types that don't store it (e.g. consolidation)

Fixes #1146

## Test plan
- [x] Existing `test_async_batch_retain.py` tests pass (13/13)
- [x] Pre-commit lint passes