### PR TITLE
fix(consolidation): deduplicate observations by semantic similarity (#1284)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -352,6 +352,7 @@ ENV_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
 )
 ENV_CONSOLIDATION_RECALL_BUDGET = "HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET"
 ENV_CONSOLIDATION_MAX_ATTEMPTS = "HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS"
+ENV_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD = "HINDSIGHT_API_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD"
 ENV_OBSERVATIONS_MISSION = "HINDSIGHT_API_OBSERVATIONS_MISSION"
 ENV_MAX_OBSERVATIONS_PER_SCOPE = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE"
 ENV_ENABLE_OBSERVATION_HISTORY = "HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY"
@@ -612,6 +613,7 @@ DEFAULT_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION = (
 )
 DEFAULT_OBSERVATIONS_MISSION = None  # Declarative spec of what observations are for this bank
 DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = -1  # Max observations per tag scope (-1 = unlimited)
+DEFAULT_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD = 0.92  # Cosine similarity threshold for deduplicating observations during consolidation (0 = disabled)
 
 # Database migrations
 DEFAULT_RUN_MIGRATIONS_ON_STARTUP = True
@@ -1034,6 +1036,7 @@ class HindsightConfig:
     consolidation_source_facts_max_tokens: int
     consolidation_source_facts_max_tokens_per_observation: int
     consolidation_max_attempts: int
+    consolidation_observation_dedup_threshold: float
     observations_mission: str | None
     max_observations_per_scope: int
 
@@ -1182,6 +1185,7 @@ class HindsightConfig:
         "consolidation_max_memories_per_round",
         "consolidation_source_facts_max_tokens",
         "consolidation_source_facts_max_tokens_per_observation",
+        "consolidation_observation_dedup_threshold",
         "observations_mission",
         "max_observations_per_scope",
         # Reflect settings
@@ -1714,6 +1718,12 @@ class HindsightConfig:
             ),
             consolidation_max_attempts=int(
                 os.getenv(ENV_CONSOLIDATION_MAX_ATTEMPTS, str(DEFAULT_CONSOLIDATION_MAX_ATTEMPTS))
+            ),
+            consolidation_observation_dedup_threshold=float(
+                os.getenv(
+                    ENV_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD,
+                    str(DEFAULT_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD),
+                )
             ),
             observations_mission=os.getenv(ENV_OBSERVATIONS_MISSION) or DEFAULT_OBSERVATIONS_MISSION,
             max_observations_per_scope=int(

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -31,6 +31,7 @@ from ..db_utils import acquire_with_retry
 from ..llm_wrapper import sanitize_llm_output
 from ..memory_engine import Budget, fq_table
 from ..retain import embedding_utils
+from ..sql import create_sql_dialect
 from .prompts import build_batch_consolidation_prompt
 
 if TYPE_CHECKING:
@@ -889,7 +890,8 @@ async def _process_memory_batch(
         if not source_mems:
             continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
-        await _execute_create_action(
+        dedup_threshold = getattr(config, "consolidation_observation_dedup_threshold", 0.0) or 0.0
+        result = await _execute_create_action(
             conn=conn,
             memory_engine=memory_engine,
             bank_id=bank_id,
@@ -901,9 +903,13 @@ async def _process_memory_batch(
             occurred_end=agg.occurred_end,
             mentioned_at=agg.mentioned_at,
             perf=perf,
+            dedup_threshold=dedup_threshold,
         )
         for m in source_mems:
-            per_memory_created.add(str(m["id"]))
+            if result.get("action") == "updated":
+                per_memory_updated.add(str(m["id"]))
+            else:
+                per_memory_created.add(str(m["id"]))
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []
@@ -1060,14 +1066,18 @@ async def _execute_create_action(
     occurred_end: datetime | None = None,
     mentioned_at: datetime | None = None,
     perf: ConsolidationPerfLog | None = None,
-) -> None:
+    dedup_threshold: float = 0.0,
+) -> dict[str, Any]:
     """
     Create a new observation from one or more source memories.
 
     Tags are inherited from the source facts (determined algorithmically, not by LLM)
     to maintain visibility scope.
+
+    Returns:
+        Dict with "action" ("created" or "updated") and "observation_id".
     """
-    await _create_observation_directly(
+    result = await _create_observation_directly(
         conn=conn,
         memory_engine=memory_engine,
         bank_id=bank_id,
@@ -1079,8 +1089,10 @@ async def _execute_create_action(
         occurred_end=occurred_end,
         mentioned_at=mentioned_at,
         perf=perf,
+        dedup_threshold=dedup_threshold,
     )
-    logger.debug(f"Created observation from {len(source_memory_ids)} source memories")
+    logger.debug(f"{result.get('action', 'created').capitalize()} observation from {len(source_memory_ids)} source memories")
+    return result
 
 
 async def _execute_delete_action(
@@ -1335,6 +1347,184 @@ async def _consolidate_batch_with_llm(
     return _BatchLLMResult(obs_count=len(union_observations), prompt_chars=len(prompt), failed=True)
 
 
+async def _find_semantic_duplicate_observation(
+    conn: "Connection",
+    bank_id: str,
+    embedding_str: str,
+    tags: list[str] | None = None,
+    threshold: float = 0.92,
+) -> tuple[str, float] | None:
+    """Find an existing observation with high semantic similarity to the proposed text.
+
+    Uses the SQL dialect's vector_similarity expression for cross-database compatibility.
+    Restricts the search to the same bank and tag scope to prevent cross-tenant leakage.
+
+    Returns:
+        Tuple of (observation_id, similarity) if a duplicate is found above the threshold,
+        else None.
+    """
+    dialect = create_sql_dialect(getattr(conn, "backend_type", "postgresql"))
+    p_emb = dialect.param(1)
+    p_bank = dialect.param(2)
+    p_thresh = dialect.param(3)
+    params: list[Any] = [embedding_str, bank_id, threshold]
+    tags_clause = ""
+    if tags:
+        p_tags = dialect.param(4)
+        tags_clause = f"AND {dialect.array_contains('tags', p_tags)}"
+        params.append(tags)
+
+    similarity_expr = dialect.vector_similarity("embedding", p_emb)
+    order_by = dialect.vector_distance("embedding", p_emb) + " ASC"
+    row = await conn.fetchrow(
+        f"""
+        SELECT id, {similarity_expr} AS similarity
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = {p_bank}
+          AND fact_type = 'observation'
+          {tags_clause}
+          AND {similarity_expr} >= {p_thresh}
+        ORDER BY {order_by}
+        LIMIT 1
+        """,
+        *params,
+    )
+    if row and row["similarity"] is not None:
+        sim = float(row["similarity"])
+        if sim >= threshold:
+            return str(row["id"]), sim
+    return None
+
+
+async def _merge_into_observation(
+    conn: "Connection",
+    memory_engine: "MemoryEngine",
+    bank_id: str,
+    observation_id: str,
+    new_text: str,
+    source_memory_ids: list[uuid.UUID],
+    source_fact_tags: list[str] | None = None,
+    source_occurred_start: datetime | None = None,
+    source_occurred_end: datetime | None = None,
+    source_mentioned_at: datetime | None = None,
+    perf: ConsolidationPerfLog | None = None,
+    embedding_str: str | None = None,
+) -> None:
+    """Merge new source memories into an existing observation, treating it as an update.
+
+    Unlike `_execute_update_action`, this does not require the `MemoryFact` model to be
+    present in the LLM's recall results. It fetches the current state from the DB and
+    performs the same merge logic (source_memory_ids, tags, temporal fields, history).
+
+    If ``embedding_str`` is provided, the embedding is reused instead of regenerating it.
+    """
+    live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
+    if not live_source_memory_ids:
+        logger.debug(
+            f"Merge skipped: all {len(source_memory_ids)} source memories for observation "
+            f"{observation_id} were deleted concurrently"
+        )
+        return
+    source_memory_ids = live_source_memory_ids
+
+    row = await conn.fetchrow(
+        f"""
+        SELECT text, source_memory_ids, tags, occurred_start, occurred_end, mentioned_at
+        FROM {fq_table("memory_units")}
+        WHERE id = $1 AND bank_id = $2 AND fact_type = 'observation'
+        """,
+        uuid.UUID(observation_id),
+        bank_id,
+    )
+    if not row:
+        logger.debug(f"Merge skipped: observation {observation_id} not found in DB")
+        return
+
+    existing_text = row["text"]
+    existing_source_ids = list(row["source_memory_ids"] or [])
+    existing_tags = set(row["tags"] or [])
+    source_tags = set(source_fact_tags or [])
+    merged_tags = list(existing_tags | source_tags)
+    # Deduplicate source memory IDs before concatenation
+    seen = set(existing_source_ids)
+    source_ids = list(existing_source_ids)
+    for sid in source_memory_ids:
+        if sid not in seen:
+            source_ids.append(sid)
+            seen.add(sid)
+
+    config = get_config()
+    history_entry = {
+        "previous_text": existing_text,
+        "previous_tags": list(existing_tags),
+        "previous_occurred_start": row["occurred_start"],
+        "previous_occurred_end": row["occurred_end"],
+        "previous_mentioned_at": row["mentioned_at"],
+        "changed_at": datetime.now(timezone.utc).isoformat(),
+        "new_source_memory_ids": [str(mid) for mid in source_memory_ids],
+    }
+
+    t0 = time.time()
+    if embedding_str is None:
+        embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [new_text])
+        embedding_str = str(embeddings[0]) if embeddings else None
+        if perf:
+            perf.record_timing("embedding", time.time() - t0)
+    # If embedding_str was passed in, no timing is recorded for the reuse
+
+    history_clause = (
+        "history = COALESCE(history, '[]'::jsonb) || $3::jsonb," if config.enable_observation_history else ""
+    )
+
+    t0 = time.time()
+    await conn.execute(
+        f"""
+        UPDATE {fq_table("memory_units")}
+        SET text = $1,
+            embedding = $2::vector,
+            {history_clause}
+            source_memory_ids = $4,
+            proof_count = $5,
+            tags = $10,
+            updated_at = now(),
+            occurred_start = LEAST(occurred_start, COALESCE($7, occurred_start)),
+            occurred_end = GREATEST(occurred_end, COALESCE($8, occurred_end)),
+            mentioned_at = GREATEST(mentioned_at, COALESCE($9, mentioned_at))
+        WHERE id = $6
+        """,
+        new_text,
+        embedding_str,
+        json.dumps([history_entry]),
+        source_ids,
+        len(source_ids),
+        uuid.UUID(observation_id),
+        source_occurred_start,
+        source_occurred_end,
+        source_mentioned_at,
+        merged_tags,
+    )
+    if perf:
+        perf.record_timing("db_write", time.time() - t0)
+
+    if memory_engine._backend.ops.uses_observation_sources_table:
+        obs_uuid = uuid.UUID(observation_id)
+        await conn.execute(
+            f"DELETE FROM {fq_table('observation_sources')} WHERE observation_id = $1",
+            obs_uuid,
+        )
+        if source_ids:
+            await conn.executemany(
+                f"""
+                INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
+                VALUES ($1, $2)
+                ON CONFLICT (observation_id, source_id) DO NOTHING
+                """,
+                [(obs_uuid, sid) for sid in dict.fromkeys(source_ids)],
+            )
+
+    logger.debug(f"Merged {len(source_memory_ids)} source memories into observation {observation_id}")
+
+
 async def _create_observation_directly(
     conn: "Connection",
     memory_engine: "MemoryEngine",
@@ -1347,8 +1537,15 @@ async def _create_observation_directly(
     occurred_end: datetime | None = None,
     mentioned_at: datetime | None = None,
     perf: ConsolidationPerfLog | None = None,
+    dedup_threshold: float = 0.0,
 ) -> dict[str, Any]:
-    """Create an observation from one or more source memories with pre-processed text."""
+    """Create an observation from one or more source memories with pre-processed text.
+
+    If ``dedup_threshold`` > 0 and an existing observation with cosine similarity >= threshold
+    is found, the new source memories are merged into the existing observation instead of
+    creating a duplicate row. This prevents unbounded observation growth when the LLM
+    repeatedly fails to match new facts to existing observations.
+    """
     live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
     if not live_source_memory_ids:
         logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted concurrently")
@@ -1361,6 +1558,34 @@ async def _create_observation_directly(
     embedding_str = str(embeddings[0]) if embeddings else None
     if perf:
         perf.record_timing("embedding", time.time() - t0)
+
+    # Deduplication guard: if an existing observation is semantically identical,
+    # merge into it instead of creating a duplicate row.
+    if dedup_threshold > 0 and embedding_str:
+        dup = await _find_semantic_duplicate_observation(
+            conn, bank_id, embedding_str, tags=tags, threshold=dedup_threshold
+        )
+        if dup:
+            dup_id, similarity = dup
+            logger.debug(
+                f"Observation dedup: merging into {dup_id} "
+                f"(similarity={similarity:.3f}, threshold={dedup_threshold})"
+            )
+            await _merge_into_observation(
+                conn=conn,
+                memory_engine=memory_engine,
+                bank_id=bank_id,
+                observation_id=dup_id,
+                new_text=observation_text,
+                source_memory_ids=source_memory_ids,
+                source_fact_tags=tags,
+                source_occurred_start=occurred_start,
+                source_occurred_end=occurred_end,
+                source_mentioned_at=mentioned_at,
+                perf=perf,
+                embedding_str=embedding_str,
+            )
+            return {"action": "updated", "observation_id": dup_id}
 
     # Create the observation as a memory_unit
     now = datetime.now(timezone.utc)

--- a/hindsight-api-slim/tests/test_consolidation_observation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_observation_dedup.py
@@ -1,0 +1,216 @@
+"""Unit test for observation deduplication during consolidation (#1284 fix).
+
+This test validates the new _find_semantic_duplicate_observation and
+_merge_into_observation helpers without needing a real PostgreSQL instance
+or sentence-transformers — it mocks the connection and the embedding call.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from hindsight_api.engine.consolidation.consolidator import (
+    _find_semantic_duplicate_observation,
+    _merge_into_observation,
+    _create_observation_directly,
+)
+from hindsight_api.engine.memory_engine import fq_table
+
+
+@pytest.fixture
+def mock_conn():
+    conn = AsyncMock()
+    conn.backend_type = "postgresql"
+    return conn
+
+
+@pytest.fixture
+def mock_memory_engine():
+    mem = MagicMock()
+    mem._backend.ops.uses_observation_sources_table = False
+    mem.embeddings = MagicMock()
+    return mem
+
+
+class TestFindSemanticDuplicateObservation:
+    """Tests for _find_semantic_duplicate_observation."""
+
+    async def test_no_match_below_threshold(self, mock_conn):
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+        result = await _find_semantic_duplicate_observation(
+            mock_conn, "bank-1", "[0.1, 0.2]", threshold=0.95
+        )
+        assert result is None
+        # Verify query was executed with correct bank_id
+        args = mock_conn.fetchrow.call_args[0]
+        assert "bank_id = $2" in mock_conn.fetchrow.call_args[0][0]
+        assert args[1] == "[0.1, 0.2]"
+        assert args[2] == "bank-1"
+
+    async def test_match_above_threshold(self, mock_conn):
+        mock_conn.fetchrow = AsyncMock(
+            return_value={"id": UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"), "similarity": 0.95}
+        )
+        result = await _find_semantic_duplicate_observation(
+            mock_conn, "bank-1", "[0.1, 0.2]", threshold=0.90
+        )
+        assert result is not None
+        assert result[0] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result[1] == 0.95
+
+    async def test_match_with_tags_filter(self, mock_conn):
+        mock_conn.fetchrow = AsyncMock(
+            return_value={"id": UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"), "similarity": 0.93}
+        )
+        result = await _find_semantic_duplicate_observation(
+            mock_conn, "bank-1", "[0.1, 0.2]", tags=["user:42"], threshold=0.90
+        )
+        assert result is not None
+        # Verify tags filter was injected into the query
+        sql = mock_conn.fetchrow.call_args[0][0]
+        assert "tags" in sql.lower()
+        # Verify params contain raw list (not json.dumps)
+        params = mock_conn.fetchrow.call_args[0][1:]
+        assert ["user:42"] in params
+
+    async def test_threshold_zero_disabled(self, mock_conn):
+        """When threshold is 0, the helper should still execute but accept any match."""
+        mock_conn.fetchrow = AsyncMock(
+            return_value={"id": UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"), "similarity": 0.5}
+        )
+        result = await _find_semantic_duplicate_observation(
+            mock_conn, "bank-1", "[0.1, 0.2]", threshold=0.0
+        )
+        assert result is not None
+        assert result[1] == 0.5
+
+
+class TestMergeIntoObservation:
+    """Tests for _merge_into_observation."""
+
+    async def test_merge_updates_fields(self, mock_conn, mock_memory_engine):
+        obs_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        existing_text = "Original observation text"
+        existing_tags = ["user:42"]
+        existing_sources = [UUID("11111111-1111-1111-1111-111111111111")]
+
+        mock_conn.fetchrow = AsyncMock(
+            return_value={
+                "text": existing_text,
+                "source_memory_ids": existing_sources,
+                "tags": existing_tags,
+                "occurred_start": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "occurred_end": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                "mentioned_at": datetime(2024, 1, 3, tzinfo=timezone.utc),
+            }
+        )
+        mock_conn.execute = AsyncMock()
+
+        # Patch the embedding call to avoid sentence-transformers dependency
+        with patch(
+            "hindsight_api.engine.consolidation.consolidator.embedding_utils.generate_embeddings_batch",
+            new=AsyncMock(return_value=[[0.1, 0.2, 0.3]]),
+        ):
+            await _merge_into_observation(
+                conn=mock_conn,
+                memory_engine=mock_memory_engine,
+                bank_id="bank-1",
+                observation_id=obs_id,
+                new_text="Updated observation text",
+                source_memory_ids=[UUID("22222222-2222-2222-2222-222222222222")],
+                source_fact_tags=["session:99"],
+                source_occurred_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                source_occurred_end=datetime(2024, 1, 5, tzinfo=timezone.utc),
+                source_mentioned_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+            )
+
+        # Verify UPDATE was issued
+        assert mock_conn.execute.call_count == 1
+        sql = mock_conn.execute.call_args[0][0]
+        assert "UPDATE" in sql.upper()
+
+        # Verify the new text and merged tags
+        args = mock_conn.execute.call_args[0]
+        assert args[1] == "Updated observation text"
+        # tags should be merged
+        merged_tags = args[10]
+        assert set(merged_tags) == {"user:42", "session:99"}
+
+    async def test_merge_skips_deleted_sources(self, mock_conn, mock_memory_engine):
+        """If all new source memories are dead, the merge should be skipped."""
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+        # Override _filter_live_source_memories to return empty
+        with patch(
+            "hindsight_api.engine.consolidation.consolidator._filter_live_source_memories",
+            new=AsyncMock(return_value=[]),
+        ):
+            await _merge_into_observation(
+                conn=mock_conn,
+                memory_engine=mock_memory_engine,
+                bank_id="bank-1",
+                observation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                new_text="Updated text",
+                source_memory_ids=[UUID("22222222-2222-2222-2222-222222222222")],
+            )
+        # No UPDATE should be issued
+        mock_conn.execute.assert_not_called()
+
+
+class TestCreateObservationDirectlyDedup:
+    """Tests that _create_observation_directly respects the dedup_threshold."""
+
+    async def test_dedup_path(self, mock_conn, mock_memory_engine):
+        """When a duplicate exists, _create_observation_directly returns 'updated'."""
+        obs_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+        # First, _find_semantic_duplicate_observation will be called
+        # Second, _merge_into_observation will be called
+        with patch(
+            "hindsight_api.engine.consolidation.consolidator._find_semantic_duplicate_observation",
+            new=AsyncMock(return_value=(obs_id, 0.95)),
+        ):
+            with patch(
+                "hindsight_api.engine.consolidation.consolidator._merge_into_observation",
+                new=AsyncMock(),
+            ):
+                result = await _create_observation_directly(
+                    conn=mock_conn,
+                    memory_engine=mock_memory_engine,
+                    bank_id="bank-1",
+                    source_memory_ids=[UUID("22222222-2222-2222-2222-222222222222")],
+                    observation_text="Duplicate text",
+                    dedup_threshold=0.90,
+                )
+        assert result["action"] == "updated"
+        assert result["observation_id"] == obs_id
+
+    async def test_no_dedup_when_threshold_zero(self, mock_conn, mock_memory_engine):
+        """When threshold is 0, the normal INSERT path runs."""
+        mock_conn.fetchrow = AsyncMock(return_value={"id": UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")})
+
+        # Patch the embedding call
+        with patch(
+            "hindsight_api.engine.consolidation.consolidator.embedding_utils.generate_embeddings_batch",
+            new=AsyncMock(return_value=[[0.1, 0.2, 0.3]]),
+        ):
+            result = await _create_observation_directly(
+                conn=mock_conn,
+                memory_engine=mock_memory_engine,
+                bank_id="bank-1",
+                source_memory_ids=[UUID("22222222-2222-2222-2222-222222222222")],
+                observation_text="New text",
+                dedup_threshold=0.0,
+            )
+        assert result["action"] == "created"
+        # An INSERT should have been issued
+        sql = mock_conn.fetchrow.call_args[0][0]
+        assert "INSERT" in sql.upper()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Fixes #1284: **Experience entries accumulate without further consolidation — entry count grows unboundedly.**  
After `retain()` fires, observations are created from facts. When the LLM repeatedly fails to match new facts to existing observations, duplicate observations accumulate. The user reported 60 entries where ~15 was expected.

## Solution

Add a **semantic deduplication guard at observation CREATE time**:

1. Compute the embedding of the proposed observation text.
2. Query existing observations in the same `bank_id` + tag scope for cosine similarity ≥ `consolidation_observation_dedup_threshold` (default **0.92**).
3. If a match is found, merge the new source memories into the existing observation (UPDATE) instead of inserting a duplicate row.

This is transparent to the LLM — CREATE actions are automatically converted to UPDATEs when a semantic duplicate exists.

### New helpers

- `_find_semantic_duplicate_observation()` — vector-similarity lookup using the SQL dialect abstraction. Works on both **PostgreSQL** and **Oracle**.
- `_merge_into_observation()` — merges source memories, tags, and temporal bounds into an existing observation without requiring the `MemoryFact` model. Accepts an optional `embedding_str` parameter to avoid double generation on the dedup path.

### Configuration

| Setting | Default | Env Var |
|---------|---------|---------|
| `consolidation_observation_dedup_threshold` | `0.92` | `HINDSIGHT_API_CONSOLIDATION_OBSERVATION_DEDUP_THRESHOLD` |

Set to `0.0` to disable deduplication.

## Security

- Always scoped to the same `bank_id`.
- Tags are passed raw to `dialect.array_contains()` for cross-database compatibility (no `json.dumps`).
- Source memory IDs are deduplicated before merge to prevent `proof_count` inflation.

## Test coverage

- `tests/test_consolidation_observation_dedup.py` — unit tests mocking DB + embeddings:
  - No match below threshold
  - Match above threshold
  - Tags filter uses correct parameter types
  - Merge updates fields correctly
  - Merge skips when all new sources are deleted
  - Dedup path on `_create_observation_directly`
  - Normal INSERT when threshold is 0

## Checklist

- [x] Code compiles (`py_compile` clean)
- [x] Dual-verdict review completed (Tech Lead + Software Engineer)
- [x] SE-requested fixes applied: dialect abstraction, raw tag params, deduplicated source IDs, embeddeding reuse
- [x] New unit tests added
- [x] Config fields added with env-var fallbacks
