### PR TITLE
fix(retain): thread ops into handle_document_tracking

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -269,6 +269,7 @@ async def handle_document_tracking(
     is_first_batch: bool,
     retain_params: dict | None = None,
     document_tags: list[str] | None = None,
+    ops=None,
 ) -> None:
     """
     Handle document tracking in the database (full-replace mode).

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1103,6 +1103,7 @@ async def _streaming_retain_batch(
                                 is_first_batch,
                                 retain_params,
                                 merged_tags,
+                                ops=pool.ops,
                             )
                         doc_tracking_done[0] = True
                         log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (0 facts in first batch)")
@@ -1205,6 +1206,7 @@ async def _streaming_retain_batch(
                                 is_first_batch,
                                 retain_params,
                                 merged_tags,
+                                ops=pool.ops,
                             )
                             log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
                         doc_tracking_done[0] = True


### PR DESCRIPTION
## Bug

Regression from #1325. `fact_storage.py:312` was changed to call `delete_stale_observations_for_memories(..., ops=ops)` but `ops` was never added to `handle_document_tracking`'s signature, so every first-batch retain raises:

```
NameError: name 'ops' is not defined
```

## Effect

Every `batch_retain` task fails on the first-batch document tracking path. Poller retries, fails again, parent operation gets marked failed. No memories get stored. The gateway log misleadingly shows `retains captured` because dispatch succeeded.

## Fix

Add `ops=None` to `handle_document_tracking`'s signature. Pass `ops=pool.ops` from both call sites in `orchestrator._streaming_retain_batch`. 3 lines changed.

## Verified

Reproduced on a live deployment running main as of d8ec2d7f. Patch applied, retain plus background consolidation now succeed end to end (`created=6 updated=3` on first run after fix).