### PR TITLE
fix: auto-confirm control plane install on first UI launch

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -499,7 +499,10 @@ class DaemonEmbedManager(EmbedManager):
         from . import __version__
 
         cp_version = os.getenv("HINDSIGHT_EMBED_CP_VERSION", __version__)
-        return ["npx", f"@vectorize-io/hindsight-control-plane@{cp_version}"]
+        # `npx` prompts before installing missing packages on first run unless `-y` is set.
+        # The UI starts in the background with stdout/stderr redirected to a log file, so an
+        # interactive prompt would be invisible to users and the health-check loop would time out.
+        return ["npx", "-y", f"@vectorize-io/hindsight-control-plane@{cp_version}"]
 
     def get_ui_url(self, profile: str, ui_port: int | None = None, hostname: str | None = None) -> str:
         """Get the URL for the UI serving this profile."""

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -1,6 +1,6 @@
 """Tests for EmbedManager interface."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from hindsight_embed import get_embed_manager
 from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
@@ -94,3 +94,16 @@ def test_register_profile_calls_create_when_api_keys_present():
         8100,
         {"HINDSIGHT_API_LLM_PROVIDER": "openai", "HINDSIGHT_API_LLM_API_KEY": "sk-123"},
     )
+
+
+def test_find_ui_command_uses_npx_yes_flag_for_published_control_plane(monkeypatch):
+    """First-run UI installs must auto-confirm the published control-plane package."""
+    manager = DaemonEmbedManager()
+    monkeypatch.setenv("HINDSIGHT_EMBED_CP_VERSION", "9.9.9")
+
+    with patch("pathlib.Path.exists", return_value=False):
+        assert manager._find_ui_command() == [
+            "npx",
+            "-y",
+            "@vectorize-io/hindsight-control-plane@9.9.9",
+        ]


### PR DESCRIPTION
## Summary
- add `-y` to the published `npx` control-plane invocation used by `hindsight-embed ui start`
- document why the first-launch prompt is a problem when UI startup is backgrounded and log-redirected
- add a regression test covering the published-package code path

## Why
On first launch, `npx @vectorize-io/hindsight-control-plane@<version>` can prompt before installing the package. Because `start_ui()` redirects stdout/stderr to the profile UI log and waits for health checks in the foreground, that prompt is invisible to the user and the startup wrapper times out.

Using `npx -y ...` keeps the first-run install non-interactive, which matches the current background-launch design.

## Testing
- `uv run pytest tests/ -q`
- `./scripts/hooks/lint.sh`

Fixes #1196
