### PR TITLE
fix(reflect): include tagged directives in isolation_mode when caller passed no tags

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5901,10 +5901,12 @@ class MemoryEngine(MemoryEngineInterface):
             async with pool.acquire() as conn:
                 return await tool_expand(conn, bank_id, memory_ids, depth)
 
-        # Load directives from the dedicated directives table
-        # Directives are hard rules that must be followed in all responses
-        # Use isolation_mode=True to prevent tag-scoped directives from leaking into untagged operations
-        # Use the same tags_match as the reflect request so directives respect the same scoping rules
+        # Load directives from the dedicated directives table.
+        # Directives are hard rules that must be followed in all responses.
+        # When the reflect call passes tags, list_directives OR-merges untagged directives
+        # with directives matching those tags (preventing cross-tag leakage). When tags is
+        # None, every active directive is loaded.
+        # Use the same tags_match as the reflect request so directives respect the same scoping rules.
         directives_raw = await self.list_directives(
             bank_id=bank_id,
             tags=tags,
@@ -7890,9 +7892,11 @@ class MemoryEngine(MemoryEngineInterface):
             limit: Maximum number of results
             offset: Offset for pagination
             request_context: Request context for authentication
-            isolation_mode: When True and tags=None, only return directives with no tags.
-                This prevents tag-scoped directives from leaking into untagged operations.
-                Default False (normal API behavior - returns all directives when tags=None)
+            isolation_mode: Retained for backwards compatibility. Currently a no-op:
+                an untagged caller (tags=None) has no tag scope to leak across, so all
+                active directives are returned regardless of this flag. Cross-tag leakage
+                prevention is handled by the tagged branch (tags!=None), which OR-merges
+                untagged directives with tag-matched ones. Default False.
 
         Returns:
             List of directive dicts
@@ -7918,8 +7922,11 @@ class MemoryEngine(MemoryEngineInterface):
             # Directives have special scoping rules:
             #   - Untagged directives (tags=[] or null) always apply regardless of reflect tags
             #   - Tagged directives only apply when the reflect operation includes matching tags
-            #   - If tags=None and isolation_mode=True: only untagged directives (no leakage)
-            #   - If tags=None and isolation_mode=False: all directives (normal API behavior)
+            #   - If tags=None: include all active directives. The tagged branch above already
+            #     prevents cross-tag leakage by OR-merging untagged directives with tag-matched
+            #     ones; an untagged caller has no tag scope to leak across, so isolation_mode
+            #     is a no-op here. (Previously this branch filtered to untagged-only, which
+            #     silently dropped every directive that had any tag — see issue #1269.)
             if tags:
                 tags_clause, tags_params, param_idx = build_tags_where_clause(
                     tags=tags, param_offset=param_idx, table_alias="", match=tags_match
@@ -7929,10 +7936,6 @@ class MemoryEngine(MemoryEngineInterface):
                     scoped_clause = tags_clause.replace("AND ", "", 1)
                     filters.append(f"((tags IS NULL OR tags = '{{}}') OR ({scoped_clause}))")
                     params.extend(tags_params)
-            elif isolation_mode:
-                # Isolation mode: only include directives with empty/null tags
-                # This ensures tag-scoped directives don't apply to untagged operations
-                filters.append("(tags IS NULL OR tags = '{}')")
 
             params.extend([limit, offset])
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -356,6 +356,56 @@ class TestDirectiveTags:
         # Cleanup
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_list_directives_isolation_mode_includes_tagged_when_no_tags(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Regression test for issue #1269.
+
+        When list_directives is called with tags=None and isolation_mode=True
+        (the path reflect always takes), every active directive should be
+        returned — both untagged and tagged. Previously the isolation branch
+        applied a (tags IS NULL OR tags = '{}') filter that silently dropped
+        every directive with at least one tag, which made `reflect` ignore all
+        tagged directives without warning.
+        """
+        bank_id = f"test-directive-isolation-untagged-{uuid.uuid4().hex[:8]}"
+
+        # Ensure bank exists
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        # Create one untagged and one tagged directive.
+        await memory.create_directive(
+            bank_id=bank_id,
+            name="Untagged Directive",
+            content="Untagged rule",
+            request_context=request_context,
+        )
+        await memory.create_directive(
+            bank_id=bank_id,
+            name="Tagged Directive",
+            content="Tagged rule",
+            tags=["safety"],
+            request_context=request_context,
+        )
+
+        # Untagged caller in isolation mode should still see every active directive;
+        # there is no tag scope to leak across.
+        results = await memory.list_directives(
+            bank_id=bank_id,
+            request_context=request_context,
+            isolation_mode=True,
+        )
+
+        names = {d["name"] for d in results}
+        assert "Untagged Directive" in names
+        assert "Tagged Directive" in names, (
+            "Tagged directive was silently dropped under isolation_mode with no caller tags "
+            "(see issue #1269)."
+        )
+
+        # Cleanup
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 class TestReflect:
     """Test reflect endpoint."""


### PR DESCRIPTION
## Summary

Closes #1269.

`reflect` calls `list_directives(..., isolation_mode=True)` and forwards its own `tags` argument (which is `None` when the caller didn't pass tags). The `isolation_mode` branch in `list_directives` filters to `(tags IS NULL OR tags = '{}')`, silently dropping every directive that has at least one tag. The result: `reflect` quietly ignores all tagged directives on banks that mix tagged and untagged directives — `directives_applied` is empty, the synthesised text doesn't honor the rules, and there is no error or warning.

The intent of `isolation_mode` was to prevent cross-tag leakage, but an untagged caller has no tag scope to leak across. Cross-tag leakage prevention is already correctly implemented in the tagged branch above, which OR-merges untagged directives with tag-matched ones. So the fix is to drop the filter in the isolation branch when the caller passed no tags.

## Before / After

```diff
-            elif isolation_mode:
-                # Isolation mode: only include directives with empty/null tags
-                # This ensures tag-scoped directives don't apply to untagged operations
-                filters.append("(tags IS NULL OR tags = '{}')")
+            # If tags=None: include all active directives. The tagged branch above already
+            # prevents cross-tag leakage by OR-merging untagged directives with tag-matched
+            # ones; an untagged caller has no tag scope to leak across, so isolation_mode
+            # is a no-op here. (Previously this branch filtered to untagged-only, which
+            # silently dropped every directive that had any tag — see issue #1269.)
```

The `isolation_mode` parameter is preserved on `list_directives` for backwards compatibility; its docstring is updated to reflect that it is now a no-op for untagged callers. The misleading comment at the `reflect` call site is also updated. No callers or behaviour change for the tagged path.

## Regression test

Added `TestDirectiveTags::test_list_directives_isolation_mode_includes_tagged_when_no_tags` in `hindsight-api-slim/tests/test_mental_models.py`. It creates one untagged and one tagged directive, then calls `list_directives(tags=None, isolation_mode=True)` and asserts both directives are returned. Without the fix this test fails because the tagged directive is dropped.

## Verification

I was not able to run the test suite locally — the test harness boots an embedded Postgres (pg0) and pulls the full `hindsight-api-slim[all]` extras via `uv sync`, which exceeded the time budget I had for this PR. The change itself is one logical line (and a comment/docstring refresh); reviewers should run `uv run pytest hindsight-api-slim/tests/test_mental_models.py -k isolation_mode` locally to confirm.

## Why we care

We're a downstream consumer in the switchroom agent framework that relies on `reflect` honouring directives. We've shipped a proxy workaround on our side, but we'd like to delete it once a fixed image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>