### PR TITLE
feat(opencode): share memory bank across git worktrees of the same repo

### DIFF
--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -145,7 +145,17 @@ For multi-project setups, enable dynamic bank ID derivation:
 export HINDSIGHT_DYNAMIC_BANK_ID=true
 ```
 
-The bank ID is composed from granularity fields (default: `agent::project`). Supported fields: `agent`, `project`, `channel`, `user`.
+The bank ID is composed from granularity fields (default: `agent::project`). Supported fields: `agent`, `project`, `gitProject`, `channel`, `user`.
+
+- `project` uses the working directory basename. With this field, separate git worktrees of the same repository end up with different bank IDs because their paths differ.
+- `gitProject` resolves to the main worktree's basename via `git rev-parse --git-common-dir`, so all linked worktrees of the same repository share a single bank. Falls back to the working directory basename when git is unavailable or the directory is not a repo. Use this in place of `project` if you want worktrees to share memory:
+
+```json
+{
+  "dynamicBankId": true,
+  "dynamicBankGranularity": ["agent", "gitProject"]
+}
+```
 
 **Note:** The bank ID is derived once when the plugin loads, from environment variables set before OpenCode starts. These dimensions are process-scoped — they don't change per session within a running OpenCode process. For per-user isolation, set the env vars before launching each user's OpenCode instance:
 

--- a/hindsight-integrations/opencode/src/bank.test.ts
+++ b/hindsight-integrations/opencode/src/bank.test.ts
@@ -1,12 +1,29 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
 import { deriveBankId, ensureBankMission } from "./bank.js";
 import { makeConfig } from "./test-helpers.js";
+
+const mockExec = vi.mocked(execFileSync);
 
 describe("deriveBankId", () => {
   const originalEnv = { ...process.env };
 
+  beforeEach(() => {
+    // Default: simulate "not in a git repo" so the project field falls back
+    // to the directory basename. Individual git-aware tests override this.
+    mockExec.mockImplementation(() => {
+      throw new Error("fatal: not a git repository");
+    });
+  });
+
   afterEach(() => {
     process.env = { ...originalEnv };
+    mockExec.mockReset();
   });
 
   it("returns default bank name in static mode", () => {
@@ -83,6 +100,68 @@ describe("deriveBankId", () => {
       dynamicBankGranularity: ["agent"],
     });
     expect(deriveBankId(config, "/home/user/proj")).toBe("dev-opencode");
+  });
+
+  describe("git-aware project resolution", () => {
+    it("uses main worktree basename when running inside a regular clone", () => {
+      // `git rev-parse --git-common-dir` returns the main repo's .git path.
+      mockExec.mockReturnValueOnce("/home/user/myproj/.git\n" as never);
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "project"],
+      });
+      expect(deriveBankId(config, "/home/user/myproj")).toBe("opencode::myproj");
+    });
+
+    it("returns the same bank id from a linked worktree of the same repo", () => {
+      // Both invocations resolve to the SAME main .git, so worktrees share the bank.
+      mockExec
+        .mockReturnValueOnce("/home/user/myproj/.git\n" as never)
+        .mockReturnValueOnce("/home/user/myproj/.git\n" as never);
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "project"],
+      });
+      const main = deriveBankId(config, "/home/user/myproj");
+      const linked = deriveBankId(config, "/tmp/worktrees/myproj-feature-x");
+      expect(main).toBe("opencode::myproj");
+      expect(linked).toBe(main);
+    });
+
+    it("uses bare repo basename when common-dir is the bare repo itself", () => {
+      mockExec.mockReturnValueOnce("/srv/git/myrepo.git\n" as never);
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["project"],
+      });
+      expect(deriveBankId(config, "/srv/git/myrepo.git")).toBe("myrepo.git");
+    });
+
+    it("falls back to directory basename when git is unavailable or directory is not a repo", () => {
+      mockExec.mockImplementationOnce(() => {
+        throw new Error("git: command not found");
+      });
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["project"],
+      });
+      expect(deriveBankId(config, "/tmp/random")).toBe("random");
+    });
+
+    it("does not invoke git in static mode", () => {
+      const config = makeConfig({ bankId: "fixed" });
+      expect(deriveBankId(config, "/home/user/myproj")).toBe("fixed");
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it("does not invoke git when project field is not in the granularity", () => {
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "channel"],
+      });
+      expect(deriveBankId(config, "/home/user/myproj")).toBe("opencode::default");
+      expect(mockExec).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/hindsight-integrations/opencode/src/bank.test.ts
+++ b/hindsight-integrations/opencode/src/bank.test.ts
@@ -102,13 +102,35 @@ describe("deriveBankId", () => {
     expect(deriveBankId(config, "/home/user/proj")).toBe("dev-opencode");
   });
 
-  describe("git-aware project resolution", () => {
+  describe("project field stays directory-only (backwards compatibility)", () => {
+    it("uses raw directory basename for `project` even inside a git repo", () => {
+      mockExec.mockReturnValueOnce("/home/user/myproj/.git\n" as never);
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "project"],
+      });
+      expect(deriveBankId(config, "/tmp/worktrees/myproj-feature-x")).toBe(
+        "opencode::myproj-feature-x"
+      );
+    });
+
+    it("does not invoke git when only `project` is in the granularity", () => {
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "project"],
+      });
+      deriveBankId(config, "/home/user/myproj");
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("gitProject field (git-aware)", () => {
     it("uses main worktree basename when running inside a regular clone", () => {
       // `git rev-parse --git-common-dir` returns the main repo's .git path.
       mockExec.mockReturnValueOnce("/home/user/myproj/.git\n" as never);
       const config = makeConfig({
         dynamicBankId: true,
-        dynamicBankGranularity: ["agent", "project"],
+        dynamicBankGranularity: ["agent", "gitProject"],
       });
       expect(deriveBankId(config, "/home/user/myproj")).toBe("opencode::myproj");
     });
@@ -120,7 +142,7 @@ describe("deriveBankId", () => {
         .mockReturnValueOnce("/home/user/myproj/.git\n" as never);
       const config = makeConfig({
         dynamicBankId: true,
-        dynamicBankGranularity: ["agent", "project"],
+        dynamicBankGranularity: ["agent", "gitProject"],
       });
       const main = deriveBankId(config, "/home/user/myproj");
       const linked = deriveBankId(config, "/tmp/worktrees/myproj-feature-x");
@@ -132,7 +154,7 @@ describe("deriveBankId", () => {
       mockExec.mockReturnValueOnce("/srv/git/myrepo.git\n" as never);
       const config = makeConfig({
         dynamicBankId: true,
-        dynamicBankGranularity: ["project"],
+        dynamicBankGranularity: ["gitProject"],
       });
       expect(deriveBankId(config, "/srv/git/myrepo.git")).toBe("myrepo.git");
     });
@@ -143,7 +165,7 @@ describe("deriveBankId", () => {
       });
       const config = makeConfig({
         dynamicBankId: true,
-        dynamicBankGranularity: ["project"],
+        dynamicBankGranularity: ["gitProject"],
       });
       expect(deriveBankId(config, "/tmp/random")).toBe("random");
     });
@@ -154,13 +176,24 @@ describe("deriveBankId", () => {
       expect(mockExec).not.toHaveBeenCalled();
     });
 
-    it("does not invoke git when project field is not in the granularity", () => {
+    it("does not invoke git when gitProject is not in the granularity", () => {
       const config = makeConfig({
         dynamicBankId: true,
         dynamicBankGranularity: ["agent", "channel"],
       });
       expect(deriveBankId(config, "/home/user/myproj")).toBe("opencode::default");
       expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it("can combine project and gitProject as separate segments", () => {
+      mockExec.mockReturnValueOnce("/home/user/myproj/.git\n" as never);
+      const config = makeConfig({
+        dynamicBankId: true,
+        dynamicBankGranularity: ["agent", "project", "gitProject"],
+      });
+      expect(deriveBankId(config, "/tmp/worktrees/myproj-feature-x")).toBe(
+        "opencode::myproj-feature-x::myproj"
+      );
     });
   });
 });

--- a/hindsight-integrations/opencode/src/bank.ts
+++ b/hindsight-integrations/opencode/src/bank.ts
@@ -4,12 +4,13 @@
  * Port of Claude Code plugin's bank.py, adapted for OpenCode's context model.
  *
  * Dimensions for dynamic bank IDs:
- *   - agent   → configured name or "opencode"
- *   - project → derived from the main worktree's basename when inside a git
- *               repository (so all linked worktrees of the same repo share a
- *               single memory bank), falling back to the working directory
- *               basename when git is unavailable or the directory is not a
- *               repo.
+ *   - agent      → configured name or "opencode"
+ *   - project    → derived from the working directory basename
+ *   - gitProject → derived from the main worktree's basename when inside a
+ *                  git repository (so all linked worktrees of the same repo
+ *                  share a single memory bank). Falls back to the working
+ *                  directory basename when git is unavailable or the
+ *                  directory is not a repo.
  */
 
 import { basename, dirname } from "node:path";
@@ -19,7 +20,7 @@ import { debugLog } from "./config.js";
 import type { HindsightClient } from "@vectorize-io/hindsight-client";
 
 const DEFAULT_BANK_NAME = "opencode";
-const VALID_FIELDS = new Set(["agent", "project", "channel", "user"]);
+const VALID_FIELDS = new Set(["agent", "project", "gitProject", "channel", "user"]);
 
 /**
  * Resolve the main worktree root for a directory inside a git repository.
@@ -59,7 +60,7 @@ function getProjectRootFromGit(directory: string): string | null {
   }
 }
 
-function deriveProjectName(directory: string): string {
+function deriveGitProjectName(directory: string): string {
   const projectRoot = getProjectRootFromGit(directory);
   if (projectRoot) return basename(projectRoot);
   return directory ? basename(directory) : "unknown";
@@ -95,11 +96,12 @@ export function deriveBankId(config: HindsightConfig, directory: string): string
   const channelId = process.env.HINDSIGHT_CHANNEL_ID || "";
   const userId = process.env.HINDSIGHT_USER_ID || "";
 
-  // Lazy resolution so we don't spawn `git` for `project` when the field
+  // Lazy resolution so we don't spawn `git` for `gitProject` when the field
   // isn't part of the configured granularity.
   const fieldResolvers: Record<string, () => string> = {
     agent: () => config.agentName || "opencode",
-    project: () => deriveProjectName(directory),
+    project: () => (directory ? basename(directory) : "unknown"),
+    gitProject: () => deriveGitProjectName(directory),
     channel: () => channelId || "default",
     user: () => userId || "anonymous",
   };

--- a/hindsight-integrations/opencode/src/bank.ts
+++ b/hindsight-integrations/opencode/src/bank.ts
@@ -5,16 +5,65 @@
  *
  * Dimensions for dynamic bank IDs:
  *   - agent   → configured name or "opencode"
- *   - project → derived from working directory basename
+ *   - project → derived from the main worktree's basename when inside a git
+ *               repository (so all linked worktrees of the same repo share a
+ *               single memory bank), falling back to the working directory
+ *               basename when git is unavailable or the directory is not a
+ *               repo.
  */
 
-import { basename } from "node:path";
+import { basename, dirname } from "node:path";
+import { execFileSync } from "node:child_process";
 import type { HindsightConfig } from "./config.js";
 import { debugLog } from "./config.js";
 import type { HindsightClient } from "@vectorize-io/hindsight-client";
 
 const DEFAULT_BANK_NAME = "opencode";
 const VALID_FIELDS = new Set(["agent", "project", "channel", "user"]);
+
+/**
+ * Resolve the main worktree root for a directory inside a git repository.
+ *
+ * Uses `git rev-parse --path-format=absolute --git-common-dir`, which always
+ * points to the .git directory of the *main* worktree, even when invoked from
+ * a linked worktree (created with `git worktree add`). The parent of that path
+ * is the main worktree root, so all linked worktrees of the same repo resolve
+ * to the same root and end up sharing one memory bank.
+ *
+ * Returns `null` when git is unavailable, the directory is not a repo, or the
+ * git invocation fails for any other reason.
+ */
+function getProjectRootFromGit(directory: string): string | null {
+  if (!directory) return null;
+  try {
+    const commonDir = execFileSync(
+      "git",
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      {
+        cwd: directory,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+      }
+    ).trim();
+    if (!commonDir) return null;
+    // For typical clones and `git worktree add`, common-dir is `<root>/.git`,
+    // so the parent is the main worktree root. For bare repos, common-dir is
+    // the bare directory itself (e.g. `myrepo.git`); use it directly.
+    if (basename(commonDir) === ".git") {
+      return dirname(commonDir);
+    }
+    return commonDir;
+  } catch {
+    return null;
+  }
+}
+
+function deriveProjectName(directory: string): string {
+  const projectRoot = getProjectRootFromGit(directory);
+  if (projectRoot) return basename(projectRoot);
+  return directory ? basename(directory) : "unknown";
+}
 
 /**
  * Derive a bank ID from context and config.
@@ -46,15 +95,17 @@ export function deriveBankId(config: HindsightConfig, directory: string): string
   const channelId = process.env.HINDSIGHT_CHANNEL_ID || "";
   const userId = process.env.HINDSIGHT_USER_ID || "";
 
-  const fieldMap: Record<string, string> = {
-    agent: config.agentName || "opencode",
-    project: directory ? basename(directory) : "unknown",
-    channel: channelId || "default",
-    user: userId || "anonymous",
+  // Lazy resolution so we don't spawn `git` for `project` when the field
+  // isn't part of the configured granularity.
+  const fieldResolvers: Record<string, () => string> = {
+    agent: () => config.agentName || "opencode",
+    project: () => deriveProjectName(directory),
+    channel: () => channelId || "default",
+    user: () => userId || "anonymous",
   };
 
   // bank_id is stored as-is server-side; HTTP path encoding is the client layer's job.
-  const segments = fields.map((f) => fieldMap[f] || "unknown");
+  const segments = fields.map((f) => fieldResolvers[f]?.() || "unknown");
   const baseBankId = segments.join("::");
 
   return prefix ? `${prefix}-${baseBankId}` : baseBankId;


### PR DESCRIPTION
## Summary

Adds a new `gitProject` value to `dynamicBankGranularity`, so users with multiple `git worktree`s of the same repo can opt into sharing a single memory bank across them.

Previously, when `dynamicBankId` was enabled, the `project` field was derived from `basename(directory)`. Linked worktrees of the same repository therefore ended up using different memory banks just because their filesystem paths differ — even though they are the same project and teams want their conventions/knowledge to apply across worktrees.

This PR keeps `project` semantics **unchanged** for backwards compatibility, and adds a separate `gitProject` field:

- `project` → `basename(directory)` (unchanged)
- `gitProject` → main worktree's basename, located via `git rev-parse --path-format=absolute --git-common-dir`. `git-common-dir` always points at the *main* worktree's `.git` even when invoked from a linked worktree, so every worktree of the same repo resolves to the same bank id. Bare repos use the bare directory's basename. Falls back to `basename(directory)` when git is unavailable / fails.

Existing users keep the default `["agent", "project"]` and see no change. Users who want worktrees to share a bank opt in:

```json
{
  "dynamicBankId": true,
  "dynamicBankGranularity": ["agent", "gitProject"]
}
```

`project` resolution is also moved to lazy evaluation so `git` is not spawned for granularities that don't include `gitProject`.

## Test plan
- [x] `bank.test.ts` cases added:
  - `project` stays directory-only inside a git repo (backwards compat)
  - `project` does not invoke git
  - `gitProject` regular clone resolves to the repo basename
  - `gitProject` linked worktree resolves to the same bank id as main
  - `gitProject` bare repo path used directly
  - `gitProject` git-unavailable fallback
  - static mode does not invoke git
  - `gitProject` not in granularity → git not invoked
  - `project` and `gitProject` can be combined as separate segments
- [x] `npm test` — 101 tests pass
- [x] `npm run build` — succeeds
- [x] `tsc --noEmit` — clean

## Notes
- No public API breakage; this is additive (new valid value for an existing array option).
- Implementation uses `execFileSync` with a 1s timeout and stderr suppressed; any failure is caught and treated as "not in a git repo".