### PR TITLE
fix(openclaw): skip retain for operational session patterns

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -141,6 +141,7 @@ Optional settings in `~/.openclaw/openclaw.json`:
 - `recallRoles` - Which message roles to include when composing the contextual recall query (default: `["user", "assistant"]`).
 - `retainEveryNTurns` - Retain every Nth turn (default: `1` = every turn). Values > 1 enable chunked retention.
 - `retainOverlapTurns` - Extra prior turns included when chunked retention fires (default: `0`).
+- `skipRetainSessionPatterns` - Skip retain for sessions matching these patterns. Bare tokens (e.g. `"heartbeat"`) auto-wrap as glob patterns `"**:heartbeat**"`. Use glob syntax for custom patterns. Defaults: `["heartbeat", "cron", "subagent"]`. Sessions matching these patterns still allow recall.
 - `debug` - Enable debug logging (default: `false`).
 
 ### Memory Isolation

--- a/hindsight-integrations/n8n/test/node-execute.test.ts
+++ b/hindsight-integrations/n8n/test/node-execute.test.ts
@@ -35,8 +35,9 @@ function createMockExecuteFunctions(
 }
 
 function getRequestMock(fns: IExecuteFunctions): ReturnType<typeof vi.fn> {
-  return (fns as unknown as { helpers: { httpRequestWithAuthentication: ReturnType<typeof vi.fn> } })
-    .helpers.httpRequestWithAuthentication;
+  return (
+    fns as unknown as { helpers: { httpRequestWithAuthentication: ReturnType<typeof vi.fn> } }
+  ).helpers.httpRequestWithAuthentication;
 }
 
 describe("Hindsight node execute()", () => {

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -285,6 +285,12 @@
         "items": { "type": "string" },
         "description": "Session key glob patterns for read-only sessions: retain is always skipped, recall is skipped when skipStatelessSessions is true. E.g. [\"agent:*:subagent:**\", \"agent:*:heartbeat:**\"]."
       },
+      "skipRetainSessionPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Bare tokens (e.g. \"heartbeat\") auto-wrap as glob patterns \"**:token**\". Use glob syntax for custom patterns. Defaults: [\"heartbeat\", \"cron\", \"subagent\"]. Sessions matching these patterns skip retain but still allow recall.",
+        "default": ["heartbeat", "cron", "subagent"]
+      },
       "skipStatelessSessions": {
         "type": "boolean",
         "description": "When true (default), sessions matching statelessSessionPatterns also skip recall. When false, they can recall but never retain.",
@@ -494,6 +500,10 @@
     "statelessSessionPatterns": {
       "label": "Stateless Session Patterns",
       "placeholder": "e.g. [\"agent:*:subagent:**\", \"agent:*:heartbeat:**\"]"
+    },
+    "skipRetainSessionPatterns": {
+      "label": "Skip Retain Session Patterns",
+      "placeholder": "e.g. [\"heartbeat\", \"cron\", \"subagent\"]"
     },
     "skipStatelessSessions": {
       "label": "Skip Stateless Sessions",

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -1488,6 +1488,14 @@ export function getPluginConfig(api: MoltbotPluginAPI): PluginConfig {
     statelessSessionPatterns: Array.isArray(config.statelessSessionPatterns)
       ? config.statelessSessionPatterns
       : [],
+    skipRetainSessionPatterns: (() => {
+      const raw = Array.isArray(config.skipRetainSessionPatterns)
+        ? config.skipRetainSessionPatterns
+        : ["heartbeat", "cron", "subagent"];
+      // Convert bare tokens to glob patterns: "heartbeat" -> "**:heartbeat**"
+      // Pass through patterns that already contain glob wildcards
+      return raw.map((p: string) => (p.includes("*") ? p : `**:${p}**`));
+    })(),
     skipStatelessSessions: config.skipStatelessSessions !== false,
     debug: config.debug ?? false,
     debugPerfTiming: config.debugPerfTiming === true,
@@ -2275,6 +2283,18 @@ ${memoriesFormatted}
           ) {
             debug(
               `[Hindsight] Skipping retain: session '${agentEndSessionKey}' matches statelessSessionPatterns`
+            );
+            return;
+          }
+          const skipRetainPatterns = compileSessionPatterns(
+            pluginConfig.skipRetainSessionPatterns ?? []
+          );
+          if (
+            skipRetainPatterns.length > 0 &&
+            matchesSessionPattern(agentEndSessionKey, skipRetainPatterns)
+          ) {
+            debug(
+              `[Hindsight] Skipping retain - operational session pattern matched: ${agentEndSessionKey}`
             );
             return;
           }

--- a/hindsight-integrations/openclaw/src/session-patterns.test.ts
+++ b/hindsight-integrations/openclaw/src/session-patterns.test.ts
@@ -84,4 +84,20 @@ describe("matchesSessionPattern", () => {
     expect(matchesSessionPattern("agent:main:heartbeat:sess-abc", patterns)).toBe(true);
     expect(matchesSessionPattern("agent:main:sess-abc", patterns)).toBe(false);
   });
+
+  it("skipRetainSessionPatterns defaults match operational sessions", () => {
+    // Default bare tokens auto-wrap: "heartbeat" -> "**:heartbeat**"
+    const patterns = compileSessionPatterns(["**:heartbeat**", "**:cron:**", "**:subagent**"]);
+    expect(matchesSessionPattern("agent:main:heartbeat:abc123", patterns)).toBe(true);
+    expect(matchesSessionPattern("agent:gardener:cron:daily:xyz", patterns)).toBe(true);
+    expect(matchesSessionPattern("agent:main:subagent:worker:456", patterns)).toBe(true);
+    expect(matchesSessionPattern("agent:main:abc123", patterns)).toBe(false);
+  });
+
+  it("skipRetainSessionPatterns with single * segments", () => {
+    const patterns = compileSessionPatterns(["agent:*:heartbeat:**"]);
+    expect(matchesSessionPattern("agent:main:heartbeat:abc123", patterns)).toBe(true);
+    expect(matchesSessionPattern("agent:gardener:heartbeat:xyz", patterns)).toBe(true);
+    expect(matchesSessionPattern("agent:main:subagent:abc", patterns)).toBe(false);
+  });
 });

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -119,6 +119,7 @@ export interface PluginConfig {
   ignoreSessionPatterns?: string[]; // Session key glob patterns to skip entirely (no recall, no retain). E.g. ["agent:main:**", "agent:*:cron:**"]
   statelessSessionPatterns?: string[]; // Session key glob patterns for read-only sessions (recall allowed, retain skipped). E.g. ["agent:*:subagent:**"]
   skipStatelessSessions?: boolean; // When true (default), stateless sessions also skip recall. When false, they recall but never retain.
+  skipRetainSessionPatterns?: string[]; // Bare tokens (e.g. "heartbeat") auto-wrapped as glob patterns "**:token**". Use glob syntax for custom patterns. Defaults: ["heartbeat", "cron", "subagent"]. Sessions matching these patterns skip retain but still allow recall.
   debug?: boolean; // Enable debug logging (default: false)
   logLevel?: "off" | "error" | "warning" | "info" | "debug"; // Console log verbosity (default: 'info').
   logSummaryIntervalMs?: number; // Batch retain/recall log summaries over this interval in ms. 0 = log every event. Default: 300000 (5 min).


### PR DESCRIPTION
Heartbeat, cron, subagent, and autonomic sessions are machine-driven and produce low-value or duplicative retains. Add a defense-in-depth gate that checks sessionKey patterns before any retention logic runs.

The :autonomic: pattern was missing from the upstream skip regex, causing autonomic sessions to flood the memory bank with procedural noise.

Closes: #1403