### PR TITLE
chore(clients): regenerate clients for time_field timeseries param

### DIFF
--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -511,6 +511,23 @@ paths:
           title: Period
           type: string
         style: form
+      - description: "Timestamp column to bucket on. `created_at` (default) = ingest\
+          \ time; `mentioned_at` / `occurred_start` = event time, useful for migrated\
+          \ corpora where ingest time is a single point and doesn't reflect the underlying\
+          \ knowledge timeline. Unknown values fall back to `created_at`."
+        explode: true
+        in: query
+        name: time_field
+        required: false
+        schema:
+          default: created_at
+          description: "Timestamp column to bucket on. `created_at` (default) = ingest\
+            \ time; `mentioned_at` / `occurred_start` = event time, useful for migrated\
+            \ corpora where ingest time is a single point and doesn't reflect the\
+            \ underlying knowledge timeline. Unknown values fall back to `created_at`."
+          title: Time Field
+          type: string
+        style: form
       - explode: false
         in: header
         name: authorization
@@ -5199,6 +5216,7 @@ components:
     MemoriesTimeseriesResponse:
       description: Time-series of memory ingestion bucketed by time and fact type.
       example:
+        time_field: created_at
         period: period
         trunc: trunc
         bank_id: bank_id
@@ -5222,6 +5240,13 @@ components:
         trunc:
           description: "Bucket granularity: minute, hour, day."
           title: Trunc
+          type: string
+        time_field:
+          default: created_at
+          description: Timestamp column used to assign each row to a bucket. `created_at`
+            shows ingest time; `mentioned_at` / `occurred_start` show event time (falls
+            back to `created_at` per row when null).
+          title: Time Field
           type: string
         buckets:
           description: "Per-bucket counts, always returned fully padded for the requested\

--- a/hindsight-clients/go/api_banks.go
+++ b/hindsight-clients/go/api_banks.go
@@ -910,11 +910,18 @@ type ApiGetMemoriesTimeseriesRequest struct {
 	ApiService *BanksAPIService
 	bankId string
 	period *string
+	timeField *string
 	authorization *string
 }
 
 func (r ApiGetMemoriesTimeseriesRequest) Period(period string) ApiGetMemoriesTimeseriesRequest {
 	r.period = &period
+	return r
+}
+
+// Timestamp column to bucket on. &#x60;created_at&#x60; (default) &#x3D; ingest time; &#x60;mentioned_at&#x60; / &#x60;occurred_start&#x60; &#x3D; event time, useful for migrated corpora where ingest time is a single point and doesn&#39;t reflect the underlying knowledge timeline. Unknown values fall back to &#x60;created_at&#x60;.
+func (r ApiGetMemoriesTimeseriesRequest) TimeField(timeField string) ApiGetMemoriesTimeseriesRequest {
+	r.timeField = &timeField
 	return r
 }
 
@@ -971,6 +978,12 @@ func (a *BanksAPIService) GetMemoriesTimeseriesExecute(r ApiGetMemoriesTimeserie
 	} else {
 		var defaultValue string = "7d"
 		r.period = &defaultValue
+	}
+	if r.timeField != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "time_field", r.timeField, "form", "")
+	} else {
+		var defaultValue string = "created_at"
+		r.timeField = &defaultValue
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/hindsight-clients/go/model_memories_timeseries_response.go
+++ b/hindsight-clients/go/model_memories_timeseries_response.go
@@ -26,6 +26,8 @@ type MemoriesTimeseriesResponse struct {
 	Period string `json:"period"`
 	// Bucket granularity: minute, hour, day.
 	Trunc string `json:"trunc"`
+	// Timestamp column used to assign each row to a bucket. `created_at` shows ingest time; `mentioned_at` / `occurred_start` show event time (falls back to `created_at` per row when null).
+	TimeField *string `json:"time_field,omitempty"`
 	// Per-bucket counts, always returned fully padded for the requested period.
 	Buckets []MemoryTimeseriesBucket `json:"buckets,omitempty"`
 }
@@ -41,6 +43,8 @@ func NewMemoriesTimeseriesResponse(bankId string, period string, trunc string) *
 	this.BankId = bankId
 	this.Period = period
 	this.Trunc = trunc
+	var timeField string = "created_at"
+	this.TimeField = &timeField
 	return &this
 }
 
@@ -49,6 +53,8 @@ func NewMemoriesTimeseriesResponse(bankId string, period string, trunc string) *
 // but it doesn't guarantee that properties required by API are set
 func NewMemoriesTimeseriesResponseWithDefaults() *MemoriesTimeseriesResponse {
 	this := MemoriesTimeseriesResponse{}
+	var timeField string = "created_at"
+	this.TimeField = &timeField
 	return &this
 }
 
@@ -124,6 +130,38 @@ func (o *MemoriesTimeseriesResponse) SetTrunc(v string) {
 	o.Trunc = v
 }
 
+// GetTimeField returns the TimeField field value if set, zero value otherwise.
+func (o *MemoriesTimeseriesResponse) GetTimeField() string {
+	if o == nil || IsNil(o.TimeField) {
+		var ret string
+		return ret
+	}
+	return *o.TimeField
+}
+
+// GetTimeFieldOk returns a tuple with the TimeField field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *MemoriesTimeseriesResponse) GetTimeFieldOk() (*string, bool) {
+	if o == nil || IsNil(o.TimeField) {
+		return nil, false
+	}
+	return o.TimeField, true
+}
+
+// HasTimeField returns a boolean if a field has been set.
+func (o *MemoriesTimeseriesResponse) HasTimeField() bool {
+	if o != nil && !IsNil(o.TimeField) {
+		return true
+	}
+
+	return false
+}
+
+// SetTimeField gets a reference to the given string and assigns it to the TimeField field.
+func (o *MemoriesTimeseriesResponse) SetTimeField(v string) {
+	o.TimeField = &v
+}
+
 // GetBuckets returns the Buckets field value if set, zero value otherwise.
 func (o *MemoriesTimeseriesResponse) GetBuckets() []MemoryTimeseriesBucket {
 	if o == nil || IsNil(o.Buckets) {
@@ -169,6 +207,9 @@ func (o MemoriesTimeseriesResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["bank_id"] = o.BankId
 	toSerialize["period"] = o.Period
 	toSerialize["trunc"] = o.Trunc
+	if !IsNil(o.TimeField) {
+		toSerialize["time_field"] = o.TimeField
+	}
 	if !IsNil(o.Buckets) {
 		toSerialize["buckets"] = o.Buckets
 	}

--- a/hindsight-clients/python/hindsight_client_api/api/banks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/banks_api.py
@@ -16,8 +16,9 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import StrictStr
+from pydantic import Field, StrictStr
 from typing import Optional
+from typing_extensions import Annotated
 from hindsight_client_api.models.add_background_request import AddBackgroundRequest
 from hindsight_client_api.models.background_response import BackgroundResponse
 from hindsight_client_api.models.bank_config_response import BankConfigResponse
@@ -2063,6 +2064,7 @@ class BanksApi:
         self,
         bank_id: StrictStr,
         period: Optional[StrictStr] = None,
+        time_field: Annotated[Optional[StrictStr], Field(description="Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2085,6 +2087,8 @@ class BanksApi:
         :type bank_id: str
         :param period:
         :type period: str
+        :param time_field: Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.
+        :type time_field: str
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2112,6 +2116,7 @@ class BanksApi:
         _param = self._get_memories_timeseries_serialize(
             bank_id=bank_id,
             period=period,
+            time_field=time_field,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2139,6 +2144,7 @@ class BanksApi:
         self,
         bank_id: StrictStr,
         period: Optional[StrictStr] = None,
+        time_field: Annotated[Optional[StrictStr], Field(description="Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2161,6 +2167,8 @@ class BanksApi:
         :type bank_id: str
         :param period:
         :type period: str
+        :param time_field: Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.
+        :type time_field: str
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2188,6 +2196,7 @@ class BanksApi:
         _param = self._get_memories_timeseries_serialize(
             bank_id=bank_id,
             period=period,
+            time_field=time_field,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2215,6 +2224,7 @@ class BanksApi:
         self,
         bank_id: StrictStr,
         period: Optional[StrictStr] = None,
+        time_field: Annotated[Optional[StrictStr], Field(description="Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2237,6 +2247,8 @@ class BanksApi:
         :type bank_id: str
         :param period:
         :type period: str
+        :param time_field: Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.
+        :type time_field: str
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2264,6 +2276,7 @@ class BanksApi:
         _param = self._get_memories_timeseries_serialize(
             bank_id=bank_id,
             period=period,
+            time_field=time_field,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2286,6 +2299,7 @@ class BanksApi:
         self,
         bank_id,
         period,
+        time_field,
         authorization,
         _request_auth,
         _content_type,
@@ -2314,6 +2328,10 @@ class BanksApi:
         if period is not None:
             
             _query_params.append(('period', period))
+            
+        if time_field is not None:
+            
+            _query_params.append(('time_field', time_field))
             
         # process the header parameters
         if authorization is not None:

--- a/hindsight-clients/python/hindsight_client_api/models/memories_timeseries_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/memories_timeseries_response.py
@@ -30,8 +30,9 @@ class MemoriesTimeseriesResponse(BaseModel):
     bank_id: StrictStr
     period: StrictStr = Field(description="One of: 1h, 12h, 1d, 7d, 30d, 90d.")
     trunc: StrictStr = Field(description="Bucket granularity: minute, hour, day.")
+    time_field: Optional[StrictStr] = Field(default='created_at', description="Timestamp column used to assign each row to a bucket. `created_at` shows ingest time; `mentioned_at` / `occurred_start` show event time (falls back to `created_at` per row when null).")
     buckets: Optional[List[MemoryTimeseriesBucket]] = Field(default=None, description="Per-bucket counts, always returned fully padded for the requested period.")
-    __properties: ClassVar[List[str]] = ["bank_id", "period", "trunc", "buckets"]
+    __properties: ClassVar[List[str]] = ["bank_id", "period", "trunc", "time_field", "buckets"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -94,6 +95,7 @@ class MemoriesTimeseriesResponse(BaseModel):
             "bank_id": obj.get("bank_id"),
             "period": obj.get("period"),
             "trunc": obj.get("trunc"),
+            "time_field": obj.get("time_field") if obj.get("time_field") is not None else 'created_at',
             "buckets": [MemoryTimeseriesBucket.from_dict(_item) for _item in obj["buckets"]] if obj.get("buckets") is not None else None
         })
         return _obj

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1813,6 +1813,12 @@ export type MemoriesTimeseriesResponse = {
    */
   trunc: string;
   /**
+   * Time Field
+   *
+   * Timestamp column used to assign each row to a bucket. `created_at` shows ingest time; `mentioned_at` / `occurred_start` show event time (falls back to `created_at` per row when null).
+   */
+  time_field?: string;
+  /**
    * Buckets
    *
    * Per-bucket counts, always returned fully padded for the requested period.
@@ -3805,6 +3811,12 @@ export type GetMemoriesTimeseriesData = {
      * Period
      */
     period?: string;
+    /**
+     * Time Field
+     *
+     * Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.
+     */
+    time_field?: string;
   };
   url: "/v1/default/banks/{bank_id}/stats/memories-timeseries";
 };

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -772,6 +772,18 @@
             }
           },
           {
+            "name": "time_field",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.",
+              "default": "created_at",
+              "title": "Time Field"
+            },
+            "description": "Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`."
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,
@@ -7898,6 +7910,12 @@
             "type": "string",
             "title": "Trunc",
             "description": "Bucket granularity: minute, hour, day."
+          },
+          "time_field": {
+            "type": "string",
+            "title": "Time Field",
+            "description": "Timestamp column used to assign each row to a bucket. `created_at` shows ingest time; `mentioned_at` / `occurred_start` show event time (falls back to `created_at` per row when null).",
+            "default": "created_at"
           },
           "buckets": {
             "items": {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -772,6 +772,18 @@
             }
           },
           {
+            "name": "time_field",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`.",
+              "default": "created_at",
+              "title": "Time Field"
+            },
+            "description": "Timestamp column to bucket on. `created_at` (default) = ingest time; `mentioned_at` / `occurred_start` = event time, useful for migrated corpora where ingest time is a single point and doesn't reflect the underlying knowledge timeline. Unknown values fall back to `created_at`."
+          },
+          {
             "name": "authorization",
             "in": "header",
             "required": false,
@@ -7898,6 +7910,12 @@
             "type": "string",
             "title": "Trunc",
             "description": "Bucket granularity: minute, hour, day."
+          },
+          "time_field": {
+            "type": "string",
+            "title": "Time Field",
+            "description": "Timestamp column used to assign each row to a bucket. `created_at` shows ingest time; `mentioned_at` / `occurred_start` show event time (falls back to `created_at` per row when null).",
+            "default": "created_at"
           },
           "buckets": {
             "items": {


### PR DESCRIPTION
## Summary

#1246 added a `time_field` query parameter to `GET /banks/{bank_id}/stats/memories-timeseries` (and a `time_field` field on `MemoriesTimeseriesResponse`) but did not run the generation scripts. The OpenAPI spec and the generated Go / Python / TypeScript clients drifted from the API, and the `verify-generated-files` CI job has been failing on every PR since.

This PR runs `./scripts/generate-openapi.sh` + `./scripts/generate-clients.sh` and commits the resulting output. No behavior change — pure codegen.

Caught by CI on #1418.

## Test plan

- [x] `./scripts/generate-openapi.sh && ./scripts/generate-bank-template-schema.sh && ./scripts/generate-clients.sh && ./scripts/generate-docs-skill.sh && ./scripts/hooks/lint.sh` produces no further diff
- [ ] CI `verify-generated-files` job green