### PR TITLE
fix(hindsight-api-slim): bump opentelemetry-{api,sdk,instrumentation,exporter} floors so PrometheusMetricReader 0.62b1 doesn't crash startup

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -28,12 +28,19 @@ dependencies = [
     "PyJWT[crypto]>=2.8.0",
     "fastmcp>=3.2.0", # SSRF/path traversal, OAuth confused deputy, command injection fixes
     "python-dateutil>=2.8.0",
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
-    "opentelemetry-instrumentation-fastapi>=0.41b0",
-    "opentelemetry-exporter-prometheus>=0.41b0",
-    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
-    "opentelemetry-semantic-conventions>=0.41b0",
+    # opentelemetry-exporter-prometheus 0.62b1 calls
+    # MetricReader.__init__(otel_component_type=…), a kwarg added in
+    # opentelemetry-sdk 1.41.0 (open-telemetry/opentelemetry-python#4970).
+    # Without these floors, pip happily resolves a 0.62b1 exporter against
+    # an older sdk and metric initialisation crashes at startup with
+    # "MetricReader.__init__() got an unexpected keyword argument
+    # 'otel_component_type'".  Keep all six pins moving together.
+    "opentelemetry-api>=1.41.0",
+    "opentelemetry-sdk>=1.41.0",
+    "opentelemetry-instrumentation-fastapi>=0.62b1",
+    "opentelemetry-exporter-prometheus>=0.62b1",
+    "opentelemetry-exporter-otlp-proto-http>=1.41.0",
+    "opentelemetry-semantic-conventions>=0.62b1",
     "dateparser>=1.2.2",
     "google-genai>=1.0.0",
     "google-auth>=2.0.0",


### PR DESCRIPTION
Fixes #1372.

## Why

`opentelemetry-exporter-prometheus 0.62b1` calls `MetricReader.__init__(otel_component_type=…)`, a kwarg that `opentelemetry-sdk` introduced only in **v1.41.0** ([open-telemetry/opentelemetry-python#4970](https://github.com/open-telemetry/opentelemetry-python/pull/4970), released 2026-04-09).

Verified by greping each tagged sdk:

| sdk version | `otel_component_type` occurrences in `metrics/_internal/export/__init__.py` |
|---|---|
| `v1.39.1` | 0 |
| `v1.40.0` | 0 |
| `v1.41.0` | 7 (kwarg added) |
| `v1.41.1` | 7 |

The previous floors in `hindsight-api-slim/pyproject.toml`:

```toml
"opentelemetry-api>=1.20.0",
"opentelemetry-sdk>=1.20.0",
"opentelemetry-instrumentation-fastapi>=0.41b0",
"opentelemetry-exporter-prometheus>=0.41b0",
"opentelemetry-exporter-otlp-proto-http>=1.20.0",
"opentelemetry-semantic-conventions>=0.41b0",
```

let pip happily resolve `opentelemetry-exporter-prometheus 0.62b1` (current latest) against a `1.39.x`/`1.40.x` sdk that was already cached in a venv/lockfile from before. `hindsight-api` then logs at startup:

```
WARNING - root - Failed to initialize metrics: MetricReader.__init__() got an unexpected keyword argument 'otel_component_type'. Metrics will be disabled (using no-op collector).
```

The daemon stays up (no-op collector kicks in) but `/metrics` is silently empty for the rest of the process lifetime.

## What

Bump all six otel-related deps to the matching `1.41.0` / `0.62b1` floor so pip's resolver keeps the otel ecosystem consistent:

```diff
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
-    "opentelemetry-instrumentation-fastapi>=0.41b0",
-    "opentelemetry-exporter-prometheus>=0.41b0",
-    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
-    "opentelemetry-semantic-conventions>=0.41b0",
+    "opentelemetry-api>=1.41.0",
+    "opentelemetry-sdk>=1.41.0",
+    "opentelemetry-instrumentation-fastapi>=0.62b1",
+    "opentelemetry-exporter-prometheus>=0.62b1",
+    "opentelemetry-exporter-otlp-proto-http>=1.41.0",
+    "opentelemetry-semantic-conventions>=0.62b1",
```

## Verification

Reproduced locally with `hindsight-api-slim 0.5.6` + `opentelemetry-sdk==1.39.1` + `opentelemetry-exporter-prometheus==0.62b1`:

```
WARNING - root - Failed to initialize metrics: MetricReader.__init__() got an unexpected keyword argument 'otel_component_type'. Metrics will be disabled (using no-op collector).
```

After upgrading the entire otel stack to 1.41.1 / 0.62b1 (workaround documented in #1372), `hindsight-api` startup logs:

```
INFO - root - Metrics initialized - available at /metrics endpoint
```

— and the `/metrics` endpoint serves data normally. With this PR's floor bumps applied, every fresh install gets that working state by default.

## Risk

Strictly raising lower bounds. Anyone already on the broken combination gets a one-time pip resolver bump on next install; anyone already on `>=1.41`/`>=0.62b1` is unaffected. No code changes.

## Notes

- `mistralai 2.3.2` separately requires `opentelemetry-semantic-conventions<0.61,>=0.60b1`, which conflicts with this PR's `>=0.62b1` floor. In the venv where I verified, mistralai is only used for an optional provider so the conflict is a `pip check` warning rather than a runtime issue. If hindsight does end up needing mistralai imported on the hot path, that's a separate upstream pin to relax in `mistralai`.