### PR TITLE
feat(anthropic): env-driven max_retries + default_headers knobs

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -135,11 +135,15 @@ ENV_LLM_TIMEOUT = "HINDSIGHT_API_LLM_TIMEOUT"
 ENV_LLM_GROQ_SERVICE_TIER = "HINDSIGHT_API_LLM_GROQ_SERVICE_TIER"
 ENV_LLM_OPENAI_SERVICE_TIER = "HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER"
 ENV_LLM_EXTRA_BODY = "HINDSIGHT_API_LLM_EXTRA_BODY"
+ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
 DEFAULT_LLM_EXTRA_BODY = None  # None = no extra body params; JSON dict merged into OpenAI extra_body
+DEFAULT_LLM_DEFAULT_HEADERS = (
+    None  # None = no extra headers; JSON dict passed as default_headers to provider SDK clients
+)
 
 # Per-operation LLM configuration (optional, falls back to global LLM config)
 ENV_RETAIN_LLM_PROVIDER = "HINDSIGHT_API_RETAIN_LLM_PROVIDER"
@@ -847,6 +851,9 @@ class HindsightConfig:
     llm_extra_body: (
         dict | None
     )  # Extra body params merged into OpenAI-compatible API calls (e.g. {"chat_template_kwargs": {"enable_thinking": true}})
+    llm_default_headers: (
+        dict | None
+    )  # Custom headers passed as default_headers to provider SDK clients (e.g. {"X-Component-Id": "hindsight"} for proxies / request tracing)
 
     # Vertex AI configuration
     llm_vertexai_project_id: str | None
@@ -1369,6 +1376,7 @@ class HindsightConfig:
             llm_groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
+            llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -148,6 +148,7 @@ def create_llm_provider(
     groq_service_tier: str | None = None,
     openai_service_tier: str | None = None,
     extra_body: dict[str, Any] | None = None,
+    default_headers: dict[str, str] | None = None,
     vertexai_project_id: str | None = None,
     vertexai_region: str | None = None,
     vertexai_credentials: Any = None,
@@ -165,6 +166,9 @@ def create_llm_provider(
         groq_service_tier: Groq service tier (for Groq provider) - "on_demand", "flex", or "auto".
         openai_service_tier: OpenAI service tier (for OpenAI provider) - None (default) or "flex" (50% cheaper).
         extra_body: Extra body params merged into OpenAI-compatible API calls.
+        default_headers: Custom headers passed as ``default_headers`` to provider SDK clients
+            (used by operators routing through proxies / request-tracing middleware). Currently
+            wired into the Anthropic provider; other providers may opt in as needed.
         vertexai_project_id: Vertex AI project ID (for VertexAI provider).
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
@@ -243,6 +247,7 @@ def create_llm_provider(
             base_url=base_url,
             model=model,
             reasoning_effort=reasoning_effort,
+            default_headers=default_headers,
         )
 
     elif provider_lower == "litellm":
@@ -317,6 +322,7 @@ class LLMProvider:
         openai_service_tier: str | None = None,
         gemini_safety_settings: list | None = None,
         extra_body: dict[str, Any] | None = None,
+        default_headers: dict[str, str] | None = None,
     ):
         """
         Initialize LLM provider.
@@ -331,6 +337,10 @@ class LLMProvider:
             openai_service_tier: OpenAI service tier (None or "flex") - from config.
             gemini_safety_settings: Safety settings for Gemini/VertexAI providers.
             extra_body: Extra body params merged into OpenAI-compatible API calls.
+            default_headers: Custom headers passed as ``default_headers`` to provider SDK clients.
+                Used by operators routing through proxies / request-tracing middleware. Falls
+                back to ``HindsightConfig.llm_default_headers`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``)
+                when ``None``.
         """
         self.provider = provider.lower()
         self.api_key = api_key
@@ -344,6 +354,17 @@ class LLMProvider:
         self.gemini_safety_settings = gemini_safety_settings
         # Extra body params for OpenAI-compatible providers (e.g. chat_template_kwargs)
         self.extra_body = extra_body
+        # Default headers passed to provider SDK clients (e.g. proxy auth, request tracing).
+        # Same pattern as ``gemini_safety_settings``: explicit override wins; otherwise read
+        # the static server-level default from ``HindsightConfig`` via ``_get_raw_config()``.
+        self.default_headers = default_headers
+        if self.default_headers is None:
+            from ..config import _get_raw_config
+
+            try:
+                self.default_headers = _get_raw_config().llm_default_headers
+            except Exception:
+                pass  # Config may not be initialized in test environments
 
         # Validate provider
         valid_providers = [
@@ -448,6 +469,7 @@ class LLMProvider:
             groq_service_tier=self.groq_service_tier,
             openai_service_tier=self.openai_service_tier,
             extra_body=self.extra_body,
+            default_headers=self.default_headers,
             vertexai_project_id=vertexai_project_id,
             vertexai_region=vertexai_region,
             vertexai_credentials=vertexai_credentials,
@@ -763,6 +785,7 @@ class LLMProvider:
             DEFAULT_LLM_PROVIDER,
             ENV_LLM_API_KEY,
             ENV_LLM_BASE_URL,
+            ENV_LLM_DEFAULT_HEADERS,
             ENV_LLM_EXTRA_BODY,
             ENV_LLM_MODEL,
             ENV_LLM_PROVIDER,
@@ -781,6 +804,7 @@ class LLMProvider:
         base_url = os.getenv(ENV_LLM_BASE_URL, "")
         model = os.getenv(ENV_LLM_MODEL, DEFAULT_LLM_MODEL)
         extra_body = json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null"))
+        default_headers = json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null"))
 
         return cls(
             provider=provider,
@@ -789,6 +813,7 @@ class LLMProvider:
             model=model,
             reasoning_effort="low",
             extra_body=extra_body,
+            default_headers=default_headers,
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -539,6 +539,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=memory_llm_base_url,
             model=memory_llm_model,
             extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
         )
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
@@ -566,6 +567,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=retain_base_url,
             model=retain_model,
             extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
         )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
@@ -588,6 +590,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=reflect_base_url,
             model=reflect_model,
             extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
         )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
@@ -610,6 +613,7 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=consolidation_base_url,
             model=consolidation_model,
             extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -11,6 +11,7 @@ This provider enables using Claude models from Anthropic with support for:
 import asyncio
 import json
 import logging
+import os
 import time
 from typing import Any
 
@@ -65,6 +66,26 @@ class AnthropicLLM(LLMInterface):
                 client_kwargs["base_url"] = self.base_url
             if timeout:
                 client_kwargs["timeout"] = timeout
+
+            # Optional env-driven knobs for operators with custom proxy / retry policy needs.
+            # Both no-op when unset, so existing deployments are unaffected.
+            _max_retries_env = os.environ.get("HINDSIGHT_API_LLM_MAX_RETRIES")
+            if _max_retries_env is not None:
+                try:
+                    client_kwargs["max_retries"] = int(_max_retries_env)
+                except ValueError as exc:
+                    logger.warning(
+                        "HINDSIGHT_API_LLM_MAX_RETRIES is not an integer, ignoring: %s", exc
+                    )
+
+            _default_headers_env = os.environ.get("HINDSIGHT_API_LLM_DEFAULT_HEADERS")
+            if _default_headers_env:
+                try:
+                    client_kwargs["default_headers"] = json.loads(_default_headers_env)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "HINDSIGHT_API_LLM_DEFAULT_HEADERS is not valid JSON, ignoring: %s", exc
+                    )
 
             self._client = AsyncAnthropic(**client_kwargs)
             logger.info(f"Anthropic client initialized for model: {self.model}")

--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -11,7 +11,6 @@ This provider enables using Claude models from Anthropic with support for:
 import asyncio
 import json
 import logging
-import os
 import time
 from typing import Any
 
@@ -38,6 +37,7 @@ class AnthropicLLM(LLMInterface):
         model: str,
         reasoning_effort: str = "low",
         timeout: float = 300.0,
+        default_headers: dict[str, str] | None = None,
         **kwargs: Any,
     ):
         """
@@ -50,6 +50,10 @@ class AnthropicLLM(LLMInterface):
             model: Model name (e.g., "claude-sonnet-4-20250514").
             reasoning_effort: Reasoning effort level (not used by Anthropic).
             timeout: Request timeout in seconds.
+            default_headers: Optional custom headers passed as ``default_headers`` to
+                the Anthropic SDK client. Used by operators routing through proxies
+                or request-tracing middleware. Sourced from ``llm_default_headers`` in
+                ``HindsightConfig`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``).
             **kwargs: Additional provider-specific parameters.
         """
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
@@ -61,31 +65,16 @@ class AnthropicLLM(LLMInterface):
         try:
             from anthropic import AsyncAnthropic
 
-            client_kwargs: dict[str, Any] = {"api_key": self.api_key}
+            # SDK retries disabled — wrapper-level retry loop in ``call`` handles
+            # backoff (mirrors ``OpenAICompatibleLLM`` so the two providers behave
+            # consistently).
+            client_kwargs: dict[str, Any] = {"api_key": self.api_key, "max_retries": 0}
             if self.base_url:
                 client_kwargs["base_url"] = self.base_url
             if timeout:
                 client_kwargs["timeout"] = timeout
-
-            # Optional env-driven knobs for operators with custom proxy / retry policy needs.
-            # Both no-op when unset, so existing deployments are unaffected.
-            _max_retries_env = os.environ.get("HINDSIGHT_API_LLM_MAX_RETRIES")
-            if _max_retries_env is not None:
-                try:
-                    client_kwargs["max_retries"] = int(_max_retries_env)
-                except ValueError as exc:
-                    logger.warning(
-                        "HINDSIGHT_API_LLM_MAX_RETRIES is not an integer, ignoring: %s", exc
-                    )
-
-            _default_headers_env = os.environ.get("HINDSIGHT_API_LLM_DEFAULT_HEADERS")
-            if _default_headers_env:
-                try:
-                    client_kwargs["default_headers"] = json.loads(_default_headers_env)
-                except json.JSONDecodeError as exc:
-                    logger.warning(
-                        "HINDSIGHT_API_LLM_DEFAULT_HEADERS is not valid JSON, ignoring: %s", exc
-                    )
+            if default_headers:
+                client_kwargs["default_headers"] = default_headers
 
             self._client = AsyncAnthropic(**client_kwargs)
             logger.info(f"Anthropic client initialized for model: {self.model}")

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -174,6 +174,7 @@ To switch between backends:
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict merged into `extra_body` for all OpenAI-compatible API calls. Useful for custom model servers (e.g., vLLM `chat_template_kwargs`). | `null` |
+| `HINDSIGHT_API_LLM_DEFAULT_HEADERS` | JSON dict passed as `default_headers` to provider SDK clients. Used by operators routing through proxies / request-tracing middleware (e.g. Cloudflare AI Gateway, Helicone, corporate proxies). Currently wired into the Anthropic provider; other providers can opt in. | `null` |
 | `HINDSIGHT_API_LLM_GEMINI_SAFETY_SETTINGS` | JSON-encoded list of `{category, threshold}` dicts for Gemini/VertexAI content safety filtering | `null` |
 
 **Provider Examples**


### PR DESCRIPTION
## Summary

Two opt-in env vars on AnthropicLLM.__init__. Both no-op when unset, so existing deployments are unaffected.

- HINDSIGHT_API_LLM_MAX_RETRIES (int) — when set, overrides the Anthropic SDK's default retry count. Useful when the deployment has its own outer retry layer (Hindsight's call() already does 2s→300s exponential backoff) and the SDK's stacked auto-retries would compound 429s.
- HINDSIGHT_API_LLM_DEFAULT_HEADERS (JSON string) — when set, parsed and passed as default_headers to AsyncAnthropic. Useful when routing through a proxy that needs custom headers (component attribution, client-fingerprint markers, etc).

## Real-world driver

Routing Hindsight through a custom proxy (in our case, Switchboard) that:
- handles retry policy at the proxy layer
- needs X-Component-Id for per-component cost attribution
- needs X-SB-Impersonate-CC: 1 for Anthropic OAuth fingerprint compat

Without these env knobs, operators have to volume-mount a patched anthropic_llm.py into the container, which is fragile across image upgrades.

## Test plan

- [x] Default behavior unchanged when env vars unset
- [x] Invalid HINDSIGHT_API_LLM_MAX_RETRIES (non-int) logs a warning and is ignored
- [x] Invalid HINDSIGHT_API_LLM_DEFAULT_HEADERS (non-JSON) logs a warning and is ignored
- [x] Verified locally on container 0.5.6 with our deployment

## Diff

Surgical: 1 import (os) + 21 lines in the constructor. No refactor, no new dependencies.