### PR TITLE
chore(perf): default CI perf-test scale to large

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -14,7 +14,7 @@ on:
           - small
           - medium
           - large
-        default: small
+        default: large
       suite:
         description: "Suite to run (blank = all)"
         type: choice
@@ -80,7 +80,7 @@ jobs:
           SUITE_ARG="--suite ${{ inputs.suite }}"
         fi
         ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'small' }} \
+          --scale ${{ inputs.scale || 'large' }} \
           $SUITE_ARG \
           --output perf-results.json
 


### PR DESCRIPTION
## Summary
- Change default perf-test scale from `small` to `large` (5K items retain, 5K bank recall, 100 iterations at concurrency 16)

Verified: large scale passes on CI in ~27 minutes. Results:
- Retain: 5.42 items/s (5K items in 921s)
- Recall: 3.79 q/s, p50=4.37s, p95=4.99s, p99=5.28s (5K bank, 100 iterations, concurrency 16)