### PR TITLE
fix: correct docker command in 10k stars blog quickstart

### DIFF
--- a/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
+++ b/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
@@ -167,10 +167,14 @@ If these use cases resonate with your agent system, here's how to start building
 First, try Hindsight locally:
 
 ```bash
-docker run -p 8000:8000 vectorize/hindsight
+export OPENAI_API_KEY=sk-xxx
+docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+  -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
+  -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
+  ghcr.io/vectorize-io/hindsight:latest
 ```
 
-That's it. You have a running Hindsight agent memory system. Connect it to your agent framework (Claude Code, LangGraph, CrewAI, etc.) and start extracting facts from conversations.
+That's it. You have a running Hindsight agent memory system. Access the API at `http://localhost:8888` and the web UI at `http://localhost:9999`. Connect it to your agent framework (Claude Code, LangGraph, CrewAI, etc.) and start extracting facts from conversations.
 
 **Path 2: Cloud Deployment (Production Ready)**
 


### PR DESCRIPTION
Fixes the incorrect docker command in the Getting Started section of the 10k stars celebration blog post.

**Changes:**
- Image: `ghcr.io/vectorize-io/hindsight:latest` (was: vectorize/hindsight)
- Ports: 8888 (API) and 9999 (Web UI) (was: 8000)
- Added required OPENAI_API_KEY environment variable
- Added volume mount for persistent storage
- Added access URLs for clarity