### PR TITLE
fix(llm): omit tool_choice="auto" and add deepseek as first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # LLM Configuration (Required)
-# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, volcano
+# Supported providers: openai, groq, ollama, gemini, anthropic, lmstudio, vertexai, minimax, deepseek, volcano
 HINDSIGHT_API_LLM_PROVIDER=openai
 HINDSIGHT_API_LLM_API_KEY=your-api-key-here
 HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
@@ -24,6 +24,11 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_PROVIDER=minimax
 # HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
 # HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+
+# Example: DeepSeek configuration (https://api.deepseek.com)
+# HINDSIGHT_API_LLM_PROVIDER=deepseek
+# HINDSIGHT_API_LLM_API_KEY=your-deepseek-api-key
+# HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash  # or deepseek-v4-pro / deepseek-chat / deepseek-reasoner
 
 # Example: LM Studio local configuration (Qwen 2.5 32B recommended)
 # HINDSIGHT_API_LLM_PROVIDER=lmstudio

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -445,6 +445,7 @@ PROVIDER_DEFAULT_MODELS = {
     "gemini": "gemini-2.5-flash",
     "groq": "openai/gpt-oss-120b",
     "minimax": "MiniMax-M2.7",
+    "deepseek": "deepseek-v4-flash",
     "ollama": "gemma3:12b",
     "llamacpp": "gemma-4-e2b-it",
     "lmstudio": "local-model",

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -283,7 +283,7 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
-    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "volcano", "openrouter"):
+    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "deepseek", "volcano", "openrouter"):
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,
@@ -360,6 +360,7 @@ class LLMProvider:
             "mock",
             "none",
             "minimax",
+            "deepseek",
             "litellm",
             "bedrock",
             "volcano",
@@ -378,6 +379,8 @@ class LLMProvider:
                 self.base_url = "http://localhost:1234/v1"
             elif self.provider == "minimax":
                 self.base_url = "https://api.minimax.io/v1"
+            elif self.provider == "deepseek":
+                self.base_url = "https://api.deepseek.com"
             elif self.provider == "openrouter":
                 self.base_url = "https://openrouter.ai/api/v1"
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1,5 +1,5 @@
 """
-OpenAI-compatible LLM provider supporting OpenAI, Groq, Ollama, LMStudio, and MiniMax.
+OpenAI-compatible LLM provider supporting OpenAI, Groq, Ollama, LMStudio, MiniMax, and DeepSeek.
 
 This provider handles all OpenAI API-compatible models including:
 - OpenAI: GPT-4, GPT-4o, GPT-5, o1, o3 (reasoning models)
@@ -7,6 +7,7 @@ This provider handles all OpenAI API-compatible models including:
 - Ollama: Local models with native streaming API support
 - LMStudio: Local models with OpenAI-compatible API
 - MiniMax: MiniMax-M2.7 models with 1M context window
+- DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via api.deepseek.com
 
 Features:
 - Reasoning models with extended thinking (o1, o3, GPT-5 families)
@@ -96,6 +97,7 @@ class OpenAICompatibleLLM(LLMInterface):
     - Ollama: Local models with native streaming API for better structured output
     - LMStudio: Local models with OpenAI-compatible API
     - MiniMax: MiniMax-M2.7 models via OpenAI-compatible API (https://api.minimax.io/v1)
+    - DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via https://api.deepseek.com
     """
 
     def __init__(
@@ -127,7 +129,17 @@ class OpenAICompatibleLLM(LLMInterface):
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
         # Validate provider
-        valid_providers = ["openai", "groq", "ollama", "lmstudio", "llamacpp", "minimax", "volcano", "openrouter"]
+        valid_providers = [
+            "openai",
+            "groq",
+            "ollama",
+            "lmstudio",
+            "llamacpp",
+            "minimax",
+            "deepseek",
+            "volcano",
+            "openrouter",
+        ]
         if self.provider not in valid_providers:
             raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
 
@@ -141,6 +153,8 @@ class OpenAICompatibleLLM(LLMInterface):
                 self.base_url = "http://localhost:1234/v1"
             elif self.provider == "minimax":
                 self.base_url = "https://api.minimax.io/v1"
+            elif self.provider == "deepseek":
+                self.base_url = "https://api.deepseek.com"
             elif self.provider == "openrouter":
                 self.base_url = "https://openrouter.ai/api/v1"
 
@@ -149,7 +163,7 @@ class OpenAICompatibleLLM(LLMInterface):
             self.api_key = "local"
 
         # Validate API key for cloud providers
-        if self.provider in ("openai", "groq", "minimax", "openrouter") and not self.api_key:
+        if self.provider in ("openai", "groq", "minimax", "deepseek", "openrouter") and not self.api_key:
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)
@@ -651,6 +665,15 @@ class OpenAICompatibleLLM(LLMInterface):
         # tool_choice values. The tools list has already been narrowed for
         # forced calls, so omitting tool_choice preserves the practical behavior.
         if "deepseek" in self.model.lower() and request_tool_choice != "auto":
+            request_tool_choice = None
+
+        # "auto" is the OpenAI API default — omitting tool_choice is semantically
+        # identical. Some providers (e.g. DeepSeek's reasoner pathway, which
+        # deepseek-v4-flash falls into when thinking mode is enabled) reject the
+        # parameter outright, returning HTTP 400 even for value "auto". Sending it
+        # only when the caller asks for a non-default behaviour avoids those 400s
+        # without changing semantics for compliant providers.
+        if request_tool_choice == "auto":
             request_tool_choice = None
 
         # DeepSeek tool-call replies can carry provider-specific reasoning_content.

--- a/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
+++ b/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
@@ -45,6 +45,28 @@ def _make_deepseek_llm(model: str = "deepseek-v4-flash") -> OpenAICompatibleLLM:
     )
 
 
+def test_deepseek_first_class_provider_sets_default_base_url():
+    """provider="deepseek" is a configuration shortcut for the api.deepseek.com endpoint."""
+    llm = OpenAICompatibleLLM(
+        provider="deepseek",
+        api_key="sk-test",
+        base_url="",
+        model="deepseek-v4-flash",
+    )
+
+    assert llm.base_url == "https://api.deepseek.com"
+
+
+def test_deepseek_first_class_provider_requires_api_key():
+    with pytest.raises(ValueError, match="API key is required for deepseek"):
+        OpenAICompatibleLLM(
+            provider="deepseek",
+            api_key="",
+            base_url="",
+            model="deepseek-v4-flash",
+        )
+
+
 def _make_tool_call_response(tool_name: str = "search_observations") -> MagicMock:
     mock_tc = MagicMock()
     mock_tc.id = "call_deepseek_123"
@@ -95,6 +117,26 @@ async def test_deepseek_named_tool_choice_filters_tools_but_omits_tool_choice():
     assert "tool_choice" not in sent_kwargs
     assert len(sent_kwargs["tools"]) == 1
     assert sent_kwargs["tools"][0]["function"]["name"] == "search_observations"
+
+
+@pytest.mark.asyncio
+async def test_deepseek_auto_tool_choice_is_omitted():
+    """DeepSeek's reasoner pathway (e.g. v4-flash + thinking mode) returns
+    400 for any tool_choice value. Since "auto" is the API default, omit it."""
+    llm = _make_deepseek_llm()
+
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _make_tool_call_response("search_observations")
+
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "Search observations."}],
+            tools=TOOLS,
+            tool_choice="auto",
+            max_retries=0,
+        )
+
+    sent_kwargs = mock_create.call_args.kwargs
+    assert "tool_choice" not in sent_kwargs
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_llm_provider.py
+++ b/hindsight-api-slim/tests/test_llm_provider.py
@@ -31,6 +31,9 @@ MODEL_MATRIX = [
     # Groq models
     ("groq", "openai/gpt-oss-120b"),
     ("groq", "openai/gpt-oss-20b"),
+    # DeepSeek models
+    ("deepseek", "deepseek-v4-flash"),
+    ("deepseek", "deepseek-chat"),
     # Gemini models
     ("gemini", "gemini-2.5-flash"),
     ("gemini", "gemini-2.5-flash-lite"),
@@ -57,6 +60,7 @@ def get_api_key_for_provider(provider: str) -> str | None:
         "anthropic": "ANTHROPIC_API_KEY",
         "groq": "GROQ_API_KEY",
         "gemini": "GEMINI_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
     }
     env_var = provider_key_map.get(provider)
     return os.getenv(env_var) if env_var else None

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -162,7 +162,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -253,6 +253,18 @@ export HINDSIGHT_API_LLM_MODEL=doubao-pro-32k
 export HINDSIGHT_API_LLM_PROVIDER=openrouter
 export HINDSIGHT_API_LLM_API_KEY=your-openrouter-api-key
 export HINDSIGHT_API_LLM_MODEL=qwen/qwen3.5-9b
+
+# DeepSeek (OpenAI-compatible, https://api.deepseek.com)
+export HINDSIGHT_API_LLM_PROVIDER=deepseek
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+# Notes:
+# - `deepseek-v4-flash` defaults to thinking mode at the API level (treated as
+#   `deepseek-reasoner`). Hindsight handles this transparently; the reflect
+#   agent will not crash with "deepseek-reasoner does not support this
+#   tool_choice".
+# - Use `deepseek-v4-pro` for the higher-quality reasoning route.
+# - Use `deepseek-chat` for the non-thinking alias (faster, cheaper).
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -86,6 +86,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `gemini` | `gemini-2.5-flash` |
 | `groq` | `openai/gpt-oss-120b` |
 | `minimax` | `MiniMax-M2.7` |
+| `deepseek` | `deepseek-v4-flash` |
 | `ollama` | `gemma3:12b` |
 | `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
 | `lmstudio` | `local-model` |
@@ -176,6 +177,11 @@ export HINDSIGHT_API_LLM_MODEL=your-local-model
 export HINDSIGHT_API_LLM_PROVIDER=minimax
 export HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
 export HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+
+# DeepSeek (https://api.deepseek.com)
+export HINDSIGHT_API_LLM_PROVIDER=deepseek
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash  # or deepseek-v4-pro / deepseek-chat / deepseek-reasoner
 
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -1,4 +1,5 @@
 import {LLMProvidersGrid} from '@site/src/components/SupportedGrids';
+import {LLMProvidersTable} from '@site/src/components/LLMProvidersTable';
 
 # Models
 
@@ -79,24 +80,7 @@ The following models have been tested and verified to work correctly with Hindsi
 
 Each provider has a recommended default model that's used when `HINDSIGHT_API_LLM_MODEL` is not explicitly set. This makes configuration simpler - just specify the provider and get a sensible default:
 
-| Provider | Default Model |
-|----------|--------------|
-| `openai` | `gpt-4o-mini` |
-| `anthropic` | `claude-haiku-4-5-20251001` |
-| `gemini` | `gemini-2.5-flash` |
-| `groq` | `openai/gpt-oss-120b` |
-| `minimax` | `MiniMax-M2.7` |
-| `deepseek` | `deepseek-v4-flash` |
-| `ollama` | `gemma3:12b` |
-| `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
-| `lmstudio` | `local-model` |
-| `vertexai` | `gemini-2.0-flash-001` |
-| `openai-codex` | `gpt-5.2-codex` |
-| `claude-code` | `claude-sonnet-4-5-20250929` |
-| `bedrock` | `us.amazon.nova-2-lite-v1:0` |
-| `volcano` | `doubao-pro-32k` |
-| `openrouter` | `qwen/qwen3.5-9b` |
-| `litellm` | `gpt-4o-mini` |
+<LLMProvidersTable />
 
 **Example:** Setting just the provider uses its default model:
 ```bash

--- a/hindsight-docs/src/components/LLMProvidersTable.tsx
+++ b/hindsight-docs/src/components/LLMProvidersTable.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {LLM_PROVIDERS} from '../data/llmProviders';
+
+/**
+ * Renders the "Provider Default Models" table from the single-source-of-truth
+ * provider list in `src/data/llmProviders.tsx`. Skips entries without a default
+ * model (e.g. the "OpenAI Compatible" pseudo-entry).
+ */
+export function LLMProvidersTable() {
+  const rows = LLM_PROVIDERS.filter(p => p.id && p.defaultModel);
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Default Model</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(({id, defaultModel, defaultModelNote}) => (
+          <tr key={id}>
+            <td><code>{id}</code></td>
+            <td>
+              <code>{defaultModel}</code>
+              {defaultModelNote && <> ({defaultModelNote})</>}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/hindsight-docs/src/components/SupportedGrids.tsx
+++ b/hindsight-docs/src/components/SupportedGrids.tsx
@@ -39,6 +39,7 @@ export function LLMProvidersGrid() {
       { label: 'LM Studio',     icon: LuBrainCog },
       { label: 'llama.cpp',     icon: LuTerminal },
       { label: 'MiniMax',            icon: LuSparkles },
+      { label: 'DeepSeek',          icon: LuBrainCog },
       { label: 'Volcano Engine',    icon: LuZap },
       { label: 'OpenAI Compatible', icon: OpenAICompatibleIcon },
       { label: 'AWS Bedrock', icon: LuCloud },

--- a/hindsight-docs/src/components/SupportedGrids.tsx
+++ b/hindsight-docs/src/components/SupportedGrids.tsx
@@ -1,19 +1,8 @@
 import React from 'react';
-import type {IconType} from 'react-icons';
 import {IconGrid} from './IconGrid';
-import {SiPython, SiGo, SiOpenai, SiAnthropic, SiGooglegemini, SiOllama} from 'react-icons/si';
-import {LuTerminal, LuPlug, LuZap, LuBrainCog, LuSparkles, LuGlobe, LuLayers, LuCloud} from 'react-icons/lu';
-
-const OpenAICompatibleIcon: IconType = ({size = 28, ...props}) => (
-  <span style={{position: 'relative', display: 'inline-flex'}}>
-    <SiOpenai size={size} {...props} />
-    <span style={{
-      position: 'absolute', bottom: -3, right: -6,
-      fontSize: Math.round((size as number) * 0.5), fontWeight: 900, lineHeight: 1,
-      color: 'currentColor',
-    }}>+</span>
-  </span>
-);
+import {SiPython, SiGo} from 'react-icons/si';
+import {LuTerminal, LuGlobe} from 'react-icons/lu';
+import {LLM_PROVIDERS} from '../data/llmProviders';
 
 export function ClientsGrid() {
   return (
@@ -29,21 +18,5 @@ export function ClientsGrid() {
 
 
 export function LLMProvidersGrid() {
-  return (
-    <IconGrid items={[
-      { label: 'OpenAI',        icon: SiOpenai },
-      { label: 'Anthropic',     icon: SiAnthropic },
-      { label: 'Google Gemini', icon: SiGooglegemini },
-      { label: 'Groq',          icon: LuZap },
-      { label: 'Ollama',        icon: SiOllama },
-      { label: 'LM Studio',     icon: LuBrainCog },
-      { label: 'llama.cpp',     icon: LuTerminal },
-      { label: 'MiniMax',            icon: LuSparkles },
-      { label: 'DeepSeek',          icon: LuBrainCog },
-      { label: 'Volcano Engine',    icon: LuZap },
-      { label: 'OpenAI Compatible', icon: OpenAICompatibleIcon },
-      { label: 'AWS Bedrock', icon: LuCloud },
-      { label: 'LiteLLM (100+)', icon: LuLayers },
-    ]} />
-  );
+  return <IconGrid items={LLM_PROVIDERS.map(({label, icon}) => ({label, icon}))} />;
 }

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -1,0 +1,19 @@
+[
+  {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini"},
+  {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5-20251001"},
+  {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-2.5-flash"},
+  {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "gemini-2.0-flash-001"},
+  {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b"},
+  {"id": "ollama",        "label": "Ollama",            "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
+  {"id": "lmstudio",      "label": "LM Studio",         "iconKey": "brain",              "defaultModel": "local-model"},
+  {"id": "llamacpp",      "label": "llama.cpp",         "iconKey": "terminal",           "defaultModel": "gemma-4-e2b-it", "defaultModelNote": "auto-downloaded GGUF"},
+  {"id": "minimax",       "label": "MiniMax",           "iconKey": "sparkles",           "defaultModel": "MiniMax-M2.7"},
+  {"id": "deepseek",      "label": "DeepSeek",          "iconKey": "brain",              "defaultModel": "deepseek-v4-flash"},
+  {"id": "volcano",       "label": "Volcano Engine",    "iconKey": "zap",                "defaultModel": "doubao-pro-32k"},
+  {"id": "openrouter",    "label": "OpenRouter",        "iconKey": "globe",              "defaultModel": "qwen/qwen3.5-9b"},
+  {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.2-codex"},
+  {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
+  {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
+  {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},
+  {"id": "litellm",       "label": "LiteLLM (100+)",    "iconKey": "layers",             "defaultModel": "gpt-4o-mini"}
+]

--- a/hindsight-docs/src/data/llmProviders.tsx
+++ b/hindsight-docs/src/data/llmProviders.tsx
@@ -1,0 +1,58 @@
+import type {IconType} from 'react-icons';
+import React from 'react';
+import {SiOpenai, SiAnthropic, SiGooglegemini, SiOllama} from 'react-icons/si';
+import {LuTerminal, LuZap, LuBrainCog, LuSparkles, LuGlobe, LuLayers, LuCloud} from 'react-icons/lu';
+
+const OpenAICompatibleIcon: IconType = ({size = 28, ...props}) => (
+  <span style={{position: 'relative', display: 'inline-flex'}}>
+    <SiOpenai size={size} {...props} />
+    <span style={{
+      position: 'absolute', bottom: -3, right: -6,
+      fontSize: Math.round((size as number) * 0.5), fontWeight: 900, lineHeight: 1,
+      color: 'currentColor',
+    }}>+</span>
+  </span>
+);
+
+export interface LLMProvider {
+  /** HINDSIGHT_API_LLM_PROVIDER value, e.g. "deepseek". Empty string for the
+   *  "OpenAI Compatible" pseudo-entry which is not a real provider id. */
+  id: string;
+  /** Display name shown in the grid tile and table. */
+  label: string;
+  /** Icon component rendered in the grid tile. */
+  icon: IconType;
+  /** Provider default model. Undefined = no entry in the default-models table
+   *  (e.g. OpenAI Compatible has no default; LiteLLM is conceptual). */
+  defaultModel?: string;
+  /** Optional note rendered in the default-models table. */
+  defaultModelNote?: string;
+}
+
+/**
+ * Single source of truth for the supported LLM providers shown in the docs.
+ *
+ * Adding a provider here updates both the LLMProvidersGrid icon grid (on the
+ * Models page) and the "Provider Default Models" table — no other doc file
+ * needs to be touched. Keep aligned with PROVIDER_DEFAULT_MODELS in
+ * hindsight-api-slim/hindsight_api/config.py.
+ */
+export const LLM_PROVIDERS: LLMProvider[] = [
+  {id: 'openai',         label: 'OpenAI',          icon: SiOpenai,          defaultModel: 'gpt-4o-mini'},
+  {id: 'anthropic',      label: 'Anthropic',       icon: SiAnthropic,       defaultModel: 'claude-haiku-4-5-20251001'},
+  {id: 'gemini',         label: 'Google Gemini',   icon: SiGooglegemini,    defaultModel: 'gemini-2.5-flash'},
+  {id: 'vertexai',       label: 'Vertex AI',       icon: SiGooglegemini,    defaultModel: 'gemini-2.0-flash-001'},
+  {id: 'groq',           label: 'Groq',            icon: LuZap,             defaultModel: 'openai/gpt-oss-120b'},
+  {id: 'ollama',         label: 'Ollama',          icon: SiOllama,          defaultModel: 'gemma3:12b'},
+  {id: 'lmstudio',       label: 'LM Studio',       icon: LuBrainCog,        defaultModel: 'local-model'},
+  {id: 'llamacpp',       label: 'llama.cpp',       icon: LuTerminal,        defaultModel: 'gemma-4-e2b-it', defaultModelNote: 'auto-downloaded GGUF'},
+  {id: 'minimax',        label: 'MiniMax',         icon: LuSparkles,        defaultModel: 'MiniMax-M2.7'},
+  {id: 'deepseek',       label: 'DeepSeek',        icon: LuBrainCog,        defaultModel: 'deepseek-v4-flash'},
+  {id: 'volcano',        label: 'Volcano Engine',  icon: LuZap,             defaultModel: 'doubao-pro-32k'},
+  {id: 'openrouter',     label: 'OpenRouter',      icon: LuGlobe,           defaultModel: 'qwen/qwen3.5-9b'},
+  {id: 'openai-codex',   label: 'OpenAI Codex',    icon: SiOpenai,          defaultModel: 'gpt-5.2-codex'},
+  {id: 'claude-code',    label: 'Claude Code',     icon: SiAnthropic,       defaultModel: 'claude-sonnet-4-5-20250929'},
+  {id: 'bedrock',        label: 'AWS Bedrock',     icon: LuCloud,           defaultModel: 'us.amazon.nova-2-lite-v1:0'},
+  {id: '',               label: 'OpenAI Compatible', icon: OpenAICompatibleIcon},
+  {id: 'litellm',        label: 'LiteLLM (100+)',  icon: LuLayers,          defaultModel: 'gpt-4o-mini'},
+];

--- a/hindsight-docs/src/data/llmProviders.tsx
+++ b/hindsight-docs/src/data/llmProviders.tsx
@@ -2,6 +2,7 @@ import type {IconType} from 'react-icons';
 import React from 'react';
 import {SiOpenai, SiAnthropic, SiGooglegemini, SiOllama} from 'react-icons/si';
 import {LuTerminal, LuZap, LuBrainCog, LuSparkles, LuGlobe, LuLayers, LuCloud} from 'react-icons/lu';
+import providersJson from './llmProviders.json';
 
 const OpenAICompatibleIcon: IconType = ({size = 28, ...props}) => (
   <span style={{position: 'relative', display: 'inline-flex'}}>
@@ -14,6 +15,21 @@ const OpenAICompatibleIcon: IconType = ({size = 28, ...props}) => (
   </span>
 );
 
+const ICON_REGISTRY: Record<string, IconType> = {
+  openai: SiOpenai,
+  anthropic: SiAnthropic,
+  gemini: SiGooglegemini,
+  ollama: SiOllama,
+  terminal: LuTerminal,
+  zap: LuZap,
+  brain: LuBrainCog,
+  sparkles: LuSparkles,
+  globe: LuGlobe,
+  layers: LuLayers,
+  cloud: LuCloud,
+  'openai-compatible': OpenAICompatibleIcon,
+};
+
 export interface LLMProvider {
   /** HINDSIGHT_API_LLM_PROVIDER value, e.g. "deepseek". Empty string for the
    *  "OpenAI Compatible" pseudo-entry which is not a real provider id. */
@@ -22,8 +38,7 @@ export interface LLMProvider {
   label: string;
   /** Icon component rendered in the grid tile. */
   icon: IconType;
-  /** Provider default model. Undefined = no entry in the default-models table
-   *  (e.g. OpenAI Compatible has no default; LiteLLM is conceptual). */
+  /** Provider default model. Undefined = no entry in the default-models table. */
   defaultModel?: string;
   /** Optional note rendered in the default-models table. */
   defaultModelNote?: string;
@@ -32,27 +47,20 @@ export interface LLMProvider {
 /**
  * Single source of truth for the supported LLM providers shown in the docs.
  *
- * Adding a provider here updates both the LLMProvidersGrid icon grid (on the
- * Models page) and the "Provider Default Models" table — no other doc file
- * needs to be touched. Keep aligned with PROVIDER_DEFAULT_MODELS in
+ * Adding a provider means editing `llmProviders.json` ONLY. That file is
+ * consumed by:
+ *   - this module (resolves iconKey -> IconType for the icon grid)
+ *   - LLMProvidersTable React component (renders the default-models table)
+ *   - scripts/generate-docs-skill.sh (renders <LLMProvidersTable /> as
+ *     markdown when copying MDX docs into the agent-facing skill)
+ *
+ * Keep aligned with PROVIDER_DEFAULT_MODELS in
  * hindsight-api-slim/hindsight_api/config.py.
  */
-export const LLM_PROVIDERS: LLMProvider[] = [
-  {id: 'openai',         label: 'OpenAI',          icon: SiOpenai,          defaultModel: 'gpt-4o-mini'},
-  {id: 'anthropic',      label: 'Anthropic',       icon: SiAnthropic,       defaultModel: 'claude-haiku-4-5-20251001'},
-  {id: 'gemini',         label: 'Google Gemini',   icon: SiGooglegemini,    defaultModel: 'gemini-2.5-flash'},
-  {id: 'vertexai',       label: 'Vertex AI',       icon: SiGooglegemini,    defaultModel: 'gemini-2.0-flash-001'},
-  {id: 'groq',           label: 'Groq',            icon: LuZap,             defaultModel: 'openai/gpt-oss-120b'},
-  {id: 'ollama',         label: 'Ollama',          icon: SiOllama,          defaultModel: 'gemma3:12b'},
-  {id: 'lmstudio',       label: 'LM Studio',       icon: LuBrainCog,        defaultModel: 'local-model'},
-  {id: 'llamacpp',       label: 'llama.cpp',       icon: LuTerminal,        defaultModel: 'gemma-4-e2b-it', defaultModelNote: 'auto-downloaded GGUF'},
-  {id: 'minimax',        label: 'MiniMax',         icon: LuSparkles,        defaultModel: 'MiniMax-M2.7'},
-  {id: 'deepseek',       label: 'DeepSeek',        icon: LuBrainCog,        defaultModel: 'deepseek-v4-flash'},
-  {id: 'volcano',        label: 'Volcano Engine',  icon: LuZap,             defaultModel: 'doubao-pro-32k'},
-  {id: 'openrouter',     label: 'OpenRouter',      icon: LuGlobe,           defaultModel: 'qwen/qwen3.5-9b'},
-  {id: 'openai-codex',   label: 'OpenAI Codex',    icon: SiOpenai,          defaultModel: 'gpt-5.2-codex'},
-  {id: 'claude-code',    label: 'Claude Code',     icon: SiAnthropic,       defaultModel: 'claude-sonnet-4-5-20250929'},
-  {id: 'bedrock',        label: 'AWS Bedrock',     icon: LuCloud,           defaultModel: 'us.amazon.nova-2-lite-v1:0'},
-  {id: '',               label: 'OpenAI Compatible', icon: OpenAICompatibleIcon},
-  {id: 'litellm',        label: 'LiteLLM (100+)',  icon: LuLayers,          defaultModel: 'gpt-4o-mini'},
-];
+export const LLM_PROVIDERS: LLMProvider[] = (providersJson as Array<{
+  id: string; label: string; iconKey: string; defaultModel?: string; defaultModelNote?: string;
+}>).map(({iconKey, ...rest}) => {
+  const icon = ICON_REGISTRY[iconKey];
+  if (!icon) throw new Error(`Unknown iconKey "${iconKey}" for provider "${rest.id || rest.label}"`);
+  return {...rest, icon};
+});

--- a/hindsight-integrations/pipecat/examples/interactive_chat.py
+++ b/hindsight-integrations/pipecat/examples/interactive_chat.py
@@ -37,7 +37,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from hindsight_pipecat import HindsightMemoryService
 from hindsight_pipecat.memory import _MEMORY_MARKER
 
-
 BLUE = "\033[94m"
 GREEN = "\033[92m"
 YELLOW = "\033[93m"
@@ -53,6 +52,7 @@ def banner(label: str, color: str = CYAN) -> None:
 def _make_frame(messages: list[dict]) -> MagicMock:
     """Build a mock OpenAILLMContextFrame (Pipecat's text context carrier)."""
     from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContextFrame
+
     frame = MagicMock(spec=OpenAILLMContextFrame)
     ctx = MagicMock()
     ctx.messages = messages
@@ -111,7 +111,10 @@ async def main() -> None:
     parser.add_argument("--bank", default=f"demo-{os.environ.get('USER', 'anon')}")
     parser.add_argument("--hindsight-url", default=os.environ.get("HINDSIGHT_API_URL", "http://localhost:8888"))
     parser.add_argument("--hindsight-api-key", default=os.environ.get("HINDSIGHT_API_KEY"))
-    parser.add_argument("--system-prompt", default="You are a friendly voice assistant with long-term memory. Use memories naturally; don't dump them verbatim. Keep responses concise.")
+    parser.add_argument(
+        "--system-prompt",
+        default="You are a friendly voice assistant with long-term memory. Use memories naturally; don't dump them verbatim. Keep responses concise.",
+    )
     args = parser.parse_args()
 
     service = HindsightMemoryService(

--- a/hindsight-integrations/pipecat/hindsight_pipecat/memory.py
+++ b/hindsight-integrations/pipecat/hindsight_pipecat/memory.py
@@ -56,8 +56,7 @@ def _resolve_client(
 
     if url is None:
         raise HindsightPipecatError(
-            "No Hindsight API URL configured. "
-            "Pass client= or hindsight_api_url=, or call configure() first."
+            "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
         )
 
     kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0}
@@ -120,12 +119,8 @@ class HindsightMemoryService(FrameProcessor):
         self._bank_id = bank_id
         self._client = _resolve_client(client, hindsight_api_url, api_key)
         config = get_config()
-        self._recall_budget = recall_budget or (
-            config.recall_budget if config else "mid"
-        )
-        self._recall_max_tokens = recall_max_tokens or (
-            config.recall_max_tokens if config else 4096
-        )
+        self._recall_budget = recall_budget or (config.recall_budget if config else "mid")
+        self._recall_max_tokens = recall_max_tokens or (config.recall_max_tokens if config else 4096)
         self._enable_recall = enable_recall
         self._enable_retain = enable_retain
         self._memory_prefix = memory_prefix
@@ -169,9 +164,7 @@ class HindsightMemoryService(FrameProcessor):
                     return content
                 # Multimodal content is a list of parts; extract text parts.
                 if isinstance(content, list):
-                    texts = [
-                        p.get("text", "") for p in content if p.get("type") == "text"
-                    ]
+                    texts = [p.get("text", "") for p in content if p.get("type") == "text"]
                     return " ".join(texts) if texts else None
         return None
 
@@ -239,9 +232,7 @@ class HindsightMemoryService(FrameProcessor):
                 lines.append(f"{i}. {result.text}")
             return "\n".join(lines)
         except Exception as e:
-            logger.warning(
-                f"Hindsight recall failed (continuing without memories): {e}"
-            )
+            logger.warning(f"Hindsight recall failed (continuing without memories): {e}")
             return None
 
     async def _retain(self, content: str) -> None:

--- a/scripts/generate-docs-skill.sh
+++ b/scripts/generate-docs-skill.sh
@@ -61,7 +61,8 @@ convert_mdx_to_md() {
     local dest="$2"
 
     # Use Python for more robust processing
-    python3 - "$src" "$dest" "$EXAMPLES_DIR" <<'PYTHON'
+    python3 - "$src" "$dest" "$EXAMPLES_DIR" "$ROOT_DIR/hindsight-docs/src/data/llmProviders.json" <<'PYTHON'
+import json
 import sys
 import re
 from pathlib import Path
@@ -69,6 +70,7 @@ from pathlib import Path
 src_file = Path(sys.argv[1])
 dest_file = Path(sys.argv[2])
 examples_dir = Path(sys.argv[3])
+llm_providers_json = Path(sys.argv[4])
 
 content = src_file.read_text()
 original_content = content  # Keep original for import searches
@@ -128,6 +130,30 @@ content = re.sub(
     inline_code_snippet,
     content
 )
+
+# Render <LLMProvidersTable /> as a markdown table sourced from
+# hindsight-docs/src/data/llmProviders.json (single source of truth shared
+# with the React grid + table components).
+def render_llm_providers_table(_match):
+    providers = json.loads(llm_providers_json.read_text())
+    rows = ["| Provider | Default Model |", "|----------|--------------|"]
+    for p in providers:
+        if not p.get("id") or not p.get("defaultModel"):
+            continue
+        model_cell = f"`{p['defaultModel']}`"
+        if p.get("defaultModelNote"):
+            model_cell += f" ({p['defaultModelNote']})"
+        rows.append(f"| `{p['id']}` | {model_cell} |")
+    return "\n".join(rows)
+
+content = re.sub(r'<LLMProvidersTable\s*/>', render_llm_providers_table, content)
+
+# Render <LLMProvidersGrid /> as a bullet list of supported provider labels.
+def render_llm_providers_grid(_match):
+    providers = json.loads(llm_providers_json.read_text())
+    return "\n".join(f"- {p['label']}" for p in providers)
+
+content = re.sub(r'<LLMProvidersGrid\s*/>', render_llm_providers_grid, content)
 
 # Convert <Tabs> to markdown sections
 # Replace <Tabs> ... </Tabs> with markdown headers

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -162,7 +162,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -253,6 +253,18 @@ export HINDSIGHT_API_LLM_MODEL=doubao-pro-32k
 export HINDSIGHT_API_LLM_PROVIDER=openrouter
 export HINDSIGHT_API_LLM_API_KEY=your-openrouter-api-key
 export HINDSIGHT_API_LLM_MODEL=qwen/qwen3.5-9b
+
+# DeepSeek (OpenAI-compatible, https://api.deepseek.com)
+export HINDSIGHT_API_LLM_PROVIDER=deepseek
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+# Notes:
+# - `deepseek-v4-flash` defaults to thinking mode at the API level (treated as
+#   `deepseek-reasoner`). Hindsight handles this transparently; the reflect
+#   agent will not crash with "deepseek-reasoner does not support this
+#   tool_choice".
+# - Use `deepseek-v4-pro` for the higher-quality reasoning route.
+# - Use `deepseek-chat` for the non-thinking alias (faster, cheaper).
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -19,7 +19,23 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 
 **Supported providers:**
 
-<LLMProvidersGrid />
+- OpenAI
+- Anthropic
+- Google Gemini
+- Vertex AI
+- Groq
+- Ollama
+- LM Studio
+- llama.cpp
+- MiniMax
+- DeepSeek
+- Volcano Engine
+- OpenRouter
+- OpenAI Codex
+- Claude Code
+- AWS Bedrock
+- OpenAI Compatible
+- LiteLLM (100+)
 
 Also supports **any OpenAI-compatible API** (e.g., Azure OpenAI, Together AI, Fireworks) and **100+ providers via LiteLLM** (e.g., AWS Bedrock, Azure OpenAI, Together AI).
 
@@ -79,17 +95,18 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `openai` | `gpt-4o-mini` |
 | `anthropic` | `claude-haiku-4-5-20251001` |
 | `gemini` | `gemini-2.5-flash` |
-| `groq` | `openai/gpt-oss-120b` |
-| `minimax` | `MiniMax-M2.7` |
-| `ollama` | `gemma3:12b` |
-| `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
-| `lmstudio` | `local-model` |
 | `vertexai` | `gemini-2.0-flash-001` |
+| `groq` | `openai/gpt-oss-120b` |
+| `ollama` | `gemma3:12b` |
+| `lmstudio` | `local-model` |
+| `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
+| `minimax` | `MiniMax-M2.7` |
+| `deepseek` | `deepseek-v4-flash` |
+| `volcano` | `doubao-pro-32k` |
+| `openrouter` | `qwen/qwen3.5-9b` |
 | `openai-codex` | `gpt-5.2-codex` |
 | `claude-code` | `claude-sonnet-4-5-20250929` |
 | `bedrock` | `us.amazon.nova-2-lite-v1:0` |
-| `volcano` | `doubao-pro-32k` |
-| `openrouter` | `qwen/qwen3.5-9b` |
 | `litellm` | `gpt-4o-mini` |
 
 **Example:** Setting just the provider uses its default model:
@@ -170,6 +187,11 @@ export HINDSIGHT_API_LLM_MODEL=your-local-model
 export HINDSIGHT_API_LLM_PROVIDER=minimax
 export HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
 export HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+
+# DeepSeek (https://api.deepseek.com)
+export HINDSIGHT_API_LLM_PROVIDER=deepseek
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash  # or deepseek-v4-pro / deepseek-chat / deepseek-reasoner
 
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -64,7 +64,23 @@ Browse all supported integrations in the Integrations Hub.
 
 ### Which LLM providers are supported?
 
-<LLMProvidersGrid />
+- OpenAI
+- Anthropic
+- Google Gemini
+- Vertex AI
+- Groq
+- Ollama
+- LM Studio
+- llama.cpp
+- MiniMax
+- DeepSeek
+- Volcano Engine
+- OpenRouter
+- OpenAI Codex
+- Claude Code
+- AWS Bedrock
+- OpenAI Compatible
+- LiteLLM (100+)
 
 See [Models](developer/models.md) for the full list of supported providers, recommended models, and configuration examples.
 


### PR DESCRIPTION
## Summary

- **Bug fix:** `OpenAICompatibleLLM.call_with_tools()` no longer sends `tool_choice="auto"` to providers. Since omission is semantically identical to `"auto"` per the OpenAI API spec, this avoids HTTP 400s from DeepSeek's reasoner pathway (which `deepseek-v4-flash` enters by default with thinking mode), without changing behaviour for compliant providers.
- **First-class DeepSeek provider:** `HINDSIGHT_API_LLM_PROVIDER=deepseek` now auto-configures `base_url=https://api.deepseek.com` and defaults the model to `deepseek-v4-flash`. Documented in `configuration.md` and `.env.example`.

## Background — the bug

`deepseek-v4-flash` defaults to thinking mode at the API level, where DeepSeek treats it as `deepseek-reasoner`. `deepseek-reasoner` rejects the `tool_choice` parameter outright (even `"auto"`), so reflect was failing with 12 consecutive 400s per call:

```
HTTP 400: {"message": "deepseek-reasoner does not support this tool_choice"}
```

Retain and consolidation were unaffected because they use `call()` with `response_format`, not `call_with_tools()`.

## Test plan

- [x] New regression test: `tests/test_deepseek_tool_call_compat.py::test_deepseek_auto_tool_choice_is_omitted`
- [x] New tests for `provider="deepseek"` shortcut: `test_deepseek_first_class_provider_sets_default_base_url`, `test_deepseek_first_class_provider_requires_api_key`
- [x] All 20 tool_choice-related tests pass (`test_deepseek_tool_call_compat.py`, `test_lmstudio_tool_choice.py`, `test_codex_tool_choice.py`)
- [x] Broader provider sweep: 233 passed (the 2 failures on `main` are unrelated codex auth issues)
- [x] Live e2e test against `api.deepseek.com` confirmed wiring (provider=deepseek + deepseek-v4-flash and deepseek-chat both reach the right endpoint)