### PR TITLE
perf: add recall-with-observations & consolidation suites, split CI steps, fix locomo

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -22,6 +22,7 @@ on:
           - ""
           - retain
           - recall
+          - recall-with-observations
         default: ""
       locomo_max_conversations:
         description: "LoComo max conversations (0 = skip, blank = all)"
@@ -81,23 +82,36 @@ jobs:
       run: |
         cd hindsight-dev && uv sync --frozen --all-extras --index-strategy unsafe-best-match
 
-    - name: Run perf tests
+    - name: "Suite: retain"
+      if: inputs.suite == '' || inputs.suite == 'retain'
       run: |
-        SUITE_ARG=""
-        if [ -n "${{ inputs.suite }}" ]; then
-          SUITE_ARG="--suite ${{ inputs.suite }}"
-        fi
         ./scripts/benchmarks/run-perf-test.sh \
           --scale ${{ inputs.scale || 'large' }} \
-          $SUITE_ARG \
-          --output perf-results.json
+          --suite retain \
+          --output perf-results-retain.json
+
+    - name: "Suite: recall"
+      if: inputs.suite == '' || inputs.suite == 'recall'
+      run: |
+        ./scripts/benchmarks/run-perf-test.sh \
+          --scale ${{ inputs.scale || 'large' }} \
+          --suite recall \
+          --output perf-results-recall.json
+
+    - name: "Suite: recall-with-observations"
+      if: inputs.suite == '' || inputs.suite == 'recall-with-observations'
+      run: |
+        ./scripts/benchmarks/run-perf-test.sh \
+          --scale ${{ inputs.scale || 'large' }} \
+          --suite recall-with-observations \
+          --output perf-results-recall-with-observations.json
 
     - name: Upload perf results
       if: always()
       uses: actions/upload-artifact@v7
       with:
         name: perf-results-${{ github.sha }}
-        path: hindsight-dev/perf-results.json
+        path: hindsight-dev/perf-results-*.json
         retention-days: 90
 
   locomo:

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -23,6 +23,7 @@ on:
           - retain
           - recall
           - recall-with-observations
+          - consolidation
         default: ""
       locomo_max_conversations:
         description: "LoComo max conversations (0 = skip, blank = all)"
@@ -105,6 +106,14 @@ jobs:
           --scale ${{ inputs.scale || 'large' }} \
           --suite recall-with-observations \
           --output perf-results-recall-with-observations.json
+
+    - name: "Suite: consolidation"
+      if: inputs.suite == '' || inputs.suite == 'consolidation'
+      run: |
+        ./scripts/benchmarks/run-perf-test.sh \
+          --scale ${{ inputs.scale || 'large' }} \
+          --suite consolidation \
+          --output perf-results-consolidation.json
 
     - name: Upload perf results
       if: always()

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -133,7 +133,7 @@ jobs:
       HINDSIGHT_API_JUDGE_LLM_PROVIDER: vertexai
       HINDSIGHT_API_JUDGE_LLM_MODEL: google/gemini-2.5-flash-lite
       HINDSIGHT_API_ANSWER_LLM_PROVIDER: vertexai
-      HINDSIGHT_API_ANSWER_LLM_MODEL: google/gemini-3.1-pro-preview
+      HINDSIGHT_API_ANSWER_LLM_MODEL: google/gemini-2.5-flash
     steps:
     - uses: actions/checkout@v6
       with:

--- a/hindsight-dev/benchmarks/common/benchmark_runner.py
+++ b/hindsight-dev/benchmarks/common/benchmark_runner.py
@@ -1041,6 +1041,72 @@ class BenchmarkRunner:
             console.print(f"    Bank template: {template_path}")
         console.print("    [green]✓[/green] Memory system initialized")
 
+        # Start a background worker poller when we need to wait for consolidation.
+        # Consolidation is submitted as an async task by retain_batch_async, but
+        # without a running worker those tasks sit in the queue forever.
+        poller_task = None
+        poller = None
+        if wait_consolidation:
+            from hindsight_api.worker.poller import WorkerPoller
+
+            poller = WorkerPoller(
+                backend=self.memory._backend,
+                worker_id="benchmark-runner-worker",
+                executor=self.memory.execute_task,
+                poll_interval_ms=500,
+                max_slots=4,
+            )
+            poller_task = asyncio.create_task(poller.run())
+            console.print("    [green]✓[/green] Background worker started (for consolidation)")
+
+        try:
+            return await self._run_inner(
+                items,
+                agent_id,
+                thinking_budget,
+                max_tokens,
+                skip_ingestion,
+                max_questions_per_item,
+                max_concurrent_questions,
+                eval_semaphore_size,
+                clear_agent_per_item,
+                specific_item,
+                separate_ingestion_phase,
+                filln,
+                max_concurrent_items,
+                output_path,
+                merge_with_existing,
+                wait_consolidation,
+            )
+        finally:
+            if poller and poller_task:
+                await poller.shutdown_graceful(timeout=60.0)
+                poller_task.cancel()
+                try:
+                    await poller_task
+                except asyncio.CancelledError:
+                    pass
+                console.print("    [green]✓[/green] Background worker stopped")
+
+    async def _run_inner(
+        self,
+        items: List[Dict[str, Any]],
+        agent_id: str,
+        thinking_budget: int,
+        max_tokens: int,
+        skip_ingestion: bool,
+        max_questions_per_item: Optional[int],
+        max_concurrent_questions: int,
+        eval_semaphore_size: int,
+        clear_agent_per_item: bool,
+        specific_item: Any,
+        separate_ingestion_phase: bool,
+        filln: bool,
+        max_concurrent_items: int,
+        output_path: Optional[Path],
+        merge_with_existing: bool,
+        wait_consolidation: bool,
+    ) -> Dict[str, Any]:
         if separate_ingestion_phase:
             # New two-phase approach: ingest all, then evaluate all
             return await self._run_two_phase(

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -43,6 +43,7 @@ from benchmarks.perf.recall_perf import (
     FACT_TEMPLATES,
     _build_engine,
     _fill_template,
+    _insert_synthetic_observations,
     _make_fact_callback,
     _RRFReranker,
     _wait_for_operation,
@@ -402,12 +403,151 @@ async def run_recall_suite(scale_cfg: dict[str, int]) -> SuiteResult:
 
 
 # ---------------------------------------------------------------------------
+# Suite: recall-with-observations
+# ---------------------------------------------------------------------------
+
+
+async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> SuiteResult:
+    """Measure recall latency/throughput with pre-populated bank including synthetic observations."""
+    from hindsight_api.engine.memory_engine import Budget
+    from hindsight_api.models import RequestContext
+
+    bank_size = scale_cfg["recall_bank_size"]
+    iterations = scale_cfg["recall_iterations"]
+    concurrency = scale_cfg["recall_concurrency"]
+    bank_id = f"perf-recall-obs-{uuid.uuid4().hex[:8]}"
+
+    console.print(
+        f"\n[bold cyan]Suite: recall-with-observations[/bold cyan]  "
+        f"bank_size={bank_size}  iterations={iterations}  concurrency={concurrency}  bank={bank_id}"
+    )
+
+    engine = _build_engine()
+    await engine.initialize()
+
+    # Use RRF reranker to isolate DB performance from cross-encoder CPU cost
+    engine._cross_encoder_reranker = _RRFReranker()
+
+    # Populate bank with facts then insert synthetic observations (1 per fact)
+    await _populate_bank(engine, bank_id, bank_size)
+
+    pool = await engine._get_pool()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress.add_task("Inserting synthetic observations…")
+        n_obs = await _insert_synthetic_observations(pool, bank_id)
+    console.print(f"  Inserted {n_obs:,} observations")
+
+    request_context = RequestContext()
+    durations: list[float] = []
+    all_phase_timings: dict[str, list[float]] = {}
+
+    async def recall_one(query: str) -> float:
+        t0 = time.perf_counter()
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=query,
+            budget=Budget.HIGH,
+            max_tokens=4096,
+            enable_trace=True,
+            request_context=request_context,
+            _quiet=True,
+        )
+        elapsed = time.perf_counter() - t0
+        if result.trace:
+            summary = result.trace.get("summary", {})
+            for pm in summary.get("phase_metrics", []):
+                all_phase_timings.setdefault(pm["phase_name"], []).append(pm["duration_seconds"])
+        return elapsed
+
+    # Run recall iterations in parallel batches
+    remaining = iterations
+    query_idx = 0
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("Running recall (with observations)…", total=iterations)
+        while remaining > 0:
+            batch_size = min(concurrency, remaining)
+            queries = [RECALL_QUERIES[(query_idx + i) % len(RECALL_QUERIES)] for i in range(batch_size)]
+            query_idx += batch_size
+            batch = await asyncio.gather(*[recall_one(q) for q in queries])
+            durations.extend(batch)
+            remaining -= batch_size
+            progress.advance(task, batch_size)
+
+    suite_duration = sum(durations)
+    throughput = iterations / (suite_duration / concurrency) if suite_duration > 0 else 0
+
+    await engine.delete_bank(bank_id=bank_id, request_context=RequestContext())
+    await engine.close()
+
+    latency_stats = PercentileStats.from_samples(durations)
+    phase_stats = {name: PercentileStats.from_samples(times) for name, times in all_phase_timings.items()}
+
+    recall_result = RecallResult(
+        bank_size=bank_size,
+        concurrency=concurrency,
+        latency=latency_stats,
+        throughput_queries_per_sec=round(throughput, 2),
+        phase_timings=phase_stats,
+    )
+
+    # Print summary
+    table = Table(title="Recall Latency (with observations)")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green", justify="right")
+    table.add_row("Bank size (facts)", f"{bank_size:,}")
+    table.add_row("Observations", f"{n_obs:,}")
+    table.add_row("Iterations", str(iterations))
+    table.add_row("Concurrency", str(concurrency))
+    table.add_row("Throughput", f"{throughput:.2f} queries/s")
+    table.add_row("Mean", f"{latency_stats.mean:.3f}s")
+    table.add_row("p50", f"{latency_stats.p50:.3f}s")
+    table.add_row("p95", f"{latency_stats.p95:.3f}s")
+    table.add_row("p99", f"{latency_stats.p99:.3f}s")
+    table.add_row("Min", f"{latency_stats.min:.3f}s")
+    table.add_row("Max", f"{latency_stats.max:.3f}s")
+    console.print(table)
+
+    if phase_stats:
+        phase_table = Table(title="Per-Step Timing Breakdown (with observations)")
+        phase_table.add_column("Step", style="cyan")
+        phase_table.add_column("Mean", style="green", justify="right")
+        phase_table.add_column("p50", style="green", justify="right")
+        phase_table.add_column("p95", style="yellow", justify="right")
+        phase_table.add_column("Max", style="red", justify="right")
+
+        sorted_phases = sorted(phase_stats.items(), key=lambda x: x[1].mean, reverse=True)
+        for name, ps in sorted_phases:
+            phase_table.add_row(name, f"{ps.mean:.3f}s", f"{ps.p50:.3f}s", f"{ps.p95:.3f}s", f"{ps.max:.3f}s")
+        console.print(phase_table)
+
+    return SuiteResult(
+        name="recall-with-observations",
+        duration_seconds=round(suite_duration, 3),
+        success=True,
+        recall=recall_result,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Registry and orchestrator
 # ---------------------------------------------------------------------------
 
 SUITES = {
     "retain": run_retain_suite,
     "recall": run_recall_suite,
+    "recall-with-observations": run_recall_with_observations_suite,
 }
 
 

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -61,24 +61,28 @@ SCALES: dict[str, dict[str, int]] = {
         "recall_bank_size": 20,
         "recall_iterations": 5,
         "recall_concurrency": 1,
+        "consolidation_items": 20,
     },
     "small": {
         "retain_items": 200,
         "recall_bank_size": 200,
         "recall_iterations": 20,
         "recall_concurrency": 4,
+        "consolidation_items": 200,
     },
     "medium": {
         "retain_items": 1_000,
         "recall_bank_size": 1_000,
         "recall_iterations": 50,
         "recall_concurrency": 8,
+        "consolidation_items": 1_000,
     },
     "large": {
         "retain_items": 5_000,
         "recall_bank_size": 5_000,
         "recall_iterations": 100,
         "recall_concurrency": 16,
+        "consolidation_items": 5_000,
     },
 }
 
@@ -149,6 +153,18 @@ class RecallResult:
 
 
 @dataclass
+class ConsolidationResult:
+    total_items: int
+    memories_processed: int
+    observations_created: int
+    observations_updated: int
+    observations_merged: int
+    skipped: int
+    total_duration_seconds: float
+    throughput_memories_per_sec: float
+
+
+@dataclass
 class SuiteResult:
     name: str
     duration_seconds: float
@@ -156,6 +172,7 @@ class SuiteResult:
     error: str | None = None
     retain: RetainResult | None = None
     recall: RecallResult | None = None
+    consolidation: ConsolidationResult | None = None
 
 
 @dataclass
@@ -541,6 +558,155 @@ async def run_recall_with_observations_suite(scale_cfg: dict[str, int]) -> Suite
 
 
 # ---------------------------------------------------------------------------
+# Suite: consolidation
+# ---------------------------------------------------------------------------
+
+
+def _make_consolidation_callback() -> tuple:
+    """
+    Return (callback, call_counter) for mock consolidation LLM.
+
+    For the consolidation scope, returns a response that creates one observation
+    per fact in the batch.  For retain scopes, delegates to the standard fact
+    extraction callback so we can populate the bank normally.
+    """
+    fact_callback, fact_counter = _make_fact_callback()
+    consolidation_counter = [0]
+
+    def callback(messages: list[dict], scope: str):
+        if scope == "consolidation":
+            consolidation_counter[0] += 1
+            # Parse the fact IDs from the prompt to build realistic create actions.
+            # The prompt contains lines like "[<uuid>] fact text"
+            import re
+
+            prompt_text = messages[-1]["content"] if messages else ""
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt_text)
+
+            from hindsight_api.engine.consolidation.consolidator import (
+                _ConsolidationBatchResponse,
+                _CreateAction,
+            )
+
+            creates = [
+                _CreateAction(
+                    text=f"Observation from fact {fid[:8]}",
+                    source_fact_ids=[fid],
+                )
+                for fid in fact_ids
+            ]
+            return _ConsolidationBatchResponse(creates=creates, updates=[], deletes=[])
+        # Delegate all other scopes to the retain callback
+        return fact_callback(messages, scope)
+
+    return callback, fact_counter, consolidation_counter
+
+
+async def run_consolidation_suite(scale_cfg: dict[str, int]) -> SuiteResult:
+    """Measure consolidation throughput with mock LLM — DB + embedding overhead."""
+    import os
+
+    from hindsight_api.engine.consolidation.consolidator import run_consolidation_job
+    from hindsight_api.models import RequestContext
+
+    total_items = scale_cfg["consolidation_items"]
+    bank_id = f"perf-consolidation-{uuid.uuid4().hex[:8]}"
+
+    console.print(f"\n[bold cyan]Suite: consolidation[/bold cyan]  items={total_items}  bank={bank_id}")
+
+    # Enable observations so consolidation has work to do
+    os.environ["HINDSIGHT_API_ENABLE_OBSERVATIONS"] = "true"
+    from hindsight_api.config import clear_config_cache
+
+    clear_config_cache()
+
+    engine = _build_engine()
+    await engine.initialize()
+
+    # Set up mock callback that handles both retain and consolidation scopes
+    callback, _, consolidation_counter = _make_consolidation_callback()
+    engine._retain_llm_config.set_response_callback(callback)
+    engine._llm_config.set_response_callback(callback)
+    engine._consolidation_llm_config.set_response_callback(callback)
+
+    # Populate bank with facts using synchronous batch retain.
+    # This queues consolidation tasks (since observations are enabled) but
+    # no worker is running so they just sit in the queue — we run consolidation
+    # explicitly below.
+    contents = [{"content": _fill_template(FACT_TEMPLATES[i % len(FACT_TEMPLATES)])} for i in range(total_items)]
+    request_context = RequestContext()
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress.add_task(f"Populating bank ({total_items:,} items)…")
+        await engine.retain_batch_async(
+            bank_id=bank_id,
+            contents=contents,
+            request_context=request_context,
+        )
+
+    # Run consolidation
+    request_context = RequestContext()
+    t0 = time.perf_counter()
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress.add_task(f"Running consolidation ({total_items:,} items)…")
+        result = await run_consolidation_job(
+            memory_engine=engine,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+
+    duration = time.perf_counter() - t0
+    memories_processed = result.get("memories_processed", 0)
+    throughput = memories_processed / duration if duration > 0 else 0
+
+    await engine.delete_bank(bank_id=bank_id, request_context=request_context)
+    await engine.close()
+
+    consolidation_result = ConsolidationResult(
+        total_items=total_items,
+        memories_processed=memories_processed,
+        observations_created=result.get("observations_created", 0),
+        observations_updated=result.get("observations_updated", 0),
+        observations_merged=result.get("observations_merged", 0),
+        skipped=result.get("skipped", 0),
+        total_duration_seconds=round(duration, 3),
+        throughput_memories_per_sec=round(throughput, 2),
+    )
+
+    # Print summary
+    table = Table(title="Consolidation Throughput")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green", justify="right")
+    table.add_row("Bank items", f"{total_items:,}")
+    table.add_row("Memories processed", str(memories_processed))
+    table.add_row("Duration", f"{duration:.3f}s")
+    table.add_row("Throughput", f"{throughput:.2f} memories/s")
+    table.add_row("Observations created", str(result.get("observations_created", 0)))
+    table.add_row("Observations updated", str(result.get("observations_updated", 0)))
+    table.add_row("Observations merged", str(result.get("observations_merged", 0)))
+    table.add_row("Skipped", str(result.get("skipped", 0)))
+    console.print(table)
+
+    return SuiteResult(
+        name="consolidation",
+        duration_seconds=round(duration, 3),
+        success=True,
+        consolidation=consolidation_result,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Registry and orchestrator
 # ---------------------------------------------------------------------------
 
@@ -548,6 +714,7 @@ SUITES = {
     "retain": run_retain_suite,
     "recall": run_recall_suite,
     "recall-with-observations": run_recall_with_observations_suite,
+    "consolidation": run_consolidation_suite,
 }
 
 
@@ -740,6 +907,45 @@ def _print_summary(results: PerfTestResults) -> None:
                     f"{ps.p95:.3f}s",
                     f"{ps.p99:.3f}s",
                 )
+
+        if suite.consolidation:
+            c = suite.consolidation
+            table.add_row(
+                suite.name,
+                status,
+                "throughput",
+                f"{c.throughput_memories_per_sec} mem/s",
+                "",
+                "",
+                "",
+            )
+            table.add_row(
+                "",
+                "",
+                "duration",
+                f"{c.total_duration_seconds}s",
+                "",
+                "",
+                "",
+            )
+            table.add_row(
+                "",
+                "",
+                "processed/total",
+                f"{c.memories_processed:,} / {c.total_items:,}",
+                "",
+                "",
+                "",
+            )
+            table.add_row(
+                "",
+                "",
+                "created/updated/merged/skipped",
+                f"{c.observations_created}/{c.observations_updated}/{c.observations_merged}/{c.skipped}",
+                "",
+                "",
+                "",
+            )
 
         if not suite.success:
             table.add_row(suite.name, status, "error", suite.error or "unknown", "", "", "")

--- a/hindsight-docs/versioned_docs/version-0.5/developer/api/mental-models.mdx
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/api/mental-models.mdx
@@ -353,6 +353,15 @@ When you call `reflect` with tags, those same tags are used to filter which ment
 
 For more details on tag matching modes (`any`, `any_strict`, `all`, `all_strict`) and worked examples, see the [Recall tags reference](./recall#tags).
 
+### Listing mental model tags
+
+`GET /v1/default/banks/{bank_id}/tags` accepts a `source` query parameter that selects which tag space to enumerate:
+
+- `source=memories` *(default)* — tags attached to memory units.
+- `source=mental_models` — tags attached to mental models in this bank.
+
+Use the `mental_models` source to populate autocomplete or filter UIs over mental-model tags, distinct from the (typically larger) memory tag set.
+
 ---
 
 ## History

--- a/hindsight-docs/versioned_sidebars/version-0.5-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.5-sidebars.json
@@ -357,6 +357,22 @@
         },
         {
           "type": "link",
+          "href": "/sdks/integrations/agentcore",
+          "label": "AgentCore Runtime",
+          "customProps": {
+            "icon": "/img/icons/agentcore.png"
+          }
+        },
+        {
+          "type": "link",
+          "href": "/sdks/integrations/smolagents",
+          "label": "SmolAgents",
+          "customProps": {
+            "icon": "/img/icons/smolagents.png"
+          }
+        },
+        {
+          "type": "link",
           "href": "/sdks/integrations/ag2",
           "label": "AG2",
           "customProps": {


### PR DESCRIPTION
## Summary
- **New perf suites**: `recall-with-observations` (recall with synthetic observations in the bank) and `consolidation` (mock LLM, measures DB + embedding overhead)
- **Split CI steps**: Each perf suite runs as a separate CI step for clearer reporting
- **Fix locomo consolidation timeout**: Start a `WorkerPoller` in `BenchmarkRunner` when `wait_consolidation=True` — consolidation tasks were queued but never processed
- **Fix locomo model 404**: Replace removed `gemini-3.1-pro-preview` with `gemini-2.5-flash` for the answer LLM

## Test plan
- [x] All 4 perf suites pass locally (`--scale tiny`)
- [x] CI run passes: perf-test (all suites) + locomo https://github.com/vectorize-io/hindsight/actions/runs/25115819326