### PR TITLE
fix(embed): satisfy ty on Windows-only subprocess attrs

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -51,8 +51,13 @@ def _detach_popen_kwargs(log_handle) -> dict:
     POSIX child inherits the parent's fds (legacy daemon-spawn behavior).
     """
     if platform.system() == "Windows":
+        # Windows-only constants; use getattr so type checkers (e.g. ty) running
+        # on Linux don't flag the attribute access. They're guaranteed present
+        # at runtime because of the platform.system() guard above.
+        detached_process = getattr(subprocess, "DETACHED_PROCESS", 0)
+        create_new_process_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
         return {
-            "creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+            "creationflags": detached_process | create_new_process_group,
             "stdin": subprocess.DEVNULL,
             "stdout": log_handle,
             "stderr": subprocess.STDOUT,


### PR DESCRIPTION
## Summary

`verify-generated-files` (the \`ty-embed\` lint job) currently fails on \`main\` because \`hindsight_embed/daemon_embed_manager.py:55\` references \`subprocess.DETACHED_PROCESS\` and \`subprocess.CREATE_NEW_PROCESS_GROUP\` — both **Windows-only** constants.

The code is already guarded with \`if platform.system() == \"Windows\":\` at line 53, so the attributes are never accessed on Linux/macOS at runtime. But \`ty\`'s static analysis doesn't track platform-conditional branches, so on the Linux CI runner it flags both as \`unresolved-attribute\` and the job fails.

## Fix

Use \`getattr(subprocess, \"DETACHED_PROCESS\", 0)\` to avoid the static-analysis false positive while preserving identical runtime behavior on Windows. Same pattern documented in [cpython subprocess docs](https://docs.python.org/3/library/subprocess.html#windows-constants) and widely used in cross-platform Python codebases.

## Why a separate PR

Spotted while debugging CI on #1258 (reindex-embeddings). That PR doesn't touch \`hindsight_embed/\` at all — its failing CI is the same unrelated pre-existing issue. Sending the lint fix as its own focused commit so:

- It can land independently (or be cherry-picked)
- #1258 doesn't have to bundle a sibling-package fix as scope creep
- The diff stays trivially reviewable (one-line behavior swap, plus a comment explaining why)

After this lands, #1258's CI should go green on rebase.

## Test plan

- [x] Manual: \`ty check hindsight_embed/daemon_embed_manager.py\` no longer flags those lines
- [x] Runtime: Windows daemon spawn behavior unchanged (\`DETACHED_PROCESS\` and \`CREATE_NEW_PROCESS_GROUP\` are still passed as the same integer values when present, which they always are on Windows)
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>