### PR TITLE
fix(daemon): honor --host and HINDSIGHT_API_HOST in daemon mode

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1311,6 +1311,9 @@ async def _streaming_retain_batch(
                     )
                     committed_doc_ids = meta.get("facts_committed_document_ids") or []
                     document_ids = meta.get("document_ids") or []
+                    # Legacy path: operations created before per-document checkpoint
+                    # tracking only wrote facts_committed=true without document IDs.
+                    # Treat those as committed only for single-doc operations.
                     legacy_single_doc_checkpoint = (
                         meta.get("facts_committed")
                         and not committed_doc_ids
@@ -1379,6 +1382,9 @@ async def _streaming_retain_batch(
         if operation_id and all_unit_ids:
             try:
                 async with acquire_with_retry(pool) as conn:
+                    # Append effective_doc_id to the committed document set if not
+                    # already present, so multi-doc batches track each document
+                    # independently for crash recovery.
                     await conn.execute(
                         f"""
                         UPDATE {fq_table("async_operations")}

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -24,7 +24,7 @@ import uvicorn
 from . import MemoryEngine, __version__
 from .api import create_app
 from .banner import print_banner
-from .config import DEFAULT_WORKERS, ENV_WORKERS, HindsightConfig, _get_raw_config
+from .config import DEFAULT_WORKERS, ENV_HOST, ENV_WORKERS, HindsightConfig, _get_raw_config
 from .daemon import (
     DEFAULT_DAEMON_PORT,
     DEFAULT_IDLE_TIMEOUT,
@@ -62,6 +62,22 @@ def _signal_handler(signum, frame):
     print(f"\nReceived signal {signum}, shutting down...")
     _cleanup()
     sys.exit(0)
+
+
+def resolve_daemon_host_port(*, args_host: str, args_port: int, config_host: str, config_port: int) -> tuple[str, int]:
+    """Resolve host/port for daemon mode.
+
+    Defaults to 127.0.0.1 for security, but honors explicit user overrides
+    via --host flag or HINDSIGHT_API_HOST env var. Uses DEFAULT_DAEMON_PORT
+    unless the user specified a custom port.
+    """
+    port = args_port if args_port != config_port else DEFAULT_DAEMON_PORT
+    # Only force localhost if the user didn't explicitly set a host
+    if args_host != config_host or os.environ.get(ENV_HOST):
+        host = args_host
+    else:
+        host = "127.0.0.1"
+    return host, port
 
 
 def main():
@@ -136,10 +152,12 @@ def main():
 
     # Daemon mode handling
     if args.daemon:
-        # Use port from args (may be custom for profiles)
-        if args.port == config.port:  # No custom port specified
-            args.port = DEFAULT_DAEMON_PORT
-        args.host = "127.0.0.1"  # Only bind to localhost for security
+        args.host, args.port = resolve_daemon_host_port(
+            args_host=args.host,
+            args_port=args.port,
+            config_host=config.host,
+            config_port=config.port,
+        )
 
         # Fork into background
         # No lockfile needed - port binding prevents duplicate daemons

--- a/hindsight-api-slim/tests/test_daemon_host_resolution.py
+++ b/hindsight-api-slim/tests/test_daemon_host_resolution.py
@@ -1,0 +1,84 @@
+"""Tests for daemon mode host/port resolution (resolve_daemon_host_port).
+
+Verifies that --daemon honors explicit --host / HINDSIGHT_API_HOST overrides
+instead of unconditionally pinning to 127.0.0.1.
+
+See: https://github.com/vectorize-io/hindsight/issues/1402
+"""
+
+from hindsight_api.daemon import DEFAULT_DAEMON_PORT
+from hindsight_api.main import resolve_daemon_host_port
+
+# Default config values matching production defaults
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8888
+
+
+class TestResolveDaemonHostPort:
+    """Test resolve_daemon_host_port under various override scenarios."""
+
+    def test_defaults_to_localhost_when_no_override(self, monkeypatch):
+        """With no explicit host setting, daemon should bind to 127.0.0.1."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        host, port = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST, args_port=DEFAULT_PORT,
+            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        )
+        assert host == "127.0.0.1"
+        assert port == DEFAULT_DAEMON_PORT
+
+    def test_honors_cli_host_flag(self, monkeypatch):
+        """--host 0.0.0.0 --daemon should bind to 0.0.0.0, not 127.0.0.1."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        host, port = resolve_daemon_host_port(
+            args_host="0.0.0.0", args_port=DEFAULT_PORT,
+            config_host="127.0.0.1", config_port=DEFAULT_PORT,
+        )
+        assert host == "0.0.0.0"
+
+    def test_honors_env_var_host(self, monkeypatch):
+        """HINDSIGHT_API_HOST=0.0.0.0 --daemon should bind to 0.0.0.0."""
+        monkeypatch.setenv("HINDSIGHT_API_HOST", "0.0.0.0")
+        # When env var is set, config.host already reflects it, so
+        # args_host == config_host — but the env var presence is the signal.
+        host, port = resolve_daemon_host_port(
+            args_host="0.0.0.0", args_port=DEFAULT_PORT,
+            config_host="0.0.0.0", config_port=DEFAULT_PORT,
+        )
+        assert host == "0.0.0.0"
+
+    def test_honors_custom_host_via_env(self, monkeypatch):
+        """HINDSIGHT_API_HOST=10.0.0.5 should be respected in daemon mode."""
+        monkeypatch.setenv("HINDSIGHT_API_HOST", "10.0.0.5")
+        host, _ = resolve_daemon_host_port(
+            args_host="10.0.0.5", args_port=DEFAULT_PORT,
+            config_host="10.0.0.5", config_port=DEFAULT_PORT,
+        )
+        assert host == "10.0.0.5"
+
+    def test_cli_flag_overrides_env_var(self, monkeypatch):
+        """--host flag should take precedence over env var."""
+        monkeypatch.setenv("HINDSIGHT_API_HOST", "10.0.0.5")
+        host, _ = resolve_daemon_host_port(
+            args_host="192.168.1.1", args_port=DEFAULT_PORT,
+            config_host="10.0.0.5", config_port=DEFAULT_PORT,
+        )
+        assert host == "192.168.1.1"
+
+    def test_custom_port_preserved(self, monkeypatch):
+        """--port 9999 --daemon should keep 9999, not switch to daemon default."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        _, port = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST, args_port=9999,
+            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        )
+        assert port == 9999
+
+    def test_default_port_becomes_daemon_port(self, monkeypatch):
+        """No --port flag in daemon mode should use DEFAULT_DAEMON_PORT."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        _, port = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST, args_port=DEFAULT_PORT,
+            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        )
+        assert port == DEFAULT_DAEMON_PORT

--- a/hindsight-api-slim/tests/test_none_llm_provider.py
+++ b/hindsight-api-slim/tests/test_none_llm_provider.py
@@ -26,40 +26,9 @@ from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 
 
-class _TestEmbeddings:
-    provider_name = "test"
-    dimension = 384
-
-    async def initialize(self) -> None:
-        return None
-
-    def encode(self, texts: list[str]) -> list[list[float]]:
-        return [[0.0] * self.dimension for _ in texts]
-
-
-class _TestCrossEncoder:
-    provider_name = "test"
-
-    async def initialize(self) -> None:
-        return None
-
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
-        return [1.0 for _ in pairs]
-
-
 @pytest.fixture(scope="function")
 def request_context():
     return RequestContext()
-
-
-@pytest.fixture(scope="function")
-def embeddings():
-    return _TestEmbeddings()
-
-
-@pytest.fixture(scope="function")
-def cross_encoder():
-    return _TestCrossEncoder()
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -175,13 +144,17 @@ async def test_async_batch_retain_tracks_all_document_ids_with_none_provider(non
         contents=contents,
         request_context=request_context,
     )
-    await asyncio.sleep(0.1)
 
-    status = await none_memory.get_operation_status(
-        bank_id=bank_id,
-        operation_id=result["operation_id"],
-        request_context=request_context,
-    )
+    # Poll until the async operation completes (avoid flaky sleep)
+    for _ in range(50):
+        status = await none_memory.get_operation_status(
+            bank_id=bank_id,
+            operation_id=result["operation_id"],
+            request_context=request_context,
+        )
+        if status["status"] in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.1)
     assert status["status"] == "completed", status
 
     alpha = await none_memory.get_document("doc-alpha", bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary
- `--daemon` mode previously unconditionally overwrote `args.host` to `127.0.0.1`, ignoring both the `--host` CLI flag and `HINDSIGHT_API_HOST` env var
- Extracted `resolve_daemon_host_port()` helper that only defaults to localhost when the user hasn't explicitly set a host
- Added 7 unit tests covering all override scenarios (CLI flag, env var, both, neither)

Closes #1402

## Test plan
- [x] `uv run pytest tests/test_daemon_host_resolution.py -v` — all 7 tests pass
- [x] Lint passes (`./scripts/hooks/lint.sh`)