### PR TITLE
fix(opencode): lower retainEveryNTurns default from 10 to 3

### DIFF
--- a/hindsight-docs/docs-integrations/opencode.md
+++ b/hindsight-docs/docs-integrations/opencode.md
@@ -97,7 +97,7 @@ This ensures memories survive context window trimming.
       "recallTags": [],
       "recallTagsMatch": "any",
       "retainTags": [],
-      "retainEveryNTurns": 10,
+      "retainEveryNTurns": 3,
       "debug": false
     }]
   ]

--- a/hindsight-docs/guides/2026-04-16-guide-opencode-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-04-16-guide-opencode-memory-with-hindsight.md
@@ -129,7 +129,7 @@ A practical starting point looks like this:
       "autoRecall": true,
       "autoRetain": true,
       "recallBudget": "mid",
-      "retainEveryNTurns": 10,
+      "retainEveryNTurns": 3,
       "debug": false
     }]
   ]

--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -92,7 +92,7 @@ Create `~/.hindsight/opencode.json` for persistent configuration:
   "hindsightApiUrl": "http://localhost:8888",
   "hindsightApiToken": "your-api-key",
   "recallBudget": "mid",
-  "retainEveryNTurns": 10,
+  "retainEveryNTurns": 3,
   "debug": false
 }
 ```

--- a/hindsight-integrations/opencode/src/config.ts
+++ b/hindsight-integrations/opencode/src/config.ts
@@ -68,7 +68,7 @@ const DEFAULTS: HindsightConfig = {
   // Retain
   autoRetain: true,
   retainMode: "full-session",
-  retainEveryNTurns: 10,
+  retainEveryNTurns: 3,
   retainOverlapTurns: 2,
   retainContext: "opencode",
   retainTags: [],

--- a/hindsight-integrations/opencode/src/test-helpers.ts
+++ b/hindsight-integrations/opencode/src/test-helpers.ts
@@ -13,7 +13,7 @@ export function makeConfig(overrides: Partial<HindsightConfig> = {}): HindsightC
     recallTagsMatch: "any",
     autoRetain: true,
     retainMode: "full-session",
-    retainEveryNTurns: 10,
+    retainEveryNTurns: 3,
     retainOverlapTurns: 2,
     retainContext: "opencode",
     retainTags: [],


### PR DESCRIPTION
## Summary
- Lowers the default `retainEveryNTurns` from `10` to `3` for the OpenCode plugin
- Users were not seeing auto-retain fire because most sessions don't reach 10 user turns
- Updates source default, test helpers, README, and docs to reflect the new value

## Test plan
- [x] All 91 existing OpenCode plugin tests pass
- [ ] Manual test: install plugin with default config and verify retain fires after 3 user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)