### PR TITLE
fix(config): default openai-codex model to gpt-5.4

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -455,7 +455,7 @@ PROVIDER_DEFAULT_MODELS = {
     "llamacpp": "gemma-4-e2b-it",
     "lmstudio": "local-model",
     "vertexai": "google/gemini-2.5-flash-lite",
-    "openai-codex": "gpt-5.4",
+    "openai-codex": "gpt-5.4-mini",
     "claude-code": "claude-sonnet-4-5-20250929",
     "mock": "mock-model",
     "none": "none",

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -455,7 +455,7 @@ PROVIDER_DEFAULT_MODELS = {
     "llamacpp": "gemma-4-e2b-it",
     "lmstudio": "local-model",
     "vertexai": "google/gemini-2.5-flash-lite",
-    "openai-codex": "gpt-5.2-codex",
+    "openai-codex": "gpt-5.4",
     "claude-code": "claude-sonnet-4-5-20250929",
     "mock": "mock-model",
     "none": "none",

--- a/hindsight-api-slim/tests/test_llm_provider.py
+++ b/hindsight-api-slim/tests/test_llm_provider.py
@@ -45,7 +45,7 @@ MODEL_MATRIX = [
     # Claude Code (uses Claude Agent SDK with Claude models)
     ("claude-code", "claude-sonnet-4-20250514"),
     # OpenAI Codex (uses MCP with Codex-specific models)
-    ("openai-codex", "gpt-5.4"),
+    ("openai-codex", "gpt-5.4-mini"),
     # Bedrock models (via LiteLLM)
     ("bedrock", "us.amazon.nova-2-lite-v1:0"),
     # Mock provider (for testing)
@@ -316,7 +316,7 @@ async def test_llm_provider_memory_operations(provider: str, model: str):
 
 @pytest.mark.parametrize("provider,model", [
     ("claude-code", "claude-sonnet-4-20250514"),
-    ("openai-codex", "gpt-5.4"),
+    ("openai-codex", "gpt-5.4-mini"),
 ])
 @pytest.mark.asyncio
 async def test_llm_provider_consolidation(memory_no_llm_verify, request_context, provider: str, model: str):

--- a/hindsight-api-slim/tests/test_llm_provider.py
+++ b/hindsight-api-slim/tests/test_llm_provider.py
@@ -45,7 +45,7 @@ MODEL_MATRIX = [
     # Claude Code (uses Claude Agent SDK with Claude models)
     ("claude-code", "claude-sonnet-4-20250514"),
     # OpenAI Codex (uses MCP with Codex-specific models)
-    ("openai-codex", "gpt-5.2-codex"),
+    ("openai-codex", "gpt-5.4"),
     # Bedrock models (via LiteLLM)
     ("bedrock", "us.amazon.nova-2-lite-v1:0"),
     # Mock provider (for testing)
@@ -316,7 +316,7 @@ async def test_llm_provider_memory_operations(provider: str, model: str):
 
 @pytest.mark.parametrize("provider,model", [
     ("claude-code", "claude-sonnet-4-20250514"),
-    ("openai-codex", "gpt-5.2-codex"),
+    ("openai-codex", "gpt-5.4"),
 ])
 @pytest.mark.asyncio
 async def test_llm_provider_consolidation(memory_no_llm_verify, request_context, provider: str, model: str):

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -235,7 +235,7 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 
 # OpenAI Codex (ChatGPT Plus/Pro subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-export HINDSIGHT_API_LLM_MODEL=gpt-5.4
+export HINDSIGHT_API_LLM_MODEL=gpt-5.4-mini
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -235,7 +235,7 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 
 # OpenAI Codex (ChatGPT Plus/Pro subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-export HINDSIGHT_API_LLM_MODEL=gpt-5.2-codex
+export HINDSIGHT_API_LLM_MODEL=gpt-5.4
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -210,7 +210,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4-mini
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -210,7 +210,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.1-codex  # defaults to gpt-5.2-codex
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -11,7 +11,7 @@
   {"id": "deepseek",      "label": "DeepSeek",          "iconKey": "brain",              "defaultModel": "deepseek-v4-flash"},
   {"id": "volcano",       "label": "Volcano Engine",    "iconKey": "zap",                "defaultModel": "doubao-pro-32k"},
   {"id": "openrouter",    "label": "OpenRouter",        "iconKey": "globe",              "defaultModel": "qwen/qwen3.5-9b"},
-  {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4"},
+  {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4-mini"},
   {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
   {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
   {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -11,7 +11,7 @@
   {"id": "deepseek",      "label": "DeepSeek",          "iconKey": "brain",              "defaultModel": "deepseek-v4-flash"},
   {"id": "volcano",       "label": "Volcano Engine",    "iconKey": "zap",                "defaultModel": "doubao-pro-32k"},
   {"id": "openrouter",    "label": "OpenRouter",        "iconKey": "globe",              "defaultModel": "qwen/qwen3.5-9b"},
-  {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.2-codex"},
+  {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4"},
   {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
   {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
   {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -235,7 +235,7 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 
 # OpenAI Codex (ChatGPT Plus/Pro subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-export HINDSIGHT_API_LLM_MODEL=gpt-5.4
+export HINDSIGHT_API_LLM_MODEL=gpt-5.4-mini
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -235,7 +235,7 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 
 # OpenAI Codex (ChatGPT Plus/Pro subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-export HINDSIGHT_API_LLM_MODEL=gpt-5.2-codex
+export HINDSIGHT_API_LLM_MODEL=gpt-5.4
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -104,7 +104,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `deepseek` | `deepseek-v4-flash` |
 | `volcano` | `doubao-pro-32k` |
 | `openrouter` | `qwen/qwen3.5-9b` |
-| `openai-codex` | `gpt-5.4` |
+| `openai-codex` | `gpt-5.4-mini` |
 | `claude-code` | `claude-sonnet-4-5-20250929` |
 | `bedrock` | `us.amazon.nova-2-lite-v1:0` |
 | `litellm` | `gpt-4o-mini` |
@@ -236,7 +236,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4-mini
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -104,7 +104,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `deepseek` | `deepseek-v4-flash` |
 | `volcano` | `doubao-pro-32k` |
 | `openrouter` | `qwen/qwen3.5-9b` |
-| `openai-codex` | `gpt-5.2-codex` |
+| `openai-codex` | `gpt-5.4` |
 | `claude-code` | `claude-sonnet-4-5-20250929` |
 | `bedrock` | `us.amazon.nova-2-lite-v1:0` |
 | `litellm` | `gpt-4o-mini` |
@@ -236,7 +236,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.1-codex  # defaults to gpt-5.2-codex
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 


### PR DESCRIPTION
## Summary
- Change the default `openai-codex` model from `gpt-5.2-codex` (deprecated by OpenAI) to `gpt-5.4`, which is in the active Codex API model list
- Update tests, docs (`configuration.md`, `models.mdx`, `llmProviders.json`) and the bundled `hindsight-docs` skill references to match

Closes #1344

## Test plan
- [ ] CI lint/tests pass
- [ ] Spot-check that `openai-codex` provider with no explicit model resolves to `gpt-5.4`