### PR TITLE
feat(pg_textsearch): add language configuration for BM25 text search …

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -268,6 +268,7 @@ async def _run_migration(
         ensure_text_search_extension(
             resolved_url,
             text_search_extension=config.text_search_extension,
+            text_search_language=config.text_search_language,
             schema=schema,
         )
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -267,6 +267,7 @@ ENV_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY = "HINDSIGHT_API_RERANKER_GOOGLE_SERVICE
 
 ENV_VECTOR_EXTENSION = "HINDSIGHT_API_VECTOR_EXTENSION"
 ENV_TEXT_SEARCH_EXTENSION = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION"
+ENV_TEXT_SEARCH_LANGUAGE = "HINDSIGHT_API_TEXT_SEARCH_LANGUAGE"
 
 ENV_HOST = "HINDSIGHT_API_HOST"
 ENV_PORT = "HINDSIGHT_API_PORT"
@@ -534,6 +535,7 @@ DEFAULT_VECTOR_EXTENSION = "pgvector"  # Options: "pgvector", "vchord", "pgvecto
 
 # Text search extension (native PostgreSQL, vchord BM25, or Timescale pg_textsearch)
 DEFAULT_TEXT_SEARCH_EXTENSION = "native"  # Options: "native", "vchord", "pg_textsearch"
+DEFAULT_TEXT_SEARCH_LANGUAGE = "english"  # Options: "english", "chinese"
 
 # LiteLLM defaults
 DEFAULT_LITELLM_API_BASE = "http://localhost:4000"
@@ -831,6 +833,7 @@ class HindsightConfig:
     database_schema: str
     vector_extension: str  # "pgvector" or "vchord"
     text_search_extension: str  # "native" or "vchord"
+    text_search_language: str  # "english" or "chinese"
 
     # LLM (default, used as fallback for per-operation config)
     llm_provider: str
@@ -1283,6 +1286,10 @@ class HindsightConfig:
                 f"Invalid text_search_extension: {self.text_search_extension}. Must be one of: {', '.join(valid_text_search)}"
             )
 
+        # Validate text_search_language (informational only — any value is accepted)
+        if not self.text_search_language:
+            raise ValueError("text_search_language must not be empty")
+
         # When LLM provider is "none", force chunks-only mode and disable LLM-dependent features
         if self.llm_provider == "none":
             self.retain_extraction_mode = "chunks"
@@ -1356,6 +1363,7 @@ class HindsightConfig:
             database_schema=os.getenv(ENV_DATABASE_SCHEMA, DEFAULT_DATABASE_SCHEMA),
             vector_extension=os.getenv(ENV_VECTOR_EXTENSION, DEFAULT_VECTOR_EXTENSION).lower(),
             text_search_extension=os.getenv(ENV_TEXT_SEARCH_EXTENSION, DEFAULT_TEXT_SEARCH_EXTENSION).lower(),
+            text_search_language=os.getenv(ENV_TEXT_SEARCH_LANGUAGE, DEFAULT_TEXT_SEARCH_LANGUAGE).lower(),
             # LLM
             llm_provider=llm_provider,
             llm_api_key=os.getenv(ENV_LLM_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1883,7 +1883,10 @@ class MemoryEngine(MemoryEngineInterface):
                         schema = tenant.schema
                         if schema:
                             ensure_text_search_extension(
-                                self.db_url, text_search_extension=config.text_search_extension, schema=schema
+                                self.db_url,
+                                text_search_extension=config.text_search_extension,
+                                text_search_language=config.text_search_language,
+                                schema=schema,
                             )
 
         logger.info(f"Connecting to database at {mask_network_location(self.db_url)}")

--- a/hindsight-api-slim/hindsight_api/extensions/context.py
+++ b/hindsight-api-slim/hindsight_api/extensions/context.py
@@ -146,7 +146,11 @@ class DefaultExtensionContext(ExtensionContext):
 
         # Ensure text search columns/indexes match the configured extension
         await asyncio.to_thread(
-            ensure_text_search_extension, db_url, text_search_extension=config.text_search_extension, text_search_language=config.text_search_language, schema=schema
+            ensure_text_search_extension,
+            db_url,
+            text_search_extension=config.text_search_extension,
+            text_search_language=config.text_search_language,
+            schema=schema,
         )
 
     def get_memory_engine(self) -> "MemoryEngineInterface":

--- a/hindsight-api-slim/hindsight_api/extensions/context.py
+++ b/hindsight-api-slim/hindsight_api/extensions/context.py
@@ -146,7 +146,7 @@ class DefaultExtensionContext(ExtensionContext):
 
         # Ensure text search columns/indexes match the configured extension
         await asyncio.to_thread(
-            ensure_text_search_extension, db_url, text_search_extension=config.text_search_extension, schema=schema
+            ensure_text_search_extension, db_url, text_search_extension=config.text_search_extension, text_search_language=config.text_search_language, schema=schema
         )
 
     def get_memory_engine(self) -> "MemoryEngineInterface":

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -106,6 +106,104 @@ def _detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
         )
 
 
+def _language_to_text_config(language: str) -> str:
+    """Map a user-friendly language name to a PostgreSQL text search config name.
+
+    Recognized shortcuts: 'english' -> 'english', 'chinese' -> 'public.zh_cn'.
+    Any other value is passed through as-is (e.g. 'german', 'french', 'simple').
+    """
+    _KNOWN_MAP: dict[str, str] = {
+        "english": "english",
+        "chinese": "public.zh_cn",
+    }
+    return _KNOWN_MAP.get(language, language)
+
+
+def _ensure_pg_textsearch_language(conn: Connection, schema_name: str, language: str) -> None:
+    """
+    Ensure the pg_textsearch BM25 index uses the correct text_config for the language.
+
+    Detects the current text_config from the index definition and rebuilds it
+    if it doesn't match the configured language.
+    """
+    target_config = _language_to_text_config(language)
+
+    # Check current text_config in the BM25 index definition
+    for table_name in ("memory_units", "reflections"):
+        index_info = conn.execute(
+            text("""
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = :schema
+                  AND tablename = :table_name
+                  AND indexname LIKE '%text_search%'
+            """),
+            {"schema": schema_name, "table_name": table_name},
+        ).fetchone()
+
+        if not index_info:
+            continue
+
+        indexdef = index_info[0]
+
+        # Check if the index already uses the target text_config
+        if f"text_config={target_config}" in indexdef or f"text_config='{target_config}'" in indexdef:
+            logger.debug(f"BM25 index on {table_name} already uses text_config={target_config}")
+            continue
+
+        logger.info(
+            f"BM25 index text_config mismatch on {table_name}: "
+            f"target={target_config}, recreating index"
+        )
+
+        # Rebuild zhparser config if Chinese
+        if language == "chinese":
+            try:
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS zhparser"))
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                ext_exists = conn.execute(
+                    text("SELECT 1 FROM pg_extension WHERE extname = 'zhparser'")
+                ).fetchone()
+                if not ext_exists:
+                    raise RuntimeError(
+                        "zhparser extension is required for Chinese text search but could not be installed. "
+                        "Ensure zhparser is available in your PostgreSQL installation."
+                    )
+
+            # CREATE TEXT SEARCH CONFIGURATION doesn't support IF NOT EXISTS
+            config_exists = conn.execute(
+                text("SELECT 1 FROM pg_ts_config WHERE cfgname = 'zh_cn'")
+            ).fetchone()
+            if not config_exists:
+                conn.execute(text("CREATE TEXT SEARCH CONFIGURATION public.zh_cn (PARSER = zhparser)"))
+                conn.execute(
+                    text("ALTER TEXT SEARCH CONFIGURATION public.zh_cn ADD MAPPING FOR n,v,a,i,e,l WITH simple")
+                )
+                conn.commit()
+
+        # Rebuild the index
+        idx_name = f"idx_{table_name.replace('.', '_')}_text_search"
+        conn.execute(text(f"DROP INDEX IF EXISTS {schema_name}.{idx_name}"))
+
+        if table_name == "memory_units":
+            index_expr = "(text)"
+        else:
+            index_expr = "(COALESCE(name, '') || ' ' || content)"
+
+        conn.execute(
+            text(f"""
+                CREATE INDEX {idx_name}
+                ON {schema_name}.{table_name}
+                USING bm25({index_expr})
+                WITH (text_config='{target_config}')
+            """)
+        )
+        conn.commit()
+        logger.info(f"Rebuilt BM25 index on {table_name} with text_config={target_config}")
+
+
 def _get_schema_lock_id(schema: str) -> int:
     """
     Generate a unique advisory lock ID for a schema.
@@ -884,6 +982,7 @@ def ensure_vector_extension(
 def ensure_text_search_extension(
     database_url: str,
     text_search_extension: str = "native",
+    text_search_language: str = "english",
     schema: str | None = None,
 ) -> None:
     """
@@ -895,9 +994,13 @@ def ensure_text_search_extension(
     - If they differ and tables are empty: drop old column/index, recreate with new type
     - If they differ and tables have data: raise error with migration guidance
 
+    For pg_textsearch, also checks that the BM25 index uses the correct text_config
+    for the configured language (e.g., 'english' vs 'public.zh_cn' for Chinese).
+
     Args:
         database_url: SQLAlchemy database URL
         text_search_extension: Configured text search extension ("native" or "vchord")
+        text_search_language: Configured text search language ("english" or "chinese")
         schema: Target PostgreSQL schema name (None for public)
 
     Raises:
@@ -1001,6 +1104,9 @@ def ensure_text_search_extension(
 
         # If no mismatches, we're done
         if not mismatched_tables:
+            # For pg_textsearch, also check that the BM25 index uses the correct text_config
+            if text_search_extension == "pg_textsearch":
+                _ensure_pg_textsearch_language(conn, schema_name, text_search_language)
             logger.debug(f"All text search columns/indexes match configured extension: {text_search_extension}")
             return
 

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -151,10 +151,7 @@ def _ensure_pg_textsearch_language(conn: Connection, schema_name: str, language:
             logger.debug(f"BM25 index on {table_name} already uses text_config={target_config}")
             continue
 
-        logger.info(
-            f"BM25 index text_config mismatch on {table_name}: "
-            f"target={target_config}, recreating index"
-        )
+        logger.info(f"BM25 index text_config mismatch on {table_name}: target={target_config}, recreating index")
 
         # Rebuild zhparser config if Chinese
         if language == "chinese":
@@ -163,9 +160,7 @@ def _ensure_pg_textsearch_language(conn: Connection, schema_name: str, language:
                 conn.commit()
             except Exception:
                 conn.rollback()
-                ext_exists = conn.execute(
-                    text("SELECT 1 FROM pg_extension WHERE extname = 'zhparser'")
-                ).fetchone()
+                ext_exists = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'zhparser'")).fetchone()
                 if not ext_exists:
                     raise RuntimeError(
                         "zhparser extension is required for Chinese text search but could not be installed. "
@@ -173,9 +168,7 @@ def _ensure_pg_textsearch_language(conn: Connection, schema_name: str, language:
                     )
 
             # CREATE TEXT SEARCH CONFIGURATION doesn't support IF NOT EXISTS
-            config_exists = conn.execute(
-                text("SELECT 1 FROM pg_ts_config WHERE cfgname = 'zh_cn'")
-            ).fetchone()
+            config_exists = conn.execute(text("SELECT 1 FROM pg_ts_config WHERE cfgname = 'zh_cn'")).fetchone()
             if not config_exists:
                 conn.execute(text("CREATE TEXT SEARCH CONFIGURATION public.zh_cn (PARSER = zhparser)"))
                 conn.execute(


### PR DESCRIPTION
…indexes

Add HINDSIGHT_API_TEXT_SEARCH_LANGUAGE env var to control the text search configuration used by pg_textsearch BM25 indexes. On startup, the system detects mismatches between the configured language and the current index definition, and rebuilds the index automatically when needed.

Supported values: "english" (default), "chinese" (uses zhparser via public.zh_cn config), or any PostgreSQL text search configuration name.