### PR TITLE
docs(mcp): document update_bank config_updates and configurable fields

### DIFF
--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -468,12 +468,32 @@ Get statistics for a memory bank (node/link counts).
 
 ### update_bank
 
-Update a memory bank's metadata.
+Update a memory bank's configuration. Updates the bank's name and/or any bank-level configuration fields — only provided fields are updated; omitted fields remain unchanged.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | No | New human-friendly name for the bank |
-| `mission` | string | No | New mission describing who the agent is and what they're trying to accomplish |
+| `name` | string | No | Human-friendly display name for the bank |
+| `mission` | string | No | **Deprecated** — alias for `config_updates.reflect_mission` |
+| `config_updates` | object | No | Dictionary of configuration fields to update. Supports all bank-configurable fields (see below). Non-configurable or credential fields are rejected |
+
+The `config_updates` object accepts any bank-configurable field by its Python field name, including:
+
+- `reflect_mission` — mission/context for Reflect operations
+- `retain_mission` — steers what gets extracted during `retain()`
+- `retain_extraction_mode` — `concise` (default), `verbose`, or `custom`
+- `retain_custom_instructions` — custom extraction prompt (active when mode is `custom`)
+- `retain_chunk_size` — maximum token size for each content chunk
+- `retain_chunk_batch_size` — number of chunks to process in parallel
+- `enable_observations` — toggle observation consolidation after `retain()`
+- `observations_mission` — controls observation synthesis rules
+- `disposition_skepticism` — critical evaluation level (1–5)
+- `disposition_literalism` — literal vs. abstract interpretation (1–5)
+- `disposition_empathy` — emotional context consideration (1–5)
+- `entity_labels` — controlled vocabulary for entity classification
+- `entities_allow_free_form` — allow labels outside `entity_labels`
+- `recall_include_chunks` — include raw chunks in recall results
+- `recall_max_tokens` — max tokens for recall results
+- `mcp_enabled_tools` — tool allowlist for this bank
 
 ---
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -468,12 +468,32 @@ Get statistics for a memory bank (node/link counts).
 
 ### update_bank
 
-Update a memory bank's metadata.
+Update a memory bank's configuration. Updates the bank's name and/or any bank-level configuration fields — only provided fields are updated; omitted fields remain unchanged.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | No | New human-friendly name for the bank |
-| `mission` | string | No | New mission describing who the agent is and what they're trying to accomplish |
+| `name` | string | No | Human-friendly display name for the bank |
+| `mission` | string | No | **Deprecated** — alias for `config_updates.reflect_mission` |
+| `config_updates` | object | No | Dictionary of configuration fields to update. Supports all bank-configurable fields (see below). Non-configurable or credential fields are rejected |
+
+The `config_updates` object accepts any bank-configurable field by its Python field name, including:
+
+- `reflect_mission` — mission/context for Reflect operations
+- `retain_mission` — steers what gets extracted during `retain()`
+- `retain_extraction_mode` — `concise` (default), `verbose`, or `custom`
+- `retain_custom_instructions` — custom extraction prompt (active when mode is `custom`)
+- `retain_chunk_size` — maximum token size for each content chunk
+- `retain_chunk_batch_size` — number of chunks to process in parallel
+- `enable_observations` — toggle observation consolidation after `retain()`
+- `observations_mission` — controls observation synthesis rules
+- `disposition_skepticism` — critical evaluation level (1–5)
+- `disposition_literalism` — literal vs. abstract interpretation (1–5)
+- `disposition_empathy` — emotional context consideration (1–5)
+- `entity_labels` — controlled vocabulary for entity classification
+- `entities_allow_free_form` — allow labels outside `entity_labels`
+- `recall_include_chunks` — include raw chunks in recall results
+- `recall_max_tokens` — max tokens for recall results
+- `mcp_enabled_tools` — tool allowlist for this bank
 
 ---
 


### PR DESCRIPTION
## Summary

PR #1168 (merged 2026-04-21) expanded the `update_bank` MCP tool to accept a `config_updates` dict and route through the config resolver, exposing all bank-configurable fields (`reflect_mission`, `retain_mission`, `retain_extraction_mode`, `retain_custom_instructions`, `retain_chunk_size`, `retain_chunk_batch_size`, `enable_observations`, `observations_mission`, `disposition_*`, `entity_labels`, `entities_allow_free_form`, `recall_include_chunks`, `recall_max_tokens`, `mcp_enabled_tools`, …). It also deprecated the standalone `mission` parameter to an alias for `config_updates.reflect_mission`.

`hindsight-docs/docs/developer/mcp-server.md` still described the tool as "Update a memory bank's metadata" with only `name` and `mission` in the parameter table — users had to read `hindsight-api-slim/hindsight_api/mcp_tools.py` to discover the full configuration surface.

## Changes

- Reword the `update_bank` intro from "metadata" to "configuration" with the "only provided fields are updated" guarantee from #1168.
- Add `config_updates` (object) to the parameter table with the rejection semantics (non-configurable/credential fields are rejected).
- Mark `mission` as **Deprecated** and link it to `config_updates.reflect_mission`.
- List the ~15+ supported field names so readers can see the full surface without reading `mcp_tools.py`.

Mirrored to `skills/hindsight-docs/references/developer/mcp-server.md` per the dual-doc convention (#1137, #1180).

Pure docs — no code or test changes.

## Test plan

- [x] Field names and descriptions copied verbatim from #1168's `update_bank` docstring (both `_stateless` and session-bound variants were identical)
- [x] Both doc copies updated identically
- [x] No stray whitespace changes outside the `### update_bank` section