### PR TITLE
fix(reflect): prevent directive leakage on empty banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -654,7 +654,15 @@ async def run_reflect_agent(
 
         # No tool calls - LLM wants to respond with text
         if not result.tool_calls:
-            if result.content:
+            # When directives are present but no evidence has been gathered,
+            # the LLM tends to echo directive content verbatim as its answer.
+            # Fall through to the final-prompt path which doesn't include
+            # directives and handles "no data" gracefully.
+            has_gathered_evidence = (
+                bool(available_memory_ids) or bool(available_mental_model_ids) or bool(available_observation_ids)
+            )
+            directive_leak_risk = directives and not has_gathered_evidence
+            if result.content and not directive_leak_risk:
                 answer = _clean_answer_text(result.content.strip())
 
                 # The call_with_tools call above is intentionally uncapped so the

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -655,6 +655,52 @@ class TestContextOverflowBehavior:
         mock_llm.call.assert_called_once()
 
 
+class TestDirectiveLeakageOnEmptyBank:
+    """Test that directives don't leak into the answer when the bank has no data.
+
+    Uses a real LLM to verify the behaviour end-to-end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_directive_not_echoed_on_empty_bank(self, memory, request_context):
+        """When a bank has a directive but zero memories, reflect must NOT
+        parrot the directive text back as its answer.
+        """
+        import uuid
+
+        directive_text = (
+            "When making SEO or content decisions, prefer observed performance data "
+            "over industry best practices. Always check the Content Performance page "
+            "before recommending a format or approach."
+        )
+
+        bank_id = f"test-directive-leak-{uuid.uuid4().hex[:8]}"
+        try:
+            # Ensure bank exists (auto-creates it), but retain nothing.
+            await memory.get_bank_profile(bank_id, request_context=request_context)
+
+            await memory.create_directive(
+                bank_id=bank_id,
+                name="SEO Directive",
+                content=directive_text,
+                request_context=request_context,
+            )
+
+            result = await memory.reflect_async(
+                bank_id=bank_id,
+                query="What content strategy should we use?",
+                request_context=request_context,
+            )
+
+            # The directive content must NOT leak into the answer.
+            assert directive_text not in result.text, (
+                f"Directive content leaked into the answer verbatim. "
+                f"Got: {result.text!r}"
+            )
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+
 class TestContextOverflowIntegration:
     """Integration test: real LLM with a very small max_context_tokens.
 


### PR DESCRIPTION
## Summary
- When a bank has directives but no memories/facts, the reflect agent echoes directive content verbatim as its answer instead of saying it has no information
- Root cause: the LLM short-circuits (returns text, no tool calls) and parrots the "MANDATORY" directive text from its system prompt
- Fix: when directives are present but no evidence has been gathered, skip the text-response path and fall through to the final-prompt path which uses `FINAL_SYSTEM_PROMPT` (no directives) and says "No data was retrieved"

## Test plan
- [x] Integration test with real LLM: create bank with directive, no memories, reflect — assert directive text not in answer
- [x] Verified red-green: test fails without fix, passes with fix
- [x] All existing `test_reflect_agent.py` tests pass (no regressions)
- [x] Lint passes