### PR TITLE
fix(reflect): scope delta mental model recall to new memories only

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2514,6 +2514,8 @@ class MemoryEngine(MemoryEngineInterface):
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
         _connection_budget: int | None = None,
         _quiet: bool = False,
     ) -> RecallResultModel:
@@ -2659,6 +2661,8 @@ class MemoryEngine(MemoryEngineInterface):
                             tags=tags,
                             tags_match=tags_match,
                             tag_groups=tag_groups,
+                            created_after=created_after,
+                            created_before=created_before,
                             connection_budget=_connection_budget,
                             quiet=_quiet,
                             include_source_facts=include_source_facts,
@@ -2787,6 +2791,8 @@ class MemoryEngine(MemoryEngineInterface):
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
         connection_budget: int | None = None,
         quiet: bool = False,
         include_source_facts: bool = False,
@@ -2911,6 +2917,8 @@ class MemoryEngine(MemoryEngineInterface):
                         tags=tags,
                         tags_match=tags_match,
                         tag_groups=tag_groups,
+                        created_after=created_after,
+                        created_before=created_before,
                     )
                     parallel_duration = time.time() - parallel_start
             finally:
@@ -5509,6 +5517,8 @@ class MemoryEngine(MemoryEngineInterface):
         recall_include_chunks: bool | None = None,
         recall_max_tokens_override: int | None = None,
         recall_chunks_max_tokens_override: int | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
         _skip_span: bool = False,
     ) -> ReflectResult:
         """
@@ -5661,6 +5671,8 @@ class MemoryEngine(MemoryEngineInterface):
                 last_consolidated_at=last_consolidated_at,
                 pending_consolidation=pending_consolidation,
                 source_facts_max_tokens=reflect_source_facts_max_tokens,
+                created_after=created_after,
+                created_before=created_before,
             )
 
         # Determine which tools to enable based on fact_types and exclude_mental_models
@@ -5688,6 +5700,8 @@ class MemoryEngine(MemoryEngineInterface):
                 max_chunk_tokens=max_chunk_tokens,
                 fact_types=recall_fact_types if fact_types is not None else None,
                 include_chunks=effective_recall_include_chunks,
+                created_after=created_after,
+                created_before=created_before,
             )
 
         async def expand_fn(memory_ids: list[str], depth: str) -> dict[str, Any]:
@@ -7077,9 +7091,26 @@ class MemoryEngine(MemoryEngineInterface):
 
             # Run reflect with the source query, excluding the mental model being refreshed
             # Skip creating a nested "hindsight.reflect" span since we already have "hindsight.mental_model_refresh"
+            # Build context to guide the reflect agent: tell it what this mental
+            # model is about so it stays on-topic and produces high-quality content.
+            mm_name = mental_model.get("name") or mental_model_id
+            refresh_context = (
+                f'You are writing a document called "{mm_name}". '
+                f"ONLY include content that directly answers the topic query. "
+                f"Discard observations that are tangential or off-topic — retrieval may return "
+                f"loosely related content that does not belong in this document.\n\n"
+                f"Quality guidelines:\n"
+                f"- Preserve concrete examples, before/after pairs, and sample sentences "
+                f"from the observations. These teach more than abstract rules.\n"
+                f"- If observations contain illustrative examples (e.g. ✅/❌ pairs, "
+                f"rewrites, sample phrases), include them in your answer.\n"
+                f"- Structure the document around the topic, not around the sources."
+            )
+
             reflect_kwargs: dict[str, Any] = dict(
                 bank_id=bank_id,
                 query=mental_model["source_query"],
+                context=refresh_context,
                 request_context=request_context,
                 tags=tag_filtering.tags,
                 tags_match=tag_filtering.tags_match,
@@ -7097,6 +7128,17 @@ class MemoryEngine(MemoryEngineInterface):
             stored_max_tokens = mental_model.get("max_tokens")
             if stored_max_tokens is not None:
                 reflect_kwargs["max_tokens"] = stored_max_tokens
+
+            # Delta mode: scope recall to memories created since the last refresh
+            # so the agentic loop only retrieves genuinely new information.
+            if use_delta:
+                last_refreshed_at_raw = mental_model.get("last_refreshed_at")
+                if last_refreshed_at_raw is not None:
+                    if isinstance(last_refreshed_at_raw, str):
+                        reflect_kwargs["created_after"] = datetime.fromisoformat(last_refreshed_at_raw)
+                    else:
+                        reflect_kwargs["created_after"] = last_refreshed_at_raw
+
             reflect_result = await self.reflect_async(**reflect_kwargs)
 
             # Build reflect_response payload to store
@@ -7126,6 +7168,20 @@ class MemoryEngine(MemoryEngineInterface):
                             }
                         )
                 based_on_serialized_payload[fact_type] = serialized_facts
+
+            # In delta mode, based_on must accumulate: the mental model is
+            # grounded on ALL facts ever used, not just the latest delta's new
+            # ones. Merge previous based_on with current, deduplicating by id.
+            if use_delta:
+                prev_rr = mental_model.get("reflect_response") or {}
+                prev_based_on = prev_rr.get("based_on") or {}
+                for ftype, prev_facts in prev_based_on.items():
+                    if not isinstance(prev_facts, list):
+                        continue
+                    new_ids = {f["id"] for f in based_on_serialized_payload.get(ftype, [])}
+                    carried = [f for f in prev_facts if isinstance(f, dict) and f.get("id") not in new_ids]
+                    if carried:
+                        based_on_serialized_payload.setdefault(ftype, []).extend(carried)
 
             reflect_response_payload = {
                 "text": reflect_result.text,
@@ -7178,6 +7234,23 @@ class MemoryEngine(MemoryEngineInterface):
                     supporting_facts: list[dict[str, Any]] = []
                     for _ftype, facts in based_on_serialized_payload.items():
                         supporting_facts.extend(facts)
+
+                    # No new facts since last refresh — skip the delta LLM call
+                    # and preserve existing content unchanged.
+                    if not supporting_facts:
+                        logger.info(
+                            f"[MENTAL_MODELS] Delta refresh for {mental_model_id}: "
+                            "no new facts found, preserving content"
+                        )
+                        reflect_response_payload["delta_applied"] = False
+                        reflect_response_payload["delta_skipped_reason"] = "no_new_facts"
+                        return await self.update_mental_model(
+                            bank_id,
+                            mental_model_id,
+                            reflect_response=reflect_response_payload,
+                            last_refreshed_source_query=current_source_query,
+                            request_context=request_context,
+                        )
 
                     # Op JSON is denser than the rendered markdown — each op
                     # carries the section_id, op type, and a full block payload
@@ -7523,7 +7596,7 @@ class MemoryEngine(MemoryEngineInterface):
             tags_match = "any"  # default: untagged MM is "global", tagged MM matches any overlap
 
         params: list[Any] = [bank_id, last_refreshed_at]
-        where = ["bank_id = $1", "created_at > $2"]
+        where = ["bank_id = $1", "updated_at > $2"]
 
         if mm_tags:
             operator, include_untagged = _parse_tags_match(tags_match)

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -525,41 +525,60 @@ def build_final_system_prompt(mission: str | None = None) -> str:
 FINAL_SYSTEM_PROMPT = build_final_system_prompt()
 
 
-STRUCTURED_DELTA_SYSTEM_PROMPT = """You are computing a *minimal patch* to a structured document.
+STRUCTURED_DELTA_SYSTEM_PROMPT = """You are integrating *new information* into an existing structured document.
 
 You will be given:
-1. CURRENT DOCUMENT (JSON) — the existing structured mental model. Each section
+1. TOPIC — the question this document answers. Content that does not help
+   answer this question is OFF-TOPIC and should be removed.
+2. CURRENT DOCUMENT (JSON) — the existing structured mental model. Each section
    has a stable ``id``, a ``heading``, a ``level`` (1..6), and an ordered list
    of ``blocks``. Blocks are typed: ``paragraph``, ``bullet_list``,
    ``ordered_list``, or ``code``.
-2. CANDIDATE SUMMARY (markdown) — a freshly generated synthesis of the latest
-   memories, useful only as a hint about *what new information exists*. You
-   MUST NOT copy its formatting or wording wholesale; it is not the target.
-3. SUPPORTING FACTS — the observations and facts the candidate is grounded in.
-   Treat these as the only source of new information.
+3. NEW INFORMATION SYNTHESIS (markdown) — a synthesis showing how the new facts
+   relate to the document's topic. Use it to understand context and relevance,
+   but do NOT copy its formatting or wording wholesale.
+4. SUPPORTING FACTS — observations and facts created since the last refresh.
+   These are genuinely new — they were NOT available when the current document
+   was written.
 
 Your task: output a JSON object ``{"operations": [...]}``. Applied to CURRENT
-DOCUMENT, the operations must produce the smallest possible change that
-reflects the new facts.
+DOCUMENT, the operations must produce a document that best answers the TOPIC
+by integrating the new facts.
 
-ABSOLUTE RULES
-- If CURRENT DOCUMENT already covers all the supporting facts, output
-  exactly ``{"operations": []}``. An empty operation list IS the correct
-  answer when nothing new has come in. This is the most common case.
+RULES
+- These facts are NEW since the last refresh. The existing document already
+  captures all prior information from earlier refreshes. Your job is to
+  integrate the new facts into the existing document.
+- **Preserve existing content**: The current document was built from prior facts
+  that you cannot see. Do NOT remove or replace existing sections just because
+  the new facts do not reference them. Only remove content when the new facts
+  explicitly contradict or supersede it.
+- **Merge overlapping topics**: When new facts cover topics that overlap with
+  existing sections, merge the new information INTO the existing section
+  rather than creating duplicates. When new facts provide more specific or
+  authoritative guidance on a topic already covered generically, update the
+  existing content to reflect the more specific guidance.
+- **Preserve examples**: Concrete examples, before/after pairs, sample sentences,
+  and illustrative ✅/❌ comparisons are MORE valuable than abstract rules.
+  When facts contain examples, include them. Never drop an example to make
+  room for an abstract restatement of the same point.
 - Operations target sections by ``section_id`` (use the ``id`` field of the
   section in CURRENT DOCUMENT, NOT the heading). Block operations target
   blocks by ``index`` (0-based, against the section's current block list).
-- Add new content with ``append_block``, ``insert_block``, or ``add_section``.
-  Prefer extending an existing section over creating a new one.
-- Modify existing content with ``replace_block`` or ``replace_section_blocks``
-  ONLY when the supporting facts contradict the current text. Do NOT rewrite
-  for style, brevity, or "improvement".
-- Remove stale content with ``remove_block`` or ``remove_section`` ONLY when
-  the supporting facts directly contradict it.
+- **Add** new content with ``append_block``, ``insert_block``, or ``add_section``
+  when facts introduce information not yet covered. Prefer extending an
+  existing section over creating a new one.
+- **Update** existing content with ``replace_block`` or ``replace_section_blocks``
+  when new facts provide corrections, updates, or more specific information
+  about topics already in the document.
+- **Remove** content with ``remove_block`` or ``remove_section`` ONLY when
+  the new facts explicitly contradict or supersede it.
 - NEVER emit operations whose only effect is to reword unchanged content.
 - NEVER emit operations to "normalize" formatting (numbered → bulleted, casing
   changes, paragraph → list, etc).
 - Every operation MUST be justifiable by a specific fact in SUPPORTING FACTS.
+- Output ``{"operations": []}`` only if the new facts are already reflected
+  in the document (e.g., from a concurrent update).
 
 ALLOWED OPERATIONS (each line shows the JSON shape)
 - ``{"op": "append_block", "section_id": "...", "block": {...}}``
@@ -587,7 +606,12 @@ Examples
 - No changes needed → ``{"operations": []}``
 - Add one bullet to an existing "Members" section →
   ``{"operations": [{"op": "append_block", "section_id": "members",
-  "block": {"type": "bullet_list", "items": ["Carol — junior engineer"]}}]}``"""
+  "block": {"type": "bullet_list", "items": ["Carol — junior engineer"]}}]}``
+- Replace a paragraph that has been corrected by new facts →
+  ``{"operations": [{"op": "replace_block", "section_id": "overview",
+  "index": 0, "block": {"type": "paragraph", "text": "Updated summary."}}]}``
+- Remove an obsolete block →
+  ``{"operations": [{"op": "remove_block", "section_id": "status", "index": 2}]}``"""
 
 
 def build_structured_delta_prompt(
@@ -631,15 +655,14 @@ def build_structured_delta_prompt(
         f"## Topic\n{source_query}\n\n"
         f"## CURRENT DOCUMENT (apply ops to this; reference section ids as listed)\n"
         f"```json\n{current_document_json}\n```\n\n"
-        f"## CANDIDATE SUMMARY (hint only — do NOT copy wording wholesale)\n"
+        f"## NEW INFORMATION SYNTHESIS (context for how new facts relate to the topic)\n"
         f"```markdown\n{candidate_markdown}\n```\n\n"
-        f"## SUPPORTING FACTS (the only source of new information)\n{facts_block}"
+        f"## SUPPORTING FACTS (new since last refresh — integrate these)\n{facts_block}"
         f"{budget_hint}\n\n"
         "## Task\n"
-        "Output a JSON object matching the operations schema. Use an empty list "
-        "if no new fact requires a change. Otherwise, emit the smallest set of "
-        "operations that reflects the new facts in CURRENT DOCUMENT, preserving "
-        "all unchanged sections and blocks by simply not mentioning them."
+        "Output a JSON object matching the operations schema. Integrate the new "
+        "supporting facts into CURRENT DOCUMENT. Add, update, or remove content "
+        "as needed. Preserve unchanged sections and blocks by not mentioning them."
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -135,6 +135,8 @@ async def tool_search_observations(
     last_consolidated_at: datetime | None = None,
     pending_consolidation: int = 0,
     source_facts_max_tokens: int = -1,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> dict[str, Any]:
     """
     Search consolidated observations using recall.
@@ -178,6 +180,8 @@ async def tool_search_observations(
         tags_match=tags_match,
         tag_groups=tag_groups,
         include_source_facts=include_source_facts,
+        created_after=created_after,
+        created_before=created_before,
         _connection_budget=1,
         _quiet=True,
         **recall_kwargs,
@@ -214,6 +218,8 @@ async def tool_recall(
     max_chunk_tokens: int = 1000,
     fact_types: list[str] | None = None,
     include_chunks: bool = True,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> dict[str, Any]:
     """
     Search memories using TEMPR retrieval.
@@ -250,6 +256,8 @@ async def tool_recall(
         tags=tags,
         tags_match=tags_match,
         tag_groups=tag_groups,
+        created_after=created_after,
+        created_before=created_before,
         _connection_budget=connection_budget,
         _quiet=True,  # Suppress logging for internal operations
         include_chunks=include_chunks,

--- a/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
@@ -8,6 +8,7 @@ of the recall pipeline.
 
 import logging
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from .tags import TagGroup, TagsMatch
 from .types import GraphRetrievalTimings, RetrievalResult
@@ -45,6 +46,8 @@ class GraphRetriever(ABC):
         tags: list[str] | None = None,  # Visibility scope tags for filtering
         tags_match: TagsMatch = "any",  # How to match tags: 'any' (OR) or 'all' (AND)
         tag_groups: list[TagGroup] | None = None,  # Compound boolean tag filter groups
+        created_after: datetime | None = None,  # Only include memory_units created after this time
+        created_before: datetime | None = None,  # Only include memory_units created before this time
     ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:
         """
         Retrieve relevant facts via graph traversal.

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -28,6 +28,8 @@ import asyncio
 import logging
 import math
 import time
+from datetime import datetime
+from typing import Any
 
 from ...config import get_config
 from ..db_utils import acquire_with_retry
@@ -49,6 +51,8 @@ async def _find_semantic_seeds(
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> list[RetrievalResult]:
     """Find semantic seeds via embedding search."""
     from .tags import build_tag_groups_where_clause, build_tags_where_clause_simple
@@ -56,10 +60,24 @@ async def _find_semantic_seeds(
     tags_clause = build_tags_where_clause_simple(tags, 6, match=tags_match)
     tag_groups_param_start = 6 + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
+
+    _next_idx = tag_groups_param_start + len(groups_params)
+    created_range_clause = ""
+    created_range_params: list[Any] = []
+    if created_after is not None:
+        created_range_params.append(created_after)
+        created_range_clause += f" AND updated_at > ${_next_idx}"
+        _next_idx += 1
+    if created_before is not None:
+        created_range_params.append(created_before)
+        created_range_clause += f" AND updated_at < ${_next_idx}"
+        _next_idx += 1
+
     params = [query_embedding_str, bank_id, fact_type, threshold, limit]
     if tags:
         params.append(tags)
     params.extend(groups_params)
+    params.extend(created_range_params)
 
     rows = await conn.fetch(
         f"""
@@ -73,6 +91,7 @@ async def _find_semantic_seeds(
           AND (1 - (embedding <=> $1::vector)) >= $4
           {tags_clause}
           {groups_clause}
+          {created_range_clause}
         ORDER BY embedding <=> $1::vector
         LIMIT $5
         """,
@@ -121,6 +140,8 @@ class LinkExpansionRetriever(GraphRetriever):
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
+        created_after: "datetime | None" = None,
+        created_before: "datetime | None" = None,
     ) -> tuple[list[RetrievalResult], GraphRetrievalTimings | None]:
         """
         Retrieve facts by expanding links from seeds.
@@ -159,6 +180,8 @@ class LinkExpansionRetriever(GraphRetriever):
                     tags=tags,
                     tags_match=tags_match,
                     tag_groups=tag_groups,
+                    created_after=created_after,
+                    created_before=created_before,
                 )
                 timings.seeds_time = time.time() - seeds_start
                 logger.debug(

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -13,7 +13,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Any, Optional
 
 from ...config import get_config
 from ..db_utils import acquire_with_retry
@@ -98,6 +98,8 @@ async def retrieve_semantic_bm25_combined(
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]]:
     """
     Combined semantic + BM25 retrieval for multiple fact types in a single query.
@@ -163,6 +165,21 @@ async def retrieve_semantic_bm25_combined(
     tag_groups_param_start = tags_param_idx + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
 
+    # --- created_at time range filter (appended after tags/groups) ---
+    # Param indices are computed relative to the final params list built below,
+    # so we pre-compute the next available index after all preceding params.
+    _next_idx = tag_groups_param_start + len(groups_params)
+    created_range_clause = ""
+    created_range_params: list[Any] = []
+    if created_after is not None:
+        created_range_params.append(created_after)
+        created_range_clause += f" AND updated_at > ${_next_idx}"
+        _next_idx += 1
+    if created_before is not None:
+        created_range_params.append(created_before)
+        created_range_clause += f" AND updated_at < ${_next_idx}"
+        _next_idx += 1
+
     # --- Semantic UNION ALL arms (one per fact_type) ---
     # Each arm has its own ORDER BY embedding <=> $1 LIMIT {hnsw_fetch}, which
     # lets the planner use the partial HNSW index for that fact_type.
@@ -180,6 +197,7 @@ async def retrieve_semantic_bm25_combined(
             f"   AND (1 - (embedding <=> $1::vector)) >= 0.3"
             f"   {tags_clause}"
             f"   {groups_clause}"
+            f"   {created_range_clause}"
             f" ORDER BY embedding <=> $1::vector"
             f" LIMIT {hnsw_fetch})"
         )
@@ -220,6 +238,7 @@ async def retrieve_semantic_bm25_combined(
                 f"   {bm25_where_filter}"
                 f"   {tags_clause}"
                 f"   {groups_clause}"
+                f"   {created_range_clause}"
                 f" ORDER BY {bm25_order_by}"
                 f" LIMIT $3)"
             )
@@ -233,6 +252,7 @@ async def retrieve_semantic_bm25_combined(
     if tags:
         params.append(tags)
     params.extend(groups_params)
+    params.extend(created_range_params)
 
     rows = await conn.fetch(query, *params)
 
@@ -266,6 +286,8 @@ async def retrieve_temporal_combined(
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> dict[str, list[RetrievalResult]]:
     """
     Temporal retrieval for multiple fact types in a single query.
@@ -299,10 +321,25 @@ async def retrieve_temporal_combined(
     tags_clause = build_tags_where_clause_simple(tags, 7, match=tags_match)
     tag_groups_param_start = 7 + (1 if tags else 0)
     groups_clause, groups_params, _ = build_tag_groups_where_clause(tag_groups, tag_groups_param_start)
+
+    # created_at time range filter (after tags/groups)
+    _next_idx = tag_groups_param_start + len(groups_params)
+    created_range_clause = ""
+    created_range_params: list[Any] = []
+    if created_after is not None:
+        created_range_params.append(created_after)
+        created_range_clause += f" AND updated_at > ${_next_idx}"
+        _next_idx += 1
+    if created_before is not None:
+        created_range_params.append(created_before)
+        created_range_clause += f" AND updated_at < ${_next_idx}"
+        _next_idx += 1
+
     params: list = [query_emb_str, bank_id, fact_types, start_date, end_date, semantic_threshold]
     if tags:
         params.append(tags)
     params.extend(groups_params)
+    params.extend(created_range_params)
 
     # Two-phase entry point query:
     # Phase 1 (date_ranked): rank by date only — no embedding computation — for all units in
@@ -334,6 +371,7 @@ async def retrieve_temporal_combined(
               )
               {tags_clause}
               {groups_clause}
+              {created_range_clause}
         ),
         sim_ranked AS (
             SELECT mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start, mu.occurred_end, mu.mentioned_at, mu.fact_type, mu.proof_count, mu.document_id, mu.chunk_id, mu.tags, mu.metadata,
@@ -536,6 +574,8 @@ async def retrieve_all_fact_types_parallel(
     tags: list[str] | None = None,
     tags_match: TagsMatch = "any",
     tag_groups: list[TagGroup] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> MultiFactTypeRetrievalResult:
     """
     Optimized retrieval for multiple fact types using batched queries.
@@ -594,6 +634,8 @@ async def retrieve_all_fact_types_parallel(
             tags=tags,
             tags_match=tags_match,
             tag_groups=tag_groups,
+            created_after=created_after,
+            created_before=created_before,
         )
         semantic_bm25_time = time.time() - semantic_bm25_start
 
@@ -613,6 +655,8 @@ async def retrieve_all_fact_types_parallel(
                 tags=tags,
                 tags_match=tags_match,
                 tag_groups=tag_groups,
+                created_after=created_after,
+                created_before=created_before,
             )
             temporal_time = time.time() - temporal_start
 
@@ -636,6 +680,8 @@ async def retrieve_all_fact_types_parallel(
             tags=tags,
             tags_match=tags_match,
             tag_groups=tag_groups,
+            created_after=created_after,
+            created_before=created_before,
         )
         return ft, results, time.time() - graph_start, graph_timing
 

--- a/hindsight-api-slim/tests/test_delta_editorial_fusion.py
+++ b/hindsight-api-slim/tests/test_delta_editorial_fusion.py
@@ -1,0 +1,191 @@
+"""Integration test: delta mental model fuses generic SEO best practices with brand voice.
+
+Scenario:
+1. Create a bank with a delta-mode mental model ("editorial-preferences").
+2. Ingest an SEO best practices document -> trigger mental model refresh.
+3. Ingest a brand voice document -> trigger mental model refresh (delta).
+4. Verify the delta fuses both documents organically.
+
+Requires: HINDSIGHT_RUN_GEMINI_EVALS=1 + a Gemini/OpenAI API key.
+"""
+
+import os
+import uuid
+from collections import Counter
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+_GEMINI_KEY = os.getenv("HINDSIGHT_GEMINI_API_KEY") or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+_OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+_RUN = os.getenv("HINDSIGHT_RUN_GEMINI_EVALS") == "1" and (bool(_GEMINI_KEY) or bool(_OPENAI_KEY))
+pytestmark = pytest.mark.skipif(not _RUN, reason="Set HINDSIGHT_RUN_GEMINI_EVALS=1 + LLM API key")
+
+# ---------------------------------------------------------------------------
+# Test documents — short but representative
+# ---------------------------------------------------------------------------
+
+SEO_BEST_PRACTICES = """\
+# SEO Content Best Practices
+
+## Content Structure
+- Use clear H1/H2/H3 heading hierarchy for every article.
+- Keep paragraphs under 3 sentences for scannability.
+- Use bullet points and numbered lists to break up dense information.
+
+## Tone and Voice
+- Write in a professional, authoritative tone.
+- Use industry-standard SEO terminology (e.g., "SERP", "CTR", "backlink").
+- Address the reader in second person ("you").
+
+## Keyword Strategy
+- Place primary keyword in H1, first paragraph, and meta description.
+- Target keyword density of 1-2% for primary terms.
+- Include long-tail question keywords in H2/H3 subheadings.
+
+## Technical Requirements
+- Meta titles: 50-60 characters, primary keyword first.
+- Meta descriptions: 150-160 characters, include CTA.
+- Internal links: minimum 3 per article.
+- Image alt text: descriptive, keyword-rich where natural.
+
+## E-E-A-T Compliance
+- Include author bios with credentials.
+- Cite authoritative sources.
+- Update content quarterly to maintain freshness.
+"""
+
+BRAND_VOICE = """\
+# Plot Brand Voice Guide
+
+## Who We Are
+Plot is a finance app for freelancers. We handle invoicing, expense tracking,
+and tax prep for people whose income is irregular.
+
+## Voice Principles
+- We talk like a smart friend who knows about money — not a bank, not a guru.
+- Clarity always wins. If a 12-year-old can't understand it, rewrite it.
+- We never lecture or moralize about financial decisions.
+
+## Tone by Context
+- Marketing: Confident, slightly wry. Example: "Built for income that doesn't show up on the same day every month."
+- Support: Direct, human, accountable. Example: "That's our bug, not yours. We're fixing it now."
+- Product UI: Quiet, precise. Example: "Income from Stripe — Mar 14."
+- Errors: Calm, specific. Example: "We couldn't sync your bank. Try reconnecting."
+
+## Writing Rules
+- Always use contractions (it's, we're, you'll).
+- Use Oxford comma.
+- Always say "you", never "users" or "customers".
+- Avoid jargon: never say "leverage", "empower", "solution", "holistic", "game-changing".
+- No puns. Wit is fine — wordplay and wry asides, not dad jokes.
+
+## What We Sound Like
+- YES: "Here's what we found." / NO: "We are pleased to present our findings."
+- YES: "Looks like this payment is late." / NO: "ALERT: Payment overdue! Action required!"
+"""
+
+
+class TestDeltaEditorialFusion:
+    """Real-LLM test verifying delta mode correctly fuses two documents."""
+
+    async def test_delta_fuses_seo_and_brand_voice(
+        self,
+        memory: MemoryEngine,
+        request_context: RequestContext,
+    ):
+        bank_id = f"test-editorial-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        try:
+            mm = await memory.create_mental_model(
+                bank_id=bank_id,
+                name="Editorial Preferences",
+                source_query=(
+                    "What are the editorial preferences and content guidelines? "
+                    "Include tone, voice, formatting rules, and vocabulary rules."
+                ),
+                content="",
+                trigger={
+                    "mode": "delta",
+                    "refresh_after_consolidation": False,
+                    "fact_types": ["observation"],
+                    "exclude_mental_models": True,
+                },
+                request_context=request_context,
+            )
+            mm_id = mm["id"]
+
+            # Phase 1: Ingest SEO best practices
+            await memory.retain_async(
+                bank_id=bank_id, content=SEO_BEST_PRACTICES,
+                document_id="seo-best-practices", request_context=request_context,
+            )
+            mm_after_seo = await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm_id, request_context=request_context,
+            )
+            seo_content = mm_after_seo["content"]
+            assert len(seo_content) > 100, f"First refresh produced too little content: {len(seo_content)} chars"
+
+            # Phase 2: Ingest brand voice -> delta refresh
+            await memory.retain_async(
+                bank_id=bank_id, content=BRAND_VOICE,
+                document_id="brand-voice", request_context=request_context,
+            )
+            mm_after_brand = await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm_id, request_context=request_context,
+            )
+            fused = mm_after_brand["content"]
+            rr = mm_after_brand.get("reflect_response") or {}
+            fused_lower = fused.lower()
+
+            # -- Verify fusion quality --
+
+            # Brand voice concepts present (LLM may paraphrase, check synonyms)
+            for concept, signals in {
+                "contractions": ["contraction", "it's", "we're", "you'll"],
+                "oxford comma": ["oxford comma"],
+                "vocabulary rules": ["jargon", "leverage", "empower", "forbidden"],
+            }.items():
+                assert any(s in fused_lower for s in signals), (
+                    f"Brand voice concept '{concept}' missing (looked for {signals}).\n"
+                    f"Fused content:\n{fused[:500]}"
+                )
+
+            # SEO concepts still present (not wiped by delta)
+            for concept, signals in {
+                "keywords": ["keyword"],
+                "structure": ["heading", "h1", "h2", "structure"],
+                "seo": ["meta", "e-e-a-t", "seo", "search"],
+            }.items():
+                assert any(s in fused_lower for s in signals), (
+                    f"SEO concept '{concept}' missing (looked for {signals}).\n"
+                    f"Fused content:\n{fused[:500]}"
+                )
+
+            # Brand voice overrides generic tone
+            assert any(t in fused_lower for t in ["friend", "wry", "plot", "witty"]), (
+                f"Brand-specific tone missing from fused content.\nFused:\n{fused[:500]}"
+            )
+
+            # No duplicate paragraphs
+            lines = [
+                ln.strip() for ln in fused.split("\n")
+                if ln.strip() and not ln.strip().startswith("#")
+            ]
+            dupes = {line: cnt for line, cnt in Counter(lines).items() if cnt > 1}
+            assert not dupes, (
+                "Duplicate paragraphs:\n" +
+                "\n".join(f"  [{c}x] {t[:80]}" for t, c in dupes.items())
+            )
+
+            # based_on accumulates from both docs
+            obs_count = len(rr.get("based_on", {}).get("observation", []))
+            assert obs_count > 5, f"Expected observations from both docs, got {obs_count}"
+
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -309,7 +309,7 @@ class TestDeltaRefreshPlumbing:
         system_msg = llm_calls[0]["messages"][0]["content"]
         user_msg = llm_calls[0]["messages"][1]["content"]
         # Prompt must include the structured doc + supporting facts + the system prompt.
-        assert "minimal patch" in system_msg.lower()
+        assert "integrating" in system_msg.lower()
         assert "operations" in system_msg.lower()
         assert "obs-bob" in user_msg
         assert "Bob joined" in user_msg
@@ -373,7 +373,12 @@ class TestDeltaRefreshPlumbing:
         normalised = first["content"]
 
         # Second refresh: zero ops again → same bytes as first refresh.
-        patch_reflect(memory, text="something completely different from existing")
+        # Must include at least one fact so the no-new-facts short-circuit doesn't fire.
+        patch_reflect(
+            memory,
+            text="something completely different from existing",
+            facts=[{"id": "obs-1", "text": "irrelevant", "type": "observation", "context": None}],
+        )
         patch_llm_call(memory, returns=[])
         second = await memory.refresh_mental_model(
             bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
@@ -423,7 +428,11 @@ class TestDeltaRefreshPlumbing:
         # Now the second refresh: LLM raises. Refresh must not crash; it should
         # store the candidate markdown.
         candidate = "# Team\n\nFallback candidate from reflect_async.\n"
-        patch_reflect(memory, text=candidate)
+        patch_reflect(
+            memory,
+            text=candidate,
+            facts=[{"id": "obs-new", "text": "some new fact", "type": "observation", "context": None}],
+        )
 
         async def boom(*, messages, **kwargs):
             raise RuntimeError("simulated provider 500")
@@ -482,7 +491,12 @@ class TestDeltaRefreshPlumbing:
         )
 
         # Reflect returns "" — this is the upstream failure mode.
-        patch_reflect(memory, text="")
+        # Must include at least one fact so the no-new-facts short-circuit doesn't fire.
+        patch_reflect(
+            memory,
+            text="",
+            facts=[{"id": "obs-new", "text": "some fact", "type": "observation", "context": None}],
+        )
 
         # Delta call also fails (mirrors the real groq behaviour where empty
         # supporting facts often produce empty / invalid JSON). Refresh then

--- a/hindsight-api-slim/tests/test_recall_time_range.py
+++ b/hindsight-api-slim/tests/test_recall_time_range.py
@@ -1,0 +1,214 @@
+"""Tests for created_after / created_before time-range filtering in recall.
+
+Inserts memory_units with known timestamps directly via SQL, then verifies
+that recall_async respects the time bounds — never returning memories
+outside the requested range.
+
+No LLM required — uses mock provider.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.engine.retain import embedding_utils
+
+# Three points in time, each 1 hour apart
+T1 = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+T3 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+# Stable UUIDs for the three facts (deterministic for assertion readability)
+ID_OLD = "00000000-0000-0000-0000-000000000001"
+ID_MID = "00000000-0000-0000-0000-000000000002"
+ID_NEW = "00000000-0000-0000-0000-000000000003"
+
+RC = RequestContext(tenant_id="default")
+
+
+async def _insert_fact(
+    conn,
+    *,
+    fact_id: str,
+    text: str,
+    bank_id: str,
+    embedding_str: str,
+    created_at: datetime,
+    updated_at: datetime | None = None,
+    fact_type: str = "world",
+) -> None:
+    """Insert a memory_unit with a specific created_at/updated_at timestamp."""
+    updated = updated_at or created_at
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5::vector, $6, $7)
+        """,
+        fact_id,
+        bank_id,
+        text,
+        fact_type,
+        embedding_str,
+        created_at,
+        updated,
+    )
+
+
+@pytest_asyncio.fixture
+async def seeded_memory(memory_no_llm_verify: MemoryEngine):
+    """Insert three facts at T1, T2, T3 and return the engine."""
+    engine = memory_no_llm_verify
+    bank_id = f"test-time-range-{uuid.uuid4().hex[:8]}"
+
+    await engine.get_bank_profile(bank_id, request_context=RC)
+
+    # Generate real embeddings so semantic retrieval works
+    embeddings = await embedding_utils.generate_embeddings_batch(
+        engine.embeddings,
+        ["the cat sat on the mat", "dogs are loyal animals", "birds can fly in the sky"],
+    )
+
+    def _to_str(emb: list[float]) -> str:
+        return "[" + ",".join(str(v) for v in emb) + "]"
+
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        await _insert_fact(
+            conn, fact_id=ID_OLD, text="the cat sat on the mat",
+            bank_id=bank_id, embedding_str=_to_str(embeddings[0]),
+            created_at=T1, updated_at=T1,
+        )
+        await _insert_fact(
+            conn, fact_id=ID_MID, text="dogs are loyal animals",
+            bank_id=bank_id, embedding_str=_to_str(embeddings[1]),
+            created_at=T2, updated_at=T2,
+        )
+        await _insert_fact(
+            conn, fact_id=ID_NEW, text="birds can fly in the sky",
+            bank_id=bank_id, embedding_str=_to_str(embeddings[2]),
+            created_at=T3, updated_at=T3,
+        )
+
+    yield engine, bank_id
+
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+def _result_ids(result) -> set[str]:
+    return {str(r.id) for r in result.results}
+
+
+class TestRecallTimeRange:
+    """Verify created_after / created_before filtering at the recall level."""
+
+    async def test_no_filter_returns_all(self, seeded_memory):
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD in ids
+        assert ID_MID in ids
+        assert ID_NEW in ids
+
+    async def test_created_after_excludes_old(self, seeded_memory):
+        """created_after=T1 excludes fact-old (updated_at == T1, not > T1)."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_after=T1,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD not in ids, "fact-old (updated_at=T1) must be excluded by created_after=T1"
+        assert ID_MID in ids
+        assert ID_NEW in ids
+
+    async def test_created_after_excludes_old_and_mid(self, seeded_memory):
+        """created_after=T2 returns only fact-new."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_after=T2,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD not in ids
+        assert ID_MID not in ids, "fact-mid (updated_at=T2) must be excluded by created_after=T2"
+        assert ID_NEW in ids
+
+    async def test_created_before_excludes_new(self, seeded_memory):
+        """created_before=T3 excludes fact-new (updated_at == T3, not < T3)."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_before=T3,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD in ids
+        assert ID_MID in ids
+        assert ID_NEW not in ids, "fact-new (updated_at=T3) must be excluded by created_before=T3"
+
+    async def test_created_before_excludes_mid_and_new(self, seeded_memory):
+        """created_before=T2 returns only fact-old."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_before=T2,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD in ids
+        assert ID_MID not in ids
+        assert ID_NEW not in ids
+
+    async def test_range_both_bounds(self, seeded_memory):
+        """created_after=T1, created_before=T3 returns only fact-mid."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_after=T1, created_before=T3,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD not in ids
+        assert ID_MID in ids, "fact-mid (T2) must be in range (T1, T3)"
+        assert ID_NEW not in ids
+
+    async def test_empty_range_returns_nothing(self, seeded_memory):
+        """A range after all facts returns empty results."""
+        engine, bank_id = seeded_memory
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_after=T3,
+        )
+        assert len(result.results) == 0, f"Expected no results after T3, got: {_result_ids(result)}"
+
+    async def test_updated_at_catches_consolidation_updates(self, seeded_memory):
+        """A fact created at T1 but updated at T3 appears with created_after=T2."""
+        engine, bank_id = seeded_memory
+
+        # Simulate consolidation updating fact-old
+        pool = await engine._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE memory_units SET updated_at = $1 WHERE id = $2",
+                T3, ID_OLD,
+            )
+
+        result = await engine.recall_async(
+            bank_id=bank_id, query="animals and nature",
+            request_context=RC, max_tokens=10000,
+            created_after=T2,
+        )
+        ids = _result_ids(result)
+        assert ID_OLD in ids, (
+            "fact-old created at T1, updated at T3 — created_after=T2 must find it via updated_at"
+        )
+        assert ID_NEW in ids


### PR DESCRIPTION
## Summary

- Delta mode mental model refresh was running a full recall across ALL memories (identical to full mode), then passing all facts to a second LLM call for delta ops. This caused content bloat, duplication (paragraphs repeated 4-5x), and made delta more expensive than full mode.
- Now delta recall is scoped to memories created/updated since `last_refreshed_at`, using `updated_at` to also catch consolidation updates.
- Delta prompt rewritten to preserve existing content, merge overlapping topics, and preserve concrete examples over abstract rules.
- Reflect agent receives context during MM refresh with document name, stay-on-topic guidance, and example preservation instructions.

## Changes

**Recall pipeline** (`retrieval.py`, `link_expansion_retrieval.py`, `graph_retrieval.py`):
- `created_after`/`created_before` time range filter on `updated_at` threaded through all retrieval strategies (semantic, BM25, temporal, graph seeds)
- Graph expansion intentionally unfiltered — seeds are the filter gate, expansion follows links to older related content for context

**Reflect + tools** (`memory_engine.py`, `tools.py`):
- Time range params threaded through `recall_async` → `_search_with_retries` → `reflect_async` → tool closures → `tool_recall`/`tool_search_observations`
- `_is_mental_model_stale` now uses `updated_at` (catches consolidation updates)

**Mental model refresh** (`memory_engine.py`):
- Delta refresh passes `created_after=last_refreshed_at` to reflect
- No-new-facts short-circuit: skip delta LLM call when nothing new, preserve existing content
- `based_on` accumulates across refreshes (merge previous + new, deduped by ID)
- Context passed to reflect agent: document name, topic-focus guidance, example preservation

**Delta prompt** (`prompts.py`):
- Rewritten: preserve existing content from prior refreshes, merge overlapping topics into existing sections, preserve concrete examples/samples over abstract rules
- Remove ops gated on explicit contradiction/supersession by new facts (not "off-topic" judgment)

## Test plan

- [x] All 58 existing unit tests pass (7 delta plumbing + 39 structured doc + 12 recall config)
- [x] New integration test (`test_delta_editorial_fusion.py`) with real SEO specialist + brand voice documents — verifies brand voice fuses organically with SEO guidance, no duplication, based_on accumulates
- [x] 3/3 stable passes on editorial fusion test
- [x] Lint clean (`ruff check`)
- [ ] Manual test on running API with control plane