### PR TITLE
enhance(api): add force mode for document reprocessing

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1426,6 +1426,7 @@ class ReprocessDocumentResponse(BaseModel):
     success: bool
     operation_id: str
     items_count: int
+    force: bool = False
 
 
 class DeleteResponse(BaseModel):
@@ -4248,7 +4249,8 @@ def _register_routes(app: FastAPI):
         response_model=ReprocessDocumentResponse,
         summary="Reprocess document",
         description="Re-run the retain pipeline on an existing document without changing its content. "
-        "This deletes the existing memory units and re-extracts facts using the current engine configuration. "
+        "By default, unchanged chunks may be skipped by delta retain. Pass force=true to bypass delta retain "
+        "and re-extract facts for unchanged content using the current engine configuration. "
         "Useful when the LLM model, chunking strategy, or extraction settings have changed.",
         operation_id="reprocess_document",
         tags=["Documents"],
@@ -4257,6 +4259,7 @@ def _register_routes(app: FastAPI):
     async def api_reprocess_document(
         bank_id: str,
         document_id: str,
+        force: bool = False,
         request_context: RequestContext = Depends(get_request_context),
     ):
         """
@@ -4270,6 +4273,7 @@ def _register_routes(app: FastAPI):
             result = await app.state.memory.reprocess_document(
                 bank_id=bank_id,
                 document_id=document_id,
+                force=force,
                 request_context=request_context,
             )
             if result is None:
@@ -4278,6 +4282,7 @@ def _register_routes(app: FastAPI):
                 success=True,
                 operation_id=result["operation_id"],
                 items_count=result["items_count"],
+                force=force,
             )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5495,6 +5495,7 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         document_id: str,
         *,
+        force: bool = False,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """
@@ -5503,6 +5504,7 @@ class MemoryEngine(MemoryEngineInterface):
         Args:
             bank_id: Bank ID
             document_id: Document ID to reprocess
+            force: If True, bypass delta retain and re-extract unchanged chunks.
             request_context: Request context for authentication.
 
         Returns:
@@ -5531,6 +5533,8 @@ class MemoryEngine(MemoryEngineInterface):
             "document_id": document_id,
             "update_mode": "replace",
         }
+        if force:
+            content_dict["force_reprocess"] = True
         if retain_params.get("context"):
             content_dict["context"] = retain_params["context"]
         if retain_params.get("event_date"):

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -269,6 +269,7 @@ async def handle_document_tracking(
     is_first_batch: bool,
     retain_params: dict | None = None,
     document_tags: list[str] | None = None,
+    ops=None,
 ) -> None:
     """
     Handle document tracking in the database (full-replace mode).
@@ -284,6 +285,7 @@ async def handle_document_tracking(
         is_first_batch: Whether this is the first batch (for chunked operations)
         retain_params: Optional parameters passed during retain (context, event_date, etc.)
         document_tags: Optional list of tags to associate with the document
+        ops: Optional SQL operations helper for database portability.
     """
     import hashlib
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -559,6 +559,8 @@ async def retain_batch(
     if not effective_doc_id:
         effective_doc_id = str(uuid.uuid4())
 
+    force_reprocess = any(bool(item.get("force_reprocess")) for item in contents_dicts)
+
     # Record effective_doc_id on the operation (idempotent set-append). Captures
     # both user-provided and generated ids so the operation shows every document
     # it touched, and lets retries reuse the same generated id.
@@ -642,7 +644,7 @@ async def retain_batch(
             return [[] for _ in contents], TokenUsage(), 0
 
     # --- Delta retain: check if we can skip unchanged chunks ---
-    if is_first_batch:
+    if is_first_batch and not force_reprocess:
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -666,6 +668,8 @@ async def retain_batch(
         )
         if delta_result is not None:
             return delta_result
+    elif is_first_batch and force_reprocess:
+        log_buffer.append("[reprocess] Force reprocess requested — bypassing delta retain")
 
     # --- Always use the streaming pipeline (producer-consumer batching) ---
     # Even small documents go through the same path — they just end up as a
@@ -711,6 +715,7 @@ async def retain_batch(
         schema=schema,
         outbox_callback=outbox_callback,
         db_semaphore=db_semaphore,
+        force_reprocess=force_reprocess,
     )
 
 
@@ -848,6 +853,7 @@ async def _streaming_retain_batch(
     schema: str | None = None,
     outbox_callback: Callable[["asyncpg.Connection"], Awaitable[None]] | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
+    force_reprocess: bool = False,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -887,24 +893,27 @@ async def _streaming_retain_batch(
     new_content_hash = hashlib.sha256(sanitized_content.encode()).hexdigest()
     is_recovery = False
 
-    try:
-        async with acquire_with_retry(pool) as conn:
-            doc_row = await conn.fetchrow(
-                f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
-                effective_doc_id,
-                bank_id,
-            )
-            if doc_row and doc_row["content_hash"] == new_content_hash:
-                existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
-                existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
-                if existing_chunk_hashes:
-                    is_recovery = True
-                    log_buffer.append(
-                        f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
-                        f"will skip matching and preserve existing data"
-                    )
-    except Exception:
-        pass  # If we can't load, just process all chunks
+    if force_reprocess:
+        log_buffer.append("[streaming] Force reprocess requested — ignoring already-committed chunks")
+    else:
+        try:
+            async with acquire_with_retry(pool) as conn:
+                doc_row = await conn.fetchrow(
+                    f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                    effective_doc_id,
+                    bank_id,
+                )
+                if doc_row and doc_row["content_hash"] == new_content_hash:
+                    existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
+                    existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
+                    if existing_chunk_hashes:
+                        is_recovery = True
+                        log_buffer.append(
+                            f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
+                            f"will skip matching and preserve existing data"
+                        )
+        except Exception:
+            pass  # If we can't load, just process all chunks
 
     # ---------------------------------------------------------------------------
     # Document tracking is DEFERRED to the first consumer batch TXN.
@@ -1103,6 +1112,7 @@ async def _streaming_retain_batch(
                                 is_first_batch,
                                 retain_params,
                                 merged_tags,
+                                ops=pool.ops,
                             )
                         doc_tracking_done[0] = True
                         log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (0 facts in first batch)")
@@ -1205,6 +1215,7 @@ async def _streaming_retain_batch(
                                 is_first_batch,
                                 retain_params,
                                 merged_tags,
+                                ops=pool.ops,
                             )
                             log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
                         doc_tracking_done[0] = True
@@ -1361,6 +1372,7 @@ async def _streaming_retain_batch(
                             is_first_batch,
                             retain_params,
                             merged_tags,
+                            ops=pool.ops,
                         )
                     doc_tracking_done[0] = True
                     log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (no facts extracted)")

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -28,6 +28,8 @@ class RetainContentDict(TypedDict, total=False):
         update_mode: How to handle existing documents with the same document_id (optional).
             "replace" (default) deletes old data and reprocesses. "append" concatenates
             new content to the existing document and reprocesses.
+        force_reprocess: Internal flag used by the document reprocess endpoint
+            to bypass delta retain and re-extract unchanged chunks.
     """
 
     content: str  # Required
@@ -41,6 +43,7 @@ class RetainContentDict(TypedDict, total=False):
         Literal["per_tag", "combined", "all_combinations"] | list[list[str]]
     )  # Observation scopes for consolidation
     update_mode: Literal["replace", "append"]
+    force_reprocess: bool
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_document_chunks_and_reprocess.py
+++ b/hindsight-api-slim/tests/test_document_chunks_and_reprocess.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.engine.response_models import TokenUsage
 
 
 # ── Fixtures ──
@@ -185,6 +186,114 @@ async def test_reprocess_document(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_reprocess_document_defaults_to_delta_mode(memory, request_context, monkeypatch):
+    """reprocess_document preserves the existing delta-aware default."""
+    bank_id = f"test_reprocess_delta_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Alice works at Google.", "document_id": "doc-reprocess-delta"}],
+            request_context=request_context,
+        )
+
+        captured = {}
+
+        async def fake_submit_async_retain(bank_id, contents, **kwargs):
+            captured["contents"] = contents
+            return {"operation_id": "op-delta", "items_count": len(contents)}
+
+        monkeypatch.setattr(memory, "submit_async_retain", fake_submit_async_retain)
+
+        result = await memory.reprocess_document(
+            bank_id=bank_id, document_id="doc-reprocess-delta", request_context=request_context
+        )
+
+        assert result == {"operation_id": "op-delta", "items_count": 1}
+        assert "force_reprocess" not in captured["contents"][0]
+        assert captured["contents"][0]["update_mode"] == "replace"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_reprocess_document_force_marks_retain_item(memory, request_context, monkeypatch):
+    """reprocess_document(force=True) marks unchanged chunks for re-extraction."""
+    bank_id = f"test_reprocess_force_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Alice works at Google.", "document_id": "doc-reprocess-force"}],
+            request_context=request_context,
+        )
+
+        captured = {}
+
+        async def fake_submit_async_retain(bank_id, contents, **kwargs):
+            captured["bank_id"] = bank_id
+            captured["contents"] = contents
+            captured["kwargs"] = kwargs
+            return {"operation_id": "op-force", "items_count": len(contents)}
+
+        monkeypatch.setattr(memory, "submit_async_retain", fake_submit_async_retain)
+
+        result = await memory.reprocess_document(
+            bank_id=bank_id, document_id="doc-reprocess-force", force=True, request_context=request_context
+        )
+
+        assert result == {"operation_id": "op-force", "items_count": 1}
+        assert captured["contents"][0]["force_reprocess"] is True
+        assert captured["contents"][0]["update_mode"] == "replace"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_force_reprocess_bypasses_delta_and_streaming_recovery(memory, request_context, monkeypatch):
+    """The internal force_reprocess flag bypasses delta retain and streaming recovery."""
+    from hindsight_api.engine.retain import orchestrator
+
+    bank_id = f"test_reprocess_skip_delta_{datetime.now(timezone.utc).timestamp()}"
+
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Alice works at Google.", "document_id": "doc-skip-delta"}],
+            request_context=request_context,
+        )
+
+        async def fail_if_delta_called(*args, **kwargs):
+            raise AssertionError("force_reprocess should bypass delta retain")
+
+        async def fake_streaming_retain_batch(*args, **kwargs):
+            assert kwargs["force_reprocess"] is True
+            return [["forced-unit"]], TokenUsage(), None
+
+        monkeypatch.setattr(orchestrator, "_try_delta_retain", fail_if_delta_called)
+        monkeypatch.setattr(orchestrator, "_streaming_retain_batch", fake_streaming_retain_batch)
+
+        result, usage = await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Alice works at Google.",
+                    "document_id": "doc-skip-delta",
+                    "update_mode": "replace",
+                    "force_reprocess": True,
+                }
+            ],
+            request_context=request_context,
+            return_usage=True,
+        )
+
+        assert result == [["forced-unit"]]
+        assert usage == TokenUsage()
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_reprocess_document_not_found(memory, request_context):
     """reprocess_document returns None for non-existent document."""
     result = await memory.reprocess_document(
@@ -281,6 +390,23 @@ async def test_http_reprocess_document(api_client, bank_id):
     data = response.json()
     assert data["success"] is True
     assert "operation_id" in data
+    assert data["force"] is False
+
+
+@pytest.mark.asyncio
+async def test_http_reprocess_document_accepts_force(api_client, bank_id):
+    """HTTP POST .../documents/{id}/reprocess?force=true exposes force mode."""
+    await _retain(api_client, bank_id, "doc-http-reprocess-force", "Alice works at Google.")
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/documents/doc-http-reprocess-force/reprocess",
+        params={"force": "true"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "operation_id" in data
+    assert data["force"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds an optional `force=true` mode to the document reprocess endpoint:

`POST /v1/default/banks/{bank_id}/documents/{document_id}/reprocess?force=true`

By default, document reprocess keeps the existing delta-aware behavior. With `force=true`, reprocess bypasses delta retain and streaming recovery so unchanged document content can still be fully re-extracted using the current bank/model/extraction configuration.

This is useful when the document text is unchanged but extraction behavior has changed, for example after tuning retain settings, model configuration, or stored retain context.

## Changes

- Add `force` query parameter and response field to the HTTP reprocess endpoint.
- Thread an internal `force_reprocess` flag through `MemoryEngine.reprocess_document`.
- Bypass delta retain when `force_reprocess` is set.
- Bypass streaming recovery reuse of already-committed chunks when `force_reprocess` is set.
- Thread the database operations helper through document re-ingest observation cleanup, matching the existing delete-document cleanup path.
- Add coverage for default delta behavior, force behavior, and HTTP `force=true`.

## Validation

- `python3 -m py_compile` on touched API/engine/test files
- `git diff --cached --check`
- Targeted container test run:
  `6 passed, 11 deselected`

Relevant issue: https://github.com/vectorize-io/hindsight/issues/1349