### PR TITLE
feat(api): expose retry_count and next_retry_at on operation responses

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2119,6 +2119,8 @@ class OperationResponse(BaseModel):
                 "created_at": "2024-01-15T10:30:00Z",
                 "status": "pending",
                 "error_message": None,
+                "retry_count": 0,
+                "next_retry_at": None,
             }
         }
     )
@@ -2130,6 +2132,20 @@ class OperationResponse(BaseModel):
     created_at: str
     status: str
     error_message: str | None
+    retry_count: int = Field(
+        default=0,
+        description="Number of times this operation has been retried after failure.",
+    )
+    next_retry_at: str | None = Field(
+        default=None,
+        description=(
+            "When the worker will next attempt this operation. For a pending "
+            "operation, a value in the future indicates the task is waiting "
+            "rather than available for immediate pickup — for example, an "
+            "extension may have raised DeferOperation to park the task until "
+            "some backpressure window opens. Always null for completed tasks."
+        ),
+    )
 
 
 class ConsolidationResponse(BaseModel):
@@ -2239,6 +2255,19 @@ class OperationStatusResponse(BaseModel):
     updated_at: str | None = None
     completed_at: str | None = None
     error_message: str | None = None
+    retry_count: int = Field(
+        default=0,
+        description="Number of times this operation has been retried after failure.",
+    )
+    next_retry_at: str | None = Field(
+        default=None,
+        description=(
+            "When the worker will next attempt this operation. For a pending "
+            "operation, a value in the future indicates the task is parked "
+            "(e.g. by an extension raising DeferOperation) rather than awaiting "
+            "immediate pickup."
+        ),
+    )
     result_metadata: dict[str, Any] | None = Field(
         default=None,
         description="Internal metadata for debugging. Structure may change without notice. Not for production use.",

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2132,8 +2132,8 @@ class OperationResponse(BaseModel):
     created_at: str
     status: str
     error_message: str | None
-    retry_count: int = Field(
-        default=0,
+    retry_count: int | None = Field(
+        default=None,
         description="Number of times this operation has been retried after failure.",
     )
     next_retry_at: str | None = Field(
@@ -2255,8 +2255,8 @@ class OperationStatusResponse(BaseModel):
     updated_at: str | None = None
     completed_at: str | None = None
     error_message: str | None = None
-    retry_count: int = Field(
-        default=0,
+    retry_count: int | None = Field(
+        default=None,
         description="Number of times this operation has been retried after failure.",
     )
     next_retry_at: str | None = Field(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -736,6 +736,7 @@ class MemoryEngine(MemoryEngineInterface):
             user_initiated=True,
             tenant_id=task_dict.get("_tenant_id"),
             api_key_id=task_dict.get("_api_key_id"),
+            retry_count=task_dict.get("_retry_count", 0),
         )
         await self.retain_batch_async(
             bank_id=bank_id,
@@ -842,6 +843,7 @@ class MemoryEngine(MemoryEngineInterface):
                     user_initiated=True,
                     tenant_id=task_dict.get("_tenant_id"),
                     api_key_id=task_dict.get("_api_key_id"),
+                    retry_count=task_dict.get("_retry_count", 0),
                 )
                 await self._operation_validator.on_file_convert_complete(
                     FileConvertResult(
@@ -986,6 +988,7 @@ class MemoryEngine(MemoryEngineInterface):
             internal=True,
             tenant_id=task_dict.get("_tenant_id"),
             api_key_id=task_dict.get("_api_key_id"),
+            retry_count=task_dict.get("_retry_count", 0),
         )
         result = await run_consolidation_job(
             memory_engine=self,
@@ -1032,6 +1035,7 @@ class MemoryEngine(MemoryEngineInterface):
             internal=True,
             tenant_id=task_dict.get("_tenant_id"),
             api_key_id=task_dict.get("_api_key_id"),
+            retry_count=task_dict.get("_retry_count", 0),
         )
 
         refreshed = await self.refresh_mental_model(
@@ -7956,7 +7960,8 @@ class MemoryEngine(MemoryEngineInterface):
             # Get operations with pagination (include result_metadata to check for parent operations)
             operations = await conn.fetch(
                 f"""
-                SELECT operation_id, operation_type, created_at, status, error_message, result_metadata
+                SELECT operation_id, operation_type, created_at, status, error_message,
+                       result_metadata, retry_count, next_retry_at
                 FROM {fq_table("async_operations")}
                 WHERE {where_clause}
                 ORDER BY created_at DESC
@@ -7977,6 +7982,7 @@ class MemoryEngine(MemoryEngineInterface):
 
                 result_metadata = json.loads(row["result_metadata"]) if row["result_metadata"] else {}
 
+                next_retry_at = row["next_retry_at"]
                 operation_list.append(
                     {
                         "id": str(row["operation_id"]),
@@ -7986,6 +7992,8 @@ class MemoryEngine(MemoryEngineInterface):
                         "created_at": row["created_at"].isoformat(),
                         "status": api_status,
                         "error_message": row["error_message"],
+                        "retry_count": row["retry_count"] or 0,
+                        "next_retry_at": next_retry_at.isoformat() if next_retry_at else None,
                     }
                 )
 
@@ -8026,7 +8034,7 @@ class MemoryEngine(MemoryEngineInterface):
             payload_column = ", task_payload" if include_payload else ""
             row = await conn.fetchrow(
                 f"""
-                SELECT operation_id, operation_type, created_at, updated_at, completed_at, status, error_message, result_metadata{payload_column}
+                SELECT operation_id, operation_type, created_at, updated_at, completed_at, status, error_message, result_metadata, retry_count, next_retry_at{payload_column}
                 FROM {fq_table("async_operations")}
                 WHERE operation_id = $1 AND bank_id = $2
                 """,
@@ -8113,6 +8121,8 @@ class MemoryEngine(MemoryEngineInterface):
                         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                         "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
                         "error_message": row["error_message"],
+                        "retry_count": row["retry_count"] or 0,
+                        "next_retry_at": row["next_retry_at"].isoformat() if row["next_retry_at"] else None,
                         "result_metadata": result_metadata,
                         "child_operations": child_statuses,
                         "task_payload": task_payload,
@@ -8127,6 +8137,8 @@ class MemoryEngine(MemoryEngineInterface):
                         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                         "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
                         "error_message": row["error_message"],
+                        "retry_count": row["retry_count"] or 0,
+                        "next_retry_at": row["next_retry_at"].isoformat() if row["next_retry_at"] else None,
                         "result_metadata": result_metadata,
                         "task_payload": task_payload,
                     }

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -24,6 +24,12 @@ class RequestContext:
     mcp_authenticated: bool = False  # True when MCP transport auth already validated (skips tenant re-auth)
     user_initiated: bool = False  # True for async operations that originated from a user request
     allowed_bank_ids: list[str] | None = None  # None = unrestricted (all banks)
+    # Number of times this task has been retried. Populated by the worker
+    # from async_operations.retry_count before dispatching to a task handler;
+    # 0 for sync/HTTP requests and for the first worker attempt. Useful for
+    # validators that want exponential backoff on repeated failures (e.g.
+    # "defer for 2^retry_count minutes") without querying the DB themselves.
+    retry_count: int = 0
 
 
 from pgvector.sqlalchemy import Vector

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -563,6 +563,134 @@ async def test_get_operation_status_include_payload(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_operation_status_exposes_retry_count_and_next_retry_at(memory, request_context):
+    """get_operation_status and list_operations return retry_count and next_retry_at.
+
+    Consumers need these to distinguish a freshly-queued pending task from
+    one that's parked for a future retry (e.g. because an extension raised
+    DeferOperation). Without them, "pending" is ambiguous and callers can't
+    render a helpful "deferred until X" state.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    bank_id = "test_retry_fields"
+    result = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[{"content": "retry-fields test item"}],
+        request_context=request_context,
+    )
+    await asyncio.sleep(0.1)
+    parent_id = result["operation_id"]
+    child_id = None
+
+    # Get the child op (the batch_retain parent holds a single child in the
+    # sync/simplified path used by SyncTaskBackend tests).
+    parent_status = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=parent_id, request_context=request_context,
+    )
+    assert "retry_count" in parent_status
+    assert "next_retry_at" in parent_status
+    assert parent_status["retry_count"] == 0
+    # Completed tasks should have next_retry_at cleared on the row (or the
+    # status field doesn't include it meaningfully), so we don't assert a
+    # specific value here — only that the key is present.
+    if parent_status.get("child_operations"):
+        child_id = parent_status["child_operations"][0]["operation_id"]
+
+    # list_operations also exposes both fields
+    listed = await memory.list_operations(
+        bank_id=bank_id, request_context=request_context, limit=10, offset=0,
+    )
+    assert listed["operations"], listed
+    for op in listed["operations"]:
+        assert "retry_count" in op
+        assert "next_retry_at" in op
+        assert isinstance(op["retry_count"], int)
+
+    # Simulate a deferred op: set next_retry_at to 15 min in the future for
+    # the child row directly in the DB, then fetch via the API and confirm
+    # the value round-trips as an ISO-8601 string.
+    if child_id:
+        pool = await memory._get_pool()
+        future = datetime.now(timezone.utc) + timedelta(minutes=15)
+        await pool.execute(
+            "UPDATE async_operations SET status = 'pending', next_retry_at = $1, retry_count = 2 WHERE operation_id = $2",
+            future,
+            uuid.UUID(child_id),
+        )
+        fetched = await memory.get_operation_status(
+            bank_id=bank_id, operation_id=child_id, request_context=request_context,
+        )
+        assert fetched["retry_count"] == 2
+        assert fetched["next_retry_at"] is not None
+        # Round-trip tolerance: within 1 second.
+        parsed = datetime.fromisoformat(fetched["next_retry_at"])
+        assert abs((parsed - future).total_seconds()) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_request_context_retry_count_propagated_to_validator(memory_no_llm_verify, request_context):
+    """_handle_batch_retain forwards the task's _retry_count as
+    RequestContext.retry_count, so validator extensions can compute
+    exponential backoff without querying async_operations themselves.
+    """
+    from hindsight_api.extensions import (
+        OperationValidatorExtension,
+        RecallContext,
+        ReflectContext,
+        RetainContext,
+        ValidationResult,
+    )
+
+    captured: dict[str, int] = {"retry_count": -1}
+
+    class CapturingValidator(OperationValidatorExtension):
+        def __init__(self):
+            super().__init__({})
+
+        async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
+            captured["retry_count"] = ctx.request_context.retry_count
+            return ValidationResult.accept()
+
+        async def validate_recall(self, ctx: RecallContext) -> ValidationResult:
+            return ValidationResult.accept()
+
+        async def validate_reflect(self, ctx: ReflectContext) -> ValidationResult:
+            return ValidationResult.accept()
+
+    memory_no_llm_verify._operation_validator = CapturingValidator()
+
+    bank_id = f"test-retry-propagate-{uuid.uuid4().hex[:8]}"
+    pool = await memory_no_llm_verify._get_pool()
+    await _ensure_bank(pool, bank_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "bank_id": bank_id,
+        "contents": [{"content": "retry-propagate test"}],
+        "_tenant_id": "default",
+        "_retry_count": 3,  # simulate 3rd retry
+    }
+    await memory_no_llm_verify._handle_batch_retain(task_dict)
+
+    assert captured["retry_count"] == 3, (
+        "Validator should see retry_count=3 from task_dict['_retry_count']; "
+        f"got {captured['retry_count']}"
+    )
+
+    # Default (missing _retry_count key) must surface as 0, not raise.
+    captured["retry_count"] = -1
+    task_dict_no_retry = {
+        "type": "batch_retain",
+        "bank_id": bank_id,
+        "contents": [{"content": "retry-propagate default test"}],
+        "_tenant_id": "default",
+    }
+    await memory_no_llm_verify._handle_batch_retain(task_dict_no_retry)
+    assert captured["retry_count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_submit_async_operation_leaves_claimable_row_when_submit_task_fails(memory):
     """Regression for the crash-window orphan bug fixed in #1091.
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5442,6 +5442,7 @@ components:
         created_at: 2024-01-15T10:30:00Z
         id: 550e8400-e29b-41d4-a716-446655440000
         items_count: 5
+        retry_count: 0
         status: pending
         task_type: retain
       properties:
@@ -5464,6 +5465,12 @@ components:
           title: Status
           type: string
         error_message:
+          nullable: true
+          type: string
+        retry_count:
+          nullable: true
+          type: integer
+        next_retry_at:
           nullable: true
           type: string
       required:
@@ -5508,6 +5515,12 @@ components:
           nullable: true
           type: string
         error_message:
+          nullable: true
+          type: string
+        retry_count:
+          nullable: true
+          type: integer
+        next_retry_at:
           nullable: true
           type: string
         result_metadata:

--- a/hindsight-clients/go/model_operation_response.go
+++ b/hindsight-clients/go/model_operation_response.go
@@ -28,6 +28,8 @@ type OperationResponse struct {
 	CreatedAt string `json:"created_at"`
 	Status string `json:"status"`
 	ErrorMessage NullableString `json:"error_message"`
+	RetryCount NullableInt32 `json:"retry_count,omitempty"`
+	NextRetryAt NullableString `json:"next_retry_at,omitempty"`
 }
 
 type _OperationResponse OperationResponse
@@ -243,6 +245,90 @@ func (o *OperationResponse) SetErrorMessage(v string) {
 	o.ErrorMessage.Set(&v)
 }
 
+// GetRetryCount returns the RetryCount field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationResponse) GetRetryCount() int32 {
+	if o == nil || IsNil(o.RetryCount.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RetryCount.Get()
+}
+
+// GetRetryCountOk returns a tuple with the RetryCount field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationResponse) GetRetryCountOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RetryCount.Get(), o.RetryCount.IsSet()
+}
+
+// HasRetryCount returns a boolean if a field has been set.
+func (o *OperationResponse) HasRetryCount() bool {
+	if o != nil && o.RetryCount.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRetryCount gets a reference to the given NullableInt32 and assigns it to the RetryCount field.
+func (o *OperationResponse) SetRetryCount(v int32) {
+	o.RetryCount.Set(&v)
+}
+// SetRetryCountNil sets the value for RetryCount to be an explicit nil
+func (o *OperationResponse) SetRetryCountNil() {
+	o.RetryCount.Set(nil)
+}
+
+// UnsetRetryCount ensures that no value is present for RetryCount, not even an explicit nil
+func (o *OperationResponse) UnsetRetryCount() {
+	o.RetryCount.Unset()
+}
+
+// GetNextRetryAt returns the NextRetryAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationResponse) GetNextRetryAt() string {
+	if o == nil || IsNil(o.NextRetryAt.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.NextRetryAt.Get()
+}
+
+// GetNextRetryAtOk returns a tuple with the NextRetryAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationResponse) GetNextRetryAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.NextRetryAt.Get(), o.NextRetryAt.IsSet()
+}
+
+// HasNextRetryAt returns a boolean if a field has been set.
+func (o *OperationResponse) HasNextRetryAt() bool {
+	if o != nil && o.NextRetryAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetNextRetryAt gets a reference to the given NullableString and assigns it to the NextRetryAt field.
+func (o *OperationResponse) SetNextRetryAt(v string) {
+	o.NextRetryAt.Set(&v)
+}
+// SetNextRetryAtNil sets the value for NextRetryAt to be an explicit nil
+func (o *OperationResponse) SetNextRetryAtNil() {
+	o.NextRetryAt.Set(nil)
+}
+
+// UnsetNextRetryAt ensures that no value is present for NextRetryAt, not even an explicit nil
+func (o *OperationResponse) UnsetNextRetryAt() {
+	o.NextRetryAt.Unset()
+}
+
 func (o OperationResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -262,6 +348,12 @@ func (o OperationResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["status"] = o.Status
 	toSerialize["error_message"] = o.ErrorMessage.Get()
+	if o.RetryCount.IsSet() {
+		toSerialize["retry_count"] = o.RetryCount.Get()
+	}
+	if o.NextRetryAt.IsSet() {
+		toSerialize["next_retry_at"] = o.NextRetryAt.Get()
+	}
 	return toSerialize, nil
 }
 

--- a/hindsight-clients/go/model_operation_status_response.go
+++ b/hindsight-clients/go/model_operation_status_response.go
@@ -28,6 +28,8 @@ type OperationStatusResponse struct {
 	UpdatedAt NullableString `json:"updated_at,omitempty"`
 	CompletedAt NullableString `json:"completed_at,omitempty"`
 	ErrorMessage NullableString `json:"error_message,omitempty"`
+	RetryCount NullableInt32 `json:"retry_count,omitempty"`
+	NextRetryAt NullableString `json:"next_retry_at,omitempty"`
 	ResultMetadata map[string]interface{} `json:"result_metadata,omitempty"`
 	ChildOperations []ChildOperationStatus `json:"child_operations,omitempty"`
 	TaskPayload map[string]interface{} `json:"task_payload,omitempty"`
@@ -312,6 +314,90 @@ func (o *OperationStatusResponse) UnsetErrorMessage() {
 	o.ErrorMessage.Unset()
 }
 
+// GetRetryCount returns the RetryCount field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationStatusResponse) GetRetryCount() int32 {
+	if o == nil || IsNil(o.RetryCount.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.RetryCount.Get()
+}
+
+// GetRetryCountOk returns a tuple with the RetryCount field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationStatusResponse) GetRetryCountOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RetryCount.Get(), o.RetryCount.IsSet()
+}
+
+// HasRetryCount returns a boolean if a field has been set.
+func (o *OperationStatusResponse) HasRetryCount() bool {
+	if o != nil && o.RetryCount.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRetryCount gets a reference to the given NullableInt32 and assigns it to the RetryCount field.
+func (o *OperationStatusResponse) SetRetryCount(v int32) {
+	o.RetryCount.Set(&v)
+}
+// SetRetryCountNil sets the value for RetryCount to be an explicit nil
+func (o *OperationStatusResponse) SetRetryCountNil() {
+	o.RetryCount.Set(nil)
+}
+
+// UnsetRetryCount ensures that no value is present for RetryCount, not even an explicit nil
+func (o *OperationStatusResponse) UnsetRetryCount() {
+	o.RetryCount.Unset()
+}
+
+// GetNextRetryAt returns the NextRetryAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *OperationStatusResponse) GetNextRetryAt() string {
+	if o == nil || IsNil(o.NextRetryAt.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.NextRetryAt.Get()
+}
+
+// GetNextRetryAtOk returns a tuple with the NextRetryAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *OperationStatusResponse) GetNextRetryAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.NextRetryAt.Get(), o.NextRetryAt.IsSet()
+}
+
+// HasNextRetryAt returns a boolean if a field has been set.
+func (o *OperationStatusResponse) HasNextRetryAt() bool {
+	if o != nil && o.NextRetryAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetNextRetryAt gets a reference to the given NullableString and assigns it to the NextRetryAt field.
+func (o *OperationStatusResponse) SetNextRetryAt(v string) {
+	o.NextRetryAt.Set(&v)
+}
+// SetNextRetryAtNil sets the value for NextRetryAt to be an explicit nil
+func (o *OperationStatusResponse) SetNextRetryAtNil() {
+	o.NextRetryAt.Set(nil)
+}
+
+// UnsetNextRetryAt ensures that no value is present for NextRetryAt, not even an explicit nil
+func (o *OperationStatusResponse) UnsetNextRetryAt() {
+	o.NextRetryAt.Unset()
+}
+
 // GetResultMetadata returns the ResultMetadata field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *OperationStatusResponse) GetResultMetadata() map[string]interface{} {
 	if o == nil {
@@ -437,6 +523,12 @@ func (o OperationStatusResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.ErrorMessage.IsSet() {
 		toSerialize["error_message"] = o.ErrorMessage.Get()
+	}
+	if o.RetryCount.IsSet() {
+		toSerialize["retry_count"] = o.RetryCount.Get()
+	}
+	if o.NextRetryAt.IsSet() {
+		toSerialize["next_retry_at"] = o.NextRetryAt.Get()
 	}
 	if o.ResultMetadata != nil {
 		toSerialize["result_metadata"] = o.ResultMetadata

--- a/hindsight-clients/python/hindsight_client_api/models/operation_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_response.py
@@ -33,7 +33,9 @@ class OperationResponse(BaseModel):
     created_at: StrictStr
     status: StrictStr
     error_message: Optional[StrictStr]
-    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "created_at", "status", "error_message"]
+    retry_count: Optional[StrictInt] = None
+    next_retry_at: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["id", "task_type", "items_count", "document_id", "created_at", "status", "error_message", "retry_count", "next_retry_at"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -84,6 +86,16 @@ class OperationResponse(BaseModel):
         if self.error_message is None and "error_message" in self.model_fields_set:
             _dict['error_message'] = None
 
+        # set to None if retry_count (nullable) is None
+        # and model_fields_set contains the field
+        if self.retry_count is None and "retry_count" in self.model_fields_set:
+            _dict['retry_count'] = None
+
+        # set to None if next_retry_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.next_retry_at is None and "next_retry_at" in self.model_fields_set:
+            _dict['next_retry_at'] = None
+
         return _dict
 
     @classmethod
@@ -102,7 +114,9 @@ class OperationResponse(BaseModel):
             "document_id": obj.get("document_id"),
             "created_at": obj.get("created_at"),
             "status": obj.get("status"),
-            "error_message": obj.get("error_message")
+            "error_message": obj.get("error_message"),
+            "retry_count": obj.get("retry_count"),
+            "next_retry_at": obj.get("next_retry_at")
         })
         return _obj
 

--- a/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/operation_status_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.child_operation_status import ChildOperationStatus
 from typing import Optional, Set
@@ -34,10 +34,12 @@ class OperationStatusResponse(BaseModel):
     updated_at: Optional[StrictStr] = None
     completed_at: Optional[StrictStr] = None
     error_message: Optional[StrictStr] = None
+    retry_count: Optional[StrictInt] = None
+    next_retry_at: Optional[StrictStr] = None
     result_metadata: Optional[Dict[str, Any]] = None
     child_operations: Optional[List[ChildOperationStatus]] = None
     task_payload: Optional[Dict[str, Any]] = None
-    __properties: ClassVar[List[str]] = ["operation_id", "status", "operation_type", "created_at", "updated_at", "completed_at", "error_message", "result_metadata", "child_operations", "task_payload"]
+    __properties: ClassVar[List[str]] = ["operation_id", "status", "operation_type", "created_at", "updated_at", "completed_at", "error_message", "retry_count", "next_retry_at", "result_metadata", "child_operations", "task_payload"]
 
     @field_validator('status')
     def status_validate_enum(cls, value):
@@ -117,6 +119,16 @@ class OperationStatusResponse(BaseModel):
         if self.error_message is None and "error_message" in self.model_fields_set:
             _dict['error_message'] = None
 
+        # set to None if retry_count (nullable) is None
+        # and model_fields_set contains the field
+        if self.retry_count is None and "retry_count" in self.model_fields_set:
+            _dict['retry_count'] = None
+
+        # set to None if next_retry_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.next_retry_at is None and "next_retry_at" in self.model_fields_set:
+            _dict['next_retry_at'] = None
+
         # set to None if result_metadata (nullable) is None
         # and model_fields_set contains the field
         if self.result_metadata is None and "result_metadata" in self.model_fields_set:
@@ -151,6 +163,8 @@ class OperationStatusResponse(BaseModel):
             "updated_at": obj.get("updated_at"),
             "completed_at": obj.get("completed_at"),
             "error_message": obj.get("error_message"),
+            "retry_count": obj.get("retry_count"),
+            "next_retry_at": obj.get("next_retry_at"),
             "result_metadata": obj.get("result_metadata"),
             "child_operations": [ChildOperationStatus.from_dict(_item) for _item in obj["child_operations"]] if obj.get("child_operations") is not None else None,
             "task_payload": obj.get("task_payload")

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2136,6 +2136,18 @@ export type OperationResponse = {
    * Error Message
    */
   error_message: string | null;
+  /**
+   * Retry Count
+   *
+   * Number of times this operation has been retried after failure.
+   */
+  retry_count?: number | null;
+  /**
+   * Next Retry At
+   *
+   * When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is waiting rather than available for immediate pickup — for example, an extension may have raised DeferOperation to park the task until some backpressure window opens. Always null for completed tasks.
+   */
+  next_retry_at?: string | null;
 };
 
 /**
@@ -2172,6 +2184,18 @@ export type OperationStatusResponse = {
    * Error Message
    */
   error_message?: string | null;
+  /**
+   * Retry Count
+   *
+   * Number of times this operation has been retried after failure.
+   */
+  retry_count?: number | null;
+  /**
+   * Next Retry At
+   *
+   * When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is parked (e.g. by an extension raising DeferOperation) rather than awaiting immediate pickup.
+   */
+  next_retry_at?: string | null;
   /**
    * Result Metadata
    *

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -8329,6 +8329,30 @@
               }
             ],
             "title": "Error Message"
+          },
+          "retry_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retry Count",
+            "description": "Number of times this operation has been retried after failure."
+          },
+          "next_retry_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Retry At",
+            "description": "When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is waiting rather than available for immediate pickup \u2014 for example, an extension may have raised DeferOperation to park the task until some backpressure window opens. Always null for completed tasks."
           }
         },
         "type": "object",
@@ -8346,6 +8370,7 @@
           "created_at": "2024-01-15T10:30:00Z",
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "items_count": 5,
+          "retry_count": 0,
           "status": "pending",
           "task_type": "retain"
         }
@@ -8420,6 +8445,30 @@
               }
             ],
             "title": "Error Message"
+          },
+          "retry_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retry Count",
+            "description": "Number of times this operation has been retried after failure."
+          },
+          "next_retry_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Retry At",
+            "description": "When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is parked (e.g. by an extension raising DeferOperation) rather than awaiting immediate pickup."
           },
           "result_metadata": {
             "anyOf": [

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -8329,6 +8329,30 @@
               }
             ],
             "title": "Error Message"
+          },
+          "retry_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retry Count",
+            "description": "Number of times this operation has been retried after failure."
+          },
+          "next_retry_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Retry At",
+            "description": "When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is waiting rather than available for immediate pickup \u2014 for example, an extension may have raised DeferOperation to park the task until some backpressure window opens. Always null for completed tasks."
           }
         },
         "type": "object",
@@ -8346,6 +8370,7 @@
           "created_at": "2024-01-15T10:30:00Z",
           "id": "550e8400-e29b-41d4-a716-446655440000",
           "items_count": 5,
+          "retry_count": 0,
           "status": "pending",
           "task_type": "retain"
         }
@@ -8420,6 +8445,30 @@
               }
             ],
             "title": "Error Message"
+          },
+          "retry_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retry Count",
+            "description": "Number of times this operation has been retried after failure."
+          },
+          "next_retry_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Retry At",
+            "description": "When the worker will next attempt this operation. For a pending operation, a value in the future indicates the task is parked (e.g. by an extension raising DeferOperation) rather than awaiting immediate pickup."
           },
           "result_metadata": {
             "anyOf": [


### PR DESCRIPTION
## Summary

The \`async_operations\` table has tracked \`retry_count\` and \`next_retry_at\` for every task since the worker poller was introduced, but neither is exposed through the generic list / status endpoints or plumbed through to validator extensions. That leaves two consumers unable to distinguish a freshly-queued pending task from one parked for a future retry:

- **API clients** watching task state (UI, SDKs) — a pending task could be awaiting immediate pickup or be parked hours out; there's no way to tell.
- **Validator extensions** deciding when to reschedule a task — without access to retry_count, they can't compute per-attempt backoff without a separate DB round-trip.

This aligns \`OperationResponse\` and \`OperationStatusResponse\` with the pattern already used by \`WebhookDeliveryResponse\` (which has exposed both fields since #1042).

## Changes

- Add \`retry_count: int = 0\` and \`next_retry_at: str | None = None\` to \`OperationResponse\` and \`OperationStatusResponse\`. Completed tasks carry \`next_retry_at=null\`; a pending task with \`next_retry_at\` in the future signals the task is parked rather than awaiting immediate pickup.
- \`list_operations\` and \`get_operation_status\`: include the columns in their SELECT, emit as ISO-8601.
- Add \`retry_count: int = 0\` to \`RequestContext\`. Worker task handlers (\`_handle_batch_retain\`, \`_handle_file_convert\`, \`_handle_consolidation\`, \`_handle_refresh_mental_model\`) populate it from \`task_dict["_retry_count"]\` before dispatching. Defaults to \`0\` for sync/HTTP requests, so no caller-side change is required.

## Test plan

- [x] \`test_operation_status_exposes_retry_count_and_next_retry_at\` — both list and status endpoints expose the fields; a future \`next_retry_at\` round-trips through the API as ISO-8601 within 1-second tolerance
- [x] \`test_request_context_retry_count_propagated_to_validator\` — validator sees \`ctx.request_context.retry_count == task_dict["_retry_count"]\`, including the default-0 case when the key is absent
- [x] Full \`test_async_batch_retain\` suite passes (14 tests)

## Compatibility

Both field additions are fully backwards-compatible: they have defaults, clients that don't read them see no change. Extensions that don't populate \`retry_count\` on \`RequestContext\` continue to see \`0\` via the default.