### PR TITLE
[codex] fix(worker): cache missing schemas_with_pending_work helper

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -15,6 +15,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import asyncpg
+
 from .exceptions import DeferOperation, RetryTaskAt
 from .stage import StageHolder, bind_holder
 
@@ -153,6 +155,10 @@ class WorkerPoller:
         # Rotation offset for per-tenant fair claiming. Advances past the last
         # schema we serviced so a busy tenant can't monopolize the poll order.
         self._next_schema_idx: int = 0
+        # None = not checked yet, True = available, False = permanently absent.
+        # Avoid re-running a missing optional helper function every poll, which
+        # otherwise spams PostgreSQL logs with UndefinedFunction errors.
+        self._schemas_with_pending_work_available: bool | None = None
 
     async def _get_schemas(self) -> list[str | None]:
         """Get list of schemas to poll. Returns [None] for default schema (no prefix)."""
@@ -195,11 +201,15 @@ class WorkerPoller:
         job alongside ``total_pending_tasks()``.
         """
         async with self._pool.acquire() as conn:
-            try:
-                rows = await conn.fetch("SELECT * FROM schemas_with_pending_work()")
-                return {r[0] for r in rows}
-            except Exception:
-                pass
+            if self._schemas_with_pending_work_available is not False:
+                try:
+                    rows = await conn.fetch("SELECT * FROM schemas_with_pending_work()")
+                    self._schemas_with_pending_work_available = True
+                    return {r[0] for r in rows}
+                except asyncpg.exceptions.UndefinedFunctionError:
+                    self._schemas_with_pending_work_available = False
+                except Exception:
+                    pass
 
             # Fallback: per-schema EXISTS checks from Python
             active: set[str | None] = set()

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2740,6 +2740,73 @@ class TestClaimBatchRotation:
             await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", op_id)
 
     @pytest.mark.asyncio
+    async def test_scan_caches_missing_server_side_pending_work_function(self):
+        """Missing optional helper function should only be probed once.
+
+        Without this cache, every poll attempts ``schemas_with_pending_work()``
+        again, which falls back correctly but spams PostgreSQL logs with
+        UndefinedFunction errors in local/self-hosted deployments.
+        """
+        import asyncpg
+
+        from hindsight_api.worker import WorkerPoller
+
+        class DummyTenantExtension:
+            async def list_tenants(self):
+                return []
+
+        class FakeConnection:
+            def __init__(self):
+                self.fetch_calls = 0
+                self.fetchval_calls = 0
+
+            async def fetch(self, query):
+                assert query == "SELECT * FROM schemas_with_pending_work()"
+                self.fetch_calls += 1
+                raise asyncpg.exceptions.UndefinedFunctionError(
+                    'function schemas_with_pending_work() does not exist'
+                )
+
+            async def fetchval(self, query):
+                self.fetchval_calls += 1
+                assert "SELECT EXISTS(SELECT 1 FROM async_operations" in query
+                return False
+
+        class FakeAcquire:
+            def __init__(self, conn):
+                self._conn = conn
+
+            async def __aenter__(self):
+                return self._conn
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakePool:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def acquire(self):
+                return FakeAcquire(self._conn)
+
+        async def noop_executor(task_dict):
+            return None
+
+        conn = FakeConnection()
+        poller = WorkerPoller(
+            pool=FakePool(conn),
+            worker_id="test-scan-cache",
+            executor=noop_executor,
+            tenant_extension=DummyTenantExtension(),
+        )
+
+        assert await poller._scan_active_schemas([None]) == set()
+        assert await poller._scan_active_schemas([None]) == set()
+        assert conn.fetch_calls == 1
+        assert conn.fetchval_calls == 2
+        assert poller._schemas_with_pending_work_available is False
+
+    @pytest.mark.asyncio
     async def test_claim_batch_only_queries_active_schemas(self, pool, clean_operations):
         """claim_batch uses _scan_active_schemas to pre-filter, then
         only calls _claim_batch_for_schema on schemas the scan found.


### PR DESCRIPTION
## Summary

- cache the absence of the optional `schemas_with_pending_work()` helper after the first `UndefinedFunctionError`
- keep the existing per-schema fallback path unchanged
- add a regression test that verifies the helper is only probed once when it is not installed

## Root Cause

`WorkerPoller._scan_active_schemas()` tried `SELECT * FROM schemas_with_pending_work()` on every poll tick until success. In local and self-hosted deployments where that optional helper function is not installed, the worker correctly fell back to per-schema `EXISTS` checks, but PostgreSQL still logged an `UndefinedFunction` error every 500ms.

That made the fallback effectively noisy forever even though the absence of the helper is a stable condition for the lifetime of the process.

## Fix

When the fast-path query fails specifically with `asyncpg.exceptions.UndefinedFunctionError`, mark the helper as unavailable for the current worker process and skip future probes. Other exception types still fall back without disabling future attempts, preserving the existing behavior for transient failures.

## Testing

- `uv run pytest tests/test_worker.py::TestClaimBatchRotation::test_scan_caches_missing_server_side_pending_work_function -v`
- `uv run ruff check hindsight_api/worker/poller.py tests/test_worker.py`
- `./scripts/hooks/lint.sh`

## Impact

This removes persistent PostgreSQL log spam in deployments that do not install the optional helper function, without changing task claiming semantics.