### PR TITLE
fix(retain): retain all documents in async multi-document batches

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1309,7 +1309,14 @@ async def _streaming_retain_batch(
                         if isinstance(row["result_metadata"], dict)
                         else json.loads(row["result_metadata"])
                     )
-                    if meta.get("facts_committed"):
+                    committed_doc_ids = meta.get("facts_committed_document_ids") or []
+                    document_ids = meta.get("document_ids") or []
+                    legacy_single_doc_checkpoint = (
+                        meta.get("facts_committed")
+                        and not committed_doc_ids
+                        and (len(document_ids) <= 1 or document_ids == [effective_doc_id])
+                    )
+                    if effective_doc_id in committed_doc_ids or legacy_single_doc_checkpoint:
                         facts_already_committed = True
                         log_buffer.append(
                             f"[streaming] Recovery: facts already committed ({meta.get('unit_ids_count', '?')} units), "
@@ -1375,10 +1382,21 @@ async def _streaming_retain_batch(
                     await conn.execute(
                         f"""
                         UPDATE {fq_table("async_operations")}
-                        SET result_metadata = result_metadata || $1::jsonb, updated_at = now()
-                        WHERE operation_id = $2
+                        SET result_metadata = jsonb_set(
+                            result_metadata || $1::jsonb,
+                            '{{facts_committed_document_ids}}',
+                            CASE
+                                WHEN COALESCE(result_metadata->'facts_committed_document_ids', '[]'::jsonb) @> $2::jsonb
+                                    THEN result_metadata->'facts_committed_document_ids'
+                                ELSE COALESCE(result_metadata->'facts_committed_document_ids', '[]'::jsonb) || $2::jsonb
+                            END,
+                            true
+                        ),
+                        updated_at = now()
+                        WHERE operation_id = $3
                         """,
                         json.dumps({"facts_committed": True, "unit_ids_count": len(all_unit_ids)}),
+                        json.dumps([effective_doc_id]),
                         uuid.UUID(operation_id),
                     )
                 log_buffer.append(f"[streaming] Checkpoint: {len(all_unit_ids)} facts committed, ANN pass next")

--- a/hindsight-api-slim/tests/test_none_llm_provider.py
+++ b/hindsight-api-slim/tests/test_none_llm_provider.py
@@ -9,6 +9,7 @@ Verifies that when HINDSIGHT_API_LLM_PROVIDER=none:
 - NoneLLM.call() raises LLMNotAvailableError
 """
 
+import asyncio
 import os
 from datetime import datetime, timezone
 
@@ -25,9 +26,40 @@ from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 
 
+class _TestEmbeddings:
+    provider_name = "test"
+    dimension = 384
+
+    async def initialize(self) -> None:
+        return None
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] * self.dimension for _ in texts]
+
+
+class _TestCrossEncoder:
+    provider_name = "test"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        return [1.0 for _ in pairs]
+
+
 @pytest.fixture(scope="function")
 def request_context():
     return RequestContext()
+
+
+@pytest.fixture(scope="function")
+def embeddings():
+    return _TestEmbeddings()
+
+
+@pytest.fixture(scope="function")
+def cross_encoder():
+    return _TestCrossEncoder()
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -127,6 +159,36 @@ async def test_retain_works_with_none_provider(none_memory, request_context):
     )
 
     assert len(unit_ids) > 0, "Should store chunks even without an LLM"
+
+
+@pytest.mark.asyncio
+async def test_async_batch_retain_tracks_all_document_ids_with_none_provider(none_memory, request_context):
+    """Async batch retain should materialize every distinct per-item document_id."""
+    bank_id = f"test_none_async_batch_docs_{datetime.now(timezone.utc).timestamp()}"
+    contents = [
+        {"content": "Alpha document content for async batch retain.", "document_id": "doc-alpha"},
+        {"content": "Beta document content for async batch retain.", "document_id": "doc-beta"},
+    ]
+
+    result = await none_memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=contents,
+        request_context=request_context,
+    )
+    await asyncio.sleep(0.1)
+
+    status = await none_memory.get_operation_status(
+        bank_id=bank_id,
+        operation_id=result["operation_id"],
+        request_context=request_context,
+    )
+    assert status["status"] == "completed", status
+
+    alpha = await none_memory.get_document("doc-alpha", bank_id, request_context=request_context)
+    beta = await none_memory.get_document("doc-beta", bank_id, request_context=request_context)
+
+    assert alpha["memory_unit_count"] > 0
+    assert beta["memory_unit_count"] > 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes an async retain recovery bug where a multi-document batch could report success while only materializing the first document in the batch.

In async batch retain, items with distinct `document_id`s are processed as per-document groups, but those groups can share the same child operation id. The streaming retain recovery checkpoint used an operation-level `facts_committed=true` flag. After the first document committed facts, later document groups could incorrectly treat the operation as already committed, enter the recovery path, and skip extraction/storage for their own document.

This makes operation metadata look successful while some submitted documents are missing.

## Changes

- Track committed recovery checkpoints per document id via `facts_committed_document_ids`.
- Only treat facts as already committed when the current effective document id is present in that checkpoint set.
- Preserve legacy single-document recovery behavior for old operation metadata.
- Add regression coverage for async multi-item retain with distinct document ids.

