### PR TITLE
fix: warn when embedded pg0 database is used instead of external PostgreSQL

### DIFF
--- a/hindsight-api-slim/hindsight_api/banner.py
+++ b/hindsight-api-slim/hindsight_api/banner.py
@@ -94,7 +94,15 @@ def print_startup_info(
     if version:
         print(f"  {dim('Version:')} {color(f'v{version}', 0.1)}")
     print(f"  {dim('URL:')} {color(f'http://{host}:{port}', 0.2)}")
-    print(f"  {dim('Database:')} {color(mask_network_location(database_url), 0.4)}")
+    is_embedded = database_url == "pg0" or database_url.startswith("pg0://")
+    db_label = mask_network_location(database_url)
+    if is_embedded:
+        db_label += "  \033[33m⚠  ephemeral — data lost on restart\033[0m"
+    print(f"  {dim('Database:')} {color(db_label, 0.4)}")
+    if is_embedded:
+        print(
+            "\033[33m  ⚠  Set HINDSIGHT_API_DATABASE_URL to a PostgreSQL DSN for persistent storage.\033[0m"
+        )
     print(f"  {dim('LLM:')} {color(f'{llm_provider} / {llm_model}', 0.6)}")
     print(f"  {dim('Embeddings:')} {color(embeddings_provider, 0.8)}")
     print(f"  {dim('Reranker:')} {color(reranker_provider, 1.0)}")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1797,8 +1797,17 @@ class HindsightConfig:
         # Silence noisy third-party loggers
         logging.getLogger("google_genai.models").setLevel(logging.WARNING)
 
+    def _warn_if_embedded_db(self) -> None:
+        """Emit a warning when the embedded pg0 database is in use."""
+        if self.database_url == DEFAULT_DATABASE_URL or self.database_url.startswith("pg0://"):
+            logger.warning(
+                "⚠️  Using embedded pg0 PostgreSQL — data will be LOST on container restart. "
+                "Set HINDSIGHT_API_DATABASE_URL to an external PostgreSQL DSN for persistent storage."
+            )
+
     def log_config(self) -> None:
         """Log the current configuration (without sensitive values)."""
+        self._warn_if_embedded_db()
         logger.info(f"Database: {self.database_url} (schema: {self.database_schema})")
         if self.migration_database_url:
             logger.info(f"Migration database: {self.migration_database_url}")


### PR DESCRIPTION
Fixes #1202

## Problem

When `HINDSIGHT_API_DATABASE_URL` is not set (or is set under a misnamed variable such as `DATABASE_URL`, `HINDSIGHT_DB_URL`, etc.), Hindsight silently falls back to the embedded `pg0` PostgreSQL. Because `pg0` is ephemeral, **all ingested data is lost on every container restart**. The service passes health checks, runs migrations, and serves traffic normally — operators only discover the problem days or weeks later when memories are missing.

## Solution

Add two warning surfaces so the problem is immediately visible:

1. **Startup banner** (`banner.py`): When `database_url` is `"pg0"` or starts with `"pg0://"`, a yellow ⚠ line is appended to the Database row in `print_startup_info()` and a second line directs operators to set `HINDSIGHT_API_DATABASE_URL`.

2. **Logger warning** (`config.py`): `log_config()` now calls `_warn_if_embedded_db()`, which emits a `logger.warning()` with the same message. This ensures the warning is captured by container log scrapers even when the banner is suppressed (daemon mode).

## Testing

Manual verification: start the server without setting `HINDSIGHT_API_DATABASE_URL` and observe the new warning in startup output and logs. Existing test suite unchanged.