### PR TITLE
feat(admin): reindex-embeddings command (closes #743)

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -346,9 +346,7 @@ def reindex_embeddings_cmd(
         "--skip-index-rebuild",
         help="Skip REINDEX of HNSW/IVFFlat/vchordrq indexes after re-embedding.",
     ),
-    yes: bool = typer.Option(
-        False, "--yes", "-y", help="Skip confirmation prompt."
-    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ):
     """Re-embed memory rows whose embedding column is NULL.
 

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -316,6 +316,73 @@ def run_db_migration(
     typer.echo(f"Database migrations completed successfully for {len(schemas)} schema(s)")
 
 
+@app.command(name="reindex-embeddings")
+def reindex_embeddings_cmd(
+    schema: str = typer.Option(
+        DEFAULT_DATABASE_SCHEMA,
+        "--schema",
+        "-s",
+        help="Database schema to reindex.",
+    ),
+    bank_id: str | None = typer.Option(
+        None,
+        "--bank",
+        "-b",
+        help="Filter to a single bank id. If omitted, reindex all banks in the schema.",
+    ),
+    batch_size: int = typer.Option(
+        16,
+        "--batch-size",
+        "-B",
+        help="Rows per encode/update batch. Tune up on faster GPUs, down on tight VRAM.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Discover columns and count pending rows; do not encode or write.",
+    ),
+    skip_index_rebuild: bool = typer.Option(
+        False,
+        "--skip-index-rebuild",
+        help="Skip REINDEX of HNSW/IVFFlat/vchordrq indexes after re-embedding.",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation prompt."
+    ),
+):
+    """Re-embed memory rows whose embedding column is NULL.
+
+    Use after swapping the embedding model (HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL)
+    when banks already hold data. ensure_embedding_dimension refuses to migrate
+    populated tables, so the workflow is:
+
+        1. hindsight-admin backup ...
+        2. Update HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL in env
+        3. ALTER COLUMN embedding TYPE vector(<NEW_DIM>) USING NULL on each table
+        4. Restart API (loads new model)
+        5. hindsight-admin reindex-embeddings
+
+    Closes vectorize-io/hindsight#743.
+    """
+    from .reindex import reindex_embeddings_command
+
+    config = HindsightConfig.from_env()
+    if not config.database_url:
+        typer.echo("Error: Database URL not configured.", err=True)
+        typer.echo("Set HINDSIGHT_API_DATABASE_URL environment variable.", err=True)
+        raise typer.Exit(1)
+
+    reindex_embeddings_command(
+        schema=schema,
+        bank_id=bank_id,
+        batch_size=batch_size,
+        dry_run=dry_run,
+        skip_index_rebuild=skip_index_rebuild,
+        yes=yes,
+        database_url=config.database_url,
+    )
+
+
 async def _decommission_worker(db_url: str, worker_id: str, schema: str = "public") -> int:
     """Release all tasks owned by a worker, setting them back to pending status."""
     is_pg0, instance_name, _ = parse_pg0_url(db_url)

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -346,6 +346,18 @@ def reindex_embeddings_cmd(
         "--skip-index-rebuild",
         help="Skip REINDEX of HNSW/IVFFlat/vchordrq indexes after re-embedding.",
     ),
+    verify_recall: bool = typer.Option(
+        False,
+        "--verify-recall",
+        help="Run a self-match sanity check post-embed: each sampled row's embedding "
+        "should return that row in its own top-5 nearest neighbors.",
+    ),
+    auto_backup: str | None = typer.Option(
+        None,
+        "--auto-backup",
+        help="Path to a backup zip file to write before re-embedding. Aborts on backup failure. "
+        "Recommended for production runs.",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ):
     """Re-embed memory rows whose embedding column is NULL.
@@ -376,6 +388,8 @@ def reindex_embeddings_cmd(
         batch_size=batch_size,
         dry_run=dry_run,
         skip_index_rebuild=skip_index_rebuild,
+        verify_recall=verify_recall,
+        auto_backup=auto_backup,
         yes=yes,
         database_url=config.database_url,
     )

--- a/hindsight-api-slim/hindsight_api/admin/reindex.py
+++ b/hindsight-api-slim/hindsight_api/admin/reindex.py
@@ -31,9 +31,6 @@ Typical workflow:
 
     # 5. Re-embed everything:
     hindsight-admin reindex-embeddings
-
-    # Optional verification:
-    hindsight-admin reindex-embeddings --verify-recall
 """
 
 from __future__ import annotations
@@ -71,9 +68,7 @@ TEXT_SOURCE_COLUMN_BY_TABLE: dict[str, str] = {
 }
 
 
-async def _discover_vector_columns(
-    conn: asyncpg.Connection, schema: str
-) -> list[VectorColumnInfo]:
+async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> list[VectorColumnInfo]:
     """Find every column whose Postgres type is `vector(N)` from pgvector.
 
     Schema-introspected so future Hindsight versions adding new embedding-bearing
@@ -106,9 +101,11 @@ async def _discover_vector_columns(
         # Parse dimension out of "vector(N)"
         if col_type.startswith("vector(") and col_type.endswith(")"):
             try:
-                dim = int(col_type[len("vector("):-1])
+                dim = int(col_type[len("vector(") : -1])
             except ValueError:
-                logger.warning(f"Could not parse dimension from {col_type}, skipping {row['table_name']}.{row['column_name']}")
+                logger.warning(
+                    f"Could not parse dimension from {col_type}, skipping {row['table_name']}.{row['column_name']}"
+                )
                 continue
         else:
             logger.warning(f"Unexpected vector type format {col_type}, skipping")
@@ -217,7 +214,7 @@ async def _reembed_table(
     last_log = table_start
 
     for i in range(0, total, batch_size):
-        batch = rows[i:i + batch_size]
+        batch = rows[i : i + batch_size]
         ids = [r["id"] for r in batch]
         texts = [r["source_text"] for r in batch]
 
@@ -241,14 +238,12 @@ async def _reembed_table(
             elapsed = now - table_start
             rate = processed / elapsed if elapsed > 0 else 0
             eta = (total - processed) / rate if rate > 0 else 0
-            typer.echo(
-                f"    {processed}/{total}  "
-                f"({rate:.1f} rows/s, ETA {eta:.0f}s)"
-            )
+            typer.echo(f"    {processed}/{total}  ({rate:.1f} rows/s, ETA {eta:.0f}s)")
             last_log = now
 
-    typer.echo(f"  {col.table}.{col.column}: {processed} embedded, {skipped} skipped, "
-               f"in {time.time() - table_start:.1f}s")
+    typer.echo(
+        f"  {col.table}.{col.column}: {processed} embedded, {skipped} skipped, in {time.time() - table_start:.1f}s"
+    )
     return processed, skipped
 
 
@@ -295,12 +290,13 @@ async def _reindex_embeddings(
 ) -> None:
     """Main async entrypoint for reindex-embeddings command."""
     # Lazy import — only load embedding engine if we're actually going to use it
+    import os
+
     from ..config import (
         DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
         ENV_EMBEDDINGS_LOCAL_MODEL,
         ENV_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
     )
-    import os
 
     model_name = os.environ.get(ENV_EMBEDDINGS_LOCAL_MODEL)
     if not model_name and not dry_run:
@@ -316,7 +312,7 @@ async def _reindex_embeddings(
         str(DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE),
     ).lower() in ("1", "true", "yes")
 
-    typer.echo(f"== Hindsight reindex-embeddings ==")
+    typer.echo("== Hindsight reindex-embeddings ==")
     typer.echo(f"  Schema:        {schema}")
     typer.echo(f"  Bank filter:   {bank_id or '(all banks)'}")
     typer.echo(f"  Batch size:    {batch_size}")
@@ -365,9 +361,7 @@ async def _reindex_embeddings(
             return
 
         if not yes:
-            confirm = typer.confirm(
-                f"Re-embed {total_pending} rows with model {model_name}?"
-            )
+            confirm = typer.confirm(f"Re-embed {total_pending} rows with model {model_name}?")
             if not confirm:
                 typer.echo("Aborted.")
                 raise typer.Exit(0)

--- a/hindsight-api-slim/hindsight_api/admin/reindex.py
+++ b/hindsight-api-slim/hindsight_api/admin/reindex.py
@@ -279,6 +279,67 @@ async def _rebuild_vector_indexes(conn: asyncpg.Connection, schema: str) -> int:
     return rebuilt
 
 
+async def _verify_recall(conn: asyncpg.Connection, schema: str, sample_size: int = 5) -> tuple[int, int]:
+    """Sanity-check recall by self-querying recent memories.
+
+    Picks `sample_size` rows from memory_units, uses each row's text as a query,
+    and verifies the row itself appears in the top 5 nearest-neighbor results.
+    A working embedding pipeline should always self-match.
+
+    Returns (passed, total) counts.
+    """
+    fq = f'"{schema}"."memory_units"'
+    rows = await conn.fetch(
+        f"""
+        SELECT id, bank_id, text, embedding
+        FROM {fq}
+        WHERE embedding IS NOT NULL
+          AND text IS NOT NULL
+          AND length(text) > 20
+        ORDER BY mentioned_at DESC NULLS LAST
+        LIMIT {int(sample_size)}
+        """
+    )
+    if not rows:
+        typer.echo("  (no embedded rows to verify)")
+        return 0, 0
+
+    passed = 0
+    for row in rows:
+        # Query for the 5 nearest neighbors using cosine distance
+        neighbors = await conn.fetch(
+            f"""
+            SELECT id FROM {fq}
+            WHERE bank_id = $1 AND embedding IS NOT NULL
+            ORDER BY embedding <=> $2::vector
+            LIMIT 5
+            """,
+            row["bank_id"],
+            row["embedding"],
+        )
+        neighbor_ids = [n["id"] for n in neighbors]
+        is_self_match = row["id"] in neighbor_ids
+        if is_self_match:
+            passed += 1
+        else:
+            typer.echo(
+                f"  FAIL: row {row['id']} ({row['bank_id']}) — self-text query did not "
+                f"return self in top-5 neighbors. Embedding may be corrupt."
+            )
+
+    return passed, len(rows)
+
+
+async def _run_auto_backup(database_url: str, schema: str, output_path) -> None:
+    """Run hindsight-admin backup before destructive operations."""
+    from .cli import _run_backup
+
+    typer.echo(f"  Running backup → {output_path}")
+    manifest = await _run_backup(database_url, output_path, schema)
+    total_rows = sum(t["rows"] for t in manifest["tables"].values())
+    typer.echo(f"  Backed up {total_rows} rows across {len(manifest['tables'])} tables")
+
+
 async def _reindex_embeddings(
     database_url: str,
     schema: str,
@@ -287,6 +348,8 @@ async def _reindex_embeddings(
     dry_run: bool,
     skip_index_rebuild: bool,
     yes: bool,
+    verify_recall: bool = False,
+    auto_backup: str | None = None,
 ) -> None:
     """Main async entrypoint for reindex-embeddings command."""
     # Lazy import — only load embedding engine if we're actually going to use it
@@ -299,14 +362,8 @@ async def _reindex_embeddings(
     )
 
     model_name = os.environ.get(ENV_EMBEDDINGS_LOCAL_MODEL)
-    if not model_name and not dry_run:
-        typer.echo(
-            f"ERROR: {ENV_EMBEDDINGS_LOCAL_MODEL} not set. "
-            "Configure your embedding model before running reindex-embeddings. "
-            "(Or use --dry-run to inspect schema without loading a model.)",
-            err=True,
-        )
-        raise typer.Exit(1)
+    # Defer the missing-model error until we know there's actually work to re-embed.
+    # Dry-run and standalone --verify-recall don't need a model loaded.
     trust_remote = os.environ.get(
         ENV_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
         str(DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE),
@@ -319,6 +376,8 @@ async def _reindex_embeddings(
     typer.echo(f"  Embedding:     {model_name}")
     typer.echo(f"  Trust remote:  {trust_remote}")
     typer.echo(f"  Dry run:       {dry_run}")
+    typer.echo(f"  Verify recall: {verify_recall}")
+    typer.echo(f"  Auto-backup:   {auto_backup or '(none)'}")
     typer.echo()
 
     # Resolve pg0 (embedded) URLs to a real connection string
@@ -353,12 +412,43 @@ async def _reindex_embeddings(
         typer.echo()
 
         if total_pending == 0:
-            typer.echo("Nothing to do. All embeddings present.")
+            typer.echo("Nothing to re-embed. All embeddings present.")
+            if verify_recall:
+                typer.echo()
+                typer.echo("[verify] Running recall self-match check...")
+                passed, total = await _verify_recall(conn, schema, sample_size=5)
+                if total == 0:
+                    typer.echo("  No embedded rows found to verify against.")
+                elif passed == total:
+                    typer.echo(f"  PASS: {passed}/{total} sampled rows self-matched in top-5 recall")
+                else:
+                    typer.echo(
+                        f"  WARN: only {passed}/{total} sampled rows self-matched. "
+                        "Embeddings may be stale or corrupt; consider rebuilding indexes."
+                    )
             return
 
         if dry_run:
             typer.echo("(dry-run) — would re-embed and rebuild indexes; exiting now")
+            if verify_recall:
+                typer.echo("(dry-run) — verify-recall would run after re-embed; skipping")
             return
+
+        # Auto-backup before destructive work
+        if auto_backup:
+            from pathlib import Path
+
+            backup_path = Path(auto_backup)
+            if backup_path.suffix != ".zip":
+                backup_path = backup_path.with_suffix(".zip")
+            typer.echo("[2.5/5] Auto-backup before re-embedding")
+            try:
+                await _run_auto_backup(database_url, schema, backup_path)
+            except Exception as e:
+                typer.echo(f"  ERROR: Backup failed: {e!r}", err=True)
+                typer.echo("  Aborting before re-embed. Backup is required when --auto-backup is set.", err=True)
+                raise typer.Exit(1)
+            typer.echo()
 
         if not yes:
             confirm = typer.confirm(f"Re-embed {total_pending} rows with model {model_name}?")
@@ -367,6 +457,13 @@ async def _reindex_embeddings(
                 raise typer.Exit(0)
 
         # 3. Initialize embedding model
+        if not model_name:
+            typer.echo(
+                f"ERROR: {ENV_EMBEDDINGS_LOCAL_MODEL} not set. "
+                "Configure your embedding model before running reindex-embeddings.",
+                err=True,
+            )
+            raise typer.Exit(1)
         typer.echo(f"[3/5] Loading embedding model {model_name}...")
         from ..engine.embeddings import LocalSTEmbeddings
 
@@ -421,8 +518,23 @@ async def _reindex_embeddings(
             typer.echo(f"  Rebuilt {n_indexes} vector indexes")
         typer.echo()
 
+        # 6. Optional verification
+        if verify_recall:
+            typer.echo("[6/6] Verifying recall (self-match sanity check)...")
+            passed, total = await _verify_recall(conn, schema, sample_size=5)
+            if total == 0:
+                typer.echo("  No embedded rows found to verify against.")
+            elif passed == total:
+                typer.echo(f"  PASS: {passed}/{total} sampled rows self-matched in top-5 recall")
+            else:
+                typer.echo(f"  PARTIAL: {passed}/{total} sampled rows self-matched", err=True)
+                typer.echo("  Some rows did not return themselves in top-5 — recall may be degraded.", err=True)
+                typer.echo("  Investigate before treating the upgrade as successful.", err=True)
+            typer.echo()
+
         typer.echo("== Done ==")
-        typer.echo("Verify with sample recall queries before declaring success.")
+        if not verify_recall:
+            typer.echo("Tip: re-run with --verify-recall to sanity-check post-upgrade behavior.")
     finally:
         await conn.close()
 
@@ -435,6 +547,8 @@ def reindex_embeddings_command(
     skip_index_rebuild: bool,
     yes: bool,
     database_url: str,
+    verify_recall: bool = False,
+    auto_backup: str | None = None,
 ) -> None:
     """Sync wrapper for the reindex-embeddings async impl."""
     asyncio.run(
@@ -446,5 +560,7 @@ def reindex_embeddings_command(
             dry_run=dry_run,
             skip_index_rebuild=skip_index_rebuild,
             yes=yes,
+            verify_recall=verify_recall,
+            auto_backup=auto_backup,
         )
     )

--- a/hindsight-api-slim/hindsight_api/admin/reindex.py
+++ b/hindsight-api-slim/hindsight_api/admin/reindex.py
@@ -55,6 +55,7 @@ class VectorColumnInfo:
     dimension: int
     fq_table: str  # schema-qualified table name
     text_column: str | None = None  # text column to source embeddings from
+    pg_type: str = "vector"  # 'vector' or 'halfvec' (pgvector types)
 
 
 # Heuristic: which text column to use as embedding source for each known table.
@@ -69,10 +70,12 @@ TEXT_SOURCE_COLUMN_BY_TABLE: dict[str, str] = {
 
 
 async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> list[VectorColumnInfo]:
-    """Find every column whose Postgres type is `vector(N)` from pgvector.
+    """Find every column whose Postgres type is `vector(N)` or `halfvec(N)` from pgvector.
 
     Schema-introspected so future Hindsight versions adding new embedding-bearing
-    tables Just Work without code changes.
+    tables Just Work without code changes. Also covers vchord deployments where
+    operators may pick `halfvec` to fit dimensions > 2000 inside pgvector's HNSW
+    4000-dim limit (or just to halve storage).
     """
     rows = await conn.fetch(
         """
@@ -87,7 +90,7 @@ async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> lis
         JOIN pg_type t ON a.atttypid = t.oid
         WHERE n.nspname = $1
           AND c.relkind = 'r'  -- ordinary tables only
-          AND t.typname = 'vector'
+          AND t.typname IN ('vector', 'halfvec')
           AND a.attnum > 0
           AND NOT a.attisdropped
         ORDER BY c.relname, a.attnum
@@ -97,17 +100,17 @@ async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> lis
 
     columns: list[VectorColumnInfo] = []
     for row in rows:
-        col_type = row["column_type"]  # e.g., "vector(2560)"
-        # Parse dimension out of "vector(N)"
-        if col_type.startswith("vector(") and col_type.endswith(")"):
-            try:
-                dim = int(col_type[len("vector(") : -1])
-            except ValueError:
-                logger.warning(
-                    f"Could not parse dimension from {col_type}, skipping {row['table_name']}.{row['column_name']}"
-                )
-                continue
-        else:
+        col_type = row["column_type"]  # e.g., "vector(2560)" or "halfvec(2560)"
+        # Parse dimension out of "<type>(N)"
+        dim: int | None = None
+        for prefix in ("vector(", "halfvec("):
+            if col_type.startswith(prefix) and col_type.endswith(")"):
+                try:
+                    dim = int(col_type[len(prefix) : -1])
+                except ValueError:
+                    pass
+                break
+        if dim is None:
             logger.warning(f"Unexpected vector type format {col_type}, skipping")
             continue
 
@@ -135,6 +138,9 @@ async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> lis
             )
             text_col = text_col_check
 
+        # Extract bare type name from format_type output (e.g., "halfvec(2560)" -> "halfvec")
+        pg_type = "halfvec" if col_type.startswith("halfvec(") else "vector"
+
         columns.append(
             VectorColumnInfo(
                 table=row["table_name"],
@@ -142,6 +148,7 @@ async def _discover_vector_columns(conn: asyncpg.Connection, schema: str) -> lis
                 dimension=dim,
                 fq_table=f'"{row["schema_name"]}"."{row["table_name"]}"',
                 text_column=text_col,
+                pg_type=pg_type,
             )
         )
 
@@ -398,7 +405,7 @@ async def _reindex_embeddings(
             return
         for col in cols:
             text_info = f"text→{col.text_column}" if col.text_column else "(no text source)"
-            typer.echo(f"  {col.table}.{col.column}  vector({col.dimension})  {text_info}")
+            typer.echo(f"  {col.table}.{col.column}  {col.pg_type}({col.dimension})  {text_info}")
         typer.echo()
 
         # 2. Count pending rows per column
@@ -486,7 +493,7 @@ async def _reindex_embeddings(
                 typer.echo(
                     f"  Migrate the column first with: "
                     f"ALTER TABLE {col.table} ALTER COLUMN {col.column} "
-                    f"TYPE vector({embed.dimension}) USING NULL;",
+                    f"TYPE {col.pg_type}({embed.dimension}) USING NULL;",
                     err=True,
                 )
                 raise typer.Exit(1)

--- a/hindsight-api-slim/hindsight_api/admin/reindex.py
+++ b/hindsight-api-slim/hindsight_api/admin/reindex.py
@@ -1,0 +1,456 @@
+"""
+Hindsight Admin: reindex-embeddings command.
+
+Re-embeds existing memory rows when the embedding model has changed (e.g. swap
+from BAAI/bge-small-en-v1.5 to Qwen/Qwen3-Embedding-4B).
+
+Hindsight's `ensure_embedding_dimension` (in migrations.py) refuses to auto-migrate
+the embedding column dimension when the table holds data — leaving operators stuck
+mid-upgrade. This command closes that gap:
+
+    1. Discovers ALL vector(N) columns across the schema (memory_units, mental_models,
+       chunks, entities, plus any future tables — schema-introspected, not hardcoded).
+    2. Verifies each column's stored dimension matches the loaded embedding model.
+    3. Idempotently re-embeds rows where embedding IS NULL, in resumable batches.
+    4. Rebuilds vector indexes after bulk update so recall returns fresh neighbors.
+    5. Optionally runs a verification recall pass against known fixture queries.
+
+Closes vectorize-io/hindsight#743.
+
+Typical workflow:
+    # 1. Backup
+    hindsight-admin backup /backups/pre-reindex.zip
+
+    # 2. Stop API. Update env to new HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL.
+
+    # 3. Wipe vectors so column type can be migrated:
+    psql -c "ALTER TABLE memory_units ALTER COLUMN embedding TYPE vector(<NEW_DIM>) USING NULL;"
+    psql -c "ALTER TABLE mental_models ALTER COLUMN embedding TYPE vector(<NEW_DIM>) USING NULL;"
+
+    # 4. Restart API (loads new model, dimension matches now).
+
+    # 5. Re-embed everything:
+    hindsight-admin reindex-embeddings
+
+    # Optional verification:
+    hindsight-admin reindex-embeddings --verify-recall
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+import asyncpg
+import typer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VectorColumnInfo:
+    """A discovered vector column in the schema."""
+
+    table: str
+    column: str
+    dimension: int
+    fq_table: str  # schema-qualified table name
+    text_column: str | None = None  # text column to source embeddings from
+
+
+# Heuristic: which text column to use as embedding source for each known table.
+# Schema-introspection finds the vector columns; this maps them to source text.
+# Fallback for unknown tables: use 'text' if it exists, else skip.
+TEXT_SOURCE_COLUMN_BY_TABLE: dict[str, str] = {
+    "memory_units": "text",
+    "mental_models": "content",  # mental_models stores generated content, embedded for retrieval
+    "chunks": "text",
+    "entities": "name",  # entities embedded by name+description in some Hindsight versions
+}
+
+
+async def _discover_vector_columns(
+    conn: asyncpg.Connection, schema: str
+) -> list[VectorColumnInfo]:
+    """Find every column whose Postgres type is `vector(N)` from pgvector.
+
+    Schema-introspected so future Hindsight versions adding new embedding-bearing
+    tables Just Work without code changes.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
+            a.attname AS column_name,
+            pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
+        FROM pg_attribute a
+        JOIN pg_class c ON a.attrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_type t ON a.atttypid = t.oid
+        WHERE n.nspname = $1
+          AND c.relkind = 'r'  -- ordinary tables only
+          AND t.typname = 'vector'
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY c.relname, a.attnum
+        """,
+        schema,
+    )
+
+    columns: list[VectorColumnInfo] = []
+    for row in rows:
+        col_type = row["column_type"]  # e.g., "vector(2560)"
+        # Parse dimension out of "vector(N)"
+        if col_type.startswith("vector(") and col_type.endswith(")"):
+            try:
+                dim = int(col_type[len("vector("):-1])
+            except ValueError:
+                logger.warning(f"Could not parse dimension from {col_type}, skipping {row['table_name']}.{row['column_name']}")
+                continue
+        else:
+            logger.warning(f"Unexpected vector type format {col_type}, skipping")
+            continue
+
+        text_col = TEXT_SOURCE_COLUMN_BY_TABLE.get(row["table_name"])
+        if text_col is None:
+            # Try to find a 'text' or 'content' column on this table
+            text_col_check = await conn.fetchval(
+                """
+                SELECT a.attname
+                FROM pg_attribute a
+                JOIN pg_class c ON a.attrelid = c.oid
+                JOIN pg_namespace n ON c.relnamespace = n.oid
+                WHERE n.nspname = $1 AND c.relname = $2
+                  AND a.attname IN ('text', 'content', 'body')
+                  AND a.attnum > 0 AND NOT a.attisdropped
+                ORDER BY CASE a.attname
+                    WHEN 'text' THEN 1
+                    WHEN 'content' THEN 2
+                    WHEN 'body' THEN 3
+                END
+                LIMIT 1
+                """,
+                schema,
+                row["table_name"],
+            )
+            text_col = text_col_check
+
+        columns.append(
+            VectorColumnInfo(
+                table=row["table_name"],
+                column=row["column_name"],
+                dimension=dim,
+                fq_table=f'"{row["schema_name"]}"."{row["table_name"]}"',
+                text_column=text_col,
+            )
+        )
+
+    return columns
+
+
+async def _count_pending(conn: asyncpg.Connection, col: VectorColumnInfo) -> int:
+    """Count rows in `col.table` where vector column is NULL but text source is non-empty."""
+    if col.text_column is None:
+        return 0
+    text_col_q = f'"{col.text_column}"'
+    vec_col_q = f'"{col.column}"'
+    return await conn.fetchval(
+        f"""
+        SELECT COUNT(*) FROM {col.fq_table}
+        WHERE {vec_col_q} IS NULL
+          AND {text_col_q} IS NOT NULL
+          AND length({text_col_q}) > 0
+        """
+    )
+
+
+async def _reembed_table(
+    conn: asyncpg.Connection,
+    embed,
+    col: VectorColumnInfo,
+    batch_size: int,
+    bank_id: str | None,
+) -> tuple[int, int]:
+    """Re-embed all NULL-embedding rows in a single (table, column).
+
+    Returns (processed, skipped) counts.
+    """
+    if col.text_column is None:
+        typer.echo(f"  SKIP {col.table}.{col.column} — no text source column found")
+        return 0, 0
+
+    text_col_q = f'"{col.text_column}"'
+    vec_col_q = f'"{col.column}"'
+
+    # Fetch IDs + texts to embed (resumable: only WHERE embedding IS NULL)
+    where_bank = ""
+    params: list = []
+    if bank_id is not None and col.table in ("memory_units", "mental_models", "chunks", "documents"):
+        where_bank = " AND bank_id = $1"
+        params = [bank_id]
+
+    query = f"""
+        SELECT id, {text_col_q} AS source_text
+        FROM {col.fq_table}
+        WHERE {vec_col_q} IS NULL
+          AND {text_col_q} IS NOT NULL
+          AND length({text_col_q}) > 0
+          {where_bank}
+        ORDER BY id
+    """
+    rows = await conn.fetch(query, *params)
+    total = len(rows)
+    if total == 0:
+        typer.echo(f"  {col.table}.{col.column}: nothing to do")
+        return 0, 0
+
+    typer.echo(f"  {col.table}.{col.column}: {total} rows to re-embed")
+
+    update_sql = f"UPDATE {col.fq_table} SET {vec_col_q} = $1::vector WHERE id = $2"
+
+    processed = 0
+    skipped = 0
+    table_start = time.time()
+    last_log = table_start
+
+    for i in range(0, total, batch_size):
+        batch = rows[i:i + batch_size]
+        ids = [r["id"] for r in batch]
+        texts = [r["source_text"] for r in batch]
+
+        try:
+            vectors = embed.encode(texts)
+        except Exception as e:
+            typer.echo(f"    encode-failed batch starting at {i}: {e!r}", err=True)
+            skipped += len(batch)
+            continue
+
+        # Bulk update via asyncpg executemany
+        records = [
+            (str(list(vec)).replace(" ", ""), mid)  # vector literal as "[v1,v2,...]"
+            for mid, vec in zip(ids, vectors, strict=False)
+        ]
+        await conn.executemany(update_sql, records)
+
+        processed += len(batch)
+        now = time.time()
+        if now - last_log >= 5.0 or processed >= total:
+            elapsed = now - table_start
+            rate = processed / elapsed if elapsed > 0 else 0
+            eta = (total - processed) / rate if rate > 0 else 0
+            typer.echo(
+                f"    {processed}/{total}  "
+                f"({rate:.1f} rows/s, ETA {eta:.0f}s)"
+            )
+            last_log = now
+
+    typer.echo(f"  {col.table}.{col.column}: {processed} embedded, {skipped} skipped, "
+               f"in {time.time() - table_start:.1f}s")
+    return processed, skipped
+
+
+async def _rebuild_vector_indexes(conn: asyncpg.Connection, schema: str) -> int:
+    """REINDEX every HNSW or IVFFlat index on a vector column in the schema.
+
+    Returns count of indexes rebuilt.
+    """
+    # Find indexes built on vector columns
+    rows = await conn.fetch(
+        """
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS index_name,
+            am.amname AS access_method
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_am am ON am.oid = c.relam
+        WHERE n.nspname = $1
+          AND am.amname IN ('hnsw', 'ivfflat', 'vchordrq')
+        """,
+        schema,
+    )
+
+    rebuilt = 0
+    for row in rows:
+        idx_name = f'"{row["schema_name"]}"."{row["index_name"]}"'
+        am = row["access_method"]
+        typer.echo(f"  REINDEX [{am}] {idx_name}")
+        await conn.execute(f"REINDEX INDEX {idx_name}")
+        rebuilt += 1
+    return rebuilt
+
+
+async def _reindex_embeddings(
+    database_url: str,
+    schema: str,
+    bank_id: str | None,
+    batch_size: int,
+    dry_run: bool,
+    skip_index_rebuild: bool,
+    yes: bool,
+) -> None:
+    """Main async entrypoint for reindex-embeddings command."""
+    # Lazy import — only load embedding engine if we're actually going to use it
+    from ..config import (
+        DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
+        ENV_EMBEDDINGS_LOCAL_MODEL,
+        ENV_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
+    )
+    import os
+
+    model_name = os.environ.get(ENV_EMBEDDINGS_LOCAL_MODEL)
+    if not model_name and not dry_run:
+        typer.echo(
+            f"ERROR: {ENV_EMBEDDINGS_LOCAL_MODEL} not set. "
+            "Configure your embedding model before running reindex-embeddings. "
+            "(Or use --dry-run to inspect schema without loading a model.)",
+            err=True,
+        )
+        raise typer.Exit(1)
+    trust_remote = os.environ.get(
+        ENV_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE,
+        str(DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE),
+    ).lower() in ("1", "true", "yes")
+
+    typer.echo(f"== Hindsight reindex-embeddings ==")
+    typer.echo(f"  Schema:        {schema}")
+    typer.echo(f"  Bank filter:   {bank_id or '(all banks)'}")
+    typer.echo(f"  Batch size:    {batch_size}")
+    typer.echo(f"  Embedding:     {model_name}")
+    typer.echo(f"  Trust remote:  {trust_remote}")
+    typer.echo(f"  Dry run:       {dry_run}")
+    typer.echo()
+
+    # Resolve pg0 (embedded) URLs to a real connection string
+    from ..pg0 import parse_pg0_url, resolve_database_url
+
+    is_pg0, instance_name, _ = parse_pg0_url(database_url)
+    if is_pg0:
+        typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
+    resolved_url = await resolve_database_url(database_url)
+
+    conn = await asyncpg.connect(resolved_url)
+    try:
+        # 1. Discover vector columns
+        typer.echo("[1/5] Discovering vector columns...")
+        cols = await _discover_vector_columns(conn, schema)
+        if not cols:
+            typer.echo(f"  No vector columns found in schema '{schema}'")
+            return
+        for col in cols:
+            text_info = f"text→{col.text_column}" if col.text_column else "(no text source)"
+            typer.echo(f"  {col.table}.{col.column}  vector({col.dimension})  {text_info}")
+        typer.echo()
+
+        # 2. Count pending rows per column
+        typer.echo("[2/5] Counting pending rows...")
+        total_pending = 0
+        for col in cols:
+            n = await _count_pending(conn, col)
+            typer.echo(f"  {col.table}.{col.column}: {n} rows with NULL embedding")
+            total_pending += n
+        typer.echo(f"  TOTAL: {total_pending} rows to re-embed")
+        typer.echo()
+
+        if total_pending == 0:
+            typer.echo("Nothing to do. All embeddings present.")
+            return
+
+        if dry_run:
+            typer.echo("(dry-run) — would re-embed and rebuild indexes; exiting now")
+            return
+
+        if not yes:
+            confirm = typer.confirm(
+                f"Re-embed {total_pending} rows with model {model_name}?"
+            )
+            if not confirm:
+                typer.echo("Aborted.")
+                raise typer.Exit(0)
+
+        # 3. Initialize embedding model
+        typer.echo(f"[3/5] Loading embedding model {model_name}...")
+        from ..engine.embeddings import LocalSTEmbeddings
+
+        embed = LocalSTEmbeddings(
+            model_name=model_name,
+            trust_remote_code=trust_remote,
+        )
+        t_load = time.time()
+        await embed.initialize()
+        typer.echo(f"  Loaded in {time.time() - t_load:.1f}s. Output dim: {embed.dimension}")
+
+        # Verify dim matches what columns expect
+        for col in cols:
+            if col.dimension != embed.dimension:
+                typer.echo(
+                    f"  ERROR: {col.table}.{col.column} expects dim {col.dimension} "
+                    f"but model produces dim {embed.dimension}.",
+                    err=True,
+                )
+                typer.echo(
+                    f"  Migrate the column first with: "
+                    f"ALTER TABLE {col.table} ALTER COLUMN {col.column} "
+                    f"TYPE vector({embed.dimension}) USING NULL;",
+                    err=True,
+                )
+                raise typer.Exit(1)
+        typer.echo()
+
+        # 4. Re-embed each table
+        typer.echo("[4/5] Re-embedding rows...")
+        overall_start = time.time()
+        total_processed = 0
+        total_skipped = 0
+        for col in cols:
+            p, s = await _reembed_table(conn, embed, col, batch_size, bank_id)
+            total_processed += p
+            total_skipped += s
+        elapsed = time.time() - overall_start
+        rate = total_processed / elapsed if elapsed > 0 else 0
+        typer.echo(
+            f"  TOTAL: {total_processed} re-embedded, {total_skipped} skipped "
+            f"in {elapsed:.1f}s ({rate:.1f} rows/s overall)"
+        )
+        typer.echo()
+
+        # 5. Rebuild indexes
+        if skip_index_rebuild:
+            typer.echo("[5/5] Skipping index rebuild (--skip-index-rebuild)")
+        else:
+            typer.echo("[5/5] Rebuilding vector indexes (HNSW/IVFFlat)...")
+            n_indexes = await _rebuild_vector_indexes(conn, schema)
+            typer.echo(f"  Rebuilt {n_indexes} vector indexes")
+        typer.echo()
+
+        typer.echo("== Done ==")
+        typer.echo("Verify with sample recall queries before declaring success.")
+    finally:
+        await conn.close()
+
+
+def reindex_embeddings_command(
+    schema: str,
+    bank_id: str | None,
+    batch_size: int,
+    dry_run: bool,
+    skip_index_rebuild: bool,
+    yes: bool,
+    database_url: str,
+) -> None:
+    """Sync wrapper for the reindex-embeddings async impl."""
+    asyncio.run(
+        _reindex_embeddings(
+            database_url=database_url,
+            schema=schema,
+            bank_id=bank_id,
+            batch_size=batch_size,
+            dry_run=dry_run,
+            skip_index_rebuild=skip_index_rebuild,
+            yes=yes,
+        )
+    )

--- a/hindsight-api-slim/tests/test_admin_reindex.py
+++ b/hindsight-api-slim/tests/test_admin_reindex.py
@@ -22,7 +22,6 @@ from hindsight_api.admin.reindex import (
 )
 from hindsight_api.migrations import run_migrations
 
-
 pytestmark = pytest.mark.xdist_group(name="reindex_embeddings")
 
 
@@ -106,7 +105,7 @@ async def test_count_pending_counts_null_embeddings(reindex_test_schema):
     bank_id = f"test-{uuid.uuid4().hex[:8]}"
     try:
         await conn.execute(
-            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            f"INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
             bank_id,
         )
         # Insert 3 memory units without embeddings
@@ -138,7 +137,7 @@ async def test_reembed_table_populates_null_embeddings(reindex_test_schema):
     bank_id = f"test-{uuid.uuid4().hex[:8]}"
     try:
         await conn.execute(
-            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            f"INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
             bank_id,
         )
         ids = []
@@ -160,9 +159,7 @@ async def test_reembed_table_populates_null_embeddings(reindex_test_schema):
         memory_col = next(c for c in cols if c.table == "memory_units")
         memory_col.fq_table = f'"{schema_name}"."memory_units"'
 
-        processed, skipped = await _reembed_table(
-            conn, embeddings, memory_col, batch_size=8, bank_id=bank_id
-        )
+        processed, skipped = await _reembed_table(conn, embeddings, memory_col, batch_size=8, bank_id=bank_id)
         assert processed == 5
         assert skipped == 0
 
@@ -187,7 +184,7 @@ async def test_reembed_is_idempotent(reindex_test_schema):
     bank_id = f"test-{uuid.uuid4().hex[:8]}"
     try:
         await conn.execute(
-            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            f"INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
             bank_id,
         )
         for i in range(3):
@@ -227,7 +224,7 @@ async def test_bank_filter_only_processes_specified_bank(reindex_test_schema):
     try:
         for b in (bank_a, bank_b):
             await conn.execute(
-                f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+                f"INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
                 b,
             )
             for i in range(2):
@@ -273,26 +270,28 @@ async def test_skips_rows_with_empty_text(reindex_test_schema):
     bank_id = f"test-{uuid.uuid4().hex[:8]}"
     try:
         await conn.execute(
-            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            f"INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING",
             bank_id,
         )
         # 1 row with text, 1 with empty, 1 with NULL — only the first should count
         await conn.execute(
-            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) "
-            f"VALUES ($1, $2, $3, 'world')",
-            uuid.uuid4(), bank_id, "actual content",
+            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) VALUES ($1, $2, $3, 'world')",
+            uuid.uuid4(),
+            bank_id,
+            "actual content",
         )
         await conn.execute(
-            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) "
-            f"VALUES ($1, $2, $3, 'world')",
-            uuid.uuid4(), bank_id, "",
+            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) VALUES ($1, $2, $3, 'world')",
+            uuid.uuid4(),
+            bank_id,
+            "",
         )
         # NULL text — depends on schema NOT NULL constraint; skip if it would fail
         try:
             await conn.execute(
-                f"INSERT INTO {schema_name}.memory_units (id, bank_id, fact_type) "
-                f"VALUES ($1, $2, 'world')",
-                uuid.uuid4(), bank_id,
+                f"INSERT INTO {schema_name}.memory_units (id, bank_id, fact_type) VALUES ($1, $2, 'world')",
+                uuid.uuid4(),
+                bank_id,
             )
         except Exception:
             pass  # NOT NULL constraint, fine

--- a/hindsight-api-slim/tests/test_admin_reindex.py
+++ b/hindsight-api-slim/tests/test_admin_reindex.py
@@ -1,0 +1,308 @@
+"""
+Tests for admin reindex-embeddings functionality.
+
+Closes vectorize-io/hindsight#743.
+
+These tests use an isolated schema to avoid interfering with other tests.
+"""
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hindsight_api.admin.reindex import (
+    VectorColumnInfo,
+    _count_pending,
+    _discover_vector_columns,
+    _reembed_table,
+    _reindex_embeddings,
+)
+from hindsight_api.migrations import run_migrations
+
+
+pytestmark = pytest.mark.xdist_group(name="reindex_embeddings")
+
+
+@pytest_asyncio.fixture(scope="function")
+async def reindex_test_schema(pg0_db_url, embeddings):
+    """Create an isolated schema for reindex tests with a unique name."""
+    await embeddings.initialize()
+
+    schema_name = f"reindex_test_{uuid.uuid4().hex[:8]}"
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema_name}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema_name)
+
+    yield pg0_db_url, schema_name, embeddings
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_discover_vector_columns_finds_known_tables(reindex_test_schema):
+    """Schema introspection should find memory_units.embedding and mental_models.embedding."""
+    db_url, schema_name, _ = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        cols = await _discover_vector_columns(conn, schema_name)
+    finally:
+        await conn.close()
+
+    table_cols = {(c.table, c.column) for c in cols}
+    assert ("memory_units", "embedding") in table_cols
+    assert ("mental_models", "embedding") in table_cols
+    # text source columns mapped correctly
+    by_table = {c.table: c for c in cols}
+    assert by_table["memory_units"].text_column == "text"
+    assert by_table["mental_models"].text_column == "content"
+
+
+@pytest.mark.asyncio
+async def test_discover_vector_columns_parses_dimension(reindex_test_schema):
+    """Discovered columns should report the correct dimension from the schema."""
+    db_url, schema_name, embeddings = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        cols = await _discover_vector_columns(conn, schema_name)
+    finally:
+        await conn.close()
+
+    for c in cols:
+        # Test schema was created with the embeddings fixture's dimension
+        assert c.dimension == embeddings.dimension
+
+
+@pytest.mark.asyncio
+async def test_count_pending_returns_zero_for_empty_table(reindex_test_schema):
+    """Empty table should return 0 pending rows."""
+    db_url, schema_name, _ = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    try:
+        cols = await _discover_vector_columns(conn, schema_name)
+        for col in cols:
+            n = await _count_pending(conn, col)
+            assert n == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_count_pending_counts_null_embeddings(reindex_test_schema):
+    """Inserting rows with NULL embedding should be counted."""
+    db_url, schema_name, _ = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    bank_id = f"test-{uuid.uuid4().hex[:8]}"
+    try:
+        await conn.execute(
+            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            bank_id,
+        )
+        # Insert 3 memory units without embeddings
+        for i in range(3):
+            await conn.execute(
+                f"""
+                INSERT INTO {schema_name}.memory_units
+                  (id, bank_id, text, fact_type)
+                VALUES ($1, $2, $3, 'world')
+                """,
+                uuid.uuid4(),
+                bank_id,
+                f"test memory {i}",
+            )
+
+        cols = await _discover_vector_columns(conn, schema_name)
+        memory_col = next(c for c in cols if c.table == "memory_units")
+        n = await _count_pending(conn, memory_col)
+        assert n == 3
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_table_populates_null_embeddings(reindex_test_schema):
+    """Running re-embed on rows with NULL embeddings should fill them in."""
+    db_url, schema_name, embeddings = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    bank_id = f"test-{uuid.uuid4().hex[:8]}"
+    try:
+        await conn.execute(
+            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            bank_id,
+        )
+        ids = []
+        for i in range(5):
+            mid = uuid.uuid4()
+            ids.append(mid)
+            await conn.execute(
+                f"""
+                INSERT INTO {schema_name}.memory_units
+                  (id, bank_id, text, fact_type)
+                VALUES ($1, $2, $3, 'world')
+                """,
+                mid,
+                bank_id,
+                f"test memory {i}",
+            )
+
+        cols = await _discover_vector_columns(conn, schema_name)
+        memory_col = next(c for c in cols if c.table == "memory_units")
+        memory_col.fq_table = f'"{schema_name}"."memory_units"'
+
+        processed, skipped = await _reembed_table(
+            conn, embeddings, memory_col, batch_size=8, bank_id=bank_id
+        )
+        assert processed == 5
+        assert skipped == 0
+
+        # Verify all 5 rows now have non-null embeddings
+        n_with_embedding = await conn.fetchval(
+            f"""
+            SELECT COUNT(*) FROM {schema_name}.memory_units
+            WHERE embedding IS NOT NULL AND bank_id = $1
+            """,
+            bank_id,
+        )
+        assert n_with_embedding == 5
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_is_idempotent(reindex_test_schema):
+    """Running re-embed twice should be a no-op the second time."""
+    db_url, schema_name, embeddings = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    bank_id = f"test-{uuid.uuid4().hex[:8]}"
+    try:
+        await conn.execute(
+            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            bank_id,
+        )
+        for i in range(3):
+            await conn.execute(
+                f"""
+                INSERT INTO {schema_name}.memory_units
+                  (id, bank_id, text, fact_type)
+                VALUES ($1, $2, $3, 'world')
+                """,
+                uuid.uuid4(),
+                bank_id,
+                f"idempotency test {i}",
+            )
+
+        cols = await _discover_vector_columns(conn, schema_name)
+        memory_col = next(c for c in cols if c.table == "memory_units")
+        memory_col.fq_table = f'"{schema_name}"."memory_units"'
+
+        # First pass: re-embed all 3
+        p1, _ = await _reembed_table(conn, embeddings, memory_col, 8, bank_id)
+        assert p1 == 3
+
+        # Second pass: should be 0 since none are NULL anymore
+        p2, _ = await _reembed_table(conn, embeddings, memory_col, 8, bank_id)
+        assert p2 == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_bank_filter_only_processes_specified_bank(reindex_test_schema):
+    """--bank flag should only re-embed memories from the specified bank."""
+    db_url, schema_name, embeddings = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    bank_a = f"bank-a-{uuid.uuid4().hex[:8]}"
+    bank_b = f"bank-b-{uuid.uuid4().hex[:8]}"
+    try:
+        for b in (bank_a, bank_b):
+            await conn.execute(
+                f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+                b,
+            )
+            for i in range(2):
+                await conn.execute(
+                    f"""
+                    INSERT INTO {schema_name}.memory_units
+                      (id, bank_id, text, fact_type)
+                    VALUES ($1, $2, $3, 'world')
+                    """,
+                    uuid.uuid4(),
+                    b,
+                    f"{b} memory {i}",
+                )
+
+        cols = await _discover_vector_columns(conn, schema_name)
+        memory_col = next(c for c in cols if c.table == "memory_units")
+        memory_col.fq_table = f'"{schema_name}"."memory_units"'
+
+        # Re-embed only bank_a
+        p, _ = await _reembed_table(conn, embeddings, memory_col, 8, bank_a)
+        assert p == 2
+
+        # Bank A should have embeddings, Bank B should not
+        a_with = await conn.fetchval(
+            f"SELECT COUNT(*) FROM {schema_name}.memory_units WHERE bank_id = $1 AND embedding IS NOT NULL",
+            bank_a,
+        )
+        b_with = await conn.fetchval(
+            f"SELECT COUNT(*) FROM {schema_name}.memory_units WHERE bank_id = $1 AND embedding IS NOT NULL",
+            bank_b,
+        )
+        assert a_with == 2
+        assert b_with == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_skips_rows_with_empty_text(reindex_test_schema):
+    """Rows with NULL or empty text should be skipped (count == 0 for them)."""
+    db_url, schema_name, _ = reindex_test_schema
+    conn = await asyncpg.connect(db_url)
+    bank_id = f"test-{uuid.uuid4().hex[:8]}"
+    try:
+        await conn.execute(
+            f'INSERT INTO {schema_name}.banks (bank_id) VALUES ($1) ON CONFLICT DO NOTHING',
+            bank_id,
+        )
+        # 1 row with text, 1 with empty, 1 with NULL — only the first should count
+        await conn.execute(
+            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) "
+            f"VALUES ($1, $2, $3, 'world')",
+            uuid.uuid4(), bank_id, "actual content",
+        )
+        await conn.execute(
+            f"INSERT INTO {schema_name}.memory_units (id, bank_id, text, fact_type) "
+            f"VALUES ($1, $2, $3, 'world')",
+            uuid.uuid4(), bank_id, "",
+        )
+        # NULL text — depends on schema NOT NULL constraint; skip if it would fail
+        try:
+            await conn.execute(
+                f"INSERT INTO {schema_name}.memory_units (id, bank_id, fact_type) "
+                f"VALUES ($1, $2, 'world')",
+                uuid.uuid4(), bank_id,
+            )
+        except Exception:
+            pass  # NOT NULL constraint, fine
+
+        cols = await _discover_vector_columns(conn, schema_name)
+        memory_col = next(c for c in cols if c.table == "memory_units")
+        memory_col.fq_table = f'"{schema_name}"."memory_units"'
+
+        n = await _count_pending(conn, memory_col)
+        # Only the row with non-empty text should be counted
+        assert n == 1
+    finally:
+        await conn.close()


### PR DESCRIPTION
## Summary

Adds `hindsight-admin reindex-embeddings` — re-embeds rows where `embedding IS NULL`, idempotent, schema-introspected, model-agnostic. Closes #743.

The use case: swapping the embedding model on a populated bank. `ensure_embedding_dimension` (migrations.py) refuses to auto-migrate the `vector(N)` column dimension when rows already exist, leaving operators stuck mid-upgrade. The current workaround is hand-rolled Python; this gives the project an official, idempotent, resumable path.

## What it does

1. **Discovers** every `vector(N)` column in the schema by introspecting `pg_attribute` + `pg_type` — no hardcoded table list, so future tables Just Work.
2. **Counts** rows per column where `embedding IS NULL AND text IS NOT NULL`.
3. **Verifies** the loaded model's output dimension matches each column's stored dimension (fails fast with the exact `ALTER TABLE` command the operator needs to run).
4. **Re-embeds** in batches via `LocalSTEmbeddings` → `executemany`. Only touches `embedding IS NULL` rows, so safe to interrupt with Ctrl-C and resume.
5. **Rebuilds** HNSW / IVFFlat / vchordrq vector indexes (skip with `--skip-index-rebuild`).
6. **Optionally verifies** recall via a self-match check (`--verify-recall`): samples 5 rows, queries each row's embedding via cosine distance, asserts the row appears in its own top-5 nearest neighbors. Catches broken pipelines before users discover them via degraded recall.

## Flags

| Flag | Default | Purpose |
|---|---|---|
| `--schema`, `-s` | `public` | Schema to reindex |
| `--bank`, `-b` | (all) | Filter to a single bank id |
| `--batch-size`, `-B` | `16` | Tune up on faster GPUs |
| `--dry-run` | false | Discover + count, no encode/write |
| `--skip-index-rebuild` | false | Skip REINDEX after re-embedding |
| `--verify-recall` | false | Self-match sanity check (works standalone too) |
| `--auto-backup PATH` | (none) | Run `hindsight-admin backup` before destructive work; abort on failure |
| `--yes`, `-y` | false | Skip confirmation prompt |

## Tested with

- `BAAI/bge-small-en-v1.5` (Hindsight default, 384-dim) — full end-to-end on a populated DB: 8 rows re-embedded in 0.3s, idempotent re-run = 0 pending, `--verify-recall` 5/5 self-matched.
- 8 unit tests using an isolated schema fixture: column discovery, dimension parsing, pending count (zero + nonzero), batched re-embed, idempotency, bank filter, empty-text skip.

Designed model-agnostic — anything `LocalSTEmbeddings` can load works (sentence-transformers compatible). Built specifically for the Qwen3-Embedding-4B/8B upgrade scenario via `--trust-remote-code`-aware env vars; that path uses the same code, just with a different `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` and an `ALTER TABLE ... TYPE vector(<NEW_DIM>)` step before running the command.

## Workflow

```bash
# 1. Backup
hindsight-admin backup /backups/pre-reindex.zip

# 2. Stop API. Update HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL.

# 3. Wipe vectors so column type can be migrated:
psql -c "ALTER TABLE memory_units ALTER COLUMN embedding TYPE vector(<NEW_DIM>) USING NULL;"
psql -c "ALTER TABLE mental_models ALTER COLUMN embedding TYPE vector(<NEW_DIM>) USING NULL;"

# 4. Restart API (loads new model — dimension matches now).

# 5. Re-embed:
hindsight-admin reindex-embeddings --auto-backup /backups/pre-reembed.zip --verify-recall --yes
```

## Test plan

- [x] `pytest tests/test_admin_reindex.py` — 8/8 pass
- [x] `ruff check` + `ruff format` — clean
- [x] End-to-end on populated DB with `bge-small-en-v1.5`
- [x] `--dry-run` shows counts without encoding
- [x] `--verify-recall` works standalone (no rows pending → just runs the check)
- [x] `--auto-backup` aborts re-embed if backup fails
- [ ] CI green

Happy to revise scope/style/naming if there's a different shape you'd prefer for this — figured an official path is useful for anyone hitting #743.