### PR TITLE
fix(retain): drop strength from causal relations (fixes #1289)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -110,12 +110,6 @@ class CausalRelation(BaseModel):
     relation_type: Literal["caused_by"] = Field(
         description="How this fact relates to the target: 'caused_by' = this fact was caused by the target"
     )
-    strength: float = Field(
-        description="Strength of relationship (0.0 to 1.0)",
-        ge=0.0,
-        le=1.0,
-        default=1.0,
-    )
 
 
 class FactCausalRelation(BaseModel):
@@ -133,12 +127,6 @@ class FactCausalRelation(BaseModel):
     )
     relation_type: Literal["caused_by"] = Field(
         description="How this fact relates to the target fact: 'caused_by' = this fact was caused by the target fact"
-    )
-    strength: float = Field(
-        description="Strength of relationship (0.0 to 1.0). 1.0 = strong, 0.5 = moderate",
-        ge=0.0,
-        le=1.0,
-        default=1.0,
     )
 
 
@@ -1216,7 +1204,6 @@ async def _extract_facts_from_chunk(
                             # New schema uses target_index
                             target_idx = rel.get("target_index")
                             relation_type = rel.get("relation_type")
-                            strength = rel.get("strength", 1.0)
 
                             if target_idx is None or relation_type is None:
                                 continue
@@ -1233,7 +1220,6 @@ async def _extract_facts_from_chunk(
                                     CausalRelation(
                                         target_fact_index=target_idx,
                                         relation_type=relation_type,
-                                        strength=strength,
                                     )
                                 )
                             except Exception as e:
@@ -1909,7 +1895,6 @@ async def extract_facts_from_contents_batch_api(
                             continue
                         target_idx = rel.get("target_index")
                         relation_type = rel.get("relation_type")
-                        strength = rel.get("strength", 1.0)
 
                         if target_idx is None or relation_type is None:
                             continue
@@ -1918,9 +1903,7 @@ async def extract_facts_from_contents_batch_api(
 
                         try:
                             validated_relations.append(
-                                CausalRelation(
-                                    target_fact_index=target_idx, relation_type=relation_type, strength=strength
-                                )
+                                CausalRelation(target_fact_index=target_idx, relation_type=relation_type)
                             )
                         except Exception:
                             pass
@@ -2250,7 +2233,6 @@ def _convert_causal_relations(relations_from_llm, fact_start_idx: int) -> list[C
         causal_relation = CausalRelationType(
             relation_type=rel.relation_type,
             target_fact_index=fact_start_idx + rel.target_fact_index,
-            strength=rel.strength,
         )
         causal_relations.append(causal_relation)
     return causal_relations

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
@@ -97,7 +97,6 @@ async def create_causal_links_batch(conn, bank_id: str, unit_ids: list[str], fac
                 {
                     "relation_type": rel.relation_type,
                     "target_fact_index": rel.target_fact_index,
-                    "strength": rel.strength,
                 }
                 for rel in fact.causal_relations
             ]

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -990,7 +990,6 @@ async def create_causal_links_batch(
             Each element is a list of dicts with:
             - target_fact_index: Index into unit_ids for the target fact
             - relation_type: "caused_by"
-            - strength: Float in [0.0, 1.0] representing relationship strength
 
     Returns:
         Number of causal links created
@@ -1017,7 +1016,6 @@ async def create_causal_links_batch(
             for relation in causal_relations:
                 target_idx = relation["target_fact_index"]
                 relation_type = relation["relation_type"]
-                strength = relation.get("strength", 1.0)
 
                 # Validate relation_type - only "caused_by" is supported (DB constraint)
                 valid_types = {"caused_by"}
@@ -1040,10 +1038,7 @@ async def create_causal_links_batch(
                 if from_unit_id == to_unit_id:
                     continue
 
-                # Add the causal link
-                # link_type is the relation_type (e.g., "causes", "caused_by")
-                # weight is the strength of the relationship
-                links.append((from_unit_id, to_unit_id, relation_type, strength, None))
+                links.append((from_unit_id, to_unit_id, relation_type, 1.0, None))
 
         if links:
             insert_start = time_mod.time()

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -99,7 +99,6 @@ class CausalRelation:
 
     relation_type: str  # "caused_by"
     target_fact_index: int  # Index of the target fact in the batch
-    strength: float = 1.0  # Strength of the causal relationship
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -112,16 +112,6 @@ class LinkExpansionRetriever(GraphRetriever):
     The Python merge step applies per-signal score transformations.
     """
 
-    def __init__(
-        self,
-        causal_weight_threshold: float = 0.3,
-    ):
-        """
-        Args:
-            causal_weight_threshold: Minimum weight for causal links to follow.
-        """
-        self.causal_weight_threshold = causal_weight_threshold
-
     @property
     def name(self) -> str:
         return "link_expansion"
@@ -387,7 +377,6 @@ class LinkExpansionRetriever(GraphRetriever):
                 JOIN {mu} mu ON ml.to_unit_id = mu.id
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
-                  AND ml.weight >= $4
                   AND mu.fact_type = $2
                 ORDER BY mu.id, ml.weight DESC
                 LIMIT $3
@@ -403,7 +392,7 @@ class LinkExpansionRetriever(GraphRetriever):
             SELECT * FROM causal_expanded
             """
 
-        params = [seed_ids, fact_type, budget, self.causal_weight_threshold]
+        params = [seed_ids, fact_type, budget]
 
         try:
             all_rows = await asyncio.wait_for(
@@ -559,7 +548,7 @@ class LinkExpansionRetriever(GraphRetriever):
                 FROM {ml} ml JOIN {mu} mu ON ml.to_unit_id = mu.id
                 WHERE ml.from_unit_id = ANY($1::uuid[])
                   AND ml.link_type IN ('causes', 'caused_by', 'enables', 'prevents')
-                  AND ml.weight >= $3 AND mu.fact_type = 'observation'
+                  AND mu.fact_type = 'observation'
                 ORDER BY mu.id, ml.weight DESC LIMIT $2
             )
             SELECT * FROM semantic_expanded
@@ -568,7 +557,6 @@ class LinkExpansionRetriever(GraphRetriever):
             """,
             seed_ids,
             budget,
-            self.causal_weight_threshold,
         )
 
         semantic_rows = [r for r in sem_causal_rows if r["source"] == "semantic"]

--- a/hindsight-api-slim/tests/test_causal_relationships.py
+++ b/hindsight-api-slim/tests/test_causal_relationships.py
@@ -54,7 +54,6 @@ After searching for weeks, I finally found a cheaper apartment in Brooklyn.
                             "from_fact_index": i,
                             "to_fact_index": rel.target_fact_index,
                             "relation_type": rel.relation_type,
-                            "strength": rel.strength,
                             "from_fact_text": fact.fact[:50],
                         }
                     )
@@ -180,29 +179,3 @@ The new role enabled me to lead a team of engineers.
                         f"Must reference previous facts only (valid range: 0 to {i - 1})"
                     )
 
-    @pytest.mark.asyncio
-    async def test_causal_relation_strength_values(self):
-        """
-        Test that causal relation strength values are within valid range [0.0, 1.0].
-        """
-        text = """
-The stock market crash directly caused the company to lay off employees.
-The layoffs indirectly led to reduced consumer spending in the area.
-Reduced spending somewhat affected local businesses.
-"""
-
-        context = "Economic impact story"
-        llm_config = LLMConfig.from_env()
-
-        facts, _, _ = await extract_facts_from_text(
-            text=text, event_date=datetime(2024, 4, 1), context=context, llm_config=llm_config, agent_name="TestUser",
-            config=_get_raw_config(),
-        )
-
-        for i, fact in enumerate(facts):
-            if fact.causal_relations:
-                for rel in fact.causal_relations:
-                    assert 0.0 <= rel.strength <= 1.0, (
-                        f"Causal relation strength {rel.strength} is outside valid range [0.0, 1.0]. "
-                        f"Fact {i}: {fact.fact[:50]}..."
-                    )


### PR DESCRIPTION
## Summary
- Removes the `strength` field from `CausalRelation`/`FactCausalRelation` Pydantic models so the JSON schema no longer emits `minimum`/`maximum` on a `number` type — the source of the Bedrock Converse API rejection in #1289
- In practice the LLM always emitted `1.0`, so the `causal_weight_threshold=0.3` filter and weight-based ranking in `link_expansion_retrieval` were no-ops. Hardcode link `weight=1.0` and drop the threshold + `AND ml.weight >= $N` filters
- Causal links still carry a `weight` column in the DB (unchanged), so a real weight signal can be re-introduced later

## Why
Fact extraction was failing silently on AWS Bedrock with:
```
BedrockException: For 'number' type, properties maximum, minimum are not supported
```
The error is caught and downgraded to WARN, so retain operations report `status: completed` while producing 0 facts. `litellm.drop_params=True` doesn't help (it strips top-level params, not nested schema keys), and LiteLLM's `filter_anthropic_output_schema` (added in BerriAI/litellm#22500) is only wired into the Anthropic-direct path, not the Bedrock Converse transformation.

## Test plan
- [x] `./scripts/hooks/lint.sh` — passes
- [x] `uv run ruff check` + `uv run ty check` on changed files — passes
- [x] 103 retain/link/fact-extraction unit tests pass
- [x] Schema dump verified: `FactExtractionResponse.model_json_schema()` no longer contains `minimum`/`maximum`/`strength`
- [ ] Manual repro on Bedrock Claude (reporter confirmed equivalent patch works)

Fixes #1289