### PR TITLE
fix(mcp): remove delete_memory tool to close authorization-bypass gap

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -111,7 +111,6 @@ def create_mcp_server(memory: MemoryEngine, multi_bank: bool = True) -> FastMCP:
             "delete_directive",
             "list_memories",
             "get_memory",
-            "delete_memory",
             "list_documents",
             "get_document",
             "delete_document",

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -290,25 +290,6 @@ class MemoryEngineInterface(ABC):
         ...
 
     @abstractmethod
-    async def delete_memory_unit(
-        self,
-        unit_id: str,
-        *,
-        request_context: "RequestContext",
-    ) -> dict[str, Any]:
-        """
-        Delete a specific memory unit.
-
-        Args:
-            unit_id: The memory unit ID.
-            request_context: Request context for authentication.
-
-        Returns:
-            Deletion result.
-        """
-        ...
-
-    @abstractmethod
     async def get_graph_data(
         self,
         bank_id: str,

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -45,7 +45,6 @@ _ALL_TOOLS: frozenset[str] = frozenset(
         "delete_directive",
         "list_memories",
         "get_memory",
-        "delete_memory",
         "list_documents",
         "get_document",
         "delete_document",
@@ -223,7 +222,6 @@ def register_mcp_tools(
         "delete_directive",
         "list_memories",
         "get_memory",
-        "delete_memory",
         "list_documents",
         "get_document",
         "delete_document",
@@ -291,9 +289,6 @@ def register_mcp_tools(
 
     if "get_memory" in tools_to_register:
         _register_get_memory(mcp, memory, config)
-
-    if "delete_memory" in tools_to_register:
-        _register_delete_memory(mcp, memory, config)
 
     # Document tools
     if "list_documents" in tools_to_register:
@@ -441,7 +436,6 @@ _AUDITABLE_MCP_TOOLS: frozenset[str] = frozenset(
         "refresh_mental_model",
         "create_directive",
         "delete_directive",
-        "delete_memory",
         "delete_document",
         "cancel_operation",
     }
@@ -2160,74 +2154,6 @@ def _register_get_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
                 return {"error": str(e)}
             except Exception as e:
                 logger.error(f"Error getting memory: {e}", exc_info=True)
-                return {"error": str(e)}
-
-
-def _register_delete_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
-    """Register the delete_memory tool."""
-
-    if config.include_bank_id_param:
-
-        @mcp.tool()
-        async def delete_memory(
-            memory_id: str,
-            bank_id: str | None = None,
-        ) -> str:
-            """
-            Delete a specific memory by ID.
-
-            Permanently removes a memory unit and its associated data.
-
-            Args:
-                memory_id: The ID of the memory to delete
-                bank_id: Optional bank (accepted for consistency, not used in deletion).
-            """
-            try:
-                target_bank = bank_id or config.bank_id_resolver()
-                if target_bank is None:
-                    return '{"error": "No bank_id configured"}'
-
-                result = await memory.delete_memory_unit(
-                    unit_id=memory_id,
-                    request_context=_get_request_context(config),
-                )
-                return json.dumps({"status": "deleted", "memory_id": memory_id, **result}, default=str)
-            except OperationValidationError as e:
-                logger.warning(f"Operation rejected: {e}")
-                return json.dumps({"error": str(e)})
-            except Exception as e:
-                logger.error(f"Error deleting memory: {e}", exc_info=True)
-                return f'{{"error": "{e}"}}'
-
-    else:
-
-        @mcp.tool()
-        async def delete_memory(
-            memory_id: str,
-        ) -> dict:
-            """
-            Delete a specific memory by ID.
-
-            Permanently removes a memory unit and its associated data.
-
-            Args:
-                memory_id: The ID of the memory to delete
-            """
-            try:
-                target_bank = config.bank_id_resolver()
-                if target_bank is None:
-                    return {"error": "No bank_id configured"}
-
-                result = await memory.delete_memory_unit(
-                    unit_id=memory_id,
-                    request_context=_get_request_context(config),
-                )
-                return {"status": "deleted", "memory_id": memory_id, **result}
-            except OperationValidationError as e:
-                logger.warning(f"Operation rejected: {e}")
-                return {"error": str(e)}
-            except Exception as e:
-                logger.error(f"Error deleting memory: {e}", exc_info=True)
                 return {"error": str(e)}
 
 

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -159,7 +159,6 @@ def mock_memory():
     # Memory browsing methods
     memory.list_memory_units = AsyncMock(return_value={"items": [{"id": "mem-1", "content": "Test"}], "total": 1})
     memory.get_memory_unit = AsyncMock(return_value={"id": "mem-1", "content": "Test memory"})
-    memory.delete_memory_unit = AsyncMock(return_value={"deleted_count": 1})
 
     # Document methods
     memory.list_documents = AsyncMock(return_value={"items": [{"id": "doc-1", "name": "Test Doc"}], "total": 1})
@@ -313,7 +312,6 @@ class TestMentalModelToolRegistration:
         memory.delete_directive = AsyncMock()
         memory.list_memory_units = AsyncMock(return_value={})
         memory.get_memory_unit = AsyncMock()
-        memory.delete_memory_unit = AsyncMock()
         memory.list_documents = AsyncMock(return_value={})
         memory.get_document = AsyncMock()
         memory.delete_document = AsyncMock()
@@ -347,7 +345,7 @@ class TestMentalModelToolRegistration:
         assert "delete_bank" in tools
         assert "clear_memories" in tools
         assert "sync_retain" in tools
-        assert len(tools) == 30
+        assert len(tools) == 29
 
 
 @pytest.fixture
@@ -1106,12 +1104,6 @@ class TestMemoryBrowsingTools:
         result = await _tools(mcp)["get_memory"].fn(memory_id="missing")
         assert "not found" in result
 
-    async def test_delete_memory(self, mock_memory):
-        mcp = _make_mcp_server(mock_memory, {"delete_memory"}, include_bank_id=True)
-        result = await _tools(mcp)["delete_memory"].fn(memory_id="mem-1")
-        assert '"deleted"' in result
-        assert mock_memory.delete_memory_unit.call_args.kwargs["unit_id"] == "mem-1"
-
     async def test_get_memory_invalid_uuid(self, mock_memory):
         mock_memory.get_memory_unit.side_effect = ValueError("Invalid memory_id: 'nonexistent' is not a valid UUID")
         mcp = _make_mcp_server(mock_memory, {"get_memory"}, include_bank_id=True)
@@ -1123,12 +1115,6 @@ class TestMemoryBrowsingTools:
         mcp = _make_mcp_server(mock_memory, {"get_memory"}, include_bank_id=False)
         result = await _tools(mcp)["get_memory"].fn(memory_id="bad")
         assert "not a valid UUID" in result["error"]
-
-    async def test_delete_memory_invalid_uuid(self, mock_memory):
-        mock_memory.delete_memory_unit.side_effect = ValueError("Invalid unit_id: 'bad' is not a valid UUID")
-        mcp = _make_mcp_server(mock_memory, {"delete_memory"}, include_bank_id=True)
-        result = await _tools(mcp)["delete_memory"].fn(memory_id="bad")
-        assert "not a valid UUID" in result
 
     async def test_list_memories_single_bank(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"list_memories"}, include_bank_id=False)
@@ -1360,19 +1346,6 @@ class TestOperationErrorHandling:
 @pytest.mark.asyncio
 class TestDeleteErrorHandling:
     """Error handling tests for delete operations."""
-
-    async def test_delete_memory_engine_error(self, mock_memory):
-        mock_memory.delete_memory_unit.side_effect = RuntimeError("DB error")
-        mcp = _make_mcp_server(mock_memory, {"delete_memory"}, include_bank_id=True)
-        result = await _tools(mcp)["delete_memory"].fn(memory_id="mem-1")
-        assert "error" in result
-        assert "DB error" in result
-
-    async def test_delete_memory_single_bank(self, mock_memory):
-        mcp = _make_mcp_server(mock_memory, {"delete_memory"}, include_bank_id=False)
-        result = await _tools(mcp)["delete_memory"].fn(memory_id="mem-1")
-        assert isinstance(result, dict)
-        assert result["status"] == "deleted"
 
     async def test_delete_document_engine_error(self, mock_memory):
         mock_memory.delete_document.side_effect = RuntimeError("DB error")

--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -137,7 +137,7 @@ const MCP_TOOL_GROUPS: { label: string; tools: string[] }[] = [
     ],
   },
   { label: "Directives", tools: ["list_directives", "create_directive", "delete_directive"] },
-  { label: "Memories", tools: ["list_memories", "get_memory", "delete_memory"] },
+  { label: "Memories", tools: ["list_memories", "get_memory"] },
   { label: "Documents", tools: ["list_documents", "get_document", "delete_document"] },
   { label: "Operations", tools: ["list_operations", "get_operation", "cancel_operation"] },
   { label: "Tags", tools: ["list_tags"] },

--- a/hindsight-docs/docs-integrations/local-mcp.md
+++ b/hindsight-docs/docs-integrations/local-mcp.md
@@ -103,7 +103,6 @@ The local server exposes the full tool set (29 tools in multi-bank mode, 26 in s
 |------|-------------|
 | `list_memories` | Browse memories with filtering and pagination |
 | `get_memory` | Get a specific memory by ID |
-| `delete_memory` | Delete a specific memory |
 
 **Documents**
 

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -254,7 +254,7 @@ An allowlist of MCP tool names that are enabled for this bank. When set, only th
 ["recall", "reflect"]
 ```
 
-Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `delete_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
+Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
 
 ### llm_gemini_safety_settings
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1121,7 +1121,7 @@ export HINDSIGHT_API_MCP_ENABLED_TOOLS=recall
 export HINDSIGHT_API_MCP_ENABLED_TOOLS=recall,reflect
 ```
 
-Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `delete_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
+Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
 
 This can also be overridden per bank via the [config API](#hierarchical-configuration):
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -371,16 +371,6 @@ Retrieve a specific memory by ID.
 
 ---
 
-### delete_memory
-
-Permanently delete a specific memory.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `memory_id` | string | Yes | The ID of the memory to delete |
-
----
-
 ### list_documents
 
 List documents that have been ingested into the memory bank.

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -272,7 +272,7 @@ An allowlist of MCP tool names that are enabled for this bank. When set, only th
 ["recall", "reflect"]
 ```
 
-Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `delete_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
+Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
 
 ### llm_gemini_safety_settings
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1121,7 +1121,7 @@ export HINDSIGHT_API_MCP_ENABLED_TOOLS=recall
 export HINDSIGHT_API_MCP_ENABLED_TOOLS=recall,reflect
 ```
 
-Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `delete_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
+Available tool names: `retain`, `recall`, `reflect`, `list_banks`, `create_bank`, `list_mental_models`, `get_mental_model`, `create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`, `list_directives`, `create_directive`, `delete_directive`, `list_memories`, `get_memory`, `list_documents`, `get_document`, `delete_document`, `list_operations`, `get_operation`, `cancel_operation`, `list_tags`, `get_bank`, `get_bank_stats`, `update_bank`, `delete_bank`, `clear_memories`.
 
 This can also be overridden per bank via the [config API](#hierarchical-configuration):
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -371,16 +371,6 @@ Retrieve a specific memory by ID.
 
 ---
 
-### delete_memory
-
-Permanently delete a specific memory.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `memory_id` | string | Yes | The ID of the memory to delete |
-
----
-
 ### list_documents
 
 List documents that have been ingested into the memory bank.


### PR DESCRIPTION
## Summary

Fixes #1218. `MemoryEngine.delete_memory_unit` never called `validate_bank_write`, so any authenticated MCP client could delete memories in any bank regardless of the configured `OperationValidatorExtension` policy. Every sibling delete method (`delete_document`, `delete_bank`, `delete_mental_model`, `delete_directive`) follows the validator pattern — `delete_memory_unit` was the lone exception.

The MCP `delete_memory` tool was the only external caller:
- No REST endpoint exposes single-memory deletion (`http.py` has no `DELETE /v1/default/banks/{bank_id}/memories/{memory_id}` route).
- The CLI already stubs `delete_memory` with `anyhow::bail!("Individual memory deletion is no longer supported")` (`hindsight-cli/src/api.rs:383`).

The product direction was already "no single-memory delete via public API." This PR finishes the removal for MCP rather than papering the validator gap.

## Changes

- Remove both `delete_memory` MCP tool registrations and `_register_delete_memory` in `hindsight-api-slim/hindsight_api/mcp_tools.py`; drop `"delete_memory"` from `_ALL_TOOLS`, `_AUDITABLE_MCP_TOOLS`, and the default tool set.
- Drop `"delete_memory"` from `_SINGLE_BANK_TOOLS` in `hindsight-api-slim/hindsight_api/api/mcp.py`.
- Remove `delete_memory_unit` from the `MemoryEngineInterface` abstract class (it's no longer part of the documented public surface). The concrete method stays on `MemoryEngine` so `tests/test_observation_invalidation.py` can still cover the stale-observation sweep through a single-unit entry point.
- Delete the MCP-tool tests for `delete_memory` in `tests/test_mcp_tools.py` and adjust the default-tool-count assertion (30 → 29).
- Remove `delete_memory` from the Memories group in the Control Plane bank-config UI.
- Update `hindsight-docs/docs/developer/mcp-server.md`, `configuration.md`, `api/memory-banks.mdx`, `docs-integrations/local-mcp.md`, and the `skills/hindsight-docs` mirrors. Versioned docs for 0.4/0.5 left untouched.

## Test plan

- [x] `./scripts/hooks/lint.sh` — all lints pass
- [x] `uv run pytest tests/test_mcp_tools.py` — 168 passed
- [x] `python -c "from hindsight_api.api import mcp; from hindsight_api import mcp_tools"` — imports fine; `_ALL_TOOLS` is now 29 entries
- [ ] CI