### PR TITLE
docs(admin-cli): document decommission-workers and worker-status

### DIFF
--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -172,6 +172,77 @@ hindsight-admin decommission-worker worker-1 --schema tenant_acme
 Worker IDs default to the hostname. In Kubernetes StatefulSets, this is the pod name (e.g., `hindsight-worker-0`). You can also set a custom ID with `HINDSIGHT_API_WORKER_ID` or `--worker-id`.
 :::
 
+
+### decommission-workers
+
+Release all currently-processing tasks from every worker, resetting them from "processing" back to "pending" status. Use this when one or more workers have crashed or been removed without graceful shutdown and you don't know which worker IDs to target.
+
+```bash
+hindsight-admin decommission-workers [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema | `public` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
+
+**Examples:**
+
+```bash
+# Release all processing tasks across all workers (with confirmation)
+hindsight-admin decommission-workers
+
+# Skip the confirmation prompt (useful in scripts)
+hindsight-admin decommission-workers --yes
+
+# Release tasks in a specific tenant schema
+hindsight-admin decommission-workers --schema tenant_acme
+```
+
+**When to Use:**
+
+- **Unknown dead workers**: Multiple workers crashed and you do not know their IDs
+- **Fleet-wide recovery**: After an infrastructure event where many workers went down
+- **"Just fix everything"**: A quick full-queue drain when per-worker cleanup is overkill
+
+:::warning Disruptive
+This releases **every** processing task regardless of worker, including tasks owned by healthy workers. Prefer `decommission-worker <WORKER_ID>` when you know which workers need cleanup.
+:::
+
+---
+
+### worker-status
+
+Show all currently-processing tasks grouped by worker, including operation type, bank, how long each task has been running, and when it was last updated. Useful for identifying orphaned tasks before decommissioning.
+
+```bash
+hindsight-admin worker-status [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema | `public` |
+
+**Examples:**
+
+```bash
+# Show all processing tasks across all workers
+hindsight-admin worker-status
+
+# Show processing tasks for a specific tenant schema
+hindsight-admin worker-status --schema tenant_acme
+```
+
+**When to Use:**
+
+- **Before decommissioning**: Inspect which workers have stale tasks and how long they have been stuck
+- **Debugging throughput**: Diagnose why the queue is not draining (are tasks stuck in processing?)
+- **Worker health check**: Spot workers whose `last_update_ago` keeps growing, indicating a dead or unresponsive worker
+
 ---
 
 ## Environment Variables

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -172,6 +172,77 @@ hindsight-admin decommission-worker worker-1 --schema tenant_acme
 Worker IDs default to the hostname. In Kubernetes StatefulSets, this is the pod name (e.g., `hindsight-worker-0`). You can also set a custom ID with `HINDSIGHT_API_WORKER_ID` or `--worker-id`.
 :::
 
+
+### decommission-workers
+
+Release all currently-processing tasks from every worker, resetting them from "processing" back to "pending" status. Use this when one or more workers have crashed or been removed without graceful shutdown and you don't know which worker IDs to target.
+
+```bash
+hindsight-admin decommission-workers [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema | `public` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
+
+**Examples:**
+
+```bash
+# Release all processing tasks across all workers (with confirmation)
+hindsight-admin decommission-workers
+
+# Skip the confirmation prompt (useful in scripts)
+hindsight-admin decommission-workers --yes
+
+# Release tasks in a specific tenant schema
+hindsight-admin decommission-workers --schema tenant_acme
+```
+
+**When to Use:**
+
+- **Unknown dead workers**: Multiple workers crashed and you do not know their IDs
+- **Fleet-wide recovery**: After an infrastructure event where many workers went down
+- **"Just fix everything"**: A quick full-queue drain when per-worker cleanup is overkill
+
+:::warning Disruptive
+This releases **every** processing task regardless of worker, including tasks owned by healthy workers. Prefer `decommission-worker <WORKER_ID>` when you know which workers need cleanup.
+:::
+
+---
+
+### worker-status
+
+Show all currently-processing tasks grouped by worker, including operation type, bank, how long each task has been running, and when it was last updated. Useful for identifying orphaned tasks before decommissioning.
+
+```bash
+hindsight-admin worker-status [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema | `public` |
+
+**Examples:**
+
+```bash
+# Show all processing tasks across all workers
+hindsight-admin worker-status
+
+# Show processing tasks for a specific tenant schema
+hindsight-admin worker-status --schema tenant_acme
+```
+
+**When to Use:**
+
+- **Before decommissioning**: Inspect which workers have stale tasks and how long they have been stuck
+- **Debugging throughput**: Diagnose why the queue is not draining (are tasks stuck in processing?)
+- **Worker health check**: Spot workers whose `last_update_ago` keeps growing, indicating a dead or unresponsive worker
+
 ---
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

PR #1165 (feat(admin): add decommission-workers and worker-status CLI commands, merged 2026-04-20) added two new `hindsight-admin` CLI commands to `hindsight-api-slim/hindsight_api/admin/cli.py` but `hindsight-docs/docs/developer/admin-cli.md` still only documents `decommission-worker` (singular).

Added dedicated sections for each new command, following the existing doc style (description / Options / Examples / When to Use):

- `decommission-workers` (no WORKER_ID arg): releases ALL processing tasks across every worker, supports `--schema` and `--yes`
- `worker-status`: prints all processing tasks grouped by worker with operation type, bank, runtime, and last-update-ago; supports `--schema`

Both sections mirror the behavior documented in the `typer.Option` definitions and docstrings in `admin/cli.py` (no new behavior invented). A `:::warning Disruptive` callout on `decommission-workers` nudges users toward the singular form when they know the worker ID.

Mirrored the same content to `skills/hindsight-docs/references/developer/admin-cli.md` to keep the docs skill in sync (same dual-doc pattern as #1137).

## Test plan

- [ ] Docs render: `run-db-migration` / `backup` / `restore` / `decommission-worker` / **`decommission-workers`** / **`worker-status`** all appear in the Commands section and have parallel structure
- [ ] No code logic changes; existing admin CLI tests unaffected