### PR TITLE
docs(self-driving-agents): document nemoclaw harness + --sandbox flag

### DIFF
--- a/hindsight-tools/self-driving-agents/README.md
+++ b/hindsight-tools/self-driving-agents/README.md
@@ -29,7 +29,8 @@ Agent name defaults to the directory name. Override with `--agent <name>`.
 ```
 npx @vectorize-io/self-driving-agents install <dir> --harness <harness> [options]
 
---harness <h>      Required. openclaw | hermes | claude-code
+--harness <h>      Required. openclaw | nemoclaw | hermes | claude-code
+--sandbox <name>   NemoClaw sandbox name (required when --harness nemoclaw; auto-detected if only one sandbox exists)
 --agent <name>     Agent name (defaults to directory name)
 --api-url <url>    Override Hindsight API URL
 --api-token <t>    Override API token


### PR DESCRIPTION
## Summary

`hindsight-tools/self-driving-agents/README.md` Options block lists `--harness <h>      Required. openclaw | hermes | claude-code` and omits `--sandbox`, but `src/cli.ts` (after #1335) accepts `--harness nemoclaw` and adds the `--sandbox <name>` flag (required when harness=nemoclaw, auto-detected if only one sandbox exists).

## Changes

- Add `nemoclaw` to the `--harness <h>` choices
- Add a `--sandbox <name>` row right under it, noting it is required for nemoclaw and auto-detected when a single sandbox exists

## Verification

`src/cli.ts`:
- L?: `harness === "nemoclaw"` branches in install / agent-creation / next-steps blocks
- `detectNemoClawSandbox()` exits 1 with `"No NemoClaw sandboxes found"` if none, returns the only one if length===1, else prompts `select`
- `if (harness === "nemoclaw" && !sandbox) sandbox = await detectNemoClawSandbox()`

No code change. Pure docs sync to the merged behavior.