### PR TITLE
fix(embed): preserve profile HINDSIGHT guardrails

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -51,8 +51,10 @@ def _detach_popen_kwargs(log_handle) -> dict:
     POSIX child inherits the parent's fds (legacy daemon-spawn behavior).
     """
     if platform.system() == "Windows":
+        detached_process = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+        create_new_process_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
         return {
-            "creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+            "creationflags": detached_process | create_new_process_group,
             "stdin": subprocess.DEVNULL,
             "stdout": log_handle,
             "stderr": subprocess.STDOUT,
@@ -266,12 +268,20 @@ class DaemonEmbedManager(EmbedManager):
         with open(paths.lock, "w") as lock_fd:
             lock_file(lock_fd)
             try:
+                # Load and merge the profile env before any already-running
+                # short-circuit. Registration rewrites the profile metadata/env,
+                # so passing only the caller-provided config would silently drop
+                # persisted HINDSIGHT_* guardrails such as daemon idle timeout or
+                # consolidation token limits.
+                profile_config = self._profile_manager.load_profile_config(profile)
+                merged_config = {**profile_config, **config}
+
                 if self.is_running(profile):
                     logger.debug(f"Daemon for profile '{profile}' came up while waiting for start lock")
                     if profile:
-                        self._register_profile(profile, paths.port, config)
+                        self._register_profile(profile, paths.port, merged_config)
                     return True
-                return self._start_daemon_locked(config, profile, paths, extra_args=extra_args)
+                return self._start_daemon_locked(merged_config, profile, paths, extra_args=extra_args)
             finally:
                 unlock_file(lock_fd)
 
@@ -301,13 +311,6 @@ class DaemonEmbedManager(EmbedManager):
             if profile:
                 self._register_profile(profile, port, config)
             return True
-
-        # Load profile's .env file and merge with provided config
-        # This fixes issue #305 where profile env vars were ignored
-        profile_config = self._profile_manager.load_profile_config(profile)
-        # Merge: profile config first, then override with explicitly provided config
-        merged_config = {**profile_config, **config}
-        config = merged_config
 
         # Build environment with LLM config
         # Support both formats: simple keys ("llm_api_key") and env var format ("HINDSIGHT_API_LLM_API_KEY")
@@ -526,14 +529,15 @@ class DaemonEmbedManager(EmbedManager):
     def _register_profile(self, profile: str, port: int, config: dict) -> None:
         """Register a named profile in metadata so it's discoverable by the CLI.
 
-        Only saves HINDSIGHT_API_* config keys (not internal daemon keys).
-        Silently ignores errors to avoid blocking daemon startup.
+        Saves all HINDSIGHT_* config keys so profile registration does not
+        erase persisted API or embedded-daemon guardrails. Silently ignores
+        errors to avoid blocking daemon startup.
         """
         try:
-            api_config = {k: v for k, v in config.items() if k.startswith("HINDSIGHT_API_")}
-            if not api_config:
+            profile_config = {k: v for k, v in config.items() if k.startswith("HINDSIGHT_")}
+            if not profile_config:
                 return
-            self._profile_manager.create_profile(profile, port, api_config)
+            self._profile_manager.create_profile(profile, port, profile_config)
         except Exception as e:
             logger.debug(f"Failed to register profile '{profile}' in metadata: {e}")
 

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -114,7 +114,7 @@ def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
     default_config_dir = temp_home / ".hindsight"
     default_config_dir.mkdir(parents=True, exist_ok=True)
     (default_config_dir / "embed").write_text(
-        "HINDSIGHT_API_LLM_PROVIDER=openai\n" "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
+        "HINDSIGHT_API_LLM_PROVIDER=openai\nHINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
     )
 
     # Create a named profile with a DIFFERENT provider
@@ -123,7 +123,7 @@ def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
 
     profile_name = "myapp"
     profile_env_path = profile_dir / f"{profile_name}.env"
-    profile_env_path.write_text("HINDSIGHT_API_LLM_PROVIDER=groq\n" "HINDSIGHT_API_LLM_MODEL=llama-3.1-70b\n")
+    profile_env_path.write_text("HINDSIGHT_API_LLM_PROVIDER=groq\nHINDSIGHT_API_LLM_MODEL=llama-3.1-70b\n")
 
     # Create metadata
     import json
@@ -447,7 +447,11 @@ def test_windows_popen_uses_detached_process_flags(temp_home, monkeypatch):
         )
 
     kwargs = captured["kwargs"]
-    expected_flags = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+    expected_flags = getattr(subprocess, "DETACHED_PROCESS", 0x00000008) | getattr(
+        subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        0x00000200,
+    )
     assert kwargs.get("creationflags") == expected_flags
     assert "start_new_session" not in kwargs
     assert kwargs.get("stdin") is subprocess.DEVNULL
@@ -493,3 +497,76 @@ def test_posix_popen_uses_start_new_session(temp_home, monkeypatch):
     kwargs = captured["kwargs"]
     assert kwargs.get("start_new_session") is True
     assert "creationflags" not in kwargs
+
+
+def test_register_profile_preserves_embed_guardrails(temp_home):
+    """Profile registration must not erase HINDSIGHT_EMBED_* daemon settings."""
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+    from hindsight_embed.profile_manager import ProfileManager
+
+    manager = DaemonEmbedManager()
+    manager._register_profile(
+        "guardrails",
+        9876,
+        {
+            "HINDSIGHT_API_LLM_PROVIDER": "groq",
+            "HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS": "512",
+            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT": "0",
+        },
+    )
+
+    config = ProfileManager().load_profile_config("guardrails")
+    assert config["HINDSIGHT_API_LLM_PROVIDER"] == "groq"
+    assert config["HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS"] == "512"
+    assert config["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
+
+
+def test_already_running_start_merges_profile_config_before_register(temp_home):
+    """Already-running daemon short-circuit must preserve profile env config.
+
+    The start lock path can observe that another process already started the
+    daemon. In that case registration still rewrites profile metadata/env, so it
+    must use profile_config + explicit config, not only the caller-provided
+    config.
+    """
+    import json
+    from unittest.mock import patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+    from hindsight_embed.profile_manager import ProfileManager
+
+    profile_dir = temp_home / ".hindsight" / "profiles"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    profile_name = "already-running"
+    (profile_dir / f"{profile_name}.env").write_text(
+        "HINDSIGHT_API_LLM_PROVIDER=groq\n"
+        "HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS=512\n"
+        "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=0\n"
+    )
+    (profile_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    profile_name: {
+                        "port": 9876,
+                        "created_at": "2024-01-01T00:00:00+00:00",
+                        "last_used": "2024-01-01T00:00:00+00:00",
+                    }
+                },
+            }
+        )
+    )
+
+    manager = DaemonEmbedManager()
+    with patch.object(manager, "is_running", return_value=True):
+        assert manager._start_daemon(
+            config={"HINDSIGHT_API_LLM_MODEL": "openai/gpt-oss-120b"},
+            profile=profile_name,
+        )
+
+    config = ProfileManager().load_profile_config(profile_name)
+    assert config["HINDSIGHT_API_LLM_PROVIDER"] == "groq"
+    assert config["HINDSIGHT_API_LLM_MODEL"] == "openai/gpt-oss-120b"
+    assert config["HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS"] == "512"
+    assert config["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"


### PR DESCRIPTION
## Summary
- load and merge profile `.env` before daemon already-running short-circuits
- preserve all `HINDSIGHT_*` keys during profile registration, including `HINDSIGHT_EMBED_*` daemon guardrails
- add regression coverage for `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` and consolidation env preservation
- avoid cross-platform `ty` false positives for Windows-only `subprocess` constants

## Why
`hindsight-embed -p <profile> daemon start` can re-register profile metadata even when a daemon is already running. Passing only the caller-provided config to registration can silently erase persisted profile guardrails such as `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=0` or consolidation token limits.

## Test plan
- `cd hindsight-embed && uv run ruff check hindsight_embed/daemon_embed_manager.py tests/test_profile_daemon_config.py`
- `cd hindsight-embed && uv run pytest tests/test_profile_daemon_config.py -q`
- `cd hindsight-embed && uv run pytest tests -q`
- `cd hindsight-embed && uv run ty check hindsight_embed/daemon_embed_manager.py tests/test_profile_daemon_config.py`
