### PR TITLE
feat(embeddings): allow Cohere output dimensions via env var

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -191,6 +191,7 @@ ENV_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY = "HINDSIGHT_API_EMBEDDINGS_VERTEXAI
 ENV_EMBEDDINGS_COHERE_API_KEY = "HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY"
 ENV_EMBEDDINGS_COHERE_MODEL = "HINDSIGHT_API_EMBEDDINGS_COHERE_MODEL"
 ENV_EMBEDDINGS_COHERE_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_COHERE_BASE_URL"
+ENV_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS"
 ENV_RERANKER_COHERE_API_KEY = "HINDSIGHT_API_RERANKER_COHERE_API_KEY"
 ENV_RERANKER_COHERE_MODEL = "HINDSIGHT_API_RERANKER_COHERE_MODEL"
 ENV_RERANKER_COHERE_BASE_URL = "HINDSIGHT_API_RERANKER_COHERE_BASE_URL"
@@ -891,6 +892,7 @@ class HindsightConfig:
     embeddings_cohere_api_key: str | None
     embeddings_cohere_model: str
     embeddings_cohere_base_url: str | None
+    embeddings_cohere_output_dimensions: int | None
     embeddings_openrouter_api_key: str | None
     embeddings_openrouter_model: str
     embeddings_litellm_api_base: str
@@ -1433,6 +1435,9 @@ class HindsightConfig:
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),
             embeddings_cohere_model=os.getenv(ENV_EMBEDDINGS_COHERE_MODEL, DEFAULT_EMBEDDINGS_COHERE_MODEL),
             embeddings_cohere_base_url=os.getenv(ENV_EMBEDDINGS_COHERE_BASE_URL) or None,
+            embeddings_cohere_output_dimensions=int(v)
+            if (v := os.getenv(ENV_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS))
+            else None,
             # OpenRouter embeddings (with fallback to shared OpenRouter key, then LLM key)
             embeddings_openrouter_api_key=os.getenv(ENV_EMBEDDINGS_OPENROUTER_API_KEY)
             or os.getenv(ENV_OPENROUTER_API_KEY)

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -516,6 +516,7 @@ class CohereEmbeddings(Embeddings):
         api_key: str,
         model: str = DEFAULT_EMBEDDINGS_COHERE_MODEL,
         base_url: str | None = None,
+        output_dimensions: int | None = None,
         batch_size: int = 96,
         timeout: float = 60.0,
         input_type: str = "search_document",
@@ -527,6 +528,7 @@ class CohereEmbeddings(Embeddings):
             api_key: Cohere API key
             model: Cohere embedding model name (default: embed-english-v3.0)
             base_url: Custom base URL for Cohere-compatible API (e.g., Azure-hosted endpoint)
+            output_dimensions: Optional output embedding dimensions (for Matryoshka-capable models)
             batch_size: Maximum batch size for embedding requests (default: 96, Cohere's limit)
             timeout: Request timeout in seconds (default: 60.0)
             input_type: Input type for embeddings (default: search_document).
@@ -535,6 +537,7 @@ class CohereEmbeddings(Embeddings):
         self.api_key = api_key
         self.model = model
         self.base_url = base_url
+        self.output_dimensions = output_dimensions
         self.batch_size = batch_size
         self.timeout = timeout
         self.input_type = input_type
@@ -570,8 +573,10 @@ class CohereEmbeddings(Embeddings):
             client_kwargs["base_url"] = self.base_url
         self._client = cohere.Client(**client_kwargs)
 
-        # Try to get dimension from known models, otherwise do a test embedding
-        if self.model in self.MODEL_DIMENSIONS:
+        # If output_dimensions is explicitly set, use that as the dimension
+        if self.output_dimensions is not None:
+            self._dimension = self.output_dimensions
+        elif self.model in self.MODEL_DIMENSIONS:
             self._dimension = self.MODEL_DIMENSIONS[self.model]
         else:
             # Do a test embedding to detect dimension
@@ -607,13 +612,23 @@ class CohereEmbeddings(Embeddings):
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
 
-            response = self._client.embed(
-                texts=batch,
-                model=self.model,
-                input_type=self.input_type,
-            )
-
-            all_embeddings.extend(response.embeddings)
+            if self.output_dimensions is not None:
+                # Use v2 API which supports output_dimension
+                response = self._client.v2.embed(
+                    texts=batch,
+                    model=self.model,
+                    input_type=self.input_type,
+                    output_dimension=self.output_dimensions,
+                    embedding_types=["float"],
+                )
+                all_embeddings.extend(response.embeddings.float_)
+            else:
+                response = self._client.embed(
+                    texts=batch,
+                    model=self.model,
+                    input_type=self.input_type,
+                )
+                all_embeddings.extend(response.embeddings)
 
         return all_embeddings
 
@@ -1127,6 +1142,7 @@ def create_embeddings_from_env() -> Embeddings:
             api_key=api_key,
             model=config.embeddings_cohere_model,
             base_url=config.embeddings_cohere_base_url,
+            output_dimensions=config.embeddings_cohere_output_dimensions,
         )
     elif provider == "litellm":
         return LiteLLMEmbeddings(

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -408,6 +408,7 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1m
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY` | Cohere API key for embeddings | - |
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_MODEL` | Cohere embedding model | `embed-english-v3.0` |
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_BASE_URL` | Custom base URL for Cohere-compatible API (e.g., Azure-hosted) | - |
+| `HINDSIGHT_API_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS` | Output embedding dimensions for Cohere (e.g., `256`, `512`, `1024`). When set, overrides the model's default dimension. | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE` | LiteLLM proxy base URL for embeddings | `http://localhost:4000` |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY` | LiteLLM proxy API key for embeddings (optional, depends on proxy config) | - |
 | `HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL` | LiteLLM embedding model (use provider prefix, e.g., `cohere/embed-english-v3.0`) | `text-embedding-3-small` |
@@ -457,6 +458,8 @@ export HINDSIGHT_API_EMBEDDINGS_OPENROUTER_MODEL=perplexity/pplx-embed-v1-0.6b
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=cohere
 export HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY=your-api-key
 export HINDSIGHT_API_EMBEDDINGS_COHERE_MODEL=embed-english-v3.0  # 1024 dimensions
+# Optional: override output dimensions (for Matryoshka-capable models)
+# export HINDSIGHT_API_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS=512
 
 # Azure-hosted Cohere - embeddings via custom endpoint
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=cohere


### PR DESCRIPTION
## Summary

Closes #1229

- Add `HINDSIGHT_API_EMBEDDINGS_COHERE_OUTPUT_DIMENSIONS` env var to configure custom embedding dimensions for Cohere models that support Matryoshka embeddings (e.g. `embed-v4.0`)
- Uses the Cohere **v2 API** (`client.v2.embed()` with `output_dimension`) when the setting is provided; falls back to the v1 API otherwise for backward compatibility
- Document the new env var in the configuration reference and examples

## Test plan

- [x] Tested with real Cohere API key against `embed-v4.0` with dimensions 256, 512, and 1024
- [x] Verified default path (no `output_dimensions`) still uses v1 API and works unchanged
- [x] Verified batch encoding works with custom dimensions
- [x] Verified config env var parsing (set and unset)
- [x] Lint passes