### PR TITLE
test(hermes-smoke): use first-person content so fact extractor has signal

### DIFF
--- a/hindsight-integration-tests/README.md
+++ b/hindsight-integration-tests/README.md
@@ -87,4 +87,4 @@ This runs both types. Self-contained tests won't conflict with the external serv
 
 - `HINDSIGHT_API_URL` — Base URL for external-server tests (default: `http://localhost:8888`)
 - `HINDSIGHT_LLM_API_KEY` / `OPENAI_API_KEY` — required by the Hermes embedded smoke test
-- `HINDSIGHT_LLM_PROVIDER`, `HINDSIGHT_LLM_MODEL` — override defaults (`openai` / `gpt-4o-mini`)
+- `HINDSIGHT_LLM_PROVIDER`, `HINDSIGHT_LLM_MODEL` — override defaults (`openai` / `gpt-4o`)

--- a/hindsight-integration-tests/tests/test_hermes_embedded_smoke.py
+++ b/hindsight-integration-tests/tests/test_hermes_embedded_smoke.py
@@ -125,11 +125,22 @@ def test_retain_then_recall_roundtrip(embedded_provider):
 
     This exercises the full Hermes plugin path: sync_turn -> aretain_batch ->
     daemon -> LLM fact extraction -> indexing -> recall -> prefetch.
+
+    Content style matters: the fact extractor mines first-person statements
+    the user makes about themselves. Synthetic Q&A where the assistant
+    asserts a fact about the user yields 0 extracted units and an empty
+    bank, even though the HTTP retain returns 200. Use a natural turn
+    where the user states the preference directly.
     """
-    fact = "The user's favorite programming language is Rust"
     embedded_provider.sync_turn(
-        user_content="What's my favorite programming language?",
-        assistant_content=fact,
+        user_content=(
+            "I've been writing Rust for the past three years and it's easily "
+            "my favorite programming language — the borrow checker just clicks "
+            "for me."
+        ),
+        assistant_content=(
+            "Got it — I'll remember that Rust is your favorite language."
+        ),
     )
     if embedded_provider._sync_thread:
         embedded_provider._sync_thread.join(timeout=60.0)


### PR DESCRIPTION
## Summary
The smoke test added in #1283 uses synthetic Q&A:

- User: *"What's my favorite programming language?"* (asks, asserts nothing)
- Assistant: *"The user's favorite programming language is Rust"*

The fact extractor is tuned to mine first-person user statements, so this content yields 0 extracted units. Retain returns 200, the bank stays empty, recall surfaces nothing → the test polls for 60s and fails.

Replace with a natural first-person user statement so the extractor has something to work with.

## Test plan
- [x] Run on macOS, hindsight-embed 0.5.6, gpt-4o-mini default — passes deterministically
