### PR TITLE
fix(llm): simplify JSON schemas for better Ollama and LLM compliance

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -132,11 +132,13 @@ ENV_LLM_TIMEOUT = "HINDSIGHT_API_LLM_TIMEOUT"
 ENV_LLM_GROQ_SERVICE_TIER = "HINDSIGHT_API_LLM_GROQ_SERVICE_TIER"
 ENV_LLM_OPENAI_SERVICE_TIER = "HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER"
 ENV_LLM_EXTRA_BODY = "HINDSIGHT_API_LLM_EXTRA_BODY"
+ENV_LLM_SIMPLIFY_JSON_SCHEMA = "HINDSIGHT_API_LLM_SIMPLIFY_JSON_SCHEMA"
 
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
 DEFAULT_LLM_EXTRA_BODY = None  # None = no extra body params; JSON dict merged into OpenAI extra_body
+DEFAULT_LLM_SIMPLIFY_JSON_SCHEMA = True  # Flatten $ref/$defs/anyOf in JSON schemas for better LLM compliance
 
 # Per-operation LLM configuration (optional, falls back to global LLM config)
 ENV_RETAIN_LLM_PROVIDER = "HINDSIGHT_API_RETAIN_LLM_PROVIDER"
@@ -840,6 +842,7 @@ class HindsightConfig:
     llm_extra_body: (
         dict | None
     )  # Extra body params merged into OpenAI-compatible API calls (e.g. {"chat_template_kwargs": {"enable_thinking": true}})
+    llm_simplify_json_schema: bool  # Flatten $ref/$defs/anyOf in JSON schemas for better LLM compliance (default: true)
 
     # Vertex AI configuration
     llm_vertexai_project_id: str | None
@@ -1335,6 +1338,10 @@ class HindsightConfig:
             llm_groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
+            llm_simplify_json_schema=os.getenv(
+                ENV_LLM_SIMPLIFY_JSON_SCHEMA, str(DEFAULT_LLM_SIMPLIFY_JSON_SCHEMA)
+            ).lower()
+            in ("true", "1"),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -60,6 +60,77 @@ def _strip_code_fences(content: str) -> str:
         return content
 
 
+def _simplify_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Simplify a Pydantic JSON schema for maximum LLM compatibility.
+
+    Pydantic v2's model_json_schema() produces schemas with $ref/$defs, anyOf
+    (for Optional fields), and const — features that Ollama's grammar-based
+    constrained decoding silently fails on, and that confuse weaker models when
+    the schema appears as a text hint in the prompt.
+
+    This function:
+    1. Resolves all $ref/$defs by inlining referenced definitions
+    2. Simplifies anyOf nullable unions (e.g. anyOf: [{type: "string"}, {type: "null"}])
+       to just the non-null type, keeping default/description
+    3. Replaces const with single-element enum
+    """
+    defs = schema.get("$defs", {})
+
+    def _resolve(node: Any) -> Any:
+        if not isinstance(node, dict):
+            if isinstance(node, list):
+                return [_resolve(item) for item in node]
+            return node
+
+        # Resolve $ref first
+        if "$ref" in node:
+            ref_path = node["$ref"]  # e.g. "#/$defs/Entity"
+            ref_name = ref_path.rsplit("/", 1)[-1]
+            if ref_name in defs:
+                # Inline the definition, merging any sibling keys (e.g. description)
+                resolved = _resolve(dict(defs[ref_name]))
+                # Preserve sibling keys from the referencing node
+                for k, v in node.items():
+                    if k != "$ref":
+                        resolved[k] = _resolve(v)
+                return resolved
+            return node  # unresolvable ref, leave as-is
+
+        result: dict[str, Any] = {}
+        for key, value in node.items():
+            if key == "$defs":
+                continue  # drop $defs — everything is inlined now
+
+            if key == "anyOf" and isinstance(value, list):
+                # Simplify nullable anyOf: [{type: "string"}, {type: "null"}] → {type: "string"}
+                non_null = [_resolve(v) for v in value if not (isinstance(v, dict) and v.get("type") == "null")]
+                if len(non_null) == 1:
+                    # Single non-null type — inline it, preserving sibling keys
+                    simplified = dict(non_null[0])
+                    for k, v in node.items():
+                        if k not in ("anyOf",) and k not in simplified:
+                            simplified[k] = _resolve(v)
+                    return simplified
+                elif len(non_null) > 1:
+                    # Multiple non-null types — keep anyOf but resolved
+                    result["anyOf"] = non_null
+                else:
+                    # All null — just use null
+                    result["type"] = "null"
+                continue
+
+            if key == "const":
+                # Replace const with single-element enum for broader compatibility
+                result["enum"] = [value]
+                continue
+
+            result[key] = _resolve(value)
+
+        return result
+
+    return _resolve(schema)
+
+
 def _summarize_status_error(e: APIStatusError, body_max: int = 400) -> str:
     """Render an APIStatusError with status code + truncated response body.
 
@@ -356,6 +427,12 @@ class OpenAICompatibleLLM(LLMInterface):
             schema = None
             if hasattr(response_format, "model_json_schema"):
                 schema = response_format.model_json_schema()
+                # Simplify schema for better LLM compliance — resolves $ref/$defs,
+                # simplifies anyOf nullables, replaces const with enum.
+                from hindsight_api.config import get_config
+
+                if get_config().llm_simplify_json_schema:
+                    schema = _simplify_json_schema(schema)
 
             if strict_schema and schema is not None:
                 # Use OpenAI's strict JSON schema enforcement
@@ -831,8 +908,14 @@ class OpenAICompatibleLLM(LLMInterface):
         """
         start_time = time.time()
 
-        # Get the JSON schema from the Pydantic model
+        # Get the JSON schema from the Pydantic model and simplify it for Ollama's
+        # grammar engine, which doesn't support $ref, anyOf, or const.
         schema = response_format.model_json_schema() if hasattr(response_format, "model_json_schema") else None
+        if schema:
+            from hindsight_api.config import get_config
+
+            if get_config().llm_simplify_json_schema:
+                schema = _simplify_json_schema(schema)
 
         # Build the base URL for Ollama's native API
         # Default OpenAI-compatible URL is http://localhost:11434/v1

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -174,6 +174,7 @@ To switch between backends:
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict merged into `extra_body` for all OpenAI-compatible API calls. Useful for custom model servers (e.g., vLLM `chat_template_kwargs`). | `null` |
+| `HINDSIGHT_API_LLM_SIMPLIFY_JSON_SCHEMA` | Flatten `$ref`/`$defs`/`anyOf` in JSON schemas before sending to LLMs. Required for Ollama structured output; improves compliance for all providers. Set to `false` to send raw Pydantic schemas. | `true` |
 | `HINDSIGHT_API_LLM_GEMINI_SAFETY_SETTINGS` | JSON-encoded list of `{category, threshold}` dicts for Gemini/VertexAI content safety filtering | `null` |
 
 **Provider Examples**


### PR DESCRIPTION
## Summary

Fixes #1274.

- Pydantic v2's `model_json_schema()` produces schemas with `$ref`/`$defs`, `anyOf` (for `Optional` fields), and `const` — features that Ollama's grammar-based constrained decoding [silently fails on](https://github.com/ollama/ollama/issues/8063), causing fallback to unconstrained generation. This also confuses weaker models when the schema appears as a text hint in the prompt for other providers (Groq, MiniMax, etc.).
- Add `_simplify_json_schema()` that resolves `$ref`/`$defs` by inlining, simplifies `anyOf` nullable unions to the non-null type, and replaces `const` with single-element `enum`
- Applied to both the Ollama native API path (`format` param) and the prompt-text schema path for all OpenAI-compatible providers
- Controlled by `HINDSIGHT_API_LLM_SIMPLIFY_JSON_SCHEMA` env var (default: `true`)

## Test plan

- [x] Existing unit tests pass (`test_strip_code_fences`, `test_fact_extraction_retry`)
- [x] Lint (`ruff check`) and type check (`ty check`) clean
- [x] Verified simplified schema output: no `$ref`, `$defs`, `anyOf` nullable unions, or `const` remain
- [ ] Manual test with Ollama + glm-5.1 to confirm structured output now works