### PR TITLE
fix(tests): make mock retain extraction deterministic

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/mock_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/mock_llm.py
@@ -6,6 +6,7 @@ without making actual API calls to external LLM services.
 """
 
 import logging
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -153,6 +154,8 @@ class MockLLM(LLMInterface):
             result = self._response_callback(messages, scope)
         elif self._mock_response is not None:
             result = self._mock_response
+        elif scope == "retain_extract_facts":
+            result = self._build_retain_extract_response(messages)
         elif response_format is not None:
             # Try to create a minimal valid instance of the response format
             try:
@@ -167,6 +170,67 @@ class MockLLM(LLMInterface):
             token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
             return result, token_usage
         return result
+
+    @staticmethod
+    def _extract_text_chunk(messages: list[dict[str, str]]) -> str:
+        """Extract the source text payload from a retain prompt."""
+        for message in reversed(messages):
+            if message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if not isinstance(content, str):
+                continue
+            marker = "\nText:\n"
+            if marker in content:
+                return content.split(marker, 1)[1].strip()
+            return content.strip()
+        return ""
+
+    @staticmethod
+    def _split_fact_sentences(text: str, max_facts: int = 50) -> list[str]:
+        """Split source text into stable fact-sized sentences."""
+        candidates = re.split(r"(?<=[.!?])\s+|\n+", text)
+        facts = []
+        for candidate in candidates:
+            cleaned = candidate.strip().strip("-*").strip()
+            if len(cleaned) < 3:
+                continue
+            facts.append(cleaned)
+            if len(facts) >= max_facts:
+                break
+        if facts:
+            return facts
+        fallback = text.strip()
+        return [fallback] if fallback else []
+
+    @staticmethod
+    def _extract_entities(sentence: str) -> list[str]:
+        """Extract obvious named entities for test-mode fact generation."""
+        entities = []
+        seen = set()
+        for match in re.finditer(r"\b(?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b", sentence):
+            entity = match.group(0)
+            if entity not in seen:
+                seen.add(entity)
+                entities.append(entity)
+        return entities
+
+    @classmethod
+    def _build_retain_extract_response(cls, messages: list[dict[str, str]]) -> dict[str, Any]:
+        """Generate deterministic fact extraction output from the input text."""
+        text = cls._extract_text_chunk(messages)
+        facts = []
+        for sentence in cls._split_fact_sentences(text):
+            fact: dict[str, Any] = {
+                "what": sentence,
+                "fact_type": "world",
+                "fact_kind": "conversation",
+            }
+            entities = cls._extract_entities(sentence)
+            if entities:
+                fact["entities"] = entities
+            facts.append(fact)
+        return {"facts": facts}
 
     async def call_with_tools(
         self,

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -1,15 +1,17 @@
 """
 Pytest configuration and shared fixtures.
 """
-import pytest
-import pytest_asyncio
+
 import asyncio
 import os
-import filelock
 from pathlib import Path
-from dotenv import load_dotenv
-from hindsight_api import MemoryEngine, LLMConfig, LocalSTEmbeddings, RequestContext
 
+import filelock
+import pytest
+import pytest_asyncio
+from dotenv import load_dotenv
+
+from hindsight_api import LLMConfig, LocalSTEmbeddings, MemoryEngine, RequestContext
 from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
 from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
@@ -213,11 +215,20 @@ async def memory(pg0_db_url, embeddings, cross_encoder, query_analyzer):
     Migrations are disabled here since they're run once at session scope in pg0_db_url.
     Uses SyncTaskBackend so async tasks execute immediately (no worker needed).
     """
+    llm_provider = os.getenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    llm_api_key = os.getenv("HINDSIGHT_API_LLM_API_KEY")
+    if llm_api_key is None and llm_provider == "mock":
+        llm_api_key = ""
+    llm_model = os.getenv(
+        "HINDSIGHT_API_LLM_MODEL",
+        "mock" if llm_provider == "mock" else "openai/gpt-oss-120b",
+    )
+
     mem = MemoryEngine(
         db_url=pg0_db_url,  # Direct postgresql:// URL, not pg0://
-        memory_llm_provider=os.getenv("HINDSIGHT_API_LLM_PROVIDER", "groq"),
-        memory_llm_api_key=os.getenv("HINDSIGHT_API_LLM_API_KEY"),
-        memory_llm_model=os.getenv("HINDSIGHT_API_LLM_MODEL", "openai/gpt-oss-120b"),
+        memory_llm_provider=llm_provider,
+        memory_llm_api_key=llm_api_key,
+        memory_llm_model=llm_model,
         memory_llm_base_url=os.getenv("HINDSIGHT_API_LLM_BASE_URL") or None,
         embeddings=embeddings,
         cross_encoder=cross_encoder,

--- a/hindsight-api-slim/tests/test_per_operation_llm_config.py
+++ b/hindsight-api-slim/tests/test_per_operation_llm_config.py
@@ -224,6 +224,41 @@ class TestMockLLMProvider:
         assert usage.output_tokens == 5
         assert usage.total_tokens == 15
 
+    def test_mock_provider_generates_facts_for_retain_extract_scope(self):
+        """Retain fact extraction should get deterministic sentence-level facts from mock."""
+        from hindsight_api.engine.llm_wrapper import LLMProvider
+
+        provider = LLMProvider(
+            provider="mock",
+            api_key="",
+            base_url="",
+            model="test-model",
+        )
+
+        import asyncio
+
+        async def make_call():
+            return await provider.call(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": (
+                            "Extract facts from the following text chunk.\n\n"
+                            "Text:\nAlice works at Google. Bob leads product at Meta."
+                        ),
+                    }
+                ],
+                scope="retain_extract_facts",
+            )
+
+        result = asyncio.get_event_loop().run_until_complete(make_call())
+        assert "facts" in result
+        assert [fact["what"] for fact in result["facts"]] == [
+            "Alice works at Google.",
+            "Bob leads product at Meta.",
+        ]
+        assert result["facts"][0]["entities"] == ["Alice", "Google"]
+
 
 class TestRetainUsesRetainLLMConfig:
     """Test that retain operations use the retain LLM config."""


### PR DESCRIPTION
## Summary
- generate deterministic sentence-level fact extraction output for the mock LLM when retain uses `scope=retain_extract_facts`
- default the shared `memory` test fixture to the mock provider when no local LLM env is configured
- add coverage for the new mock retain behavior

## Why
Running `hindsight-api-slim` tests locally without a populated `.env` currently falls back to a real provider (`groq`) and fails early, or, when forced to `mock`, retain-heavy integration tests extract zero facts and produce large misleading failure clusters. This keeps the generic mock behavior intact while making local retain/recall integration tests deterministic and useful.

## Validation
- `uv run pytest tests/test_per_operation_llm_config.py::TestMockLLMProvider::test_mock_provider_generates_facts_for_retain_extract_scope -q`
- `uv run pytest tests/test_retain_append_mode.py::test_append_mode_concatenates_content -q`
- `uv run pytest tests/test_tags_visibility.py -q`
- `uv run ruff check hindsight_api/engine/providers/mock_llm.py tests/conftest.py tests/test_per_operation_llm_config.py`

## Follow-up
A broader local no-env test pass still has a second cluster around richer mock behaviors (`consolidation`, `causal_relations`, `entity_labels`, and zero-fact edge cases). I kept this PR scoped to the first large retain/recall failure wave.
