### PR TITLE
fix(mcp): report Hindsight's version in serverInfo, not FastMCP's

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -8,6 +8,7 @@ from contextvars import ContextVar
 from fastmcp import FastMCP
 
 from hindsight_api import MemoryEngine
+from hindsight_api import __version__ as HINDSIGHT_VERSION
 from hindsight_api.config import _get_raw_config
 from hindsight_api.engine.memory_engine import _current_schema
 from hindsight_api.extensions import MCPExtension, load_extension
@@ -89,7 +90,7 @@ def create_mcp_server(memory: MemoryEngine, multi_bank: bool = True) -> FastMCP:
     Returns:
         Configured FastMCP server instance
     """
-    mcp = FastMCP("hindsight-mcp-server")
+    mcp = FastMCP("hindsight-mcp-server", version=HINDSIGHT_VERSION)
 
     global_config = _get_raw_config()
 

--- a/hindsight-api-slim/tests/test_mcp_server_version.py
+++ b/hindsight-api-slim/tests/test_mcp_server_version.py
@@ -1,0 +1,13 @@
+"""Tests for MCP server identity reported via serverInfo."""
+
+from unittest.mock import MagicMock
+
+from hindsight_api import __version__ as HINDSIGHT_VERSION
+from hindsight_api.api.mcp import create_mcp_server
+
+
+def test_mcp_server_reports_hindsight_version():
+    """serverInfo.version should be Hindsight's version, not the FastMCP library version."""
+    memory = MagicMock()
+    server = create_mcp_server(memory, multi_bank=True)
+    assert server.version == HINDSIGHT_VERSION


### PR DESCRIPTION
## Summary

When constructing the MCP server, `FastMCP` defaults `serverInfo.version` to its own library version if no explicit `version` is passed. That means clients listing the MCP server were seeing the **FastMCP** version (e.g. `3.0.0` / `3.2.4`, depending on the deployed image) instead of Hindsight's actual version.

This passes `HINDSIGHT_VERSION` explicitly to the constructor so `serverInfo.version` reflects this project.

## Changes
- `hindsight-api-slim/hindsight_api/api/mcp.py` — pass `version=HINDSIGHT_VERSION` to `FastMCP(...)`.
- `hindsight-api-slim/tests/test_mcp_server_version.py` — new unit test asserting `server.version == HINDSIGHT_VERSION` to guard against regressions.

## Test plan
- [x] `cd hindsight-api-slim && uv run pytest tests/test_mcp_server_version.py` — passes
- [x] `./scripts/hooks/lint.sh` — passes
- [ ] CI green