### PR TITLE
fix(embed): defer LLM model default to hindsight-api

### DIFF
--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -138,7 +138,7 @@ def get_config():
     return {
         "llm_api_key": os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY"),
         "llm_provider": provider,
-        "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL", default_model),
+        "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL"),  # let hindsight-api resolve provider-default
         "bank_id": os.environ.get("HINDSIGHT_EMBED_BANK_ID", "default"),
     }
 


### PR DESCRIPTION
## Summary

`cli.py.get_config()` tries to compute the default model via `get_default_model_for_provider()`, which imports `hindsight_api.config.PROVIDER_DEFAULT_MODELS`. **That import fails** when `hindsight-embed` runs in its own venv — `hindsight-embed` does not depend on `hindsight-api`, which is the normal case for both `uvx hindsight-embed` and bundled install flows.

The `except ImportError` branch then falls back to a hardcoded `"gpt-4o-mini"` regardless of provider, and the value gets injected into the daemon's env as `HINDSIGHT_API_LLM_MODEL=gpt-4o-mini` via `configureProfile`.

Downstream, `hindsight-api`'s `HindsightConfig.from_env()` sees the env var already set and skips its own correctly-keyed `PROVIDER_DEFAULT_MODELS` lookup. For non-OpenAI providers this is silently wrong:

- **openai-codex**: Codex returns HTTP 400 `gpt-4o-mini not supported when using Codex with a ChatGPT account`. The retain endpoint still returns `success:true` but every fact-extraction LLM call silently fails and zero memories get stored.
- **anthropic / gemini / etc.**: same shape — provider rejects the OpenAI-shaped model id; data isn't actually retained.

## Fix

Don't synthesize the model at this layer. If `HINDSIGHT_API_LLM_MODEL` is unset, leave it unset. `daemon_embed_manager` already skips the env-var injection when the value is `None`/falsy, and the daemon then resolves the right provider-keyed default itself via `HindsightConfig.from_env()`.

This is a 1-line change: drop the `default_model` second arg from `os.environ.get(...)`.

## Test plan

- [x] Reproduced silent fact-extraction failure with `HINDSIGHT_API_LLM_PROVIDER=openai-codex` (no model set)
- [x] Confirmed `hindsight_api.config.PROVIDER_DEFAULT_MODELS` import does fail in hindsight-embed's standalone venv
- [x] Verified daemon now picks the correct codex default (`gpt-5.2-codex` or per-tier model) when no model is explicitly set
- [x] No-regression for openai provider (default `gpt-4o-mini` is still chosen, just by hindsight-api instead of hindsight-embed)
