### PR TITLE
fix(openclaw): add WeakSet registration guard keyed by API instance

### DIFF
--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1412,7 +1412,18 @@ function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
   };
 }
 
+// Registration guard: WeakSet keyed by api instance to prevent double-registration
+// on the same api object while allowing fresh registration on new api objects.
+// Does not reintroduce issue #1029 because WeakSet.has() checks object identity,
+// not a module-level boolean.
+const _registeredApis = new WeakSet<MoltbotPluginAPI>();
+
 export default function (api: MoltbotPluginAPI) {
+  if (_registeredApis.has(api)) {
+    debug("[Hindsight] Plugin entry skipped (this api instance already registered)");
+    return;
+  }
+  _registeredApis.add(api);
   try {
     log.info("plugin entry invoked");
     debug("[Hindsight] Plugin loading...");


### PR DESCRIPTION
Adds a WeakSet<MoltbotPluginAPI> guard at the top of the plugin entry function. If the same api object is passed again (registry churn), the entry function exits immediately without re-registering hooks or event listeners.

WeakSet is keyed by object identity, not a module-level boolean. A new api object (e.g. after a registry migration) will have a different reference and pass through unconditionally -- this does not reintroduce the bug fixed by #1029 where a module-level boolean blocked new registries from ever getting hooks.

Old api objects that are no longer referenced are garbage-collected by the WeakSet (no memory leak).

Closes: #1404
Refs: #1029