### PR TITLE
fix(oracle): update CHECK constraints in baseline to match PG schema

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/o1a2b3c4d5e6_oracle_baseline.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/o1a2b3c4d5e6_oracle_baseline.py
@@ -219,7 +219,7 @@ _TABLES: tuple[str, ...] = (
         CONSTRAINT pk_mental_models PRIMARY KEY (id, bank_id),
         CONSTRAINT fk_mm_bank FOREIGN KEY (bank_id) REFERENCES banks(bank_id) ON DELETE CASCADE,
         CONSTRAINT fk_mm_entity FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE SET NULL,
-        CONSTRAINT chk_mm_subtype CHECK (subtype IN ('structural', 'emergent', 'pinned', 'learned'))
+        CONSTRAINT chk_mm_subtype CHECK (subtype IN ('directive', 'pinned'))
     )
     """,
     """
@@ -256,7 +256,7 @@ _TABLES: tuple[str, ...] = (
         completed_at      TIMESTAMP WITH TIME ZONE,
         CONSTRAINT pk_async_operations PRIMARY KEY (operation_id),
         CONSTRAINT fk_ao_bank FOREIGN KEY (bank_id) REFERENCES banks(bank_id) ON DELETE CASCADE,
-        CONSTRAINT chk_ao_status CHECK (status IN ('pending', 'processing', 'completed', 'failed'))
+        CONSTRAINT chk_ao_status CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'cancelled'))
     )
     """,
     """


### PR DESCRIPTION
## Summary

- `async_operations.status` CHECK constraint was missing `'cancelled'` (added in PG migration `i4j5k6l7m8n9`)
- `mental_models.subtype` CHECK constraint had stale values `('structural', 'emergent', 'pinned', 'learned')` instead of current `('directive', 'pinned')` (changed in PG migration `o0j1k2l3m4n5`)

Both would cause runtime constraint violations on Oracle when cancelling operations or creating directives. Since Oracle hasn't shipped, no follow-up ALTER migration is needed — fixing the baseline DDL is sufficient.

## Test plan

- [x] `test_migration_shape.py` — 60/60 pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)