### PR TITLE
feat(self-driving-agents): add Hermes Agent harness support

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -135,15 +135,11 @@ ENV_LLM_TIMEOUT = "HINDSIGHT_API_LLM_TIMEOUT"
 ENV_LLM_GROQ_SERVICE_TIER = "HINDSIGHT_API_LLM_GROQ_SERVICE_TIER"
 ENV_LLM_OPENAI_SERVICE_TIER = "HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER"
 ENV_LLM_EXTRA_BODY = "HINDSIGHT_API_LLM_EXTRA_BODY"
-ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
 DEFAULT_LLM_EXTRA_BODY = None  # None = no extra body params; JSON dict merged into OpenAI extra_body
-DEFAULT_LLM_DEFAULT_HEADERS = (
-    None  # None = no extra headers; JSON dict passed as default_headers to provider SDK clients
-)
 
 # Per-operation LLM configuration (optional, falls back to global LLM config)
 ENV_RETAIN_LLM_PROVIDER = "HINDSIGHT_API_RETAIN_LLM_PROVIDER"
@@ -851,9 +847,6 @@ class HindsightConfig:
     llm_extra_body: (
         dict | None
     )  # Extra body params merged into OpenAI-compatible API calls (e.g. {"chat_template_kwargs": {"enable_thinking": true}})
-    llm_default_headers: (
-        dict | None
-    )  # Custom headers passed as default_headers to provider SDK clients (e.g. {"X-Component-Id": "hindsight"} for proxies / request tracing)
 
     # Vertex AI configuration
     llm_vertexai_project_id: str | None
@@ -1376,7 +1369,6 @@ class HindsightConfig:
             llm_groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
-            llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -148,7 +148,6 @@ def create_llm_provider(
     groq_service_tier: str | None = None,
     openai_service_tier: str | None = None,
     extra_body: dict[str, Any] | None = None,
-    default_headers: dict[str, str] | None = None,
     vertexai_project_id: str | None = None,
     vertexai_region: str | None = None,
     vertexai_credentials: Any = None,
@@ -166,9 +165,6 @@ def create_llm_provider(
         groq_service_tier: Groq service tier (for Groq provider) - "on_demand", "flex", or "auto".
         openai_service_tier: OpenAI service tier (for OpenAI provider) - None (default) or "flex" (50% cheaper).
         extra_body: Extra body params merged into OpenAI-compatible API calls.
-        default_headers: Custom headers passed as ``default_headers`` to provider SDK clients
-            (used by operators routing through proxies / request-tracing middleware). Currently
-            wired into the Anthropic provider; other providers may opt in as needed.
         vertexai_project_id: Vertex AI project ID (for VertexAI provider).
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
@@ -247,7 +243,6 @@ def create_llm_provider(
             base_url=base_url,
             model=model,
             reasoning_effort=reasoning_effort,
-            default_headers=default_headers,
         )
 
     elif provider_lower == "litellm":
@@ -322,7 +317,6 @@ class LLMProvider:
         openai_service_tier: str | None = None,
         gemini_safety_settings: list | None = None,
         extra_body: dict[str, Any] | None = None,
-        default_headers: dict[str, str] | None = None,
     ):
         """
         Initialize LLM provider.
@@ -337,10 +331,6 @@ class LLMProvider:
             openai_service_tier: OpenAI service tier (None or "flex") - from config.
             gemini_safety_settings: Safety settings for Gemini/VertexAI providers.
             extra_body: Extra body params merged into OpenAI-compatible API calls.
-            default_headers: Custom headers passed as ``default_headers`` to provider SDK clients.
-                Used by operators routing through proxies / request-tracing middleware. Falls
-                back to ``HindsightConfig.llm_default_headers`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``)
-                when ``None``.
         """
         self.provider = provider.lower()
         self.api_key = api_key
@@ -354,17 +344,6 @@ class LLMProvider:
         self.gemini_safety_settings = gemini_safety_settings
         # Extra body params for OpenAI-compatible providers (e.g. chat_template_kwargs)
         self.extra_body = extra_body
-        # Default headers passed to provider SDK clients (e.g. proxy auth, request tracing).
-        # Same pattern as ``gemini_safety_settings``: explicit override wins; otherwise read
-        # the static server-level default from ``HindsightConfig`` via ``_get_raw_config()``.
-        self.default_headers = default_headers
-        if self.default_headers is None:
-            from ..config import _get_raw_config
-
-            try:
-                self.default_headers = _get_raw_config().llm_default_headers
-            except Exception:
-                pass  # Config may not be initialized in test environments
 
         # Validate provider
         valid_providers = [
@@ -469,7 +448,6 @@ class LLMProvider:
             groq_service_tier=self.groq_service_tier,
             openai_service_tier=self.openai_service_tier,
             extra_body=self.extra_body,
-            default_headers=self.default_headers,
             vertexai_project_id=vertexai_project_id,
             vertexai_region=vertexai_region,
             vertexai_credentials=vertexai_credentials,
@@ -785,7 +763,6 @@ class LLMProvider:
             DEFAULT_LLM_PROVIDER,
             ENV_LLM_API_KEY,
             ENV_LLM_BASE_URL,
-            ENV_LLM_DEFAULT_HEADERS,
             ENV_LLM_EXTRA_BODY,
             ENV_LLM_MODEL,
             ENV_LLM_PROVIDER,
@@ -804,7 +781,6 @@ class LLMProvider:
         base_url = os.getenv(ENV_LLM_BASE_URL, "")
         model = os.getenv(ENV_LLM_MODEL, DEFAULT_LLM_MODEL)
         extra_body = json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null"))
-        default_headers = json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null"))
 
         return cls(
             provider=provider,
@@ -813,7 +789,6 @@ class LLMProvider:
             model=model,
             reasoning_effort="low",
             extra_body=extra_body,
-            default_headers=default_headers,
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -539,7 +539,6 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=memory_llm_base_url,
             model=memory_llm_model,
             extra_body=config.llm_extra_body,
-            default_headers=config.llm_default_headers,
         )
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
@@ -567,7 +566,6 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=retain_base_url,
             model=retain_model,
             extra_body=config.llm_extra_body,
-            default_headers=config.llm_default_headers,
         )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
@@ -590,7 +588,6 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=reflect_base_url,
             model=reflect_model,
             extra_body=config.llm_extra_body,
-            default_headers=config.llm_default_headers,
         )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
@@ -613,7 +610,6 @@ class MemoryEngine(MemoryEngineInterface):
             base_url=consolidation_base_url,
             model=consolidation_model,
             extra_body=config.llm_extra_body,
-            default_headers=config.llm_default_headers,
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -37,7 +37,6 @@ class AnthropicLLM(LLMInterface):
         model: str,
         reasoning_effort: str = "low",
         timeout: float = 300.0,
-        default_headers: dict[str, str] | None = None,
         **kwargs: Any,
     ):
         """
@@ -50,10 +49,6 @@ class AnthropicLLM(LLMInterface):
             model: Model name (e.g., "claude-sonnet-4-20250514").
             reasoning_effort: Reasoning effort level (not used by Anthropic).
             timeout: Request timeout in seconds.
-            default_headers: Optional custom headers passed as ``default_headers`` to
-                the Anthropic SDK client. Used by operators routing through proxies
-                or request-tracing middleware. Sourced from ``llm_default_headers`` in
-                ``HindsightConfig`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``).
             **kwargs: Additional provider-specific parameters.
         """
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
@@ -65,16 +60,11 @@ class AnthropicLLM(LLMInterface):
         try:
             from anthropic import AsyncAnthropic
 
-            # SDK retries disabled — wrapper-level retry loop in ``call`` handles
-            # backoff (mirrors ``OpenAICompatibleLLM`` so the two providers behave
-            # consistently).
-            client_kwargs: dict[str, Any] = {"api_key": self.api_key, "max_retries": 0}
+            client_kwargs: dict[str, Any] = {"api_key": self.api_key}
             if self.base_url:
                 client_kwargs["base_url"] = self.base_url
             if timeout:
                 client_kwargs["timeout"] = timeout
-            if default_headers:
-                client_kwargs["default_headers"] = default_headers
 
             self._client = AsyncAnthropic(**client_kwargs)
             logger.info(f"Anthropic client initialized for model: {self.model}")

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from fastmcp import FastMCP
-from pydantic import TypeAdapter
 
 from hindsight_api import MemoryEngine
 from hindsight_api.config import (
@@ -22,11 +21,8 @@ from hindsight_api.config import (
 from hindsight_api.engine.audit import AuditEntry, AuditLogger
 from hindsight_api.engine.memory_engine import Budget
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES
-from hindsight_api.engine.search.tags import TagGroup
 from hindsight_api.extensions import OperationValidationError
 from hindsight_api.models import RequestContext
-
-_TAG_GROUP_LIST_ADAPTER = TypeAdapter(list[TagGroup])
 
 # All tools available in the system (explicit list — no wildcards).
 # Defined here (shared module) to avoid circular imports with api/mcp.py.
@@ -777,7 +773,6 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             types: list[str] | None = None,
             tags: list[str] | None = None,
             tags_match: str = "any",
-            tag_groups: list[dict] | None = None,
             query_timestamp: str | None = None,
             bank_id: str | None = None,
         ) -> str | dict:
@@ -787,12 +782,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 max_tokens: Maximum tokens to return in results (default: 4096)
                 budget: Search budget - 'low', 'mid', or 'high' (default: 'high'). Higher budgets search more thoroughly.
                 types: Fact types to include (e.g., ['world', 'experience']). Default: all types.
-                tags: Optional tags to filter results by (e.g., ['project:alpha']). Mutually exclusive with tag_groups.
+                tags: Optional tags to filter results by (e.g., ['project:alpha'])
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
-                tag_groups: Compound tag filter using boolean groups (AND-ed together). Each group is a leaf
-                    {"tags": [...], "match": "any_strict"} or compound {"and": [...]}, {"or": [...]}, {"not": {...}}.
-                    Example: [{"not": {"tags": ["closeout"], "match": "any_strict"}}] excludes memories tagged closeout.
-                    Mutually exclusive with tags.
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z'). Helps retrieve time-relevant memories.
                 bank_id: Optional bank to search in (defaults to session bank). Use for cross-bank operations.
             """
@@ -800,11 +791,6 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 target_bank = bank_id or config.bank_id_resolver()
                 if target_bank is None:
                     return "Error: No bank_id configured"
-
-                if tags is not None and tag_groups is not None:
-                    raise ValueError(
-                        "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
-                    )
 
                 budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
                 budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
@@ -821,8 +807,6 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 if tags is not None:
                     recall_kwargs["tags"] = tags
                     recall_kwargs["tags_match"] = tags_match
-                if tag_groups is not None:
-                    recall_kwargs["tag_groups"] = _TAG_GROUP_LIST_ADAPTER.validate_python(tag_groups)
                 if query_timestamp is not None:
                     recall_kwargs["question_date"] = parse_timestamp(query_timestamp)
 
@@ -848,7 +832,6 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             types: list[str] | None = None,
             tags: list[str] | None = None,
             tags_match: str = "any",
-            tag_groups: list[dict] | None = None,
             query_timestamp: str | None = None,
         ) -> dict:
             """
@@ -857,23 +840,14 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 max_tokens: Maximum tokens to return in results (default: 4096)
                 budget: Search budget - 'low', 'mid', or 'high' (default: 'high'). Higher budgets search more thoroughly.
                 types: Fact types to include (e.g., ['world', 'experience']). Default: all types.
-                tags: Optional tags to filter results by (e.g., ['project:alpha']). Mutually exclusive with tag_groups.
+                tags: Optional tags to filter results by (e.g., ['project:alpha'])
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
-                tag_groups: Compound tag filter using boolean groups (AND-ed together). Each group is a leaf
-                    {"tags": [...], "match": "any_strict"} or compound {"and": [...]}, {"or": [...]}, {"not": {...}}.
-                    Example: [{"not": {"tags": ["closeout"], "match": "any_strict"}}] excludes memories tagged closeout.
-                    Mutually exclusive with tags.
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z'). Helps retrieve time-relevant memories.
             """
             try:
                 target_bank = config.bank_id_resolver()
                 if target_bank is None:
                     return {"error": "No bank_id configured", "results": []}
-
-                if tags is not None and tag_groups is not None:
-                    raise ValueError(
-                        "'tags' and 'tag_groups' are mutually exclusive. Use 'tag_groups' for compound filtering."
-                    )
 
                 budget_map = {"low": Budget.LOW, "mid": Budget.MID, "high": Budget.HIGH}
                 budget_enum = budget_map.get(budget.lower(), Budget.HIGH)
@@ -890,8 +864,6 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 if tags is not None:
                     recall_kwargs["tags"] = tags
                     recall_kwargs["tags_match"] = tags_match
-                if tag_groups is not None:
-                    recall_kwargs["tag_groups"] = _TAG_GROUP_LIST_ADAPTER.validate_python(tag_groups)
                 if query_timestamp is not None:
                     recall_kwargs["question_date"] = parse_timestamp(query_timestamp)
 

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -949,51 +949,6 @@ class TestRecallNewParams:
         call_kwargs = mock_memory.recall_async.call_args.kwargs
         assert call_kwargs["question_date"] == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-    async def test_recall_with_tag_groups_negative_filter(self, mock_memory):
-        """tag_groups with NOT should pass through to engine after Pydantic validation."""
-        from hindsight_api.engine.search.tags import TagGroupNot
-
-        mcp = _make_mcp_server(mock_memory, {"recall"})
-        await _tools(mcp)["recall"].fn(
-            query="test",
-            tag_groups=[{"not": {"tags": ["closeout"], "match": "any_strict"}}],
-        )
-        call_kwargs = mock_memory.recall_async.call_args.kwargs
-        assert "tag_groups" in call_kwargs
-        assert len(call_kwargs["tag_groups"]) == 1
-        group = call_kwargs["tag_groups"][0]
-        assert isinstance(group, TagGroupNot)
-        assert group.filter.tags == ["closeout"]
-
-    async def test_recall_without_tag_groups_no_kwarg(self, mock_memory):
-        """tag_groups omitted should not appear in engine kwargs."""
-        mcp = _make_mcp_server(mock_memory, {"recall"})
-        await _tools(mcp)["recall"].fn(query="test")
-        call_kwargs = mock_memory.recall_async.call_args.kwargs
-        assert "tag_groups" not in call_kwargs
-
-    async def test_recall_tags_and_tag_groups_mutually_exclusive(self, mock_memory):
-        """Passing both tags and tag_groups returns an error and does not call engine."""
-        mcp = _make_mcp_server(mock_memory, {"recall"})
-        result = await _tools(mcp)["recall"].fn(
-            query="test",
-            tags=["project:x"],
-            tag_groups=[{"tags": ["closeout"], "match": "any_strict"}],
-        )
-        assert "mutually exclusive" in result
-        mock_memory.recall_async.assert_not_called()
-
-    async def test_recall_tag_groups_single_bank(self, mock_memory):
-        """tag_groups should also work in single-bank mode."""
-        mcp = _make_mcp_server(mock_memory, {"recall"}, include_bank_id=False)
-        await _tools(mcp)["recall"].fn(
-            query="test",
-            tag_groups=[{"tags": ["scope:work"], "match": "all_strict"}],
-        )
-        call_kwargs = mock_memory.recall_async.call_args.kwargs
-        assert "tag_groups" in call_kwargs
-        assert len(call_kwargs["tag_groups"]) == 1
-
 
 @pytest.mark.asyncio
 class TestReflectNewParams:

--- a/hindsight-clients/typescript/tests/deno_setup.ts
+++ b/hindsight-clients/typescript/tests/deno_setup.ts
@@ -1,6 +1,6 @@
 /**
  * Preload script for running Jest-style tests under Deno.
- * Injects Jest-compatible globals (describe, test, beforeAll, expect, jest)
+ * Injects Jest-compatible globals (describe, test, beforeAll, expect)
  * using Deno's standard library BDD and expect modules.
  *
  * Usage:
@@ -11,91 +11,6 @@
 import { beforeAll, beforeEach, afterAll, afterEach, describe, it } from "jsr:@std/testing/bdd";
 import { expect } from "jsr:@std/expect";
 
-// @std/expect recognises mock functions via this well-known symbol
-const MOCK_SYMBOL = Symbol.for("@MOCK");
-
-type MockCall = {
-  args: unknown[];
-  returned?: unknown;
-  thrown?: unknown;
-  timestamp: number;
-  returns: boolean;
-  throws: boolean;
-};
-
-function createMock(impl?: (...args: unknown[]) => unknown) {
-  let currentImpl = impl;
-  const calls: MockCall[] = [];
-  const mockInfo = { calls };
-
-  const mockFn = function (this: unknown, ...args: unknown[]) {
-    const call: MockCall = {
-      args,
-      timestamp: Date.now(),
-      returns: false,
-      throws: false,
-    };
-    calls.push(call);
-    try {
-      const result = currentImpl ? currentImpl.apply(this, args) : undefined;
-      call.returned = result;
-      call.returns = true;
-      return result;
-    } catch (err) {
-      call.thrown = err;
-      call.throws = true;
-      throw err;
-    }
-  };
-
-  (mockFn as any)[MOCK_SYMBOL] = mockInfo;
-
-  (mockFn as any).mockResolvedValue = (val: unknown) => {
-    currentImpl = () => Promise.resolve(val);
-    return mockFn;
-  };
-  (mockFn as any).mockRejectedValue = (val: unknown) => {
-    currentImpl = () => Promise.reject(val);
-    return mockFn;
-  };
-  (mockFn as any).mockImplementation = (fn: (...args: unknown[]) => unknown) => {
-    currentImpl = fn;
-    return mockFn;
-  };
-  (mockFn as any).mockReturnValue = (val: unknown) => {
-    currentImpl = () => val;
-    return mockFn;
-  };
-  (mockFn as any).mockReset = () => {
-    calls.length = 0;
-    currentImpl = undefined;
-    return mockFn;
-  };
-  (mockFn as any).mockClear = () => {
-    calls.length = 0;
-    return mockFn;
-  };
-  (mockFn as any).mockRestore = () => {};
-
-  return mockFn;
-}
-
-const jest = {
-  fn: (impl?: (...args: unknown[]) => unknown) => createMock(impl),
-  spyOn: <T extends Record<string, unknown>>(obj: T, method: keyof T) => {
-    const original = obj[method];
-    const mock = createMock(
-      typeof original === "function" ? (original as (...args: unknown[]) => unknown) : undefined
-    );
-    const restore = () => {
-      obj[method] = original;
-    };
-    (mock as any).mockRestore = restore;
-    obj[method] = mock as unknown as T[keyof T];
-    return mock;
-  },
-};
-
 Object.assign(globalThis, {
   describe,
   test: it,
@@ -105,5 +20,4 @@ Object.assign(globalThis, {
   afterAll,
   afterEach,
   expect,
-  jest,
 });

--- a/hindsight-clients/typescript/tests/main_operations.test.ts
+++ b/hindsight-clients/typescript/tests/main_operations.test.ts
@@ -470,11 +470,7 @@ describe("TestMission", () => {
   });
 });
 
-// Skip under Deno: jest.spyOn cannot patch ES-module namespace objects whose
-// properties are frozen. These unit tests are covered by the Jest suite.
-const canSpyOnModules = typeof (globalThis as any).Deno === "undefined";
-
-(canSpyOnModules ? describe : describe.skip)("TestAbortSignal", () => {
+describe("TestAbortSignal", () => {
   test("retain passes abort signal to SDK", async () => {
     const bankId = randomBankId();
     const controller = new AbortController();

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -174,7 +174,6 @@ To switch between backends:
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict merged into `extra_body` for all OpenAI-compatible API calls. Useful for custom model servers (e.g., vLLM `chat_template_kwargs`). | `null` |
-| `HINDSIGHT_API_LLM_DEFAULT_HEADERS` | JSON dict passed as `default_headers` to provider SDK clients. Used by operators routing through proxies / request-tracing middleware (e.g. Cloudflare AI Gateway, Helicone, corporate proxies). Currently wired into the Anthropic provider; other providers can opt in. | `null` |
 | `HINDSIGHT_API_LLM_GEMINI_SAFETY_SETTINGS` | JSON-encoded list of `{category, threshold}` dicts for Gemini/VertexAI content safety filtering | `null` |
 
 **Provider Examples**

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -10,7 +10,6 @@ import os
 import platform
 import re
 import subprocess
-import sysconfig
 import time
 from pathlib import Path
 from typing import IO, Optional
@@ -133,23 +132,12 @@ class DaemonEmbedManager(EmbedManager):
         if dev_api_path.exists() and (dev_api_path / "pyproject.toml").exists():
             return ["uv", "run", "--project", str(dev_api_path), "--extra", "all", "hindsight-api"]
 
-        # Prefer a hindsight-api entry point installed alongside hindsight-embed.
-        # Try two strategies:
-        #
-        # 1. sysconfig: resolves <venv>/bin or <venv>/Scripts for standard
-        #    pip/venv installs (issue #1401).
-        # 2. __file__-relative: resolves <target>/bin or <target>/Scripts for
-        #    `pip install --target` layouts where sysconfig still points at the
-        #    system/venv scripts dir (issue #1240).
-        binary_name = "hindsight-api.exe" if platform.system() == "Windows" else "hindsight-api"
-
-        scripts_dir = Path(sysconfig.get_path("scripts"))
-        candidate = scripts_dir / binary_name
-        if candidate.exists():
-            return [str(candidate)]
-
-        # --target installs place binaries alongside site-packages contents
+        # Prefer a hindsight-api entry point installed alongside hindsight-embed
+        # (e.g. `uv pip install hindsight-all` or `--target`). Falling through
+        # to uvx in that case downloads a standalone Python whose ABI won't
+        # match the sibling site-packages' C extensions (issue #1240).
         package_root = Path(__file__).parent.parent
+        binary_name = "hindsight-api.exe" if platform.system() == "Windows" else "hindsight-api"
         for bin_dir in ("bin", "Scripts"):
             candidate = package_root / bin_dir / binary_name
             if candidate.exists():

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -109,64 +109,38 @@ def test_find_ui_command_uses_npx_yes_flag_for_published_control_plane(monkeypat
         ]
 
 
-def test_find_api_command_prefers_installed_binary_over_uvx(tmp_path, monkeypatch):
+def test_find_api_command_prefers_sibling_binary_over_uvx(tmp_path, monkeypatch):
     """
     When hindsight-api is installed alongside hindsight-embed (e.g. via
-    `pip install hindsight-all`), _find_api_command should invoke that
-    binary directly rather than shelling out to uvx. Uses sysconfig to
-    locate the venv's scripts directory (issue #1401, #1240).
+    `uv pip install hindsight-all`), _find_api_command should invoke that
+    binary directly rather than shelling out to uvx. uvx downloads a
+    standalone Python whose ABI won't match sibling C extensions compiled
+    for the host Python (regression for issue #1240, NixOS asyncpg failure).
     """
-    scripts_dir = tmp_path / "bin"
-    scripts_dir.mkdir()
-    api_binary = scripts_dir / "hindsight-api"
-    api_binary.touch()
-
-    manager = DaemonEmbedManager()
-    # Point __file__ away from monorepo so dev-mode check doesn't trigger
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"))
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
-
-    assert manager._find_api_command() == [str(api_binary)]
-
-
-def test_find_api_command_target_install_uses_file_relative_fallback(tmp_path, monkeypatch):
-    """
-    When installed with `pip install --target`, sysconfig still points at the
-    system/venv scripts dir (no binary there). The __file__-relative fallback
-    should find the sibling binary in <target>/bin/ (issue #1240).
-    """
-    # sysconfig points to an empty venv scripts dir (no binary)
-    venv_scripts = tmp_path / "venv_bin"
-    venv_scripts.mkdir()
-
-    # --target layout: binary sits next to site-packages contents
-    target_dir = tmp_path / "target"
-    pkg_dir = target_dir / "hindsight_embed"
-    pkg_dir.mkdir(parents=True)
-    fake_module = pkg_dir / "daemon_embed_manager.py"
+    package_root = tmp_path / "site-packages" / "hindsight_embed"
+    package_root.mkdir(parents=True)
+    fake_module = package_root / "daemon_embed_manager.py"
     fake_module.write_text("")
-    sibling_bin = target_dir / "bin" / "hindsight-api"
-    sibling_bin.parent.mkdir()
+    sibling_bin = tmp_path / "site-packages" / "bin" / "hindsight-api"
+    sibling_bin.parent.mkdir(parents=True)
     sibling_bin.touch()
 
     manager = DaemonEmbedManager()
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(fake_module))
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(venv_scripts))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
 
     assert manager._find_api_command() == [str(sibling_bin)]
 
 
-def test_find_api_command_falls_back_to_uvx_when_no_binary(tmp_path, monkeypatch):
-    """Without an installed binary or dev checkout, fall back to uvx."""
-    scripts_dir = tmp_path / "bin"
-    scripts_dir.mkdir()
-    # No hindsight-api binary in scripts_dir
+def test_find_api_command_falls_back_to_uvx_when_no_sibling_binary(tmp_path, monkeypatch):
+    """Without a sibling binary or dev checkout, fall back to uvx."""
+    package_root = tmp_path / "site-packages" / "hindsight_embed"
+    package_root.mkdir(parents=True)
+    fake_module = package_root / "daemon_embed_manager.py"
+    fake_module.write_text("")
 
     manager = DaemonEmbedManager()
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"))
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(fake_module))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
     monkeypatch.setenv("HINDSIGHT_EMBED_API_VERSION", "1.2.3")
 
@@ -174,16 +148,17 @@ def test_find_api_command_falls_back_to_uvx_when_no_binary(tmp_path, monkeypatch
 
 
 def test_find_api_command_windows_uses_exe_suffix(tmp_path, monkeypatch):
-    """On Windows, the installed binary has a .exe suffix."""
-    scripts_dir = tmp_path / "Scripts"
-    scripts_dir.mkdir()
-    api_binary = scripts_dir / "hindsight-api.exe"
-    api_binary.touch()
+    """On Windows, the sibling binary has a .exe suffix."""
+    package_root = tmp_path / "site-packages" / "hindsight_embed"
+    package_root.mkdir(parents=True)
+    fake_module = package_root / "daemon_embed_manager.py"
+    fake_module.write_text("")
+    sibling_bin = tmp_path / "site-packages" / "Scripts" / "hindsight-api.exe"
+    sibling_bin.parent.mkdir(parents=True)
+    sibling_bin.touch()
 
     manager = DaemonEmbedManager()
-    # Point __file__ away from monorepo so dev-mode check doesn't trigger
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"))
-    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(fake_module))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
 
-    assert manager._find_api_command() == [str(api_binary)]
+    assert manager._find_api_command() == [str(sibling_bin)]

--- a/hindsight-tools/self-driving-agents/hermes-plugin/__init__.py
+++ b/hindsight-tools/self-driving-agents/hermes-plugin/__init__.py
@@ -1,0 +1,355 @@
+"""Self-driving agents Hindsight plugin for Hermes.
+
+Registers agent_knowledge_* tools as a regular plugin (not a memory provider),
+so it coexists with the bundled hindsight memory provider or any other provider.
+
+Config read from ~/.self-driving-agents/hermes/<agent>/config.json:
+  { "api_url": "...", "api_token": "...", "bank_id": "..." }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+PAGE_DEFAULTS = {
+    "mode": "delta",
+    "refresh_after_consolidation": True,
+    "exclude_mental_models": True,
+    "fact_types": ["observation"],
+}
+
+
+def _get_hermes_home() -> Path:
+    """Get the active HERMES_HOME (respects profile isolation)."""
+    env = os.environ.get("HERMES_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".hermes"
+
+
+def _load_config() -> dict | None:
+    """Load Hindsight config from the active Hermes profile.
+
+    Reads the same config.json the bundled hindsight provider uses,
+    so both share the same bank, API URL, and credentials.
+    """
+    cfg_path = _get_hermes_home() / "hindsight" / "config.json"
+    if not cfg_path.exists():
+        return None
+    try:
+        cfg = json.loads(cfg_path.read_text())
+        # Normalize field names (bundled provider uses api_url/api_key,
+        # we expose as api_url/api_token for consistency with other harnesses)
+        return {
+            "api_url": cfg.get("api_url", ""),
+            "api_token": cfg.get("api_key", ""),
+            "bank_id": cfg.get("bank_id", "hermes"),
+        }
+    except Exception:
+        return None
+
+
+def _api(
+    api_url: str,
+    path: str,
+    method: str = "GET",
+    body: dict | None = None,
+    token: str | None = None,
+    timeout: float = 30.0,
+) -> Any:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = httpx.request(
+        method,
+        f"{api_url}{path}",
+        json=body,
+        headers=headers,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp.json() if resp.content else {}
+
+
+def _is_available() -> bool:
+    return _load_config() is not None
+
+
+# ── Tool handlers ───────────────────────────────────────
+
+
+def _handle_list_pages(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        result = _api(api_url, f"/v1/default/banks/{bank_id}/mental-models?detail=metadata", "GET", token=token)
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_get_page(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        result = _api(api_url, f"/v1/default/banks/{bank_id}/mental-models/{args['page_id']}", "GET", token=token)
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_create_page(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        result = _api(
+            api_url,
+            f"/v1/default/banks/{bank_id}/mental-models",
+            "POST",
+            body={
+                "id": args["page_id"],
+                "name": args["name"],
+                "source_query": args["source_query"],
+                "max_tokens": 4096,
+                "trigger": PAGE_DEFAULTS,
+            },
+            token=token,
+        )
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_update_page(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        body: dict[str, str] = {}
+        if args.get("name"):
+            body["name"] = args["name"]
+        if args.get("source_query"):
+            body["source_query"] = args["source_query"]
+        result = _api(api_url, f"/v1/default/banks/{bank_id}/mental-models/{args['page_id']}", "PATCH", body=body, token=token)
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_delete_page(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        _api(api_url, f"/v1/default/banks/{bank_id}/mental-models/{args['page_id']}", "DELETE", token=token)
+        return json.dumps({"success": True})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_recall(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        result = _api(
+            api_url,
+            f"/v1/default/banks/{bank_id}/memories/recall",
+            "POST",
+            body={"query": args["query"], "max_results": args.get("max_results", 10)},
+            token=token,
+        )
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def _handle_ingest(args: dict, **kwargs: Any) -> str:
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "Plugin not configured"})
+    api_url = config["api_url"].rstrip("/")
+    token = config.get("api_token")
+    bank_id = config["bank_id"]
+    try:
+        doc_id = args["title"].lower().replace(" ", "-")
+        result = _api(
+            api_url,
+            f"/v1/default/banks/{bank_id}/memories",
+            "POST",
+            body={"items": [{"content": args["content"], "document_id": doc_id}], "async": True},
+            token=token,
+        )
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+# ── Tool schemas ────────────────────────────────────────
+
+_TOOLS = [
+    (
+        "agent_knowledge_list_pages",
+        {
+            "name": "agent_knowledge_list_pages",
+            "description": "List all your knowledge pages (IDs and names only). Use agent_knowledge_get_page to read the full content of a specific page.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        _handle_list_pages,
+        "📚",
+    ),
+    (
+        "agent_knowledge_get_page",
+        {
+            "name": "agent_knowledge_get_page",
+            "description": "Read a specific knowledge page by its ID. Returns the full synthesized content.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_id": {"type": "string", "description": "Page ID (e.g. 'user-preferences')"},
+                },
+                "required": ["page_id"],
+            },
+        },
+        _handle_get_page,
+        "📖",
+    ),
+    (
+        "agent_knowledge_create_page",
+        {
+            "name": "agent_knowledge_create_page",
+            "description": (
+                "Create a new knowledge page. The source_query is a question the system "
+                "re-asks after each consolidation to rebuild the page from conversation observations."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_id": {"type": "string", "description": "Unique page ID, lowercase with hyphens"},
+                    "name": {"type": "string", "description": "Human-readable page name"},
+                    "source_query": {"type": "string", "description": "The question that rebuilds this page"},
+                },
+                "required": ["page_id", "name", "source_query"],
+            },
+        },
+        _handle_create_page,
+        "📝",
+    ),
+    (
+        "agent_knowledge_update_page",
+        {
+            "name": "agent_knowledge_update_page",
+            "description": "Update a page's name or source query. Content re-synthesizes on next consolidation.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_id": {"type": "string", "description": "Page ID to update"},
+                    "name": {"type": "string", "description": "New name (optional)"},
+                    "source_query": {"type": "string", "description": "New source query (optional)"},
+                },
+                "required": ["page_id"],
+            },
+        },
+        _handle_update_page,
+        "✏️",
+    ),
+    (
+        "agent_knowledge_delete_page",
+        {
+            "name": "agent_knowledge_delete_page",
+            "description": "Permanently delete a knowledge page.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_id": {"type": "string", "description": "Page ID to delete"},
+                },
+                "required": ["page_id"],
+            },
+        },
+        _handle_delete_page,
+        "🗑️",
+    ),
+    (
+        "agent_knowledge_recall",
+        {
+            "name": "agent_knowledge_recall",
+            "description": "Search across all retained conversations and documents for specific facts, numbers, or details not covered by your knowledge pages.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "What to search for"},
+                    "max_results": {"type": "number", "description": "Max results (default 10)"},
+                },
+                "required": ["query"],
+            },
+        },
+        _handle_recall,
+        "🔍",
+    ),
+    (
+        "agent_knowledge_ingest",
+        {
+            "name": "agent_knowledge_ingest",
+            "description": (
+                "Upload a document into your memory bank. Pass the full raw content — "
+                "never summarize before ingesting. The title becomes the document ID."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Document title (becomes the document ID)"},
+                    "content": {"type": "string", "description": "Full raw document content"},
+                },
+                "required": ["title", "content"],
+            },
+        },
+        _handle_ingest,
+        "📥",
+    ),
+]
+
+
+# ── Registration ────────────────────────────────────────
+
+
+def register(ctx: Any) -> None:
+    """Register agent_knowledge_* tools. Called once by the Hermes plugin loader."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="hindsight-sda",
+            schema=schema,
+            handler=handler,
+            check_fn=_is_available,
+            emoji=emoji,
+        )
+    logger.info("[hindsight-sda] registered %d tools", len(_TOOLS))

--- a/hindsight-tools/self-driving-agents/hermes-plugin/plugin.yaml
+++ b/hindsight-tools/self-driving-agents/hermes-plugin/plugin.yaml
@@ -1,0 +1,7 @@
+name: hindsight-sda
+version: 0.1.0
+description: "Self-driving agents knowledge tools powered by Hindsight. Provides agent_knowledge_* tools for managing knowledge pages, recall, and ingestion."
+kind: standalone
+pip_dependencies:
+  - "httpx>=0.27"
+requires_env: []

--- a/hindsight-tools/self-driving-agents/package.json
+++ b/hindsight-tools/self-driving-agents/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "dist",
-    "skill"
+    "skill",
+    "hermes-plugin"
   ],
   "scripts": {
     "build": "tsc",

--- a/hindsight-tools/self-driving-agents/src/cli.ts
+++ b/hindsight-tools/self-driving-agents/src/cli.ts
@@ -452,199 +452,127 @@ async function ensureNemoClawPlugin(sandboxName: string, agentId: string): Promi
   }
 }
 
-// ── Claude (Chat/Cowork) skill generation ─────────────
+// ── Hermes plugin management ───────────────────────────
 
-const CLAUDE_SKILLS_DIR = join(homedir(), "self-driving-agents", "claude");
-
-async function generateClaudeSkill(
+function ensureHermesPlugin(
   agentId: string,
   apiUrl: string,
   bankId: string,
-  apiToken?: string,
-): Promise<string> {
-  const skillDir = join(CLAUDE_SKILLS_DIR, agentId);
-  mkdirSync(skillDir, { recursive: true });
+  apiToken?: string
+): void {
+  // Check hermes is installed
+  try {
+    execSync("which hermes", { stdio: "pipe" });
+  } catch {
+    p.cancel(
+      "hermes not found. Install it: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+    );
+    process.exit(1);
+  }
 
-  // Auth header snippet — baked into curl commands
-  const authHeader = apiToken
-    ? `-H "Authorization: Bearer ${apiToken}"`
-    : "";
+  // Create a Hermes profile for this agent (or reuse if exists)
+  let profileHome: string;
+  try {
+    const showOut = execSync(`hermes profile show ${agentId}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const pathMatch = showOut.match(/Path:\s+(\S+)/);
+    profileHome = pathMatch ? pathMatch[1] : join(homedir(), ".hermes", "profiles", agentId);
+    p.log.info(`Hermes profile '${agentId}' already exists`);
+  } catch {
+    // Profile doesn't exist — create it (clone config from default)
+    try {
+      execSync(`hermes profile create ${agentId} --clone`, {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const showOut = execSync(`hermes profile show ${agentId}`, {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const pathMatch = showOut.match(/Path:\s+(\S+)/);
+      profileHome = pathMatch ? pathMatch[1] : join(homedir(), ".hermes", "profiles", agentId);
+      p.log.success(`Hermes profile '${agentId}' created`);
+    } catch (err: any) {
+      const msg = err?.stderr?.toString?.()?.trim() || err?.message || String(err);
+      p.cancel(`Failed to create Hermes profile: ${msg}`);
+      process.exit(1);
+    }
+  }
+
+  // Install plugin into the profile
+  const pluginDir = join(profileHome, "plugins", "hindsight-sda");
+  const sdaPluginSrc = join(__dirname, "..", "hermes-plugin");
+  mkdirSync(pluginDir, { recursive: true });
+  for (const file of ["plugin.yaml", "__init__.py"]) {
+    const src = join(sdaPluginSrc, file);
+    if (existsSync(src)) {
+      writeFileSync(join(pluginDir, file), readFileSync(src, "utf-8"));
+    }
+  }
+  p.log.success("Hermes plugin installed");
+
+  // Write hindsight/config.json in the profile — single source of truth for
+  // both the bundled hindsight provider (auto-retain) and our tool plugin.
+  // Static bank_id, no template — both read the same bank.
+  const hindsightCfgDir = join(profileHome, "hindsight");
+  mkdirSync(hindsightCfgDir, { recursive: true });
   writeFileSync(
-    join(skillDir, "SKILL.md"),
-    `---
-name: ${agentId}
-description: Activate the ${agentId} agent. Loads knowledge pages from Hindsight memory.
----
-
-# ${agentId}
-
-You are the **${agentId}** agent with long-term memory powered by Hindsight.
-
-## Startup — run these steps immediately
-
-1. List your knowledge pages and read each one:
-
-\`\`\`bash
-curl -s ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models?detail=metadata"
-\`\`\`
-
-2. For each page, read its content:
-
-\`\`\`bash
-curl -s ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models/PAGE_ID?detail=full"
-\`\`\`
-
-3. Use the knowledge from your pages to inform this conversation.
-
-## Creating pages
-
-When you learn something durable — a user preference, a working procedure, performance data — create a page:
-
-\`\`\`bash
-curl -s -X POST ${authHeader} -H "Content-Type: application/json" \\
-  "${apiUrl}/v1/default/banks/${bankId}/mental-models" \\
-  -d '{
-    "id": "PAGE_ID",
-    "name": "Page Name",
-    "source_query": "Question that rebuilds this page from observations",
-    "max_tokens": 4096,
-    "trigger": {"mode": "delta", "refresh_after_consolidation": true, "fact_types": ["observation"], "exclude_mental_models": true}
-  }'
-\`\`\`
-
-## Searching memories
-
-\`\`\`bash
-curl -s -X POST ${authHeader} -H "Content-Type: application/json" \\
-  "${apiUrl}/v1/default/banks/${bankId}/memories/recall" \\
-  -d '{"query": "SEARCH_QUERY", "max_tokens": 1024, "budget": "mid"}'
-\`\`\`
-
-## Ingesting documents
-
-\`\`\`bash
-curl -s -X POST ${authHeader} -H "Content-Type: application/json" \\
-  "${apiUrl}/v1/default/banks/${bankId}/memories" \\
-  -d '{"items": [{"content": "FULL_CONTENT", "document_id": "DOC_ID"}], "async": true}'
-\`\`\`
-
-## Updating and deleting pages
-
-\`\`\`bash
-# Update
-curl -s -X PATCH ${authHeader} -H "Content-Type: application/json" \\
-  "${apiUrl}/v1/default/banks/${bankId}/mental-models/PAGE_ID" \\
-  -d '{"name": "New Name", "source_query": "New query"}'
-
-# Delete
-curl -s -X DELETE ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models/PAGE_ID"
-\`\`\`
-
-## Retaining conversations
-
-There are no automatic hooks in this environment. You MUST retain important information yourself as the conversation happens. Whenever the user:
-
-- States a preference or opinion
-- Gives you feedback on your work
-- Shares data, metrics, or results
-- Makes a decision or changes direction
-- Teaches you something about their workflow
-
-Immediately retain it — don't wait for the end of the conversation:
-
-\`\`\`bash
-curl -s -X POST ${authHeader} -H "Content-Type: application/json" \\
-  "${apiUrl}/v1/default/banks/${bankId}/memories" \\
-  -d '{"items": [{"content": "CONVERSATION_CONTENT_HERE", "document_id": "SESSION_TIMESTAMP"}], "async": true}'
-\`\`\`
-
-Use the full relevant context (user message + your response) as the content. Use a descriptive document_id like \`conversation-2026-05-04-seo-audit\`. Do this silently — don't announce it to the user.
-
-## Important
-
-- Pages update automatically — don't edit content directly
-- Create pages silently — don't announce it to the user
-- Retain user feedback and preferences immediately — don't wait
-- Prefer fewer broad pages over many narrow ones
-`
+    join(hindsightCfgDir, "config.json"),
+    JSON.stringify(
+      {
+        mode: "cloud",
+        api_url: apiUrl,
+        api_key: apiToken,
+        bank_id: bankId,
+        bank_id_template: "",
+        recall_budget: "mid",
+        memory_mode: "hybrid",
+      },
+      null,
+      2
+    ) + "\n"
   );
 
-  // Zip the skill for upload — zip must contain agentId/SKILL.md (directory name = skill name)
-  const zipPath = join(CLAUDE_SKILLS_DIR, `${agentId}.zip`);
-  try {
-    execSync(`cd ${JSON.stringify(join(skillDir, ".."))} && zip -r ${JSON.stringify(zipPath)} ${JSON.stringify(agentId)}`, {
-      stdio: "pipe",
-    });
-    p.log.success(`Skill ready: ${color.dim(zipPath)}`);
-  } catch (err: any) {
-    p.log.warn(`Failed to create zip — upload the folder directly: ${skillDir}`);
+  // Set the bundled hindsight as memory provider + enable our plugin in config.yaml
+  const hermesConfigPath = join(profileHome, "config.yaml");
+  if (existsSync(hermesConfigPath)) {
+    let config = readFileSync(hermesConfigPath, "utf-8");
+
+    // Set memory.provider to hindsight (bundled provider for auto-retain)
+    const lines = config.split("\n");
+    let inMemory = false;
+    for (let i = 0; i < lines.length; i++) {
+      if (/^memory:/.test(lines[i])) inMemory = true;
+      else if (/^\S/.test(lines[i]) && inMemory) inMemory = false;
+      if (inMemory && /^\s+provider:\s/.test(lines[i])) {
+        lines[i] = lines[i].replace(/provider:\s*\S+/, "provider: hindsight");
+        break;
+      }
+    }
+    config = lines.join("\n");
+
+    // Enable our tool plugin in plugins.enabled
+    if (!config.includes("hindsight-sda")) {
+      if (/plugins:\s*\n\s+enabled:/.test(config)) {
+        config = config.replace(/(plugins:\s*\n\s+enabled:\s*\n)/, "$1    - hindsight-sda\n");
+      } else if (/plugins:/.test(config)) {
+        config = config.replace(/(plugins:)/, "$1\n  enabled:\n    - hindsight-sda");
+      } else {
+        config += "\nplugins:\n  enabled:\n    - hindsight-sda\n";
+      }
+    }
+
+    writeFileSync(hermesConfigPath, config);
   }
+  p.log.success("Hindsight memory + knowledge tools configured");
 
-  return zipPath;
-}
-
-// ── Cowork config prompt ──────────────────────────────
-
-const HINDSIGHT_CLOUD_API_URL = "https://api.hindsight.vectorize.io";
-
-async function promptClaudeConfig(agentId: string): Promise<{ apiUrl: string; bankId: string; apiToken?: string }> {
-  const mode = await p.select({
-    message: "Where is your Hindsight server?",
-    options: [
-      { value: "cloud", label: "Hindsight Cloud", hint: "api.hindsight.vectorize.io" },
-      { value: "self-hosted", label: "Self-hosted", hint: "Your own server URL" },
-    ],
-  });
-  if (p.isCancel(mode)) { p.cancel("Cancelled."); process.exit(0); }
-
-  let apiUrl: string;
-  if (mode === "cloud") {
-    apiUrl = HINDSIGHT_CLOUD_API_URL;
-  } else {
-    p.log.warn(
-      `Self-hosted servers must be reachable from Anthropic's cloud infrastructure.\n` +
-      `  Claude Chat/Cowork connects from Anthropic's servers, not your local machine.\n` +
-      `  Using API authentication is highly recommended.`
-    );
-    const url = await p.text({
-      message: "Hindsight API URL (must be publicly accessible):",
-      placeholder: "https://your-hindsight-server.com",
-      validate: (v: string | undefined) => {
-        if (!v) return "URL required";
-        try {
-          const parsed = new URL(v);
-          if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-            return "Claude connects from Anthropic's cloud — localhost won't work. Use a public URL.";
-          }
-        } catch {
-          return "Invalid URL";
-        }
-      },
-    });
-    if (p.isCancel(url)) { p.cancel("Cancelled."); process.exit(0); }
-    apiUrl = (url as string).replace(/\/+$/, "");
-  }
-
-  const token = await p.text({
-    message: "API token:",
-    placeholder: "your-api-token",
-    validate: (v: string | undefined) => {
-      if (!v) return "API token is required";
-    },
-  });
-  if (p.isCancel(token)) { p.cancel("Cancelled."); process.exit(0); }
-
-  const bank = await p.text({
-    message: "Bank ID:",
-    initialValue: agentId,
-  });
-  if (p.isCancel(bank)) { p.cancel("Cancelled."); process.exit(0); }
-
-  return {
-    apiUrl,
-    bankId: (bank as string) || agentId,
-    apiToken: (token as string) || undefined,
-  };
+  // Install skill into the profile
+  const skillDir = join(profileHome, "skills", "agent-knowledge");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), SKILL_MD);
+  p.log.success("Knowledge skill installed");
 }
 
 // ── Main ────────────────────────────────────────────────
@@ -665,7 +593,7 @@ async function main() {
     ${color.cyan("./local-dir")}                 → local directory
 
   ${color.dim("Options:")}
-    ${color.cyan("--harness <h>")}      Required. openclaw | nemoclaw | claude
+    ${color.cyan("--harness <h>")}      Required. openclaw | nemoclaw | hermes
     ${color.cyan("--agent <name>")}     Agent name (defaults to directory name)
     ${color.cyan("--sandbox <name>")}   NemoClaw sandbox (auto-detected if only one exists)
 `);
@@ -683,6 +611,7 @@ async function main() {
   let harness: string | undefined;
   let agentName: string | undefined;
   let sandbox: string | undefined;
+
   for (let i = 0; i < restArgs.length; i++) {
     if (restArgs[i] === "--harness" && restArgs[i + 1]) harness = restArgs[++i];
     else if (restArgs[i] === "--agent" && restArgs[i + 1]) agentName = restArgs[++i];
@@ -690,13 +619,7 @@ async function main() {
   }
 
   if (!harness) {
-    p.cancel("--harness required (openclaw | nemoclaw | claude)");
-    process.exit(1);
-  }
-
-  const SUPPORTED_HARNESSES = ["openclaw", "nemoclaw", "claude"];
-  if (!SUPPORTED_HARNESSES.includes(harness)) {
-    p.cancel(`Unknown harness: "${harness}". Supported: ${SUPPORTED_HARNESSES.join(", ")}`);
+    p.cancel("--harness required (openclaw | nemoclaw)");
     process.exit(1);
   }
 
@@ -711,10 +634,24 @@ async function main() {
   const { dir, source, defaultName, cleanup } = await resolveAgentDir(dirArg, spin);
 
   try {
-    const agentId = agentName || defaultName;
-    let claudeSkillZip: string | undefined;
+    let agentId: string;
+    if (agentName) {
+      agentId = agentName;
+    } else if (process.stdin.isTTY) {
+      const nameInput = await p.text({
+        message: "Agent name:",
+        initialValue: defaultName,
+      });
+      if (p.isCancel(nameInput)) {
+        p.cancel("Cancelled.");
+        process.exit(0);
+      }
+      agentId = (nameInput as string).trim() || defaultName;
+    } else {
+      agentId = defaultName;
+    }
 
-    // Step 1: Ensure plugin + resolve bank/API
+    // Step 1: Ensure plugin
     let apiUrl: string;
     let bankId: string;
     let apiToken: string | undefined;
@@ -726,14 +663,80 @@ async function main() {
     } else if (harness === "nemoclaw") {
       await ensureNemoClawPlugin(sandbox!, agentId);
       ({ apiUrl, bankId, apiToken } = resolveFromPlugin(agentId));
-    } else if (harness === "claude") {
-      // Cowork: prompt for connection details (Cowork runs in a sandbox, localhost won't work)
-      const coworkConfig = await promptClaudeConfig(agentId);
-      apiUrl = coworkConfig.apiUrl;
-      bankId = coworkConfig.bankId;
-      apiToken = coworkConfig.apiToken;
+    } else if (harness === "hermes") {
+      // Resolve Hindsight connection: hermes config > openclaw config > prompt
+      const hermesHsCfgPath = join(homedir(), ".hermes", "hindsight", "config.json");
+      let defaultUrl = "https://api.hindsight.vectorize.io";
+      let defaultToken = "";
+
+      // Check existing hermes hindsight config first
+      if (existsSync(hermesHsCfgPath)) {
+        try {
+          const hsCfg = JSON.parse(readFileSync(hermesHsCfgPath, "utf-8"));
+          if (hsCfg.api_url) defaultUrl = hsCfg.api_url;
+          if (hsCfg.api_key) defaultToken = hsCfg.api_key;
+        } catch {
+          /* ignore */
+        }
+      }
+
+      // Fall back to openclaw config
+      if (!defaultToken) {
+        const config = readOpenClawConfig();
+        const pc = config?.plugins?.entries?.["hindsight-openclaw"]?.config;
+        if (pc?.hindsightApiUrl) defaultUrl = pc.hindsightApiUrl;
+        if (pc?.hindsightApiToken) defaultToken = pc.hindsightApiToken;
+      }
+
+      // If we have credentials, confirm; otherwise prompt
+      if (defaultUrl && defaultToken) {
+        const ok = await p.confirm({
+          message: `Hindsight: ${color.cyan(defaultUrl)}. Use this?`,
+        });
+        if (p.isCancel(ok)) {
+          p.cancel("Cancelled.");
+          process.exit(0);
+        }
+        if (ok) {
+          apiUrl = defaultUrl;
+          apiToken = defaultToken;
+        } else {
+          const urlInput = await p.text({
+            message: "Hindsight API URL:",
+            initialValue: defaultUrl,
+          });
+          if (p.isCancel(urlInput)) {
+            p.cancel("Cancelled.");
+            process.exit(0);
+          }
+          const tokenInput = await p.text({ message: "Hindsight API token:" });
+          if (p.isCancel(tokenInput)) {
+            p.cancel("Cancelled.");
+            process.exit(0);
+          }
+          apiUrl = urlInput as string;
+          apiToken = tokenInput as string;
+        }
+      } else {
+        const urlInput = await p.text({ message: "Hindsight API URL:", initialValue: defaultUrl });
+        if (p.isCancel(urlInput)) {
+          p.cancel("Cancelled.");
+          process.exit(0);
+        }
+        const tokenInput = await p.text({ message: "Hindsight API token:" });
+        if (p.isCancel(tokenInput)) {
+          p.cancel("Cancelled.");
+          process.exit(0);
+        }
+        apiUrl = urlInput as string;
+        apiToken = tokenInput as string;
+      }
+
+      bankId = agentId;
+      ensureHermesPlugin(agentId, apiUrl, bankId, apiToken);
     } else {
-      throw new Error(`Unknown harness: ${harness}`);
+      p.cancel(`Unknown harness: ${harness}`);
+      process.exit(1);
     }
 
     const workspaceDir = join(homedir(), ".self-driving-agents", harness, agentId);
@@ -802,10 +805,9 @@ async function main() {
       spin.stop(`Ingested ${contentFiles.length} file(s)`);
     }
 
-    // Step 6: Create agent + install skill
-    if (harness === "claude") {
-      // Claude: generate per-agent skill with API/bank baked in
-      claudeSkillZip = await generateClaudeSkill(agentId, apiUrl, bankId, apiToken);
+    // Step 6: Create agent + install skill (hermes handled in ensureHermesPlugin)
+    if (harness === "hermes") {
+      // Skill + plugin already installed by ensureHermesPlugin
     } else if (harness === "nemoclaw") {
       // NemoClaw: install skill into the sandbox via nemoclaw CLI
       const tmpSkillDir = join(tmpdir(), `sda-skill-${Date.now()}`);
@@ -873,14 +875,8 @@ async function main() {
 
     // Next steps
     let nextSteps: string[];
-    if (harness === "claude") {
-      const apiHost = new URL(apiUrl).hostname;
-      nextSteps = [
-        `${color.dim("1.")} Open Claude → Customize → Skills → Upload skill`,
-        `${color.dim("2.")} Select: ${color.cyan(claudeSkillZip!)}`,
-        `${color.dim("3.")} Allowlist the API host: Settings → Capabilities → add ${color.cyan(apiHost)}`,
-        `${color.dim("4.")} Start a conversation and type ${color.cyan(`/${agentId}`)} to activate the agent`,
-      ];
+    if (harness === "hermes") {
+      nextSteps = [`${color.dim("1.")} hermes -p ${agentId} chat`];
     } else if (harness === "nemoclaw") {
       nextSteps = [
         `${color.dim("1.")} nemoclaw ${sandbox} connect`,

--- a/hindsight-tools/self-driving-agents/tests/cli.test.ts
+++ b/hindsight-tools/self-driving-agents/tests/cli.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync, rmSync } from "fs";
-import { execSync } from "child_process";
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "fs";
 import { extname, relative, basename } from "path";
 
 // ── Extracted helpers (mirroring cli.ts logic for unit testing) ──
@@ -380,219 +379,92 @@ describe("harness argument parsing", () => {
     expect(sandbox).toBeUndefined();
   });
 
-  it("parses claude harness", () => {
-    const { harness } = parseHarness(["--harness", "claude"]);
-    expect(harness).toBe("claude");
+  it("parses hermes harness", () => {
+    const { harness } = parseHarness(["--harness", "hermes"]);
+    expect(harness).toBe("hermes");
   });
 });
 
-// ── Claude skill generation (mirroring generateClaudeSkill logic) ──
-
-function generateSkillMd(
-  agentId: string,
-  apiUrl: string,
-  bankId: string,
-  apiToken?: string
-): string {
-  const authHeader = apiToken ? `-H "Authorization: Bearer ${apiToken}"` : "";
-  return `---
-name: ${agentId}
-description: Activate the ${agentId} agent. Loads knowledge pages from Hindsight memory.
----
-
-# ${agentId}
-
-You are the **${agentId}** agent with long-term memory powered by Hindsight.
-
-## Startup — run these steps immediately
-
-1. List your knowledge pages and read each one:
-
-\`\`\`bash
-curl -s ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models?detail=metadata"
-\`\`\`
-`.trim();
-}
-
-describe("generateClaudeSkill", () => {
+describe("hermes hindsight config", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), "sda-claude-test-"));
+    tmpDir = await mkdtemp(join(tmpdir(), "sda-hermes-test-"));
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("generates SKILL.md with correct frontmatter", () => {
-    const md = generateSkillMd("marketing-seo", "https://api.example.com", "marketing-seo", "tok-123");
+  it("generates correct hindsight/config.json", async () => {
+    const hindsightDir = join(tmpDir, "hindsight");
+    await mkdir(hindsightDir, { recursive: true });
+    const cfg = {
+      mode: "cloud",
+      api_url: "https://api.hindsight.vectorize.io",
+      api_key: "hsk_test",
+      bank_id: "marketing-seo",
+      bank_id_template: "",
+      recall_budget: "mid",
+      memory_mode: "hybrid",
+    };
+    await writeFile(join(hindsightDir, "config.json"), JSON.stringify(cfg));
 
-    // Required frontmatter fields
-    expect(md).toContain("name: marketing-seo");
-    expect(md).toContain("description: Activate the marketing-seo agent");
-
-    // Starts with frontmatter
-    expect(md.startsWith("---")).toBe(true);
+    const loaded = JSON.parse(readFileSync(join(hindsightDir, "config.json"), "utf-8"));
+    expect(loaded.bank_id).toBe("marketing-seo");
+    expect(loaded.bank_id_template).toBe("");
+    expect(loaded.api_url).toBe("https://api.hindsight.vectorize.io");
+    expect(loaded.api_key).toBe("hsk_test");
+    expect(loaded.mode).toBe("cloud");
   });
 
-  it("bakes API URL and bank ID into curl commands", () => {
-    const md = generateSkillMd("my-agent", "https://api.hindsight.vectorize.io", "my-bank");
+  it("empty bank_id_template prevents dynamic resolution", () => {
+    // Mirrors _resolve_bank_id_template logic: empty template → use fallback
+    function resolveTemplate(template: string, fallback: string): string {
+      if (!template) return fallback;
+      return template; // simplified — real impl does placeholder substitution
+    }
 
-    expect(md).toContain("https://api.hindsight.vectorize.io/v1/default/banks/my-bank/mental-models");
+    expect(resolveTemplate("", "marketing-seo")).toBe("marketing-seo");
+    expect(resolveTemplate("hermes-{profile}", "fallback")).toBe("hermes-{profile}");
   });
 
-  it("bakes auth token into curl commands when provided", () => {
-    const md = generateSkillMd("my-agent", "https://api.example.com", "bank", "secret-token");
+  it("plugin config is read from hindsight/config.json", async () => {
+    // Simulates what the hermes plugin does: read from HERMES_HOME/hindsight/config.json
+    const hindsightDir = join(tmpDir, "hindsight");
+    await mkdir(hindsightDir, { recursive: true });
+    const cfg = {
+      mode: "cloud",
+      api_url: "https://custom.api.com",
+      api_key: "hsk_custom",
+      bank_id: "my-agent",
+    };
+    await writeFile(join(hindsightDir, "config.json"), JSON.stringify(cfg));
 
-    expect(md).toContain('-H "Authorization: Bearer secret-token"');
-  });
-
-  it("omits auth header when no token", () => {
-    const md = generateSkillMd("my-agent", "https://api.example.com", "bank");
-
-    expect(md).not.toContain("Authorization");
-  });
-
-  it("uses agent ID as skill name", () => {
-    const md = generateSkillMd("seo-writer", "https://api.example.com", "bank");
-
-    expect(md).toContain("name: seo-writer");
-    expect(md).toContain("# seo-writer");
-  });
-
-  it("generates valid zip structure with directory wrapping", () => {
-    const agentId = "test-agent";
-    const skillDir = join(tmpDir, agentId);
-    mkdirSync(skillDir, { recursive: true });
-    writeFileSync(join(skillDir, "SKILL.md"), generateSkillMd(agentId, "https://api.example.com", "bank"));
-
-    // Zip the same way the CLI does: cd to parent, zip the directory
-    const zipPath = join(tmpDir, `${agentId}.zip`);
-    execSync(`cd ${JSON.stringify(tmpDir)} && zip -r ${JSON.stringify(zipPath)} ${JSON.stringify(agentId)}`, {
-      stdio: "pipe",
-    });
-
-    expect(existsSync(zipPath)).toBe(true);
-
-    // Verify zip contents have directory structure: test-agent/SKILL.md
-    const listing = execSync(`unzip -l ${JSON.stringify(zipPath)}`, { encoding: "utf-8" });
-    expect(listing).toContain(`${agentId}/SKILL.md`);
-    // Should NOT have SKILL.md at root
-    expect(listing).not.toMatch(/^\s+\d+.*\s+SKILL\.md$/m);
-  });
-
-  it("generates skill with list pages curl command", () => {
-    const md = generateSkillMd("my-agent", "https://api.example.com", "my-bank", "tok");
-
-    expect(md).toContain("curl -s");
-    expect(md).toContain("/mental-models?detail=metadata");
-  });
-});
-
-describe("claude skill content completeness", () => {
-  // Test against a full skill generation to verify all API operations are present
-  function generateFullSkillMd(
-    agentId: string,
-    apiUrl: string,
-    bankId: string,
-    apiToken?: string
-  ): string {
-    const authHeader = apiToken ? `-H "Authorization: Bearer ${apiToken}"` : "";
-    // This mirrors the full template from cli.ts
-    return [
-      `curl -s ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models?detail=metadata"`,
-      `curl -s ${authHeader} "${apiUrl}/v1/default/banks/${bankId}/mental-models/PAGE_ID?detail=full"`,
-      `curl -s -X POST ${authHeader}`,
-      `"${apiUrl}/v1/default/banks/${bankId}/mental-models"`,
-      `curl -s -X POST ${authHeader}`,
-      `"${apiUrl}/v1/default/banks/${bankId}/memories/recall"`,
-      `curl -s -X POST ${authHeader}`,
-      `"${apiUrl}/v1/default/banks/${bankId}/memories"`,
-      `curl -s -X PATCH ${authHeader}`,
-      `curl -s -X DELETE ${authHeader}`,
-    ].join("\n");
-  }
-
-  it("includes list pages endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("/mental-models?detail=metadata");
-  });
-
-  it("includes get page endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("/mental-models/PAGE_ID?detail=full");
-  });
-
-  it("includes create page endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("POST");
-    expect(md).toContain("/mental-models");
-  });
-
-  it("includes recall endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("/memories/recall");
-  });
-
-  it("includes retain/ingest endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("/memories");
-  });
-
-  it("includes update endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("PATCH");
-  });
-
-  it("includes delete endpoint", () => {
-    const md = generateFullSkillMd("a", "https://h.io", "b");
-    expect(md).toContain("DELETE");
-  });
-});
-
-describe("claude config validation", () => {
-  it("rejects localhost URLs", () => {
-    const validate = (v: string | undefined) => {
-      if (!v) return "URL required";
-      try {
-        const parsed = new URL(v);
-        if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-          return "Claude connects from Anthropic's cloud — localhost won't work. Use a public URL.";
-        }
-      } catch {
-        return "Invalid URL";
-      }
+    // Read it back the way the plugin does
+    const cfgPath = join(tmpDir, "hindsight", "config.json");
+    const loaded = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    const normalized = {
+      api_url: loaded.api_url || "",
+      api_token: loaded.api_key || "",
+      bank_id: loaded.bank_id || "hermes",
     };
 
-    expect(validate("http://localhost:9077")).toContain("localhost");
-    expect(validate("http://127.0.0.1:9077")).toContain("localhost");
-    expect(validate("https://api.example.com")).toBeUndefined();
-    expect(validate("")).toBe("URL required");
-    expect(validate(undefined)).toBe("URL required");
-    expect(validate("not-a-url")).toBe("Invalid URL");
+    expect(normalized.api_url).toBe("https://custom.api.com");
+    expect(normalized.api_token).toBe("hsk_custom");
+    expect(normalized.bank_id).toBe("my-agent");
   });
 
-  it("cloud URL is the correct constant", () => {
-    const HINDSIGHT_CLOUD_API_URL = "https://api.hindsight.vectorize.io";
-    expect(HINDSIGHT_CLOUD_API_URL).toMatch(/^https:\/\//);
-    expect(HINDSIGHT_CLOUD_API_URL).not.toContain("localhost");
-  });
-});
+  it("falls back to default bank_id when not set", async () => {
+    const hindsightDir = join(tmpDir, "hindsight");
+    await mkdir(hindsightDir, { recursive: true });
+    await writeFile(
+      join(hindsightDir, "config.json"),
+      JSON.stringify({ mode: "cloud", api_url: "https://api.example.com", api_key: "tok" })
+    );
 
-describe("harness validation", () => {
-  const SUPPORTED_HARNESSES = ["openclaw", "nemoclaw", "claude"];
-
-  it("accepts all supported harnesses", () => {
-    for (const h of SUPPORTED_HARNESSES) {
-      expect(SUPPORTED_HARNESSES.includes(h)).toBe(true);
-    }
-  });
-
-  it("rejects unknown harnesses", () => {
-    expect(SUPPORTED_HARNESSES.includes("chatgpt")).toBe(false);
-    expect(SUPPORTED_HARNESSES.includes("claude-code")).toBe(false);
-    expect(SUPPORTED_HARNESSES.includes("claude-cowork")).toBe(false);
-    expect(SUPPORTED_HARNESSES.includes("")).toBe(false);
+    const loaded = JSON.parse(readFileSync(join(hindsightDir, "config.json"), "utf-8"));
+    const bankId = loaded.bank_id || "hermes";
+    expect(bankId).toBe("hermes");
   });
 });


### PR DESCRIPTION
## Summary

- Add `--harness hermes` to the self-driving-agents CLI
- Creates a Hermes profile per agent for isolation
- Installs a standalone Python tool plugin (`hindsight-sda`) that registers 7 `agent_knowledge_*` tools
- Plugin coexists with the bundled `hindsight` memory provider — bundled handles auto-retain/recall, our plugin adds knowledge page management
- Both read from the same `hindsight/config.json` in the profile — single source of truth, same bank
- Static `bank_id` with empty `bank_id_template` prevents dynamic resolution mismatch
- Prompts for Hindsight credentials (pre-fills from existing hermes or openclaw config)
- Prompts for agent name (pre-fills from path)
- Installs skill to profile's `skills/` directory

### Architecture

```
~/.hermes/profiles/<agent>/
  plugins/hindsight-sda/     ← our tool plugin (agent_knowledge_*)
  hindsight/config.json      ← shared config (both plugins read this)
  skills/agent-knowledge/    ← SKILL.md
  config.yaml                ← memory.provider: hindsight + plugins.enabled: [hindsight-sda]
```

## Test plan

- [x] 43 unit tests pass (5 new for hermes)
- [x] `--harness hermes` creates profile, installs plugin, configures memory provider
- [x] Tools registered and visible in `hermes tools`
- [x] Knowledge tools call Hindsight API correctly
- [x] Bundled hindsight provider handles auto-retain on same bank
- [x] Existing hermes/openclaw config detected and offered for reuse