### PR TITLE
feat(api): add exclude_parents filter to list operations

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4395,12 +4395,19 @@ def _register_routes(app: FastAPI):
         ),
         limit: int = Query(default=20, ge=1, le=100, description="Maximum number of operations to return"),
         offset: int = Query(default=0, ge=0, description="Number of operations to skip"),
+        exclude_parents: bool = Query(default=False, description="Exclude parent batch operations from results"),
         request_context: RequestContext = Depends(get_request_context),
     ):
         """List async operations for a memory bank with optional filtering and pagination."""
         try:
             result = await app.state.memory.list_operations(
-                bank_id, status=status, task_type=type, limit=limit, offset=offset, request_context=request_context
+                bank_id,
+                status=status,
+                task_type=type,
+                limit=limit,
+                offset=offset,
+                exclude_parents=exclude_parents,
+                request_context=request_context,
             )
             return OperationsListResponse(
                 bank_id=bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8002,6 +8002,7 @@ class MemoryEngine(MemoryEngineInterface):
         task_type: str | None = None,
         limit: int = 20,
         offset: int = 0,
+        exclude_parents: bool = False,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """List async operations for a bank with optional filtering and pagination.
@@ -8012,6 +8013,7 @@ class MemoryEngine(MemoryEngineInterface):
             task_type: Optional operation type filter (retain, consolidation, etc.)
             limit: Maximum number of operations to return (default 20)
             offset: Number of operations to skip (default 0)
+            exclude_parents: If True, exclude parent batch operations (is_parent=True in result_metadata)
             request_context: Request context for authentication
 
         Returns:
@@ -8041,6 +8043,9 @@ class MemoryEngine(MemoryEngineInterface):
             if task_type:
                 where_conditions.append(f"operation_type = ${len(params) + 1}")
                 params.append(task_type)
+
+            if exclude_parents:
+                where_conditions.append("NOT (result_metadata::jsonb @> '{\"is_parent\": true}'::jsonb)")
 
             where_clause = " AND ".join(where_conditions)
 

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -629,6 +629,74 @@ async def test_operation_status_exposes_retry_count_and_next_retry_at(memory, re
 
 
 @pytest.mark.asyncio
+async def test_list_operations_exclude_parents(memory, request_context):
+    """list_operations with exclude_parents=True hides parent batch operations."""
+    bank_id = "test_exclude_parents"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+
+    # Create a parent operation (is_parent=True)
+    parent_id = uuid.uuid4()
+    child_id = uuid.uuid4()
+    standalone_id = uuid.uuid4()
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, result_metadata, status)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            parent_id,
+            bank_id,
+            "batch_retain",
+            json.dumps({"items_count": 10, "num_sub_batches": 1, "is_parent": True}),
+            "completed",
+        )
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, result_metadata, status)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            child_id,
+            bank_id,
+            "retain",
+            json.dumps({"items_count": 10, "parent_operation_id": str(parent_id), "sub_batch_index": 1, "total_sub_batches": 1}),
+            "completed",
+        )
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, result_metadata, status)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            standalone_id,
+            bank_id,
+            "consolidation",
+            json.dumps({}),
+            "completed",
+        )
+
+    # Without exclude_parents: all 3 operations visible
+    all_ops = await memory.list_operations(
+        bank_id=bank_id, request_context=request_context, limit=10, offset=0,
+    )
+    all_ids = {op["id"] for op in all_ops["operations"]}
+    assert str(parent_id) in all_ids
+    assert str(child_id) in all_ids
+    assert str(standalone_id) in all_ids
+    assert all_ops["total"] == 3
+
+    # With exclude_parents: parent is hidden
+    filtered_ops = await memory.list_operations(
+        bank_id=bank_id, request_context=request_context, limit=10, offset=0, exclude_parents=True,
+    )
+    filtered_ids = {op["id"] for op in filtered_ops["operations"]}
+    assert str(parent_id) not in filtered_ids
+    assert str(child_id) in filtered_ids
+    assert str(standalone_id) in filtered_ids
+    assert filtered_ops["total"] == 2
+
+
+@pytest.mark.asyncio
 async def test_request_context_retry_count_propagated_to_validator(memory_no_llm_verify, request_context):
     """_handle_batch_retain forwards the task's _retry_count as
     RequestContext.retry_count, so validator extensions can compute

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -338,7 +338,7 @@ impl ApiClient {
             loop {
                 let response = self
                     .client
-                    .list_operations(agent_id, None, None, None, None, None)
+                    .list_operations(agent_id, None, None, None, None, None, None)
                     .await?;
                 let ops = response.into_inner();
 
@@ -470,7 +470,7 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .list_operations(agent_id, None, None, None, None, None)
+                .list_operations(agent_id, None, None, None, None, None, None)
                 .await?;
             let value = response.into_inner();
             // Convert to JSON Value first, then parse into our type

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1805,6 +1805,17 @@ paths:
           title: Offset
           type: integer
         style: form
+      - description: Exclude parent batch operations from results
+        explode: true
+        in: query
+        name: exclude_parents
+        required: false
+        schema:
+          default: false
+          description: Exclude parent batch operations from results
+          title: Exclude Parents
+          type: boolean
+        style: form
       - explode: false
         in: header
         name: authorization

--- a/hindsight-clients/go/api_operations.go
+++ b/hindsight-clients/go/api_operations.go
@@ -296,6 +296,7 @@ type ApiListOperationsRequest struct {
 	type_ *string
 	limit *int32
 	offset *int32
+	excludeParents *bool
 	authorization *string
 }
 
@@ -320,6 +321,12 @@ func (r ApiListOperationsRequest) Limit(limit int32) ApiListOperationsRequest {
 // Number of operations to skip
 func (r ApiListOperationsRequest) Offset(offset int32) ApiListOperationsRequest {
 	r.offset = &offset
+	return r
+}
+
+// Exclude parent batch operations from results
+func (r ApiListOperationsRequest) ExcludeParents(excludeParents bool) ApiListOperationsRequest {
+	r.excludeParents = &excludeParents
 	return r
 }
 
@@ -388,6 +395,12 @@ func (a *OperationsAPIService) ListOperationsExecute(r ApiListOperationsRequest)
 	} else {
 		var defaultValue int32 = 0
 		r.offset = &defaultValue
+	}
+	if r.excludeParents != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "exclude_parents", r.excludeParents, "form", "")
+	} else {
+		var defaultValue bool = false
+		r.excludeParents = &defaultValue
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/hindsight-clients/python/hindsight_client_api/api/operations_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/operations_api.py
@@ -653,6 +653,7 @@ class OperationsApi:
         type: Annotated[Optional[StrictStr], Field(description="Filter by operation type: retain, consolidation, refresh_mental_model, file_convert_retain, webhook_delivery")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of operations to return")] = None,
         offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Number of operations to skip")] = None,
+        exclude_parents: Annotated[Optional[StrictBool], Field(description="Exclude parent batch operations from results")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -681,6 +682,8 @@ class OperationsApi:
         :type limit: int
         :param offset: Number of operations to skip
         :type offset: int
+        :param exclude_parents: Exclude parent batch operations from results
+        :type exclude_parents: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -711,6 +714,7 @@ class OperationsApi:
             type=type,
             limit=limit,
             offset=offset,
+            exclude_parents=exclude_parents,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -741,6 +745,7 @@ class OperationsApi:
         type: Annotated[Optional[StrictStr], Field(description="Filter by operation type: retain, consolidation, refresh_mental_model, file_convert_retain, webhook_delivery")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of operations to return")] = None,
         offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Number of operations to skip")] = None,
+        exclude_parents: Annotated[Optional[StrictBool], Field(description="Exclude parent batch operations from results")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -769,6 +774,8 @@ class OperationsApi:
         :type limit: int
         :param offset: Number of operations to skip
         :type offset: int
+        :param exclude_parents: Exclude parent batch operations from results
+        :type exclude_parents: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -799,6 +806,7 @@ class OperationsApi:
             type=type,
             limit=limit,
             offset=offset,
+            exclude_parents=exclude_parents,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -829,6 +837,7 @@ class OperationsApi:
         type: Annotated[Optional[StrictStr], Field(description="Filter by operation type: retain, consolidation, refresh_mental_model, file_convert_retain, webhook_delivery")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of operations to return")] = None,
         offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Number of operations to skip")] = None,
+        exclude_parents: Annotated[Optional[StrictBool], Field(description="Exclude parent batch operations from results")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -857,6 +866,8 @@ class OperationsApi:
         :type limit: int
         :param offset: Number of operations to skip
         :type offset: int
+        :param exclude_parents: Exclude parent batch operations from results
+        :type exclude_parents: bool
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -887,6 +898,7 @@ class OperationsApi:
             type=type,
             limit=limit,
             offset=offset,
+            exclude_parents=exclude_parents,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -912,6 +924,7 @@ class OperationsApi:
         type,
         limit,
         offset,
+        exclude_parents,
         authorization,
         _request_auth,
         _content_type,
@@ -952,6 +965,10 @@ class OperationsApi:
         if offset is not None:
             
             _query_params.append(('offset', offset))
+            
+        if exclude_parents is not None:
+            
+            _query_params.append(('exclude_parents', exclude_parents))
             
         # process the header parameters
         if authorization is not None:

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4833,6 +4833,12 @@ export type ListOperationsData = {
      * Number of operations to skip
      */
     offset?: number;
+    /**
+     * Exclude Parents
+     *
+     * Exclude parent batch operations from results
+     */
+    exclude_parents?: boolean;
   };
   url: "/v1/default/banks/{bank_id}/operations";
 };

--- a/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
@@ -12,11 +12,12 @@ export async function GET(
     const type = searchParams.get("type") || undefined;
     const limit = searchParams.get("limit") ? parseInt(searchParams.get("limit")!) : undefined;
     const offset = searchParams.get("offset") ? parseInt(searchParams.get("offset")!) : undefined;
+    const excludeParents = searchParams.get("exclude_parents") === "true" ? true : undefined;
 
     const response = await sdk.listOperations({
       client: lowLevelClient,
       path: { bank_id: agentId },
-      query: { status, type, limit, offset },
+      query: { status, type, limit, offset, exclude_parents: excludeParents },
     });
     return NextResponse.json(response.data || {}, { status: 200 });
   } catch (error) {

--- a/hindsight-control-plane/src/components/bank-operations-view.tsx
+++ b/hindsight-control-plane/src/components/bank-operations-view.tsx
@@ -130,6 +130,7 @@ export function BankOperationsView() {
           type: newTaskTypeFilter || undefined,
           limit,
           offset: newOffset,
+          excludeParents: true,
         });
         setOperations(opsData.operations || []);
         setTotalOperations(opsData.total || 0);

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -348,13 +348,20 @@ export class ControlPlaneClient {
    */
   async listOperations(
     bankId: string,
-    options?: { status?: string; type?: string; limit?: number; offset?: number }
+    options?: {
+      status?: string;
+      type?: string;
+      limit?: number;
+      offset?: number;
+      excludeParents?: boolean;
+    }
   ) {
     const params = new URLSearchParams();
     if (options?.status) params.append("status", options.status);
     if (options?.type) params.append("type", options.type);
     if (options?.limit) params.append("limit", options.limit.toString());
     if (options?.offset) params.append("offset", options.offset.toString());
+    if (options?.excludeParents) params.append("exclude_parents", "true");
     const query = params.toString();
     return this.fetchApi<{
       bank_id: string;

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -2635,6 +2635,18 @@
             "description": "Number of operations to skip"
           },
           {
+            "name": "exclude_parents",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Exclude parent batch operations from results",
+              "default": false,
+              "title": "Exclude Parents"
+            },
+            "description": "Exclude parent batch operations from results"
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -2635,6 +2635,18 @@
             "description": "Number of operations to skip"
           },
           {
+            "name": "exclude_parents",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Exclude parent batch operations from results",
+              "default": false,
+              "title": "Exclude Parents"
+            },
+            "description": "Exclude parent batch operations from results"
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,


### PR DESCRIPTION
## Summary
- Adds `exclude_parents` query parameter to the list operations API endpoint, filtering out parent batch retain operations (`is_parent=true` in `result_metadata`)
- Control plane UI passes `exclude_parents=true` by default so users only see leaf operations, not the synthetic parent wrappers
- Wired through control plane proxy route and TypeScript client

## Test plan
- [ ] Verify operations list hides parent batch retain operations in the UI
- [ ] Verify `?exclude_parents=true` filters correctly via API
- [ ] Verify `?exclude_parents=false` (default) still returns all operations
- [ ] Existing operation tests pass (`test_async_batch_retain.py`, `test_op_cancellation.py`)