### PR TITLE
fix(stats): timeseries buckets should return tz-aware ISO

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6611,7 +6611,10 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
         # Build the canonical bucket list anchored on the most recent UTC boundary.
-        now_utc = datetime.utcnow()
+        # Use tz-aware UTC throughout so serialized ISO strings include a `+00:00`
+        # offset; a naive ISO (`2026-04-18T00:00:00`) would be parsed by browsers
+        # as local time per ECMA-262, producing an off-by-timezone display.
+        now_utc = datetime.now(timezone.utc)
         if cfg.trunc == "minute":
             end = now_utc.replace(second=0, microsecond=0)
         elif cfg.trunc == "hour":
@@ -6628,11 +6631,13 @@ class MemoryEngine(MemoryEngineInterface):
             by_iso[entry.time] = entry
 
         for row in rows:
-            # asyncpg hands us a tz-aware datetime when the column is timestamptz.
-            # Normalize to the naive-UTC format we used for the dict keys.
+            # asyncpg hands us a tz-aware datetime when the column is timestamptz;
+            # ensure UTC so the ISO key matches `by_iso` (also tz-aware UTC).
             bucket_dt = row["bucket"]
-            if bucket_dt.tzinfo is not None:
-                bucket_dt = bucket_dt.astimezone(timezone.utc).replace(tzinfo=None)
+            if bucket_dt.tzinfo is None:
+                bucket_dt = bucket_dt.replace(tzinfo=timezone.utc)
+            else:
+                bucket_dt = bucket_dt.astimezone(timezone.utc)
             entry = by_iso.get(bucket_dt.isoformat())
             if entry is None:
                 # Row fell outside the requested window (clock skew / edge case).

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -108,6 +108,12 @@ async def test_memories_timeseries_periods(
 
         for bucket in body["buckets"]:
             assert "time" in bucket
+            # Bucket `time` must serialize as a tz-aware ISO (ending in `+00:00` or `Z`).
+            # A naive ISO (`2026-04-18T00:00:00`) would be parsed as local time by
+            # `new Date()` per ECMA-262, shifting the chart by the browser's timezone.
+            assert bucket["time"].endswith("+00:00") or bucket["time"].endswith("Z"), (
+                f"bucket time must include UTC offset, got {bucket['time']!r}"
+            )
             assert bucket["world"] >= 0
             assert bucket["experience"] >= 0
             assert bucket["observation"] >= 0

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -219,8 +219,17 @@ function formatRelativeTime(ts: string | null): string {
   return `${days}d ago`;
 }
 
+// Bucket timestamps arrive from the memories-timeseries endpoint, which is
+// canonically UTC. An ISO string without an explicit offset (e.g. `2026-04-18T00:00:00`)
+// would be parsed by `new Date()` as *local* time per ECMA-262, shifting the
+// displayed bucket by the browser's timezone. Append `Z` when the offset is
+// missing so we always anchor to UTC before converting to the user's locale.
+function parseBucketIso(iso: string): Date {
+  return new Date(/[+\-Z]$/.test(iso) || /[+\-]\d\d:?\d\d$/.test(iso) ? iso : `${iso}Z`);
+}
+
 function formatBucketLabel(iso: string, trunc: string): string {
-  const d = new Date(iso);
+  const d = parseBucketIso(iso);
   if (trunc === "day") {
     return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
   }
@@ -228,7 +237,7 @@ function formatBucketLabel(iso: string, trunc: string): string {
 }
 
 function formatBucketTooltip(iso: string, trunc: string): string {
-  const d = new Date(iso);
+  const d = parseBucketIso(iso);
   if (trunc === "day") {
     return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
   }


### PR DESCRIPTION
## Summary

The `/v1/default/banks/{bank_id}/stats/memories-timeseries` endpoint returns bucket timestamps as naive ISO strings (`2026-04-18T00:00:00`) instead of tz-aware (`2026-04-18T00:00:00+00:00`). Per ECMA-262, browsers parse a naive ISO date-time as **local time**, so the control plane's *Memories ingested* chart (via `formatBucketLabel` in `bank-stats-view.tsx`) was rendering buckets shifted by the browser's timezone offset — e.g. a user in UTC+8 would see UTC 05:00 labeled as 05:00 instead of 13:00.

Every other endpoint (e.g. `/memories/list`) already serializes timestamps with a `+00:00` offset; this one just happened to strip it.

## Changes

**Backend** (`hindsight-api-slim/hindsight_api/engine/memory_engine.py`)
- Anchor `now_utc` with `datetime.now(timezone.utc)` (tz-aware) instead of the deprecated `datetime.utcnow()` (naive).
- Normalize `asyncpg` row timestamps to UTC-aware instead of stripping `tzinfo`.
- Result: bucket `time` strings now end in `+00:00`.

**Test** (`hindsight-api-slim/tests/test_bank_stats.py`)
- Extends `test_memories_timeseries_periods` to assert every bucket `time` carries an explicit UTC offset.

**Frontend** (`hindsight-control-plane/src/components/bank-stats-view.tsx`)
- Defensive parse: `parseBucketIso` appends `Z` when no offset is present, so a control plane paired with an older API still renders correctly. Paired with the backend fix it's a no-op.

## Repro (before)

```bash
curl -s http://localhost:8000/v1/default/banks/main/stats/memories-timeseries?period=1h \
  | jq '.buckets[0].time'
# "2026-04-24T05:06:00"  ← no offset
```

## After

```bash
# "2026-04-24T05:06:00+00:00"
```

## Test plan

- [x] `pytest tests/test_bank_stats.py::test_memories_timeseries_periods` passes for every period (minute/hour/day truncation)
- [x] Manually verified the *Memories ingested* chart on a UTC+8 browser renders the correct local hour after the fix
- [x] Before the backend fix, the added assertion fails; confirms regression coverage