### PR TITLE
fix(embeddings): add allowed_openai_params for OpenAI-compatible embedding dimensions

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -836,6 +836,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 embed_kwargs["api_base"] = self.api_base
             if self.output_dimensions is not None:
                 embed_kwargs["dimensions"] = self.output_dimensions
+                if self.model.startswith("openai/"):
+                    embed_kwargs["allowed_openai_params"] = ["dimensions"]
 
             # Use async embedding method (standard in litellm)
             response = await self._litellm.aembedding(**embed_kwargs)
@@ -886,6 +888,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                     embed_kwargs["api_base"] = self.api_base
                 if self.output_dimensions is not None:
                     embed_kwargs["dimensions"] = self.output_dimensions
+                    if self.model.startswith("openai/"):
+                        embed_kwargs["allowed_openai_params"] = ["dimensions"]
 
                 # Use sync embedding (litellm doesn't have async in thread-safe way)
                 response = self._litellm.embedding(**embed_kwargs)

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -18,7 +18,6 @@ from hindsight_api.config import (
     ENV_EMBEDDINGS_LITELLM_SDK_API_KEY,
     ENV_EMBEDDINGS_LITELLM_SDK_MODEL,
     ENV_EMBEDDINGS_PROVIDER,
-    HindsightConfig,
 )
 from hindsight_api.engine.embeddings import LiteLLMSDKEmbeddings, create_embeddings_from_env
 
@@ -292,12 +291,39 @@ class TestLiteLLMSDKEmbeddings:
 
             init_call_args = mock_litellm.aembedding.call_args
             assert init_call_args.kwargs["dimensions"] == 768
+            assert "allowed_openai_params" not in init_call_args.kwargs
 
             mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
             emb.encode(["test"])
 
             encode_call_args = mock_litellm.embedding.call_args
             assert encode_call_args.kwargs["dimensions"] == 768
+            assert "allowed_openai_params" not in encode_call_args.kwargs
+
+    async def test_openai_output_dimensions_allows_litellm_dimensions_param(self, mock_litellm):
+        """OpenAI-compatible custom models need LiteLLM's explicit dimensions allow-list."""
+        with patch(
+            "builtins.__import__",
+            side_effect=lambda name, *args: mock_litellm if name == "litellm" else __import__(name, *args),
+        ):
+            emb = LiteLLMSDKEmbeddings(
+                api_key="test_key",
+                model="openai/Qwen3-Embedding-4B-4bit-DWQ",
+                api_base="https://custom.api.com",
+                output_dimensions=2000,
+            )
+            await emb.initialize()
+
+            init_call_args = mock_litellm.aembedding.call_args
+            assert init_call_args.kwargs["dimensions"] == 2000
+            assert init_call_args.kwargs["allowed_openai_params"] == ["dimensions"]
+
+            mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 2000, "index": 0}]
+            emb.encode(["test"])
+
+            encode_call_args = mock_litellm.embedding.call_args
+            assert encode_call_args.kwargs["dimensions"] == 2000
+            assert encode_call_args.kwargs["allowed_openai_params"] == ["dimensions"]
 
     async def test_output_dimensions_omitted_when_unset(self, mock_litellm):
         """Test output dimensions are omitted when not configured."""
@@ -337,6 +363,7 @@ class TestLiteLLMSDKEmbeddings:
             init_call_args = mock_litellm.aembedding.call_args
             assert init_call_args.kwargs["api_base"] == "https://custom.api.com"
             assert init_call_args.kwargs["dimensions"] == 768
+            assert "allowed_openai_params" not in init_call_args.kwargs
 
             mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
             emb.encode(["test"])
@@ -344,6 +371,7 @@ class TestLiteLLMSDKEmbeddings:
             encode_call_args = mock_litellm.embedding.call_args
             assert encode_call_args.kwargs["api_base"] == "https://custom.api.com"
             assert encode_call_args.kwargs["dimensions"] == 768
+            assert "allowed_openai_params" not in encode_call_args.kwargs
 
     async def test_encoding_format_default_is_float(self, mock_litellm):
         """Test that encoding_format defaults to 'float' for backwards compatibility."""


### PR DESCRIPTION
## What

Fix the `allowed_openai_params` issue in `LiteLLMSDKEmbeddings` when using OpenAI-compatible custom embedding models.

## Problem

When using `litellm-sdk` as the embeddings provider with an OpenAI-compatible custom model (e.g., `openai/Qwen3-Embedding-4B-4bit-DWQ`), the `dimensions` parameter is silently rejected by litellm unless it is explicitly allow-listed via `allowed_openai_params`.

This means `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS` has no effect — the embedding returns the model's default dimension instead of the configured one.

## Solution

Add `allowed_openai_params = ["dimensions"]` to the litellm kwargs when the model name starts with `openai/` and `output_dimensions` is set.

This affects both the async (`aembedding`) and sync (`embedding`) code paths in `LiteLLMSDKEmbeddings`.

## Changes

- `hindsight-api-slim/hindsight_api/engine/embeddings.py`: Add `allowed_openai_params` in 2 places (async and sync paths)
- `hindsight-api-slim/tests/test_litellm_sdk_embeddings.py`: Add test `test_openai_output_dimensions_allows_litellm_dimensions_param` and update existing tests to verify `allowed_openai_params` behavior

## Testing

- Unit tests pass (see `test_litellm_sdk_embeddings.py`)
- Verified locally with `litellm-sdk` + OpenAI-compatible custom embedding endpoint + `OUTPUT_DIMENSIONS=2000`
