### PR TITLE
fix(embed): drop gpt-4o-mini fallback when hindsight-api import fails

### DIFF
--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -210,11 +210,10 @@ def _do_configure_from_env():
     api_key = os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
     provider = os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai")
 
-    if provider not in PROVIDER_API_KEYS:
-        print(
-            f"Error: Unknown provider '{provider}'. Supported: {', '.join(PROVIDER_API_KEYS.keys())}", file=sys.stderr
-        )
-        return 1
+    # Don't gate on PROVIDER_API_KEYS — that's only the interactive-menu set
+    # (5 entries). hindsight-api's PROVIDER_DEFAULT_MODELS supports ~18
+    # providers (anthropic, claude-code, bedrock, openrouter, ...). Let the
+    # daemon validate; rejecting here would block valid configurations.
 
     # Check for API key (required for non-ollama and non-vertexai providers)
     # vertexai uses GCP service account credentials instead of an API key

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -13,7 +13,7 @@ Usage:
 Environment variables:
     HINDSIGHT_API_LLM_API_KEY: Required. API key for LLM provider.
     HINDSIGHT_API_LLM_PROVIDER: Optional. LLM provider (default: "openai").
-    HINDSIGHT_API_LLM_MODEL: Optional. LLM model (default: "gpt-4o-mini").
+    HINDSIGHT_API_LLM_MODEL: Optional. LLM model (default: provider-specific, resolved by hindsight-api).
     HINDSIGHT_EMBED_BANK_ID: Optional. Memory bank ID (default: "default").
     HINDSIGHT_EMBED_API_URL: Optional. Use external API server instead of starting local daemon.
     HINDSIGHT_EMBED_API_TOKEN: Optional. Authentication token for external API (sent as Bearer token).
@@ -116,40 +116,31 @@ def load_config_file():
                         os.environ[key] = value
 
 
-def get_default_model_for_provider(provider: str) -> str:
-    """Return the default model for a given provider.
-
-    Delegates to hindsight_api.config when available (same Python environment),
-    with a minimal fallback for standalone use.
-    """
-    try:
-        from hindsight_api.config import PROVIDER_DEFAULT_MODELS
-
-        return PROVIDER_DEFAULT_MODELS.get(provider, "gpt-4o-mini")
-    except ImportError:
-        return "gpt-4o-mini"
-
-
 def get_config():
-    """Get configuration from environment variables."""
+    """Get configuration from environment variables.
+
+    `llm_model` is left unset (None) when the env var is missing — the daemon's
+    hindsight-api process owns `PROVIDER_DEFAULT_MODELS` and resolves the
+    provider-keyed default itself. Duplicating that table here would silently
+    desync, and importing it from `hindsight_api.config` fails in standalone
+    venvs (e.g. `uvx hindsight-embed`) where `hindsight-api` isn't installed.
+    """
     load_config_file()
-    provider = os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai")
-    default_model = get_default_model_for_provider(provider)
     return {
         "llm_api_key": os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY"),
-        "llm_provider": provider,
-        "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL", default_model),
+        "llm_provider": os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai"),
+        "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL"),
         "bank_id": os.environ.get("HINDSIGHT_EMBED_BANK_ID", "default"),
     }
 
 
-# Provider choices for interactive configure: (provider_id, default_model, env_key_name)
-PROVIDER_DEFAULTS = {
-    "openai": ("openai", get_default_model_for_provider("openai"), "OPENAI_API_KEY"),
-    "groq": ("groq", get_default_model_for_provider("groq"), "GROQ_API_KEY"),
-    "gemini": ("gemini", get_default_model_for_provider("gemini"), "GEMINI_API_KEY"),
-    "ollama": ("ollama", get_default_model_for_provider("ollama"), None),
-    "vertexai": ("vertexai", get_default_model_for_provider("vertexai"), None),
+# Provider -> API-key env var (None = no key needed)
+PROVIDER_API_KEYS = {
+    "openai": "OPENAI_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "ollama": None,
+    "vertexai": None,
 }
 
 
@@ -219,13 +210,11 @@ def _do_configure_from_env():
     api_key = os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
     provider = os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai")
 
-    if provider not in PROVIDER_DEFAULTS:
+    if provider not in PROVIDER_API_KEYS:
         print(
-            f"Error: Unknown provider '{provider}'. Supported: {', '.join(PROVIDER_DEFAULTS.keys())}", file=sys.stderr
+            f"Error: Unknown provider '{provider}'. Supported: {', '.join(PROVIDER_API_KEYS.keys())}", file=sys.stderr
         )
         return 1
-
-    _, default_model, env_key = PROVIDER_DEFAULTS[provider]
 
     # Check for API key (required for non-ollama and non-vertexai providers)
     # vertexai uses GCP service account credentials instead of an API key
@@ -235,17 +224,19 @@ def _do_configure_from_env():
         print("For non-interactive (CI) mode, set environment variables:", file=sys.stderr)
         print("  HINDSIGHT_API_LLM_API_KEY=<your-api-key>", file=sys.stderr)
         print(f"  HINDSIGHT_API_LLM_PROVIDER={provider}  # optional, default: openai", file=sys.stderr)
-        print(f"  HINDSIGHT_API_LLM_MODEL=<model>  # optional, default: {default_model}", file=sys.stderr)
+        print(
+            "  HINDSIGHT_API_LLM_MODEL=<model>  # optional, defaults to provider's recommended model", file=sys.stderr
+        )
         return 1
 
-    model = os.environ.get("HINDSIGHT_API_LLM_MODEL", default_model)
+    model = os.environ.get("HINDSIGHT_API_LLM_MODEL")
     bank_id = os.environ.get("HINDSIGHT_EMBED_BANK_ID", "default")
 
     print()
     print("\033[1m\033[36m  Hindsight Embed - Non-interactive Configuration\033[0m")
     print()
     print(f"  \033[2mProvider:\033[0m {provider}")
-    print(f"  \033[2mModel:\033[0m {model}")
+    print(f"  \033[2mModel:\033[0m {model or '(provider default)'}")
     print(f"  \033[2mBank ID:\033[0m {bank_id}")
 
     # Save configuration
@@ -255,7 +246,8 @@ def _do_configure_from_env():
         f.write("# Hindsight Embed Configuration\n")
         f.write("# Generated by hindsight-embed configure (non-interactive)\n\n")
         f.write(f"HINDSIGHT_API_LLM_PROVIDER={provider}\n")
-        f.write(f"HINDSIGHT_API_LLM_MODEL={model}\n")
+        if model:
+            f.write(f"HINDSIGHT_API_LLM_MODEL={model}\n")
         f.write(f"HINDSIGHT_EMBED_BANK_ID={bank_id}\n")
         if api_key:
             f.write(f"HINDSIGHT_API_LLM_API_KEY={api_key}\n")
@@ -402,7 +394,7 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         print("\n\033[33m⚠\033[0m Configuration cancelled.")
         return 1
 
-    _, default_model, env_key = PROVIDER_DEFAULTS[provider]
+    env_key = PROVIDER_API_KEYS[provider]
     print()
 
     # API key
@@ -423,8 +415,8 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
                 return 1
             print()
 
-    # Model selection
-    model = _prompt_text("Model name", default=default_model)
+    # Empty = let the daemon pick the provider default (PROVIDER_DEFAULT_MODELS)
+    model = _prompt_text("Model name (leave empty for provider default)")
     if model is None:
         return 1
     print()
@@ -437,12 +429,12 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
     # Save configuration
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Prepare config dict
     config_dict = {
         "HINDSIGHT_API_LLM_PROVIDER": provider,
-        "HINDSIGHT_API_LLM_MODEL": model,
         "HINDSIGHT_EMBED_BANK_ID": bank_id,
     }
+    if model:
+        config_dict["HINDSIGHT_API_LLM_MODEL"] = model
     if api_key:
         config_dict["HINDSIGHT_API_LLM_API_KEY"] = api_key
 

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -114,7 +114,7 @@ def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
     default_config_dir = temp_home / ".hindsight"
     default_config_dir.mkdir(parents=True, exist_ok=True)
     (default_config_dir / "embed").write_text(
-        "HINDSIGHT_API_LLM_PROVIDER=openai\n" "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
+        "HINDSIGHT_API_LLM_PROVIDER=openai\nHINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
     )
 
     # Create a named profile with a DIFFERENT provider
@@ -123,7 +123,7 @@ def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
 
     profile_name = "myapp"
     profile_env_path = profile_dir / f"{profile_name}.env"
-    profile_env_path.write_text("HINDSIGHT_API_LLM_PROVIDER=groq\n" "HINDSIGHT_API_LLM_MODEL=llama-3.1-70b\n")
+    profile_env_path.write_text("HINDSIGHT_API_LLM_PROVIDER=groq\nHINDSIGHT_API_LLM_MODEL=llama-3.1-70b\n")
 
     # Create metadata
     import json
@@ -493,3 +493,64 @@ def test_posix_popen_uses_start_new_session(temp_home, monkeypatch):
     kwargs = captured["kwargs"]
     assert kwargs.get("start_new_session") is True
     assert "creationflags" not in kwargs
+
+
+def test_get_config_does_not_default_llm_model(temp_home, monkeypatch):
+    """Regression test for issue #1360.
+
+    When `HINDSIGHT_API_LLM_MODEL` is unset, `get_config()` must return None
+    rather than a hardcoded `gpt-4o-mini`. Previously the CLI tried to import
+    `hindsight_api.config.PROVIDER_DEFAULT_MODELS` to compute a provider-keyed
+    default, but that import fails in standalone venvs (`uvx hindsight-embed`,
+    bundled installs) where `hindsight-api` isn't installed, and the fallback
+    silently routed every non-OpenAI provider to `gpt-4o-mini` — which they
+    reject, causing retain to silently store zero memories.
+
+    Leaving the value unset lets the daemon (which has hindsight-api) resolve
+    the correct provider default itself.
+    """
+    from hindsight_embed.cli import get_config, set_cli_profile_override
+
+    set_cli_profile_override(None)
+    monkeypatch.delenv("HINDSIGHT_EMBED_PROFILE", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+
+    config = get_config()
+
+    assert config["llm_provider"] == "gemini"
+    assert config["llm_model"] is None, (
+        "llm_model must be None when env var is unset so the daemon resolves "
+        "the provider default; got a hardcoded fallback instead"
+    )
+
+
+def test_configure_from_env_omits_model_when_unset(temp_home, monkeypatch):
+    """Regression test for issue #1360.
+
+    `_do_configure_from_env` must not write a hardcoded `HINDSIGHT_API_LLM_MODEL`
+    line into the profile .env when the user didn't set one — that line would
+    then be re-injected on every daemon start and suppress the daemon's
+    provider-keyed default lookup.
+    """
+    from hindsight_embed import cli
+
+    # CONFIG_DIR/CONFIG_FILE are computed from Path.home() at module import time,
+    # so the temp_home fixture's HOME override doesn't reach them. Redirect the
+    # module-level constants for the duration of this test.
+    config_dir = temp_home / ".hindsight"
+    monkeypatch.setattr(cli, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", config_dir / "embed")
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "test-key")
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+
+    rc = cli._do_configure_from_env()
+    assert rc == 0
+
+    contents = (config_dir / "embed").read_text()
+    assert "HINDSIGHT_API_LLM_PROVIDER=gemini" in contents
+    assert "HINDSIGHT_API_LLM_MODEL" not in contents, (
+        "model line must be omitted when the user didn't set one, so the daemon picks the provider default"
+    )

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -554,3 +554,29 @@ def test_configure_from_env_omits_model_when_unset(temp_home, monkeypatch):
     assert "HINDSIGHT_API_LLM_MODEL" not in contents, (
         "model line must be omitted when the user didn't set one, so the daemon picks the provider default"
     )
+
+
+def test_configure_from_env_accepts_providers_outside_interactive_menu(temp_home, monkeypatch):
+    """Regression test for issue #1360.
+
+    `_do_configure_from_env` previously rejected any provider not in the small
+    interactive-menu set (`PROVIDER_API_KEYS` — 5 entries) with "Unknown
+    provider". hindsight-api supports ~18 providers (anthropic, claude-code,
+    bedrock, openrouter, ...), so the gate blocked valid CI configurations.
+    Validation belongs in the daemon, not in the CLI's UX-only menu list.
+    """
+    from hindsight_embed import cli
+
+    config_dir = temp_home / ".hindsight"
+    monkeypatch.setattr(cli, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", config_dir / "embed")
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-ant-test")
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+
+    rc = cli._do_configure_from_env()
+    assert rc == 0, "anthropic must be accepted — the daemon validates providers, not the CLI"
+
+    contents = (config_dir / "embed").read_text()
+    assert "HINDSIGHT_API_LLM_PROVIDER=anthropic" in contents


### PR DESCRIPTION
## Summary

Closes #1360.

`hindsight-embed/pyproject.toml` only depends on `httpx` + `rich`, so the `from hindsight_api.config import PROVIDER_DEFAULT_MODELS` import in `cli.py` always fails in standalone venvs (`uvx hindsight-embed`, bundled OpenClaw installs). The `except ImportError` branch returned `gpt-4o-mini` for every provider, which flowed into 4 sites and silently broke retain for every non-OpenAI provider — `success:true` but zero memories stored because the provider rejected the OpenAI-shaped model id.

## Why #1342's closure was incorrect

The maintainer's comment was *"we already read the default model via the same code so this pr is not useful"*. That's true inside the **daemon** process (which has hindsight-api), but `get_config()` runs in the **embed CLI** process (separate venv, no hindsight-api). The CLI computed `gpt-4o-mini`, shipped it as `HINDSIGHT_API_LLM_MODEL=...` to the daemon, and the daemon then saw a set value and skipped its own correct provider-keyed lookup at `config.py:1349`.

## Fix

The CLI doesn't need its own copy of the provider→model table. The daemon already resolves the right default. Just leave `HINDSIGHT_API_LLM_MODEL` unset in the CLI when the user didn't specify one:

- `get_config()` returns `llm_model=None` when env unset; daemon forwards env vars only when truthy (`daemon_embed_manager.py:333`), so it's never set in the daemon env.
- `_do_configure_from_env` omits the `HINDSIGHT_API_LLM_MODEL` line in the profile `.env` when the user didn't pass one (otherwise it gets re-injected on every daemon start and suppresses the default).
- `_do_configure_interactive` drops the model default in the prompt and labels it *"(leave empty for provider default)"*.
- `PROVIDER_DEFAULTS` renamed to `PROVIDER_API_KEYS` — the model field is gone, only the API-key env-var name is still used.

This avoids the duplication-and-drift risk of inlining the table (which churns frequently — see e.g. recent commits `a8189209`, `35e7c492`).

## Test plan

- [x] Two regression tests added in `tests/test_profile_daemon_config.py`:
  - `test_get_config_does_not_default_llm_model` — `get_config()` returns `None` (not `gpt-4o-mini`) for non-OpenAI providers when env unset.
  - `test_configure_from_env_omits_model_when_unset` — profile `.env` does not get a hardcoded model line.
- [x] Full hindsight-embed test suite passes (71/71).
- [x] `./scripts/hooks/lint.sh` passes.
- [x] `uv run ty check hindsight_embed/` passes.