### PR TITLE
docs(installation): document memory footprint and hardware requirements

### DIFF
--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -45,6 +45,24 @@ Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configura
 
 You need an LLM API key for fact extraction, entity resolution, and answer generation. See [Models](./models) for supported providers, model recommendations, and configuration.
 
+### Hardware
+
+Hindsight is designed to run on commodity hardware. The footprint depends mainly on whether the **full** image (which bundles local embedding and reranker models) or the **slim** image (which delegates those to external providers) is used.
+
+| Component | Minimum RAM | Recommended RAM | Notes |
+|-----------|-------------|-----------------|-------|
+| **API — Full image** | 1.5 GB | 2 GB | Loads local BGE embedder (~130 MB) and MiniLM cross-encoder (~90 MB) into memory, plus PyTorch/ONNX runtime arenas. Idle RSS settles around 0.8–1.0 GB; expect 1.2–1.5 GB under load. |
+| **API — Slim image** | 512 MB | 1 GB | No local models. Steady-state RSS is dominated by Python runtime and DB connections. Requires [external embedding and reranker providers](./configuration#embeddings) (e.g. TEI, OpenAI, Cohere). |
+| **Control Plane (UI)** | 128 MB | 256 MB | Next.js process, lightweight. |
+| **Worker** (if separated) | Same as API image variant | Same as API image variant | Workers load the same models as the API server. |
+| **PostgreSQL** | 512 MB | 1 GB+ | Scales with the number of memories and indexes. |
+
+:::tip Reducing the footprint
+The bulk of the full image's memory comes from the bundled embedding and reranker models and their PyTorch/ONNX runtimes. To shrink the deployment to a few hundred MB of RAM, switch to the **slim** image and configure [external embedding and reranker providers](./configuration#embeddings).
+:::
+
+CPU: 2 vCPUs is enough for development. For production, scale CPU with the rate of `retain` and `recall` calls — local embedding and reranking are CPU-bound. GPU is not required.
+
 ---
 
 ## Docker
@@ -67,10 +85,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 ### Docker Image Variants
 
-| Variant | Size (AMD64) | Size (ARM64) | When to use |
-|---------|--------------|--------------|-------------|
-| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Works out of the box with no external services except the LLM. |
-| **Slim** (`slim`) | ~500 MB | ~500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys. Requires [external providers](./configuration#embeddings). |
+| Variant | Size (AMD64) | Size (ARM64) | Idle RAM | When to use |
+|---------|--------------|--------------|----------|-------------|
+| **Full** (`latest`) | ~9 GB | ~3.7 GB | ~1.2 GB | Default. Works out of the box with no external services except the LLM. Bundles local embedder and reranker models. |
+| **Slim** (`slim`) | ~500 MB | ~500 MB | ~300–500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys, and lower memory. Requires [external providers](./configuration#embeddings). |
+
+Idle RAM is for the API + Control Plane container at rest; expect ~20–30% more under load. See [Hardware](#hardware) for the breakdown.
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -61,7 +61,7 @@ Hindsight is designed to run on commodity hardware. The footprint depends mainly
 The bulk of the full image's memory comes from the bundled embedding and reranker models and their PyTorch/ONNX runtimes. To shrink the deployment to a few hundred MB of RAM, switch to the **slim** image and configure [external embedding and reranker providers](./configuration#embeddings).
 :::
 
-CPU: 2 vCPUs is enough for development. For production, scale CPU with the rate of `retain` and `recall` calls — local embedding and reranking are CPU-bound. GPU is not required.
+CPU vs GPU: 2 vCPUs on CPU-only is fine for development and basic workloads. For production traffic, the local reranker (cross-encoder) is the main bottleneck and typically benefits from a GPU to keep recall latency reasonable; alternatively, offload reranking to an [external reranker provider](./configuration#embeddings) (e.g. TEI, Cohere) on dedicated GPU hardware.
 
 ---
 
@@ -85,12 +85,10 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 ### Docker Image Variants
 
-| Variant | Size (AMD64) | Size (ARM64) | Idle RAM | When to use |
-|---------|--------------|--------------|----------|-------------|
-| **Full** (`latest`) | ~9 GB | ~3.7 GB | ~1.2 GB | Default. Works out of the box with no external services except the LLM. Bundles local embedder and reranker models. |
-| **Slim** (`slim`) | ~500 MB | ~500 MB | ~300–500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys, and lower memory. Requires [external providers](./configuration#embeddings). |
-
-Idle RAM is for the API + Control Plane container at rest; expect ~20–30% more under load. See [Hardware](#hardware) for the breakdown.
+| Variant | Size (AMD64) | Size (ARM64) | When to use |
+|---------|--------------|--------------|-------------|
+| **Full** (`latest`) | ~9 GB | ~3.7 GB | Default. Works out of the box with no external services except the LLM. |
+| **Slim** (`slim`) | ~500 MB | ~500 MB | Use when you already rely on external services for embeddings and reranking (OpenAI, Cohere, TEI). Significantly smaller image, faster deploys. Requires [external providers](./configuration#embeddings). |
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
 

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -45,6 +45,24 @@ Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configura
 
 You need an LLM API key for fact extraction, entity resolution, and answer generation. See [Models](./models) for supported providers, model recommendations, and configuration.
 
+### Hardware
+
+Hindsight is designed to run on commodity hardware. The footprint depends mainly on whether the **full** image (which bundles local embedding and reranker models) or the **slim** image (which delegates those to external providers) is used.
+
+| Component | Minimum RAM | Recommended RAM | Notes |
+|-----------|-------------|-----------------|-------|
+| **API — Full image** | 1.5 GB | 2 GB | Loads local BGE embedder (~130 MB) and MiniLM cross-encoder (~90 MB) into memory, plus PyTorch/ONNX runtime arenas. Idle RSS settles around 0.8–1.0 GB; expect 1.2–1.5 GB under load. |
+| **API — Slim image** | 512 MB | 1 GB | No local models. Steady-state RSS is dominated by Python runtime and DB connections. Requires [external embedding and reranker providers](./configuration#embeddings) (e.g. TEI, OpenAI, Cohere). |
+| **Control Plane (UI)** | 128 MB | 256 MB | Next.js process, lightweight. |
+| **Worker** (if separated) | Same as API image variant | Same as API image variant | Workers load the same models as the API server. |
+| **PostgreSQL** | 512 MB | 1 GB+ | Scales with the number of memories and indexes. |
+
+:::tip Reducing the footprint
+The bulk of the full image's memory comes from the bundled embedding and reranker models and their PyTorch/ONNX runtimes. To shrink the deployment to a few hundred MB of RAM, switch to the **slim** image and configure [external embedding and reranker providers](./configuration#embeddings).
+:::
+
+CPU vs GPU: 2 vCPUs on CPU-only is fine for development and basic workloads. For production traffic, the local reranker (cross-encoder) is the main bottleneck and typically benefits from a GPU to keep recall latency reasonable; alternatively, offload reranking to an [external reranker provider](./configuration#embeddings) (e.g. TEI, Cohere) on dedicated GPU hardware.
+
 ---
 
 ## Docker


### PR DESCRIPTION
## Summary
- Add a **Hardware** subsection under Prerequisites in `installation.md` with per-component RAM guidance (full vs slim API image, control plane, worker, postgres) plus a CPU note.
- Extend the **Docker Image Variants** table with an **Idle RAM** column (~1.2 GB full / ~300–500 MB slim) and a one-liner pointing readers at the Hardware section for the breakdown.

The numbers are based on the recent investigation of the Slack-reported memory issue: v0.5.4+ reaches steady-state at ~0.8–1.0 GB API RSS without drift; the bulk comes from the bundled BGE embedder + MiniLM cross-encoder and their PyTorch/ONNX runtimes. Slim image + external embedding/reranker providers (TEI/Cohere/OpenAI) brings this down by ~700 MB+.

## Test plan
- [ ] Render docs locally (`./scripts/dev/start-docs.sh`) and verify both tables format correctly and the `#hardware` anchor link from the Docker Image Variants section resolves.