### PR TITLE
feat(claude-code): add knowledge tools via Python MCP server

### DIFF
--- a/hindsight-integrations/claude-code/.claude-plugin/plugin.json
+++ b/hindsight-integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hindsight-memory",
-  "description": "Automatic long-term memory for Claude Code via Hindsight. Recalls relevant memories before each prompt and retains conversation transcripts after each response.",
-  "version": "0.4.0",
+  "description": "Automatic long-term memory for Claude Code via Hindsight. Recalls relevant memories before each prompt, retains conversation transcripts, and provides knowledge page tools.",
+  "version": "0.5.0",
   "author": {"name": "Hindsight Team", "url": "https://vectorize.io/hindsight"},
   "license": "MIT",
   "keywords": ["memory", "hindsight", "recall", "retain"]

--- a/hindsight-integrations/claude-code/.mcp.json
+++ b/hindsight-integrations/claude-code/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hindsight": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"]
+    }
+  }
+}

--- a/hindsight-integrations/claude-code/hooks/hooks.json
+++ b/hindsight-integrations/claude-code/hooks/hooks.json
@@ -22,6 +22,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__hindsight__agent_knowledge_.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/inject_bank_id.py\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/hindsight-integrations/claude-code/scripts/inject_bank_id.py
+++ b/hindsight-integrations/claude-code/scripts/inject_bank_id.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: inject bank_id into agent_knowledge_* MCP tool calls.
+
+Intercepts mcp__hindsight__agent_knowledge_* tool calls and injects
+the resolved bank_id into tool_input, using the same derivation logic
+as the recall/retain hooks (config chain + cwd context).
+
+Exit codes:
+  0 — always (allow the tool call to proceed)
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.bank import derive_bank_id
+from lib.config import debug_log, load_config
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    tool_input = hook_input.get("tool_input", {})
+
+    # Skip if bank_id already provided (explicit override)
+    if tool_input.get("bank_id"):
+        return
+
+    config = load_config()
+
+    if not config.get("enableKnowledgeTools"):
+        return
+
+    bank_id = derive_bank_id(hook_input, config)
+    debug_log(config, f"Injecting bank_id={bank_id} into {hook_input.get('tool_name')}")
+
+    # Return updatedInput with bank_id injected
+    updated = dict(tool_input)
+    updated["bank_id"] = bank_id
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": updated,
+        }
+    }
+    json.dump(output, sys.stdout)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[Hindsight] inject_bank_id error: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -57,7 +57,7 @@ class HindsightClient:
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers
 
-    def _request(self, method: str, path: str, body: Optional[dict] = None, timeout: int = DEFAULT_TIMEOUT) -> dict:
+    def request(self, method: str, path: str, body: Optional[dict] = None, timeout: int = DEFAULT_TIMEOUT) -> dict:
         url = f"{self.api_url}{path}"
         data = json.dumps(body).encode() if body else None
         req = urllib.request.Request(url, data=data, headers=self._headers(), method=method)
@@ -115,7 +115,7 @@ class HindsightClient:
             body["budget"] = budget
         if types:
             body["types"] = types
-        return self._request("POST", path, body, timeout=timeout)
+        return self.request("POST", path, body, timeout=timeout)
 
     def retain(
         self,
@@ -147,7 +147,7 @@ class HindsightClient:
             "items": [item],
             "async": True,
         }
-        return self._request("POST", path, body, timeout=timeout)
+        return self.request("POST", path, body, timeout=timeout)
 
     def set_bank_mission(
         self, bank_id: str, mission: str, retain_mission: Optional[str] = None, timeout: int = 15
@@ -161,4 +161,4 @@ class HindsightClient:
         updates = {"reflect_mission": mission}
         if retain_mission:
             updates["retain_mission"] = retain_mission
-        return self._request("PATCH", path, {"updates": updates}, timeout=timeout)
+        return self.request("PATCH", path, {"updates": updates}, timeout=timeout)

--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Hindsight MCP server for Claude Code plugin.
+
+Runs as a stdio subprocess managed by the plugin system.
+Exposes knowledge tools (list/get/create/update/delete pages, recall, ingest).
+Reuses the existing plugin config chain and client.
+
+Each tool accepts an optional bank_id parameter. When omitted, falls back to the
+default bank derived from config at startup. The PreToolUse hook (inject_bank_id.py)
+injects bank_id from session context (cwd, agentName) before calls reach here.
+"""
+
+import json
+import os
+import sys
+import urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP
+
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.daemon import get_api_url
+from lib.bank import derive_bank_id
+
+# ── Server setup ────────────────────────────────────────
+
+mcp = FastMCP("hindsight")
+
+# Resolve config at startup
+_config = load_config()
+_dbg = lambda *a: debug_log(_config, *a)
+
+if not _config.get("enableKnowledgeTools"):
+    _dbg("Knowledge tools disabled (enableKnowledgeTools=false), MCP server exiting")
+    sys.exit(0)
+
+try:
+    _api_url = get_api_url(_config, debug_fn=_dbg, allow_daemon_start=True)
+except Exception as e:
+    print(f"[Hindsight MCP] Failed to resolve API URL: {e}", file=sys.stderr)
+    sys.exit(1)
+
+_hook_input = {"cwd": os.getcwd(), "session_id": ""}
+_default_bank_id = derive_bank_id(_hook_input, _config)
+_client = HindsightClient(_api_url, _config.get("hindsightApiToken"))
+
+_dbg(f"MCP server starting — API: {_api_url}, default bank: {_default_bank_id}")
+
+
+def _bank(bank_id: str = "") -> str:
+    """Resolve bank ID: use explicit value if provided, else fall back to default."""
+    return bank_id if bank_id else _default_bank_id
+
+
+def _encode_bank(bank_id: str) -> str:
+    return urllib.parse.quote(bank_id, safe="")
+
+
+# ── Mental model defaults ───────────────────────────────
+
+PAGE_DEFAULTS = {
+    "mode": "delta",
+    "refresh_after_consolidation": True,
+    "fact_types": ["observation"],
+    "exclude_mental_models": True,
+}
+
+# ── Tools ───────────────────────────────────────────────
+
+
+@mcp.tool()
+def agent_knowledge_list_pages(bank_id: str = "") -> str:
+    """List all your knowledge pages (IDs and names only). Use agent_knowledge_get_page to read the full content of a specific page."""
+    bid = _bank(bank_id)
+    resp = _client.request("GET", f"/v1/default/banks/{_encode_bank(bid)}/mental-models", timeout=10)
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_get_page(page_id: str, bank_id: str = "") -> str:
+    """Read a specific knowledge page by its ID. Returns the full synthesized content."""
+    bid = _bank(bank_id)
+    resp = _client.request(
+        "GET", f"/v1/default/banks/{_encode_bank(bid)}/mental-models/{page_id}?detail=full", timeout=10
+    )
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_create_page(page_id: str, name: str, source_query: str, bank_id: str = "") -> str:
+    """Create a new knowledge page. The source_query is a question the system re-asks after each consolidation to rebuild the page from conversation observations. Pages auto-update as you have more conversations."""
+    bid = _bank(bank_id)
+    resp = _client.request(
+        "POST",
+        f"/v1/default/banks/{_encode_bank(bid)}/mental-models",
+        body={
+            "id": page_id,
+            "name": name,
+            "source_query": source_query,
+            "max_tokens": 4096,
+            "trigger": PAGE_DEFAULTS,
+        },
+        timeout=15,
+    )
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_update_page(page_id: str, name: str = "", source_query: str = "", bank_id: str = "") -> str:
+    """Update a page's name or source query. The content will re-synthesize on next consolidation."""
+    body = {}
+    if name:
+        body["name"] = name
+    if source_query:
+        body["source_query"] = source_query
+    if not body:
+        return json.dumps({"error": "Provide name or source_query to update"})
+    bid = _bank(bank_id)
+    resp = _client.request(
+        "PATCH", f"/v1/default/banks/{_encode_bank(bid)}/mental-models/{page_id}", body=body, timeout=10
+    )
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_delete_page(page_id: str, bank_id: str = "") -> str:
+    """Permanently delete a knowledge page."""
+    bid = _bank(bank_id)
+    resp = _client.request("DELETE", f"/v1/default/banks/{_encode_bank(bid)}/mental-models/{page_id}", timeout=10)
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_recall(query: str, max_results: int = 10, bank_id: str = "") -> str:
+    """Search across all retained conversations and documents for specific facts, numbers, or details not covered by your knowledge pages."""
+    bid = _bank(bank_id)
+    resp = _client.recall(bank_id=bid, query=query, max_tokens=max_results, budget="mid", timeout=10)
+    return json.dumps(resp, indent=2)
+
+
+@mcp.tool()
+def agent_knowledge_ingest(title: str, content: str, bank_id: str = "") -> str:
+    """Upload a document into your memory bank. Pass the full raw content — never summarize before ingesting. The title becomes the document ID (re-ingesting replaces it)."""
+    bid = _bank(bank_id)
+    doc_id = title.lower().replace(" ", "-")
+    resp = _client.retain(bank_id=bid, content=content, document_id=doc_id, timeout=15)
+    return json.dumps(resp, indent=2)
+
+
+# ── Entry point ─────────────────────────────────────────
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/hindsight-integrations/claude-code/scripts/subagent_retain.py
+++ b/hindsight-integrations/claude-code/scripts/subagent_retain.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Stop hook for subagent: retain conversation to the agent's bank.
+
+Called from a subagent's Stop hook with HINDSIGHT_BANK_ID set in the
+environment. Reads the transcript, formats it, and posts to the
+agent-specific bank.
+
+This is separate from the main plugin's retain.py which retains to
+the global bank derived from config. This script always retains to
+the bank specified in HINDSIGHT_BANK_ID.
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.content import prepare_retention_transcript
+from lib.daemon import get_api_url
+
+
+def read_transcript(transcript_path: str) -> list:
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return []
+    messages = []
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    if entry.get("type") in ("user", "assistant"):
+                        msg = entry.get("message", {})
+                        if isinstance(msg, dict) and msg.get("role"):
+                            messages.append(msg)
+                    elif "role" in entry and "content" in entry:
+                        messages.append(entry)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return messages
+
+
+def main():
+    bank_id = os.environ.get("HINDSIGHT_BANK_ID")
+    if not bank_id:
+        return
+
+    config = load_config()
+
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+
+    transcript_path = hook_input.get("transcript_path", "")
+    session_id = hook_input.get("session_id", "unknown")
+
+    messages = read_transcript(transcript_path)
+    if not messages:
+        debug_log(config, "Subagent retain: no messages, skipping")
+        return
+
+    transcript, message_count = prepare_retention_transcript(
+        messages,
+        retain_roles=["user", "assistant"],
+        retain_full_window=True,
+        include_tool_calls=config.get("retainToolCalls", True),
+    )
+
+    if not transcript:
+        return
+
+    def _dbg(*a):
+        debug_log(config, *a)
+
+    try:
+        api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=True)
+    except RuntimeError as e:
+        print(f"[Hindsight] Subagent retain: {e}", file=sys.stderr)
+        return
+
+    try:
+        client = HindsightClient(api_url, config.get("hindsightApiToken"))
+    except ValueError as e:
+        print(f"[Hindsight] Subagent retain: {e}", file=sys.stderr)
+        return
+
+    document_id = f"{session_id}-{int(time.time() * 1000)}"
+
+    debug_log(
+        config,
+        f"Subagent retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages",
+    )
+
+    try:
+        client.retain(
+            bank_id=bank_id,
+            content=transcript,
+            document_id=document_id,
+            context="claude-code-subagent",
+            metadata={
+                "retained_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "message_count": str(message_count),
+                "session_id": session_id,
+            },
+        )
+    except Exception as e:
+        print(f"[Hindsight] Subagent retain failed: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[Hindsight] Subagent retain error: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -32,5 +32,6 @@
   "llmProvider": null,
   "llmModel": null,
   "llmApiKeyEnv": null,
+  "enableKnowledgeTools": false,
   "debug": false
 }

--- a/hindsight-integrations/claude-code/skills/agent-knowledge/SKILL.md
+++ b/hindsight-integrations/claude-code/skills/agent-knowledge/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: agent-knowledge
+description: Your long-term knowledge pages. Read them at session start. Create new pages when you learn something worth remembering across sessions. Pages auto-update from your conversations via Hindsight.
+---
+
+# Agent Knowledge
+
+You have knowledge pages that persist across sessions and auto-update from your conversations.
+
+**How it works:** Your conversations are automatically retained into a Hindsight memory bank. The system extracts observations and uses them to keep your pages current. Each page has a "source query" — a question the system re-answers after every consolidation cycle to rebuild the page content. You create pages; the system maintains them.
+
+## At session start
+
+Call `agent_knowledge_list_pages` to see what pages exist, then `agent_knowledge_get_page` for each one you need.
+
+## Reading
+
+- `agent_knowledge_list_pages()` — list page IDs and names (no content)
+- `agent_knowledge_get_page(page_id)` — read the full content of a page
+
+## Creating pages
+
+When you learn something durable — a user preference, a working procedure, performance data — create a page immediately.
+
+`agent_knowledge_create_page(page_id, name, source_query)`
+
+- `page_id`: lowercase with hyphens (`editorial-preferences`)
+- `source_query`: a question that produces the page content from observations
+
+Examples:
+
+- `"What are the user's preferences for tone, length, and formatting?"`
+- `"What content strategies have performed well or poorly? Include numbers."`
+- `"What are the best practices for [topic], preferring our data over generic advice?"`
+
+## Searching memories
+
+`agent_knowledge_recall(query)` — search across all retained conversations and documents for specific facts.
+
+Use when pages don't cover what you need.
+
+## Ingesting documents
+
+`agent_knowledge_ingest(title, content)` — upload raw content into memory. Never summarize before ingesting. Save large content to a file first, read it, then pass the full text.
+
+## Updating and deleting
+
+- `agent_knowledge_update_page(page_id, name?, source_query?)` — change what a page tracks
+- `agent_knowledge_delete_page(page_id)` — remove a page
+
+## Important
+
+- Pages update automatically — don't edit content directly
+- State preferences clearly in your responses so the system captures them
+- Create pages silently — don't announce it to the user
+- Prefer fewer broad pages over many narrow ones

--- a/hindsight-tools/self-driving-agents/src/cli.ts
+++ b/hindsight-tools/self-driving-agents/src/cli.ts
@@ -575,6 +575,240 @@ function ensureHermesPlugin(
   p.log.success("Knowledge skill installed");
 }
 
+// ── Claude skill generation ────────────────────────────
+
+const CLAUDE_SKILLS_DIR = join(homedir(), "self-driving-agents", "claude");
+const HINDSIGHT_CLOUD_API_URL = "https://api.hindsight.vectorize.io";
+
+async function generateClaudeSkill(
+  agentId: string,
+  apiUrl: string,
+  bankId: string,
+  apiToken?: string
+): Promise<string> {
+  const authHeader = apiToken ? `-H "Authorization: Bearer ${apiToken}" \\\n      ` : "";
+  const skillMd = `# Hindsight Memory — ${agentId}
+
+## Mandatory Startup Sequence
+
+On every new conversation, run these commands **before doing anything else**:
+
+### 1. List all knowledge pages
+\`\`\`bash
+curl -s ${apiUrl}/v1/default/banks/${bankId}/knowledge/pages \\
+  ${authHeader}-H "Content-Type: application/json"
+\`\`\`
+
+### 2. Read each page (replace PAGE_ID)
+\`\`\`bash
+curl -s ${apiUrl}/v1/default/banks/${bankId}/knowledge/pages/PAGE_ID \\
+  ${authHeader}-H "Content-Type: application/json"
+\`\`\`
+
+Read **every** page listed in step 1 to load the agent's full knowledge base.
+
+## Creating Knowledge Pages
+
+\`\`\`bash
+curl -s -X POST ${apiUrl}/v1/default/banks/${bankId}/knowledge/pages \\
+  ${authHeader}-H "Content-Type: application/json" \\
+  -d '{"title": "Page Title", "content": "Markdown content here"}'
+\`\`\`
+
+## Searching Memories
+
+\`\`\`bash
+curl -s -X POST ${apiUrl}/v1/default/banks/${bankId}/memories/recall \\
+  ${authHeader}-H "Content-Type: application/json" \\
+  -d '{"query": "your search query"}'
+\`\`\`
+
+## Ingesting Documents
+
+\`\`\`bash
+curl -s -X POST ${apiUrl}/v1/default/banks/${bankId}/memories/retain \\
+  ${authHeader}-H "Content-Type: application/json" \\
+  -d '{"content": "Document content to remember"}'
+\`\`\`
+
+## Updating Knowledge Pages
+
+\`\`\`bash
+curl -s -X PUT ${apiUrl}/v1/default/banks/${bankId}/knowledge/pages/PAGE_ID \\
+  ${authHeader}-H "Content-Type: application/json" \\
+  -d '{"title": "Updated Title", "content": "Updated content"}'
+\`\`\`
+
+## Deleting Knowledge Pages
+
+\`\`\`bash
+curl -s -X DELETE ${apiUrl}/v1/default/banks/${bankId}/knowledge/pages/PAGE_ID \\
+  ${authHeader}-H "Content-Type: application/json"
+\`\`\`
+
+## Retaining Conversations
+
+Claude Chat and Cowork do not have automatic hooks. You must **self-retain** important conversation content.
+
+After any significant exchange (decisions, new information, task outcomes), retain it:
+
+\`\`\`bash
+curl -s -X POST ${apiUrl}/v1/default/banks/${bankId}/memories/retain \\
+  ${authHeader}-H "Content-Type: application/json" \\
+  -d '{"content": "Summary of the conversation or key information learned"}'
+\`\`\`
+
+**When to self-retain:**
+- After learning user preferences or project context
+- After completing a task (retain the outcome)
+- After receiving corrections or feedback
+- After discovering important facts during research
+
+## Important Notes
+
+- Always run the startup sequence at the beginning of every conversation
+- Knowledge pages are persistent — they survive across conversations
+- Use recall to search existing memories before creating duplicates
+- Self-retain is essential since there are no automatic hooks in Claude Chat/Cowork
+`;
+
+  const outDir = join(CLAUDE_SKILLS_DIR, agentId);
+  mkdirSync(outDir, { recursive: true });
+  const skillPath = join(outDir, "SKILL.md");
+  writeFileSync(skillPath, skillMd);
+
+  // Create a zip of the skill directory
+  const zipPath = join(outDir, `${agentId}-skill.zip`);
+  execSync(`cd "${outDir}" && zip -j "${zipPath}" SKILL.md`, { stdio: "pipe" });
+
+  return zipPath;
+}
+
+async function promptClaudeConfig(
+  agentId: string
+): Promise<{ apiUrl: string; bankId: string; apiToken?: string }> {
+  const deploymentType = await p.select({
+    message: "Hindsight deployment:",
+    options: [
+      { value: "cloud", label: "Cloud (api.hindsight.vectorize.io)" },
+      { value: "self-hosted", label: "Self-hosted" },
+    ],
+  });
+  if (p.isCancel(deploymentType)) {
+    p.cancel("Cancelled.");
+    process.exit(0);
+  }
+
+  let apiUrl: string;
+  if (deploymentType === "cloud") {
+    apiUrl = HINDSIGHT_CLOUD_API_URL;
+  } else {
+    const urlInput = await p.text({
+      message: "Hindsight API URL:",
+      placeholder: "https://your-hindsight.example.com",
+      validate: (val) => {
+        if (!val) return "URL is required";
+        if (val.startsWith("http://localhost") || val.startsWith("http://127.0.0.1")) {
+          return "Claude cannot reach localhost. Use a publicly accessible URL.";
+        }
+        return undefined;
+      },
+    });
+    if (p.isCancel(urlInput)) {
+      p.cancel("Cancelled.");
+      process.exit(0);
+    }
+    apiUrl = urlInput as string;
+    p.log.warn("Make sure your Hindsight instance is publicly accessible from Claude's servers.");
+  }
+
+  const tokenInput = await p.text({ message: "Hindsight API token:" });
+  if (p.isCancel(tokenInput)) {
+    p.cancel("Cancelled.");
+    process.exit(0);
+  }
+  const apiToken = (tokenInput as string) || undefined;
+
+  const bankInput = await p.text({
+    message: "Bank ID:",
+    initialValue: agentId,
+  });
+  if (p.isCancel(bankInput)) {
+    p.cancel("Cancelled.");
+    process.exit(0);
+  }
+  const bankId = (bankInput as string).trim() || agentId;
+
+  return { apiUrl, bankId, apiToken };
+}
+
+// ── Claude Code plugin management ─────────────────────
+
+const CLAUDE_CODE_USER_CONFIG_DIR = join(homedir(), ".hindsight");
+const CLAUDE_CODE_USER_CONFIG_PATH = join(CLAUDE_CODE_USER_CONFIG_DIR, "claude-code.json");
+
+function readClaudeCodeConfig(): any {
+  if (!existsSync(CLAUDE_CODE_USER_CONFIG_PATH)) return null;
+  return JSON.parse(readFileSync(CLAUDE_CODE_USER_CONFIG_PATH, "utf-8"));
+}
+
+function writeClaudeCodeConfig(config: any): void {
+  mkdirSync(CLAUDE_CODE_USER_CONFIG_DIR, { recursive: true });
+  writeFileSync(CLAUDE_CODE_USER_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+}
+
+function resolveFromClaudeCode(agentId: string): {
+  apiUrl: string;
+  bankId: string;
+  apiToken?: string;
+} {
+  const config = readClaudeCodeConfig();
+  if (!config) throw new Error("Claude Code config not found at " + CLAUDE_CODE_USER_CONFIG_PATH);
+
+  const apiUrl = config.apiUrl || HINDSIGHT_CLOUD_API_URL;
+  const apiToken = config.apiToken || undefined;
+
+  let bankId: string;
+  if (config.dynamicBankId === false && config.bankId) {
+    bankId = config.bankId;
+  } else {
+    const granularity: string[] = config.dynamicBankGranularity || ["agent"];
+    const fieldMap: Record<string, string> = {
+      agent: agentId,
+    };
+    const base = granularity.map((f) => encodeURIComponent(fieldMap[f] || "unknown")).join("::");
+    bankId = config.bankIdPrefix ? `${config.bankIdPrefix}-${base}` : base;
+  }
+
+  return { apiUrl, bankId, apiToken };
+}
+
+async function ensureClaudeCodePlugin(agentId: string): Promise<{ apiUrl: string; bankId: string; apiToken?: string }> {
+  // Write or update config
+  const config = readClaudeCodeConfig() || {};
+  config.agentName = agentId;
+  config.enableKnowledgeTools = true;
+
+  // Always prompt for Hindsight connection — each agent install needs correct API + token
+  let resolvedApiUrl = config.hindsightApiUrl || `http://localhost:${config.apiPort || 9077}`;
+  let resolvedBankId = agentId;
+  let resolvedApiToken = config.hindsightApiToken || undefined;
+
+  if (process.stdin.isTTY) {
+    const claudeConfig = await promptClaudeConfig(agentId);
+    config.hindsightApiUrl = claudeConfig.apiUrl;
+    config.hindsightApiToken = claudeConfig.apiToken;
+    config.dynamicBankId = false;
+    resolvedApiUrl = claudeConfig.apiUrl;
+    resolvedBankId = claudeConfig.bankId;
+    resolvedApiToken = claudeConfig.apiToken;
+  }
+
+  writeClaudeCodeConfig(config);
+
+  return { apiUrl: resolvedApiUrl, bankId: resolvedBankId, apiToken: resolvedApiToken };
+}
+
 // ── Main ────────────────────────────────────────────────
 
 async function main() {
@@ -593,7 +827,7 @@ async function main() {
     ${color.cyan("./local-dir")}                 → local directory
 
   ${color.dim("Options:")}
-    ${color.cyan("--harness <h>")}      Required. openclaw | nemoclaw | hermes
+    ${color.cyan("--harness <h>")}      Required. openclaw | nemoclaw | hermes | claude | claude-code
     ${color.cyan("--agent <name>")}     Agent name (defaults to directory name)
     ${color.cyan("--sandbox <name>")}   NemoClaw sandbox (auto-detected if only one exists)
 `);
@@ -619,7 +853,7 @@ async function main() {
   }
 
   if (!harness) {
-    p.cancel("--harness required (openclaw | nemoclaw)");
+    p.cancel("--harness required (openclaw | nemoclaw | hermes | claude | claude-code)");
     process.exit(1);
   }
 
@@ -655,6 +889,7 @@ async function main() {
     let apiUrl: string;
     let bankId: string;
     let apiToken: string | undefined;
+    let claudeSkillZip: string | undefined;
 
     if (harness === "openclaw") {
       await ensurePlugin();
@@ -734,6 +969,13 @@ async function main() {
 
       bankId = agentId;
       ensureHermesPlugin(agentId, apiUrl, bankId, apiToken);
+    } else if (harness === "claude") {
+      const claudeConfig = await promptClaudeConfig(agentId);
+      apiUrl = claudeConfig.apiUrl;
+      bankId = claudeConfig.bankId;
+      apiToken = claudeConfig.apiToken;
+    } else if (harness === "claude-code") {
+      ({ apiUrl, bankId, apiToken } = await ensureClaudeCodePlugin(agentId));
     } else {
       p.cancel(`Unknown harness: ${harness}`);
       process.exit(1);
@@ -806,7 +1048,71 @@ async function main() {
     }
 
     // Step 6: Create agent + install skill (hermes handled in ensureHermesPlugin)
-    if (harness === "hermes") {
+    if (harness === "claude") {
+      claudeSkillZip = await generateClaudeSkill(agentId, apiUrl, bankId, apiToken);
+    } else if (harness === "claude-code") {
+      // Install per-agent subagent at ~/.claude/agents/<agentId>.md
+      const agentsDir = join(homedir(), ".claude", "agents");
+      mkdirSync(agentsDir, { recursive: true });
+      const agentFile = join(agentsDir, `${agentId}.md`);
+      writeFileSync(
+        agentFile,
+        `---
+name: ${agentId}
+description: ${agentId} agent with long-term memory. Delegate to this agent for tasks related to ${agentId.replace(/-/g, " ")}. It has access to knowledge pages and memory search via Hindsight.
+skills:
+  - agent-knowledge
+mcpServers:
+  - hindsight
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: HINDSIGHT_BANK_ID="${bankId}" python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/subagent_retain.py"
+          timeout: 15
+          async: true
+---
+
+You are the **${agentId}** agent with long-term memory powered by Hindsight.
+
+## Startup — run these steps immediately
+
+1. Call \`agent_knowledge_list_pages(bank_id="${bankId}")\` to see your knowledge pages.
+2. Call \`agent_knowledge_get_page(page_id, bank_id="${bankId}")\` for each page to load your knowledge.
+3. Use this knowledge to inform everything you do in this conversation.
+
+## Creating pages
+
+When you learn something durable — a user preference, a working procedure, performance data — create a page:
+
+\`agent_knowledge_create_page(page_id, name, source_query, bank_id="${bankId}")\`
+
+- \`page_id\`: lowercase with hyphens (\`editorial-preferences\`)
+- \`source_query\`: a question that rebuilds the page from observations
+
+## Searching memories
+
+\`agent_knowledge_recall(query, bank_id="${bankId}")\` — search conversations and documents for specific facts.
+
+## Ingesting documents
+
+\`agent_knowledge_ingest(title, content, bank_id="${bankId}")\` — upload raw content into memory.
+
+## Updating and deleting
+
+- \`agent_knowledge_update_page(page_id, name?, source_query?, bank_id="${bankId}")\`
+- \`agent_knowledge_delete_page(page_id, bank_id="${bankId}")\`
+
+## Important
+
+- Always pass \`bank_id="${bankId}"\` on every agent_knowledge_* tool call
+- Pages update automatically — don't edit content directly
+- Create pages silently — don't announce it to the user
+- Prefer fewer broad pages over many narrow ones
+`
+      );
+      p.log.success(`Subagent installed at ${color.dim(agentFile)}`);
+    } else if (harness === "hermes") {
       // Skill + plugin already installed by ensureHermesPlugin
     } else if (harness === "nemoclaw") {
       // NemoClaw: install skill into the sandbox via nemoclaw CLI
@@ -875,7 +1181,21 @@ async function main() {
 
     // Next steps
     let nextSteps: string[];
-    if (harness === "hermes") {
+    if (harness === "claude") {
+      const apiHost = new URL(apiUrl).hostname;
+      nextSteps = [
+        `${color.dim("1.")} Open Claude → Customize → Skills → Upload skill`,
+        `${color.dim("2.")} Select: ${color.cyan(claudeSkillZip!)}`,
+        `${color.dim("3.")} Allowlist the API host: Settings → Capabilities → add ${color.cyan(apiHost)}`,
+        `${color.dim("4.")} Start a conversation and type ${color.cyan(`/${agentId}`)} to activate the agent`,
+      ];
+    } else if (harness === "claude-code") {
+      nextSteps = [
+        `${color.dim("1.")} Start Claude Code: ${color.cyan("claude")}`,
+        `${color.dim("2.")} Claude will auto-delegate to ${color.cyan(agentId)} when relevant, or mention ${color.cyan(`@${agentId}`)}`,
+        `${color.dim("3.")} Conversations are automatically retained via hooks`,
+      ];
+    } else if (harness === "hermes") {
       nextSteps = [`${color.dim("1.")} hermes -p ${agentId} chat`];
     } else if (harness === "nemoclaw") {
       nextSteps = [

--- a/hindsight-tools/self-driving-agents/tests/cli.test.ts
+++ b/hindsight-tools/self-driving-agents/tests/cli.test.ts
@@ -383,6 +383,16 @@ describe("harness argument parsing", () => {
     const { harness } = parseHarness(["--harness", "hermes"]);
     expect(harness).toBe("hermes");
   });
+
+  it("parses claude harness", () => {
+    const { harness } = parseHarness(["--harness", "claude"]);
+    expect(harness).toBe("claude");
+  });
+
+  it("parses claude-code harness", () => {
+    const { harness } = parseHarness(["--harness", "claude-code"]);
+    expect(harness).toBe("claude-code");
+  });
 });
 
 describe("hermes hindsight config", () => {
@@ -466,5 +476,138 @@ describe("hermes hindsight config", () => {
     const loaded = JSON.parse(readFileSync(join(hindsightDir, "config.json"), "utf-8"));
     const bankId = loaded.bank_id || "hermes";
     expect(bankId).toBe("hermes");
+  });
+});
+
+// ── Claude skill generation tests ─────────────────────
+
+describe("claude skill generation", () => {
+  function generateSkillFrontmatter(agentId: string, apiToken?: string): string {
+    const authHeader = apiToken ? `-H "Authorization: Bearer ${apiToken}"` : "";
+    return `---\nname: ${agentId}\ndescription: Activate the ${agentId} agent. Loads knowledge pages from Hindsight memory.\n---`;
+  }
+
+  it("includes required name frontmatter field", () => {
+    const fm = generateSkillFrontmatter("marketing-seo");
+    expect(fm).toContain("name: marketing-seo");
+  });
+
+  it("includes description frontmatter field", () => {
+    const fm = generateSkillFrontmatter("my-agent");
+    expect(fm).toContain("description: Activate the my-agent agent");
+  });
+
+  it("bakes auth token when provided", () => {
+    const authHeader = "secret-token" ? `-H "Authorization: Bearer secret-token"` : "";
+    expect(authHeader).toContain("Bearer secret-token");
+  });
+
+  it("omits auth header when no token", () => {
+    const authHeader = undefined ? `-H "Authorization: Bearer undefined"` : "";
+    expect(authHeader).toBe("");
+  });
+});
+
+describe("claude config validation", () => {
+  function validateUrl(v: string | undefined): string | undefined {
+    if (!v) return "URL required";
+    try {
+      const parsed = new URL(v);
+      if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+        return "Claude connects from Anthropic's cloud — localhost won't work. Use a public URL.";
+      }
+    } catch {
+      return "Invalid URL";
+    }
+  }
+
+  it("rejects localhost URLs", () => {
+    expect(validateUrl("http://localhost:9077")).toContain("localhost");
+    expect(validateUrl("http://127.0.0.1:9077")).toContain("localhost");
+  });
+
+  it("accepts public URLs", () => {
+    expect(validateUrl("https://api.example.com")).toBeUndefined();
+    expect(validateUrl("https://api.hindsight.vectorize.io")).toBeUndefined();
+  });
+
+  it("rejects empty/missing URLs", () => {
+    expect(validateUrl("")).toBe("URL required");
+    expect(validateUrl(undefined)).toBe("URL required");
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(validateUrl("not-a-url")).toBe("Invalid URL");
+  });
+});
+
+describe("claude-code config resolution", () => {
+  function resolveFromConfig(
+    agentId: string,
+    config: Record<string, any>
+  ): { apiUrl: string; bankId: string; apiToken?: string } {
+    const apiUrl = config.hindsightApiUrl || `http://localhost:${config.apiPort || 9077}`;
+    const apiToken = config.hindsightApiToken || undefined;
+    let bankId: string;
+    if (config.dynamicBankId === false && config.bankId) {
+      bankId = config.bankId;
+    } else if (config.dynamicBankId) {
+      const granularity: string[] = config.dynamicBankGranularity || ["agent", "project"];
+      const fieldMap: Record<string, string> = {
+        agent: config.agentName || agentId, project: "unknown",
+        session: "unknown", channel: "default", user: "anonymous",
+      };
+      const base = granularity.map((f: string) => encodeURIComponent(fieldMap[f] || "unknown")).join("::");
+      bankId = config.bankIdPrefix ? `${config.bankIdPrefix}-${base}` : base;
+    } else {
+      bankId = config.bankIdPrefix ? `${config.bankIdPrefix}-${agentId}` : agentId;
+    }
+    return { apiUrl, bankId, apiToken };
+  }
+
+  it("uses external API URL when set", () => {
+    const r = resolveFromConfig("agent", { hindsightApiUrl: "https://api.example.com", hindsightApiToken: "tok" });
+    expect(r.apiUrl).toBe("https://api.example.com");
+    expect(r.apiToken).toBe("tok");
+  });
+
+  it("defaults to localhost:9077", () => {
+    const r = resolveFromConfig("agent", {});
+    expect(r.apiUrl).toBe("http://localhost:9077");
+  });
+
+  it("uses agentId as default bank", () => {
+    const r = resolveFromConfig("marketing-seo", {});
+    expect(r.bankId).toBe("marketing-seo");
+  });
+
+  it("uses static bankId when dynamicBankId=false", () => {
+    const r = resolveFromConfig("agent", { dynamicBankId: false, bankId: "my-bank" });
+    expect(r.bankId).toBe("my-bank");
+  });
+
+  it("computes dynamic bankId", () => {
+    const r = resolveFromConfig("seo", { dynamicBankId: true, agentName: "seo", dynamicBankGranularity: ["agent"] });
+    expect(r.bankId).toBe("seo");
+  });
+
+  it("applies bankIdPrefix", () => {
+    const r = resolveFromConfig("agent", { bankIdPrefix: "prod" });
+    expect(r.bankId).toBe("prod-agent");
+  });
+});
+
+describe("harness validation", () => {
+  const SUPPORTED_HARNESSES = ["openclaw", "nemoclaw", "hermes", "claude", "claude-code"];
+
+  it("accepts all supported harnesses", () => {
+    for (const h of SUPPORTED_HARNESSES) {
+      expect(SUPPORTED_HARNESSES.includes(h)).toBe(true);
+    }
+  });
+
+  it("rejects unknown harnesses", () => {
+    expect(SUPPORTED_HARNESSES.includes("chatgpt")).toBe(false);
+    expect(SUPPORTED_HARNESSES.includes("")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Add self-driving agent knowledge tools to the claude-code plugin via a Python MCP server, matching the pattern used by the openclaw plugin's `enableKnowledgeTools` feature.

### Plugin changes (`hindsight-integrations/claude-code/`)
- **`scripts/mcp_server.py`** — Python FastMCP stdio server exposing 7 `agent_knowledge_*` tools (list/get/create/update/delete pages, recall, ingest). Reuses existing `scripts/lib/` for config, client, bank ID derivation, and daemon management.
- **`.mcp.json`** — Plugin MCP server config (stdio transport, runs on host machine)
- **`skills/agent-knowledge/SKILL.md`** — Skill referencing the MCP tool names
- **`settings.json`** — Added `enableKnowledgeTools` config flag (default: false). MCP server exits immediately if disabled.
- **`scripts/lib/client.py`** — Made `request()` public (was `_request`)
- Bumped plugin version to 0.5.0

### CLI changes (`hindsight-tools/self-driving-agents/`)
- Added `--harness claude-code` — configures `~/.hindsight/claude-code.json` with `enableKnowledgeTools: true`, agent name, and API connection
- Prompts for auto-detect LLM or external server if not configured
- Updated tests for new harness

## How it works

```bash
npx @vectorize-io/self-driving-agents install marketing/seo --harness claude-code
```

1. Configures `~/.hindsight/claude-code.json` with `enableKnowledgeTools: true`
2. Ingests agent content into Hindsight bank
3. User starts `claude` — plugin MCP server auto-starts with knowledge tools available
4. Hooks continue to auto-retain conversations

## Test plan

- [ ] Run MCP server directly: `python3 scripts/mcp_server.py` with stdio JSON-RPC
- [ ] Verify tools/list returns 7 agent_knowledge_* tools
- [ ] Verify tools/call works for list_pages, create_page, get_page, delete_page
- [ ] Install plugin with `--plugin-dir`, verify MCP tools appear in Claude Code
- [ ] Run `--harness claude-code`, verify config written
- [ ] Verify existing Python hooks still work (auto-recall, auto-retain)
- [ ] Verify MCP server exits cleanly when `enableKnowledgeTools=false`