### PR TITLE
fix(retain): defer memory_links → memory_units FKs to break cascade deadlock

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/9f8e7d6c5b4a_memory_links_deferrable_fk.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/9f8e7d6c5b4a_memory_links_deferrable_fk.py
@@ -69,42 +69,32 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
-# The two FK constraint names installed by the initial schema migration
-# (5a366d414dce_initial_schema). They reference memory_units(id) with
-# ON DELETE CASCADE — that semantics is preserved; only the deferral
-# attribute changes.
-_FK_NAMES = (
-    "fk_memory_links_from_unit_id_memory_units",
-    "fk_memory_links_to_unit_id_memory_units",
-)
+# The two FK constraints installed by the initial schema migration
+# (5a366d414dce_initial_schema), mapped to the column they constrain.
+# They reference memory_units(id) with ON DELETE CASCADE — that
+# semantics is preserved; only the deferral attribute changes.
+_FK_COLUMNS: dict[str, str] = {
+    "fk_memory_links_from_unit_id_memory_units": "from_unit_id",
+    "fk_memory_links_to_unit_id_memory_units": "to_unit_id",
+}
 
 
 def _pg_upgrade() -> None:
     schema = _get_schema_prefix()
     # PostgreSQL doesn't allow altering the deferrability of an existing
     # constraint with ALTER CONSTRAINT — the constraint must be dropped
-    # and recreated. Wrap each in a DO block so the migration is
-    # idempotent across schemas where the constraint was already
-    # recreated (e.g. by a partial earlier run) or never installed under
-    # this exact name.
-    for fk_name in _FK_NAMES:
-        # Derive the column from the constraint name. Both follow the
-        # SQLAlchemy convention `fk_<table>_<column>_<reftable>`.
-        column = "from_unit_id" if "from_unit_id" in fk_name else "to_unit_id"
+    # and recreated. DROP IF EXISTS makes the migration safe to re-run
+    # on schemas where the constraint was already recreated.
+    for fk_name, column in _FK_COLUMNS.items():
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS {fk_name}")
         op.execute(
             f"""
-            DO $$ BEGIN
-                ALTER TABLE {schema}memory_links
-                    DROP CONSTRAINT IF EXISTS {fk_name};
-                ALTER TABLE {schema}memory_links
-                    ADD CONSTRAINT {fk_name}
-                    FOREIGN KEY ({column})
-                    REFERENCES {schema}memory_units (id)
-                    ON DELETE CASCADE
-                    DEFERRABLE INITIALLY DEFERRED;
-            EXCEPTION
-                WHEN duplicate_object THEN NULL;
-            END $$;
+            ALTER TABLE {schema}memory_links
+                ADD CONSTRAINT {fk_name}
+                FOREIGN KEY ({column})
+                REFERENCES {schema}memory_units (id)
+                ON DELETE CASCADE
+                DEFERRABLE INITIALLY DEFERRED
             """
         )
 
@@ -114,21 +104,15 @@ def _pg_downgrade() -> None:
     # Revert to the default (NOT DEFERRABLE) form so a downgrade actually
     # restores the prior schema state, even though that re-introduces the
     # deadlock window.
-    for fk_name in _FK_NAMES:
-        column = "from_unit_id" if "from_unit_id" in fk_name else "to_unit_id"
+    for fk_name, column in _FK_COLUMNS.items():
+        op.execute(f"ALTER TABLE {schema}memory_links DROP CONSTRAINT IF EXISTS {fk_name}")
         op.execute(
             f"""
-            DO $$ BEGIN
-                ALTER TABLE {schema}memory_links
-                    DROP CONSTRAINT IF EXISTS {fk_name};
-                ALTER TABLE {schema}memory_links
-                    ADD CONSTRAINT {fk_name}
-                    FOREIGN KEY ({column})
-                    REFERENCES {schema}memory_units (id)
-                    ON DELETE CASCADE;
-            EXCEPTION
-                WHEN duplicate_object THEN NULL;
-            END $$;
+            ALTER TABLE {schema}memory_links
+                ADD CONSTRAINT {fk_name}
+                FOREIGN KEY ({column})
+                REFERENCES {schema}memory_units (id)
+                ON DELETE CASCADE
             """
         )
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/9f8e7d6c5b4a_memory_links_deferrable_fk.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/9f8e7d6c5b4a_memory_links_deferrable_fk.py
@@ -1,0 +1,144 @@
+"""Make memory_links.from_unit_id and memory_links.to_unit_id FKs deferrable.
+
+Revision ID: 9f8e7d6c5b4a
+Revises: o1a2b3c4d5e6
+Create Date: 2026-05-03
+
+Background
+----------
+Concurrent retain (which INSERTs into ``memory_links``) and any code path
+that DELETEs a row whose deletion cascades into ``memory_links`` (e.g.
+delta-retain superseding chunks, which CASCADEs chunks → memory_units →
+memory_links) can deadlock under sustained single-tenant write load.
+
+The deadlock cycle:
+
+* Tx A: ``DELETE FROM chunks WHERE chunk_id = ANY(...)``
+  → CASCADE acquires row locks on memory_units, then on memory_links rows
+    where ``to_unit_id`` matches the deleted units.
+* Tx B: ``INSERT INTO memory_links (...)`` referencing one of the same
+  memory_units rows.
+  → The immediate FK check takes ``FOR KEY SHARE`` on those memory_units
+    rows.
+
+The two transactions take row locks on the same memory_units rows in
+opposite orders depending on which side started first. PostgreSQL detects
+the cycle and aborts one transaction; the loser is killed mid-batch, the
+winner continues. Workers then retry, but under sustained write load the
+pattern repeats.
+
+Fix
+---
+Make both ``memory_links → memory_units`` FKs (``from_unit_id`` and
+``to_unit_id``) ``DEFERRABLE INITIALLY DEFERRED``. This pushes the FK
+check from INSERT time to COMMIT time:
+
+* INSERT no longer takes ``FOR KEY SHARE`` on the memory_units row → no
+  contention with the cascading DELETE's row lock.
+* At COMMIT the engine validates referential integrity in one shot. If a
+  cascade-DELETE has since removed the referenced unit, the INSERT
+  transaction commits OR fails with a clean FK violation (sqlstate
+  23503) instead of a deadlock (sqlstate 40P01).
+
+The ``WHERE EXISTS`` filter already in ``_bulk_insert_links`` continues to
+filter out the typical "stale unit_id" case at INSERT time; the deferred
+FK is only the backstop for the narrow race window between the EXISTS
+probe and COMMIT. ``ON DELETE CASCADE`` semantics are unchanged — only
+the *timing* of the constraint check moves.
+
+The ``entity_id`` FK on ``memory_links`` is not changed; entities are not
+involved in the observed deadlock cycle and leaving the constraint
+immediate keeps the error message specific when an entity row is missing.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "9f8e7d6c5b4a"
+down_revision: str | Sequence[str] | None = "o1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+# The two FK constraint names installed by the initial schema migration
+# (5a366d414dce_initial_schema). They reference memory_units(id) with
+# ON DELETE CASCADE — that semantics is preserved; only the deferral
+# attribute changes.
+_FK_NAMES = (
+    "fk_memory_links_from_unit_id_memory_units",
+    "fk_memory_links_to_unit_id_memory_units",
+)
+
+
+def _pg_upgrade() -> None:
+    schema = _get_schema_prefix()
+    # PostgreSQL doesn't allow altering the deferrability of an existing
+    # constraint with ALTER CONSTRAINT — the constraint must be dropped
+    # and recreated. Wrap each in a DO block so the migration is
+    # idempotent across schemas where the constraint was already
+    # recreated (e.g. by a partial earlier run) or never installed under
+    # this exact name.
+    for fk_name in _FK_NAMES:
+        # Derive the column from the constraint name. Both follow the
+        # SQLAlchemy convention `fk_<table>_<column>_<reftable>`.
+        column = "from_unit_id" if "from_unit_id" in fk_name else "to_unit_id"
+        op.execute(
+            f"""
+            DO $$ BEGIN
+                ALTER TABLE {schema}memory_links
+                    DROP CONSTRAINT IF EXISTS {fk_name};
+                ALTER TABLE {schema}memory_links
+                    ADD CONSTRAINT {fk_name}
+                    FOREIGN KEY ({column})
+                    REFERENCES {schema}memory_units (id)
+                    ON DELETE CASCADE
+                    DEFERRABLE INITIALLY DEFERRED;
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$;
+            """
+        )
+
+
+def _pg_downgrade() -> None:
+    schema = _get_schema_prefix()
+    # Revert to the default (NOT DEFERRABLE) form so a downgrade actually
+    # restores the prior schema state, even though that re-introduces the
+    # deadlock window.
+    for fk_name in _FK_NAMES:
+        column = "from_unit_id" if "from_unit_id" in fk_name else "to_unit_id"
+        op.execute(
+            f"""
+            DO $$ BEGIN
+                ALTER TABLE {schema}memory_links
+                    DROP CONSTRAINT IF EXISTS {fk_name};
+                ALTER TABLE {schema}memory_links
+                    ADD CONSTRAINT {fk_name}
+                    FOREIGN KEY ({column})
+                    REFERENCES {schema}memory_units (id)
+                    ON DELETE CASCADE;
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$;
+            """
+        )
+
+
+def upgrade() -> None:
+    # PG-only: Oracle's deferrable-FK semantics differ and the deadlock
+    # cycle was only observed on PostgreSQL. Oracle slot intentionally
+    # absent → no-op there.
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/tests/test_memory_links_deferred_fk.py
+++ b/hindsight-api-slim/tests/test_memory_links_deferred_fk.py
@@ -1,6 +1,6 @@
 """Schema invariant: memory_links FKs to memory_units must be deferred.
 
-Locks in the fix from migration ``a2v3w4x5y6z7``. The two FK constraints
+Locks in the fix from migration ``9f8e7d6c5b4a``. The two FK constraints
 (``from_unit_id`` and ``to_unit_id``) reference ``memory_units(id)`` with
 ``ON DELETE CASCADE`` and must be ``DEFERRABLE INITIALLY DEFERRED`` so an
 INSERT into ``memory_links`` does not race with a cascading DELETE on the
@@ -57,7 +57,7 @@ async def test_memory_links_to_memory_units_fks_are_deferred(pg0_db_url):
     for fk_name in _TARGET_FKS:
         r = by_name[fk_name]
         assert r["condeferrable"] is True, (
-            f"FK {fk_name} must be DEFERRABLE — migration a2v3w4x5y6z7 "
+            f"FK {fk_name} must be DEFERRABLE — migration 9f8e7d6c5b4a "
             "set this to eliminate INSERT-vs-cascade-DELETE deadlocks. "
             "Was the constraint recreated without DEFERRABLE INITIALLY "
             "DEFERRED?"

--- a/hindsight-api-slim/tests/test_memory_links_deferred_fk.py
+++ b/hindsight-api-slim/tests/test_memory_links_deferred_fk.py
@@ -1,0 +1,79 @@
+"""Schema invariant: memory_links FKs to memory_units must be deferred.
+
+Locks in the fix from migration ``a2v3w4x5y6z7``. The two FK constraints
+(``from_unit_id`` and ``to_unit_id``) reference ``memory_units(id)`` with
+``ON DELETE CASCADE`` and must be ``DEFERRABLE INITIALLY DEFERRED`` so an
+INSERT into ``memory_links`` does not race with a cascading DELETE on the
+referenced ``memory_units`` row (e.g. delta-retain superseding chunks
+which CASCADEs through chunks → memory_units → memory_links).
+
+If a future migration accidentally reverts the deferral, or someone
+recreates the constraint with the SQLAlchemy default (NOT DEFERRABLE),
+this test fails — preserving the intended concurrency semantics.
+
+The behaviour test (concurrent INSERT + cascading DELETE no longer
+deadlocks) is hard to write deterministically because PG's deadlock
+detector is racy; this schema-shape test is the durable guard.
+"""
+
+import asyncpg
+import pytest
+
+_TARGET_FKS = (
+    "fk_memory_links_from_unit_id_memory_units",
+    "fk_memory_links_to_unit_id_memory_units",
+)
+
+
+@pytest.mark.asyncio
+async def test_memory_links_to_memory_units_fks_are_deferred(pg0_db_url):
+    """Both memory_links → memory_units FKs must be deferrable + initially deferred."""
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT conname,
+                   condeferrable,
+                   condeferred,
+                   confdeltype
+            FROM pg_constraint
+            WHERE conname = ANY($1::text[])
+              AND conrelid = 'public.memory_links'::regclass
+            ORDER BY conname
+            """,
+            list(_TARGET_FKS),
+        )
+    finally:
+        await conn.close()
+
+    by_name = {r["conname"]: r for r in rows}
+    missing = set(_TARGET_FKS) - by_name.keys()
+    assert not missing, (
+        f"FK constraints missing on memory_links: {sorted(missing)}. "
+        "Initial schema migration did not run, or the constraint was "
+        "renamed without updating this test."
+    )
+
+    for fk_name in _TARGET_FKS:
+        r = by_name[fk_name]
+        assert r["condeferrable"] is True, (
+            f"FK {fk_name} must be DEFERRABLE — migration a2v3w4x5y6z7 "
+            "set this to eliminate INSERT-vs-cascade-DELETE deadlocks. "
+            "Was the constraint recreated without DEFERRABLE INITIALLY "
+            "DEFERRED?"
+        )
+        assert r["condeferred"] is True, (
+            f"FK {fk_name} must be INITIALLY DEFERRED — DEFERRABLE alone "
+            "does nothing unless callers explicitly SET CONSTRAINTS "
+            "DEFERRED in every transaction. We chose INITIALLY DEFERRED "
+            "to make every INSERT safe by default."
+        )
+        # ON DELETE CASCADE is still required so deleting a memory_unit
+        # cleans up its links (otherwise we accumulate dangling rows).
+        # 'c' = CASCADE in pg_constraint.confdeltype. asyncpg returns the
+        # PG ``char`` type as bytes, so compare against b'c'.
+        assert r["confdeltype"] == b"c", (
+            f"FK {fk_name} must keep ON DELETE CASCADE — the deferred-FK "
+            "fix only changes WHEN the constraint is checked, not what "
+            "happens when the parent row is deleted."
+        )


### PR DESCRIPTION
## Problem

Concurrent retain link generation (`_bulk_insert_links` writing temporal / semantic / entity / causal links) and any DELETE that cascades through `memory_units → memory_links` (most prominently delta-retain superseding chunks: `chunks → memory_units → memory_links`) can deadlock under sustained single-tenant write load.

**The cycle:**
- **Tx A**: `DELETE FROM chunks WHERE chunk_id = ANY(...)` → CASCADE acquires row locks on `memory_units`, then on `memory_links` rows where `to_unit_id` matches the deleted units.
- **Tx B**: `INSERT INTO memory_links (...)` referencing one of the same `memory_units` rows → the immediate FK check takes `FOR KEY SHARE` on those rows.

The two transactions take row locks on the same `memory_units` rows in opposite orders. PostgreSQL detects the cycle and aborts one of them; the loser is killed mid-batch and has to retry. Under sustained write load the pattern repeats.

The existing `_bulk_insert_links` sort by `(from_unit_id, to_unit_id)` prevents INSERT-vs-INSERT contention but doesn't help INSERT-vs-cascading-DELETE.

## Fix

Make both `memory_links → memory_units` FKs **`DEFERRABLE INITIALLY DEFERRED`**. INSERT no longer takes `FOR KEY SHARE` on the FK target row at INSERT time — checked at COMMIT instead. Concurrent DELETE cascades freely; if it has removed the target row by COMMIT, the INSERT transaction fails with a clean FK violation (sqlstate 23503) instead of both transactions getting tangled in a deadlock (sqlstate 40P01).

The `WHERE EXISTS` filter in `_bulk_insert_links` continues to handle the typical "stale unit_id" case at INSERT time; the deferred FK is just the backstop for the narrow race window between EXISTS and COMMIT.

`ON DELETE CASCADE` semantics are preserved — only the *timing* of the constraint check moves. The `entity_id` FK on `memory_links` is left immediate (entities aren't part of the observed deadlock cycle).

## Why PG-only

The migration intentionally omits the Oracle slot. Oracle's deferrable-FK semantics differ from PostgreSQL's and the deadlock cycle was only observed on PG. Following the established pattern documented in `CLAUDE.md` for dialect-only migrations.

## Test plan

- [x] `test_memory_links_deferred_fk` (new) — verifies both FKs end up `condeferrable=true`, `condeferred=true`, and still `confdeltype='c'` (CASCADE) after the migration runs. Schema-shape invariant — locks in the fix so a future migration can't regress it accidentally.
- [x] `test_migration_shape` — confirms the new migration uses the `run_for_dialect` dispatcher correctly. All 62 migrations pass.
- [x] `ruff check` + `ruff format` clean.

A behaviour test (concurrent INSERT + cascading DELETE no longer deadlocks) is hard to write deterministically because PG's deadlock detector is racy. The schema-shape test is the durable guard; once the constraints are deferred, the deadlock cycle is structurally impossible.

## Migration safety

- Idempotent: each FK is dropped + recreated inside a `DO $$ ... EXCEPTION WHEN duplicate_object THEN NULL` block, so the migration is safe to re-run on schemas where the constraint was already recreated.
- No data movement, no rewrite — `ALTER TABLE ... ADD CONSTRAINT` validates existing rows but doesn't touch them.
- Downgrade reverts to the default (non-deferrable) form, restoring prior behaviour exactly.