### PR TITLE
fix: clean up async batch retain test fixtures and comments

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1311,6 +1311,9 @@ async def _streaming_retain_batch(
                     )
                     committed_doc_ids = meta.get("facts_committed_document_ids") or []
                     document_ids = meta.get("document_ids") or []
+                    # Legacy path: operations created before per-document checkpoint
+                    # tracking only wrote facts_committed=true without document IDs.
+                    # Treat those as committed only for single-doc operations.
                     legacy_single_doc_checkpoint = (
                         meta.get("facts_committed")
                         and not committed_doc_ids
@@ -1379,6 +1382,9 @@ async def _streaming_retain_batch(
         if operation_id and all_unit_ids:
             try:
                 async with acquire_with_retry(pool) as conn:
+                    # Append effective_doc_id to the committed document set if not
+                    # already present, so multi-doc batches track each document
+                    # independently for crash recovery.
                     await conn.execute(
                         f"""
                         UPDATE {fq_table("async_operations")}

--- a/hindsight-api-slim/tests/test_none_llm_provider.py
+++ b/hindsight-api-slim/tests/test_none_llm_provider.py
@@ -26,40 +26,9 @@ from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 
 
-class _TestEmbeddings:
-    provider_name = "test"
-    dimension = 384
-
-    async def initialize(self) -> None:
-        return None
-
-    def encode(self, texts: list[str]) -> list[list[float]]:
-        return [[0.0] * self.dimension for _ in texts]
-
-
-class _TestCrossEncoder:
-    provider_name = "test"
-
-    async def initialize(self) -> None:
-        return None
-
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
-        return [1.0 for _ in pairs]
-
-
 @pytest.fixture(scope="function")
 def request_context():
     return RequestContext()
-
-
-@pytest.fixture(scope="function")
-def embeddings():
-    return _TestEmbeddings()
-
-
-@pytest.fixture(scope="function")
-def cross_encoder():
-    return _TestCrossEncoder()
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -175,13 +144,17 @@ async def test_async_batch_retain_tracks_all_document_ids_with_none_provider(non
         contents=contents,
         request_context=request_context,
     )
-    await asyncio.sleep(0.1)
 
-    status = await none_memory.get_operation_status(
-        bank_id=bank_id,
-        operation_id=result["operation_id"],
-        request_context=request_context,
-    )
+    # Poll until the async operation completes (avoid flaky sleep)
+    for _ in range(50):
+        status = await none_memory.get_operation_status(
+            bank_id=bank_id,
+            operation_id=result["operation_id"],
+            request_context=request_context,
+        )
+        if status["status"] in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.1)
     assert status["status"] == "completed", status
 
     alpha = await none_memory.get_document("doc-alpha", bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Follow-up to #1382. Fixes review items from the async batch retain checkpoint PR:

- **Remove duplicate test fixtures** that shadowed conftest's session-scoped `embeddings`/`cross_encoder` — the local function-scoped fakes used zero-vector embeddings instead of real sentence-transformer models
- **Replace flaky `asyncio.sleep(0.1)`** with a polling loop (up to 5s) to avoid CI race conditions
- **Add clarifying comments** on the legacy single-doc checkpoint guard and the `jsonb_set` checkpoint SQL

## Test plan

- [ ] `cd hindsight-api-slim && uv run pytest tests/test_none_llm_provider.py -v` passes
- [ ] Async batch retain test completes reliably without timing flakes