### PR TITLE
docs(models): document litellm-sdk embeddings provider

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -377,6 +377,7 @@ Converts text into dense vector representations for semantic similarity search.
 | `google` | Google embeddings (Gemini API or Vertex AI) | Production, multilingual, high quality |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
 | `litellm` | LiteLLM proxy (unified gateway) | Multi-provider setups |
+| `litellm-sdk` | LiteLLM SDK (direct API, no proxy) | Multi-provider, simpler setup |
 
 ### Local Models
 
@@ -447,6 +448,11 @@ export HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm
 export HINDSIGHT_API_LITELLM_API_BASE=http://localhost:4000
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL=text-embedding-3-small
+
+# LiteLLM SDK (direct, no proxy)
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm-sdk
+export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=openai/text-embedding-3-small
 ```
 
 See [Configuration](./configuration#embeddings) for all options including Azure OpenAI and custom endpoints.
@@ -566,3 +572,4 @@ export HINDSIGHT_API_RERANKER_PROVIDER=rrf
 ```
 
 See [Configuration](./configuration#reranker) for all options including Azure-hosted endpoints and batch settings.
+

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -399,6 +399,7 @@ Converts text into dense vector representations for semantic similarity search.
 | `google` | Google embeddings (Gemini API or Vertex AI) | Production, multilingual, high quality |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
 | `litellm` | LiteLLM proxy (unified gateway) | Multi-provider setups |
+| `litellm-sdk` | LiteLLM SDK (direct API, no proxy) | Multi-provider, simpler setup |
 
 ### Local Models
 
@@ -468,6 +469,11 @@ export HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm
 export HINDSIGHT_API_LITELLM_API_BASE=http://localhost:4000
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL=text-embedding-3-small
+
+# LiteLLM SDK (direct, no proxy)
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm-sdk
+export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=openai/text-embedding-3-small
 ```
 
 See [Configuration](./configuration#embeddings) for all options including Azure OpenAI and custom endpoints.
@@ -587,3 +593,4 @@ export HINDSIGHT_API_RERANKER_PROVIDER=rrf
 ```
 
 See [Configuration](./configuration#reranker) for all options including Azure-hosted endpoints and batch settings.
+


### PR DESCRIPTION
## Summary

`litellm-sdk` is a real, functional embeddings provider (registered via `embeddings_litellm_sdk_*` config in `hindsight-api-slim/hindsight_api/config.py`, instantiated by the `LiteLLMSDKEmbeddings` class at `embeddings.py:753`, and listed in the unknown-provider error message: `"Supported: 'local', 'tei', 'openai', 'cohere', 'google', 'litellm', 'litellm-sdk'"` at `embeddings.py:1209`). It also gets continued investment — #1320 (merged a few hours ago) wired `allowed_openai_params=["dimensions"]` so `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS` actually works for OpenAI-compatible custom models.

But the **embedding** providers table at `docs/developer/models.mdx` only lists six providers (`local` / `openai` / `cohere` / `google` / `tei` / `litellm`) — `litellm-sdk` is missing. The **cross-encoder** providers table on the same page already documents it (`| litellm-sdk | LiteLLM SDK (direct API, no proxy) | Multi-provider, simpler setup |`), so users reading the embeddings section can't tell the SDK path is supported.

## What's in the PR

- `hindsight-docs/docs/developer/models.mdx` (+5 LOC): one new row in the embedding providers table mirroring the cross-encoder description; one new `# LiteLLM SDK (direct, no proxy)` stanza in the Configuration Examples block (mirrors the existing `# LiteLLM proxy` stanza style).
- `skills/hindsight-docs/references/developer/models.md` (+5 LOC): byte-for-byte mirror.

## Source of truth

- Provider name: `LiteLLMSDKEmbeddings.provider_name` returns `"litellm-sdk"` (`embeddings.py:802`); factory dispatches `provider == "litellm-sdk"` (`embeddings.py:1173`).
- Env var names: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY` and `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL` defined at `config.py:223-224`. API key is required (factory raises `ValueError` if unset, `embeddings.py:1175-1178`).
- Example model `openai/text-embedding-3-small` follows the LiteLLM provider-prefix convention used throughout the existing docs (and is the path #1320 just made fully functional).

Pure docs, no behavior change.
