### PR TITLE
docs: add nodes_by_fact_type field to Document Response Format example

### DIFF
--- a/hindsight-docs/docs/developer/api/documents.mdx
+++ b/hindsight-docs/docs/developer/api/documents.mdx
@@ -232,6 +232,11 @@ hindsight document list my-bank --tags team-a --tags team-b
   "original_text": "Alice presented the Q4 roadmap...",
   "content_hash": "abc123def456",
   "memory_unit_count": 12,
+  "nodes_by_fact_type": {
+    "world": 5,
+    "experience": 4,
+    "observation": 3
+  },
   "created_at": "2024-03-15T14:00:00Z",
   "updated_at": "2024-03-15T14:00:00Z"
 }

--- a/skills/hindsight-docs/references/developer/api/documents.md
+++ b/skills/hindsight-docs/references/developer/api/documents.md
@@ -436,6 +436,11 @@ hindsight document list my-bank --tags team-a --tags team-b
   "original_text": "Alice presented the Q4 roadmap...",
   "content_hash": "abc123def456",
   "memory_unit_count": 12,
+  "nodes_by_fact_type": {
+    "world": 5,
+    "experience": 4,
+    "observation": 3
+  },
   "created_at": "2024-03-15T14:00:00Z",
   "updated_at": "2024-03-15T14:00:00Z"
 }


### PR DESCRIPTION
## Summary

Adds the `nodes_by_fact_type` field to the Document Response Format JSON example — catches docs drift introduced by #1236 (merged 2026-04-23 by @nicoloboschi), which added the field to the `GET /banks/{bank_id}/documents/{document_id}` response with shape `{"world": N, "experience": N, "observation": N}` derived from the SQL query returning `world_count`/`experience_count`/`observation_count` (memory_engine.py).

## What changed

- `hindsight-docs/docs/developer/api/documents.mdx`: add `nodes_by_fact_type` to the Document Response Format JSON block.
- `skills/hindsight-docs/references/developer/api/documents.md`: mirror the same addition.

Example values (`world: 5`, `experience: 4`, `observation: 3`) sum to `memory_unit_count: 12` to keep the illustration internally consistent.

Docs only, no code changes.