### PR TITLE
feat(retain): expose processed_content_tokens on RetainResult

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2267,6 +2267,11 @@ class MemoryEngine(MemoryEngineInterface):
         # Calculate total token count
         total_tokens = sum(count_tokens(item.get("content", "")) for item in contents)
         total_usage = TokenUsage()
+        # Aggregate "content tokens that actually went through extraction after
+        # chunk-level dedup" across sub-batches. ``None`` in any sub-batch
+        # means that sub-batch bypassed dedup, so the aggregate is None
+        # (see RetainResult.processed_content_tokens).
+        total_processed_content_tokens: int | None = 0
 
         # Get batch size threshold from config
         config = get_config()
@@ -2318,7 +2323,7 @@ class MemoryEngine(MemoryEngineInterface):
                     f"Processing sub-batch {i}/{len(sub_batches)}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens"
                 )
 
-                sub_results, sub_usage = await self._retain_batch_async_internal(
+                sub_results, sub_usage, sub_processed = await self._retain_batch_async_internal(
                     bank_id=bank_id,
                     contents=sub_batch,
                     request_context=request_context,
@@ -2334,6 +2339,10 @@ class MemoryEngine(MemoryEngineInterface):
                 )
                 all_results.extend(sub_results)
                 total_usage = total_usage + sub_usage
+                if total_processed_content_tokens is None or sub_processed is None:
+                    total_processed_content_tokens = None
+                else:
+                    total_processed_content_tokens = total_processed_content_tokens + sub_processed
 
             total_time = time.time() - start_time
             logger.info(
@@ -2342,7 +2351,7 @@ class MemoryEngine(MemoryEngineInterface):
             result = all_results
         else:
             # Small batch - use internal method directly
-            result, total_usage = await self._retain_batch_async_internal(
+            result, total_usage, total_processed_content_tokens = await self._retain_batch_async_internal(
                 bank_id=bank_id,
                 contents=contents,
                 request_context=request_context,
@@ -2371,6 +2380,7 @@ class MemoryEngine(MemoryEngineInterface):
                 llm_input_tokens=total_usage.input_tokens,
                 llm_output_tokens=total_usage.output_tokens,
                 llm_total_tokens=total_usage.total_tokens,
+                processed_content_tokens=total_processed_content_tokens,
             )
             try:
                 await self._operation_validator.on_retain_complete(result_ctx)
@@ -2403,7 +2413,7 @@ class MemoryEngine(MemoryEngineInterface):
         operation_id: str | None = None,
         outbox_callback: "Callable[[asyncpg.Connection], Awaitable[None]] | None" = None,
         strategy: str | None = None,
-    ) -> tuple[list[list[str]], "TokenUsage"]:
+    ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.
 
@@ -2422,7 +2432,9 @@ class MemoryEngine(MemoryEngineInterface):
             document_tags: Tags applied to all items in this batch
 
         Returns:
-            Tuple of (unit ID lists, token usage for fact extraction)
+            Tuple of (unit ID lists, LLM token usage, processed_content_tokens).
+            See ``RetainResult.processed_content_tokens`` for the semantics of
+            the third element.
         """
         # Use the new modular orchestrator
         from .retain import orchestrator

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -16,13 +16,39 @@ from typing import Any
 
 from ...worker.stage import set_stage
 from ..db_utils import acquire_with_retry
-from ..memory_engine import fq_table
+from ..memory_engine import count_tokens, fq_table
 from . import bank_utils
 
 
 def utcnow():
     """Get current UTC time."""
     return datetime.now(UTC)
+
+
+def _merge_processed_content_tokens(a: int | None, b: int | None) -> int | None:
+    """Combine the processed-content-tokens signal across sub-results.
+
+    Semantics (see RetainResult.processed_content_tokens):
+      * None means "this part of the retain did not go through chunk-level
+        dedup" — i.e. the entire submitted payload was processed. If any
+        sub-result is None, the aggregate is None so callers conservatively
+        bill the full content.
+      * Otherwise, accumulate the int values.
+    """
+    if a is None or b is None:
+        return None
+    return a + b
+
+
+def _count_delta_content_tokens(delta_contents: list["RetainContent"]) -> int:
+    """Sum content + context tokens across the chunk items that were
+    actually fed into the extraction pipeline on a partial-delta retain.
+    """
+    total = 0
+    for c in delta_contents:
+        total += count_tokens(c.content or "")
+        total += count_tokens(c.context or "")
+    return total
 
 
 def parse_datetime_flexible(value: Any) -> datetime:
@@ -417,13 +443,21 @@ async def retain_batch(
     schema: str | None = None,
     outbox_callback: Callable[["asyncpg.Connection"], Awaitable[None]] | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
-) -> tuple[list[list[str]], TokenUsage]:
+) -> tuple[list[list[str]], TokenUsage, int | None]:
     """
     Process a batch of content through the retain pipeline.
 
     Supports delta retain: when upserting a document that already has chunks,
     only re-processes chunks whose content has changed. Unchanged chunks keep
     their existing facts, entities, and links.
+
+    Returns a three-tuple of:
+      * per-content-item unit ID lists
+      * aggregate LLM token usage
+      * processed_content_tokens — content+context tokens that actually went
+        through extraction after chunk-level dedup, or ``None`` if this path
+        didn't dedup (caller should treat as "bill full submitted content").
+        See ``RetainResult.processed_content_tokens`` for details.
     """
     start_time = time.time()
     total_chars = sum(len(item.get("content", "")) for item in contents_dicts)
@@ -463,8 +497,9 @@ async def retain_batch(
             # Process each group and merge results back in original order
             result_unit_ids: list[list[str]] = [[] for _ in contents_dicts]
             total_usage = TokenUsage()
+            total_processed_tokens: int | None = 0
             for doc_key, (group_dicts, group_contents) in groups.items():
-                group_ids, group_usage = await retain_batch(
+                group_ids, group_usage, group_processed = await retain_batch(
                     pool=pool,
                     embeddings_model=embeddings_model,
                     llm_config=llm_config,
@@ -486,7 +521,8 @@ async def retain_batch(
                     if group_idx < len(group_ids):
                         result_unit_ids[orig_idx] = group_ids[group_idx]
                 total_usage = total_usage + group_usage
-            return result_unit_ids, total_usage
+                total_processed_tokens = _merge_processed_content_tokens(total_processed_tokens, group_processed)
+            return result_unit_ids, total_usage, total_processed_tokens
 
     # Resolve effective document_id early so both delta and streaming paths
     # can find existing chunks from a prior attempt. On retry, a generated
@@ -595,7 +631,9 @@ async def retain_batch(
                 f"{datetime.fromtimestamp(start_time, tz=UTC).isoformat()})"
             )
             logger.info("\n" + "\n".join(log_buffer) + "\n")
-            return [[] for _ in contents], TokenUsage()
+            # No new content was processed — report 0 so callers can skip
+            # billing cleanly instead of falling back to full-content billing.
+            return [[] for _ in contents], TokenUsage(), 0
 
     # --- Delta retain: check if we can skip unchanged chunks ---
     if is_first_batch:
@@ -1388,7 +1426,10 @@ async def _streaming_retain_batch(
     # Map all unit_ids back to the original content items.
     # For streaming mode with a single document, all units belong to content 0.
     result_unit_ids = [all_unit_ids] + [[] for _ in contents[1:]]
-    return result_unit_ids, total_usage
+    # The streaming path doesn't compute per-chunk content-hash dedup in
+    # a way that lets us report a partial-processed tokens count — signal
+    # ``None`` so callers bill against the full submitted payload.
+    return result_unit_ids, total_usage, None
 
 
 # ---------------------------------------------------------------------------
@@ -1416,10 +1457,15 @@ async def _try_delta_retain(
     schema,
     outbox_callback,
     db_semaphore: "asyncio.Semaphore | None" = None,
-):
+) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
     Attempt delta retain for a document upsert. Returns result tuple if delta
     was performed, or None to fall back to full retain.
+
+    When a result tuple is returned, the third element is the content+context
+    token count for the chunks that actually went through extraction
+    (``0`` if the submission matched prior content exactly and nothing was
+    re-extracted).
     """
     # Need a single document_id
     effective_doc_id = document_id
@@ -1678,7 +1724,12 @@ async def _try_delta_retain(
             await _run_delta_db_work()
     else:
         await _run_delta_db_work()
-    return result_unit_ids, usage
+    # Count content + context tokens that actually went through extraction.
+    # ``delta_contents`` holds the per-chunk RetainContent items for the
+    # changed/new chunks (see ``_build_delta_contents``) — i.e. exactly what
+    # the LLM pipeline saw this call. Unchanged chunks contribute zero.
+    processed_tokens = _count_delta_content_tokens(delta_contents)
+    return result_unit_ids, usage, processed_tokens
 
 
 async def _delta_metadata_only(
@@ -1718,7 +1769,11 @@ async def _delta_metadata_only(
     total_time = time.time() - start_time
     log_buffer.append(f"DELTA RETAIN (no changes): metadata updated in {total_time:.3f}s")
     logger.info("\n" + "\n".join(log_buffer) + "\n")
-    return [[] for _ in contents], TokenUsage()
+    # Nothing went through the extraction pipeline — report 0 processed
+    # content tokens so callers can bill accordingly (a caller that's been
+    # told ``0`` knows the retain was a pure metadata update and should
+    # charge nothing for content).
+    return [[] for _ in contents], TokenUsage(), 0
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
+++ b/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
@@ -176,6 +176,22 @@ class RetainResult:
     llm_input_tokens: int | None = None
     llm_output_tokens: int | None = None
     llm_total_tokens: int | None = None
+    # Content tokens the retain pipeline actually processed, after
+    # chunk-level content-hash deduplication. Semantics:
+    #   None — no dedup signal available (e.g. a first-time retain or a
+    #          path that doesn't compute it). Callers that care about
+    #          "what was actually new on this retain" should treat None
+    #          as "the full submitted content was processed."
+    #   0    — the entire submission was a duplicate of prior content
+    #          (all chunks matched by content_hash); nothing went
+    #          through LLM extraction.
+    #   N>0  — only N tokens of content + context went through the
+    #          extraction pipeline. The remainder was dedup'd against
+    #          existing chunks.
+    # This is the basis most billing/metering extensions want to use
+    # when the customer's client resubmits growing payloads to the same
+    # document_id (e.g. a session transcript appended to on each turn).
+    processed_content_tokens: int | None = None
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -9,12 +9,45 @@ import pytest
 
 from hindsight_api import RequestContext
 from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.extensions import (
+    OperationValidatorExtension,
+    RecallContext,
+    ReflectContext,
+    RetainContext,
+    RetainResult,
+    ValidationResult,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def _ts():
     return datetime.now(timezone.utc).timestamp()
+
+
+class _RetainResultCapture(OperationValidatorExtension):
+    """Minimal OperationValidator that records each RetainResult it receives.
+
+    Used by tests to assert on fields the engine sets on RetainResult (e.g.
+    processed_content_tokens), without having to scrape logs or internals.
+    The pre-operation validators must be implemented to satisfy the
+    abstract base class, but they always accept.
+    """
+
+    def __init__(self) -> None:
+        self.results: list[RetainResult] = []
+
+    async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_recall(self, ctx: RecallContext) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_reflect(self, ctx: ReflectContext) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def on_retain_complete(self, result: RetainResult) -> None:
+        self.results.append(result)
 
 
 # ============================================================
@@ -839,4 +872,186 @@ async def test_delta_retain_recall_with_chunks(memory, request_context):
                 )
 
     finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ============================================================
+# processed_content_tokens on RetainResult
+# ============================================================
+#
+# These tests verify the signal the engine exposes via
+# RetainResult.processed_content_tokens for the post-retain hook. That
+# field lets a metering/billing extension tell the difference between:
+#   * a retain that went through the full extraction pipeline (None),
+#   * a retain whose chunks all matched prior content (0),
+#   * a retain where only some chunks were new/changed (N>0, the
+#     content+context tokens of the chunks that were actually processed).
+
+
+def test_merge_processed_content_tokens_helper():
+    """Unit check on the None-propagating aggregator used by the engine."""
+    from hindsight_api.engine.retain.orchestrator import (
+        _merge_processed_content_tokens,
+    )
+
+    assert _merge_processed_content_tokens(0, 0) == 0
+    assert _merge_processed_content_tokens(5, 7) == 12
+    # None "wins" in either slot — once any sub-result bypassed dedup, the
+    # aggregate is None so callers bill full content.
+    assert _merge_processed_content_tokens(None, 10) is None
+    assert _merge_processed_content_tokens(10, None) is None
+    assert _merge_processed_content_tokens(None, None) is None
+
+
+@pytest.mark.asyncio
+async def test_processed_content_tokens_first_retain_is_none(memory, request_context):
+    """
+    First retain to a new document goes through the full (non-delta) path,
+    so processed_content_tokens should be None — the caller has no dedup
+    signal and should bill the full submitted content.
+    """
+    bank_id = f"test_pct_first_{_ts()}"
+    document_id = "new-doc"
+    capture = _RetainResultCapture()
+    memory._operation_validator = capture
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Alice works at Google.",
+            context="test",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(capture.results) == 1
+        assert capture.results[0].processed_content_tokens is None, (
+            "First retain (full path) should report processed_content_tokens=None"
+        )
+    finally:
+        memory._operation_validator = None
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_processed_content_tokens_unchanged_resubmit_is_zero(memory, request_context):
+    """
+    Re-retaining identical content to the same document_id should hit the
+    'no chunks changed' path and report processed_content_tokens=0.
+    """
+    bank_id = f"test_pct_unchanged_{_ts()}"
+    document_id = "conversation-001"
+    capture = _RetainResultCapture()
+    memory._operation_validator = capture
+    content = "Alice works at Google. Bob works at Microsoft."
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=content,
+            context="team info",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        # Identical resubmit.
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=content,
+            context="team info",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(capture.results) == 2
+        assert capture.results[0].processed_content_tokens is None
+        assert capture.results[1].processed_content_tokens == 0, (
+            "Unchanged resubmit should report zero processed content tokens"
+        )
+    finally:
+        memory._operation_validator = None
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_processed_content_tokens_appended_reports_delta(memory, request_context):
+    """
+    Appending new content to an existing document should surface a
+    non-zero processed_content_tokens that is less than the full
+    submitted content tokens — only the new/changed chunks are counted.
+    """
+    bank_id = f"test_pct_appended_{_ts()}"
+    document_id = "growing-doc"
+    capture = _RetainResultCapture()
+    memory._operation_validator = capture
+
+    v1 = "Alice works at Google."
+    # Make v2 large enough that the delta diff classifies some chunks as
+    # unchanged (shared prefix) and some as new (the appended tail). The
+    # chunker splits on ``retain_chunk_size`` (default 3000), so we pad
+    # each part with a comfortable margin of filler text to force a chunk
+    # boundary between them.
+    filler = " The project budget is fine. " * 400  # ~12 KB
+    v2 = v1 + filler + " Bob works at Microsoft."
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=v1,
+            context="profile",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=v2,
+            context="profile",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(capture.results) == 2
+
+        # Second retain should either:
+        #   * Be on the delta path with a positive partial count strictly
+        #     less than the full submission (the common case), OR
+        #   * Fall back to full retain if the chunker decided nothing
+        #     matched (in which case we report None and bill full).
+        # Both are correct signals for the billing extension; the test
+        # just asserts they're shaped sanely.
+        from hindsight_api.engine.memory_engine import count_tokens
+
+        submitted_tokens = count_tokens(v2) + count_tokens("profile")
+        second = capture.results[1].processed_content_tokens
+        if second is None:
+            # Fell back to full retain — acceptable signal.
+            return
+        assert second > 0, "Partial-delta retain should report a positive token count"
+        assert second < submitted_tokens, (
+            "Partial-delta retain should report fewer processed tokens "
+            "than the full submitted payload"
+        )
+    finally:
+        memory._operation_validator = None
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_processed_content_tokens_without_document_id_is_none(memory, request_context):
+    """
+    A retain without a document_id can't participate in per-document
+    dedup, so the engine should report processed_content_tokens=None
+    and let the caller bill the full submitted payload.
+    """
+    bank_id = f"test_pct_no_doc_{_ts()}"
+    capture = _RetainResultCapture()
+    memory._operation_validator = capture
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="A one-off observation with no document_id.",
+            context="test",
+            request_context=request_context,
+        )
+        assert len(capture.results) == 1
+        assert capture.results[0].processed_content_tokens is None
+    finally:
+        memory._operation_validator = None
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -513,10 +513,7 @@ def main() -> None:
 def _print_summary(results: PerfTestResults) -> None:
     """Print a unified summary table across all suites."""
     console.print(f"\n[bold]{'=' * 60}[/bold]")
-    console.print(
-        f"[bold]Performance Report[/bold]  "
-        f"scale={results.scale}  sha={results.git_sha}  {results.timestamp}"
-    )
+    console.print(f"[bold]Performance Report[/bold]  scale={results.scale}  sha={results.git_sha}  {results.timestamp}")
     console.print(f"[bold]{'=' * 60}[/bold]")
 
     table = Table(title="Results Summary", show_lines=True)
@@ -534,31 +531,48 @@ def _print_summary(results: PerfTestResults) -> None:
         if suite.retain:
             r = suite.retain
             table.add_row(
-                suite.name, status,
-                "throughput", f"{r.throughput_items_per_sec} items/s",
-                "", "", "",
+                suite.name,
+                status,
+                "throughput",
+                f"{r.throughput_items_per_sec} items/s",
+                "",
+                "",
+                "",
             )
             table.add_row(
-                "", "",
-                "duration", f"{r.total_duration_seconds}s",
-                "", "", "",
+                "",
+                "",
+                "duration",
+                f"{r.total_duration_seconds}s",
+                "",
+                "",
+                "",
             )
             table.add_row(
-                "", "",
-                "items", str(r.total_items),
-                "", "", "",
+                "",
+                "",
+                "items",
+                str(r.total_items),
+                "",
+                "",
+                "",
             )
 
         if suite.recall:
             rc = suite.recall
             lat = rc.latency
             table.add_row(
-                suite.name, status,
-                "throughput", f"{rc.throughput_queries_per_sec} q/s",
-                "", "", "",
+                suite.name,
+                status,
+                "throughput",
+                f"{rc.throughput_queries_per_sec} q/s",
+                "",
+                "",
+                "",
             )
             table.add_row(
-                "", "",
+                "",
+                "",
                 "latency",
                 f"mean={lat.mean:.3f}s",
                 f"{lat.p50:.3f}s",
@@ -566,16 +580,20 @@ def _print_summary(results: PerfTestResults) -> None:
                 f"{lat.p99:.3f}s",
             )
             table.add_row(
-                "", "",
+                "",
+                "",
                 "bank/concurrency",
                 f"{rc.bank_size:,} / {rc.concurrency}",
-                "", "", "",
+                "",
+                "",
+                "",
             )
             # Phase breakdown — top 5 by mean
             sorted_phases = sorted(rc.phase_timings.items(), key=lambda x: x[1].mean, reverse=True)
             for phase_name, ps in sorted_phases[:5]:
                 table.add_row(
-                    "", "",
+                    "",
+                    "",
                     f"  {phase_name}",
                     f"mean={ps.mean:.3f}s",
                     f"{ps.p50:.3f}s",


### PR DESCRIPTION
## Summary

Delta retain (PR #701) already computes, at chunk-level granularity, which content on an upsert is new vs. a duplicate of existing chunks. This PR surfaces that signal to post-retain hooks so extensions can reason about "how much content actually went through the extraction pipeline" without re-implementing the dedup logic themselves.

New field on `RetainResult`:

```python
processed_content_tokens: int | None = None
```

with these semantics:

| Value | Meaning |
|-------|---------|
| `None` | Retain went through the full (non-delta) path, or has no dedup signal. Treat as "the full submitted payload was processed." |
| `0` | Submission matched prior content exactly (all chunks matched by `content_hash`). No chunks went through LLM extraction — metadata-only update. |
| `N > 0` | Only `N` tokens of content+context were actually re-extracted. Remaining chunks matched existing `content_hash` and were skipped. |

## Motivation

Clients that append to a growing document on each call (e.g. a session transcript that's upserted under a stable `document_id` as turns accumulate) already benefit from chunk-level dedup inside the retain pipeline — unchanged chunks don't re-enter LLM extraction. But the post-retain hook currently sees only the submitted content list, with no signal about how much of it was genuinely new.

Surfacing `processed_content_tokens` lets a metering or rate-limiting extension charge / account for the actually-new portion without shadowing the dedup state table.

## Where it's populated

- **Streaming / full retain path** → `None` (no per-chunk dedup was performed).
- **`_try_delta_retain` "no changes" fallthrough** (`_delta_metadata_only`) → `0`.
- **`_try_delta_retain` partial-delta success** → sum of `count_tokens(content) + count_tokens(context)` across the items built for extraction (`delta_contents`). Chunks matched by `content_hash` contribute zero.
- **Sub-batch aggregation** (`retain_batch_async` when the payload is auto-chunked) → `None` if any sub-batch bypassed dedup, otherwise sum. Conservative so callers never undercount when only part of a large batch was eligible for delta processing.
- **Multi-document grouping** inside `retain_batch` applies the same `None`-propagating merge rule.

## Backward compatibility

- `RetainResult` gains a new field with a `None` default — existing extensions compile and run unchanged.
- The internal return signature of `retain_batch` / `_retain_batch_async_internal` changes from `(unit_ids, usage)` to `(unit_ids, usage, processed_content_tokens)`. The public `retain_batch_async` return (and its `return_usage=True` form) is unchanged — the new signal is delivered only via the `RetainResult` hook.
- No storage / schema changes. This is a surfacing-only change on top of PR #701's existing chunk content-hash state.

## Test plan

- [x] Unit check on the None-propagating aggregation helper.
- [x] First retain to a new `document_id` → `processed_content_tokens is None`.
- [x] Identical resubmit under same `document_id` → `processed_content_tokens == 0`.
- [x] Appended-content retain → `processed_content_tokens` is either a positive value strictly less than submitted tokens, or `None` (if the chunker forced a full-retain fallback). Both are legitimate signals.
- [x] Retain without a `document_id` → `processed_content_tokens is None`.
- [x] `uv run ruff check` clean.