### PR TITLE
fix(consolidation): reduce memory fan-out during consolidation recall

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1667,9 +1667,7 @@ class HindsightConfig:
             consolidation_max_tokens=int(
                 os.getenv(ENV_CONSOLIDATION_MAX_TOKENS, str(DEFAULT_CONSOLIDATION_MAX_TOKENS))
             ),
-            consolidation_recall_budget=os.getenv(
-                ENV_CONSOLIDATION_RECALL_BUDGET, DEFAULT_CONSOLIDATION_RECALL_BUDGET
-            ),
+            consolidation_recall_budget=os.getenv(ENV_CONSOLIDATION_RECALL_BUDGET, DEFAULT_CONSOLIDATION_RECALL_BUDGET),
             consolidation_source_facts_max_tokens=int(
                 os.getenv(ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS, str(DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS))
             ),

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -245,6 +245,7 @@ ENV_RERANKER_TEI_HTTP_TIMEOUT = "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT"
 ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
+ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA = "HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA"
 
 # ZeroEntropy configuration (reranker only)
 ENV_RERANKER_ZEROENTROPY_API_KEY = "HINDSIGHT_API_RERANKER_ZEROENTROPY_API_KEY"
@@ -345,6 +346,7 @@ ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS = "HINDSIGHT_API_CONSOLIDATION_SOURCE_
 ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
     "HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION"
 )
+ENV_CONSOLIDATION_RECALL_BUDGET = "HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET"
 ENV_CONSOLIDATION_MAX_ATTEMPTS = "HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS"
 ENV_OBSERVATIONS_MISSION = "HINDSIGHT_API_OBSERVATIONS_MISSION"
 ENV_MAX_OBSERVATIONS_PER_SCOPE = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE"
@@ -505,6 +507,7 @@ DEFAULT_RERANKER_TEI_HTTP_TIMEOUT = 30.0  # HTTP timeout for TEI reranker reques
 DEFAULT_RERANKER_MAX_CANDIDATES = 300
 DEFAULT_RERANKER_FLASHRANK_MODEL = "ms-marco-MiniLM-L-12-v2"  # Best balance of speed and quality
 DEFAULT_RERANKER_FLASHRANK_CACHE_DIR = None  # Use default cache directory
+DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA = False  # Disable ONNX CPU memory arena to bound RSS
 
 DEFAULT_EMBEDDINGS_COHERE_MODEL = "embed-english-v3.0"
 DEFAULT_RERANKER_COHERE_MODEL = "rerank-english-v3.0"
@@ -594,9 +597,10 @@ DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = (
 )
 DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 8  # Facts per LLM call (1 = no batching; >1 = batch mode)
 DEFAULT_CONSOLIDATION_MAX_TOKENS = 512  # Max tokens for recall when finding related observations
+DEFAULT_CONSOLIDATION_RECALL_BUDGET = "low"  # Budget level for consolidation recall (low/mid/high)
 DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS = (
-    -1
-)  # Total token budget for source facts in consolidation recall (-1 = unlimited)
+    4096  # Total token budget for source facts in consolidation recall (-1 = unlimited)
+)
 DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
     256  # Max tokens of source facts per observation in consolidation prompt (-1 = unlimited)
 )
@@ -1018,6 +1022,7 @@ class HindsightConfig:
     consolidation_max_memories_per_round: int
     consolidation_llm_batch_size: int
     consolidation_max_tokens: int
+    consolidation_recall_budget: str
     consolidation_source_facts_max_tokens: int
     consolidation_source_facts_max_tokens_per_observation: int
     consolidation_max_attempts: int
@@ -1661,6 +1666,9 @@ class HindsightConfig:
             ),
             consolidation_max_tokens=int(
                 os.getenv(ENV_CONSOLIDATION_MAX_TOKENS, str(DEFAULT_CONSOLIDATION_MAX_TOKENS))
+            ),
+            consolidation_recall_budget=os.getenv(
+                ENV_CONSOLIDATION_RECALL_BUDGET, DEFAULT_CONSOLIDATION_RECALL_BUDGET
             ),
             consolidation_source_facts_max_tokens=int(
                 os.getenv(ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS, str(DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS))

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, field_validator
 
 from ...config import get_config
 from ..llm_wrapper import sanitize_llm_output
-from ..memory_engine import fq_table
+from ..memory_engine import Budget, fq_table
 from ..retain import embedding_utils
 from .prompts import build_batch_consolidation_prompt
 
@@ -1138,10 +1138,14 @@ async def _find_related_observations(
     else:
         recall_span = None
 
+    # Resolve budget: consolidation doesn't need deep recall, default to LOW to reduce memory fan-out
+    recall_budget = Budget(config.consolidation_recall_budget)
+
     try:
         recall_result = await memory_engine.recall_async(
             bank_id=bank_id,
             query=query,
+            budget=recall_budget,
             max_tokens=config.consolidation_max_tokens,  # Token budget for observations (configurable)
             fact_type=["observation"],  # Only retrieve observations
             request_context=request_context,

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -19,6 +19,7 @@ from ..config import (
     DEFAULT_LITELLM_API_BASE,
     DEFAULT_RERANKER_COHERE_MODEL,
     DEFAULT_RERANKER_FLASHRANK_CACHE_DIR,
+    DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA,
     DEFAULT_RERANKER_FLASHRANK_MODEL,
     DEFAULT_RERANKER_GOOGLE_MODEL,
     DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC,
@@ -39,6 +40,7 @@ from ..config import (
     ENV_RERANKER_COHERE_API_KEY,
     ENV_RERANKER_COHERE_MODEL,
     ENV_RERANKER_FLASHRANK_CACHE_DIR,
+    ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA,
     ENV_RERANKER_FLASHRANK_MODEL,
     ENV_RERANKER_GOOGLE_PROJECT_ID,
     ENV_RERANKER_LITELLM_SDK_API_KEY,
@@ -864,6 +866,7 @@ class FlashRankCrossEncoder(CrossEncoderModel):
         cache_dir: str | None = None,
         max_length: int = 512,
         max_concurrent: int = 4,
+        cpu_mem_arena: bool = False,
     ):
         """
         Initialize FlashRank cross-encoder.
@@ -873,10 +876,15 @@ class FlashRankCrossEncoder(CrossEncoderModel):
             cache_dir: Directory to cache downloaded models. Default: system cache
             max_length: Maximum sequence length for reranking. Default: 512
             max_concurrent: Maximum concurrent reranking calls. Default: 4
+            cpu_mem_arena: Enable ONNX Runtime CPU memory arena. Default: False.
+                          When True, ONNX pre-allocates a memory arena that never
+                          shrinks, causing RSS to grow monotonically. False trades
+                          slightly slower per-call allocation for bounded RSS.
         """
         self.model_name = model_name or DEFAULT_RERANKER_FLASHRANK_MODEL
         self.cache_dir = cache_dir or DEFAULT_RERANKER_FLASHRANK_CACHE_DIR
         self.max_length = max_length
+        self.cpu_mem_arena = cpu_mem_arena
         self._ranker = None
         FlashRankCrossEncoder._max_concurrent = max_concurrent
 
@@ -894,14 +902,46 @@ class FlashRankCrossEncoder(CrossEncoderModel):
         except ImportError:
             raise ImportError("flashrank is required for FlashRankCrossEncoder. Install it with: pip install flashrank")
 
-        logger.info(f"Reranker: initializing FlashRank provider with model {self.model_name}")
+        logger.info(
+            f"Reranker: initializing FlashRank provider with model {self.model_name}"
+            f" (cpu_mem_arena={self.cpu_mem_arena})"
+        )
+
+        # Configure ONNX session options before Ranker creates the session.
+        # When cpu_mem_arena=False (default), ONNX won't pre-allocate an arena
+        # that grows monotonically, keeping RSS bounded after rerank batches.
+        if not self.cpu_mem_arena:
+            import onnxruntime as ort
+
+            session_options = ort.SessionOptions()
+            session_options.enable_cpu_mem_arena = False
+        else:
+            session_options = None
 
         # Initialize ranker with optional cache directory
-        ranker_kwargs = {"model_name": self.model_name, "max_length": self.max_length}
+        ranker_kwargs: dict = {"model_name": self.model_name, "max_length": self.max_length}
         if self.cache_dir:
             ranker_kwargs["cache_dir"] = self.cache_dir
 
         self._ranker = Ranker(**ranker_kwargs)
+
+        # Patch the ONNX session options if arena is disabled.
+        # FlashRank's Ranker doesn't expose SessionOptions in its API,
+        # so we replace the session after initialization.
+        if session_options is not None and hasattr(self._ranker, "session"):
+            import onnxruntime as ort
+
+            model_file = None
+            model_dir = getattr(self._ranker, "model_dir", None)
+            if model_dir:
+                from pathlib import Path
+
+                for candidate in Path(model_dir).glob("*.onnx"):
+                    model_file = str(candidate)
+                    break
+            if model_file:
+                self._ranker.session = ort.InferenceSession(model_file, sess_options=session_options)
+                logger.info("Reranker: replaced FlashRank ONNX session with cpu_mem_arena=False")
 
         # Initialize shared executor
         if FlashRankCrossEncoder._executor is None:
@@ -1552,7 +1592,10 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
     elif provider == "flashrank":
         model = os.environ.get(ENV_RERANKER_FLASHRANK_MODEL, DEFAULT_RERANKER_FLASHRANK_MODEL)
         cache_dir = os.environ.get(ENV_RERANKER_FLASHRANK_CACHE_DIR, DEFAULT_RERANKER_FLASHRANK_CACHE_DIR)
-        return FlashRankCrossEncoder(model_name=model, cache_dir=cache_dir)
+        cpu_mem_arena = os.environ.get(
+            ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA, str(DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA)
+        ).lower() in ("true", "1", "yes")
+        return FlashRankCrossEncoder(model_name=model, cache_dir=cache_dir, cpu_mem_arena=cpu_mem_arena)
     elif provider == "litellm":
         return LiteLLMCrossEncoder(
             api_base=config.reranker_litellm_api_base,

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -660,11 +660,7 @@ class OpenAICompatibleLLM(LLMInterface):
         if "deepseek" in self.model.lower():
             normalized_messages: list[dict[str, Any]] = []
             for msg in messages:
-                if (
-                    msg.get("role") == "assistant"
-                    and msg.get("tool_calls")
-                    and "reasoning_content" not in msg
-                ):
+                if msg.get("role") == "assistant" and msg.get("tool_calls") and "reasoning_content" not in msg:
                     normalized_msg = dict(msg)
                     normalized_msg["reasoning_content"] = ""
                     normalized_messages.append(normalized_msg)

--- a/hindsight-clients/typescript/generated/client/client.gen.ts
+++ b/hindsight-clients/typescript/generated/client/client.gen.ts
@@ -78,9 +78,11 @@ export const createClient = (config: Config = {}): Client => {
   const request: Client["request"] = async (options) => {
     // @ts-expect-error
     const { opts, url } = await beforeRequest(options);
+    // Exclude hey-api internal fields that conflict with Deno's RequestInit.client
+    const { client: _client, ...optsForRequest } = opts as typeof opts & { client?: unknown };
     const requestInit: ReqInit = {
       redirect: "follow",
-      ...opts,
+      ...optsForRequest,
       body: getValidRequestBody(opts),
     };
 

--- a/hindsight-clients/typescript/generated/client/client.gen.ts
+++ b/hindsight-clients/typescript/generated/client/client.gen.ts
@@ -78,11 +78,9 @@ export const createClient = (config: Config = {}): Client => {
   const request: Client["request"] = async (options) => {
     // @ts-expect-error
     const { opts, url } = await beforeRequest(options);
-    // Exclude hey-api internal fields that conflict with Deno's RequestInit.client
-    const { client: _client, ...optsForRequest } = opts as typeof opts & { client?: unknown };
     const requestInit: ReqInit = {
       redirect: "follow",
-      ...optsForRequest,
+      ...opts,
       body: getValidRequestBody(opts),
     };
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -561,6 +561,7 @@ Google's `gemini-embedding-001` produces 3072 dimensions natively but supports c
 | `HINDSIGHT_API_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY` | Path to service account JSON key (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`). If unset, uses ADC. | - |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_MODEL` | FlashRank model for fast CPU-based reranking | `ms-marco-MiniLM-L-12-v2` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR` | Cache directory for FlashRank models | System default |
+| `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
 ```bash
@@ -1026,7 +1027,8 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND` | Maximum memories processed per consolidation round. When the limit is reached, the job yields its worker slot and re-queues itself so other banks get fair scheduling. Mental model refreshes only run on the final round. `0` = unlimited. Configurable per bank. | `100` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS` | Max tokens for recall when finding related observations during consolidation | `1024` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` | Number of facts sent to the LLM in a single consolidation call. Higher values reduce LLM calls and improve throughput at the cost of larger prompts. Set to `1` to disable batching. Configurable per bank. | `8` |
-| `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `-1` |
+| `HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET` | Budget level for the recall pass inside consolidation (`low`, `mid`, `high`). Lower budgets fetch fewer candidate rows, reducing peak memory usage on large banks. | `low` |
+| `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `4096` |
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION` | Per-observation token cap for source facts in the consolidation prompt. Each observation independently gets at most this many tokens of source facts. `-1` = unlimited. Configurable per bank. | `256` |
 | `HINDSIGHT_API_OBSERVATIONS_MISSION` | What this bank should synthesise into durable observations. Replaces the built-in consolidation rules — leave unset to use the server default. | - |
 | `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` | Maximum number of observations allowed per tag scope. When the limit is reached, consolidation will only update or delete existing observations — no new ones are created. Applies per tag scope (e.g., per-tag when using `per_tag` observation scopes). Observations with no tags are not subject to this limit. `-1` = unlimited. Configurable per bank. | `-1` |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -561,6 +561,7 @@ Google's `gemini-embedding-001` produces 3072 dimensions natively but supports c
 | `HINDSIGHT_API_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY` | Path to service account JSON key (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`). If unset, uses ADC. | - |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_MODEL` | FlashRank model for fast CPU-based reranking | `ms-marco-MiniLM-L-12-v2` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR` | Cache directory for FlashRank models | System default |
+| `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |
 | `HINDSIGHT_API_RERANKER_JINA_MLX_MODEL_PATH` | Local path to downloaded `jina-reranker-v3-mlx` model (auto-downloads from HuggingFace if unset) | - |
 
 ```bash
@@ -1026,7 +1027,8 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND` | Maximum memories processed per consolidation round. When the limit is reached, the job yields its worker slot and re-queues itself so other banks get fair scheduling. Mental model refreshes only run on the final round. `0` = unlimited. Configurable per bank. | `100` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS` | Max tokens for recall when finding related observations during consolidation | `1024` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` | Number of facts sent to the LLM in a single consolidation call. Higher values reduce LLM calls and improve throughput at the cost of larger prompts. Set to `1` to disable batching. Configurable per bank. | `8` |
-| `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `-1` |
+| `HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET` | Budget level for the recall pass inside consolidation (`low`, `mid`, `high`). Lower budgets fetch fewer candidate rows, reducing peak memory usage on large banks. | `low` |
+| `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` | Total token budget for source facts included with observations in the consolidation prompt. `-1` = unlimited. Configurable per bank. | `4096` |
 | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION` | Per-observation token cap for source facts in the consolidation prompt. Each observation independently gets at most this many tokens of source facts. `-1` = unlimited. Configurable per bank. | `256` |
 | `HINDSIGHT_API_OBSERVATIONS_MISSION` | What this bank should synthesise into durable observations. Replaces the built-in consolidation rules — leave unset to use the server default. | - |
 | `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` | Maximum number of observations allowed per tag scope. When the limit is reached, consolidation will only update or delete existing observations — no new ones are created. Applies per tag scope (e.g., per-tag when using `per_tag` observation scopes). Observations with no tags are not subject to this limit. `-1` = unlimited. Configurable per bank. | `-1` |


### PR DESCRIPTION
## Summary

Addresses #996 — unbounded RSS growth during consolidation on large banks.

Three root causes identified from the issue thread (credit to @vikramwalia and @ChampPABA for the detailed investigation):

- **Consolidation recall fan-out**: Default `Budget.MID` causes `hnsw_fetch = 1,500` rows per recall arm. With 8 parallel recalls per sub-batch × 2 worker slots, up to 24,000 rows materialize in Python simultaneously. Changed default to `Budget.LOW` (`hnsw_fetch = 500`), reducing peak in-flight rows ~3x. Configurable via `HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET` (low/mid/high).

- **Unbounded source-fact hydration**: `consolidation_source_facts_max_tokens` defaulted to `-1` (unlimited), meaning every source memory referenced by recalled observations was fetched into Python before any token filtering. Changed default to `4096`. Env var `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` already existed.

- **ONNX memory arena retention** (FlashRank reranker only): ONNX Runtime's `enable_cpu_mem_arena=True` default pre-allocates an arena that never shrinks, causing RSS to stay pinned after consolidation batches complete. Now defaults to `False`. Configurable via `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA`.

## Test plan

- [x] `TestConsolidationSourceFactsConfig` tests pass (verify budget/tokens forwarded to recall)
- [x] Ruff lint clean
- [ ] Consolidation integration test on a large bank (>1k memories) to verify RSS stays bounded
- [ ] FlashRank reranker users: verify rerank quality unchanged with arena disabled