### PR TITLE
docs(mental-models): document tags?source=mental_models per #1296

### DIFF
--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -353,6 +353,15 @@ When you call `reflect` with tags, those same tags are used to filter which ment
 
 For more details on tag matching modes (`any`, `any_strict`, `all`, `all_strict`) and worked examples, see the [Recall tags reference](./recall#tags).
 
+### Listing mental model tags
+
+`GET /v1/default/banks/{bank_id}/tags` accepts a `source` query parameter that selects which tag space to enumerate:
+
+- `source=memories` *(default)* — tags attached to memory units.
+- `source=mental_models` — tags attached to mental models in this bank.
+
+Use the `mental_models` source to populate autocomplete or filter UIs over mental-model tags, distinct from the (typically larger) memory tag set.
+
 ---
 
 ## History

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -493,6 +493,15 @@ When you call `reflect` with tags, those same tags are used to filter which ment
 
 For more details on tag matching modes (`any`, `any_strict`, `all`, `all_strict`) and worked examples, see the [Recall tags reference](./recall#tags).
 
+### Listing mental model tags
+
+`GET /v1/default/banks/{bank_id}/tags` accepts a `source` query parameter that selects which tag space to enumerate:
+
+- `source=memories` *(default)* — tags attached to memory units.
+- `source=mental_models` — tags attached to mental models in this bank.
+
+Use the `mental_models` source to populate autocomplete or filter UIs over mental-model tags, distinct from the (typically larger) memory tag set.
+
 ---
 
 ## History


### PR DESCRIPTION
## Summary

#1296 added a `source` query parameter to `GET /v1/default/banks/{bank_id}/tags` so the new Mental Models List view can fetch the mental-model tag set instead of the memory tag set. The [v0.5.5 release blog](/blog/version-0-5-5#mental-models-list-view) and the [`Use Mental Model Tags` guide](/guides/2026-04-28-guide-use-mental-model-tags-in-hindsight-list-view) both describe this, but the API reference under `developer/api/mental-models` (and the sidecar reference) doesn't mention the parameter — SDK / integration developers reading the API docs to wire up tag autocomplete won't know this primitive exists.

## What's in the PR

- `hindsight-docs/docs/developer/api/mental-models.mdx` (+8 LOC): adds a `### Listing mental model tags` subsection at the end of the existing `## Tags and Visibility` section, documenting the `source` parameter (enum: `memories` *(default)* / `mental_models`).
- `skills/hindsight-docs/references/developer/api/mental-models.md` (+8 LOC): byte-for-byte mirror.

## Source of truth

Pulled from `hindsight-docs/static/openapi.json`:

```
GET /v1/default/banks/{bank_id}/tags
  param source:
    enum: ['memories', 'mental_models']
    default: 'memories'
    description: "Where to read tags from: 'memories' (memory_units, default) or 'mental_models'."
```

Pure docs, no behavior change.