### PR TITLE
fix(embed): include 'all' extras when spawning hindsight-api from sibling source

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -130,7 +130,7 @@ class DaemonEmbedManager(EmbedManager):
         # Check if we're in development mode
         dev_api_path = Path(__file__).parent.parent.parent / "hindsight-api-slim"
         if dev_api_path.exists() and (dev_api_path / "pyproject.toml").exists():
-            return ["uv", "run", "--project", str(dev_api_path), "hindsight-api"]
+            return ["uv", "run", "--project", str(dev_api_path), "--extra", "all", "hindsight-api"]
 
         # Prefer a hindsight-api entry point installed alongside hindsight-embed
         # (e.g. `uv pip install hindsight-all` or `--target`). Falling through


### PR DESCRIPTION
## Summary

When `hindsight-embed` spawns `hindsight-api` from a sibling source checkout (the dev-mode / bundled path), it currently runs:

```
uv run --project <hindsight-api-slim> hindsight-api
```

without any `--extra`, so only base deps install. On a fresh environment without a pre-synced workspace `.venv`, the daemon crashes on startup with `pg0-embedded is required` (and would also miss `sentence-transformers` for local embeddings/reranker).

## Fix

Use the explicit `all` extra defined in `hindsight-api-slim/pyproject.toml`, which is `local-ml + embedded-db` (deliberately excludes `local-llm` so it doesn't drag in `llama-cpp-python` and require gcc/cmake on customer machines).

```
uv run --project <hindsight-api-slim> --extra all hindsight-api
```

Local dev hides this because the workspace `.venv` is typically pre-synced (`uv sync --all-extras` or the explicit subset), so the spawn finds everything already installed.

## Why this is the right extra

- `[all]` = `local-ml, embedded-db`. Both are needed for the embed daemon's default zero-config setup (embedded Postgres + local sentence-transformers).
- `[local-llm]` is intentionally excluded because `llama-cpp-python` requires a working C/C++ toolchain at install time, which often fails on minimal VPS images.

## Test plan

- [x] Reproduced `pg0-embedded is required` crash on a fresh env without pre-synced `.venv`
- [x] Verified daemon starts cleanly after this change
- [x] Verified `--extra all` does not pull `llama-cpp-python`
