### PR TITLE
fix(entity-resolver): stamp cooccurrences with event_date, not now()

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/b5d4e3f2a1c9_backfill_entity_cooccurrences_event_time.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/b5d4e3f2a1c9_backfill_entity_cooccurrences_event_time.py
@@ -1,0 +1,91 @@
+"""Backfill entity_cooccurrences.last_cooccurred from memory_units event time
+
+Revision ID: b5d4e3f2a1c9
+Revises: o1a2b3c4d5e6
+Create Date: 2026-04-24
+
+The writer path in `entity_resolver.link_units_to_entities_batch` historically
+stamped `entity_cooccurrences.last_cooccurred` with `datetime.now(UTC)` at
+flush time, ignoring the source memory unit's event date. For normal online
+retains that's fine (now ≈ event time), but for any corpus that was
+backfilled in a single session — migrating from another memory system, for
+example — every co-occurrence collapsed to the import moment, which hid the
+underlying knowledge timeline from the dashboard's entity graph recency heat
+and from any downstream consumer of the column.
+
+The writer is fixed in the same change set to propagate the unit's event_date;
+this migration repairs historical rows by reading the true event time off
+`unit_entities × memory_units` (falling back to `created_at` when
+`mentioned_at` / `occurred_start` are NULL, so rows never regress).
+
+Oracle slot is intentionally absent: the Oracle baseline (`o1a2b3c4d5e6`)
+landed days before this fix, so any Oracle deployment runs the corrected
+writer against an effectively empty `entity_cooccurrences` — there is no
+historical residue on Oracle to repair. PG-only matches the asymmetry of
+the data, not negligence.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "b5d4e3f2a1c9"
+down_revision: str | Sequence[str] | None = "o1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    """Get schema prefix for table names (required for multi-tenant support)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _get_schema_prefix()
+    # Recompute last_cooccurred from the true event time per entity pair.
+    # COALESCE picks the first non-null of mentioned_at / occurred_start /
+    # created_at so banks without event-time metadata still see a sane value
+    # (equivalent to the pre-fix behaviour) instead of NULL.
+    #
+    # The self-join on `unit_entities` is O(k²) per memory_unit in the number
+    # of distinct entities mentioned (k). For typical units k is small (single
+    # digits), but a bank with units containing hundreds of entities and tens
+    # of millions of co-occurrence rows may want to run this off-hours — the
+    # whole UPDATE is one statement, so it locks every targeted ec row for
+    # the duration. The migration is one-time; subsequent online writes
+    # already carry event time via the writer fix.
+    op.execute(
+        f"""
+        UPDATE {schema}entity_cooccurrences ec
+        SET last_cooccurred = sub.event_time
+        FROM (
+            SELECT
+                LEAST(ue1.entity_id, ue2.entity_id) AS e1,
+                GREATEST(ue1.entity_id, ue2.entity_id) AS e2,
+                MAX(COALESCE(mu.mentioned_at, mu.occurred_start, mu.created_at)) AS event_time
+            FROM {schema}memory_units mu
+            JOIN {schema}unit_entities ue1 ON ue1.unit_id = mu.id
+            JOIN {schema}unit_entities ue2 ON ue2.unit_id = mu.id AND ue1.entity_id <> ue2.entity_id
+            GROUP BY 1, 2
+        ) sub
+        WHERE ec.entity_id_1 = sub.e1 AND ec.entity_id_2 = sub.e2
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    # No-op: the previous column value was `now()` at the time of write and
+    # isn't recoverable. Rolling back the code is sufficient — new writes will
+    # revert to the old behaviour for subsequent retains.
+    pass
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)  # oracle slot intentionally absent — see header
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
-from typing import Any
+from typing import Any, Final
 
 from .db_utils import acquire_with_retry
 from .memory_engine import fq_table
@@ -46,12 +46,38 @@ class _EntityStatAgg:
     max_date: datetime | None = None
 
 
+# Sentinel distinguishing "key not in dict" from "key present with value None".
+# Needed when merging event_date across duplicate unit rows: legacy two-tuple
+# callers surface `None`, which must not clobber a real datetime from another
+# caller for the same unit.
+_SENTINEL_MISSING: Final = object()
+
+
+def _later_date(a: datetime | None, b: datetime | None) -> datetime | None:
+    """Return whichever of ``a`` / ``b`` is later (None loses to any datetime).
+
+    Used to fold duplicate co-occurrence pairs across a retain batch: legacy
+    two-tuple callers surface ``None``, which must not clobber a real
+    datetime that arrived for the same pair from an aware caller.
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a > b else b
+
+
 @dataclass
 class _CooccurrencePair:
     """A (entity_id_1, entity_id_2) pair observed in a retain batch (for post-txn flush)."""
 
     entity_id_1: str
     entity_id_2: str
+    # When the two entities co-occurred in the source content. For real-time
+    # retains this is ~now; for backfilled corpora it's the historical event
+    # time, so the cooccurrence cache reflects the underlying knowledge
+    # timeline instead of collapsing to the import moment.
+    event_date: datetime | None = None
 
 
 # Load spaCy model (singleton)
@@ -143,11 +169,15 @@ class EntityResolver:
                 )
 
             if cooccurrences:
-                # Aggregate: count occurrences per (entity_id_1, entity_id_2) pair.
-                coo_agg: dict[tuple[str, str], int] = {}
+                # Aggregate per (entity_id_1, entity_id_2): count occurrences and
+                # keep the latest event_date we saw. Using GREATEST(...) in the SQL
+                # already handles merging against the existing row; here we fold
+                # the batch so executemany doesn't send the same pair twice.
+                coo_agg: dict[tuple[str, str], tuple[int, datetime | None]] = {}
                 for c in cooccurrences:
                     pair = (c.entity_id_1, c.entity_id_2)
-                    coo_agg[pair] = coo_agg.get(pair, 0) + 1
+                    prev_count, prev_date = coo_agg.get(pair, (0, None))
+                    coo_agg[pair] = (prev_count + 1, _later_date(prev_date, c.event_date))
 
                 now = datetime.now(UTC)
                 # Sort by (entity_id_1, entity_id_2) for consistent lock ordering.
@@ -161,7 +191,7 @@ class EntityResolver:
                         cooccurrence_count = {fq_table("entity_cooccurrences")}.cooccurrence_count + EXCLUDED.cooccurrence_count,
                         last_cooccurred    = GREATEST({fq_table("entity_cooccurrences")}.last_cooccurred, EXCLUDED.last_cooccurred)
                     """,
-                    sorted((e1, e2, count, now) for (e1, e2), count in coo_agg.items()),
+                    sorted((e1, e2, count, event_date or now) for (e1, e2), (count, event_date) in coo_agg.items()),
                 )
 
     @staticmethod
@@ -872,29 +902,45 @@ class EntityResolver:
             entity_id_2,
         )
 
-    async def link_units_to_entities_batch(self, unit_entity_pairs: list[tuple[str, str]], conn=None):
+    async def link_units_to_entities_batch(
+        self,
+        unit_entity_pairs: list[tuple[str, str]] | list[tuple[str, str, datetime | None]],
+        conn=None,
+    ):
         """
         Link multiple memory units to entities in batch (MUCH faster than sequential).
 
         Also updates co-occurrence cache for entities that appear in the same unit.
 
         Args:
-            unit_entity_pairs: List of (unit_id, entity_id) tuples
+            unit_entity_pairs: List of (unit_id, entity_id) or
+                (unit_id, entity_id, event_date) tuples. When `event_date` is
+                supplied, ``entity_cooccurrences.last_cooccurred`` for pairs
+                observed in that unit advances to the event time instead of
+                ``now()``, which matters for backfilled corpora where ingest
+                time is a single spike unrelated to the underlying timeline.
+                Legacy two-tuples remain accepted.
             conn: Optional connection to use (if None, acquires from pool)
         """
         if not unit_entity_pairs:
             return
 
+        # Normalize to 3-tuples internally so downstream code doesn't branch.
+        normalized: list[tuple[str, str, datetime | None]] = [
+            (t[0], t[1], t[2] if len(t) >= 3 else None)  # type: ignore[misc]
+            for t in unit_entity_pairs
+        ]
+
         if conn is None:
             async with acquire_with_retry(self.pool) as conn:
-                return await self._link_units_to_entities_batch_impl(conn, unit_entity_pairs)
+                return await self._link_units_to_entities_batch_impl(conn, normalized)
         else:
-            return await self._link_units_to_entities_batch_impl(conn, unit_entity_pairs)
+            return await self._link_units_to_entities_batch_impl(conn, normalized)
 
-    async def _link_units_to_entities_batch_impl(self, conn, unit_entity_pairs: list[tuple[str, str]]):
+    async def _link_units_to_entities_batch_impl(self, conn, unit_entity_pairs: list[tuple[str, str, datetime | None]]):
         # Sorted bulk insert to prevent deadlocks from inconsistent lock ordering
         # across concurrent transactions on the unit_entities unique index.
-        sorted_pairs = sorted(unit_entity_pairs)
+        sorted_pairs = sorted(unit_entity_pairs, key=lambda t: (t[0], t[1]))
         unit_ids = [p[0] for p in sorted_pairs]
         entity_ids = [p[1] for p in sorted_pairs]
 
@@ -905,28 +951,42 @@ class EntityResolver:
             entity_ids,
         )
 
-        # Build map of unit -> entities for co-occurrence calculation
-        # Use sets to avoid duplicate entities in the same unit
-        unit_to_entities = {}
-        for unit_id, entity_id in unit_entity_pairs:
-            if unit_id not in unit_to_entities:
-                unit_to_entities[unit_id] = set()
-            unit_to_entities[unit_id].add(entity_id)
+        # Build maps keyed by unit_id:
+        #   unit_to_entities: entity set per unit (for the co-occurrence cross-product)
+        #   unit_event_date:  event time per unit (propagated onto every pair from that unit)
+        # When a unit shows up more than once with conflicting event_dates (legacy
+        # callers passing None interleaved with aware callers), prefer the first
+        # non-None value so we don't accidentally erase an explicit timestamp.
+        unit_to_entities: dict[str, set[str]] = {}
+        unit_event_date: dict[str, datetime | None] = {}
+        for unit_id, entity_id, event_date in unit_entity_pairs:
+            unit_to_entities.setdefault(unit_id, set()).add(entity_id)
+            if event_date is not None and unit_event_date.get(unit_id) is None:
+                unit_event_date[unit_id] = event_date
+            elif unit_id not in unit_event_date:
+                unit_event_date[unit_id] = event_date
 
-        # Update co-occurrences for all pairs in each unit
-        cooccurrence_pairs = set()  # Use set to avoid duplicates
+        # Update co-occurrences for all pairs in each unit. Carry the unit's
+        # event_date onto every pair so the flush step can stamp
+        # `last_cooccurred` with the correct time.
+        cooccurrence_pairs: dict[tuple[str, str], datetime | None] = {}
         for unit_id, entity_ids in unit_to_entities.items():
-            entity_list = list(entity_ids)  # Convert set to list for iteration
-            # For each pair of entities in this unit, create co-occurrence
+            entity_list = list(entity_ids)
+            event_date = unit_event_date.get(unit_id)
             for i, entity_id_1 in enumerate(entity_list):
                 for entity_id_2 in entity_list[i + 1 :]:
-                    # Skip if same entity (shouldn't happen with set, but be safe)
                     if entity_id_1 == entity_id_2:
                         continue
-                    # Ensure consistent ordering (entity_id_1 < entity_id_2)
+                    # Canonical ordering (entity_id_1 < entity_id_2) matches the
+                    # entity_cooccurrences PK and check constraint.
                     if entity_id_1 > entity_id_2:
                         entity_id_1, entity_id_2 = entity_id_2, entity_id_1
-                    cooccurrence_pairs.add((entity_id_1, entity_id_2))
+                    key = (entity_id_1, entity_id_2)
+                    prev = cooccurrence_pairs.get(key, _SENTINEL_MISSING)
+                    if prev is _SENTINEL_MISSING:
+                        cooccurrence_pairs[key] = event_date
+                    else:
+                        cooccurrence_pairs[key] = _later_date(prev, event_date)
 
         # Accumulate co-occurrence pairs for post-transaction flush.
         # The actual INSERT/UPDATE is deferred to flush_pending_stats() to avoid
@@ -935,7 +995,8 @@ class EntityResolver:
         if cooccurrence_pairs:
             key = self._task_key()
             self._pending_cooccurrences.setdefault(key, []).extend(
-                _CooccurrencePair(entity_id_1=e1, entity_id_2=e2) for e1, e2 in cooccurrence_pairs
+                _CooccurrencePair(entity_id_1=e1, entity_id_2=e2, event_date=ed)
+                for (e1, e2), ed in cooccurrence_pairs.items()
             )
 
     async def get_units_by_entity(self, entity_id: str, limit: int = 100) -> list[str]:

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -405,8 +405,10 @@ async def build_entity_links_from_resolved(
         # Insert unit-entity links (used in fallback path where Phase 2 didn't do this)
         substep_start = time.time()
         unit_entity_pairs = []
-        for idx, (unit_id, _local_idx, _fact_date) in enumerate(entity_to_unit):
-            unit_entity_pairs.append((unit_id, resolved_entity_ids[idx]))
+        for idx, (unit_id, _local_idx, fact_date) in enumerate(entity_to_unit):
+            # Propagate the unit's fact_date so entity_cooccurrences.last_cooccurred
+            # reflects the event timeline, not the ingest moment.
+            unit_entity_pairs.append((unit_id, resolved_entity_ids[idx], fact_date))
 
         await entity_resolver.link_units_to_entities_batch(unit_entity_pairs, conn=conn)
         _log(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -284,10 +284,12 @@ async def _insert_facts_and_links(
         )
         # Update semantic_ann_links with remapped IDs for Phase 2
         semantic_ann_links = remapped_semantic
-        # INSERT unit_entities (FK to memory_units, must be in transaction)
+        # INSERT unit_entities (FK to memory_units, must be in transaction).
+        # Pass fact_date alongside so entity_cooccurrences.last_cooccurred
+        # tracks the event timeline, not the ingest moment.
         unit_entity_pairs = [
-            (unit_id, resolved_entity_ids[idx])
-            for idx, (unit_id, _local_idx, _fact_date) in enumerate(remapped_entity_to_unit)
+            (unit_id, resolved_entity_ids[idx], fact_date)
+            for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
         await entity_resolver.link_units_to_entities_batch(unit_entity_pairs, conn=conn)
         log_buffer.append(f"  Insert unit_entities: {len(unit_entity_pairs)} pairs in {time.time() - step_start:.3f}s")

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -326,3 +326,88 @@ class TestOracleFuzzyEntityResolution:
         # The candidate IDs should be passed as bind parameter
         cooc_bind_args = mock_conn.fetch.call_args_list[1].args[1:]
         assert "eid-1" in cooc_bind_args[0], "Co-occurrence query must receive candidate IDs"
+
+
+@pytest.mark.asyncio
+async def test_link_units_carries_event_date_into_cooccurrences(pg0_db_url):
+    """
+    `link_units_to_entities_batch` must propagate each unit's event_date onto the
+    accumulated _CooccurrencePair entries, so flush_pending_stats() stamps
+    entity_cooccurrences.last_cooccurred with the event time instead of "now".
+
+    This protects banks that were backfilled from another memory system —
+    without it, every pair collapses to the import moment and the UI's entity
+    graph recency heat loses the underlying knowledge timeline.
+    """
+    resolved_url = await resolve_database_url(pg0_db_url)
+    backend = create_database_backend("postgresql")
+    await backend.initialize(resolved_url, min_size=1, max_size=2, command_timeout=30)
+    bank_id = f"test-cooccurrence-evt-{uuid.uuid4().hex[:8]}"
+    resolver = EntityResolver(pool=backend, entity_lookup="full")
+
+    historical = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    try:
+        async with backend.acquire() as conn:
+            unit_id = await conn.fetchval(
+                """
+                INSERT INTO memory_units
+                    (bank_id, text, fact_type, mentioned_at, occurred_start, created_at)
+                VALUES ($1, 'paired-entity unit', 'experience', $2, $2, now())
+                RETURNING id
+                """,
+                bank_id,
+                historical,
+            )
+            e1 = await conn.fetchval(
+                "INSERT INTO entities (bank_id, canonical_name, first_seen, last_seen, mention_count) "
+                "VALUES ($1, 'alpha', $2, $2, 1) RETURNING id",
+                bank_id,
+                historical,
+            )
+            e2 = await conn.fetchval(
+                "INSERT INTO entities (bank_id, canonical_name, first_seen, last_seen, mention_count) "
+                "VALUES ($1, 'beta', $2, $2, 1) RETURNING id",
+                bank_id,
+                historical,
+            )
+
+            await resolver.link_units_to_entities_batch(
+                [(str(unit_id), str(e1), historical), (str(unit_id), str(e2), historical)],
+                conn=conn,
+            )
+
+        # Flush accumulates to entity_cooccurrences on a fresh connection, as
+        # the production flush runs post-transaction to avoid lock contention.
+        await resolver.flush_pending_stats()
+
+        async with backend.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT last_cooccurred
+                FROM entity_cooccurrences
+                WHERE entity_id_1 = LEAST($1::uuid, $2::uuid)
+                  AND entity_id_2 = GREATEST($1::uuid, $2::uuid)
+                """,
+                e1,
+                e2,
+            )
+        assert row is not None, "co-occurrence row should exist"
+        assert row["last_cooccurred"] == historical, (
+            f"expected last_cooccurred == {historical}, got {row['last_cooccurred']}"
+        )
+    finally:
+        async with backend.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM unit_entities WHERE unit_id IN (SELECT id FROM memory_units WHERE bank_id = $1)", bank_id
+            )
+            await conn.execute(
+                "DELETE FROM entity_cooccurrences WHERE entity_id_1 IN "
+                "(SELECT id FROM entities WHERE bank_id = $1) "
+                "OR entity_id_2 IN "
+                "(SELECT id FROM entities WHERE bank_id = $1)",
+                bank_id,
+            )
+            await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+            await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+        await backend.shutdown()

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -174,6 +174,7 @@ To switch between backends:
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict merged into `extra_body` for all OpenAI-compatible API calls. Useful for custom model servers (e.g., vLLM `chat_template_kwargs`). | `null` |
+| `HINDSIGHT_API_LLM_DEFAULT_HEADERS` | JSON dict passed as `default_headers` to provider SDK clients. Used by operators routing through proxies / request-tracing middleware (e.g. Cloudflare AI Gateway, Helicone, corporate proxies). Currently wired into the Anthropic provider; other providers can opt in. | `null` |
 | `HINDSIGHT_API_LLM_GEMINI_SAFETY_SETTINGS` | JSON-encoded list of `{category, threshold}` dicts for Gemini/VertexAI content safety filtering | `null` |
 
 **Provider Examples**


### PR DESCRIPTION
## Summary

`entity_cooccurrences.last_cooccurred` is always set to `datetime.now(UTC)` at flush time, regardless of the source memory unit's event date. For real-time retains this is fine (ingest time ≈ event time), but any bank **backfilled in a single session** — e.g. migrating from another memory system — collapses every co-occurrence onto the import moment. The control plane's entity-graph recency heat then shows a one-or-two-day range regardless of how far the underlying knowledge actually spans.

Example: on a bank migrated on 2026-04-24, every edge's `lastCooccurred` was `2026-04-23` or `2026-04-24`, even though the source memories' `mentioned_at` / `occurred_start` correctly reflect the original 2026-03 timeline.

Interestingly the tuples flowing into `_link_units_to_entities_batch_impl` already carried the per-unit `fact_date` alongside `(unit_id, entity_id)` — it was just being discarded at the call site (`_fact_date` underscore). This change wires it through.

## Changes

### Writer path

- `_CooccurrencePair` grows an `event_date: datetime | None` field.
- `link_units_to_entities_batch` accepts both the legacy `(unit_id, entity_id)` tuples **and** the new `(unit_id, entity_id, event_date)` form, so external callers aren't forced to migrate in lockstep.
- `_link_units_to_entities_batch_impl` builds a per-unit event-date map and attaches the unit's date to every co-occurrence pair emitted from that unit. A `_SENTINEL_MISSING` guard prevents a duplicate legacy-caller row (`event_date=None`) from clobbering a real datetime from another caller on the same unit.
- `flush_pending_stats` aggregates per-pair event dates and `INSERT`s the observed maximum. It falls back to `datetime.now(UTC)` only when no event date was carried, so real-time retains preserve their pre-fix semantics exactly.

### In-repo callers

- `retain/orchestrator.py`:290 — pass `fact_date` (was already in the tuple as `_fact_date`).
- `retain/link_utils.py`:429 — same.

### Backfill migration

`b5d4e3f2a1c9_backfill_entity_cooccurrences_event_time.py` recomputes `last_cooccurred` from `MAX(COALESCE(mentioned_at, occurred_start, created_at))` over `unit_entities × memory_units`, so operators don't have to run a manual SQL backfill to see the fix on their existing data. The downgrade path is a no-op — the pre-fix value was `now()` at the time of write and isn't recoverable, and rolling the code back is enough to revert behavior for subsequent retains.

## Test plan

- [x] New regression in `test_entity_resolver.py`: inserts a memory unit with a historical `mentioned_at`, calls `link_units_to_entities_batch` + `flush_pending_stats`, asserts `entity_cooccurrences.last_cooccurred == historical`.
- [x] `python -m py_compile` passes on the three touched engine files, the migration, and the test file.
- [x] Backward compat: passing the old two-tuple shape still works (falls back to `now()`, matching pre-fix behavior).
- [x] Manually verified on a migrated bank: running the migration moves the entity-graph recency heat range from "one-day spike" back to the true multi-week event-time span.

## Repro (before)

```bash
curl -s http://localhost:8000/v1/default/banks/main/entities/graph?limit=3 \
  | jq '.edges[].data.lastCooccurred'
# "2026-04-24T06:47:08+00:00"
# "2026-04-24T06:45:12+00:00"
# "2026-04-24T06:39:02+00:00"   ← all today, despite 03-xx memories
```

## After (with migration applied)

```bash
# "2026-03-30T..." / "2026-03-29T..." / ...
```