### PR TITLE
feat(embeddings): add HINDSIGHT_API_EMBEDDINGS_GEMINI_FORCE_IPV4 opt-in

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -183,6 +183,7 @@ ENV_EMBEDDINGS_OPENAI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"
 ENV_EMBEDDINGS_GEMINI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY"
 ENV_EMBEDDINGS_GEMINI_MODEL = "HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL"
 ENV_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY"
+ENV_EMBEDDINGS_GEMINI_FORCE_IPV4 = "HINDSIGHT_API_EMBEDDINGS_GEMINI_FORCE_IPV4"
 ENV_EMBEDDINGS_VERTEXAI_PROJECT_ID = "HINDSIGHT_API_EMBEDDINGS_VERTEXAI_PROJECT_ID"
 ENV_EMBEDDINGS_VERTEXAI_REGION = "HINDSIGHT_API_EMBEDDINGS_VERTEXAI_REGION"
 ENV_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY = "HINDSIGHT_API_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY"
@@ -484,6 +485,7 @@ DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
+DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
 DEFAULT_EMBEDDING_DIMENSION = 384
 
 DEFAULT_RERANKER_PROVIDER = "local"
@@ -905,6 +907,7 @@ class HindsightConfig:
     embeddings_gemini_api_key: str | None
     embeddings_gemini_model: str
     embeddings_gemini_output_dimensionality: int | None
+    embeddings_gemini_force_ipv4: bool
     embeddings_vertexai_project_id: str | None
     embeddings_vertexai_region: str | None
     embeddings_vertexai_service_account_key: str | None
@@ -1464,6 +1467,11 @@ class HindsightConfig:
                     str(DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY),
                 )
             ),
+            embeddings_gemini_force_ipv4=os.getenv(
+                ENV_EMBEDDINGS_GEMINI_FORCE_IPV4,
+                str(DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4),
+            ).lower()
+            in ("true", "1"),
             embeddings_vertexai_project_id=os.getenv(ENV_EMBEDDINGS_VERTEXAI_PROJECT_ID)
             or os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID),
             embeddings_vertexai_region=os.getenv(ENV_EMBEDDINGS_VERTEXAI_REGION) or os.getenv(ENV_LLM_VERTEXAI_REGION),

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -911,8 +911,8 @@ class GeminiEmbeddings(Embeddings):
         vertexai_region: str | None = None,
         vertexai_service_account_key: str | None = None,
         output_dimensionality: int | None = None,
-        force_ipv4: bool = False,
         batch_size: int = 100,
+        force_ipv4: bool = False,
     ):
         self.model = model
         self.api_key = api_key
@@ -920,8 +920,8 @@ class GeminiEmbeddings(Embeddings):
         self.vertexai_region = vertexai_region or "us-central1"
         self.vertexai_service_account_key = vertexai_service_account_key
         self.output_dimensionality = output_dimensionality
-        self.force_ipv4 = force_ipv4
         self.batch_size = batch_size
+        self.force_ipv4 = force_ipv4
         self._client = None
         self._httpx_client = None
         self._dimension: int | None = None

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -911,6 +911,7 @@ class GeminiEmbeddings(Embeddings):
         vertexai_region: str | None = None,
         vertexai_service_account_key: str | None = None,
         output_dimensionality: int | None = None,
+        force_ipv4: bool = False,
         batch_size: int = 100,
     ):
         self.model = model
@@ -919,8 +920,10 @@ class GeminiEmbeddings(Embeddings):
         self.vertexai_region = vertexai_region or "us-central1"
         self.vertexai_service_account_key = vertexai_service_account_key
         self.output_dimensionality = output_dimensionality
+        self.force_ipv4 = force_ipv4
         self.batch_size = batch_size
         self._client = None
+        self._httpx_client = None
         self._dimension: int | None = None
         self._is_vertexai = vertexai_project_id is not None
         self._embed_config = None  # EmbedContentConfig, built during initialize()
@@ -946,7 +949,7 @@ class GeminiEmbeddings(Embeddings):
         if self._is_vertexai:
             self._init_vertexai(genai)
         else:
-            self._init_gemini(genai)
+            self._init_gemini(genai, genai_types)
 
         # Build EmbedContentConfig if output_dimensionality is set
         if self.output_dimensionality is not None:
@@ -968,12 +971,25 @@ class GeminiEmbeddings(Embeddings):
             f"Embeddings: google provider initialized (auth: {auth_mode}, model: {self.model}, dim: {self._dimension})"
         )
 
-    def _init_gemini(self, genai) -> None:
+    def _init_gemini(self, genai, genai_types) -> None:
         """Initialize Gemini API client with API key."""
         if not self.api_key:
             raise ValueError("Gemini embeddings provider requires an API key")
 
-        self._client = genai.Client(api_key=self.api_key)
+        client_kwargs = {"api_key": self.api_key}
+        if self.force_ipv4:
+            import httpx
+
+            self._httpx_client = httpx.Client(
+                timeout=10,
+                transport=httpx.HTTPTransport(local_address="0.0.0.0"),
+            )
+            client_kwargs["http_options"] = genai_types.HttpOptions(
+                timeout=10000,
+                httpxClient=self._httpx_client,
+            )
+
+        self._client = genai.Client(**client_kwargs)
         logger.info(f"Embeddings: initializing Gemini provider with model {self.model}")
 
     def _init_vertexai(self, genai) -> None:
@@ -1165,6 +1181,7 @@ def create_embeddings_from_env() -> Embeddings:
             vertexai_region=config.embeddings_vertexai_region,
             vertexai_service_account_key=config.embeddings_vertexai_service_account_key,
             output_dimensionality=config.embeddings_gemini_output_dimensionality,
+            force_ipv4=config.embeddings_gemini_force_ipv4,
         )
     else:
         raise ValueError(

--- a/hindsight-api-slim/tests/test_gemini_embeddings.py
+++ b/hindsight-api-slim/tests/test_gemini_embeddings.py
@@ -49,6 +49,7 @@ def _make_mock_google_module(mock_genai: MagicMock) -> MagicMock:
     mod = MagicMock()
     mod.genai = mock_genai
     mod.genai.types.EmbedContentConfig = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    mod.genai.types.HttpOptions = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
     return mod
 
 
@@ -171,6 +172,23 @@ class TestGeminiEmbeddings:
         call_kwargs = mock_genai.Client.return_value.models.embed_content.call_args
         assert "config" not in call_kwargs.kwargs
 
+    async def test_force_ipv4_passes_http_options(self):
+        """Test that force_ipv4 configures the Gemini client with custom HTTP options."""
+        mock_genai = _make_mock_genai()
+        mock_transport = MagicMock()
+        mock_httpx_client = MagicMock()
+        emb = GeminiEmbeddings(model="gemini-embedding-001", api_key="test-key", force_ipv4=True)
+
+        with _patch_google_import(mock_genai):
+            with patch("httpx.HTTPTransport", return_value=mock_transport) as mock_http_transport:
+                with patch("httpx.Client", return_value=mock_httpx_client) as mock_http_client:
+                    await emb.initialize()
+
+        mock_http_transport.assert_called_once_with(local_address="0.0.0.0")
+        mock_http_client.assert_called_once_with(timeout=10, transport=mock_transport)
+        assert emb._httpx_client is mock_httpx_client
+        assert "http_options" in mock_genai.Client.call_args.kwargs
+
     def test_auto_detect_vertexai(self):
         """Test that _is_vertexai is auto-detected from vertexai_project_id."""
         assert GeminiEmbeddings(model="m", api_key="k")._is_vertexai is False
@@ -287,6 +305,7 @@ class TestGeminiEmbeddingsFactory:
         defaults["embeddings_gemini_api_key"] = "test-key"
         defaults["embeddings_gemini_model"] = "gemini-embedding-001"
         defaults["embeddings_gemini_output_dimensionality"] = 768
+        defaults["embeddings_gemini_force_ipv4"] = False
         defaults["embeddings_vertexai_project_id"] = None
         defaults["embeddings_vertexai_region"] = None
         defaults["embeddings_vertexai_service_account_key"] = None
@@ -302,6 +321,14 @@ class TestGeminiEmbeddingsFactory:
         assert emb.provider_name == "google"
         assert emb.api_key == "test-key"
         assert emb._is_vertexai is False
+        assert emb.force_ipv4 is False
+
+    def test_create_with_force_ipv4(self):
+        config = self._make_config(embeddings_gemini_force_ipv4=True)
+        with patch("hindsight_api.config.get_config", return_value=config):
+            emb = create_embeddings_from_env()
+        assert isinstance(emb, GeminiEmbeddings)
+        assert emb.force_ipv4 is True
 
     def test_create_with_vertexai(self):
         config = self._make_config(

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -419,6 +419,7 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1m
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY` | Gemini API key for embeddings (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL` | Gemini embedding model | `gemini-embedding-001` |
 | `HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY` | Output embedding dimensions (Gemini supports configurable dimensionality) | `768` |
+| `HINDSIGHT_API_EMBEDDINGS_GEMINI_FORCE_IPV4` | Force the Gemini embeddings client to use an IPv4-only HTTP transport. Useful in environments where IPv6 egress is broken (e.g. some Docker/VPC setups) and AAAA DNS records cause long hangs. | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_PROJECT_ID` | Vertex AI project ID for embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_REGION` | Vertex AI region for embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_REGION`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY` | Service account key for Vertex AI embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`) | - |


### PR DESCRIPTION
## Summary

Add an opt-in `HINDSIGHT_API_EMBEDDINGS_GEMINI_FORCE_IPV4` flag that configures the Gemini embeddings client with an IPv4-only `httpx` transport. Works around environments where AAAA records resolve but IPv6 egress is broken (some Docker / VPC setups), which causes the default google-genai client to hang on connect.

## Motivation

Hit this in a Docker environment where Gemini embedding calls would hang indefinitely on the first outbound request. Root cause was the default dual-stack resolver picking an AAAA record and the egress path silently blackholing IPv6. Forcing the httpx transport's `local_address` to `0.0.0.0` bypasses IPv6 entirely.

## Behavior

- **Off by default** (`false`) — zero change for existing deployments.
- When enabled, `GeminiEmbeddings._init_gemini` constructs an `httpx.Client(timeout=10, transport=httpx.HTTPTransport(local_address=\"0.0.0.0\"))` and passes it to `genai.Client(...)` via `genai_types.HttpOptions(timeout=10000, httpxClient=...)`.
- Only the API-key path is affected; the Vertex AI path is unchanged (Vertex AI uses its own SDK auth flow and doesn't take an `httpx` client).

## Config classification

Treated as **static** (server-level) — not added to `_CONFIGURABLE_FIELDS` — per the project's hierarchical-config guidelines (\`CLAUDE.md\`): infrastructure/deployment concerns are static, per-tenant business settings are hierarchical.

## Changes

- \`hindsight-api-slim/hindsight_api/config.py\` — new \`ENV_EMBEDDINGS_GEMINI_FORCE_IPV4\`, \`DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4\`, and \`embeddings_gemini_force_ipv4\` field on \`HindsightConfig\`, parsed in \`from_env()\`.
- \`hindsight-api-slim/hindsight_api/engine/embeddings.py\` — \`GeminiEmbeddings.__init__\` accepts \`force_ipv4\`; \`_init_gemini\` builds the httpx client and \`HttpOptions\` when enabled; factory wires the new config field through.
- \`hindsight-api-slim/tests/test_gemini_embeddings.py\` — new \`test_force_ipv4_passes_http_options\` verifies the transport/client construction, and \`test_create_with_force_ipv4\` covers the factory path.
- \`hindsight-docs/docs/developer/configuration.md\` — documents the new env var alongside the other \`GEMINI_*\` embedding rows.

## Test plan

- [x] \`./scripts/hooks/lint.sh\` passes (ruff, ty, eslint, prettier)
- [x] \`uv run pytest tests/test_gemini_embeddings.py\` — 27/27 pass, including the 2 new tests
- [ ] Smoke-tested in the original broken IPv6 environment (flag flipped, Gemini embedding calls complete instead of hanging)