### PR TITLE
fix: redirect daemon subprocess stdout/stderr on POSIX to prevent TUI corruption

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -47,8 +47,8 @@ def _detach_popen_kwargs(log_handle) -> dict:
     write from the child crashes with "handle is invalid".
 
     If a `log_handle` is supplied, stdout/stderr are routed to it on both
-    platforms (matches the existing UI-spawn behavior). If `None`, the
-    POSIX child inherits the parent's fds (legacy daemon-spawn behavior).
+    platforms. If `None`, the POSIX child inherits the parent's fds (only
+    used when the caller intentionally wants to surface child output).
     """
     if platform.system() == "Windows":
         # Windows-only constants; use getattr so type checkers (e.g. ty) running
@@ -387,19 +387,13 @@ class DaemonEmbedManager(EmbedManager):
             cmd.extend(extra_args)
 
         try:
-            # Start daemon. On Windows we must redirect stdout/stderr before
-            # the child Python runs; DETACHED_PROCESS leaves it without a
-            # console so any print/log to stdio would raise. We open the
-            # daemon log for append here and hand it to the child; Python's
-            # own logging (via HINDSIGHT_API_DAEMON_LOG) will append to the
-            # same path once logging initializes. On POSIX we keep the
-            # existing inherit-fd behavior to avoid touching working code.
-            if platform.system() == "Windows":
-                daemon_log_handle = open(daemon_log, "ab")
-                popen_kwargs = _detach_popen_kwargs(daemon_log_handle)
-            else:
-                daemon_log_handle = None
-                popen_kwargs = _detach_popen_kwargs(None)
+            # Start daemon. Redirect stdout/stderr to the daemon log so that
+            # any output from the subprocess (e.g. uvx download progress,
+            # Python library init messages) does not leak into the parent
+            # process terminal. Python's own logging (via
+            # HINDSIGHT_API_DAEMON_LOG) will append to the same path.
+            daemon_log_handle = open(daemon_log, "ab")
+            popen_kwargs = _detach_popen_kwargs(daemon_log_handle)
             subprocess.Popen(cmd, env=env, **popen_kwargs)
 
             # Wait for daemon to be ready with rich UI


### PR DESCRIPTION
## Problem

On POSIX, the daemon subprocess spawned by `DaemonEmbedManager._start_daemon_locked()` inherited the parent process's stdout/stderr file descriptors. When running inside a TUI (e.g. Hermes terminal UI) that uses stdio pipes for JSON-RPC communication, any output from the daemon subprocess leaks into the parent's terminal, corrupting the Ink UI rendering.

**Symptoms observed:**
- Python package download/install progress lines appear during daemon startup (uvx, pip)
- Python library init messages (torch, sentence-transformers, etc.)
- Rich UI frames from daemon manager
- These outputs contain ANSI escape sequences that interfere with terminal rendering
- TUI input bar layout corruption, timer display misalignment

## Root Cause

The code had platform-specific behavior:
- **Windows**: Redirected stdout/stderr to daemon_log (mandatory, since DETACHED_PROCESS removes the console)
- **POSIX**: Inherited parent's fds ("legacy daemon-spawn behavior")

On POSIX, the child process inherits the parent's file descriptors. When the parent is a gateway process communicating via stdio pipes (TUI mode), any write from the child to stdout/stderr goes through those pipes and corrupts the JSON-RPC protocol or TUI rendering.

## Fix

Make POSIX behavior consistent with Windows by always passing a log_handle to `_detach_popen_kwargs()`. The daemon's stdout/stderr are now redirected to daemon_log on both platforms.

This matches the existing UI-spawn behavior (line 625), which already uses `_detach_popen_kwargs(log_file)`.

## Changes

- `hindsight-embed/hindsight_embed/daemon_embed_manager.py`:
  - Removed the Windows/POSIX if-else branch in `_start_daemon_locked()`
  - Always open daemon_log and pass it to `_detach_popen_kwargs()`
  - Updated docstring to reflect that log_handle=None is no longer the default for daemon spawns
  - Updated code comment to explain the rationale

## Testing

- Manual test on macOS with Hermes TUI: daemon startup no longer causes UI corruption
- The daemon log file captures all subprocess output (uvx progress, Python init, Rich UI)
- Existing behavior unchanged: Python's own logging (via HINDSIGHT_API_DAEMON_LOG) still appends to the same file
