### PR TITLE
docs(blog): align retainEveryNTurns default with #1186 (10 → 3)

### DIFF
--- a/hindsight-docs/blog/2026-04-20-opencode-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-20-opencode-persistent-memory.md
@@ -132,7 +132,7 @@ Here's the lifecycle of a session with the plugin active:
 4. **Session idles** — the `session.idle` event triggers auto-retain of the conversation transcript
 5. **Context compaction** — if the context window fills up, the plugin retains the current conversation and injects recalled memories into the compaction context, so nothing important is lost
 
-The auto-retain uses a sliding window controlled by `retainEveryNTurns` (default: 10). This prevents redundant storage while keeping recent context fresh.
+The auto-retain uses a sliding window controlled by `retainEveryNTurns` (default: 3). This prevents redundant storage while keeping recent context fresh.
 
 ---
 
@@ -167,7 +167,7 @@ You can configure the plugin at three levels (later wins):
 | `autoRecall` | `true` | Inject memories on session start |
 | `autoRetain` | `true` | Capture conversation on idle |
 | `recallBudget` | `mid` | How many memories to retrieve: `low`, `mid`, `high` |
-| `retainEveryNTurns` | `10` | Auto-retain frequency (user turns) |
+| `retainEveryNTurns` | `3` | Auto-retain frequency (user turns) |
 | `retainMode` | `full-session` | `full-session` upserts the whole conversation; `last-turn` creates chunked windows |
 | `bankMission` | *(none)* | Guides what Hindsight extracts and how it reflects |
 | `dynamicBankId` | `false` | Derive bank ID from project/agent context |


### PR DESCRIPTION
The OpenCode persistent-memory blog post still documents `retainEveryNTurns` default as `10` in two places (prose and the config table), but #1186 (DK09876, merged 2026-04-22) lowered the source default to `3`. Source of truth (`hindsight-integrations/opencode/src/config.ts:71`):

```ts
retainEveryNTurns: 3,
```

The companion `hindsight-docs/docs-integrations/opencode.md` was updated to `3` in #1186; this blog post was missed.

Aligning two `10` references to `3`:
- L135 prose `(default: 10)` → `(default: 3)`
- L170 config table row `\`10\`` → `\`3\``

Pure docs, no behavior change.