### PR TITLE
docs(python-sdk): document retain_async kwarg per #1306

### DIFF
--- a/hindsight-docs/docs/sdks/python.md
+++ b/hindsight-docs/docs/sdks/python.md
@@ -77,6 +77,7 @@ client.retain(
     timestamp=datetime(2024, 1, 15),
     document_id="conversation_001",
     metadata={"source": "slack"},
+    retain_async=False,  # Set True for background processing
 )
 ```
 

--- a/skills/hindsight-docs/references/sdks/python.md
+++ b/skills/hindsight-docs/references/sdks/python.md
@@ -77,6 +77,7 @@ client.retain(
     timestamp=datetime(2024, 1, 15),
     document_id="conversation_001",
     metadata={"source": "slack"},
+    retain_async=False,  # Set True for background processing
 )
 ```
 


### PR DESCRIPTION
## Summary

#1306 added `retain_async: bool = False` to `client.retain()` / `client.aretain()` so the convenience wrappers reach parity with `retain_batch()` / `aretain_batch()` and the TypeScript SDK. The Python SDK doc still documents the kwarg only on `retain_batch()` (line 93), leaving the new behavior undiscoverable from `### Retain (Store Memory)`.

This PR adds the same `retain_async=False  # Set True for background processing` line to the existing "With options" example for `client.retain()`, mirroring the wording used in the `retain_batch` block right below it (line 93) and in the Node.js SDK doc's `retain()` example (`async: false`).

## Changes

- `hindsight-docs/docs/sdks/python.md`: +1 line in the Retain (Store Memory) "With options" example.
- `skills/hindsight-docs/references/sdks/python.md`: same +1 line in the skill mirror.

## Notes

- Defaults match the implementation in #1306 (`retain_async: bool = False`, fully backwards compatible).
- `versioned_docs/version-0.5/sdks/python.md` mirror is intentionally left for the next `chore(docs): sync version-0.5 docs from next` pass (cf. #1328).
- No code changes; doctest harness should be unaffected.