### PR TITLE
fix(claude-code): prevent compaction from overwriting retained memories

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/state.py
+++ b/hindsight-integrations/claude-code/scripts/lib/state.py
@@ -126,3 +126,71 @@ def increment_turn_count(session_id: str) -> int:
             del turns[k]
     write_state("turns.json", turns)
     return turns[session_id]
+
+
+def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
+    """Read-modify-write a state file under flock.
+
+    modify_fn receives the current state dict and returns (updated_dict, result).
+    Returns the result from modify_fn.
+    """
+    lock_path = _state_file(lock_name)
+    if fcntl is not None:
+        try:
+            lock_fd = open(lock_path, "w")
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            try:
+                data = read_state(state_name, {})
+                data, result = modify_fn(data)
+                write_state(state_name, data)
+                return result
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                lock_fd.close()
+        except OSError:
+            pass
+
+    # Fallback without lock
+    data = read_state(state_name, {})
+    data, result = modify_fn(data)
+    write_state(state_name, data)
+    return result
+
+
+def track_retention(session_id: str, message_count: int) -> tuple:
+    """Track retention state and detect compaction.
+
+    Compares the current message count against the last retained count for this
+    session.  When the transcript shrinks (compaction), increments a chunk counter
+    so the caller can use a distinct document_id, preserving the pre-compaction
+    document.
+
+    Returns:
+        (chunk_index, compacted) — chunk_index for building document_id,
+        compacted is True if compaction was detected this call.
+    """
+
+    def _update(data):
+        entry = data.get(session_id, {"message_count": 0, "chunk": 0})
+        last_count = entry["message_count"]
+        chunk = entry["chunk"]
+        compacted = False
+
+        if message_count < last_count:
+            # Transcript shrank — compaction happened
+            chunk += 1
+            compacted = True
+
+        entry["message_count"] = message_count
+        entry["chunk"] = chunk
+        data[session_id] = entry
+
+        # Cap tracked sessions
+        if len(data) > 10000:
+            sorted_keys = sorted(data.keys())
+            for k in sorted_keys[: len(sorted_keys) // 2]:
+                del data[k]
+
+        return data, (chunk, compacted)
+
+    return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -32,7 +32,7 @@ from lib.content import (
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
-from lib.state import increment_turn_count
+from lib.state import increment_turn_count, track_retention
 
 
 def read_transcript(transcript_path: str) -> list:
@@ -157,12 +157,25 @@ def main():
     bank_id = derive_bank_id(hook_input, config)
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
 
-    # Document ID: use session_id so the same session always upserts the same document.
-    # In chunked mode, append timestamp to create distinct documents per chunk.
+    # Document ID strategy:
+    # - Chunked mode: each chunk gets a timestamped document_id.
+    # - Full-session mode: uses session_id as base, but tracks message count
+    #   to detect compaction.  When Claude Code compacts the conversation the
+    #   transcript shrinks — if we kept the same document_id we'd overwrite the
+    #   pre-compaction document with a shorter one, losing context.  Instead we
+    #   increment a chunk counter so the old document is preserved.
     if retain_mode == "chunked" and retain_every_n > 1:
         document_id = f"{session_id}-{int(time.time() * 1000)}"
     else:
-        document_id = session_id
+        chunk_index, compacted = track_retention(session_id, len(all_messages))
+        if compacted:
+            debug_log(
+                config,
+                f"Compaction detected for session {session_id}: transcript shrank, "
+                f"advancing to chunk {chunk_index} to preserve prior document",
+            )
+        # chunk 0 → plain session_id (backwards compatible with existing docs)
+        document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
 
     # Resolve template variables in tags and metadata.
     # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -424,6 +424,78 @@ class TestRetainHook:
         assert "first question" in item["content"]
         assert "second question" in item["content"]
 
+    def test_full_session_new_document_after_compaction(self, monkeypatch, tmp_path):
+        """After compaction shrinks the transcript, retain should use a new document_id
+        to avoid overwriting the pre-compaction document."""
+        # First retain: 4 messages
+        messages_full = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_full)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-compact-test")
+        captured_calls = []
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 1
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-compact-test"
+        assert "first question" in captured_calls[0]["items"][0]["content"]
+
+        # Second retain: compaction happened — transcript now has only 2 messages
+        messages_compacted = [
+            {"role": "user", "content": "third question"},
+            {"role": "assistant", "content": "third answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_compacted)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-compact-test")
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 2
+        # Should use a new document_id with chunk suffix
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-compact-test-c1"
+        assert "third question" in captured_calls[1]["items"][0]["content"]
+
+    def test_full_session_same_document_when_growing(self, monkeypatch, tmp_path):
+        """When transcript grows (no compaction), retain should keep the same document_id."""
+        messages_2 = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_2)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-grow-test")
+        captured_calls = []
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        # Second retain: transcript grew to 4 messages
+        messages_4 = messages_2 + [
+            {"role": "user", "content": "more stuff"},
+            {"role": "assistant", "content": "more response"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_4)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-grow-test")
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 2
+        # Both should use the same plain session_id
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-grow-test"
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test"
+
     def test_full_session_respects_retain_every_n_turns(self, monkeypatch, tmp_path):
         """In full-session mode, retainEveryNTurns should still gate when retain fires."""
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]

--- a/hindsight-integrations/claude-code/tests/test_state.py
+++ b/hindsight-integrations/claude-code/tests/test_state.py
@@ -1,0 +1,125 @@
+"""Unit tests for lib/state.py — retention tracking and compaction detection."""
+
+import json
+
+import pytest
+
+from lib.state import read_state, track_retention, write_state
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch, tmp_path):
+    """Point all state operations at a temp directory."""
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# track_retention — core compaction detection
+# ---------------------------------------------------------------------------
+
+
+class TestTrackRetention:
+    def test_first_call_returns_chunk_zero(self):
+        chunk, compacted = track_retention("sess-1", 10)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_growing_transcript_keeps_same_chunk(self):
+        track_retention("sess-1", 4)
+        chunk, compacted = track_retention("sess-1", 8)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_equal_count_keeps_same_chunk(self):
+        track_retention("sess-1", 5)
+        chunk, compacted = track_retention("sess-1", 5)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_shrinking_transcript_triggers_compaction(self):
+        track_retention("sess-1", 10)
+        chunk, compacted = track_retention("sess-1", 3)
+        assert chunk == 1
+        assert compacted is True
+
+    def test_multiple_compactions_increment_chunk(self):
+        track_retention("sess-1", 10)
+
+        chunk, compacted = track_retention("sess-1", 3)
+        assert chunk == 1
+        assert compacted is True
+
+        # Grow again after compaction
+        track_retention("sess-1", 8)
+
+        # Second compaction
+        chunk, compacted = track_retention("sess-1", 2)
+        assert chunk == 2
+        assert compacted is True
+
+    def test_growth_after_compaction_stays_on_same_chunk(self):
+        track_retention("sess-1", 10)
+        track_retention("sess-1", 3)  # compaction → chunk 1
+
+        chunk, compacted = track_retention("sess-1", 6)
+        assert chunk == 1
+        assert compacted is False
+
+    def test_sessions_are_independent(self):
+        track_retention("sess-a", 10)
+        track_retention("sess-b", 20)
+
+        # Compaction on sess-a only
+        chunk_a, compacted_a = track_retention("sess-a", 3)
+        chunk_b, compacted_b = track_retention("sess-b", 25)
+
+        assert chunk_a == 1
+        assert compacted_a is True
+        assert chunk_b == 0
+        assert compacted_b is False
+
+    def test_persists_across_calls(self, tmp_path):
+        """State file is written to disk and survives between calls."""
+        track_retention("sess-1", 10)
+
+        # Verify the state file exists
+        state_file = tmp_path / "state" / "retention_tracking.json"
+        assert state_file.exists()
+
+        data = json.loads(state_file.read_text())
+        assert data["sess-1"]["message_count"] == 10
+        assert data["sess-1"]["chunk"] == 0
+
+    def test_compaction_from_one_message(self):
+        """Edge case: transcript shrinks to a single message."""
+        track_retention("sess-1", 50)
+        chunk, compacted = track_retention("sess-1", 1)
+        assert chunk == 1
+        assert compacted is True
+
+    def test_shrink_by_one_triggers_compaction(self):
+        """Even shrinking by a single message counts as compaction."""
+        track_retention("sess-1", 10)
+        chunk, compacted = track_retention("sess-1", 9)
+        assert chunk == 1
+        assert compacted is True
+
+
+# ---------------------------------------------------------------------------
+# read_state / write_state basics
+# ---------------------------------------------------------------------------
+
+
+class TestReadWriteState:
+    def test_read_nonexistent_returns_default(self):
+        assert read_state("does_not_exist.json") is None
+        assert read_state("does_not_exist.json", {"key": "val"}) == {"key": "val"}
+
+    def test_write_then_read_roundtrips(self):
+        write_state("test_roundtrip.json", {"foo": 42})
+        assert read_state("test_roundtrip.json") == {"foo": 42}
+
+    def test_write_overwrites_previous(self):
+        write_state("test_overwrite.json", {"v": 1})
+        write_state("test_overwrite.json", {"v": 2})
+        assert read_state("test_overwrite.json") == {"v": 2}


### PR DESCRIPTION
## Summary

- After Claude Code compacts the conversation, the transcript shrinks. In full-session mode the retain hook used the same `document_id` (`session_id`), so the shorter post-compaction transcript would overwrite the full pre-compaction document — losing all earlier context.
- Track per-session message counts in `retention_tracking.json` and detect when the transcript shrinks. On compaction, increment a chunk counter and use a suffixed `document_id` (e.g. `session-c1`, `session-c2`) so the pre-compaction document is preserved.
- Chunk 0 uses the plain `session_id` (backwards compatible with existing documents). `/resume` is safe because Claude Code appends to the same transcript with the same session_id, so message count only grows.

## Test plan

- [x] Unit tests for `track_retention`: first call, growth, equal count, shrink, multiple compactions, cross-session independence, persistence, edge cases (13 tests in `test_state.py`)
- [x] End-to-end hook tests: `test_full_session_new_document_after_compaction`, `test_full_session_same_document_when_growing` (2 tests in `test_hooks.py`)
- [x] All 148 tests pass