### PR TITLE
feat(python-client): expose retain_async in retain() and aretain()

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -258,6 +258,7 @@ class Hindsight:
         entities: list[dict[str, str]] | None = None,
         tags: list[str] | None = None,
         update_mode: str | None = None,
+        retain_async: bool = False,
     ) -> RetainResponse:
         """
         Store a single memory (sync wrapper — prefer :meth:`aretain` in async code).
@@ -272,6 +273,7 @@ class Hindsight:
             entities: Optional list of entities [{"text": "...", "type": "..."}]
             tags: Optional list of tags for filtering memories during recall/reflect
             update_mode: How to handle existing documents ('replace' or 'append')
+            retain_async: If True, process asynchronously in background (default: False)
 
         Returns:
             RetainResponse with success status
@@ -290,6 +292,7 @@ class Hindsight:
             bank_id=bank_id,
             items=[item],
             document_id=document_id,
+            retain_async=retain_async,
         )
 
     def retain_batch(
@@ -772,6 +775,7 @@ class Hindsight:
         entities: list[dict[str, str]] | None = None,
         tags: list[str] | None = None,
         update_mode: str | None = None,
+        retain_async: bool = False,
     ) -> RetainResponse:
         """
         Store a single memory (async — preferred over :meth:`retain`).
@@ -786,6 +790,7 @@ class Hindsight:
             entities: Optional list of entities [{"text": "...", "type": "..."}]
             tags: Optional list of tags for filtering memories during recall/reflect
             update_mode: How to handle existing documents ('replace' or 'append')
+            retain_async: If True, process asynchronously in background (default: False)
 
         Returns:
             RetainResponse with success status
@@ -804,6 +809,7 @@ class Hindsight:
             bank_id=bank_id,
             items=[item],
             document_id=document_id,
+            retain_async=retain_async,
         )
 
     async def arecall(

--- a/hindsight-clients/python/tests/test_retain_async_kwarg.py
+++ b/hindsight-clients/python/tests/test_retain_async_kwarg.py
@@ -1,0 +1,50 @@
+"""
+Test that retain() and aretain() forward retain_async to the batch methods.
+
+Prevents silent regressions where retain_async is accepted in the signature
+but dropped before reaching the API request (similar to the bug fixed in #709).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from hindsight_client import Hindsight
+
+
+def _make_client():
+    return Hindsight(base_url="http://localhost:8888")
+
+
+async def test_aretain_forwards_retain_async_default():
+    """aretain() should forward retain_async=False by default."""
+    client = _make_client()
+    client.aretain_batch = AsyncMock()
+
+    await client.aretain("bank", "content")
+    assert client.aretain_batch.call_args.kwargs["retain_async"] is False
+
+
+async def test_aretain_forwards_retain_async_true():
+    """aretain(retain_async=True) should forward it to aretain_batch()."""
+    client = _make_client()
+    client.aretain_batch = AsyncMock()
+
+    await client.aretain("bank", "content", retain_async=True)
+    assert client.aretain_batch.call_args.kwargs["retain_async"] is True
+
+
+def test_retain_forwards_retain_async_default():
+    """retain() should forward retain_async=False by default."""
+    client = _make_client()
+    client.retain_batch = MagicMock()
+
+    client.retain("bank", "content")
+    assert client.retain_batch.call_args.kwargs["retain_async"] is False
+
+
+def test_retain_forwards_retain_async_true():
+    """retain(retain_async=True) should forward it to retain_batch()."""
+    client = _make_client()
+    client.retain_batch = MagicMock()
+
+    client.retain("bank", "content", retain_async=True)
+    assert client.retain_batch.call_args.kwargs["retain_async"] is True


### PR DESCRIPTION
## Summary

The REST API's `/v1/default/banks/{bank_id}/memories` endpoint accepts `async: bool` on every retain request, and both `retain_batch()` / `aretain_batch()` already expose this via `retain_async: bool = False`. However, the single-memory convenience wrappers `retain()` / `aretain()` have never exposed it. Since these wrappers simply delegate to the batch methods, there is no technical reason to omit the parameter — users who want async on a single memory today must switch to the batch API, which is an unnecessary friction.

The TypeScript SDK also exposes `async?: boolean` on its `retain()` method, so this brings the Python SDK in line.

PR #709 fixed `aretain_batch()` to actually pass `retain_async` through to the request model (it was silently dropped before), but the convenience wrappers were left without the parameter.

## Changes

- Add `retain_async: bool = False` to both `retain()` and `aretain()`, forwarding it to the underlying batch methods.
- Add unit tests verifying the kwarg is forwarded (prevents silent regressions like #709).

Fully backwards compatible — default is `False`, matching existing behavior.

## Test plan

- [x] Pre-commit hooks pass
- [x] `retain(bank_id, content)` and `aretain(bank_id, content)` bind correctly without the new kwarg
- [x] New unit tests: 4/4 pass (`tests/test_retain_async_kwarg.py`)
