### PR TITLE
chore(docs): sync version-0.5 docs from next

### DIFF
--- a/hindsight-docs/versioned_docs/version-0.5/developer/api/mental-models.mdx
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/api/mental-models.mdx
@@ -353,6 +353,15 @@ When you call `reflect` with tags, those same tags are used to filter which ment
 
 For more details on tag matching modes (`any`, `any_strict`, `all`, `all_strict`) and worked examples, see the [Recall tags reference](./recall#tags).
 
+### Listing mental model tags
+
+`GET /v1/default/banks/{bank_id}/tags` accepts a `source` query parameter that selects which tag space to enumerate:
+
+- `source=memories` *(default)* — tags attached to memory units.
+- `source=mental_models` — tags attached to mental models in this bank.
+
+Use the `mental_models` source to populate autocomplete or filter UIs over mental-model tags, distinct from the (typically larger) memory tag set.
+
 ---
 
 ## History

--- a/hindsight-docs/versioned_sidebars/version-0.5-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.5-sidebars.json
@@ -357,6 +357,22 @@
         },
         {
           "type": "link",
+          "href": "/sdks/integrations/agentcore",
+          "label": "AgentCore Runtime",
+          "customProps": {
+            "icon": "/img/icons/agentcore.png"
+          }
+        },
+        {
+          "type": "link",
+          "href": "/sdks/integrations/smolagents",
+          "label": "SmolAgents",
+          "customProps": {
+            "icon": "/img/icons/smolagents.png"
+          }
+        },
+        {
+          "type": "link",
           "href": "/sdks/integrations/ag2",
           "label": "AG2",
           "customProps": {


### PR DESCRIPTION
## Summary
- Syncs latest docs from `next` (docs/) into `versioned_docs/version-0.5/`
- Picks up mental-models docs update and sidebar changes

## Test plan
- [ ] CI passes
- [ ] Docs build succeeds