### PR TITLE
fix(codex): filter synthetic AGENTS startup messages

### DIFF
--- a/hindsight-integrations/codex/scripts/lib/content.py
+++ b/hindsight-integrations/codex/scripts/lib/content.py
@@ -45,6 +45,25 @@ def strip_memory_tags(content: str) -> str:
     return content
 
 
+def is_synthetic_codex_user_message(content: str) -> bool:
+    """Return True for setup messages Codex persists as user chat.
+
+    Codex records AGENTS.md startup instructions as a normal user message in
+    rollout JSONL. Retaining those messages teaches Hindsight about hook and
+    agent rules instead of the user's work, and can create very large retain
+    payloads in long-running sessions.
+    """
+    if not isinstance(content, str):
+        return False
+
+    stripped = content.lstrip()
+    return (
+        stripped.startswith("# AGENTS.md instructions for ")
+        and "<INSTRUCTIONS>" in stripped
+        and "</INSTRUCTIONS>" in stripped
+    )
+
+
 # ---------------------------------------------------------------------------
 # Transcript reading
 # ---------------------------------------------------------------------------
@@ -118,6 +137,8 @@ def _read_transcript_text(transcript_path: str) -> list:
                                     if t:
                                         text_parts.append(t)
                             text = "\n".join(text_parts).strip()
+                            if role == "user" and is_synthetic_codex_user_message(text):
+                                continue
                             if text:
                                 messages.append({"role": role, "content": text})
                     # Flat format (testing / future compatibility)
@@ -187,6 +208,8 @@ def _read_transcript_rich(transcript_path: str) -> list:
                         if role == "user":
                             _flush_assistant()
                             text = _extract_text_from_content_blocks(payload.get("content", []))
+                            if is_synthetic_codex_user_message(text):
+                                continue
                             if text:
                                 messages.append({"role": "user", "content": [{"type": "text", "text": text}]})
                         elif role == "assistant":

--- a/hindsight-integrations/codex/tests/test_content.py
+++ b/hindsight-integrations/codex/tests/test_content.py
@@ -9,6 +9,7 @@ import pytest
 from lib.content import (
     compose_recall_query,
     format_memories,
+    is_synthetic_codex_user_message,
     prepare_retention_transcript,
     read_transcript,
     slice_last_turns_by_user_boundary,
@@ -49,6 +50,16 @@ class TestStripMemoryTags:
     def test_strips_multiline_block(self):
         raw = "<hindsight_memories>\n- mem1\n- mem2\n</hindsight_memories>"
         assert strip_memory_tags(raw).strip() == ""
+
+
+class TestSyntheticCodexUserMessage:
+    def test_detects_agents_startup_instructions(self):
+        raw = "# AGENTS.md instructions for /home/coder/project\n\n<INSTRUCTIONS>\nremember things\n</INSTRUCTIONS>"
+        assert is_synthetic_codex_user_message(raw)
+
+    def test_does_not_match_normal_agents_discussion(self):
+        raw = "We should update AGENTS.md instructions for this repo."
+        assert not is_synthetic_codex_user_message(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +170,35 @@ class TestReadTranscriptCodexFormat:
         path = _write_jsonl(tmp_path, entries)
         msgs = read_transcript(path)
         assert len(msgs) == 0
+
+    def test_skips_codex_agents_startup_instructions(self, tmp_path):
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "# AGENTS.md instructions for /home/coder/project\n\n<INSTRUCTIONS>\nsetup rules\n</INSTRUCTIONS>",
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "actual user request"}],
+                },
+            },
+        ]
+        path = _write_jsonl(tmp_path, entries)
+        msgs = read_transcript(path)
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "actual user request"
 
     def test_skips_blank_lines_gracefully(self, tmp_path):
         f = tmp_path / "transcript.jsonl"
@@ -397,6 +437,35 @@ class TestReadTranscriptRich:
         assert msgs[0]["content"] == [{"type": "text", "text": "hello"}]
         assert msgs[1]["role"] == "assistant"
         assert msgs[1]["content"] == [{"type": "text", "text": "hi there"}]
+
+    def test_skips_codex_agents_startup_instructions(self, tmp_path):
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "# AGENTS.md instructions for /home/coder/project\n\n<INSTRUCTIONS>\nsetup rules\n</INSTRUCTIONS>",
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "actual user request"}],
+                },
+            },
+        ]
+        path = _write_jsonl(tmp_path, entries)
+        msgs = read_transcript(path, include_tool_calls=True)
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == [{"type": "text", "text": "actual user request"}]
 
     def test_reads_function_call(self, tmp_path):
         entries = [


### PR DESCRIPTION
## Summary

Filters Codex synthetic AGENTS.md startup messages out of the Codex integration transcript reader.

Codex can persist project startup instructions as a normal `response_item` with `role: "user"` and content shaped like:

`# AGENTS.md instructions for ...`
`<INSTRUCTIONS>...</INSTRUCTIONS>`

The Codex integration previously treated that as normal user conversation, so auto-retain and recall transcript composition could include agent rules/setup context instead of only the actual user/assistant session.

## Why

This can pollute retained memory with hook rules, memory policy, MCP setup instructions, and other agent-control text that the user did not actually say as part of the working conversation.

In long-running Codex sessions, this can also contribute to oversized auto-retain payloads because the retained transcript includes synthetic setup context before the real conversation starts.

## Implementation

- Adds a small detector for Codex AGENTS.md startup instruction messages.
- Skips those synthetic user messages in the text transcript reader.
- Skips the same synthetic messages in the rich transcript reader used when tool calls are retained.
- Leaves normal user discussion of AGENTS.md untouched.

## Validation

- `pytest hindsight-integrations/codex/tests/test_content.py`
- `pytest hindsight-integrations/codex/tests/test_hooks.py`
- Tested against a real Codex rollout transcript where the AGENTS startup block was persisted as a user message. After this change, the startup block is no longer present in parsed transcript output or retained chunk content.