### PR TITLE
fix(perf): fix perf-test CI install and WorkerPoller kwarg

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Install hindsight-dev dependencies
       run: |
-        cd hindsight-dev && uv sync --frozen --index-strategy unsafe-best-match
+        cd hindsight-dev && uv sync --frozen --all-extras --index-strategy unsafe-best-match
 
     - name: Run perf tests
       run: |

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -209,7 +209,6 @@ async def _populate_bank(engine: Any, bank_id: str, size: int) -> None:
         executor=engine.execute_task,
         poll_interval_ms=200,
         max_slots=8,
-        consolidation_max_slots=0,
     )
     poller_task = asyncio.create_task(poller.run())
 


### PR DESCRIPTION
## Summary
- Add `--all-extras` to `uv sync` in perf-test workflow to ensure workspace deps resolve from source
- Remove `consolidation_max_slots` kwarg from WorkerPoller call — uses default, avoids coupling to a specific API version

Verified: workflow dispatch on this branch passes both suites.