### PR TITLE
fix(recall): inherit observation entities through source_memory_ids

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3595,6 +3595,69 @@ class MemoryEngine(MemoryEngineInterface):
                                 {"entity_id": str(row["entity_id"]), "canonical_name": row["canonical_name"]}
                             )
 
+                        # Observations don't carry rows in unit_entities; their entity
+                        # association lives transitively through source_memory_ids.
+                        # Mirror get_memory_unit's fallback so observation-only recall
+                        # surfaces the same entities the per-memory endpoint exposes,
+                        # both per-result and in the top-level aggregate map.
+                        obs_unit_ids_without_entities = [
+                            uuid.UUID(sr.id)
+                            for sr in top_scored
+                            if sr.retrieval.fact_type == "observation" and str(sr.id) not in fact_entity_map
+                        ]
+                        if obs_unit_ids_without_entities:
+                            source_id_rows = await entity_conn.fetch(
+                                f"""
+                                SELECT id, source_memory_ids
+                                FROM {fq_table("memory_units")}
+                                WHERE id = ANY($1::uuid[]) AND fact_type = 'observation'
+                                """,
+                                obs_unit_ids_without_entities,
+                            )
+                            obs_to_sources: dict[str, list[uuid.UUID]] = {}
+                            all_source_ids: set[uuid.UUID] = set()
+                            for row in source_id_rows:
+                                sids = [
+                                    s if isinstance(s, uuid.UUID) else uuid.UUID(str(s))
+                                    for s in (row["source_memory_ids"] or [])
+                                ]
+                                if not sids:
+                                    continue
+                                obs_to_sources[str(row["id"])] = sids
+                                all_source_ids.update(sids)
+
+                            if all_source_ids:
+                                source_entity_rows = await entity_conn.fetch(
+                                    f"""
+                                    SELECT ue.unit_id, e.id as entity_id, e.canonical_name
+                                    FROM {fq_table("unit_entities")} ue
+                                    JOIN {fq_table("entities")} e ON ue.entity_id = e.id
+                                    WHERE ue.unit_id = ANY($1::uuid[])
+                                    """,
+                                    list(all_source_ids),
+                                )
+                                source_unit_to_entities: dict[str, list[dict[str, str]]] = {}
+                                for row in source_entity_rows:
+                                    sid = str(row["unit_id"])
+                                    source_unit_to_entities.setdefault(sid, []).append(
+                                        {
+                                            "entity_id": str(row["entity_id"]),
+                                            "canonical_name": row["canonical_name"],
+                                        }
+                                    )
+
+                                for obs_id, sids in obs_to_sources.items():
+                                    seen: set[str] = set()
+                                    inherited: list[dict[str, str]] = []
+                                    for sid in sids:
+                                        for ent in source_unit_to_entities.get(str(sid), []):
+                                            if ent["entity_id"] in seen:
+                                                continue
+                                            seen.add(ent["entity_id"])
+                                            inherited.append(ent)
+                                    if inherited:
+                                        fact_entity_map[obs_id] = inherited
+
             # Convert results to MemoryFact objects
             memory_facts = []
             for result_dict in top_results_dicts:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3572,91 +3572,23 @@ class MemoryEngine(MemoryEngineInterface):
                                     source_facts_dict[sid] = _make_source_fact(sid, r)
                                     total_source_tokens += fact_tokens
 
-            # Get entities for each fact if include_entities is requested
-            fact_entity_map = {}  # unit_id -> list of (entity_id, entity_name)
+            # Get entities for each fact if include_entities is requested.
+            # _entity_rows_for_units_sql resolves both direct unit_entities rows
+            # and observation-via-source-memory inheritance in a single query.
+            fact_entity_map = {}  # unit_id -> list of {entity_id, canonical_name}
             if include_entities and top_scored:
                 unit_ids = [uuid.UUID(sr.id) for sr in top_scored]
                 if unit_ids:
                     async with acquire_with_retry(backend) as entity_conn:
                         entity_rows = await entity_conn.fetch(
-                            f"""
-                            SELECT ue.unit_id, e.id as entity_id, e.canonical_name
-                            FROM {fq_table("unit_entities")} ue
-                            JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                            WHERE ue.unit_id = ANY($1::uuid[])
-                            """,
+                            self._entity_rows_for_units_sql(unit_ids_placeholder=1),
                             unit_ids,
                         )
                         for row in entity_rows:
                             unit_id = str(row["unit_id"])
-                            if unit_id not in fact_entity_map:
-                                fact_entity_map[unit_id] = []
-                            fact_entity_map[unit_id].append(
+                            fact_entity_map.setdefault(unit_id, []).append(
                                 {"entity_id": str(row["entity_id"]), "canonical_name": row["canonical_name"]}
                             )
-
-                        # Observations don't carry rows in unit_entities; their entity
-                        # association lives transitively through source_memory_ids.
-                        # Mirror get_memory_unit's fallback so observation-only recall
-                        # surfaces the same entities the per-memory endpoint exposes,
-                        # both per-result and in the top-level aggregate map.
-                        obs_unit_ids_without_entities = [
-                            uuid.UUID(sr.id)
-                            for sr in top_scored
-                            if sr.retrieval.fact_type == "observation" and str(sr.id) not in fact_entity_map
-                        ]
-                        if obs_unit_ids_without_entities:
-                            source_id_rows = await entity_conn.fetch(
-                                f"""
-                                SELECT id, source_memory_ids
-                                FROM {fq_table("memory_units")}
-                                WHERE id = ANY($1::uuid[]) AND fact_type = 'observation'
-                                """,
-                                obs_unit_ids_without_entities,
-                            )
-                            obs_to_sources: dict[str, list[uuid.UUID]] = {}
-                            all_source_ids: set[uuid.UUID] = set()
-                            for row in source_id_rows:
-                                sids = [
-                                    s if isinstance(s, uuid.UUID) else uuid.UUID(str(s))
-                                    for s in (row["source_memory_ids"] or [])
-                                ]
-                                if not sids:
-                                    continue
-                                obs_to_sources[str(row["id"])] = sids
-                                all_source_ids.update(sids)
-
-                            if all_source_ids:
-                                source_entity_rows = await entity_conn.fetch(
-                                    f"""
-                                    SELECT ue.unit_id, e.id as entity_id, e.canonical_name
-                                    FROM {fq_table("unit_entities")} ue
-                                    JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                                    WHERE ue.unit_id = ANY($1::uuid[])
-                                    """,
-                                    list(all_source_ids),
-                                )
-                                source_unit_to_entities: dict[str, list[dict[str, str]]] = {}
-                                for row in source_entity_rows:
-                                    sid = str(row["unit_id"])
-                                    source_unit_to_entities.setdefault(sid, []).append(
-                                        {
-                                            "entity_id": str(row["entity_id"]),
-                                            "canonical_name": row["canonical_name"],
-                                        }
-                                    )
-
-                                for obs_id, sids in obs_to_sources.items():
-                                    seen: set[str] = set()
-                                    inherited: list[dict[str, str]] = []
-                                    for sid in sids:
-                                        for ent in source_unit_to_entities.get(str(sid), []):
-                                            if ent["entity_id"] in seen:
-                                                continue
-                                            seen.add(ent["entity_id"])
-                                            inherited.append(ent)
-                                    if inherited:
-                                        fact_entity_map[obs_id] = inherited
 
             # Convert results to MemoryFact objects
             memory_facts = []
@@ -3750,6 +3682,59 @@ class MemoryEngine(MemoryEngineInterface):
             if not quiet:
                 logger.error("\n" + "\n".join(log_buffer))
             raise Exception(f"Failed to search memories: {type(e).__name__}: {e}")
+
+    def _entity_rows_for_units_sql(self, unit_ids_placeholder: int) -> str:
+        """SQL SELECT producing ``(unit_id, entity_id, canonical_name)`` rows for
+        the given unit IDs.
+
+        Direct rows come from ``unit_entities``. Observations rarely carry
+        direct rows there; their entity association lives transitively through
+        their source memories (``source_memory_ids`` on PG, the
+        ``observation_sources`` junction on Oracle). When an observation has
+        no direct entity rows the SELECT inherits its source memories'
+        entities, so the result is the same set callers would get from
+        ``get_memory_unit``.
+
+        ``unit_ids_placeholder`` is the 1-based parameter index that holds the
+        ``uuid[]`` of unit IDs. The placeholder is referenced twice — both
+        sides of the UNION need it — so callers should not reuse the slot.
+        """
+        ue = fq_table("unit_entities")
+        ents = fq_table("entities")
+        mu = fq_table("memory_units")
+        p = unit_ids_placeholder
+
+        direct = (
+            f"SELECT ue.unit_id, e.id AS entity_id, e.canonical_name "
+            f"FROM {ue} ue "
+            f"JOIN {ents} e ON e.id = ue.entity_id "
+            f"WHERE ue.unit_id = ANY(${p}::uuid[])"
+        )
+
+        if self._backend.ops.uses_observation_sources_table:
+            os_t = fq_table("observation_sources")
+            inherited = (
+                f"SELECT os.observation_id AS unit_id, e.id AS entity_id, e.canonical_name "
+                f"FROM {os_t} os "
+                f"JOIN {ue} src_ue ON src_ue.unit_id = os.source_id "
+                f"JOIN {ents} e ON e.id = src_ue.entity_id "
+                f"WHERE os.observation_id = ANY(${p}::uuid[]) "
+                f"AND NOT EXISTS (SELECT 1 FROM {ue} d WHERE d.unit_id = os.observation_id)"
+            )
+        else:
+            inherited = (
+                f"SELECT obs.id AS unit_id, e.id AS entity_id, e.canonical_name "
+                f"FROM {mu} obs "
+                f"CROSS JOIN LATERAL unnest(obs.source_memory_ids) AS src_id "
+                f"JOIN {ue} src_ue ON src_ue.unit_id = src_id "
+                f"JOIN {ents} e ON e.id = src_ue.entity_id "
+                f"WHERE obs.id = ANY(${p}::uuid[]) "
+                f"AND obs.fact_type = 'observation' "
+                f"AND obs.source_memory_ids IS NOT NULL "
+                f"AND NOT EXISTS (SELECT 1 FROM {ue} d WHERE d.unit_id = obs.id)"
+            )
+
+        return f"({direct}) UNION ({inherited})"
 
     def _filter_by_token_budget(
         self, results: list[dict[str, Any]], max_tokens: int
@@ -5104,30 +5089,14 @@ class MemoryEngine(MemoryEngineInterface):
             if not row:
                 return None
 
-            # Get entity information
+            # Get entity information. _entity_rows_for_units_sql handles the
+            # observation→source_memory_ids inheritance fallback in SQL, so a
+            # single query covers direct rows and inherited ones.
             entities_rows = await conn.fetch(
-                f"""
-                SELECT e.canonical_name
-                FROM {fq_table("unit_entities")} ue
-                JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                WHERE ue.unit_id = $1
-                """,
-                row["id"],
+                self._entity_rows_for_units_sql(unit_ids_placeholder=1),
+                [row["id"]],
             )
             entities = [r["canonical_name"] for r in entities_rows]
-
-            # For observations with no direct entities, inherit from source memories
-            if not entities and row["fact_type"] == "observation" and row["source_memory_ids"]:
-                source_entities_rows = await conn.fetch(
-                    f"""
-                    SELECT DISTINCT e.canonical_name
-                    FROM {fq_table("unit_entities")} ue
-                    JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                    WHERE ue.unit_id = ANY($1::uuid[])
-                    """,
-                    row["source_memory_ids"],
-                )
-                entities = [r["canonical_name"] for r in source_entities_rows]
 
             result = {
                 "id": str(row["id"]),

--- a/hindsight-api-slim/tests/test_recall_observation_entities.py
+++ b/hindsight-api-slim/tests/test_recall_observation_entities.py
@@ -1,0 +1,186 @@
+"""Recall projects entities for observations through source_memory_ids.
+
+Observations don't carry rows in `unit_entities`; their entity association
+lives transitively via `memory_units.source_memory_ids`. The per-memory
+endpoint (`get_memory_unit`) follows that chain, but recall used to query
+`unit_entities` directly and silently dropped entities for every observation
+result, even when `include_entities=True` was set.
+
+This test seeds an observation linked through `source_memory_ids` to a fact
+with entities, runs an observation-only recall, and asserts both the
+per-result `entities` field and the top-level aggregate map carry the
+inherited entities.
+
+No LLM required.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.engine.retain import embedding_utils
+
+# Tests in this file insert memory_units with shared hardcoded UUIDs and
+# memory_units.id is a global PK; share an xdist group so parallel workers
+# don't collide on the same row IDs.
+pytestmark = pytest.mark.xdist_group("recall_observation_entities")
+
+ID_FACT = "11111111-0000-0000-0000-000000000001"
+ID_OBS_INHERITED = "11111111-0000-0000-0000-000000000002"
+ID_OBS_DIRECT = "11111111-0000-0000-0000-000000000003"
+
+RC = RequestContext(tenant_id="default")
+
+
+def _to_str(emb: list[float]) -> str:
+    return "[" + ",".join(str(v) for v in emb) + "]"
+
+
+@pytest_asyncio.fixture
+async def seeded(memory_no_llm_verify: MemoryEngine):
+    engine = memory_no_llm_verify
+    bank_id = f"test-recall-obs-ent-{uuid.uuid4().hex[:8]}"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+
+    embeddings = await embedding_utils.generate_embeddings_batch(
+        engine.embeddings,
+        [
+            "HeadClaw waitlist tracked in Google Sheets",
+            "HeadClaw users sign up via the waitlist",
+            "Reddit thread mentions HeadClaw waitlist signups",
+        ],
+    )
+
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM memory_units WHERE id IN ($1, $2, $3)",
+            ID_FACT,
+            ID_OBS_INHERITED,
+            ID_OBS_DIRECT,
+        )
+        await conn.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+
+        # Source fact with two entities. The observation that lacks direct
+        # entity rows must inherit both through source_memory_ids.
+        headclaw_id = await conn.fetchval(
+            """
+            INSERT INTO entities (bank_id, canonical_name, mention_count)
+            VALUES ($1, $2, 1) RETURNING id
+            """,
+            bank_id,
+            "HeadClaw",
+        )
+        waitlist_id = await conn.fetchval(
+            """
+            INSERT INTO entities (bank_id, canonical_name, mention_count)
+            VALUES ($1, $2, 1) RETURNING id
+            """,
+            bank_id,
+            "waitlist users",
+        )
+        # Independent entity attached directly to the second observation —
+        # exercises the existing direct-link path so we don't regress it.
+        reddit_id = await conn.fetchval(
+            """
+            INSERT INTO entities (bank_id, canonical_name, mention_count)
+            VALUES ($1, $2, 1) RETURNING id
+            """,
+            bank_id,
+            "Reddit",
+        )
+
+        await conn.execute(
+            """
+            INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, event_date)
+            VALUES ($1, $2, $3, 'world', $4::vector, now())
+            """,
+            ID_FACT,
+            bank_id,
+            "HeadClaw waitlist tracked in Google Sheets",
+            _to_str(embeddings[0]),
+        )
+        await conn.execute(
+            """
+            INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2), ($1, $3)
+            """,
+            ID_FACT,
+            headclaw_id,
+            waitlist_id,
+        )
+
+        # Observation with NO direct unit_entities — must inherit HeadClaw +
+        # waitlist users from source_memory_ids.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (
+                id, bank_id, text, fact_type, embedding, event_date,
+                source_memory_ids, history, proof_count
+            )
+            VALUES ($1, $2, $3, 'observation', $4::vector, now(), $5::uuid[], '[]'::jsonb, 1)
+            """,
+            ID_OBS_INHERITED,
+            bank_id,
+            "HeadClaw users sign up via the waitlist",
+            _to_str(embeddings[1]),
+            [ID_FACT],
+        )
+
+        # Observation with a DIRECT unit_entities link — must keep its own entity.
+        await conn.execute(
+            """
+            INSERT INTO memory_units (
+                id, bank_id, text, fact_type, embedding, event_date,
+                source_memory_ids, history, proof_count
+            )
+            VALUES ($1, $2, $3, 'observation', $4::vector, now(), NULL, '[]'::jsonb, 1)
+            """,
+            ID_OBS_DIRECT,
+            bank_id,
+            "Reddit thread mentions HeadClaw waitlist signups",
+            _to_str(embeddings[2]),
+        )
+        await conn.execute(
+            "INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)",
+            ID_OBS_DIRECT,
+            reddit_id,
+        )
+
+    yield engine, bank_id
+
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+@pytest.mark.asyncio
+async def test_recall_includes_inherited_entities_for_observations(seeded):
+    """Observation-only recall must surface entities inherited from source memories."""
+    engine, bank_id = seeded
+
+    result = await engine.recall_async(
+        bank_id=bank_id,
+        query="HeadClaw waitlist users",
+        fact_type=["observation"],
+        request_context=RC,
+        max_tokens=4000,
+        include_entities=True,
+        max_entity_tokens=2000,
+    )
+
+    by_id = {str(r.id): r for r in result.results}
+    assert ID_OBS_INHERITED in by_id, f"Expected inherited-entity observation in results, got {list(by_id)}"
+    assert ID_OBS_DIRECT in by_id, f"Expected direct-entity observation in results, got {list(by_id)}"
+
+    inherited = by_id[ID_OBS_INHERITED].entities or []
+    assert "HeadClaw" in inherited, f"Observation entities must inherit through source_memory_ids; got {inherited}"
+    assert "waitlist users" in inherited, f"All source entities should propagate; got {inherited}"
+
+    direct = by_id[ID_OBS_DIRECT].entities or []
+    assert "Reddit" in direct, f"Direct unit_entities link must still project on observation results; got {direct}"
+
+    assert result.entities is not None, "Top-level entities map must populate when include_entities=True"
+    aggregate_names = set(result.entities.keys())
+    assert {"HeadClaw", "waitlist users", "Reddit"}.issubset(aggregate_names), (
+        f"Top-level entities map must include inherited + direct entities; got {aggregate_names}"
+    )

--- a/hindsight-api-slim/tests/test_recall_observation_entities.py
+++ b/hindsight-api-slim/tests/test_recall_observation_entities.py
@@ -184,3 +184,31 @@ async def test_recall_includes_inherited_entities_for_observations(seeded):
     assert {"HeadClaw", "waitlist users", "Reddit"}.issubset(aggregate_names), (
         f"Top-level entities map must include inherited + direct entities; got {aggregate_names}"
     )
+
+
+@pytest.mark.asyncio
+async def test_get_memory_unit_inherits_observation_entities(seeded):
+    """get_memory_unit shares the recall helper, so observation inheritance
+    must keep working through the per-memory endpoint as well.
+    """
+    engine, bank_id = seeded
+
+    inherited = await engine.get_memory_unit(
+        memory_id=ID_OBS_INHERITED,
+        bank_id=bank_id,
+        request_context=RC,
+    )
+    assert inherited is not None
+    assert set(inherited["entities"]) >= {"HeadClaw", "waitlist users"}, (
+        f"Observation must inherit source-memory entities; got {inherited['entities']}"
+    )
+
+    direct = await engine.get_memory_unit(
+        memory_id=ID_OBS_DIRECT,
+        bank_id=bank_id,
+        request_context=RC,
+    )
+    assert direct is not None
+    assert "Reddit" in direct["entities"], (
+        f"Direct unit_entities link must still resolve via get_memory_unit; got {direct['entities']}"
+    )


### PR DESCRIPTION
## Summary

Recall returns `entities: null` for every observation result, even when `include_entities=true` is set, while `GET /v1/default/banks/{bank_id}/memories/{id}` returns the same observation with its inherited entities populated. The asymmetry strips entity context (e.g. URLs, named projects) from observation-only recall and silently drops those entities from the top-level `entities` aggregate map.

Related: #1374 fixes the same conceptual gap on the document detail view (per-document graph + Observations tab were empty because the observation→source edge wasn't traversed). This PR is the recall-projection sibling: observation results lose their entities for the same underlying reason — code paths that need to traverse the observation→source edge weren't doing it.

## Root cause

`get_memory_unit` (`hindsight_api/engine/memory_engine.py`) already handles observations explicitly: if a unit has no rows in `unit_entities`, it inherits entities from its source memories. The recall path's entity fetch only queried `unit_entities` directly; observations have no direct rows there, so every observation in the recall result lost its entities.

The inheritance edge is dialect-shaped: PG stores it on `memory_units.source_memory_ids`, Oracle keeps it in the `observation_sources` junction (same setup #1374 navigates with `_observations_via_source_match_sql`).

## Fix

Two commits:

1. **`fix(recall): inherit observation entities through source_memory_ids`** — mirror `get_memory_unit`'s fallback inside recall's `include_entities` block: for observation result IDs with no direct `unit_entities` rows, look up `source_memory_ids`, fetch entities for the union of source IDs, project back. Downstream code derives the per-result `entities` field and the top-level aggregate map from the same map, so inheritance flows through both automatically.

2. **`refactor(recall): consolidate observation entity inheritance in one SQL helper`** — replace the procedural fallback with `_entity_rows_for_units_sql`, a private engine helper that returns one dialect-correct UNION SELECT covering both direct and inherited entity rows. Mirrors the shape of `_observations_via_source_match_sql` from #1374. Also fixes silent Oracle-parity gap (the procedural patch reached for `source_memory_ids` directly, which is PG-only). `get_memory_unit` is refactored to use the same helper, so the two call sites that hand-rolled the same inheritance now share one source of truth.

## Reproduction (before fix)

```bash
# Same observation via memory get returns entities
curl -sS "$API/v1/default/banks/$BANK/memories/$OBS_ID" | jq '.entities'
# => ["HeadClaw","Reddit","waitlist users"]

# But via recall they are stripped, even with include.entities forced on
curl -sS -X POST "$API/v1/default/banks/$BANK/memories/recall" \
  -H 'Content-Type: application/json' \
  -d '{"query":"...","types":["observation"],"include":{"entities":{"max_tokens":1000}}}' \
  | jq '.results[0].entities, .entities'
# => null
# => null
```

A mixed-type recall (`["observation","world","experience"]`) populates the top-level entities map but only via world/experience contributions; observation results still come back with `entities: null`.

## Test plan

- [x] New regression test (`tests/test_recall_observation_entities.py`) seeds:
  - A `world` fact with two entities linked via `unit_entities`,
  - One observation referencing that fact via `source_memory_ids` and zero direct entity links,
  - One observation with its own direct `unit_entities` link,
  and asserts that:
  - both observations come back from `recall_async` with the expected `entities` (inherited and direct),
  - the top-level `entities` aggregate map is populated with all of them,
  - `get_memory_unit` on the same observations also surfaces inherited and direct entities (guards against drift between the two call sites that share the helper).
- [x] Test fails on `main` with `AssertionError: Observation entities must inherit through source_memory_ids; got []` and passes after the fix.
- [x] `tests/test_observations.py` and `tests/test_graph_filtering.py` continue to pass.
- [x] `ruff check` and `ruff format` clean.
