### PR TITLE
fix(llm): handle DeepSeek tool-call compatibility

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -206,7 +206,12 @@ class OpenAICompatibleLLM(LLMInterface):
     def _supports_reasoning_model(self) -> bool:
         """Check if the current model is a reasoning model (o1, o3, GPT-5, DeepSeek)."""
         model_lower = self.model.lower()
-        return any(x in model_lower for x in ["gpt-5", "o1", "o3", "deepseek"])
+        if "deepseek" in model_lower:
+            # DeepSeek v4-flash is the non-thinking route. Treating every
+            # DeepSeek model as a reasoning model injects reasoning_effort,
+            # which conflicts with thinking-disabled flash calls.
+            return any(x in model_lower for x in ["v4-pro", "reasoner", "r1", "thinking"])
+        return any(x in model_lower for x in ["gpt-5", "o1", "o3"])
 
     def _get_max_reasoning_tokens(self) -> int | None:
         """Get max reasoning tokens for reasoning models."""
@@ -627,26 +632,54 @@ class OpenAICompatibleLLM(LLMInterface):
         """
         start_time = time.time()
 
+        request_tool_choice: str | dict[str, Any] | None = tool_choice
+
         # Normalize named tool_choice dicts to "required" + filter tools.
         # Some providers (e.g. LM Studio, Ollama) reject the OpenAI named format
         # {"type": "function", "function": {"name": "..."}}.  The semantics are
         # identical to tool_choice="required" with the tools list restricted to
-        # just the requested tool, so we apply that transformation universally.
-        if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
-            forced_name = tool_choice.get("function", {}).get("name")
+        # just the requested tool, so we apply that transformation where supported.
+        if isinstance(request_tool_choice, dict) and request_tool_choice.get("type") == "function":
+            forced_name = request_tool_choice.get("function", {}).get("name")
             if forced_name:
                 filtered = [t for t in tools if t.get("function", {}).get("name") == forced_name]
                 if filtered:
                     tools = filtered
-                tool_choice = "required"
+                request_tool_choice = "required"
+
+        # DeepSeek accepts tool calls but rejects explicit required/named
+        # tool_choice values. The tools list has already been narrowed for
+        # forced calls, so omitting tool_choice preserves the practical behavior.
+        if "deepseek" in self.model.lower() and request_tool_choice != "auto":
+            request_tool_choice = None
+
+        # DeepSeek tool-call replies can carry provider-specific reasoning_content.
+        # The normalized tool result does not retain it, but replaying assistant
+        # tool_calls without the field can trigger a 400. DeepSeek accepts an
+        # empty-string fallback, matching the provider's history-replay contract.
+        if "deepseek" in self.model.lower():
+            normalized_messages: list[dict[str, Any]] = []
+            for msg in messages:
+                if (
+                    msg.get("role") == "assistant"
+                    and msg.get("tool_calls")
+                    and "reasoning_content" not in msg
+                ):
+                    normalized_msg = dict(msg)
+                    normalized_msg["reasoning_content"] = ""
+                    normalized_messages.append(normalized_msg)
+                else:
+                    normalized_messages.append(msg)
+            messages = normalized_messages
 
         # Build call parameters
         call_params: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "tools": tools,
-            "tool_choice": tool_choice,
         }
+        if request_tool_choice is not None:
+            call_params["tool_choice"] = request_tool_choice
 
         if max_completion_tokens is not None:
             call_params[self._max_tokens_param_name()] = max_completion_tokens

--- a/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
+++ b/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
@@ -1,0 +1,166 @@
+"""Regression tests for DeepSeek OpenAI-compatible tool-call quirks."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_observations",
+            "description": "Search observations",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "recall",
+            "description": "Recall memories",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+]
+
+
+def _make_deepseek_llm(model: str = "deepseek-v4-flash") -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="openai",
+        api_key="sk-test",
+        base_url="https://api.deepseek.com",
+        model=model,
+    )
+
+
+def _make_tool_call_response(tool_name: str = "search_observations") -> MagicMock:
+    mock_tc = MagicMock()
+    mock_tc.id = "call_deepseek_123"
+    mock_tc.function.name = tool_name
+    mock_tc.function.arguments = json.dumps({"query": "test"})
+
+    mock_response = MagicMock()
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 20
+    mock_response.usage.total_tokens = 120
+    mock_response.choices[0].finish_reason = "tool_calls"
+    mock_response.choices[0].message.content = None
+    mock_response.choices[0].message.tool_calls = [mock_tc]
+    return mock_response
+
+
+def test_deepseek_flash_is_not_treated_as_reasoning_model():
+    llm = _make_deepseek_llm("deepseek-v4-flash")
+
+    assert llm._supports_reasoning_model() is False
+
+
+def test_deepseek_reasoning_models_still_use_reasoning_parameters():
+    llm = _make_deepseek_llm("deepseek-v4-pro")
+
+    assert llm._supports_reasoning_model() is True
+
+
+@pytest.mark.asyncio
+async def test_deepseek_named_tool_choice_filters_tools_but_omits_tool_choice():
+    """DeepSeek rejects required/named tool_choice but accepts a narrowed tools list."""
+    llm = _make_deepseek_llm()
+    named_tool_choice = {"type": "function", "function": {"name": "search_observations"}}
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _make_tool_call_response("search_observations")
+
+        result = await llm.call_with_tools(
+            messages=[{"role": "user", "content": "Search observations for Project-Rin."}],
+            tools=TOOLS,
+            tool_choice=named_tool_choice,
+            max_retries=0,
+        )
+
+    assert result.tool_calls[0].name == "search_observations"
+
+    sent_kwargs = mock_create.call_args.kwargs
+    assert "tool_choice" not in sent_kwargs
+    assert len(sent_kwargs["tools"]) == 1
+    assert sent_kwargs["tools"][0]["function"]["name"] == "search_observations"
+
+
+@pytest.mark.asyncio
+async def test_deepseek_tool_history_gets_empty_reasoning_content_fallback():
+    """DeepSeek requires reasoning_content when replaying assistant tool_calls."""
+    llm = _make_deepseek_llm()
+    messages = [
+        {"role": "user", "content": "Search observations."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_deepseek_123",
+                    "type": "function",
+                    "function": {"name": "search_observations", "arguments": json.dumps({"query": "test"})},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_deepseek_123", "content": "{}"},
+    ]
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _make_tool_call_response("recall")
+
+        await llm.call_with_tools(
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+            max_retries=0,
+        )
+
+    sent_messages = mock_create.call_args.kwargs["messages"]
+    assert sent_messages[1]["reasoning_content"] == ""
+    assert "reasoning_content" not in messages[1]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_tool_history_preserves_existing_reasoning_content():
+    llm = _make_deepseek_llm()
+    messages = [
+        {"role": "user", "content": "Search observations."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "provider reasoning scratchpad",
+            "tool_calls": [
+                {
+                    "id": "call_deepseek_123",
+                    "type": "function",
+                    "function": {"name": "search_observations", "arguments": json.dumps({"query": "test"})},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_deepseek_123", "content": "{}"},
+    ]
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _make_tool_call_response("recall")
+
+        await llm.call_with_tools(
+            messages=messages,
+            tools=TOOLS,
+            tool_choice="auto",
+            max_retries=0,
+        )
+
+    sent_messages = mock_create.call_args.kwargs["messages"]
+    assert sent_messages[1]["reasoning_content"] == "provider reasoning scratchpad"


### PR DESCRIPTION
## Summary

Fix DeepSeek OpenAI-compatible tool-call behavior in `OpenAICompatibleLLM`.

DeepSeek accepts tool calls, but can reject explicit `tool_choice="required"` or named tool-choice values. This patch preserves forced-tool behavior by narrowing the tools list while omitting unsupported `tool_choice` values for DeepSeek.

It also adds a `reasoning_content=""` fallback for replayed assistant tool-call messages, because DeepSeek may reject assistant `tool_calls` history without this field.

## Changes

- Do not treat `deepseek-v4-flash` as a reasoning model.
- Keep DeepSeek reasoning classification for `v4-pro`, `reasoner`, `r1`, and `thinking` model names.
- Omit unsupported `tool_choice` values for DeepSeek while preserving narrowed tool-list behavior.
- Add `reasoning_content=""` fallback for assistant messages with `tool_calls`.
- Add regression tests for DeepSeek tool-call compatibility.

## Test plan

- `python3 -m py_compile hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py hindsight-api-slim/tests/test_deepseek_tool_call_compat.py`
- `PYTHONPATH=/app/api /app/api/.venv/bin/python -m pytest /tmp/test_deepseek_tool_call_compat.py -q` -> 5 passed
- `PYTHONPATH=/app/api /app/api/.venv/bin/python -m pytest /tmp/test_lmstudio_tool_choice.py -q` -> 10 passed
- `ruff check` on changed provider file and related tool-choice tests -> passed
