### PR TITLE
fix(claude-code): handle list-content tool_results in transcript parsing

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -276,8 +276,19 @@ def _extract_message_blocks(content, role: str = "") -> list:
                 blocks.append({"type": "tool_use", "name": name, "input": inp})
 
         elif block_type == "tool_result":
-            # Include tool results for context
+            # Include tool results for context.
+            # content can be a plain string or a list of content blocks
+            # (e.g. [{"type": "text", "text": "..."}] for Agent results).
             result_content = block.get("content", "")
+            if isinstance(result_content, list):
+                # Extract text from content blocks
+                parts = []
+                for item in result_content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        t = item.get("text", "").strip()
+                        if t:
+                            parts.append(t)
+                result_content = "\n".join(parts)
             if isinstance(result_content, str) and result_content.strip():
                 text = result_content.strip()
                 # Truncate very long results

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -428,6 +428,41 @@ class TestPrepareRetentionTranscript:
         result_block = next(b for b in result_msg["content"] if b["type"] == "tool_result")
         assert "file1.py" in result_block["content"]
 
+    def test_json_format_handles_list_content_tool_results(self):
+        """Tool results with list content (e.g. Agent subagent responses) should be extracted."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": "analyze the code"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "Agent", "input": {"prompt": "check code"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_abc",
+                        "content": [
+                            {"type": "text", "text": "Found 3 issues in the codebase."},
+                            {"type": "text", "text": "1. Missing error handling in auth module"},
+                        ],
+                    },
+                ],
+            },
+        ]
+        transcript, _ = prepare_retention_transcript(
+            msgs, retain_full_window=True, include_tool_calls=True
+        )
+        data = json.loads(transcript)
+        result_msg = next(m for m in data if any(b.get("type") == "tool_result" for b in m["content"]))
+        result_block = next(b for b in result_msg["content"] if b["type"] == "tool_result")
+        assert "Found 3 issues" in result_block["content"]
+        assert "Missing error handling" in result_block["content"]
+
     def test_without_tool_calls_uses_text_format(self):
         """Default (include_tool_calls=False) should use legacy text format."""
         msgs = _msgs(("user", "hello"), ("assistant", "world"))


### PR DESCRIPTION
## Summary

- `tool_result` blocks in Claude Code transcripts can have `content` as a list of content blocks (e.g. `[{"type": "text", "text": "..."}]`) instead of a plain string — this happens with Agent subagent responses
- Previously these were silently dropped during retention because the code only handled `isinstance(result_content, str)`, losing ~1-4% of tool results (the most information-rich ones)
- Extract text from list content blocks before applying the existing string handling and truncation logic

## Test plan

- [x] Added `test_json_format_handles_list_content_tool_results` verifying list-content extraction
- [x] Existing `test_json_format_includes_tool_results` still passes (string content path unchanged)
- [x] All 150 tests pass