### PR TITLE
feat(helm): add configurable consolidation options

### DIFF
--- a/helm/hindsight/Chart.yaml
+++ b/helm/hindsight/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hindsight
 description: Hindsight helm chart
 type: application
-version: 0.5.5
-appVersion: "0.5.5"
+version: 0.5.6
+appVersion: "0.5.6"
 keywords:
   - ai
   - memory

--- a/helm/hindsight/templates/api-deployment.yaml
+++ b/helm/hindsight/templates/api-deployment.yaml
@@ -63,6 +63,57 @@ spec:
         {{- /* Explicitly set port to override K8s service discovery env var (HINDSIGHT_API_PORT) */}}
         - name: HINDSIGHT_API_PORT
           value: {{ .Values.api.service.targetPort | quote }}
+        {{- /* Consolidation/observation settings */}}
+        {{- if .Values.consolidation }}
+        {{- if hasKey .Values.consolidation "enableObservations" }}
+        - name: HINDSIGHT_API_ENABLE_OBSERVATIONS
+          value: {{ .Values.consolidation.enableObservations | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxMemoriesPerRound" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND
+          value: {{ .Values.consolidation.maxMemoriesPerRound | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "batchSize" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE
+          value: {{ .Values.consolidation.batchSize | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmBatchSize" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE
+          value: {{ .Values.consolidation.llmBatchSize | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxTokens" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS
+          value: {{ .Values.consolidation.maxTokens | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "recallBudget" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET
+          value: {{ .Values.consolidation.recallBudget | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "sourceFactsMaxTokens" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS
+          value: {{ .Values.consolidation.sourceFactsMaxTokens | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "sourceFactsMaxTokensPerObservation" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION
+          value: {{ .Values.consolidation.sourceFactsMaxTokensPerObservation | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxAttempts" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS
+          value: {{ .Values.consolidation.maxAttempts | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmProvider" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER
+          value: {{ .Values.consolidation.llmProvider | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmModel" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_MODEL
+          value: {{ .Values.consolidation.llmModel | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmBaseUrl" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL
+          value: {{ .Values.consolidation.llmBaseUrl | quote }}
+        {{- end }}
+        {{- end }}
         {{- range $key, $value := .Values.api.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/helm/hindsight/templates/worker-statefulset.yaml
+++ b/helm/hindsight/templates/worker-statefulset.yaml
@@ -65,6 +65,57 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- /* Consolidation settings (same as api) */}}
+        {{- if .Values.consolidation }}
+        {{- if hasKey .Values.consolidation "enableObservations" }}
+        - name: HINDSIGHT_API_ENABLE_OBSERVATIONS
+          value: {{ .Values.consolidation.enableObservations | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxMemoriesPerRound" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND
+          value: {{ .Values.consolidation.maxMemoriesPerRound | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "batchSize" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE
+          value: {{ .Values.consolidation.batchSize | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmBatchSize" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE
+          value: {{ .Values.consolidation.llmBatchSize | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxTokens" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS
+          value: {{ .Values.consolidation.maxTokens | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "recallBudget" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET
+          value: {{ .Values.consolidation.recallBudget | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "sourceFactsMaxTokens" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS
+          value: {{ .Values.consolidation.sourceFactsMaxTokens | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "sourceFactsMaxTokensPerObservation" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION
+          value: {{ .Values.consolidation.sourceFactsMaxTokensPerObservation | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "maxAttempts" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS
+          value: {{ .Values.consolidation.maxAttempts | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmProvider" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER
+          value: {{ .Values.consolidation.llmProvider | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmModel" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_MODEL
+          value: {{ .Values.consolidation.llmModel | quote }}
+        {{- end }}
+        {{- if hasKey .Values.consolidation "llmBaseUrl" }}
+        - name: HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL
+          value: {{ .Values.consolidation.llmBaseUrl | quote }}
+        {{- end }}
+        {{- end }}
         {{- /* Worker-specific env vars */}}
         {{- range $key, $value := .Values.worker.env }}
         - name: {{ $key }}

--- a/helm/hindsight/values.yaml
+++ b/helm/hindsight/values.yaml
@@ -104,6 +104,42 @@ api:
     # HINDSIGHT_API_LLM_API_KEY: "your-api-key"
     # HINDSIGHT_API_LLM_BASE_URL: "https://api.groq.com/openai/v1"
 
+# Consolidation settings (observation generation from retained facts)
+# Each setting maps to a HINDSIGHT_API_* env var. Set via the per-cluster values override.
+# All are optional — Hindsight uses safe defaults if unset.
+consolidation:
+  # Master toggle for observation consolidation
+  # enableObservations: true
+
+  # Max memories processed per consolidation run (0 = unlimited)
+  # maxMemoriesPerRound: 100
+
+  # Memories to load per batch (internal optimization)
+  # batchSize: 50
+
+  # Facts per LLM call (1 = no batching, each fact gets its own LLM call)
+  # llmBatchSize: 8
+
+  # Max tokens for recall when finding related observations
+  # maxTokens: 8192
+
+  # Budget level for consolidation recall: low, mid, high
+  # recallBudget: "low"
+
+  # Max tokens of source facts to include in consolidation prompt (-1 = unlimited)
+  # sourceFactsMaxTokens: 4096
+
+  # Max tokens of source facts per observation (-1 = unlimited)
+  # sourceFactsMaxTokensPerObservation: 256
+
+  # Retry attempts when LLM call fails
+  # maxAttempts: 3
+
+  # Optional dedicated LLM for consolidation (falls back to main LLM if unset)
+  # llmProvider: ""
+  # llmModel: ""
+  # llmBaseUrl: ""
+
 # Worker settings (distributed task processing)
 # When enabled, dedicated worker pods process tasks and the API's internal worker is disabled
 worker:


### PR DESCRIPTION
## Description

Add a new `consolidation` values section to the Helm chart that exposes all observation consolidation settings as configurable environment variables.

## Changes

- **values.yaml**: Added `consolidation.` block with 12 optional settings (all commented out by default, safe defaults used when unset)
- **api-deployment.yaml**: Injects consolidation env vars into the API container (conditional — only when explicitly set)
- **worker-statefulset.yaml**: Same consolidation env vars for the worker container
- **Chart.yaml**: Bump version 0.5.5 → 0.5.6

## Consolidation settings exposed

| Setting | Env var |
|---|---|
| `enableObservations` | `HINDSIGHT_API_ENABLE_OBSERVATIONS` |
| `maxMemoriesPerRound` | `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND` |
| `batchSize` | `HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE` |
| `llmBatchSize` | `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE` |
| `maxTokens` | `HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS` |
| `recallBudget` | `HINDSIGHT_API_CONSOLIDATION_RECALL_BUDGET` |
| `sourceFactsMaxTokens` | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS` |
| `sourceFactsMaxTokensPerObservation` | `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS_PER_OBSERVATION` |
| `maxAttempts` | `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS` |
| `llmProvider` | `HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER` |
| `llmModel` | `HINDSIGHT_API_CONSOLIDATION_LLM_MODEL` |
| `llmBaseUrl` | `HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL` |

## Backward compatibility

All env vars use `hasKey` checks — existing deployments with no `consolidation:` block are completely unaffected.