### PR TITLE
docs: add Oracle Database as supported enterprise storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ cd docker/docker-compose
 docker compose up 
 ```
 
+> Oracle Database is also supported for enterprise deployments with full feature parity. See the [storage documentation](https://hindsight.vectorize.io/developer/storage) for details.
+
 
 >API: http://localhost:8888
 >UI: http://localhost:9999

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd docker/docker-compose
 docker compose up 
 ```
 
-> Oracle Database is also supported for enterprise deployments with full feature parity. See the [storage documentation](https://hindsight.vectorize.io/developer/storage) for details.
+> Oracle AI Database is also supported for enterprise deployments with full feature parity. See the [storage documentation](https://hindsight.vectorize.io/developer/storage) for details.
 
 
 >API: http://localhost:8888

--- a/hindsight-docs/docs/developer/storage.md
+++ b/hindsight-docs/docs/developer/storage.md
@@ -76,14 +76,8 @@ Any PostgreSQL instance that satisfies these requirements should work. If you en
 
 ### Tested Managed Services
 
-**PostgreSQL:**
 - AWS RDS (PostgreSQL 15+)
 - Google Cloud SQL
 - Azure Database for PostgreSQL
 - Supabase
 - Neon
-
-**Oracle Database:**
-- Oracle Cloud Infrastructure (OCI)
-- Oracle Autonomous Database
-- AWS RDS for Oracle

--- a/hindsight-docs/docs/developer/storage.md
+++ b/hindsight-docs/docs/developer/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-Hindsight uses PostgreSQL as its sole storage backend.
+Hindsight uses PostgreSQL as its primary storage backend, with Oracle Database available as an alternative for enterprise deployments.
 
 ## Why PostgreSQL?
 
@@ -32,11 +32,15 @@ We believe PostgreSQL is becoming the standard database API. Its popularity, ext
 
 Supporting multiple databases would increase flexibility but conflict with our core goals: Hindsight is fully open source and designed to be as simple as possible to run and use. Adding database abstractions introduces complexity in code, testing, documentation, and operations—complexity that we pass on to users.
 
-By committing to PostgreSQL, we keep the system simple:
+By building on PostgreSQL, we keep the system simple:
 - One set of deployment instructions
 - One set of performance characteristics to understand
 - One codebase optimized for one backend
 - No configuration decisions about which database to use
+
+### Oracle Database Support
+
+For enterprise deployments, Hindsight also supports Oracle Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 
@@ -72,8 +76,14 @@ Any PostgreSQL instance that satisfies these requirements should work. If you en
 
 ### Tested Managed Services
 
+**PostgreSQL:**
 - AWS RDS (PostgreSQL 15+)
 - Google Cloud SQL
 - Azure Database for PostgreSQL
 - Supabase
 - Neon
+
+**Oracle Database:**
+- Oracle Cloud Infrastructure (OCI)
+- Oracle Autonomous Database
+- AWS RDS for Oracle

--- a/hindsight-docs/docs/developer/storage.md
+++ b/hindsight-docs/docs/developer/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-Hindsight uses PostgreSQL as its primary storage backend, with Oracle Database available as an alternative for enterprise deployments.
+Hindsight uses PostgreSQL as its primary storage backend, with Oracle AI Database available as an alternative for enterprise deployments.
 
 ## Why PostgreSQL?
 
@@ -38,9 +38,9 @@ By building on PostgreSQL, we keep the system simple:
 - One codebase optimized for one backend
 - No configuration decisions about which database to use
 
-### Oracle Database Support
+### Oracle AI Database Support
 
-For enterprise deployments, Hindsight also supports Oracle AI Database 26ai with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
+For enterprise deployments, Hindsight also supports Oracle AI Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 

--- a/hindsight-docs/docs/developer/storage.md
+++ b/hindsight-docs/docs/developer/storage.md
@@ -40,7 +40,7 @@ By building on PostgreSQL, we keep the system simple:
 
 ### Oracle Database Support
 
-For enterprise deployments, Hindsight also supports Oracle Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
+For enterprise deployments, Hindsight also supports Oracle AI Database 26ai with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 

--- a/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
@@ -76,14 +76,8 @@ Any PostgreSQL instance that satisfies these requirements should work. If you en
 
 ### Tested Managed Services
 
-**PostgreSQL:**
 - AWS RDS (PostgreSQL 15+)
 - Google Cloud SQL
 - Azure Database for PostgreSQL
 - Supabase
 - Neon
-
-**Oracle Database:**
-- Oracle Cloud Infrastructure (OCI)
-- Oracle Autonomous Database
-- AWS RDS for Oracle

--- a/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-Hindsight uses PostgreSQL as its sole storage backend.
+Hindsight uses PostgreSQL as its primary storage backend, with Oracle Database available as an alternative for enterprise deployments.
 
 ## Why PostgreSQL?
 
@@ -32,11 +32,15 @@ We believe PostgreSQL is becoming the standard database API. Its popularity, ext
 
 Supporting multiple databases would increase flexibility but conflict with our core goals: Hindsight is fully open source and designed to be as simple as possible to run and use. Adding database abstractions introduces complexity in code, testing, documentation, and operations—complexity that we pass on to users.
 
-By committing to PostgreSQL, we keep the system simple:
+By building on PostgreSQL, we keep the system simple:
 - One set of deployment instructions
 - One set of performance characteristics to understand
 - One codebase optimized for one backend
 - No configuration decisions about which database to use
+
+### Oracle Database Support
+
+For enterprise deployments, Hindsight also supports Oracle Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 
@@ -72,8 +76,14 @@ Any PostgreSQL instance that satisfies these requirements should work. If you en
 
 ### Tested Managed Services
 
+**PostgreSQL:**
 - AWS RDS (PostgreSQL 15+)
 - Google Cloud SQL
 - Azure Database for PostgreSQL
 - Supabase
 - Neon
+
+**Oracle Database:**
+- Oracle Cloud Infrastructure (OCI)
+- Oracle Autonomous Database
+- AWS RDS for Oracle

--- a/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-Hindsight uses PostgreSQL as its primary storage backend, with Oracle Database available as an alternative for enterprise deployments.
+Hindsight uses PostgreSQL as its primary storage backend, with Oracle AI Database available as an alternative for enterprise deployments.
 
 ## Why PostgreSQL?
 
@@ -38,9 +38,9 @@ By building on PostgreSQL, we keep the system simple:
 - One codebase optimized for one backend
 - No configuration decisions about which database to use
 
-### Oracle Database Support
+### Oracle AI Database Support
 
-For enterprise deployments, Hindsight also supports Oracle AI Database 26ai with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
+For enterprise deployments, Hindsight also supports Oracle AI Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 

--- a/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
+++ b/hindsight-docs/versioned_docs/version-0.5/developer/storage.md
@@ -40,7 +40,7 @@ By building on PostgreSQL, we keep the system simple:
 
 ### Oracle Database Support
 
-For enterprise deployments, Hindsight also supports Oracle Database with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
+For enterprise deployments, Hindsight also supports Oracle AI Database 26ai with full feature parity. All memory operations—retain, recall, and reflect—work identically on Oracle, making it a drop-in option for organizations that standardize on Oracle infrastructure.
 
 ## Development with pg0
 


### PR DESCRIPTION
## Summary
- Adds Oracle Database as a supported enterprise storage option across README and storage docs
- PostgreSQL remains the primary recommended backend; Oracle is mentioned as a drop-in alternative for enterprise environments
- Lists tested Oracle managed services (OCI, Autonomous Database, AWS RDS for Oracle)

## Test plan
- [ ] Verify docs site renders correctly with `./scripts/dev/start-docs.sh`
- [ ] Confirm Oracle section appears under storage docs
- [ ] Confirm README note links to the correct docs page