### PR TITLE
guide batch, OpenClaw and Hermes memory

### DIFF
--- a/hindsight-docs/guides/2026-04-20-guide-hermes-memory-bank-strategy-for-production.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-memory-bank-strategy-for-production.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-hermes-memory-bank-strategy-for-production.png
 hide_table_of_contents: true
 ---
 
-![Hermes Memory Bank Strategy for Production](/img/blog/guide-hermes-memory-bank-strategy-for-production.png)
-
 If you are designing a **Hermes memory bank strategy for production**, the part that matters most is not the model choice. It is how you divide memory space across users, teams, and environments. That one decision controls recall quality, isolation safety, and how easy the system is to debug when something looks wrong.
 
 The mistake I see most often is choosing one bank too early, then stretching it across unrelated workflows. That feels simple at first, but it turns recall into a grab bag. The healthier approach is to pick a bank naming scheme that matches how the agent will actually be used, then keep the scheme stable over time.

--- a/hindsight-docs/guides/2026-04-20-guide-hermes-memory-bank-strategy-for-production.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-memory-bank-strategy-for-production.md
@@ -1,0 +1,177 @@
+---
+title: "Hermes Memory Bank Strategy for Production"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, hermes, memory, production, configuration]
+description: "Choose the right Hermes memory bank strategy for production with Hindsight, scope banks safely, and keep recall clean across users, teams, and environments."
+image: /img/blog/guide-hermes-memory-bank-strategy-for-production.png
+hide_table_of_contents: true
+---
+
+![Hermes Memory Bank Strategy for Production](/img/blog/guide-hermes-memory-bank-strategy-for-production.png)
+
+If you are designing a **Hermes memory bank strategy for production**, the part that matters most is not the model choice. It is how you divide memory space across users, teams, and environments. That one decision controls recall quality, isolation safety, and how easy the system is to debug when something looks wrong.
+
+The mistake I see most often is choosing one bank too early, then stretching it across unrelated workflows. That feels simple at first, but it turns recall into a grab bag. The healthier approach is to pick a bank naming scheme that matches how the agent will actually be used, then keep the scheme stable over time.
+
+This guide walks through the bank patterns that work in production, when to use each one, and how to keep staging, production, multi-user, and shared-team setups from stepping on each other. Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall), and the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) nearby while you design it.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. One user or one workflow should map to one bank identity.
+> 2. Add tenant and environment markers early, not after the first incident.
+> 3. Use a shared bank only when collaboration is intentional.
+> 4. Keep the naming scheme stable so recall quality compounds over time.
+> 5. Treat `bank_id` as architecture, not as a throwaway config field.
+
+## Prerequisites
+
+Before you lock in a production bank strategy, make sure:
+
+- Hermes already uses the native Hindsight provider.
+- You know whether the deployment is single-user, multi-user, or multi-agent.
+- You know whether staging and production share the same Hindsight backend.
+
+Reference material: [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), [docs home](https://hindsight.vectorize.io/docs), [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).
+
+## Step by step
+
+### 1. Match the bank to the memory consumer
+
+Start with the question, “who should this memory help?” The answer usually falls into one of four buckets:
+
+| Pattern | Example | Best for |
+|---|---|---|
+| Personal | `user:12345` | one user, one assistant |
+| Tenant plus user | `tenant:acme:user:12345` | multi-tenant apps |
+| Shared team | `team:product-alpha` | coordinated group workflows |
+| Environment-scoped | `tenant:acme:user:12345:env:prod` | staging and prod on one backend |
+
+If you do not know which row fits, do not choose a bank yet.
+
+### 2. Add environment scoping before you need it
+
+This is the easiest production win in the whole setup:
+
+```text
+tenant:{tenant_id}:user:{user_id}:env:{environment}
+```
+
+That one suffix prevents staging data from showing up in production recall and makes debugging much easier.
+
+### 3. Choose between per-user and shared-team memory deliberately
+
+Per-user memory is safer by default. Shared-team memory is better when several operators or agents need the same project context.
+
+If you want one bank per user:
+
+```json
+{
+  "bank_id": "tenant:acme:user:12345:env:prod"
+}
+```
+
+If you want one shared bank for a coordinated workflow:
+
+```json
+{
+  "bank_id": "team:product-alpha:env:prod"
+}
+```
+
+The important thing is not which one you choose. It is that you choose it because the workflow demands it.
+
+### 4. Keep the naming scheme stable
+
+Memory only compounds if the bank identity stays consistent. If the bank name drifts over time, the same workflow gets split into multiple half-useful banks.
+
+Avoid patterns that depend on:
+
+- temporary session IDs
+- deploy timestamps
+- rotating container IDs
+- ad hoc branch names
+
+### 5. Write the bank choice into your launch path
+
+Do not set `bank_id` manually by hand in production. Generate it from known inputs:
+
+```bash
+python - <<'PY'
+import json, pathlib
+user_id = '12345'
+tenant_id = 'acme'
+env = 'prod'
+base = pathlib.Path.home() / '.hermes'
+path = base / 'hindsight' / 'config.json'
+path.parent.mkdir(parents=True, exist_ok=True)
+
+cfg = {
+    'provider': 'hindsight',
+    'hindsight_api_url': 'https://api.hindsight.vectorize.io',
+    'api_key': 'YOUR_HINDSIGHT_TOKEN',
+    'bank_id': f'tenant:{tenant_id}:user:{user_id}:env:{env}',
+    'memory_mode': 'hybrid',
+    'prefetch_method': 'recall'
+}
+
+path.write_text(json.dumps(cfg, indent=2) + '\n')
+print(f'Wrote {path} with bank_id={cfg["bank_id"]}')
+PY
+```
+
+## Verifying it works
+
+### Check the effective bank ID
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+base = pathlib.Path(os.environ.get('HERMES_HOME', pathlib.Path.home() / '.hermes'))
+path = base / 'hindsight' / 'config.json'
+cfg = json.loads(path.read_text())
+print('bank_id:', cfg.get('bank_id'))
+PY
+```
+
+### Check that the same workflow stays in the same bank
+
+Store a durable fact in one session, then confirm it is still recalled in the next session for the same user or team. That is the core production test.
+
+## Troubleshooting / common errors
+
+### Staging and production contaminate each other
+
+You need an explicit environment suffix.
+
+### One team bank feels noisy
+
+It is too broad. Split by workflow or customer segment.
+
+### Returning users do not see old context
+
+The bank naming rule is not stable across launches.
+
+## FAQ
+
+### Is one bank per user always best?
+
+No. It is the safest default, but team workflows often benefit from a shared bank.
+
+### Should I include tenant even if user IDs look unique?
+
+Usually yes. It makes future debugging much easier.
+
+### Can one deployment use multiple patterns?
+
+Yes. Different Hermes workflows can and often should use different bank shapes.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want a managed backend for production Hermes.
+- Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes) open for the provider config surface.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need a backend.
+- Read the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) before you tune retrieval and storage.
+- Compare the team-oriented tradeoffs in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-hermes-multi-user-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-multi-user-memory-with-hindsight.md
@@ -1,0 +1,189 @@
+---
+title: "Hermes Multi-User Memory Setup with Hindsight"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, hermes, memory, multi-user, configuration]
+description: "Set up Hermes multi-user memory with Hindsight, map each user to the right bank, and keep recall isolated so one user never inherits another user’s context."
+image: /img/blog/guide-hermes-multi-user-memory-with-hindsight.png
+hide_table_of_contents: true
+---
+
+![Hermes Multi-User Memory Setup with Hindsight](/img/blog/guide-hermes-multi-user-memory-with-hindsight.png)
+
+If you want **Hermes multi-user memory with Hindsight**, the design decision that matters most is not `memory_mode`. It is how you derive `bank_id` for each user. A single static bank is fine for a personal assistant. It is risky in a multi-user deployment, because recall gets better only when the bank contains the right person's history.
+
+The safe rule is simple: one user, one bank identity. In practice that usually means deriving `bank_id` from a stable user identifier, and often a tenant identifier too, then passing that value into the Hermes Hindsight provider for each session. Once that is in place, recall stays relevant and memory isolation becomes much easier to reason about.
+
+This guide shows how to pick a bank naming scheme, how to generate per-user config for Hermes, when to include a tenant prefix, and how to verify that one user's preferences never bleed into another user's session. Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [docs home](https://hindsight.vectorize.io/docs), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) nearby while you work.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Derive a unique `bank_id` per user, and per tenant if your deployment is multi-tenant.
+> 2. Pass that bank into Hermes before the session starts.
+> 3. Keep `memory_mode` and `prefetch_method` separate from identity, they solve different problems.
+> 4. Verify isolation by storing a fact for User A, then confirming User B cannot recall it.
+> 5. Add an environment suffix if you run staging and production side by side.
+
+## Prerequisites
+
+Before you wire Hermes for multiple users, make sure:
+
+- Hermes is already using the native Hindsight provider.
+- You can control how Hermes is launched for each user session.
+- Your app has a stable user ID, not a transient connection ID.
+- You know whether users belong to separate tenants.
+
+If you still need the base provider setup, start with the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain), and the [docs home](https://hindsight.vectorize.io/docs).
+
+## Step by step
+
+### 1. Pick the right bank naming pattern
+
+A reliable multi-user naming scheme usually looks like one of these:
+
+```text
+user:12345
+tenant:acme:user:12345
+tenant:acme:user:12345:env:prod
+```
+
+The point is not the exact string format. The point is that it should be:
+
+- stable across sessions
+- unique per user
+- easy to inspect during debugging
+- safe across tenants and environments
+
+If users can exist in multiple tenants, include the tenant. If you run staging and production against the same backend, include the environment too.
+
+### 2. Generate per-user Hermes config before launch
+
+Hermes stores Hindsight provider config in `~/.hermes/hindsight/config.json` by default. In a multi-user app, you can generate a session-specific config that sets `bank_id` for the current user:
+
+```bash
+python - <<'PY'
+import json, pathlib
+user_id = '12345'
+tenant_id = 'acme'
+base = pathlib.Path.home() / '.hermes'
+path = base / 'hindsight' / 'config.json'
+path.parent.mkdir(parents=True, exist_ok=True)
+
+cfg = {
+    'provider': 'hindsight',
+    'hindsight_api_url': 'https://api.hindsight.vectorize.io',
+    'api_key': 'YOUR_HINDSIGHT_TOKEN',
+    'bank_id': f'tenant:{tenant_id}:user:{user_id}:env:prod',
+    'memory_mode': 'hybrid',
+    'prefetch_method': 'recall'
+}
+
+path.write_text(json.dumps(cfg, indent=2) + '\n')
+print(f'Wrote {path} with bank_id={cfg["bank_id"]}')
+PY
+```
+
+This is the core move. Everything else, including memory mode, sits on top of the bank identity.
+
+### 3. Separate isolation from recall behavior
+
+Do not mix these two concerns:
+
+- `bank_id` decides whose memory you are reading.
+- `memory_mode` decides how Hermes uses memory during a turn.
+
+A safe starting point for multi-user assistants is:
+
+```json
+{
+  "bank_id": "tenant:acme:user:12345:env:prod",
+  "memory_mode": "hybrid",
+  "prefetch_method": "recall"
+}
+```
+
+Use `hybrid` when you want automatic recall plus explicit tools. If you prefer a cleaner tool surface, switch to `context`. The [Hermes memory modes guide](https://hindsight.vectorize.io/guides/2026/04/14/guide-hermes-memory-modes-with-hindsight-hybrid-context-tools) is the best place to tune that part later.
+
+### 4. Add tenant and environment boundaries early
+
+Multi-user bugs often show up only after a second customer lands in the same environment. That is why I recommend adding tenant and environment markers before you think you need them.
+
+A good production pattern is:
+
+```text
+tenant:{tenant_id}:user:{user_id}:env:{environment}
+```
+
+This makes it obvious which bank a session should hit, and it gives you a predictable rule for debugging unexpected recall.
+
+### 5. Verify isolation with two real users
+
+Do not stop at config inspection. Test the actual behavior.
+
+1. Launch Hermes as User A.
+2. Tell it something durable, for example: “Remember that I prefer weekly summaries on Fridays.”
+3. End the session so retention completes.
+4. Launch Hermes as User B with a different `bank_id`.
+5. Ask what it remembers about summary preferences.
+
+Expected result: User B should not inherit User A's fact.
+
+Then launch Hermes again as User A and confirm the preference is still present.
+
+## Verifying it works
+
+### Print the effective bank ID
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+base = pathlib.Path(os.environ.get('HERMES_HOME', pathlib.Path.home() / '.hermes'))
+path = base / 'hindsight' / 'config.json'
+cfg = json.loads(path.read_text())
+print('bank_id:', cfg.get('bank_id'))
+print('memory_mode:', cfg.get('memory_mode'))
+print('prefetch_method:', cfg.get('prefetch_method'))
+PY
+```
+
+### Run an isolation test, not just a health check
+
+`hermes memory status` tells you the provider is configured. It does not prove isolation. Isolation is proven only when two users cannot recall each other's context.
+
+## Troubleshooting / common errors
+
+### Two users still share context
+
+Usually they are still using the same `bank_id`, or a wrapper forgot to overwrite the default config before launch.
+
+### Recall is empty for returning users
+
+The provider may be switching bank IDs between sessions because the user identity source is unstable. Do not use a connection ID or a temporary session token.
+
+### Staging polluted production memory
+
+Add an explicit environment suffix to the bank naming scheme.
+
+## FAQ
+
+### Should I use one bank per user or one bank plus tags?
+
+For most Hermes multi-user setups, one bank per user is the simpler and safer answer. Tags are useful when you have a strong reason to group users inside one retrieval space.
+
+### Should I include the tenant even if user IDs are globally unique?
+
+If you are certain they are globally unique, you can skip it. In practice, tenant prefixes make debugging easier and reduce future surprises.
+
+### Do I need a different memory mode for multi-user setups?
+
+No. Identity and recall mode are separate decisions. Start with `hybrid` unless you have a clear reason to prefer `context` or `tools`.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want a managed backend for multi-user Hermes.
+- Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes) open for the provider config surface.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need a backend.
+- Read the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) to understand what gets surfaced and stored.
+- Compare the bank-scoping tradeoffs in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-hermes-multi-user-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-multi-user-memory-with-hindsight.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-hermes-multi-user-memory-with-hindsight.png
 hide_table_of_contents: true
 ---
 
-![Hermes Multi-User Memory Setup with Hindsight](/img/blog/guide-hermes-multi-user-memory-with-hindsight.png)
-
 If you want **Hermes multi-user memory with Hindsight**, the design decision that matters most is not `memory_mode`. It is how you derive `bank_id` for each user. A single static bank is fine for a personal assistant. It is risky in a multi-user deployment, because recall gets better only when the bank contains the right person's history.
 
 The safe rule is simple: one user, one bank identity. In practice that usually means deriving `bank_id` from a stable user identifier, and often a tenant identifier too, then passing that value into the Hermes Hindsight provider for each session. Once that is in place, recall stays relevant and memory isolation becomes much easier to reason about.

--- a/hindsight-docs/guides/2026-04-20-guide-hermes-shared-memory-across-agents.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-shared-memory-across-agents.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-hermes-shared-memory-across-agents.png
 hide_table_of_contents: true
 ---
 
-![Hermes Shared Memory Across Agents Setup](/img/blog/guide-hermes-shared-memory-across-agents.png)
-
 If you want **Hermes shared memory across agents**, the setup is much simpler than most people expect. Multiple agents do not need a special federation layer. They just need to point at the same Hindsight backend and the same `bank_id`. Once that happens, the agents can retrieve and retain against the same memory space.
 
 That simplicity is powerful, but it also means you need to be intentional. Shared memory only improves outcomes when the participating agents truly belong to the same workflow. If two unrelated agents write into the same bank, recall gets noisy fast. If two cooperating agents share a bank with a focused mission, the effect is the opposite, each one becomes smarter because it can build on what the others already learned.

--- a/hindsight-docs/guides/2026-04-20-guide-hermes-shared-memory-across-agents.md
+++ b/hindsight-docs/guides/2026-04-20-guide-hermes-shared-memory-across-agents.md
@@ -1,0 +1,167 @@
+---
+title: "Hermes Shared Memory Across Agents Setup"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, hermes, memory, multi-agent, configuration]
+description: "Set up Hermes shared memory across agents with Hindsight, reuse one bank on purpose, and test that multiple agents can build on the same context safely."
+image: /img/blog/guide-hermes-shared-memory-across-agents.png
+hide_table_of_contents: true
+---
+
+![Hermes Shared Memory Across Agents Setup](/img/blog/guide-hermes-shared-memory-across-agents.png)
+
+If you want **Hermes shared memory across agents**, the setup is much simpler than most people expect. Multiple agents do not need a special federation layer. They just need to point at the same Hindsight backend and the same `bank_id`. Once that happens, the agents can retrieve and retain against the same memory space.
+
+That simplicity is powerful, but it also means you need to be intentional. Shared memory only improves outcomes when the participating agents truly belong to the same workflow. If two unrelated agents write into the same bank, recall gets noisy fast. If two cooperating agents share a bank with a focused mission, the effect is the opposite, each one becomes smarter because it can build on what the others already learned.
+
+This guide shows how to choose the right shared bank, how to configure multiple Hermes agents to reuse it, how to keep role boundaries without splitting the bank, and how to verify that one agent can recall memories produced by another. Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) open while you work.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Pick one shared `bank_id` for the workflow, not for your whole organization.
+> 2. Configure each Hermes agent to use the same backend and the same bank.
+> 3. Keep agent roles distinct in prompts and missions, not in separate banks, if collaboration is the goal.
+> 4. Test with two agents, one writes a durable fact and the other recalls it.
+> 5. Split the bank later if unrelated context starts polluting recall.
+
+## Prerequisites
+
+Before you share memory between Hermes agents, make sure:
+
+- Every agent already uses the native Hindsight provider.
+- You control the config for each agent.
+- The agents really belong to the same project, customer workflow, or team process.
+- You know what durable context should be shared.
+
+If you still need the base provider setup, start with the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [docs home](https://hindsight.vectorize.io/docs), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall).
+
+## Step by step
+
+### 1. Choose a bank name that matches one real workflow
+
+Good shared-bank examples:
+
+- `support-escalations`
+- `team-product-alpha`
+- `launch-ops-q2`
+
+Bad examples:
+
+- `shared`
+- `general`
+- `everyone`
+
+A bank should reflect one collaborative memory space. If you cannot explain which agents belong in it, the bank is probably too broad.
+
+### 2. Configure the first Hermes agent
+
+In the Hermes Hindsight config, set the shared bank explicitly:
+
+```json
+{
+  "provider": "hindsight",
+  "hindsight_api_url": "https://api.hindsight.vectorize.io",
+  "api_key": "YOUR_HINDSIGHT_TOKEN",
+  "bank_id": "team-product-alpha",
+  "memory_mode": "hybrid",
+  "prefetch_method": "recall"
+}
+```
+
+This first agent becomes one writer and reader in the shared bank.
+
+### 3. Configure the second agent with the same bank
+
+Use the same backend and the same `bank_id` for the second agent too:
+
+```json
+{
+  "provider": "hindsight",
+  "hindsight_api_url": "https://api.hindsight.vectorize.io",
+  "api_key": "YOUR_HINDSIGHT_TOKEN",
+  "bank_id": "team-product-alpha",
+  "memory_mode": "hybrid",
+  "prefetch_method": "recall"
+}
+```
+
+Now both agents are attached to the same memory space. Their roles can still differ in prompts, tool access, and operating rules, but their memory bank is shared.
+
+### 4. Keep roles separate in instructions, not bank IDs
+
+A common mistake is trying to preserve role differences by splitting the bank. That defeats the point of shared memory. Instead:
+
+- keep one shared bank
+- use different prompts or skills per agent
+- use a focused retain mission so only durable workflow context gets stored
+
+This is the same mental model discussed in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents) and [Adding memory to Codex with Hindsight](https://hindsight.vectorize.io/blog/adding-memory-to-codex-with-hindsight).
+
+### 5. Test a real cross-agent handoff
+
+A simple test looks like this:
+
+1. Agent A learns: “The customer wants concise weekly summaries and the billing export must include tax codes.”
+2. The session ends and retention completes.
+3. Agent B is launched on the same shared bank.
+4. Ask Agent B a question where those facts matter.
+
+If the shared bank is working, Agent B should recall the retained context without you repeating it.
+
+## Verifying it works
+
+### Confirm both agents use the same bank ID
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+base = pathlib.Path(os.environ.get('HERMES_HOME', pathlib.Path.home() / '.hermes'))
+path = base / 'hindsight' / 'config.json'
+cfg = json.loads(path.read_text())
+print(cfg.get('bank_id'))
+PY
+```
+
+Run that check in each agent environment. The value should match exactly.
+
+### Confirm cross-agent recall, not just single-agent recall
+
+If Agent A remembers its own facts and Agent B does not, the problem is not Hindsight itself. It is that the two agents are not on the same bank.
+
+## Troubleshooting / common errors
+
+### The second agent does not recall anything
+
+Usually the bank IDs do not match, or one agent is still pointing at a different Hindsight backend.
+
+### Shared recall is too noisy
+
+The bank is too broad. Split by workflow or team rather than letting every Hermes agent write into one general bank.
+
+### Agents overwrite each other conceptually
+
+That usually means the retain mission is too vague. Tighten what should count as durable shared memory.
+
+## FAQ
+
+### Should every Hermes agent in the company share one bank?
+
+Usually no. Shared memory works best for one bounded workflow, not a whole organization.
+
+### Can I combine a shared bank with different memory modes per agent?
+
+Yes. The bank can stay shared while one agent uses `hybrid` and another uses `context`, if that matches the UX you want.
+
+### Is one shared bank better than passing notes manually?
+
+For ongoing workflows, yes. Shared memory reduces repeated handoff context and lets agents compound knowledge over time.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want one managed backend for all Hermes agents.
+- Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes) open for full provider configuration details.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need a backend.
+- Read the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) to tune retrieval and storage.
+- Compare the collaboration model in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-move-hermes-memory-from-local-files-to-hindsight-cloud.md
+++ b/hindsight-docs/guides/2026-04-20-guide-move-hermes-memory-from-local-files-to-hindsight-cloud.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-move-hermes-memory-from-local-files-to-hindsight-cloud.pn
 hide_table_of_contents: true
 ---
 
-![Move Hermes Memory to Hindsight Cloud Guide](/img/blog/guide-move-hermes-memory-from-local-files-to-hindsight-cloud.png)
-
 If you want to **move Hermes memory from local files to Hindsight Cloud**, the migration is mostly about separating two kinds of memory that used to live together. Hermes can keep its local, bounded file memory for agent-local context, while Hindsight Cloud becomes the durable long-term memory backend that survives sessions and scales better across devices or shared workflows.
 
 The important part is not copying every local artifact byte for byte. It is preserving the durable facts you actually care about, then pointing Hermes at the managed Hindsight backend so future retention and recall happen there. In practice, that means backing up your current Hermes memory files, switching the provider config to Cloud, and validating recall with a few known facts before you fully trust the new path.

--- a/hindsight-docs/guides/2026-04-20-guide-move-hermes-memory-from-local-files-to-hindsight-cloud.md
+++ b/hindsight-docs/guides/2026-04-20-guide-move-hermes-memory-from-local-files-to-hindsight-cloud.md
@@ -1,0 +1,167 @@
+---
+title: "Move Hermes Memory to Hindsight Cloud Guide"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, hermes, memory, cloud, migration]
+description: "Move Hermes memory from local files to Hindsight Cloud, keep the setup clean, and verify that recall still works after the switch to a managed backend."
+image: /img/blog/guide-move-hermes-memory-from-local-files-to-hindsight-cloud.png
+hide_table_of_contents: true
+---
+
+![Move Hermes Memory to Hindsight Cloud Guide](/img/blog/guide-move-hermes-memory-from-local-files-to-hindsight-cloud.png)
+
+If you want to **move Hermes memory from local files to Hindsight Cloud**, the migration is mostly about separating two kinds of memory that used to live together. Hermes can keep its local, bounded file memory for agent-local context, while Hindsight Cloud becomes the durable long-term memory backend that survives sessions and scales better across devices or shared workflows.
+
+The important part is not copying every local artifact byte for byte. It is preserving the durable facts you actually care about, then pointing Hermes at the managed Hindsight backend so future retention and recall happen there. In practice, that means backing up your current Hermes memory files, switching the provider config to Cloud, and validating recall with a few known facts before you fully trust the new path.
+
+This guide shows a safe migration path, how to configure Hermes for Hindsight Cloud, and how to test that your assistant still remembers what matters after the switch. Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain), and the [docs home](https://hindsight.vectorize.io/docs) open while you work.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Back up your current Hermes local memory files first.
+> 2. Decide which durable context is worth preserving.
+> 3. Configure Hermes to use Hindsight Cloud with a stable `bank_id`.
+> 4. Seed the new bank with a short retained summary if needed.
+> 5. Verify recall before you remove or ignore the old local files.
+
+## Prerequisites
+
+Before you migrate, make sure:
+
+- You have a Hindsight Cloud account and API token.
+- Hermes already works locally, so you know what behavior you are trying to preserve.
+- You can edit `~/.hermes/hindsight/config.json`.
+
+Reference material: [Hindsight Cloud](https://hindsight.vectorize.io), [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes), [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain).
+
+## Step by step
+
+### 1. Back up the local Hermes memory files
+
+Make a backup before you change anything:
+
+```bash
+mkdir -p ~/hermes-memory-backup
+cp -R ~/.hermes ~/hermes-memory-backup/hermes-$(date +%Y%m%d-%H%M%S)
+```
+
+You may not need every file later, but you do want a clean rollback point.
+
+### 2. Decide what should be preserved
+
+Local file memory often contains a mix of durable context and short-lived session detail. For the move to Hindsight Cloud, preserve the durable layer:
+
+- user preferences
+- project context
+- ongoing commitments
+- key decisions
+- stable workflows
+
+If needed, create a compact summary you can retain into the new bank once Cloud is configured.
+
+### 3. Configure Hermes for Hindsight Cloud
+
+Update the native Hindsight provider config:
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+base = pathlib.Path(os.environ.get('HERMES_HOME', pathlib.Path.home() / '.hermes'))
+path = base / 'hindsight' / 'config.json'
+path.parent.mkdir(parents=True, exist_ok=True)
+
+cfg = {
+    'provider': 'hindsight',
+    'hindsight_api_url': 'https://api.hindsight.vectorize.io',
+    'api_key': 'YOUR_HINDSIGHT_TOKEN',
+    'bank_id': 'hermes-primary',
+    'memory_mode': 'hybrid',
+    'prefetch_method': 'recall'
+}
+
+path.write_text(json.dumps(cfg, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+This does not delete your local Hermes files. It changes where long-term memory is read and written going forward.
+
+### 4. Seed the new bank if you need continuity on day one
+
+If there are a few critical facts you want available immediately, retain a compact summary into the new bank. For example:
+
+```text
+The user prefers concise answers, is launching Product Alpha in May, uses Postgres, and cares most about billing reliability and release checklists.
+```
+
+You do not need to seed everything. Seed only the durable context that would be frustrating to lose.
+
+### 5. Verify recall in a fresh session
+
+After switching to Cloud:
+
+1. Launch Hermes.
+2. Teach it one new durable fact.
+3. End the session.
+4. Start a new session.
+5. Ask about the fact.
+
+If recall works across the fresh session, the Cloud path is healthy.
+
+## Verifying it works
+
+### Print the active config
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+base = pathlib.Path(os.environ.get('HERMES_HOME', pathlib.Path.home() / '.hermes'))
+path = base / 'hindsight' / 'config.json'
+cfg = json.loads(path.read_text())
+print('hindsight_api_url:', cfg.get('hindsight_api_url'))
+print('bank_id:', cfg.get('bank_id'))
+print('memory_mode:', cfg.get('memory_mode'))
+PY
+```
+
+### Run a clean-session recall test
+
+A successful migration is not “the file looks right.” It is “a new session still recalls the right durable context.”
+
+## Troubleshooting / common errors
+
+### Recall stopped working after the switch
+
+Usually the API token or URL is wrong, or the new `bank_id` does not match the bank you expected.
+
+### The assistant feels like it forgot everything
+
+That usually means nothing was seeded and the old durable context only existed in local files. Retain a compact summary into the new bank to bridge the gap.
+
+### I am seeing staging and production mix together
+
+Split the bank by environment, for example `hermes-primary-prod` and `hermes-primary-staging`.
+
+## FAQ
+
+### Do I need to migrate every local memory file exactly?
+
+No. Preserve the durable facts, not every artifact.
+
+### Should I keep the same `bank_id` forever after moving to Cloud?
+
+If you want continuity, yes. Change it only when you intentionally want a fresh bank.
+
+### Is Hindsight Cloud better than local files for every Hermes use case?
+
+Not automatically. Cloud is better when you want durability, sharing, or simpler operations. Local files can still be fine for narrow personal workflows.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you have not created the backend yet.
+- Keep the [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes) open for the native provider configuration surface.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you want the self-hosted path instead of Cloud.
+- Read the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) and [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) if you want to seed or tune the new bank more deliberately.
+- Compare adjacent migration ideas in [Adding memory to Codex with Hindsight](https://hindsight.vectorize.io/blog/adding-memory-to-codex-with-hindsight) and [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-and-claude-code-shared-memory.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-and-claude-code-shared-memory.md
@@ -1,0 +1,186 @@
+---
+title: "OpenClaw and Claude Code Shared Memory Setup"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, openclaw, claude-code, memory, workflow]
+description: "Set up shared memory between OpenClaw and Claude Code with Hindsight, reuse one bank across both tools, and verify that context moves cleanly between chat and coding work."
+image: /img/blog/guide-openclaw-and-claude-code-shared-memory.png
+hide_table_of_contents: true
+---
+
+![OpenClaw and Claude Code Shared Memory Setup](/img/blog/guide-openclaw-and-claude-code-shared-memory.png)
+
+If you want **OpenClaw and Claude Code shared memory**, the trick is not installing another memory system. It is making both tools point at the same Hindsight bank on purpose. Once that is true, context learned in chat can show up in coding sessions, and discoveries from coding sessions can come back into chat without anyone retyping the whole backstory.
+
+This setup is useful when one workflow spans both tools. You might discuss product requirements with an OpenClaw assistant, switch to Claude Code to implement them, then return to OpenClaw for status updates. Without shared memory, each tool starts from zero. With a shared bank, they can reuse the same project facts, preferences, and working context.
+
+This guide shows the safest way to wire that up, when to use a fixed shared `bankId`, how to keep the bank narrow enough to stay useful, and how to test that context really moves from one tool to the other. Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), the [Claude Code post](https://hindsight.vectorize.io/blog/claude-code-persistent-memory), and the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) open while you configure it.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Pick a single shared `bankId` for the workflow, for example `team-product-alpha`.
+> 2. Configure Claude Code and OpenClaw to use the same Hindsight backend and the same bank.
+> 3. Use a focused retain mission so both tools store compatible, durable context.
+> 4. Write one memory in OpenClaw, recall it in Claude Code, then test the reverse path.
+> 5. Split the bank later if unrelated projects begin to pollute recall.
+
+## Prerequisites
+
+Before you share memory between tools, make sure:
+
+- Hindsight is already running, local or cloud.
+- OpenClaw is installed and the Hindsight plugin is healthy.
+- Claude Code has the Hindsight plugin installed.
+- You understand which project or team should own the shared bank.
+
+If you still need the base setup, start with the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), the [docs home](https://hindsight.vectorize.io/docs), and the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain).
+
+## Step by step
+
+### 1. Choose one intentional shared bank ID
+
+A shared bank should map to one real workflow, not your entire life. Good examples:
+
+- `team-product-alpha`
+- `customer-support-escalations`
+- `launch-ops-q2`
+
+Bad examples:
+
+- `default`
+- `shared`
+- `everything`
+
+The bank name should tell you who the memory is for and what work belongs in it. That one decision does more for recall quality than almost any token-setting tweak.
+
+### 2. Point OpenClaw at the shared bank
+
+Update the OpenClaw plugin config to use a fixed `bankId`:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+entries = config.setdefault('plugins', {}).setdefault('entries', {})
+plugin = entries.setdefault('hindsight-openclaw', {'enabled': True, 'config': {}})
+plugin['enabled'] = True
+cfg = plugin.setdefault('config', {})
+cfg['dynamicBankId'] = False
+cfg['bankId'] = 'team-product-alpha'
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+This intentionally overrides the default dynamic bank behavior. You are telling OpenClaw, “for this agent, always write and recall from the same shared brain.”
+
+### 3. Point Claude Code at the same bank
+
+In the Claude Code Hindsight plugin config, use the same `bankId` and the same backend credentials:
+
+```json
+{
+  "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+  "hindsightApiToken": "YOUR_TOKEN",
+  "bankId": "team-product-alpha",
+  "retainMission": "Extract durable project decisions, coding conventions, important constraints, and user preferences that should help across chat and coding sessions."
+}
+```
+
+The exact location of your Claude Code plugin config can vary with install method, so use the plugin's own config surface, but the important thing is the shared `bankId`. If Claude Code points at `team-product-alpha` and OpenClaw points at `team-product-alpha`, they are reading and writing the same bank.
+
+### 4. Align the retention mission across both tools
+
+A shared bank only works if the stored memories make sense in both environments. That means both tools should prioritize:
+
+- project decisions
+- user preferences
+- open tasks and constraints
+- architecture context
+- naming conventions and patterns
+
+They should avoid storing:
+
+- transient chat filler
+- duplicate logs
+- one-off operational noise
+
+This is where the [team shared memory post](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents) and [Adding memory to Codex with Hindsight](https://hindsight.vectorize.io/blog/adding-memory-to-codex-with-hindsight) are helpful, because they show what a useful shared bank looks like in practice.
+
+### 5. Test both directions
+
+First, write in OpenClaw and recall in Claude Code.
+
+1. In OpenClaw, tell the assistant: “Remember that the new launch checklist must include billing smoke tests and the team prefers concise summaries.”
+2. Let the turn finish.
+3. In Claude Code, ask it to continue launch work or summarize what it knows about the checklist.
+
+Then test the reverse path.
+
+1. In Claude Code, make a decision during implementation, for example: “We are using background jobs for webhook retries, not in-request processing.”
+2. End the session so retention runs.
+3. In OpenClaw, ask for a status summary.
+
+If the shared bank is wired correctly, context should move both ways.
+
+## Verifying it works
+
+### Check the bank configuration
+
+OpenClaw should show a fixed `bankId`:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+cfg = config['plugins']['entries']['hindsight-openclaw']['config']
+print('dynamicBankId:', cfg.get('dynamicBankId'))
+print('bankId:', cfg.get('bankId'))
+PY
+```
+
+Claude Code should show the same bank in its Hindsight plugin config.
+
+### Check cross-tool recall, not just local recall
+
+The real success criterion is cross-tool continuity. If each tool recalls only what it retained itself, you still do not have shared memory.
+
+## Troubleshooting / common errors
+
+### OpenClaw and Claude Code still feel separate
+
+One of them is almost always pointing at a different bank or a different backend URL.
+
+### Recall quality is noisy
+
+Your bank is too broad. Split by team, project, or customer workflow instead of using one bank for everything.
+
+### One tool stores useful context, the other stores junk
+
+Align the `retainMission`. Shared memory breaks down when one tool writes durable facts and the other writes conversation clutter.
+
+## FAQ
+
+### Should I use a fixed bank or dynamic banks here?
+
+For true cross-tool sharing, use a fixed bank. Dynamic banks are great when you want automatic isolation, but a fixed bank is simpler when the whole point is sharing.
+
+### Can multiple Claude Code users share the same bank too?
+
+Yes, but only if that is intentional. A shared bank should match a real shared workflow, not a vague convenience setting.
+
+### Is this better than copying notes manually between tools?
+
+Yes, when the workflow is active and ongoing. Manual notes still matter, but shared memory reduces the repeated “catch-up” work.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want one backend shared between chat and coding tools.
+- Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw) and the [Claude Code persistent memory post](https://hindsight.vectorize.io/blog/claude-code-persistent-memory) open while you configure both sides.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need a Hindsight server.
+- Review the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) to tune how much context moves between tools.
+- Read [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents) if you want to expand the pattern to a whole team.

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-and-claude-code-shared-memory.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-and-claude-code-shared-memory.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-openclaw-and-claude-code-shared-memory.png
 hide_table_of_contents: true
 ---
 
-![OpenClaw and Claude Code Shared Memory Setup](/img/blog/guide-openclaw-and-claude-code-shared-memory.png)
-
 If you want **OpenClaw and Claude Code shared memory**, the trick is not installing another memory system. It is making both tools point at the same Hindsight bank on purpose. Once that is true, context learned in chat can show up in coding sessions, and discoveries from coding sessions can come back into chat without anyone retyping the whole backstory.
 
 This setup is useful when one workflow spans both tools. You might discuss product requirements with an OpenClaw assistant, switch to Claude Code to implement them, then return to OpenClaw for status updates. Without shared memory, each tool starts from zero. With a shared bank, they can reuse the same project facts, preferences, and working context.

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-memory-bank-strategy-for-teams.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-memory-bank-strategy-for-teams.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-openclaw-memory-bank-strategy-for-teams.png
 hide_table_of_contents: true
 ---
 
-![OpenClaw Memory Bank Strategy for Teams](/img/blog/guide-openclaw-memory-bank-strategy-for-teams.png)
-
 If you are choosing an **OpenClaw memory bank strategy for teams**, the important question is not “should we use memory?” It is “what should count as one memory space?” That answer determines whether recall feels focused, whether team context compounds usefully, and whether one user's chat history stays out of another user's answers.
 
 OpenClaw gives you several viable patterns through Hindsight bank configuration. You can isolate per user, per provider, per channel, or collapse down to one intentionally shared bank for a team workflow. None of those options is universally right. The best choice depends on whether your agents serve individuals, shared queues, or a small team working on one project together.

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-memory-bank-strategy-for-teams.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-memory-bank-strategy-for-teams.md
@@ -1,0 +1,178 @@
+---
+title: "OpenClaw Memory Bank Strategy for Teams"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, openclaw, memory, teams, configuration]
+description: "Choose the right OpenClaw memory bank strategy for teams with Hindsight, compare per-user and shared patterns, and avoid the most common isolation mistakes."
+image: /img/blog/guide-openclaw-memory-bank-strategy-for-teams.png
+hide_table_of_contents: true
+---
+
+![OpenClaw Memory Bank Strategy for Teams](/img/blog/guide-openclaw-memory-bank-strategy-for-teams.png)
+
+If you are choosing an **OpenClaw memory bank strategy for teams**, the important question is not “should we use memory?” It is “what should count as one memory space?” That answer determines whether recall feels focused, whether team context compounds usefully, and whether one user's chat history stays out of another user's answers.
+
+OpenClaw gives you several viable patterns through Hindsight bank configuration. You can isolate per user, per provider, per channel, or collapse down to one intentionally shared bank for a team workflow. None of those options is universally right. The best choice depends on whether your agents serve individuals, shared queues, or a small team working on one project together.
+
+This guide explains the three patterns that matter most, how to pick one without overcomplicating the setup, and how to migrate later if your needs change. Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), the [docs home](https://hindsight.vectorize.io/docs), the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall), and the [team shared memory post](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents) open while you compare.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Use `["provider", "user"]` for most team assistants that serve individuals.
+> 2. Use one fixed shared `bankId` only for tightly shared workflows.
+> 3. Avoid one bank for every user unless the agent is explicitly collaborative.
+> 4. Tighten `retainMission` before you widen sharing.
+> 5. Reevaluate the layout when recall gets noisy, not only when setup changes.
+
+## Prerequisites
+
+Before choosing a team strategy, make sure:
+
+- OpenClaw and the Hindsight plugin are already installed.
+- Your team knows which conversations should stay personal and which should be shared.
+- You have one Hindsight backend, local or cloud, that all participating agents can reach.
+
+Base setup references: [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), [Retain API reference](https://hindsight.vectorize.io/docs/api/retain), and [docs home](https://hindsight.vectorize.io/docs).
+
+## Step by step
+
+### 1. Understand the three bank patterns that matter
+
+For most teams, the real choices are:
+
+| Pattern | Example | Best for |
+|---|---|---|
+| Per-user | `["provider", "user"]` | personal assistants, support bots that serve individuals |
+| Per-user plus per-agent | `["agent", "provider", "user"]` | strict isolation between agent roles |
+| Shared fixed bank | `bankId="team-product-alpha"` | collaborative team workflows |
+
+The default pattern is safer. The shared pattern is more powerful. Which one you want depends on how much coordination the team actually needs.
+
+### 2. Start with per-user unless the workflow is truly shared
+
+Most teams should begin with:
+
+```json
+["provider", "user"]
+```
+
+Why? Because it keeps one human's context together across channels on the same platform, but it still avoids mixing different users or different providers automatically.
+
+You can apply it with:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+entries = config.setdefault('plugins', {}).setdefault('entries', {})
+plugin = entries.setdefault('hindsight-openclaw', {'enabled': True, 'config': {}})
+cfg = plugin.setdefault('config', {})
+cfg['dynamicBankId'] = True
+cfg['dynamicBankGranularity'] = ['provider', 'user']
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+### 3. Move to a fixed shared bank only when collaboration is the point
+
+If multiple people or multiple agents need to build on one shared context, use a fixed bank instead:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+entries = config.setdefault('plugins', {}).setdefault('entries', {})
+plugin = entries.setdefault('hindsight-openclaw', {'enabled': True, 'config': {}})
+cfg = plugin.setdefault('config', {})
+cfg['dynamicBankId'] = False
+cfg['bankId'] = 'team-product-alpha'
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+This works well for team planning, shared project coordination, and collective knowledge capture. It works badly for personal assistant workflows.
+
+### 4. Use `retainMission` to keep recall clean
+
+Whatever bank pattern you choose, a focused retention rule matters more in team setups because the bank fills faster:
+
+```text
+Extract durable project decisions, recurring tasks, stable preferences, important constraints, and shared context. Ignore one-off chatter, duplicate logs, and transient tool output.
+```
+
+This is one of the highest leverage settings in the whole system. It often matters more than recall budget.
+
+### 5. Pick one pattern per workflow, not per company
+
+A company usually needs more than one strategy.
+
+For example:
+
+- customer support agent: per user
+- shared release manager: fixed team bank
+- engineering assistant: team bank or project bank
+
+That is a healthier model than forcing the whole organization into one memory shape.
+
+## Verifying it works
+
+### Print the active bank settings
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+plugin = config['plugins']['entries']['hindsight-openclaw']['config']
+print('dynamicBankId:', plugin.get('dynamicBankId'))
+print('dynamicBankGranularity:', plugin.get('dynamicBankGranularity'))
+print('bankId:', plugin.get('bankId'))
+PY
+```
+
+### Test the pattern you actually chose
+
+- If you chose per-user sharing, the same user should retain continuity across channels.
+- If you chose a shared team bank, different team members or agent roles should be able to build on the same context.
+
+## Troubleshooting / common errors
+
+### Recall is too noisy
+
+Your bank is too broad, or your retain mission is too loose.
+
+### Users see each other's context
+
+You picked a shared bank for a workflow that should have been per-user.
+
+### Team knowledge never compounds
+
+You stayed on a strict per-user pattern even though the workflow is collaborative.
+
+## FAQ
+
+### Should we always remove `agent` from the bank granularity?
+
+No. Remove it only when agents should collaborate through the same memory bank.
+
+### Is one fixed bank easier to manage?
+
+Yes, but easy is not always correct. A single bank is only useful when the shared workflow is intentional.
+
+### Can we change strategies later?
+
+Yes. You can migrate from dynamic banks to a fixed bank, or the reverse, as long as you understand that each strategy points at a different memory space.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if your team wants one managed backend.
+- Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw) open for the full plugin configuration surface.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need a backend.
+- Read the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) before tuning retrieval or storage.
+- Compare the broader collaboration pattern in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-project-scoped-memory-setup.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-project-scoped-memory-setup.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-openclaw-project-scoped-memory-setup.png
 hide_table_of_contents: true
 ---
 
-![OpenClaw Project-Scoped Memory Setup Guide](/img/blog/guide-openclaw-project-scoped-memory-setup.png)
-
 If you want **OpenClaw project-scoped memory**, the goal is simple: when the agent is working on Project A, it should not recall facts from Project B. In practice, the cleanest way to get that behavior is to give each project its own bank, either with a fixed `bankId` per project agent or with a deliberate deployment pattern that maps one agent instance to one project.
 
 This is different from per-user memory. Per-user memory answers “who is talking?” Project-scoped memory answers “which body of work should this conversation draw from?” If your OpenClaw setup supports several repos, products, or client environments, project scoping often matters more than user scoping.

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-project-scoped-memory-setup.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-project-scoped-memory-setup.md
@@ -1,0 +1,167 @@
+---
+title: "OpenClaw Project-Scoped Memory Setup Guide"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, openclaw, memory, projects, configuration]
+description: "Set up OpenClaw project-scoped memory with Hindsight, keep one project’s context separate from another, and choose when to use fixed banks versus dynamic isolation."
+image: /img/blog/guide-openclaw-project-scoped-memory-setup.png
+hide_table_of_contents: true
+---
+
+![OpenClaw Project-Scoped Memory Setup Guide](/img/blog/guide-openclaw-project-scoped-memory-setup.png)
+
+If you want **OpenClaw project-scoped memory**, the goal is simple: when the agent is working on Project A, it should not recall facts from Project B. In practice, the cleanest way to get that behavior is to give each project its own bank, either with a fixed `bankId` per project agent or with a deliberate deployment pattern that maps one agent instance to one project.
+
+This is different from per-user memory. Per-user memory answers “who is talking?” Project-scoped memory answers “which body of work should this conversation draw from?” If your OpenClaw setup supports several repos, products, or client environments, project scoping often matters more than user scoping.
+
+This guide shows when project-scoped memory is the right fit, how to create one bank per project, and how to verify that cross-project bleed is gone without losing continuity inside the project itself. Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), the [docs home](https://hindsight.vectorize.io/docs), the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), and the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) nearby while you configure it.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Create one bank per project, for example `project-alpha` and `project-beta`.
+> 2. Configure each OpenClaw agent or deployment to use the correct fixed `bankId`.
+> 3. Keep project memory separate from personal memory unless you truly need both combined.
+> 4. Test by teaching a fact in one project and confirming it does not appear in another.
+> 5. Add a focused `retainMission` so each project bank stores durable project knowledge.
+
+## Prerequisites
+
+Before you scope memory by project, make sure:
+
+- OpenClaw and the Hindsight plugin are already installed.
+- You can run separate OpenClaw agents or config variants per project.
+- You know which projects deserve isolated memory banks.
+
+Reference material: [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), [quickstart guide](https://hindsight.vectorize.io/docs/quickstart), [Recall API reference](https://hindsight.vectorize.io/docs/api/recall), and [docs home](https://hindsight.vectorize.io/docs).
+
+## Step by step
+
+### 1. Decide what counts as a project boundary
+
+A project boundary should map to real work, for example:
+
+- one repo
+- one customer deployment
+- one product line
+- one internal initiative
+
+If the projects are unrelated enough that wrong recall would be distracting, they deserve separate banks.
+
+### 2. Use a fixed bank per project
+
+The simplest reliable pattern is one fixed bank per project agent:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+entries = config.setdefault('plugins', {}).setdefault('entries', {})
+plugin = entries.setdefault('hindsight-openclaw', {'enabled': True, 'config': {}})
+plugin['enabled'] = True
+cfg = plugin.setdefault('config', {})
+cfg['dynamicBankId'] = False
+cfg['bankId'] = 'project-alpha'
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+Then give the second project a different bank:
+
+```json
+{
+  "bankId": "project-beta"
+}
+```
+
+### 3. Keep the retain mission project-focused
+
+A project bank works best when the agent retains:
+
+- architecture decisions
+- naming conventions
+- deployment constraints
+- recurring workflows
+- known bugs and workarounds
+
+A useful project mission looks like:
+
+```text
+Extract durable project decisions, architecture context, workflows, constraints, and recurring implementation details. Ignore casual chatter and temporary task noise.
+```
+
+### 4. Map one agent or one config variant to one project
+
+This is the cleanest deployment pattern:
+
+- Agent A -> `project-alpha`
+- Agent B -> `project-beta`
+
+That model is easier to reason about than trying to switch one live agent between several project banks ad hoc.
+
+### 5. Test for cross-project isolation
+
+1. In Project Alpha, tell the agent: “Remember that Alpha uses Postgres and deploys from GitHub Actions.”
+2. Let retention finish.
+3. Switch to Project Beta.
+4. Ask what it remembers about the deployment stack.
+
+Expected result: the Project Alpha fact should not appear in Project Beta.
+
+## Verifying it works
+
+### Print the active bank
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+cfg = config['plugins']['entries']['hindsight-openclaw']['config']
+print('dynamicBankId:', cfg.get('dynamicBankId'))
+print('bankId:', cfg.get('bankId'))
+PY
+```
+
+### Test with a distinctive project fact
+
+Pick a fact that would be obviously wrong in the other project, then confirm it stays isolated.
+
+## Troubleshooting / common errors
+
+### The agent still recalls the wrong project context
+
+You are probably reusing the same bank across both projects, or the wrong config file is being loaded.
+
+### Useful personal preferences stopped showing up
+
+That is normal if you split project memory from user memory. If you need both, keep them separate conceptually and decide which one should win for the workflow.
+
+### One project bank is too noisy
+
+Tighten the retain mission so only durable project context is stored.
+
+## FAQ
+
+### Is project-scoped memory better than per-user memory?
+
+Not always. They answer different questions. Project scope is about work context. Per-user scope is about person context.
+
+### Can one user work across several project banks?
+
+Yes. That is often the point. The same person can interact with different project agents that each use their own bank.
+
+### Should every repo get its own bank?
+
+Only if wrong recall across repos would hurt more than shared context would help.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want one managed backend for multiple project agents.
+- Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw) open for the full plugin configuration surface.
+- Use the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need to stand up Hindsight.
+- Read the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) before tuning retrieval or storage.
+- Compare adjacent collaboration patterns in [OpenClaw shared memory](https://hindsight.vectorize.io/blog/openclaw-shared-memory) and [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-shared-memory-across-agents.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-shared-memory-across-agents.md
@@ -1,0 +1,211 @@
+---
+title: "OpenClaw Shared Memory Across Agents Guide"
+authors: [benfrank241]
+date: 2026-04-20
+tags: [how-to, openclaw, memory, configuration]
+description: "Set up OpenClaw shared memory across agents with Hindsight, choose the right bank granularity, and verify that multiple agents reuse the same context safely."
+image: /img/blog/guide-openclaw-shared-memory-across-agents.png
+hide_table_of_contents: true
+---
+
+![OpenClaw Shared Memory Across Agents Guide](/img/blog/guide-openclaw-shared-memory-across-agents.png)
+
+If you want **OpenClaw shared memory across agents**, the real question is not whether Hindsight can do it. It can. The question is how much of the default bank-isolation scheme you want to keep. Out of the box, the OpenClaw plugin isolates memory by `agent`, `channel`, and `user`, which is a safe starting point but also means two agents can talk to the same human and still behave like strangers.
+
+That default is useful when each agent should keep a separate brain. It is the wrong layout when you deliberately want a support bot, an operations bot, and a personal assistant to share the same user context. In that case, the fix is simple: remove `agent` from the bank key, keep the user dimension, and make sure every agent points at the same Hindsight backend.
+
+This guide shows how to configure that shared setup, how to decide between `["provider", "user"]` and `["user"]`, how to keep shared memory clean with a focused retain mission, and how to test that one agent can actually reuse what another agent learned. Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw), the [docs home](https://hindsight.vectorize.io/docs), and the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) open while you work.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Install and configure `hindsight-openclaw` normally on every agent.
+> 2. Remove `agent` from `dynamicBankGranularity` so all agents derive the same bank for the same user.
+> 3. Start with `["provider", "user"]`, not `["user"]`, unless cross-platform sharing is intentional.
+> 4. Add a shared `retainMission` so the bank stores durable context instead of per-agent noise.
+> 5. Restart every agent and test with the same user on two agents.
+
+## Prerequisites
+
+Before you share memory across agents, make sure these basics are already true:
+
+- OpenClaw is installed and the gateway is healthy.
+- `@vectorize-io/hindsight-openclaw` is installed for every agent that will participate.
+- Every participating agent points at the same Hindsight backend, local or cloud.
+- You know whether you want sharing per provider or across every provider.
+
+If you have not installed the plugin yet, start there:
+
+```bash
+openclaw plugins install @vectorize-io/hindsight-openclaw
+npx --package @vectorize-io/hindsight-openclaw hindsight-openclaw-setup
+openclaw gateway status
+```
+
+It is also worth skimming the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall), the [Retain API reference](https://hindsight.vectorize.io/docs/api/retain), and the [OpenClaw shared memory post](https://hindsight.vectorize.io/blog/openclaw-shared-memory). Those three references make the tradeoffs much clearer.
+
+## Step by step
+
+### 1. Understand why agents do not share memory by default
+
+The default bank granularity is conservative:
+
+```json
+["agent", "channel", "user"]
+```
+
+That means bank identity changes when any of these change:
+
+- the OpenClaw agent identity
+- the channel or room
+- the user
+
+If Agent A learns that a user prefers concise replies, Agent B will not see that preference later because the `agent` dimension is different. Nothing is broken, the agents are simply isolated.
+
+You can inspect the current setting directly:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+plugin = config['plugins']['entries']['hindsight-openclaw']['config']
+print(plugin.get('dynamicBankGranularity', ['agent', 'channel', 'user']))
+PY
+```
+
+If `agent` appears in the list, memory is still isolated per agent.
+
+### 2. Choose the right shared-memory scope
+
+For most multi-agent OpenClaw setups, the best default is:
+
+```json
+["provider", "user"]
+```
+
+This gives you one shared memory bank per user, per platform. The same user can move between multiple OpenClaw agents on Slack and keep continuity, but their Slack and Telegram memories still stay separate.
+
+Use `["user"]` only if you intentionally want a single user bank shared across every platform too. That can be useful, but it raises more identity and privacy questions.
+
+### 3. Update every agent to use the same bank pattern
+
+Patch `~/.openclaw/openclaw.json` on each participating agent so the bank no longer includes `agent`:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+entries = config.setdefault('plugins', {}).setdefault('entries', {})
+plugin = entries.setdefault('hindsight-openclaw', {'enabled': True, 'config': {}})
+plugin['enabled'] = True
+cfg = plugin.setdefault('config', {})
+cfg['dynamicBankId'] = True
+cfg['dynamicBankGranularity'] = ['provider', 'user']
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+The key is consistency. If one agent uses `["agent", "channel", "user"]` and another uses `["provider", "user"]`, they will not share a bank even though both are configured correctly in isolation.
+
+### 4. Use a retention mission built for shared memory
+
+Shared banks are valuable because they compound context. They are dangerous when they accumulate every temporary detail. Add the same `retainMission` to each agent:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+cfg = config['plugins']['entries']['hindsight-openclaw']['config']
+cfg['retainMission'] = (
+    'Extract durable user preferences, recurring tasks, project context, '
+    'important constraints, and decisions that should help any cooperating '
+    'agent. Ignore one-off chatter, duplicate tool output, and transient noise.'
+)
+path.write_text(json.dumps(config, indent=2) + '\n')
+print(f'Updated {path}')
+PY
+```
+
+If you want the mental model behind this setup, the [team shared memory post](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents) and [Adding memory to Codex with Hindsight](https://hindsight.vectorize.io/blog/adding-memory-to-codex-with-hindsight) are useful comparisons.
+
+### 5. Restart every agent and run a handoff test
+
+Once the config is changed, restart the gateway for each agent:
+
+```bash
+openclaw gateway restart
+```
+
+Then test a real cross-agent flow:
+
+1. Ask Agent A to learn something durable, for example: “Remember that I prefer concise summaries and my current launch date is May 15.”
+2. Wait for the turn to finish so retention completes.
+3. Ask Agent B a question where that context matters.
+4. Confirm the second agent can answer with the retained preference or project fact.
+
+## Verifying it works
+
+Use two signals, not one.
+
+### Confirm the config
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+config = json.loads(path.read_text())
+plugin = config['plugins']['entries']['hindsight-openclaw']['config']
+print('dynamicBankId:', plugin.get('dynamicBankId', True))
+print('dynamicBankGranularity:', plugin.get('dynamicBankGranularity'))
+print('retainMission:', plugin.get('retainMission'))
+PY
+```
+
+### Confirm the behavior
+
+The real test is not the file, it is whether a second agent feels informed. If Agent B still answers like it has never met the user, sharing is not working yet.
+
+## Troubleshooting / common errors
+
+### The agents still do not share memory
+
+Usually one agent still includes `agent` or `channel` in the granularity list. Print the effective config on both agents and compare them line by line.
+
+### Memory is too broad
+
+If unrelated facts keep surfacing, your bank is too shared or your `retainMission` is too loose. Start by tightening the mission before you widen isolation again.
+
+### Cross-platform sharing is happening when you did not want it
+
+That means you used `["user"]` when `["provider", "user"]` was the safer fit.
+
+## FAQ
+
+### Should I ever share one bank across all users too?
+
+Usually no. For most OpenClaw assistants, shared memory should be per user, not global. A fully shared bank is appropriate only for specialized team agents.
+
+### Is `["provider", "user"]` better than `["user"]`?
+
+For most deployments, yes. It preserves continuity within one platform without assuming a user identity is trustworthy across every platform.
+
+### Do I need the same Hindsight API credentials on every agent?
+
+Yes. If the agents point at different backends or different accounts, they are not sharing the same memory system.
+
+### Can I combine this with the per-user guide?
+
+Yes. This guide builds on the same idea. The earlier per-user guide focuses on channel sharing for one agent. This guide extends that model across multiple agents.
+
+## Next Steps
+
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want one shared backend for every agent.
+- Keep the [OpenClaw integration docs](https://hindsight.vectorize.io/docs/integrations/openclaw) open for the full plugin reference.
+- Review the [quickstart guide](https://hindsight.vectorize.io/docs/quickstart) if you still need to stand up Hindsight.
+- Use the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) when you tune retrieval and storage.
+- Compare the broader pattern in [Team Shared Memory for AI Coding Agents](https://hindsight.vectorize.io/blog/team-shared-memory-ai-coding-agents).

--- a/hindsight-docs/guides/2026-04-20-guide-openclaw-shared-memory-across-agents.md
+++ b/hindsight-docs/guides/2026-04-20-guide-openclaw-shared-memory-across-agents.md
@@ -8,8 +8,6 @@ image: /img/blog/guide-openclaw-shared-memory-across-agents.png
 hide_table_of_contents: true
 ---
 
-![OpenClaw Shared Memory Across Agents Guide](/img/blog/guide-openclaw-shared-memory-across-agents.png)
-
 If you want **OpenClaw shared memory across agents**, the real question is not whether Hindsight can do it. It can. The question is how much of the default bank-isolation scheme you want to keep. Out of the box, the OpenClaw plugin isolates memory by `agent`, `channel`, and `user`, which is a safe starting point but also means two agents can talk to the same human and still behave like strangers.
 
 That default is useful when each agent should keep a separate brain. It is the wrong layout when you deliberately want a support bot, an operations bot, and a personal assistant to share the same user context. In that case, the fix is simple: remove `agent` from the bank key, keep the user dimension, and make sure every agent points at the same Hindsight backend.


### PR DESCRIPTION
## Guide batch, OpenClaw and Hermes memory

This PR adds 8 new guide pages from a heuristic content pass, GSC step skipped by request.

### Included guides
- OpenClaw shared memory across agents
- OpenClaw and Claude Code shared memory
- Hermes multi-user memory with Hindsight
- Hermes shared memory across agents
- OpenClaw memory bank strategy for teams
- Hermes memory bank strategy for production
- OpenClaw project-scoped memory setup
- Move Hermes memory from local files to Hindsight Cloud

### Topic angles
- openclaw
- hermes
- team workflow / shared memory
- bank strategy / production setup

### Internal links included
- Hindsight Cloud signup
- Docs home
- Quickstart
- Recall API reference
- Retain API reference
- OpenClaw or Hermes integration docs
- Related Claude Code, Codex, and team memory posts where relevant

### Cover images needed
- hindsight-docs/static/img/blog/guide-openclaw-shared-memory-across-agents.png
- hindsight-docs/static/img/blog/guide-openclaw-and-claude-code-shared-memory.png
- hindsight-docs/static/img/blog/guide-hermes-multi-user-memory-with-hindsight.png
- hindsight-docs/static/img/blog/guide-hermes-shared-memory-across-agents.png
- hindsight-docs/static/img/blog/guide-openclaw-memory-bank-strategy-for-teams.png
- hindsight-docs/static/img/blog/guide-hermes-memory-bank-strategy-for-production.png
- hindsight-docs/static/img/blog/guide-openclaw-project-scoped-memory-setup.png
- hindsight-docs/static/img/blog/guide-move-hermes-memory-from-local-files-to-hindsight-cloud.png

---
Generated in one batched pass. Review technical accuracy and brand voice before merge.
