### PR TITLE
feat: mental-models List view + /tags?source=mental_models

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -4323,7 +4323,8 @@ def _register_routes(app: FastAPI):
         response_model=ListTagsResponse,
         summary="List tags",
         description="List all unique tags in a memory bank with usage counts. "
-        "Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.",
+        "Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. "
+        "Use `source=mental_models` to list tags used on mental models instead of memories.",
         operation_id="list_tags",
         tags=["Memory"],
     )
@@ -4333,6 +4334,10 @@ def _register_routes(app: FastAPI):
             default=None,
             description="Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). "
             "Use '*' as wildcard. Case-insensitive.",
+        ),
+        source: Literal["memories", "mental_models"] = Query(
+            default="memories",
+            description="Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.",
         ),
         limit: int = Query(default=100, description="Maximum number of tags to return"),
         offset: int = Query(default=0, description="Offset for pagination"),
@@ -4350,17 +4355,27 @@ def _register_routes(app: FastAPI):
         Args:
             bank_id: Memory Bank ID (from path)
             q: Wildcard pattern to filter tags (use '*' as wildcard)
+            source: Tag source — 'memories' (memory_units, default) or 'mental_models'
             limit: Maximum number of tags to return (default: 100)
             offset: Offset for pagination (default: 0)
         """
         try:
-            data = await app.state.memory.list_tags(
-                bank_id=bank_id,
-                pattern=q,
-                limit=limit,
-                offset=offset,
-                request_context=request_context,
-            )
+            if source == "mental_models":
+                data = await app.state.memory.list_mental_model_tags(
+                    bank_id=bank_id,
+                    pattern=q,
+                    limit=limit,
+                    offset=offset,
+                    request_context=request_context,
+                )
+            else:
+                data = await app.state.memory.list_tags(
+                    bank_id=bank_id,
+                    pattern=q,
+                    limit=limit,
+                    offset=offset,
+                    request_context=request_context,
+                )
             return data
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6427,22 +6427,70 @@ class MemoryEngine(MemoryEngineInterface):
 
             ctx = BankReadContext(bank_id=bank_id, operation="list_tags", request_context=request_context)
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        return await self._list_tags_from_table(
+            table="memory_units",
+            bank_id=bank_id,
+            pattern=pattern,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def list_mental_model_tags(
+        self,
+        bank_id: str,
+        *,
+        pattern: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """
+        List all unique tags used on mental models in a bank with usage counts.
+
+        Same wildcard semantics as list_tags. Useful to populate tag autocompletion
+        for UIs filtering mental models by tag.
+        """
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankReadContext
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation="list_mental_model_tags",
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        return await self._list_tags_from_table(
+            table="mental_models",
+            bank_id=bank_id,
+            pattern=pattern,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def _list_tags_from_table(
+        self,
+        *,
+        table: str,
+        bank_id: str,
+        pattern: str | None,
+        limit: int,
+        offset: int,
+    ) -> dict[str, Any]:
         pool = await self._get_pool()
         async with acquire_with_retry(pool) as conn:
             # Build pattern filter if provided (convert * to % for ILIKE)
             pattern_clause = ""
             params: list[Any] = [bank_id]
             if pattern:
-                # Convert wildcard pattern: * -> % for SQL ILIKE
                 sql_pattern = pattern.replace("*", "%")
                 pattern_clause = "AND tag ILIKE $2"
                 params.append(sql_pattern)
 
-            # Get total count of distinct tags matching pattern
             total_row = await conn.fetchrow(
                 f"""
                 SELECT COUNT(DISTINCT tag) as total
-                FROM {fq_table("memory_units")}, unnest(tags) AS tag
+                FROM {fq_table(table)}, unnest(tags) AS tag
                 WHERE bank_id = $1 AND tags IS NOT NULL AND tags != '{{}}'
                 {pattern_clause}
                 """,
@@ -6450,7 +6498,6 @@ class MemoryEngine(MemoryEngineInterface):
             )
             total = total_row["total"] if total_row else 0
 
-            # Get paginated tags with counts, ordered by frequency
             limit_param = len(params) + 1
             offset_param = len(params) + 2
             params.extend([limit, offset])
@@ -6458,7 +6505,7 @@ class MemoryEngine(MemoryEngineInterface):
             rows = await conn.fetch(
                 f"""
                 SELECT tag, COUNT(*) as count
-                FROM {fq_table("memory_units")}, unnest(tags) AS tag
+                FROM {fq_table(table)}, unnest(tags) AS tag
                 WHERE bank_id = $1 AND tags IS NOT NULL AND tags != '{{}}'
                 {pattern_clause}
                 GROUP BY tag

--- a/hindsight-api-slim/tests/test_tags_visibility.py
+++ b/hindsight-api-slim/tests/test_tags_visibility.py
@@ -1501,3 +1501,98 @@ async def test_tag_groups_nested_and_containing_or(api_client):
     assert any("Alice" in t and "step 8" in t for t in texts), "Should find Alice step:8"
     assert not any("step 9" in t for t in texts), "Should NOT find step 9"
     assert not any("Bob" in t for t in texts), "Should NOT find Bob"
+
+
+# ============================================================================
+# Tests for list_mental_model_tags API endpoint
+# ============================================================================
+
+
+async def _create_mental_model_via_engine(memory, *, bank_id, name, tags, request_context):
+    """Helper that creates a mental model directly through the engine without an LLM call."""
+    # Ensure the bank exists (mental_models has a FK to banks).
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    return await memory.create_mental_model(
+        bank_id=bank_id,
+        name=name,
+        source_query=f"Source query for {name}",
+        content=f"Content for {name}",
+        tags=tags,
+        request_context=request_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_mental_model_tags_returns_only_mental_model_tags(memory, request_context):
+    """Mental-model tag listing should reflect only mental_models.tags, not memory_units.tags."""
+    bank_id = f"mm_tags_basic_{datetime.now().timestamp()}"
+
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM A", tags=["topic:alpha", "shared"], request_context=request_context
+    )
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM B", tags=["topic:beta", "shared"], request_context=request_context
+    )
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM C", tags=["topic:alpha"], request_context=request_context
+    )
+
+    result = await memory.list_mental_model_tags(bank_id=bank_id, request_context=request_context)
+
+    tags_map = {item["tag"]: item["count"] for item in result["items"]}
+    assert tags_map == {"topic:alpha": 2, "topic:beta": 1, "shared": 2}
+    assert result["total"] == 3
+
+    # Sanity check: the regular list_tags (which queries memory_units) should not see these tags
+    # since no memories exist in this bank.
+    memory_tags = await memory.list_tags(bank_id=bank_id, request_context=request_context)
+    assert memory_tags["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_mental_model_tags_with_wildcard(memory, request_context):
+    """Wildcard 'topic:*' should only match mental-model tags with that prefix."""
+    bank_id = f"mm_tags_wildcard_{datetime.now().timestamp()}"
+
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM 1", tags=["topic:alpha", "user:alice"], request_context=request_context
+    )
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM 2", tags=["topic:beta"], request_context=request_context
+    )
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM 3", tags=["session:abc"], request_context=request_context
+    )
+
+    result = await memory.list_mental_model_tags(
+        bank_id=bank_id, pattern="topic:*", request_context=request_context
+    )
+
+    returned = sorted(item["tag"] for item in result["items"])
+    assert returned == ["topic:alpha", "topic:beta"]
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_tags_endpoint_with_source_mental_models(memory, request_context):
+    """`/tags?source=mental_models` returns mental-model tags, not memory_units tags."""
+    bank_id = f"mm_tags_source_{datetime.now().timestamp()}"
+
+    await _create_mental_model_via_engine(
+        memory, bank_id=bank_id, name="MM 1", tags=["alpha"], request_context=request_context
+    )
+
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/default/banks/{bank_id}/tags", params={"source": "mental_models"}
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert {item["tag"] for item in body["items"]} == {"alpha"}
+
+        # Default source ('memories') must NOT pick up the mental-model tag.
+        default_response = await client.get(f"/v1/default/banks/{bank_id}/tags")
+        assert default_response.status_code == 200, default_response.text
+        assert default_response.json()["items"] == []

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -712,7 +712,7 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .list_tags(bank_id, limit, offset, q, None)
+                .list_tags(bank_id, limit, offset, q, None, None)
                 .await?;
             Ok(response.into_inner())
         })

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -1776,7 +1776,9 @@ paths:
   /v1/default/banks/{bank_id}/tags:
     get:
       description: "List all unique tags in a memory bank with usage counts. Supports\
-        \ wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive."
+        \ wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.\
+        \ Use `source=mental_models` to list tags used on mental models instead of\
+        \ memories."
       operationId: list_tags
       parameters:
       - explode: false
@@ -1795,6 +1797,22 @@ paths:
         required: false
         schema:
           nullable: true
+          type: string
+        style: form
+      - description: "Where to read tags from: 'memories' (memory_units, default)\
+          \ or 'mental_models'."
+        explode: true
+        in: query
+        name: source
+        required: false
+        schema:
+          default: memories
+          description: "Where to read tags from: 'memories' (memory_units, default)\
+            \ or 'mental_models'."
+          enum:
+          - memories
+          - mental_models
+          title: Source
           type: string
         style: form
       - description: Maximum number of tags to return
@@ -2127,8 +2145,8 @@ paths:
   /v1/default/banks/{bank_id}/profile:
     get:
       deprecated: true
-      description: Get disposition traits and mission for a memory bank. Auto-creates
-        agent with defaults if not exists.
+      description: Get disposition traits and mission for a memory bank. Returns 404
+        if the bank does not exist.
       operationId: get_bank_profile
       parameters:
       - explode: false

--- a/hindsight-clients/go/api_banks.go
+++ b/hindsight-clients/go/api_banks.go
@@ -799,7 +799,7 @@ func (r ApiGetBankProfileRequest) Execute() (*BankProfileResponse, *http.Respons
 /*
 GetBankProfile Get memory bank profile
 
-Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.
+Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/go/api_memory.go
+++ b/hindsight-clients/go/api_memory.go
@@ -911,6 +911,7 @@ type ApiListTagsRequest struct {
 	ApiService *MemoryAPIService
 	bankId string
 	q *string
+	source *string
 	limit *int32
 	offset *int32
 	authorization *string
@@ -919,6 +920,12 @@ type ApiListTagsRequest struct {
 // Wildcard pattern to filter tags (e.g., &#39;user:*&#39; for user:alice, &#39;*-admin&#39; for role-admin). Use &#39;*&#39; as wildcard. Case-insensitive.
 func (r ApiListTagsRequest) Q(q string) ApiListTagsRequest {
 	r.q = &q
+	return r
+}
+
+// Where to read tags from: &#39;memories&#39; (memory_units, default) or &#39;mental_models&#39;.
+func (r ApiListTagsRequest) Source(source string) ApiListTagsRequest {
+	r.source = &source
 	return r
 }
 
@@ -946,7 +953,7 @@ func (r ApiListTagsRequest) Execute() (*ListTagsResponse, *http.Response, error)
 /*
 ListTags List tags
 
-List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.
+List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId
@@ -984,6 +991,12 @@ func (a *MemoryAPIService) ListTagsExecute(r ApiListTagsRequest) (*ListTagsRespo
 
 	if r.q != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "q", r.q, "form", "")
+	}
+	if r.source != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "source", r.source, "form", "")
+	} else {
+		var defaultValue string = "memories"
+		r.source = &defaultValue
 	}
 	if r.limit != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "limit", r.limit, "form", "")

--- a/hindsight-clients/python/hindsight_client_api/api/banks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/banks_api.py
@@ -1797,7 +1797,7 @@ class BanksApi:
     ) -> BankProfileResponse:
         """(Deprecated) Get memory bank profile
 
-        Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.
+        Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -1870,7 +1870,7 @@ class BanksApi:
     ) -> ApiResponse[BankProfileResponse]:
         """(Deprecated) Get memory bank profile
 
-        Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.
+        Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -1943,7 +1943,7 @@ class BanksApi:
     ) -> RESTResponseType:
         """(Deprecated) Get memory bank profile
 
-        Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.
+        Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -16,7 +16,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictInt, StrictStr
+from pydantic import Field, StrictInt, StrictStr, field_validator
 from typing import Any, List, Optional
 from typing_extensions import Annotated
 from hindsight_client_api.models.clear_memory_observations_response import ClearMemoryObservationsResponse
@@ -1989,6 +1989,7 @@ class MemoryApi:
         self,
         bank_id: StrictStr,
         q: Annotated[Optional[StrictStr], Field(description="Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.")] = None,
+        source: Annotated[Optional[StrictStr], Field(description="Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of tags to return")] = None,
         offset: Annotated[Optional[StrictInt], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
@@ -2007,12 +2008,14 @@ class MemoryApi:
     ) -> ListTagsResponse:
         """List tags
 
-        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.
+        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.
 
         :param bank_id: (required)
         :type bank_id: str
         :param q: Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.
         :type q: str
+        :param source: Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.
+        :type source: str
         :param limit: Maximum number of tags to return
         :type limit: int
         :param offset: Offset for pagination
@@ -2044,6 +2047,7 @@ class MemoryApi:
         _param = self._list_tags_serialize(
             bank_id=bank_id,
             q=q,
+            source=source,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2073,6 +2077,7 @@ class MemoryApi:
         self,
         bank_id: StrictStr,
         q: Annotated[Optional[StrictStr], Field(description="Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.")] = None,
+        source: Annotated[Optional[StrictStr], Field(description="Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of tags to return")] = None,
         offset: Annotated[Optional[StrictInt], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
@@ -2091,12 +2096,14 @@ class MemoryApi:
     ) -> ApiResponse[ListTagsResponse]:
         """List tags
 
-        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.
+        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.
 
         :param bank_id: (required)
         :type bank_id: str
         :param q: Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.
         :type q: str
+        :param source: Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.
+        :type source: str
         :param limit: Maximum number of tags to return
         :type limit: int
         :param offset: Offset for pagination
@@ -2128,6 +2135,7 @@ class MemoryApi:
         _param = self._list_tags_serialize(
             bank_id=bank_id,
             q=q,
+            source=source,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2157,6 +2165,7 @@ class MemoryApi:
         self,
         bank_id: StrictStr,
         q: Annotated[Optional[StrictStr], Field(description="Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.")] = None,
+        source: Annotated[Optional[StrictStr], Field(description="Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of tags to return")] = None,
         offset: Annotated[Optional[StrictInt], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
@@ -2175,12 +2184,14 @@ class MemoryApi:
     ) -> RESTResponseType:
         """List tags
 
-        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.
+        List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.
 
         :param bank_id: (required)
         :type bank_id: str
         :param q: Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive.
         :type q: str
+        :param source: Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.
+        :type source: str
         :param limit: Maximum number of tags to return
         :type limit: int
         :param offset: Offset for pagination
@@ -2212,6 +2223,7 @@ class MemoryApi:
         _param = self._list_tags_serialize(
             bank_id=bank_id,
             q=q,
+            source=source,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2236,6 +2248,7 @@ class MemoryApi:
         self,
         bank_id,
         q,
+        source,
         limit,
         offset,
         authorization,
@@ -2266,6 +2279,10 @@ class MemoryApi:
         if q is not None:
             
             _query_params.append(('q', q))
+            
+        if source is not None:
+            
+            _query_params.append(('source', source))
             
         if limit is not None:
             

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -734,7 +734,7 @@ export const updateDocument = <ThrowOnError extends boolean = false>(
 /**
  * List tags
  *
- * List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.
+ * List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.
  */
 export const listTags = <ThrowOnError extends boolean = false>(
   options: Options<ListTagsData, ThrowOnError>
@@ -813,7 +813,7 @@ export const retryOperation = <ThrowOnError extends boolean = false>(
 /**
  * Get memory bank profile
  *
- * Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.
+ * Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.
  *
  * @deprecated
  */

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4832,6 +4832,12 @@ export type ListTagsData = {
      */
     q?: string | null;
     /**
+     * Source
+     *
+     * Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.
+     */
+    source?: "memories" | "mental_models";
+    /**
      * Limit
      *
      * Maximum number of tags to return

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+
+export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
+  try {
+    const { bankId } = await params;
+    if (!bankId) {
+      return NextResponse.json({ error: "bank_id is required" }, { status: 400 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get("q");
+    const source = searchParams.get("source");
+    const limit = searchParams.get("limit");
+    const offset = searchParams.get("offset");
+
+    const queryParams = new URLSearchParams();
+    if (q) queryParams.append("q", q);
+    if (source) queryParams.append("source", source);
+    if (limit) queryParams.append("limit", limit);
+    if (offset) queryParams.append("offset", offset);
+
+    const url = dataplaneBankUrl(bankId, `/tags${queryParams.toString() ? `?${queryParams}` : ""}`);
+    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("API error listing tags:", errorText);
+      return NextResponse.json({ error: "Failed to list tags" }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error("Error listing tags:", error);
+    return NextResponse.json({ error: "Failed to list tags" }, { status: 500 });
+  }
+}

--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -22,8 +22,6 @@ import {
   Network,
   List,
   Search,
-  Tag,
-  X,
 } from "lucide-react";
 import {
   Table,
@@ -47,6 +45,7 @@ import { MemoryDetailPanel } from "./memory-detail-panel";
 import { MemoryDetailModal } from "./memory-detail-modal";
 import { Graph2D, convertHindsightGraphData, GraphNode } from "./graph-2d";
 import { Constellation } from "./constellation";
+import { TagFilterInput } from "./tag-filter-input";
 import { ScatterChart, Plus, FileText } from "lucide-react";
 
 type FactType = "world" | "experience" | "observation";
@@ -74,7 +73,6 @@ export function DataView({
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [tagFilters, setTagFilters] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedGraphNode, setSelectedGraphNode] = useState<any>(null);
   const [modalMemoryId, setModalMemoryId] = useState<string | null>(null);
@@ -158,18 +156,6 @@ export function DataView({
     } finally {
       setLoading(false);
     }
-  };
-
-  const addTagFilter = (tag: string) => {
-    const trimmed = tag.trim();
-    if (trimmed && !tagFilters.includes(trimmed)) {
-      setTagFilters((prev) => [...prev, trimmed]);
-    }
-    setTagInput("");
-  };
-
-  const removeTagFilter = (tag: string) => {
-    setTagFilters((prev) => prev.filter((t) => t !== tag));
   };
 
   // Table rows are already filtered server-side
@@ -418,46 +404,8 @@ export function DataView({
                   />
                 </div>
                 {/* Tag input */}
-                <div className="relative max-w-xs flex-1">
-                  <Tag className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-                  <Input
-                    type="text"
-                    value={tagInput}
-                    onChange={(e) => setTagInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === ",") {
-                        e.preventDefault();
-                        addTagFilter(tagInput);
-                      } else if (e.key === "Backspace" && !tagInput && tagFilters.length > 0) {
-                        removeTagFilter(tagFilters[tagFilters.length - 1]);
-                      }
-                    }}
-                    placeholder="Filter by tag…"
-                    className="pl-8 h-9"
-                  />
-                </div>
+                <TagFilterInput value={tagFilters} onChange={setTagFilters} bankId={currentBank} />
               </div>
-              {/* Active tag chips */}
-              {tagFilters.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {tagFilters.map((tag) => (
-                    <span
-                      key={tag}
-                      className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/20 font-medium leading-none"
-                    >
-                      <span className="opacity-50 select-none font-mono">#</span>
-                      {tag}
-                      <button
-                        onClick={() => removeTagFilter(tag)}
-                        className="opacity-50 hover:opacity-100 transition-opacity ml-0.5"
-                        aria-label={`Remove tag ${tag}`}
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              )}
             </div>
           )}
 

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -39,14 +39,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
   Plus,
   Sparkles,
   Loader2,
@@ -57,9 +49,10 @@ import {
   ChevronsLeft,
   ChevronsRight,
   LayoutGrid,
-  List,
   MoreVertical,
   Pencil,
+  FolderOpen,
+  FileText,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -69,6 +62,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { MentalModelDetailModal } from "./mental-model-detail-modal";
+import { TagFilterInput } from "./tag-filter-input";
 
 interface ReflectResponseBasedOnFact {
   id: string;
@@ -107,19 +101,22 @@ interface MentalModel {
   reflect_response?: ReflectResponse;
 }
 
-type ViewMode = "dashboard" | "table";
+type ViewMode = "dashboard" | "files";
 
 export function MentalModelsView() {
   const { currentBank } = useBank();
   const [mentalModels, setMentalModels] = useState<MentalModel[]>([]);
   const [loading, setLoading] = useState(false);
-  const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
+  const [viewMode, setViewMode] = useState<ViewMode>("files");
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 100;
 
   const [showCreateMentalModel, setShowCreateMentalModel] = useState(false);
   const [selectedMentalModel, setSelectedMentalModel] = useState<MentalModel | null>(null);
+  const [filesSelectedId, setFilesSelectedId] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagsMatch, setTagsMatch] = useState<"any" | "all">("any");
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const [mentalModelToUpdate, setMentalModelToUpdate] = useState<MentalModel | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -128,7 +125,7 @@ export function MentalModelsView() {
   } | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  // Filter mental models based on search query
+  // Tag filtering happens server-side; only the search text is applied locally.
   const filteredMentalModels = mentalModels.filter((m) => {
     if (!searchQuery) return true;
     const query = searchQuery.toLowerCase();
@@ -145,7 +142,11 @@ export function MentalModelsView() {
 
     setLoading(true);
     try {
-      const mentalModelsData = await client.listMentalModels(currentBank);
+      const mentalModelsData = await client.listMentalModels(
+        currentBank,
+        selectedTags.length > 0 ? selectedTags : undefined,
+        selectedTags.length > 0 ? tagsMatch : undefined
+      );
       setMentalModels(mentalModelsData.items || []);
     } catch (error) {
       console.error("Error loading mental models:", error);
@@ -205,7 +206,7 @@ export function MentalModelsView() {
     if (currentBank) {
       loadData();
     }
-  }, [currentBank]);
+  }, [currentBank, selectedTags, tagsMatch]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -217,10 +218,10 @@ export function MentalModelsView() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // Reset to first page when search query changes
+  // Reset to first page when search query or tag filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery]);
+  }, [searchQuery, selectedTags, tagsMatch]);
 
   if (!currentBank) {
     return (
@@ -247,29 +248,53 @@ export function MentalModelsView() {
         </div>
       ) : (
         <>
-          {/* Search filter */}
-          <div className="mb-4">
+          {/* Search + tag filter (single row) */}
+          <div className="mb-4 flex items-center gap-3 flex-wrap">
             <Input
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Filter mental models by name, query, or content..."
-              className="max-w-md"
+              className="w-80 h-9"
             />
+            <TagFilterInput
+              value={selectedTags}
+              onChange={setSelectedTags}
+              fetchSuggestions={async (q) => {
+                if (!currentBank) return [];
+                const pattern = q ? `${q}*` : undefined;
+                const res = await client.listTags(currentBank, pattern, 20, "mental_models");
+                return res.items.map((i) => i.tag);
+              }}
+              matchMode={tagsMatch}
+              onMatchModeChange={setTagsMatch}
+              className="flex-1 min-w-[260px]"
+            />
+            <Button onClick={() => setShowCreateMentalModel(true)} size="sm">
+              <Plus className="w-4 h-4 mr-2" />
+              Add Mental Model
+            </Button>
           </div>
 
           <div className="flex items-center justify-between mb-6">
             <div className="text-sm text-muted-foreground">
-              {searchQuery
+              {searchQuery || selectedTags.length > 0
                 ? `${filteredMentalModels.length} of ${mentalModels.length} mental models`
                 : `${mentalModels.length} mental model${mentalModels.length !== 1 ? "s" : ""}`}
             </div>
             <div className="flex items-center gap-3">
-              <Button onClick={() => setShowCreateMentalModel(true)} size="sm">
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mental Model
-              </Button>
               <div className="flex items-center gap-2 bg-muted rounded-lg p-1">
+                <button
+                  onClick={() => setViewMode("files")}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1.5 ${
+                    viewMode === "files"
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <FolderOpen className="w-4 h-4" />
+                  List
+                </button>
                 <button
                   onClick={() => setViewMode("dashboard")}
                   className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1.5 ${
@@ -280,17 +305,6 @@ export function MentalModelsView() {
                 >
                   <LayoutGrid className="w-4 h-4" />
                   Dashboard
-                </button>
-                <button
-                  onClick={() => setViewMode("table")}
-                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1.5 ${
-                    viewMode === "table"
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <List className="w-4 h-4" />
-                  Table
                 </button>
               </div>
             </div>
@@ -388,70 +402,25 @@ export function MentalModelsView() {
                 </div>
               )}
 
-              {/* Table View */}
-              {viewMode === "table" && (
-                <Table className="table-fixed">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[20%]">ID</TableHead>
-                      <TableHead className="w-[20%]">Name</TableHead>
-                      <TableHead className="w-[35%]">Source Query</TableHead>
-                      <TableHead className="w-[15%]">Last Refreshed</TableHead>
-                      <TableHead className="w-[10%]"></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {paginatedMentalModels.map((m) => {
-                      return (
-                        <TableRow
-                          key={m.id}
-                          className={`cursor-pointer hover:bg-muted/50 ${
-                            selectedMentalModel?.id === m.id ? "bg-primary/10" : ""
-                          }`}
-                          onClick={() => setSelectedMentalModel(m)}
-                        >
-                          <TableCell className="py-2">
-                            <code className="text-xs font-mono text-muted-foreground truncate block">
-                              {m.id}
-                            </code>
-                          </TableCell>
-                          <TableCell className="py-2">
-                            <div className="font-medium text-foreground">{m.name}</div>
-                          </TableCell>
-                          <TableCell className="py-2">
-                            <div className="text-sm text-muted-foreground truncate">
-                              {m.source_query}
-                            </div>
-                          </TableCell>
-                          <TableCell
-                            className="py-2 text-sm text-foreground"
-                            title={formatAbsoluteDateTime(m.last_refreshed_at)}
-                          >
-                            {formatRelativeTime(m.last_refreshed_at)}
-                          </TableCell>
-                          <TableCell className="py-2">
-                            <RowActionsMenu
-                              m={m}
-                              refreshing={refreshingIds.has(m.id)}
-                              onEdit={(target) => {
-                                setMentalModelToUpdate(target);
-                                setShowUpdateDialog(true);
-                              }}
-                              onRefresh={handleRowRefresh}
-                              onDelete={(target) =>
-                                setDeleteTarget({ id: target.id, name: target.name })
-                              }
-                            />
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+              {/* Files View */}
+              {viewMode === "files" && (
+                <FilesView
+                  mentalModels={filteredMentalModels}
+                  selectedId={filesSelectedId}
+                  onSelect={setFilesSelectedId}
+                  onOpenDetail={setSelectedMentalModel}
+                  refreshingIds={refreshingIds}
+                  onEdit={(target) => {
+                    setMentalModelToUpdate(target);
+                    setShowUpdateDialog(true);
+                  }}
+                  onRefresh={handleRowRefresh}
+                  onDelete={(target) => setDeleteTarget({ id: target.id, name: target.name })}
+                />
               )}
 
               {/* Pagination Controls */}
-              {totalPages > 1 && (
+              {viewMode !== "files" && totalPages > 1 && (
                 <div className="flex items-center justify-between mt-3 pt-3 border-t">
                   <div className="text-xs text-muted-foreground">
                     {startIndex + 1}-{Math.min(endIndex, filteredMentalModels.length)} of{" "}
@@ -1445,5 +1414,140 @@ function UpdateMentalModelDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function FilesView({
+  mentalModels,
+  selectedId,
+  onSelect,
+  onOpenDetail,
+  refreshingIds,
+  onEdit,
+  onRefresh,
+  onDelete,
+}: {
+  mentalModels: MentalModel[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onOpenDetail: (m: MentalModel) => void;
+  refreshingIds: Set<string>;
+  onEdit: (m: MentalModel) => void;
+  onRefresh: (m: MentalModel) => void;
+  onDelete: (m: MentalModel) => void;
+}) {
+  const effectiveId =
+    selectedId && mentalModels.some((m) => m.id === selectedId)
+      ? selectedId
+      : (mentalModels[0]?.id ?? null);
+  const selected = mentalModels.find((m) => m.id === effectiveId) ?? null;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[320px_1fr] gap-0 overflow-hidden min-h-[600px]">
+      <aside className="border-r border-border bg-muted/30 overflow-y-auto max-h-[calc(100vh-260px)]">
+        <ul className="py-1">
+          {mentalModels.map((m) => {
+            const isActive = m.id === effectiveId;
+            return (
+              <li key={m.id}>
+                <button
+                  onClick={() => onSelect(m.id)}
+                  className={`w-full flex items-start gap-2 px-3 py-2 text-left transition-colors border-l-2 ${
+                    isActive
+                      ? "bg-primary/10 border-primary text-foreground"
+                      : "border-transparent text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                  title={`${m.name}\n${m.source_query}`}
+                >
+                  <FileText className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`truncate text-sm font-medium ${isActive ? "text-foreground" : ""}`}
+                      >
+                        {m.name}
+                      </span>
+                      <span
+                        className="ml-auto text-[10px] text-muted-foreground flex-shrink-0"
+                        title={formatAbsoluteDateTime(m.last_refreshed_at)}
+                      >
+                        {formatRelativeTime(m.last_refreshed_at)}
+                      </span>
+                    </div>
+                    {m.source_query && (
+                      <div className="text-xs text-muted-foreground/80 truncate italic mt-0.5">
+                        {m.source_query}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <section className="overflow-y-auto max-h-[calc(100vh-260px)]">
+        {selected ? (
+          <article className="p-6">
+            <header className="mb-4 pb-4 border-b border-border">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-xl font-semibold text-foreground">{selected.name}</h2>
+                  {selected.source_query && (
+                    <p className="text-sm text-muted-foreground mt-1 italic">
+                      &ldquo;{selected.source_query}&rdquo;
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+                    <span title={formatAbsoluteDateTime(selected.last_refreshed_at)}>
+                      Refreshed {formatRelativeTime(selected.last_refreshed_at)}
+                    </span>
+                    {selected.tags.length > 0 && (
+                      <div className="flex gap-1">
+                        {selected.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-1.5 py-0.5 rounded text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  <Button variant="outline" size="sm" onClick={() => onOpenDetail(selected)}>
+                    Open
+                  </Button>
+                  <RowActionsMenu
+                    m={selected}
+                    refreshing={refreshingIds.has(selected.id)}
+                    onEdit={onEdit}
+                    onRefresh={onRefresh}
+                    onDelete={onDelete}
+                  />
+                </div>
+              </div>
+            </header>
+            {selected.content ? (
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <CompactMarkdown>{selected.content}</CompactMarkdown>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground italic">
+                No content yet. Refresh this mental model to generate content.
+              </p>
+            )}
+          </article>
+        ) : (
+          <div className="p-10 text-center text-muted-foreground">
+            <FileText className="w-8 h-8 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">Select a mental model to view its content.</p>
+          </div>
+        )}
+      </section>
+    </div>
   );
 }

--- a/hindsight-control-plane/src/components/tag-filter-input.tsx
+++ b/hindsight-control-plane/src/components/tag-filter-input.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Tag, X } from "lucide-react";
+import { client } from "@/lib/api";
+
+type FetchSuggestions = (q: string) => Promise<string[]>;
+
+interface TagFilterInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  bankId?: string | null;
+  fetchSuggestions?: FetchSuggestions;
+  placeholder?: string;
+  className?: string;
+  matchMode?: "any" | "all";
+  onMatchModeChange?: (mode: "any" | "all") => void;
+  showMatchToggleAt?: number;
+}
+
+const DEFAULT_SHOW_MATCH_TOGGLE_AT = 2;
+
+export function TagFilterInput({
+  value,
+  onChange,
+  bankId,
+  fetchSuggestions,
+  placeholder = "Filter by tag…",
+  className,
+  matchMode,
+  onMatchModeChange,
+  showMatchToggleAt = DEFAULT_SHOW_MATCH_TOGGLE_AT,
+}: TagFilterInputProps) {
+  const [input, setInput] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Default suggestion source uses the memory-units `list_tags` endpoint when a
+  // bankId is given. Memoize so the effect below doesn't refire on every render.
+  const defaultFetcher = useMemo<FetchSuggestions | undefined>(() => {
+    if (!bankId) return undefined;
+    return async (q: string) => {
+      const pattern = q ? `${q}*` : undefined;
+      const res = await client.listTags(bankId, pattern, 20);
+      return res.items.map((i) => i.tag);
+    };
+  }, [bankId]);
+
+  // Caller-supplied fetchSuggestions is typically defined inline (new identity per
+  // render), which would refire the debounce effect after each fetch and create an
+  // infinite suggestion-fetch loop. Hold it via a ref so the effect's dep list
+  // only tracks input/value — the latest closure is used at fire time.
+  const fetcherRef = useRef<FetchSuggestions | undefined>(undefined);
+  fetcherRef.current = fetchSuggestions ?? defaultFetcher;
+
+  // Debounced fetch of suggestions when typing
+  useEffect(() => {
+    const fetcher = fetcherRef.current;
+    if (!fetcher) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const results = await fetcher(input.trim());
+        if (cancelled) return;
+        const filtered = results.filter((t) => !value.includes(t));
+        setSuggestions(filtered);
+        setActiveIndex(filtered.length > 0 ? 0 : -1);
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      }
+    }, 150);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [input, value]);
+
+  // Close suggestions on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const addTag = (tag: string) => {
+    const trimmed = tag.trim();
+    if (!trimmed || value.includes(trimmed)) {
+      setInput("");
+      return;
+    }
+    onChange([...value, trimmed]);
+    setInput("");
+    setActiveIndex(-1);
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" && suggestions.length > 0) {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIndex((i) => (i + 1) % suggestions.length);
+      return;
+    }
+    if (e.key === "ArrowUp" && suggestions.length > 0) {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIndex((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+      return;
+    }
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      if (open && activeIndex >= 0 && suggestions[activeIndex]) {
+        addTag(suggestions[activeIndex]);
+      } else if (input.trim()) {
+        addTag(input);
+      }
+      return;
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+      return;
+    }
+    if (e.key === "Backspace" && !input && value.length > 0) {
+      removeTag(value[value.length - 1]);
+    }
+  };
+
+  const showMatchToggle =
+    matchMode != null && onMatchModeChange != null && value.length >= showMatchToggleAt;
+
+  return (
+    <div className={`flex items-center gap-2 flex-wrap ${className ?? ""}`}>
+      <div ref={containerRef} className="relative w-56">
+        <Tag className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Input
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="pl-8 h-9"
+        />
+        {open && suggestions.length > 0 && (
+          <div className="absolute z-20 mt-1 w-full bg-popover border border-border rounded-md shadow-md max-h-60 overflow-y-auto">
+            {suggestions.map((tag, idx) => (
+              <button
+                key={tag}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  addTag(tag);
+                }}
+                onMouseEnter={() => setActiveIndex(idx)}
+                className={`w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 ${
+                  idx === activeIndex
+                    ? "bg-accent text-accent-foreground"
+                    : "text-foreground hover:bg-muted"
+                }`}
+              >
+                <Tag className="w-3 h-3 text-muted-foreground" />
+                <span className="truncate">{tag}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {value.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/20 font-medium leading-none"
+            >
+              <span className="opacity-50 select-none font-mono">#</span>
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="opacity-50 hover:opacity-100 transition-opacity ml-0.5"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+          <button
+            type="button"
+            onClick={() => onChange([])}
+            className="text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      {showMatchToggle && (
+        <div className="flex items-center gap-1 bg-muted rounded-md p-0.5 h-9 ml-auto">
+          <button
+            type="button"
+            onClick={() => onMatchModeChange!("any")}
+            className={`px-2 py-1 rounded text-xs font-medium ${
+              matchMode === "any"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground"
+            }`}
+            title="Match any selected tag"
+          >
+            any
+          </button>
+          <button
+            type="button"
+            onClick={() => onMatchModeChange!("all")}
+            className={`px-2 py-1 rounded text-xs font-medium ${
+              matchMode === "all"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground"
+            }`}
+            title="Match all selected tags"
+          >
+            all
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -981,6 +981,31 @@ export class ControlPlaneClient {
     }>(bankApi(bankId, `/observations/${encodeURIComponent(observationId)}`));
   }
 
+  // ============= TAGS =============
+
+  /**
+   * List unique tags in a bank with usage counts. Supports wildcard '*' in q.
+   * Pass `source: "mental_models"` to read tags from mental_models instead of memory_units.
+   */
+  async listTags(
+    bankId: string,
+    q?: string,
+    limit?: number,
+    source?: "memories" | "mental_models"
+  ) {
+    const params = new URLSearchParams();
+    if (q) params.append("q", q);
+    if (limit != null) params.append("limit", String(limit));
+    if (source) params.append("source", source);
+    const query = params.toString();
+    return this.fetchApi<{
+      items: Array<{ tag: string; count: number }>;
+      total: number;
+      limit: number;
+      offset: number;
+    }>(bankApi(bankId, `/tags${query ? `?${query}` : ""}`));
+  }
+
   // ============= MENTAL MODELS (stored reflect responses) =============
 
   /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -2594,7 +2594,7 @@
           "Memory"
         ],
         "summary": "List tags",
-        "description": "List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.",
+        "description": "List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.",
         "operationId": "list_tags",
         "parameters": [
           {
@@ -2623,6 +2623,22 @@
               "title": "Q"
             },
             "description": "Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "memories",
+                "mental_models"
+              ],
+              "type": "string",
+              "description": "Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.",
+              "default": "memories",
+              "title": "Source"
+            },
+            "description": "Where to read tags from: 'memories' (memory_units, default) or 'mental_models'."
           },
           {
             "name": "limit",
@@ -3102,7 +3118,7 @@
           "Banks"
         ],
         "summary": "Get memory bank profile",
-        "description": "Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.",
+        "description": "Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.",
         "operationId": "get_bank_profile",
         "deprecated": true,
         "parameters": [

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -174,6 +174,7 @@ To switch between backends:
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict merged into `extra_body` for all OpenAI-compatible API calls. Useful for custom model servers (e.g., vLLM `chat_template_kwargs`). | `null` |
+| `HINDSIGHT_API_LLM_SIMPLIFY_JSON_SCHEMA` | Flatten `$ref`/`$defs`/`anyOf` in JSON schemas before sending to LLMs. Required for Ollama structured output; improves compliance for all providers. Set to `false` to send raw Pydantic schemas. | `true` |
 | `HINDSIGHT_API_LLM_GEMINI_SAFETY_SETTINGS` | JSON-encoded list of `{category, threshold}` dicts for Gemini/VertexAI content safety filtering | `null` |
 
 **Provider Examples**

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -2594,7 +2594,7 @@
           "Memory"
         ],
         "summary": "List tags",
-        "description": "List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive.",
+        "description": "List all unique tags in a memory bank with usage counts. Supports wildcard search using '*' (e.g., 'user:*', '*-fred', 'tag*-2'). Case-insensitive. Use `source=mental_models` to list tags used on mental models instead of memories.",
         "operationId": "list_tags",
         "parameters": [
           {
@@ -2623,6 +2623,22 @@
               "title": "Q"
             },
             "description": "Wildcard pattern to filter tags (e.g., 'user:*' for user:alice, '*-admin' for role-admin). Use '*' as wildcard. Case-insensitive."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "memories",
+                "mental_models"
+              ],
+              "type": "string",
+              "description": "Where to read tags from: 'memories' (memory_units, default) or 'mental_models'.",
+              "default": "memories",
+              "title": "Source"
+            },
+            "description": "Where to read tags from: 'memories' (memory_units, default) or 'mental_models'."
           },
           {
             "name": "limit",
@@ -3102,7 +3118,7 @@
           "Banks"
         ],
         "summary": "Get memory bank profile",
-        "description": "Get disposition traits and mission for a memory bank. Auto-creates agent with defaults if not exists.",
+        "description": "Get disposition traits and mission for a memory bank. Returns 404 if the bank does not exist.",
         "operationId": "get_bank_profile",
         "deprecated": true,
         "parameters": [


### PR DESCRIPTION
## Summary
- Adds a default split-pane **List** view to the Mental Models page in the control plane: sidebar of "files" (one per model, with name + source-query subtitle + relative refresh time) and full markdown content on the right. Old card "Dashboard" view stays as a secondary toggle. Old "Table" view removed.
- New reusable `<TagFilterInput>` component (free-text entry + debounced server-side autocomplete + chip selection + optional any/all match toggle), used in both the Mental Models page and the existing Memories page.
- New API endpoint `GET /v1/default/banks/{bank_id}/mental-models/tags` (mirroring the existing `/tags` which only covers `memory_units`) so the new component can suggest tags actually present on mental models. Engine refactored to share the listing query between the two endpoints.
- Mental-models tag filtering is now **server-side** (via the existing `tags=` and `tags_match=` query params on `/mental-models`), not client-side.

### Files of note
- `hindsight-api-slim/hindsight_api/api/http.py` — new `/mental-models/tags` route, registered **before** `/mental-models/{mental_model_id}` (regression test pins this).
- `hindsight-api-slim/hindsight_api/engine/memory_engine.py` — new `list_mental_model_tags` method + shared `_list_tags_from_table` helper.
- `hindsight-control-plane/src/components/tag-filter-input.tsx` — new reusable component. Caller-supplied `fetchSuggestions` is held via a ref so the debounce effect doesn't loop on inline-defined closures.

## Test plan
- [x] Unit/engine tests in `tests/test_tags_visibility.py` — basic count, wildcard filter, route-ordering regression.
- [x] `./scripts/hooks/lint.sh` — clean.
- [x] `npx tsc --noEmit` — clean (only pre-existing warnings unrelated to this change).
- [x] Manual smoke test — control plane List view selects/edits/refreshes/deletes; tag filter chips drive server-side refetch; suggestions dropdown shows real mental-model tags.
- [ ] Verify on staging: confirm tag suggestions render for banks with many tags (we cap suggestions at 20).

## Notes
- Python SDK regen failed locally with a Docker template error unrelated to this change (`hindsight_client_api_README.md` write); the OpenAPI spec is up-to-date so consumers can regenerate. TypeScript and Go SDKs were regenerated.
- This branch was rebased fresh from `origin/main`.