### PR TITLE
docs(ops): document processing + cancelled statuses from #1231

### DIFF
--- a/hindsight-docs/docs/developer/api/operations.md
+++ b/hindsight-docs/docs/developer/api/operations.md
@@ -85,8 +85,10 @@ Response:
 | Status | Description |
 |--------|-------------|
 | `pending` | Operation is queued and waiting to be processed |
+| `processing` | Operation is actively being processed by a worker |
 | `completed` | Operation finished successfully |
 | `failed` | Operation failed (check `error_message` for details) |
+| `cancelled` | Operation was cancelled via the DELETE endpoint before processing |
 
 ## Managing Operations
 
@@ -113,7 +115,7 @@ Response:
 }
 ```
 
-The operation status resets to `pending` and the worker picks it up again. Returns `409` if the operation is not in `failed` state.
+The operation status resets to `pending` and the worker picks it up again. Returns `409` if the operation is not in `failed` or `cancelled` state.
 
 ## Next Steps
 

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -85,8 +85,10 @@ Response:
 | Status | Description |
 |--------|-------------|
 | `pending` | Operation is queued and waiting to be processed |
+| `processing` | Operation is actively being processed by a worker |
 | `completed` | Operation finished successfully |
 | `failed` | Operation failed (check `error_message` for details) |
+| `cancelled` | Operation was cancelled via the DELETE endpoint before processing |
 
 ## Managing Operations
 
@@ -113,7 +115,7 @@ Response:
 }
 ```
 
-The operation status resets to `pending` and the worker picks it up again. Returns `409` if the operation is not in `failed` state.
+The operation status resets to `pending` and the worker picks it up again. Returns `409` if the operation is not in `failed` or `cancelled` state.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

#1231 (merged ~4h ago) exposed `processing` and `cancelled` as first-class operation statuses (previously `processing` was collapsed into `pending` in the API, and `cancelled` didn't exist). It also extended retry to accept cancelled operations in addition to failed ones.

`hindsight-docs/docs/developer/api/operations.md` still lists only three statuses in the **Operation Status Values** table, and the retry section still says "Returns \`409\` if the operation is not in \`failed\` state" — which no longer matches `hindsight-api-slim/hindsight_api/engine/memory_engine.py` (rejects retry only when status is neither `failed` nor `cancelled`).

## Changes

- Add `processing` and `cancelled` rows to the **Operation Status Values** table.
- Update the retry 409 sentence to include `cancelled`.
- Mirror both edits in `skills/hindsight-docs/references/developer/api/operations.md` (dual-doc).

## Verification

- Diff traced back to #1231: alembic migration adds `'cancelled'` to the `async_operations_status_check` constraint; `list_operations` handler stops collapsing `processing` into `pending`; `retry_operation` allows `cancelled` alongside `failed`.
- `docs/developer/mcp-server.md`, `configuration.md`, `api/memory-banks.mdx` — unrelated to this drift; left untouched.