### PR TITLE
feat(stats): add time_field toggle to memories-timeseries chart

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1519,6 +1519,14 @@ class MemoriesTimeseriesResponse(BaseModel):
     bank_id: str
     period: str = Field(description="One of: 1h, 12h, 1d, 7d, 30d, 90d.")
     trunc: str = Field(description="Bucket granularity: minute, hour, day.")
+    time_field: str = Field(
+        default="created_at",
+        description=(
+            "Timestamp column used to assign each row to a bucket. "
+            "`created_at` shows ingest time; `mentioned_at` / `occurred_start` "
+            "show event time (falls back to `created_at` per row when null)."
+        ),
+    )
     buckets: list[MemoryTimeseriesBucket] = Field(
         default_factory=list,
         description="Per-bucket counts, always returned fully padded for the requested period.",
@@ -3513,11 +3521,20 @@ def _register_routes(app: FastAPI):
     async def api_memories_timeseries(
         bank_id: str,
         period: str = "7d",
+        time_field: str = Query(
+            default="created_at",
+            description=(
+                "Timestamp column to bucket on. `created_at` (default) = ingest time; "
+                "`mentioned_at` / `occurred_start` = event time, useful for migrated "
+                "corpora where ingest time is a single point and doesn't reflect the "
+                "underlying knowledge timeline. Unknown values fall back to `created_at`."
+            ),
+        ),
         request_context: RequestContext = Depends(get_request_context),
     ):
         try:
             data = await app.state.memory.get_memories_timeseries(
-                bank_id, period=period, request_context=request_context
+                bank_id, period=period, time_field=time_field, request_context=request_context
             )
             return MemoriesTimeseriesResponse(**data)
         except OperationValidationError as e:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6756,6 +6756,7 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         period: str,
         request_context: "RequestContext",
+        time_field: str = "created_at",
     ) -> dict[str, Any]:
         """Memory ingestion bucketed by time, broken down by fact_type.
 
@@ -6765,6 +6766,14 @@ class MemoryEngine(MemoryEngineInterface):
         timezone) so the API response is deterministic regardless of where
         the database is deployed, and so the control-plane chart can match
         buckets by ISO key on the client side.
+
+        ``time_field`` selects which timestamp column drives the bucket
+        assignment. ``created_at`` (default) shows when records were ingested;
+        ``mentioned_at`` / ``occurred_start`` reflect the event time carried
+        over from the source data, which is what you want for migrated or
+        backfilled corpora. For the event-time columns we fall back to
+        ``created_at`` per-row via ``COALESCE`` so records that lack an event
+        timestamp still show up in the chart.
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
@@ -6777,15 +6786,22 @@ class MemoryEngine(MemoryEngineInterface):
         if period not in _MEMORIES_TIMESERIES_PERIODS:
             period = "7d"
 
+        # Whitelist time_field — it is interpolated into SQL, must never come from untrusted input.
+        _ALLOWED_TIME_FIELDS = ("created_at", "mentioned_at", "occurred_start")
+        if time_field not in _ALLOWED_TIME_FIELDS:
+            time_field = "created_at"
+        # COALESCE onto created_at for event-time fields so null rows don't vanish.
+        bucket_expr = time_field if time_field == "created_at" else f"COALESCE({time_field}, created_at)"
+
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             rows = await conn.fetch(
                 f"""
-                SELECT date_trunc('{cfg.trunc}', created_at AT TIME ZONE 'UTC') AS bucket,
+                SELECT date_trunc('{cfg.trunc}', {bucket_expr} AT TIME ZONE 'UTC') AS bucket,
                        fact_type, COUNT(*) AS count
                 FROM {fq_table("memory_units")}
                 WHERE bank_id = $1
-                  AND created_at >= now() - interval '{cfg.interval}'
+                  AND {bucket_expr} >= now() - interval '{cfg.interval}'
                 GROUP BY bucket, fact_type
                 ORDER BY bucket
                 """,
@@ -6836,6 +6852,7 @@ class MemoryEngine(MemoryEngineInterface):
             "bank_id": bank_id,
             "period": period,
             "trunc": cfg.trunc,
+            "time_field": time_field,
             "buckets": [b.as_dict() for b in buckets],
         }
 

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
@@ -8,9 +8,10 @@ export async function GET(
   try {
     const { agentId } = await params;
     const period = request.nextUrl.searchParams.get("period") || "7d";
+    const timeField = request.nextUrl.searchParams.get("time_field") || "created_at";
     const url = dataplaneBankUrl(
       agentId,
-      `/stats/memories-timeseries?period=${encodeURIComponent(period)}`
+      `/stats/memories-timeseries?period=${encodeURIComponent(period)}&time_field=${encodeURIComponent(timeField)}`
     );
     const upstream = await fetch(url, { headers: getDataplaneHeaders() });
     const body = await upstream.json();

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -73,6 +73,14 @@ interface BankStats {
 type Period = "1h" | "12h" | "1d" | "7d" | "30d" | "90d";
 const PERIODS: Period[] = ["1h", "12h", "1d", "7d", "30d", "90d"];
 
+type TimeField = "created_at" | "mentioned_at" | "occurred_start";
+const TIME_FIELD_LABELS: Record<TimeField, { short: string; long: string }> = {
+  created_at: { short: "Ingested", long: "When records were ingested" },
+  mentioned_at: { short: "Mentioned", long: "When facts were mentioned (event time)" },
+  occurred_start: { short: "Occurred", long: "When the underlying event started" },
+};
+const TIME_FIELDS: TimeField[] = ["created_at", "mentioned_at", "occurred_start"];
+
 interface TimeseriesBucket {
   time: string;
   world: number;
@@ -781,6 +789,7 @@ export function BankStatsView() {
   const [mentalModels, setMentalModels] = useState<MentalModel[]>([]);
   const [loading, setLoading] = useState(false);
   const [period, setPeriod] = useState<Period>("7d");
+  const [timeField, setTimeField] = useState<TimeField>("created_at");
   const [timeseries, setTimeseries] = useState<{ trunc: string; buckets: TimeseriesBucket[] }>({
     trunc: "day",
     buckets: [],
@@ -812,7 +821,7 @@ export function BankStatsView() {
   const loadTimeseries = async () => {
     if (!currentBank) return;
     try {
-      const data = await client.getMemoriesTimeseries(currentBank, period);
+      const data = await client.getMemoriesTimeseries(currentBank, period, timeField);
       setTimeseries({ trunc: data.trunc, buckets: data.buckets || [] });
     } catch (error) {
       console.error("Error loading memories timeseries:", error);
@@ -833,7 +842,7 @@ export function BankStatsView() {
       const interval = setInterval(loadTimeseries, 5000);
       return () => clearInterval(interval);
     }
-  }, [currentBank, period]);
+  }, [currentBank, period, timeField]);
 
   if (loading && !stats) {
     return (
@@ -956,7 +965,9 @@ export function BankStatsView() {
           <Card className="lg:col-span-2">
             <CardHeader className="pb-2 space-y-2">
               <div className="flex flex-row items-center justify-between">
-                <CardTitle className="text-sm font-semibold">Memories ingested</CardTitle>
+                <CardTitle className="text-sm font-semibold">
+                  Memories by {TIME_FIELD_LABELS[timeField].short.toLowerCase()} time
+                </CardTitle>
                 <div className="flex items-center gap-0.5 rounded-md bg-muted/60 p-0.5">
                   {PERIODS.map((p) => (
                     <button
@@ -972,6 +983,22 @@ export function BankStatsView() {
                     </button>
                   ))}
                 </div>
+              </div>
+              <div className="flex items-center gap-0.5 rounded-md bg-muted/60 p-0.5 w-fit">
+                {TIME_FIELDS.map((tf) => (
+                  <button
+                    key={tf}
+                    onClick={() => setTimeField(tf)}
+                    title={TIME_FIELD_LABELS[tf].long}
+                    className={`px-2 py-0.5 text-[11px] font-medium rounded transition-colors ${
+                      timeField === tf
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {TIME_FIELD_LABELS[tf].short}
+                  </button>
+                ))}
               </div>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -308,18 +308,28 @@ export class ControlPlaneClient {
     return this.fetchApi(bankStatsApi(bankId));
   }
 
-  async getMemoriesTimeseries(bankId: string, period: string) {
+  async getMemoriesTimeseries(
+    bankId: string,
+    period: string,
+    timeField: "created_at" | "mentioned_at" | "occurred_start" = "created_at",
+  ) {
     return this.fetchApi<{
       bank_id: string;
       period: string;
       trunc: string;
+      time_field: string;
       buckets: Array<{
         time: string;
         world: number;
         experience: number;
         observation: number;
       }>;
-    }>(bankStatsApi(bankId, `/memories-timeseries?period=${encodeURIComponent(period)}`));
+    }>(
+      bankStatsApi(
+        bankId,
+        `/memories-timeseries?period=${encodeURIComponent(period)}&time_field=${encodeURIComponent(timeField)}`,
+      ),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

The *Memories ingested* chart on the bank dashboard always buckets by `memory_units.created_at` (ingest time). For a bank built up in real time, ingest time ≈ event time and that's the right default. But when a corpus is **backfilled in a single session** — for example migrating from another memory system — every record's `created_at` collapses to the import moment, so the chart shows "all knowledge is new" and the underlying timeline disappears.

Adds a `time_field` query parameter (and a three-way UI toggle) that lets the viewer pick which timestamp column drives the bucket assignment:

| Value | Meaning |
|---|---|
| `created_at` (default) | Ingest time — matches old behavior exactly |
| `mentioned_at` | Event time: when the fact was mentioned |
| `occurred_start` | Event time: when the underlying event started |

For the event-time columns we `COALESCE(<col>, created_at)` per row so records lacking an event timestamp still show up in the chart instead of silently disappearing. The field is whitelisted (never interpolated from untrusted input), unknown values fall back to `created_at`, and the chosen column is echoed back in the response for UI affordance.

## Changes

**Backend** (`hindsight-api-slim`)
- `memory_engine.get_memories_timeseries` gains a `time_field` keyword arg, validates it against an allowlist, and composes `bucket_expr` with `COALESCE` for the event-time columns.
- `MemoriesTimeseriesResponse` adds a `time_field` field.
- API endpoint exposes `time_field` as a query param with a clear description.

**Control Plane** (`hindsight-control-plane`)
- `getMemoriesTimeseries` SDK helper accepts a `timeField` argument, defaulting to `created_at`.
- `/api/stats/[agentId]/memories-timeseries` proxy forwards the param.
- `bank-stats-view.tsx` renders an **Ingested / Mentioned / Occurred** segmented control below the period selector; the card title updates so the chart reads unambiguously (e.g. *"Memories by mentioned time"*).

## Screenshots

On a bank migrated from another memory system, toggling to **Mentioned** spreads the chart across the actual event timeline instead of a single ingest-day spike:

- `created_at` → two-day spike (04-23, 04-24)  
- `mentioned_at` → spread across 03-26 through 03-29 (real history)

## Test plan

- [x] `curl .../memories-timeseries?period=30d&time_field=mentioned_at` returns non-zero buckets spanning the corpus's actual timeline
- [x] `time_field=nonsense` falls back to `created_at` (parity with the invalid-period behavior)
- [x] Response includes `time_field` so the UI can display the active dimension
- [x] Control plane chart updates immediately when the toggle changes, with no stale frames

## Notes

- Defaults stay `created_at` everywhere; existing integrations see no behavioral change.
- Builds on #1245 (tz-aware bucket ISO). Without that fix the chart is off-by-timezone in non-UTC browsers regardless of which `time_field` is selected.