### PR TITLE
fix(consolidation): skip null-payload operations in deduplication query

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8309,16 +8309,37 @@ class MemoryEngine(MemoryEngineInterface):
 
         pool = await self._get_pool()
 
-        # Check for existing pending task if deduplication is enabled
+        # Check for existing pending task if deduplication is enabled.
         # Note: We only check 'pending', not 'processing', because a processing task
         # uses a watermark from when it started - new memories added after that point
         # would need another consolidation run to be processed.
+        # Also skip tasks with NULL task_payload — these are corrupted rows from
+        # older versions where the INSERT didn't include task_payload atomically.
+        # The worker's claim query rejects null-payload rows, so deduplicating
+        # to one creates a dead-end where no new consolidation can ever be claimed.
         if dedupe_by_bank:
             async with acquire_with_retry(pool) as conn:
+                # Also count null-payload zombies for diagnostic logging
+                null_count = await conn.fetchval(
+                    f"""
+                    SELECT COUNT(*) FROM {fq_table("async_operations")}
+                    WHERE bank_id = $1 AND operation_type = $2 AND status = 'pending'
+                      AND task_payload IS NULL
+                    """,
+                    bank_id,
+                    operation_type,
+                )
+                if null_count and null_count > 0:
+                    logger.warning(
+                        f"Skipping {null_count} null-payload pending {operation_type} "
+                        f"operations for bank_id={bank_id} (corrupted from older version)"
+                    )
+
                 existing = await conn.fetchrow(
                     f"""
                     SELECT operation_id FROM {fq_table("async_operations")}
                     WHERE bank_id = $1 AND operation_type = $2 AND status = 'pending'
+                      AND task_payload IS NOT NULL
                     LIMIT 1
                     """,
                     bank_id,


### PR DESCRIPTION
``markdown
## Bug

Consolidation tasks permanently stuck as pending and never claimed by workers after LLM failures.

### Root Cause

The deduplication check in _submit_async_operation() matches existing pending operations by bank_id + operation_type + status='pending' **without verifying task_payload IS NOT NULL**.

When a corrupted row exists (status='pending', task_payload=NULL — from older code where the INSERT didn't include task_payload atomically, or from a crash between INSERT and UPDATE):

1. Zombie consolidation row sits with status='pending', task_payload=NULL
2. Every new POST /consolidate request deduplicates to the zombie (deduplicated=True)
3. Worker claim SQL requires task_payload IS NOT NULL → rejects the zombie
4. **Deadlock**: no new consolidation can ever be claimed or processed

### Observed Symptoms

- Worker logs: consolidation: total=1 claimable=1 payload_null=0 retry_blocked=0 assigned=0 — task appears claimable but never claimed across 40+ poll cycles
- LLM metrics: zero scope="consolidation" calls despite retain working fine
- pending_consolidation grows continuously
- last_consolidated_at frozen

### Fix

Two changes in hindsight-api-slim/hindsight_api/engine/memory_engine.py:

1. Add AND task_payload IS NOT NULL` to the deduplication query — skips corrupted zombie rows
Diagnostic warning log when null-payload zombies are detected

Verification
Before: consolidation stuck 10+ hours, 158+ pending items, zero consolidation LLM calls
 
After: consolidation resumed within 60 seconds, backlog draining, 3 successful LLM calls within 60 seconds
```