### PR TITLE
fix(litellm): handle streaming responses in _store_conversation

### DIFF
--- a/hindsight-docs/docs-integrations/litellm.md
+++ b/hindsight-docs/docs-integrations/litellm.md
@@ -13,12 +13,13 @@ Universal LLM memory integration via [LiteLLM](https://github.com/BerriAI/litell
 ## Features
 
 - **Universal LLM Support** - Works with 100+ LLM providers via LiteLLM (OpenAI, Anthropic, Groq, Azure, AWS Bedrock, Google Vertex AI, and more)
-- **Simple Integration** - Just configure, enable, and use `hindsight_litellm.completion()`
+- **Simple Integration** - Just configure, set defaults, enable, and use `hindsight_litellm.completion()`
 - **Automatic Memory Injection** - Relevant memories are injected into prompts before LLM calls
-- **Automatic Conversation Storage** - Conversations are stored to Hindsight for future recall
+- **Automatic Conversation Storage** - Conversations are stored to Hindsight for future recall (async by default for performance)
 - **Two Memory Modes** - Choose between `reflect` (synthesized context) or `recall` (raw memory retrieval)
 - **Direct Memory APIs** - Query, synthesize, and store memories manually
 - **Native Client Wrappers** - Alternative wrappers for OpenAI and Anthropic SDKs
+- **Debug Mode** - Inspect exactly what memories are being injected
 
 ## Installation
 
@@ -31,19 +32,30 @@ pip install hindsight-litellm
 ```python
 import hindsight_litellm
 
-# Configure and enable memory integration
+# Step 1: Configure static settings
 hindsight_litellm.configure(
     hindsight_api_url="http://localhost:8888",
-    bank_id="my-agent",
+    verbose=True,
 )
+
+# Step 2: Set defaults (bank_id is required)
+hindsight_litellm.set_defaults(
+    bank_id="my-agent",
+    use_reflect=True,  # Use reflect for synthesized context
+)
+
+# Step 3: Enable memory integration
 hindsight_litellm.enable()
 
-# Use the convenience wrapper - memory is automatically injected and stored
+# Step 4: Use completion with memory
 response = hindsight_litellm.completion(
     model="gpt-4o-mini",
-    messages=[{"role": "user", "content": "What did we discuss about AI?"}]
+    messages=[{"role": "user", "content": "What did we discuss about AI?"}],
+    hindsight_query="What do I know about AI discussions?",
 )
 ```
+
+**Important:** When `inject_memories=True` (default), you can provide `hindsight_query` to specify what to search for in memory. If omitted, the last user message is used as the query.
 
 ## How It Works
 
@@ -57,47 +69,85 @@ When you call `completion()`, the following happens automatically:
 
 ## Configuration Options
 
+The API is split into two functions for clarity:
+
+### 1. `configure()` - Static Settings
+
+Settings that typically don't change during a session:
+
 ```python
 hindsight_litellm.configure(
     # Required
     hindsight_api_url="http://localhost:8888",  # Hindsight API server URL
-    bank_id="my-agent",                          # Memory bank ID
 
-    api_key="your-api-key",        # Optional API key for authentication
+    # Optional - Authentication
+    api_key="your-api-key",        # API key for Hindsight authentication
 
     # Optional - Memory behavior
     store_conversations=True,      # Store conversations after LLM calls
     inject_memories=True,          # Inject relevant memories into prompts
-    use_reflect=False,             # Use reflect API (synthesized) vs recall (raw memories)
-    reflect_include_facts=False,   # Include source facts with reflect responses
-    max_memories=None,             # Maximum memories to inject (None = unlimited)
-    max_memory_tokens=4096,        # Maximum tokens for memory context
-    recall_budget="mid",           # Recall budget: "low", "mid", "high"
-    fact_types=["world", "agent"], # Filter fact types to inject
-
-    # Optional - Bank Configuration
-    bank_name="My Agent",          # Human-readable display name for the memory bank
-    mission="This agent...",       # Instructions guiding what Hindsight should remember
+    sync_storage=False,            # False = async storage (default, better performance)
+                                   # True = sync storage (blocks, raises errors immediately)
 
     # Optional - Advanced
-    injection_mode="system_message",  # or "prepend_user"
-    excluded_models=["gpt-3.5*"],     # Exclude certain models
+    injection_mode="system_message",  # How to inject: "system_message" or "prepend_user"
+    excluded_models=["gpt-3.5*"],     # Exclude certain models from interception
     verbose=True,                     # Enable verbose logging and debug info
 )
 ```
 
-### Bank Configuration
+### 2. `set_defaults()` - Per-Call Defaults
 
-The `mission` and `bank_name` parameters configure the memory bank itself. When provided, `configure()` will automatically create or update the bank with these settings.
+Default values for per-call settings. These can be overridden on individual calls using `hindsight_*` kwargs:
 
 ```python
-hindsight_litellm.configure(
-    hindsight_api_url="http://localhost:8888",
-    bank_id="support-router",
-    bank_name="Customer Support Router",
-    mission="""You're a customer support router - keep track of which types of issues
-    should go to which teams (billing, technical, sales), customer preferences for
-    communication channels, and past issue resolutions.""",
+hindsight_litellm.set_defaults(
+    # Required
+    bank_id="my-agent",            # Memory bank ID
+
+    # Optional - Memory retrieval
+    budget="mid",                  # Budget level: "low", "mid", "high"
+    fact_types=["world", "opinion"],  # Filter fact types to retrieve
+    max_memories=10,               # Maximum memories to inject (None = unlimited)
+    max_memory_tokens=4096,        # Maximum tokens for memory context
+    include_entities=True,         # Include entity observations in recall
+
+    # Optional - Reflect mode
+    use_reflect=True,              # Use reflect API (synthesized) vs recall (raw memories)
+    reflect_include_facts=False,   # Include source facts in debug info
+    reflect_context="I am a delivery agent finding recipients.",  # Context for reflect reasoning
+    reflect_response_schema={...}, # JSON Schema for structured reflect output
+
+    # Optional - Debugging
+    trace=False,                   # Enable trace info for debugging
+    document_id="conversation-1",  # Document ID for grouping conversations
+)
+```
+
+### 3. Per-Call Overrides
+
+Override any default on individual calls using `hindsight_*` kwargs:
+
+```python
+response = hindsight_litellm.completion(
+    model="gpt-4o-mini",
+    messages=[...],
+    hindsight_query="Where is Alice located?",      # Custom query for memory lookup
+    hindsight_reflect_context="Currently on floor 3",  # Per-call reflect context override
+    # hindsight_bank_id="other-bank",               # Override bank_id for this call
+)
+```
+
+### Bank Configuration: mission
+
+Use `set_bank_mission()` to configure what the memory bank should learn and remember (used for mental models):
+
+```python
+hindsight_litellm.set_bank_mission(
+    mission="""This agent routes customer support requests to the appropriate team.
+    Remember which types of issues should go to which teams (billing, technical, sales).
+    Track customer preferences for communication channels and past issue resolutions.""",
+    name="Customer Support Router",  # Optional display name
 )
 ```
 
@@ -108,18 +158,19 @@ hindsight_litellm.configure(
 
 ```python
 # Recall mode - raw memories
-hindsight_litellm.configure(
-    bank_id="my-agent",
-    use_reflect=False,  # Default
-)
-# Injects: "1. [WORLD] User prefers Python\n2. [MENTAL MODEL] User prefers simple code..."
+hindsight_litellm.set_defaults(bank_id="my-agent", use_reflect=False)
+# Injects: "1. [WORLD] User prefers Python\n2. [OPINION] User dislikes Java..."
 
 # Reflect mode - synthesized context
-hindsight_litellm.configure(
+hindsight_litellm.set_defaults(bank_id="my-agent", use_reflect=True)
+# Injects: "Based on previous conversations, the user is a Python developer who..."
+
+# Reflect with context - shapes LLM reasoning (not retrieval)
+hindsight_litellm.set_defaults(
     bank_id="my-agent",
     use_reflect=True,
+    reflect_context="I am a delivery agent looking for package recipients.",
 )
-# Injects: "Based on previous conversations, the user is a Python developer who..."
 ```
 
 ## Multi-Provider Support
@@ -129,29 +180,29 @@ Works with any LiteLLM-supported provider:
 ```python
 import hindsight_litellm
 
-hindsight_litellm.configure(
-    hindsight_api_url="http://localhost:8888",
-    bank_id="my-agent",
-)
+hindsight_litellm.configure(hindsight_api_url="http://localhost:8888")
+hindsight_litellm.set_defaults(bank_id="my-agent")
 hindsight_litellm.enable()
 
+messages = [{"role": "user", "content": "Hello!"}]
+
 # OpenAI
-hindsight_litellm.completion(model="gpt-4o", messages=[...])
+hindsight_litellm.completion(model="gpt-4o", messages=messages, hindsight_query="greeting")
 
 # Anthropic
-hindsight_litellm.completion(model="claude-3-5-sonnet-20241022", messages=[...])
+hindsight_litellm.completion(model="claude-sonnet-4-20250514", messages=messages, hindsight_query="greeting")
 
 # Groq
-hindsight_litellm.completion(model="groq/llama-3.1-70b-versatile", messages=[...])
+hindsight_litellm.completion(model="groq/llama-3.1-70b-versatile", messages=messages, hindsight_query="greeting")
 
 # Azure OpenAI
-hindsight_litellm.completion(model="azure/gpt-4", messages=[...])
+hindsight_litellm.completion(model="azure/gpt-4", messages=messages, hindsight_query="greeting")
 
 # AWS Bedrock
-hindsight_litellm.completion(model="bedrock/anthropic.claude-3", messages=[...])
+hindsight_litellm.completion(model="bedrock/anthropic.claude-3", messages=messages, hindsight_query="greeting")
 
 # Google Vertex AI
-hindsight_litellm.completion(model="vertex_ai/gemini-pro", messages=[...])
+hindsight_litellm.completion(model="vertex_ai/gemini-pro", messages=messages, hindsight_query="greeting")
 ```
 
 ## Direct Memory APIs
@@ -159,9 +210,10 @@ hindsight_litellm.completion(model="vertex_ai/gemini-pro", messages=[...])
 ### Recall - Query raw memories
 
 ```python
-from hindsight_litellm import configure, recall
+from hindsight_litellm import configure, set_defaults, recall
 
-configure(bank_id="my-agent", hindsight_api_url="http://localhost:8888")
+configure(hindsight_api_url="http://localhost:8888")
+set_defaults(bank_id="my-agent")
 
 memories = recall("what projects am I working on?", budget="mid")
 for m in memories:
@@ -171,25 +223,47 @@ for m in memories:
 ### Reflect - Get synthesized context
 
 ```python
-from hindsight_litellm import configure, reflect
+from hindsight_litellm import configure, set_defaults, reflect
 
-configure(bank_id="my-agent", hindsight_api_url="http://localhost:8888")
+configure(hindsight_api_url="http://localhost:8888")
+set_defaults(bank_id="my-agent")
 
 result = reflect("what do you know about the user's preferences?")
 print(result.text)
+
+# With context to shape the response (doesn't affect retrieval)
+result = reflect(
+    query="what do I know about Alice?",
+    context="I am a delivery agent looking for package recipients.",
+)
 ```
 
 ### Retain - Store memories
 
 ```python
-from hindsight_litellm import configure, retain
+from hindsight_litellm import configure, set_defaults, retain, get_pending_retain_errors
 
-configure(bank_id="my-agent", hindsight_api_url="http://localhost:8888")
+configure(hindsight_api_url="http://localhost:8888")
+set_defaults(bank_id="my-agent")
 
+# Async retain (default) - fast, non-blocking
 result = retain(
     content="User mentioned they're working on a machine learning project",
     context="Discussion about current projects",
 )
+
+# Sync retain - blocks until complete, raises errors immediately
+result = retain(
+    content="Critical information that must be stored",
+    context="Important data",
+    sync=True,
+)
+
+# Check for async retain errors (call periodically)
+errors = get_pending_retain_errors()
+if errors:
+    for e in errors:
+        print(f"Background retain failed: {e}")
 ```
 
 ### Async APIs
@@ -240,7 +314,7 @@ wrapped = wrap_anthropic(
 )
 
 response = wrapped.messages.create(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-20250514",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Hello!"}]
 )
@@ -251,18 +325,16 @@ response = wrapped.messages.create(
 When `verbose=True`, you can inspect exactly what memories are being injected:
 
 ```python
-from hindsight_litellm import configure, enable, completion, get_last_injection_debug
+from hindsight_litellm import configure, set_defaults, enable, completion, get_last_injection_debug
 
-configure(
-    bank_id="my-agent",
-    hindsight_api_url="http://localhost:8888",
-    verbose=True,
-)
+configure(hindsight_api_url="http://localhost:8888", verbose=True)
+set_defaults(bank_id="my-agent", use_reflect=True)
 enable()
 
 response = completion(
     model="gpt-4o-mini",
-    messages=[{"role": "user", "content": "What's my favorite color?"}]
+    messages=[{"role": "user", "content": "What's my favorite color?"}],
+    hindsight_query="What is the user's favorite color?",
 )
 
 # Inspect what was injected
@@ -272,6 +344,8 @@ if debug:
     print(f"Injected: {debug.injected}")   # True/False
     print(f"Results: {debug.results_count}")
     print(f"Memory context:\n{debug.memory_context}")
+    if debug.error:
+        print(f"Error: {debug.error}")
 ```
 
 ## Context Manager
@@ -281,7 +355,11 @@ from hindsight_litellm import hindsight_memory
 import litellm
 
 with hindsight_memory(bank_id="user-123"):
-    response = litellm.completion(model="gpt-4", messages=[...])
+    response = litellm.completion(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "Hello!"}],
+        hindsight_query="greeting context",
+    )
 # Memory integration automatically disabled after context
 ```
 
@@ -303,7 +381,8 @@ cleanup()
 
 | Function | Description |
 |----------|-------------|
-| `configure(...)` | Configure global Hindsight settings |
+| `configure(...)` | Configure static Hindsight settings (API URL, auth, storage options) |
+| `set_defaults(...)` | Set defaults for per-call settings (bank_id, budget, reflect options) |
 | `enable()` | Enable memory integration with LiteLLM |
 | `disable()` | Disable memory integration |
 | `is_enabled()` | Check if memory integration is enabled |
@@ -313,20 +392,30 @@ cleanup()
 
 | Function | Description |
 |----------|-------------|
-| `get_config()` | Get current configuration |
-| `is_configured()` | Check if Hindsight is configured |
-| `reset_config()` | Reset configuration to defaults |
+| `get_config()` | Get current static configuration |
+| `get_defaults()` | Get current per-call defaults |
+| `is_configured()` | Check if Hindsight is configured with a bank_id |
+| `reset_config()` | Reset all configuration to defaults |
+| `set_document_id(id)` | Convenience function to update document_id |
+| `set_bank_mission(...)` | Set mission/instructions for a memory bank (for mental models) |
 
 ### Memory Functions
 
 | Function | Description |
 |----------|-------------|
-| `recall(query, ...)` | Synchronously query raw memories |
-| `arecall(query, ...)` | Asynchronously query raw memories |
-| `reflect(query, ...)` | Synchronously get synthesized memory context |
-| `areflect(query, ...)` | Asynchronously get synthesized memory context |
-| `retain(content, ...)` | Synchronously store a memory |
-| `aretain(content, ...)` | Asynchronously store a memory |
+| `recall(query, ...)` | Query raw memories (sync) |
+| `arecall(query, ...)` | Query raw memories (async) |
+| `reflect(query, ...)` | Get synthesized memory context (sync) |
+| `areflect(query, ...)` | Get synthesized memory context (async) |
+| `retain(content, sync=False, ...)` | Store a memory (async by default, use `sync=True` to block) |
+| `aretain(content, ...)` | Store a memory (async) |
+
+### Error Tracking Functions
+
+| Function | Description |
+|----------|-------------|
+| `get_pending_retain_errors()` | Get and clear errors from background retain operations |
+| `get_pending_storage_errors()` | Get and clear errors from background conversation storage |
 
 ### Debug Functions
 
@@ -342,8 +431,14 @@ cleanup()
 | `wrap_openai(client, ...)` | Wrap OpenAI client with memory |
 | `wrap_anthropic(client, ...)` | Wrap Anthropic client with memory |
 
+## Streaming
+
+Streaming responses (`stream=True`) are supported but **conversation storage is skipped** for streaming calls in the monkeypatch (`enable()`) and callback modes. This is because streaming responses are consumed incrementally by the caller and the full response content is not available at storage time.
+
+For streaming with conversation storage, use the **native client wrappers** (`wrap_openai()`, `wrap_anthropic()`), which collect streamed chunks and store the complete conversation after the stream is fully consumed.
+
 ## Requirements
 
 - Python >= 3.10
-- litellm >= 1.40.0
+- litellm >= 1.83.0
 - A running Hindsight API server

--- a/hindsight-docs/docs-integrations/litellm.md
+++ b/hindsight-docs/docs-integrations/litellm.md
@@ -433,9 +433,12 @@ cleanup()
 
 ## Streaming
 
-Streaming responses (`stream=True`) are supported but **conversation storage is skipped** for streaming calls in the monkeypatch (`enable()`) and callback modes. This is because streaming responses are consumed incrementally by the caller and the full response content is not available at storage time.
+Streaming responses (`stream=True`) are fully supported. When streaming is detected, the response is automatically wrapped to collect chunks as they are consumed. Once the stream is fully consumed (or the context manager exits), the complete conversation is stored to Hindsight.
 
-For streaming with conversation storage, use the **native client wrappers** (`wrap_openai()`, `wrap_anthropic()`), which collect streamed chunks and store the complete conversation after the stream is fully consumed.
+This works across all integration modes:
+- **Monkeypatch wrappers** (`enable()` / `completion()` / `acompletion()`) — streaming responses are wrapped transparently
+- **Native client wrappers** (`wrap_openai()`, `wrap_anthropic()`) — same chunk-collection behavior
+- **Callback handler** — streaming responses are skipped in the callback since the callback doesn't control the return value; use the monkeypatch or native wrapper modes for streaming with storage
 
 ## Requirements
 

--- a/hindsight-integrations/litellm/README.md
+++ b/hindsight-integrations/litellm/README.md
@@ -255,7 +255,7 @@ messages = [{"role": "user", "content": "Hello!"}]
 hindsight_litellm.completion(model="gpt-4o", messages=messages, hindsight_query="greeting")
 
 # Anthropic
-hindsight_litellm.completion(model="claude-3-5-sonnet-20241022", messages=messages, hindsight_query="greeting")
+hindsight_litellm.completion(model="claude-sonnet-4-20250514", messages=messages, hindsight_query="greeting")
 
 # Groq
 hindsight_litellm.completion(model="groq/llama-3.1-70b-versatile", messages=messages, hindsight_query="greeting")
@@ -390,7 +390,7 @@ wrapped = wrap_anthropic(
 )
 
 response = wrapped.messages.create(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-20250514",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Hello!"}]
 )
@@ -510,7 +510,7 @@ cleanup()
 ## Requirements
 
 - Python >= 3.10
-- litellm >= 1.40.0
+- litellm >= 1.83.0
 - A running Hindsight API server
 
 ## License

--- a/hindsight-integrations/litellm/hindsight_litellm/__init__.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/__init__.py
@@ -1276,9 +1276,10 @@ def completion(*args, **kwargs):
     # Step 3: Store conversation (raises HindsightError on failure)
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
-        if _is_streaming_response(response):
-            return _LiteLLMStreamWrapper(response, final_messages, model or "unknown")
-        _store_conversation(final_messages, response, model or "unknown")
+        if final_messages:
+            if _is_streaming_response(response):
+                return _LiteLLMStreamWrapper(response, final_messages, model or "unknown")
+            _store_conversation(final_messages, response, model or "unknown")
 
     return response
 
@@ -1353,9 +1354,10 @@ async def acompletion(*args, **kwargs):
     # Step 3: Store conversation (raises HindsightError on failure)
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
-        if _is_streaming_response(response):
-            return _LiteLLMAsyncStreamWrapper(response, final_messages, model or "unknown")
-        _store_conversation(final_messages, response, model or "unknown")
+        if final_messages:
+            if _is_streaming_response(response):
+                return _LiteLLMAsyncStreamWrapper(response, final_messages, model or "unknown")
+            _store_conversation(final_messages, response, model or "unknown")
 
     return response
 

--- a/hindsight-integrations/litellm/hindsight_litellm/__init__.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/__init__.py
@@ -735,14 +735,23 @@ def cleanup() -> None:
 # =============================================================================
 
 
+def _is_streaming_response(response) -> bool:
+    """Check if the response is a streaming wrapper rather than a complete ModelResponse."""
+    return not hasattr(response, "choices")
+
+
 def _format_conversation_for_storage(
     messages: List[dict],
     response,
 ) -> str:
     """Format conversation messages and response for storage to Hindsight.
 
-    Returns the formatted conversation text.
+    Returns the formatted conversation text, or empty string for streaming responses.
     """
+    # Streaming responses (CustomStreamWrapper) don't have .choices — skip storage
+    if _is_streaming_response(response):
+        return ""
+
     items = []
 
     for msg in messages:

--- a/hindsight-integrations/litellm/hindsight_litellm/__init__.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/__init__.py
@@ -561,6 +561,8 @@ def _wrapped_completion(*args, **kwargs):
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
         if final_messages:
+            if _is_streaming_response(response):
+                return _LiteLLMStreamWrapper(response, final_messages, model or "unknown")
             _store_conversation(final_messages, response, model or "unknown")
 
     return response
@@ -608,6 +610,8 @@ async def _wrapped_acompletion(*args, **kwargs):
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
         if final_messages:
+            if _is_streaming_response(response):
+                return _LiteLLMAsyncStreamWrapper(response, final_messages, model or "unknown")
             _store_conversation(final_messages, response, model or "unknown")
 
     return response
@@ -740,38 +744,24 @@ def _is_streaming_response(response) -> bool:
     return not hasattr(response, "choices")
 
 
-def _format_conversation_for_storage(
-    messages: List[dict],
-    response,
-) -> str:
-    """Format conversation messages and response for storage to Hindsight.
+def _format_messages_for_storage(messages: List[dict]) -> List[str]:
+    """Format conversation messages into storage items (without the response).
 
-    Returns the formatted conversation text, or empty string for streaming responses.
+    Returns a list of formatted message strings.
     """
-    # Streaming responses (CustomStreamWrapper) don't have .choices — skip storage
-    if _is_streaming_response(response):
-        return ""
-
     items = []
-
     for msg in messages:
         role = msg.get("role", "").upper()
         content = msg.get("content", "")
 
-        # Skip system messages
         if role == "SYSTEM":
             continue
-
-        # Skip injected memory context
         if isinstance(content, str) and content.startswith("# Relevant Memories"):
             continue
-
-        # Handle tool results
         if role == "TOOL":
             items.append(f"TOOL_RESULT: {content}")
             continue
 
-        # Handle assistant messages with tool calls
         tool_calls = msg.get("tool_calls", [])
         if tool_calls:
             tc_strs = []
@@ -787,7 +777,6 @@ def _format_conversation_for_storage(
                 items.append(f"ASSISTANT: {content}")
             continue
 
-        # Handle structured content (vision messages)
         if isinstance(content, list):
             text_parts = []
             for item in content:
@@ -798,6 +787,142 @@ def _format_conversation_for_storage(
         if content:
             label = "USER" if role == "USER" else "ASSISTANT"
             items.append(f"{label}: {content}")
+
+    return items
+
+
+class _LiteLLMStreamWrapper:
+    """Wraps a LiteLLM sync streaming response to collect chunks and store conversation on completion."""
+
+    def __init__(self, stream, messages: List[dict], model: str):
+        self._stream = stream
+        self._messages = messages
+        self._model = model
+        self._collected_content: List[str] = []
+        self._finished = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            chunk = next(self._stream)
+            if hasattr(chunk, "choices") and chunk.choices:
+                delta = chunk.choices[0].delta
+                if hasattr(delta, "content") and delta.content:
+                    self._collected_content.append(delta.content)
+            return chunk
+        except StopIteration:
+            self._store_if_needed()
+            raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._store_if_needed()
+        if hasattr(self._stream, "__exit__"):
+            return self._stream.__exit__(exc_type, exc_val, exc_tb)
+
+    def _store_if_needed(self):
+        if self._finished:
+            return
+        self._finished = True
+        if not self._collected_content:
+            return
+
+        assistant_output = "".join(self._collected_content)
+        if not assistant_output:
+            return
+
+        items = _format_messages_for_storage(self._messages)
+        items.append(f"ASSISTANT: {assistant_output}")
+        conversation_text = "\n\n".join(items)
+        if conversation_text:
+            _store_conversation_from_text(conversation_text, self._model)
+
+    def close(self):
+        self._store_if_needed()
+        if hasattr(self._stream, "close"):
+            self._stream.close()
+
+    def __getattr__(self, name: str):
+        return getattr(self._stream, name)
+
+
+class _LiteLLMAsyncStreamWrapper:
+    """Wraps a LiteLLM async streaming response to collect chunks and store conversation on completion."""
+
+    def __init__(self, stream, messages: List[dict], model: str):
+        self._stream = stream
+        self._messages = messages
+        self._model = model
+        self._collected_content: List[str] = []
+        self._finished = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            chunk = await self._stream.__anext__()
+            if hasattr(chunk, "choices") and chunk.choices:
+                delta = chunk.choices[0].delta
+                if hasattr(delta, "content") and delta.content:
+                    self._collected_content.append(delta.content)
+            return chunk
+        except StopAsyncIteration:
+            self._store_if_needed()
+            raise
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._store_if_needed()
+        if hasattr(self._stream, "__aexit__"):
+            return await self._stream.__aexit__(exc_type, exc_val, exc_tb)
+
+    def _store_if_needed(self):
+        if self._finished:
+            return
+        self._finished = True
+        if not self._collected_content:
+            return
+
+        assistant_output = "".join(self._collected_content)
+        if not assistant_output:
+            return
+
+        items = _format_messages_for_storage(self._messages)
+        items.append(f"ASSISTANT: {assistant_output}")
+        conversation_text = "\n\n".join(items)
+        if conversation_text:
+            _store_conversation_from_text(conversation_text, self._model)
+
+    async def aclose(self):
+        self._store_if_needed()
+        if hasattr(self._stream, "aclose"):
+            await self._stream.aclose()
+
+    def __getattr__(self, name: str):
+        return getattr(self._stream, name)
+
+
+def _format_conversation_for_storage(
+    messages: List[dict],
+    response,
+) -> str:
+    """Format conversation messages and response for storage to Hindsight.
+
+    Returns the formatted conversation text, or empty string for streaming responses.
+    """
+    # Streaming responses (CustomStreamWrapper) don't have .choices — skip storage.
+    # Streaming is handled by _LiteLLMStreamWrapper/_LiteLLMAsyncStreamWrapper instead.
+    if _is_streaming_response(response):
+        return ""
+
+    items = _format_messages_for_storage(messages)
 
     # Add the response
     if response.choices and len(response.choices) > 0:
@@ -941,6 +1066,62 @@ def get_pending_storage_errors() -> List[Exception]:
         errors = list(_pending_storage_errors)
         _pending_storage_errors.clear()
         return errors
+
+
+def _store_conversation_from_text(conversation_text: str, model: str) -> None:
+    """Store pre-formatted conversation text to Hindsight.
+
+    Used by stream wrappers which collect chunks and format the conversation themselves.
+    Follows the same sync/async storage logic as _store_conversation.
+    """
+    config = get_config()
+    defaults = get_defaults()
+
+    if not config or not config.store_conversations:
+        return
+    if not defaults or not defaults.bank_id:
+        _storage_logger.warning("No bank_id configured for storage. Call set_defaults(bank_id=...).")
+        return
+    if not conversation_text:
+        return
+
+    if config.sync_storage:
+        try:
+            content_to_store = conversation_text
+            if defaults.effective_document_id:
+                existing_content = _get_existing_document_content(
+                    defaults.bank_id, defaults.effective_document_id, config.verbose
+                )
+                if existing_content:
+                    content_to_store = f"{existing_content}\n\n{conversation_text}"
+
+            retain(
+                content=content_to_store,
+                bank_id=defaults.bank_id,
+                context=f"conversation:litellm:{model}",
+                document_id=defaults.effective_document_id,
+                tags=defaults.tags,
+                metadata={"source": "litellm", "model": model},
+            )
+            if config.verbose:
+                _storage_logger.info(f"Stored streamed conversation to bank: {defaults.bank_id}")
+        except Exception as e:
+            raise HindsightError(f"Failed to store conversation: {e}") from e
+        return
+
+    thread = threading.Thread(
+        target=_store_conversation_sync,
+        args=(
+            conversation_text,
+            defaults.bank_id,
+            defaults.effective_document_id,
+            defaults.tags,
+            model,
+            config.verbose,
+        ),
+        daemon=True,
+    )
+    thread.start()
 
 
 def _store_conversation(
@@ -1095,6 +1276,8 @@ def completion(*args, **kwargs):
     # Step 3: Store conversation (raises HindsightError on failure)
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
+        if _is_streaming_response(response):
+            return _LiteLLMStreamWrapper(response, final_messages, model or "unknown")
         _store_conversation(final_messages, response, model or "unknown")
 
     return response
@@ -1170,6 +1353,8 @@ async def acompletion(*args, **kwargs):
     # Step 3: Store conversation (raises HindsightError on failure)
     if config and config.store_conversations:
         final_messages = kwargs.get("messages", messages)
+        if _is_streaming_response(response):
+            return _LiteLLMAsyncStreamWrapper(response, final_messages, model or "unknown")
         _store_conversation(final_messages, response, model or "unknown")
 
     return response

--- a/hindsight-integrations/litellm/hindsight_litellm/callbacks.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/callbacks.py
@@ -509,6 +509,12 @@ class HindsightCallback(CustomLogger):
                 "or pass hindsight_bank_id=... to the completion call."
             )
 
+        # Streaming responses (CustomStreamWrapper) don't have .choices — skip storage
+        if not hasattr(response, "choices"):
+            if config.verbose:
+                logger.debug("Skipping storage for streaming response (no .choices attribute)")
+            return
+
         # Extract assistant response from the LLM response
         assistant_output = ""
         assistant_tool_calls = []

--- a/hindsight-integrations/litellm/tests/test_integration.py
+++ b/hindsight-integrations/litellm/tests/test_integration.py
@@ -657,6 +657,107 @@ class TestSetDefaults:
         assert get_defaults() is None
 
 
+class TestStreamingResponseHandling:
+    """Tests for streaming response handling in monkeypatch wrappers and callbacks.
+
+    Regression tests for https://github.com/vectorize-io/hindsight/issues/1221
+    CustomStreamWrapper objects don't have .choices and crash _format_conversation_for_storage.
+    """
+
+    def setup_method(self):
+        """Reset state before each test."""
+        cleanup()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        cleanup()
+
+    def test_format_conversation_for_storage_crashes_on_stream_wrapper(self):
+        """Test that _format_conversation_for_storage crashes when given a stream object.
+
+        This reproduces the exact bug from issue #1221.
+        """
+        from hindsight_litellm import _format_conversation_for_storage
+
+        # Simulate a CustomStreamWrapper - an object without .choices
+        class FakeStreamWrapper:
+            """Mimics litellm.utils.CustomStreamWrapper which lacks .choices."""
+            pass
+
+        messages = [{"role": "user", "content": "Hello"}]
+        stream_response = FakeStreamWrapper()
+
+        # This should NOT crash - but currently does with AttributeError
+        result = _format_conversation_for_storage(messages, stream_response)
+        # Should gracefully return empty string for non-ModelResponse objects
+        assert isinstance(result, str)
+
+    def test_store_conversation_skips_stream_response(self):
+        """Test that _store_conversation handles streaming responses gracefully."""
+        from unittest.mock import patch
+        from hindsight_litellm import _store_conversation
+
+        configure(hindsight_api_url="http://localhost:8888")
+        set_defaults(bank_id="test-agent")
+
+        class FakeStreamWrapper:
+            pass
+
+        messages = [{"role": "user", "content": "Hello"}]
+        stream_response = FakeStreamWrapper()
+
+        # Should not raise, should skip storage
+        _store_conversation(messages, stream_response, "gpt-4o-mini")
+
+    def test_wrapped_completion_with_stream_true(self):
+        """Test that _wrapped_completion handles stream=True without crashing."""
+        from unittest.mock import patch, MagicMock
+
+        configure(hindsight_api_url="http://localhost:8888", store_conversations=True)
+        set_defaults(bank_id="test-agent")
+        enable()
+
+        class FakeStreamWrapper:
+            pass
+
+        fake_stream = FakeStreamWrapper()
+
+        with patch("litellm.completion", return_value=fake_stream):
+            import hindsight_litellm
+            # Call with stream=True - should not crash on storage
+            response = hindsight_litellm.completion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+            )
+            assert response is fake_stream
+
+    def test_callback_log_success_with_stream_response(self):
+        """Test that HindsightCallback.log_success_event handles stream responses."""
+        from hindsight_litellm.callbacks import HindsightCallback
+
+        configure(hindsight_api_url="http://localhost:8888", store_conversations=True)
+        set_defaults(bank_id="test-agent")
+
+        callback = HindsightCallback()
+
+        class FakeStreamWrapper:
+            pass
+
+        kwargs = {
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        # Should not raise AttributeError
+        callback.log_success_event(
+            kwargs=kwargs,
+            response_obj=FakeStreamWrapper(),
+            start_time=0.0,
+            end_time=1.0,
+        )
+
+
 class TestStreamingSupport:
     """Tests for streaming support in wrappers."""
 

--- a/hindsight-integrations/litellm/tests/test_integration.py
+++ b/hindsight-integrations/litellm/tests/test_integration.py
@@ -672,14 +672,25 @@ class TestStreamingResponseHandling:
         """Clean up after each test."""
         cleanup()
 
-    def test_format_conversation_for_storage_crashes_on_stream_wrapper(self):
-        """Test that _format_conversation_for_storage crashes when given a stream object.
+    def _make_fake_chunks(self):
+        """Create fake streaming chunks mimicking LiteLLM's ModelResponseStream."""
+        from unittest.mock import MagicMock
 
-        This reproduces the exact bug from issue #1221.
+        chunks = []
+        for text in ["Hello", " ", "world", "!"]:
+            chunk = MagicMock()
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = text
+            chunks.append(chunk)
+        return chunks
+
+    def test_format_conversation_for_storage_returns_empty_for_stream(self):
+        """Test that _format_conversation_for_storage returns empty for stream objects.
+
+        Reproduces the exact bug from issue #1221.
         """
         from hindsight_litellm import _format_conversation_for_storage
 
-        # Simulate a CustomStreamWrapper - an object without .choices
         class FakeStreamWrapper:
             """Mimics litellm.utils.CustomStreamWrapper which lacks .choices."""
             pass
@@ -687,14 +698,11 @@ class TestStreamingResponseHandling:
         messages = [{"role": "user", "content": "Hello"}]
         stream_response = FakeStreamWrapper()
 
-        # This should NOT crash - but currently does with AttributeError
         result = _format_conversation_for_storage(messages, stream_response)
-        # Should gracefully return empty string for non-ModelResponse objects
-        assert isinstance(result, str)
+        assert result == ""
 
     def test_store_conversation_skips_stream_response(self):
         """Test that _store_conversation handles streaming responses gracefully."""
-        from unittest.mock import patch
         from hindsight_litellm import _store_conversation
 
         configure(hindsight_api_url="http://localhost:8888")
@@ -706,17 +714,19 @@ class TestStreamingResponseHandling:
         messages = [{"role": "user", "content": "Hello"}]
         stream_response = FakeStreamWrapper()
 
-        # Should not raise, should skip storage
+        # Should not raise
         _store_conversation(messages, stream_response, "gpt-4o-mini")
 
-    def test_wrapped_completion_with_stream_true(self):
-        """Test that _wrapped_completion handles stream=True without crashing."""
+    def test_wrapped_completion_returns_stream_wrapper(self):
+        """Test that completion() wraps streaming responses for deferred storage."""
         from unittest.mock import patch, MagicMock
+        from hindsight_litellm import _LiteLLMStreamWrapper
 
         configure(hindsight_api_url="http://localhost:8888", store_conversations=True)
         set_defaults(bank_id="test-agent")
         enable()
 
+        # Create a fake stream (no .choices attribute)
         class FakeStreamWrapper:
             pass
 
@@ -724,13 +734,70 @@ class TestStreamingResponseHandling:
 
         with patch("litellm.completion", return_value=fake_stream):
             import hindsight_litellm
-            # Call with stream=True - should not crash on storage
             response = hindsight_litellm.completion(
                 model="gpt-4o-mini",
                 messages=[{"role": "user", "content": "Hello"}],
                 stream=True,
             )
-            assert response is fake_stream
+            # Should return a stream wrapper, not the raw stream
+            assert isinstance(response, _LiteLLMStreamWrapper)
+
+    def test_stream_wrapper_yields_all_chunks(self):
+        """Test that _LiteLLMStreamWrapper passes through all chunks."""
+        from hindsight_litellm import _LiteLLMStreamWrapper
+
+        configure(hindsight_api_url="http://localhost:8888", store_conversations=False)
+        set_defaults(bank_id="test-agent")
+
+        chunks = self._make_fake_chunks()
+        messages = [{"role": "user", "content": "Hello"}]
+
+        wrapper = _LiteLLMStreamWrapper(iter(chunks), messages, "gpt-4o-mini")
+
+        collected = list(wrapper)
+        assert len(collected) == 4
+
+    def test_stream_wrapper_stores_conversation_on_exhaustion(self):
+        """Test that _LiteLLMStreamWrapper stores conversation when stream is consumed."""
+        from unittest.mock import patch
+        from hindsight_litellm import _LiteLLMStreamWrapper
+
+        configure(hindsight_api_url="http://localhost:8888", store_conversations=True)
+        set_defaults(bank_id="test-agent")
+
+        chunks = self._make_fake_chunks()
+        messages = [{"role": "user", "content": "Hello"}]
+
+        wrapper = _LiteLLMStreamWrapper(iter(chunks), messages, "gpt-4o-mini")
+
+        with patch("hindsight_litellm._store_conversation_from_text") as mock_store:
+            # Consume all chunks
+            list(wrapper)
+
+            mock_store.assert_called_once()
+            stored_text = mock_store.call_args[0][0]
+            assert "USER: Hello" in stored_text
+            assert "ASSISTANT: Hello world!" in stored_text
+
+    def test_stream_wrapper_stores_on_context_manager_exit(self):
+        """Test that _LiteLLMStreamWrapper stores conversation on context manager exit."""
+        from unittest.mock import patch
+        from hindsight_litellm import _LiteLLMStreamWrapper
+
+        configure(hindsight_api_url="http://localhost:8888", store_conversations=True)
+        set_defaults(bank_id="test-agent")
+
+        chunks = self._make_fake_chunks()
+        messages = [{"role": "user", "content": "Hello"}]
+
+        wrapper = _LiteLLMStreamWrapper(iter(chunks), messages, "gpt-4o-mini")
+
+        with patch("hindsight_litellm._store_conversation_from_text") as mock_store:
+            with wrapper:
+                for _ in wrapper:
+                    pass
+            # Should store exactly once (not double-store)
+            mock_store.assert_called_once()
 
     def test_callback_log_success_with_stream_response(self):
         """Test that HindsightCallback.log_success_event handles stream responses."""


### PR DESCRIPTION
## Summary

Fixes #1221 — `hindsight-litellm` crashes with `AttributeError: 'CustomStreamWrapper' object has no attribute 'choices'` when the LLM client uses `stream=True`.

### Streaming fix
- Added `_LiteLLMStreamWrapper` (sync) and `_LiteLLMAsyncStreamWrapper` (async) that wrap streaming responses, collect `delta.content` from each chunk, and store the complete conversation when the stream is fully consumed
- All 4 wrapper functions (`_wrapped_completion`, `_wrapped_acompletion`, `completion()`, `acompletion()`) detect streaming responses and return the wrapper instead of attempting immediate storage
- Callback handler (`log_success_event` / `async_log_success_event`) guards against streaming responses since callbacks can't control the return value
- Refactored message formatting into `_format_messages_for_storage()` shared between stream wrappers and `_format_conversation_for_storage()`

### Docs updates
- Synced `docs-integrations/litellm.md` with the current `configure()` + `set_defaults()` API (was using the old single-function API)
- Added missing documentation for `set_bank_mission()`, `set_document_id()`, error tracking, `hindsight_query`, and streaming behavior
- Fixed `litellm>=1.40.0` → `litellm>=1.83.0` in README to match pyproject.toml
- Updated outdated model names (`claude-3-5-sonnet-20241022` → `claude-sonnet-4-20250514`)

## Test plan

- [x] 7 regression tests in `TestStreamingResponseHandling`:
  - `_format_conversation_for_storage` returns empty for stream objects (the original crash)
  - `_store_conversation` skips stream responses gracefully
  - `completion()` returns a `_LiteLLMStreamWrapper` for streaming responses
  - Stream wrapper yields all chunks transparently
  - Stream wrapper stores conversation when stream is fully consumed
  - Stream wrapper stores conversation on context manager exit (no double-store)
  - Callback `log_success_event` handles stream responses without crashing
- [x] Full test suite passes (75/75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)