### PR TITLE
fix(recall): preserve original exception in recall_async error path

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3681,12 +3681,14 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
         except Exception as e:
+            # Use repr(e) so exceptions with empty __str__ (e.g. raise SomeError())
+            # still emit a discriminating class+args string into operations.error_message.
             log_buffer.append(
-                f"[RECALL {recall_id}] ERROR after {time.time() - recall_start:.3f}s: {type(e).__name__}: {e}"
+                f"[RECALL {recall_id}] ERROR after {time.time() - recall_start:.3f}s: {type(e).__name__}: {e!r}"
             )
             if not quiet:
-                logger.error("\n" + "\n".join(log_buffer))
-            raise Exception(f"Failed to search memories: {type(e).__name__}: {e}")
+                logger.error("\n" + "\n".join(log_buffer), exc_info=True)
+            raise RuntimeError(f"Failed to search memories ({type(e).__name__}): {e!r}") from e
 
     def _filter_by_token_budget(
         self, results: list[dict[str, Any]], max_tokens: int

--- a/hindsight-api-slim/tests/test_recall_error_propagation.py
+++ b/hindsight-api-slim/tests/test_recall_error_propagation.py
@@ -1,0 +1,56 @@
+"""Tests that recall_async surfaces a non-opaque error message when the
+underlying retrieval pipeline raises an exception with empty __str__.
+
+Regression for issue #1384: ``raise Exception(f"Failed to search memories: ...{e}")``
+collapsed to ``Failed to search memories: `` for any exception whose __str__()
+returns blank, dropping the original class name and traceback chain.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+
+RC = RequestContext(tenant_id="default")
+
+
+class _SilentError(Exception):
+    """Mimics asyncpg.exceptions.ConnectionDoesNotExistError() and similar
+    exceptions whose __str__() returns blank when raised with no args."""
+
+
+async def _raise_silent(*_args, **_kwargs):
+    raise _SilentError()
+
+
+async def test_recall_async_error_preserves_original(memory_no_llm_verify: MemoryEngine):
+    engine = memory_no_llm_verify
+    bank_id = "test-error-propagation"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+
+    try:
+        with patch(
+            "hindsight_api.engine.memory_engine.embedding_utils.generate_embeddings_batch",
+            side_effect=_raise_silent,
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                await engine.recall_async(
+                    bank_id=bank_id,
+                    query="anything",
+                    request_context=RC,
+                )
+
+        # The wrapping message must include the original exception class name —
+        # the symptom in #1384 was an empty trailer like "Failed to search memories: ".
+        message = str(excinfo.value)
+        assert "Failed to search memories" in message
+        assert "_SilentError" in message, (
+            f"wrapper message dropped the original exception class: {message!r}"
+        )
+
+        # `from e` chain must be preserved so worker logs / debuggers can walk
+        # back to the real cause.
+        assert isinstance(excinfo.value.__cause__, _SilentError)
+    finally:
+        await engine.delete_bank(bank_id, request_context=RC)


### PR DESCRIPTION
## Summary

Closes #1384.

`MemoryEngine.recall_async` swallowed the original exception class and traceback when recall failed, leaving `operations.error_message` as an opaque `Failed to search memories: ` (or `Failed to search memories: : `) for any exception whose `__str__()` returned blank — common for asyncpg wrappers, custom exceptions, or `raise SomeError()` with no arg. Worker logs also lacked a traceback.

Three minimal changes to the `except` block at `memory_engine.py:3683`:

- `{e}` → `{e!r}` in the log line and wrapper message — `repr()` always emits a discriminating class+args string even when `__str__()` is empty.
- `logger.error(...)` now passes `exc_info=True` so worker logs carry the full traceback.
- `raise Exception(...)` → `raise RuntimeError(...) from e` — preserves the original exception class and traceback chain via `__cause__`.

## Test plan

- [x] New regression test `tests/test_recall_error_propagation.py` patches `embedding_utils.generate_embeddings_batch` to raise an exception with empty `__str__()`, then asserts:
  - the wrapper is `RuntimeError` (not bare `Exception`),
  - the message contains the original class name (`_SilentError`),
  - `__cause__` chain is preserved.
- [x] Verified the test fails on `main` with the original opaque message: `Exception: Failed to search memories: _SilentError:`.
- [x] `./scripts/hooks/lint.sh` passes.