### PR TITLE
fix(api): include observations in per-document graph and counts

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3723,6 +3723,36 @@ class MemoryEngine(MemoryEngineInterface):
 
         return filtered_results, total_tokens
 
+    def _observations_via_source_match_sql(
+        self,
+        source_column: str,
+        source_placeholder: int,
+        bank_placeholder: int | None,
+    ) -> str:
+        """SQL predicate matching `memory_units` rows that are observations
+        whose source memories satisfy ``<source_column> = $source_placeholder``.
+
+        Observations have no `document_id` / `chunk_id` of their own; the link
+        to a source row lives in `source_memory_ids` (PG) or the
+        `observation_sources` junction (Oracle).
+        """
+        if source_column not in ("document_id", "chunk_id"):
+            raise ValueError(f"Unsupported source_column: {source_column!r}")
+        if self._backend.ops.uses_observation_sources_table:
+            bank_clause = f" AND src.bank_id = ${bank_placeholder}" if bank_placeholder else ""
+            return (
+                f"id IN (SELECT os.observation_id "
+                f"FROM {fq_table('observation_sources')} os "
+                f"JOIN {fq_table('memory_units')} src ON src.id = os.source_id "
+                f"WHERE src.{source_column} = ${source_placeholder}{bank_clause})"
+            )
+        bank_clause = f" AND bank_id = ${bank_placeholder}" if bank_placeholder else ""
+        return (
+            f"source_memory_ids && (SELECT array_agg(id) "
+            f"FROM {fq_table('memory_units')} "
+            f"WHERE {source_column} = ${source_placeholder}{bank_clause})"
+        )
+
     async def get_document(
         self,
         document_id: str,
@@ -3749,6 +3779,12 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
+            obs_match = self._observations_via_source_match_sql("document_id", source_placeholder=1, bank_placeholder=2)
+            observation_count_sql = (
+                f"(SELECT COUNT(*) FROM {fq_table('memory_units')} "
+                f"WHERE bank_id = $2 AND fact_type = 'observation' AND {obs_match})"
+            )
+
             # Use a subquery for counts to avoid GROUP BY on CLOB columns
             # (Oracle cannot use CLOB types as comparison keys in GROUP BY).
             doc = await conn.fetchrow(
@@ -3758,14 +3794,13 @@ class MemoryEngine(MemoryEngineInterface):
                        COALESCE(stats.unit_count, 0) as unit_count,
                        COALESCE(stats.world_count, 0) as world_count,
                        COALESCE(stats.experience_count, 0) as experience_count,
-                       COALESCE(stats.observation_count, 0) as observation_count
+                       COALESCE({observation_count_sql}, 0) as observation_count
                 FROM {fq_table("documents")} d
                 LEFT JOIN (
                     SELECT mu.document_id, mu.bank_id,
                            COUNT(mu.id) as unit_count,
                            COUNT(CASE WHEN mu.fact_type = 'world' THEN 1 END) as world_count,
-                           COUNT(CASE WHEN mu.fact_type = 'experience' THEN 1 END) as experience_count,
-                           COUNT(CASE WHEN mu.fact_type = 'observation' THEN 1 END) as observation_count
+                           COUNT(CASE WHEN mu.fact_type = 'experience' THEN 1 END) as experience_count
                     FROM {fq_table("memory_units")} mu
                     WHERE mu.document_id = $1 AND mu.bank_id = $2
                     GROUP BY mu.document_id, mu.bank_id
@@ -4478,8 +4513,10 @@ class MemoryEngine(MemoryEngineInterface):
             query_params = []
             param_count = 0
 
+            bank_id_placeholder: int | None = None
             if bank_id:
                 param_count += 1
+                bank_id_placeholder = param_count
                 query_conditions.append(f"bank_id = ${param_count}")
                 query_params.append(bank_id)
 
@@ -4490,12 +4527,20 @@ class MemoryEngine(MemoryEngineInterface):
 
             if document_id:
                 param_count += 1
-                query_conditions.append(f"document_id = ${param_count}")
+                obs_match = self._observations_via_source_match_sql(
+                    "document_id", source_placeholder=param_count, bank_placeholder=bank_id_placeholder
+                )
+                query_conditions.append(
+                    f"(document_id = ${param_count} OR (fact_type = 'observation' AND {obs_match}))"
+                )
                 query_params.append(document_id)
 
             if chunk_id:
                 param_count += 1
-                query_conditions.append(f"chunk_id = ${param_count}")
+                obs_match = self._observations_via_source_match_sql(
+                    "chunk_id", source_placeholder=param_count, bank_placeholder=bank_id_placeholder
+                )
+                query_conditions.append(f"(chunk_id = ${param_count} OR (fact_type = 'observation' AND {obs_match}))")
                 query_params.append(chunk_id)
 
             if q:

--- a/hindsight-api-slim/tests/test_document_chunks_and_reprocess.py
+++ b/hindsight-api-slim/tests/test_document_chunks_and_reprocess.py
@@ -151,8 +151,11 @@ async def test_get_document_nodes_by_fact_type(memory, request_context):
         assert isinstance(nbt["experience"], int)
         assert isinstance(nbt["observation"], int)
 
-        # Total should match memory_unit_count
-        assert nbt["world"] + nbt["experience"] + nbt["observation"] == doc["memory_unit_count"]
+        # memory_unit_count counts facts with document_id set (world + experience).
+        # Observations have no document_id and are counted via source links, so
+        # they are reported separately.
+        assert nbt["world"] + nbt["experience"] == doc["memory_unit_count"]
+        assert nbt["observation"] >= 0
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_graph_filtering.py
+++ b/hindsight-api-slim/tests/test_graph_filtering.py
@@ -4,6 +4,8 @@ Tests for server-side filtering in the graph API endpoint.
 Verifies that q (text search) and tags filters work correctly
 when passed as query parameters to GET /v1/default/banks/{bank_id}/graph.
 """
+
+import uuid
 from datetime import datetime
 
 import httpx
@@ -69,9 +71,7 @@ async def test_graph_q_filter_returns_matching(api_client, test_bank_id):
     assert response.status_code == 200
     data = response.json()
     texts = [row["text"] for row in data["table_rows"]]
-    assert all("Alice" in t or "alice" in t.lower() for t in texts), (
-        f"Expected only Alice memories, got: {texts}"
-    )
+    assert all("Alice" in t or "alice" in t.lower() for t in texts), f"Expected only Alice memories, got: {texts}"
     assert not any("Bob" in t for t in texts)
 
 
@@ -147,6 +147,106 @@ async def test_graph_q_and_tags_filter_combined(api_client, test_bank_id):
     assert any("hiking" in t.lower() for t in texts)
     assert not any("coding" in t.lower() for t in texts)
     assert not any("Bob" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_graph_document_filter_includes_observations_via_source_memories(
+    memory, api_client, test_bank_id, request_context
+):
+    """Filtering the graph by document_id surfaces observations whose source
+    memories belong to that document.
+
+    Observations are consolidated rows that have no document_id of their own,
+    so a naive equality filter on memory_units.document_id excludes them and
+    leaves the document detail's Observations tab perpetually empty even when
+    the bank has observations consolidated from facts in that document.
+    """
+    bank_id = test_bank_id
+    document_id = f"doc-{uuid.uuid4().hex[:8]}"
+
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    fact_id = uuid.uuid4()
+    observation_id = uuid.uuid4()
+    other_fact_id = uuid.uuid4()
+    unrelated_observation_id = uuid.uuid4()
+
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO documents (id, bank_id, original_text, content_hash)
+            VALUES ($1, $2, $3, $4)
+            """,
+            document_id,
+            bank_id,
+            "doc body",
+            "hash-test",
+        )
+
+        # World fact tied to the document.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (id, bank_id, text, fact_type, document_id, history)
+            VALUES ($1, $2, $3, 'world', $4, '[]'::jsonb)
+            """,
+            fact_id,
+            bank_id,
+            "fact in document",
+            document_id,
+        )
+
+        # Unrelated fact NOT tied to the document.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (id, bank_id, text, fact_type, history)
+            VALUES ($1, $2, $3, 'world', '[]'::jsonb)
+            """,
+            other_fact_id,
+            bank_id,
+            "unrelated fact",
+        )
+
+        # Observation consolidated from the document fact.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (
+                id, bank_id, text, fact_type, source_memory_ids, history, proof_count
+            )
+            VALUES ($1, $2, $3, 'observation', $4::uuid[], '[]'::jsonb, 1)
+            """,
+            observation_id,
+            bank_id,
+            "observation from document",
+            [fact_id],
+        )
+
+        # Observation that has no overlap with the document; should NOT match.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (
+                id, bank_id, text, fact_type, source_memory_ids, history, proof_count
+            )
+            VALUES ($1, $2, $3, 'observation', $4::uuid[], '[]'::jsonb, 1)
+            """,
+            unrelated_observation_id,
+            bank_id,
+            "observation from elsewhere",
+            [other_fact_id],
+        )
+
+    response = await api_client.get(
+        f"/v1/default/banks/{bank_id}/graph",
+        params={"type": "observation", "document_id": document_id},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    returned_ids = {row["id"] for row in data["table_rows"]}
+    assert str(observation_id) in returned_ids, (
+        f"Observation linked via source memory should be returned; got {returned_ids}"
+    )
+    assert str(unrelated_observation_id) not in returned_ids, (
+        "Unrelated observation must not leak into document-scoped results"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The control plane's document detail view ships an **Observations** tab and a **Memory Composition** card alongside *World* and *Experience*. Both were permanently empty for every document.

## Root cause

`get_graph_data` and `get_document` filter `memory_units` by `document_id` (and `chunk_id`) with a direct equality. Observations are consolidated rows whose `document_id` / `chunk_id` columns are always `NULL`; the link back to a document lives on `source_memory_ids` (PG) or in the `observation_sources` junction table (Oracle). The equality filter therefore excludes every observation, regardless of how its source memories were extracted.

## Fix

- Added `MemoryEngine._observations_via_source_match_sql`: a backend-aware predicate matching observations whose source memories satisfy a column equality, scoped to a bank. One helper now serves both call sites and any future ones.
- `get_graph_data`: extend `document_id` / `chunk_id` filters with an `OR` branch via the helper so observations linked through their sources are returned. Bank-scope the inner subquery.
- `get_document`: replace the broken `observation_count` aggregation with a `COUNT(*)` subquery built on the same helper. `nodes_by_fact_type.observation` now reflects observations for the document.

## Test plan

- [x] New regression test `test_graph_document_filter_includes_observations_via_source_memories` seeds a document with a source fact, an observation linked via `source_memory_ids`, and an unrelated observation. Verifies the graph endpoint returns only the linked observation when filtering by `document_id`. Confirmed to fail without the fix.
- [x] Existing `test_get_document_nodes_by_fact_type` assertion updated: `memory_unit_count` covers facts with `document_id` (world + experience); observations are reported separately in `nodes_by_fact_type`.
- [x] `tests/test_graph_filtering.py` and `tests/test_document_chunks_and_reprocess.py` pass (19 passed, 1 pre-existing skip).
- [x] `ruff check` / `ruff format` clean on touched files.