### PR TITLE
fix(startup): downgrade LLM verify_connection failure to warning

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1708,17 +1708,23 @@ class MemoryEngine(MemoryEngineInterface):
             await loop.run_in_executor(None, self.query_analyzer.load)
 
         async def verify_llm():
-            """Verify LLM connections are working for all unique configs."""
+            """Verify LLM connections are working for all unique configs.
+
+            Failures are logged as warnings instead of raising — the server will
+            still start so queued operations can be processed once the LLM
+            provider becomes available (e.g. after a quota reset).
+            """
             if not self._skip_llm_verification:
-                # Verify default config
-                await self._llm_config.verify_connection()
+                configs_to_verify: list[tuple[str, LLMConfig]] = [("default", self._llm_config)]
+
                 # Verify retain config if different from default
                 retain_is_different = (
                     self._retain_llm_config.provider != self._llm_config.provider
                     or self._retain_llm_config.model != self._llm_config.model
                 )
                 if retain_is_different:
-                    await self._retain_llm_config.verify_connection()
+                    configs_to_verify.append(("retain", self._retain_llm_config))
+
                 # Verify reflect config if different from default and retain
                 reflect_is_different = (
                     self._reflect_llm_config.provider != self._llm_config.provider
@@ -1728,7 +1734,8 @@ class MemoryEngine(MemoryEngineInterface):
                     or self._reflect_llm_config.model != self._retain_llm_config.model
                 )
                 if reflect_is_different:
-                    await self._reflect_llm_config.verify_connection()
+                    configs_to_verify.append(("reflect", self._reflect_llm_config))
+
                 # Verify consolidation config if different from all others
                 consolidation_is_different = (
                     (
@@ -1745,7 +1752,19 @@ class MemoryEngine(MemoryEngineInterface):
                     )
                 )
                 if consolidation_is_different:
-                    await self._consolidation_llm_config.verify_connection()
+                    configs_to_verify.append(("consolidation", self._consolidation_llm_config))
+
+                for config_name, llm_config in configs_to_verify:
+                    try:
+                        await llm_config.verify_connection()
+                    except Exception as e:
+                        logger.warning(
+                            "LLM connection verification failed for '%s' config: %s. "
+                            "Server will start but LLM-dependent operations may fail "
+                            "until the provider is available.",
+                            config_name,
+                            e,
+                        )
 
         # Build list of initialization tasks
         init_tasks = [

--- a/hindsight-api-slim/tests/test_verify_connection_soft_fail.py
+++ b/hindsight-api-slim/tests/test_verify_connection_soft_fail.py
@@ -1,0 +1,157 @@
+"""
+Tests that LLM connection verification failures don't crash server startup.
+
+When the LLM provider is unavailable (e.g. 429 quota exhaustion), the server
+should log a warning and continue booting rather than crash-looping.
+See: https://github.com/vectorize-io/hindsight/issues/1147
+"""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine
+from hindsight_api.engine.task_backend import SyncTaskBackend
+
+
+@pytest_asyncio.fixture(scope="function")
+async def engine_with_failing_llm(pg0_db_url, embeddings, cross_encoder, query_analyzer):
+    """Create a MemoryEngine whose LLM verify_connection raises."""
+    mem = MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="mock",
+        memory_llm_api_key="",
+        memory_llm_model="mock",
+        embeddings=embeddings,
+        cross_encoder=cross_encoder,
+        query_analyzer=query_analyzer,
+        pool_min_size=1,
+        pool_max_size=5,
+        run_migrations=False,
+        task_backend=SyncTaskBackend(),
+        skip_llm_verification=False,  # Enable verification — we want to test the soft-fail path
+    )
+    yield mem
+    try:
+        if mem._pool and not mem._pool._closing:
+            await mem.close()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_initialize_succeeds_when_verify_connection_fails(
+    engine_with_failing_llm,
+    caplog,
+):
+    """Server should start even if LLM verify_connection raises (e.g. 429)."""
+    engine = engine_with_failing_llm
+
+    # Patch the mock provider's verify_connection to simulate a 429 error
+    with patch.object(
+        engine._llm_config._provider_impl,
+        "verify_connection",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("429 RESOURCE_EXHAUSTED: Quota exceeded"),
+    ):
+        with caplog.at_level(logging.WARNING):
+            # Should NOT raise — the server boots despite the LLM being unavailable
+            await engine.initialize()
+
+    # Verify the warning was logged
+    assert any("LLM connection verification failed" in record.message for record in caplog.records)
+    assert any("429 RESOURCE_EXHAUSTED" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_initialize_logs_warning_per_failing_config(
+    pg0_db_url,
+    embeddings,
+    cross_encoder,
+    query_analyzer,
+    caplog,
+):
+    """Each distinct LLM config that fails verification gets its own warning."""
+    engine = MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="mock",
+        memory_llm_api_key="",
+        memory_llm_model="default-model",
+        retain_llm_provider="mock",
+        retain_llm_model="retain-model",  # Different model → separate verification
+        embeddings=embeddings,
+        cross_encoder=cross_encoder,
+        query_analyzer=query_analyzer,
+        pool_min_size=1,
+        pool_max_size=5,
+        run_migrations=False,
+        task_backend=SyncTaskBackend(),
+        skip_llm_verification=False,
+    )
+
+    # Both default and retain verify_connection will raise
+    with (
+        patch.object(
+            engine._llm_config._provider_impl,
+            "verify_connection",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("429 quota exceeded for default"),
+        ),
+        patch.object(
+            engine._retain_llm_config._provider_impl,
+            "verify_connection",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("429 quota exceeded for retain"),
+        ),
+    ):
+        with caplog.at_level(logging.WARNING):
+            await engine.initialize()
+
+    warning_messages = [r.message for r in caplog.records if "LLM connection verification failed" in r.message]
+    assert len(warning_messages) == 2
+    assert any("'default'" in msg for msg in warning_messages)
+    assert any("'retain'" in msg for msg in warning_messages)
+
+    try:
+        if engine._pool and not engine._pool._closing:
+            await engine.close()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_initialize_succeeds_when_verify_connection_succeeds(
+    pg0_db_url,
+    embeddings,
+    cross_encoder,
+    query_analyzer,
+    caplog,
+):
+    """Verify the happy path still works — no warnings when verification passes."""
+    engine = MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="mock",
+        memory_llm_api_key="",
+        memory_llm_model="mock",
+        embeddings=embeddings,
+        cross_encoder=cross_encoder,
+        query_analyzer=query_analyzer,
+        pool_min_size=1,
+        pool_max_size=5,
+        run_migrations=False,
+        task_backend=SyncTaskBackend(),
+        skip_llm_verification=False,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await engine.initialize()
+
+    assert not any("LLM connection verification failed" in r.message for r in caplog.records)
+
+    try:
+        if engine._pool and not engine._pool._closing:
+            await engine.close()
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- When the LLM provider is unavailable at startup (e.g. 429 quota exhaustion), the server now logs a warning and continues booting instead of crash-looping
- Each distinct LLM config (default, retain, reflect, consolidation) is verified independently — a failure on one doesn't skip the others
- Adds unit tests using mock provider to verify the soft-fail and happy-path behavior

Fixes #1147

## Test plan
- [x] `test_initialize_succeeds_when_verify_connection_fails` — verify_connection raises, server still boots, warning logged
- [x] `test_initialize_logs_warning_per_failing_config` — two distinct configs fail, two separate warnings logged with config names
- [x] `test_initialize_succeeds_when_verify_connection_succeeds` — happy path, no warnings