### PR TITLE
fix: repair 4 broken tests on main

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/m3rg3h3ad5f6_merge_deferrable_fk_and_cooccurrence_backfill.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/m3rg3h3ad5f6_merge_deferrable_fk_and_cooccurrence_backfill.py
@@ -7,15 +7,25 @@ Create Date: 2026-05-04
 
 from collections.abc import Sequence
 
+from hindsight_api.alembic._dialect import run_for_dialect
+
 revision: str = "m3rg3h3ad5f6"
 down_revision: tuple[str, ...] = ("9f8e7d6c5b4a", "b5d4e3f2a1c9")
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
-def upgrade() -> None:
+def _pg_upgrade() -> None:
     pass
+
+
+def _pg_downgrade() -> None:
+    pass
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
 
 
 def downgrade() -> None:
-    pass
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/alembic/versions/m3rg3h3ad5f6_merge_deferrable_fk_and_cooccurrence_backfill.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/m3rg3h3ad5f6_merge_deferrable_fk_and_cooccurrence_backfill.py
@@ -1,0 +1,21 @@
+"""Merge divergent heads from deferrable FK and cooccurrence backfill
+
+Revision ID: m3rg3h3ad5f6
+Revises: 9f8e7d6c5b4a, b5d4e3f2a1c9
+Create Date: 2026-05-04
+"""
+
+from collections.abc import Sequence
+
+revision: str = "m3rg3h3ad5f6"
+down_revision: tuple[str, ...] = ("9f8e7d6c5b4a", "b5d4e3f2a1c9")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/hindsight-api-slim/tests/test_custom_embedding_dimension.py
+++ b/hindsight-api-slim/tests/test_custom_embedding_dimension.py
@@ -69,7 +69,7 @@ def create_isolated_schema(db_url: str, schema_name: str, dimension: int | None 
 
     # Adjust embedding dimension if specified
     if dimension is not None:
-        ensure_embedding_dimension(db_url, dimension, schema=schema_name)
+        _ensure_embedding_dimension_with_retry(db_url, dimension, schema=schema_name)
 
 
 def drop_schema(db_url: str, schema_name: str):
@@ -91,6 +91,25 @@ def drop_schema(db_url: str, schema_name: str):
 
                 time.sleep(0.5)
             # Best-effort teardown — don't fail the test over cleanup issues
+
+
+def _ensure_embedding_dimension_with_retry(db_url: str, dimension: int, schema: str):
+    """Wrapper around ensure_embedding_dimension with OID race retry.
+
+    pg0 with concurrent xdist workers can cause 'could not open relation with OID'
+    when one worker's DROP SCHEMA CASCADE invalidates pg_indexes references mid-query.
+    """
+    import time
+
+    for attempt in range(3):
+        try:
+            ensure_embedding_dimension(db_url, dimension, schema=schema)
+            return
+        except Exception as e:
+            if "could not open relation with OID" in str(e) and attempt < 2:
+                time.sleep(0.5)
+                continue
+            raise
 
 
 def get_column_dimension(db_url: str, schema: str = "public", table: str = "memory_units") -> int | None:
@@ -201,7 +220,7 @@ class TestEmbeddingDimension:
         assert initial_dim == 384, f"Expected 384, got {initial_dim}"
 
         # Call ensure_embedding_dimension with matching dimension
-        ensure_embedding_dimension(db_url, 384, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
 
         # Dimension should still be 384
         assert get_column_dimension(db_url, schema) == 384
@@ -215,14 +234,14 @@ class TestEmbeddingDimension:
         assert get_row_count(db_url, schema) == 0
 
         # Change dimension to 768
-        ensure_embedding_dimension(db_url, 768, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 768, schema=schema)
 
         # Verify dimension changed
         new_dim = get_column_dimension(db_url, schema)
         assert new_dim == 768, f"Expected 768, got {new_dim}"
 
         # Change back to 384 for other tests
-        ensure_embedding_dimension(db_url, 384, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
         assert get_column_dimension(db_url, schema) == 384
 
     def test_dimension_change_blocked_with_data(self, dimension_test_schema):
@@ -256,7 +275,7 @@ class TestEmbeddingDimension:
         initial_dim = get_column_dimension(db_url, schema, table="mental_models")
         assert initial_dim == 384, f"Expected 384, got {initial_dim}"
 
-        ensure_embedding_dimension(db_url, 384, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
 
         assert get_column_dimension(db_url, schema, table="mental_models") == 384
 
@@ -266,12 +285,12 @@ class TestEmbeddingDimension:
 
         clear_mental_model_embeddings(db_url, schema)
 
-        ensure_embedding_dimension(db_url, 768, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 768, schema=schema)
 
         assert get_column_dimension(db_url, schema, table="mental_models") == 768
 
         # Change back for other tests
-        ensure_embedding_dimension(db_url, 384, schema=schema)
+        _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
         assert get_column_dimension(db_url, schema, table="mental_models") == 384
 
     def test_mental_models_dimension_change_blocked_with_data(self, dimension_test_schema):

--- a/hindsight-api-slim/tests/test_custom_embedding_dimension.py
+++ b/hindsight-api-slim/tests/test_custom_embedding_dimension.py
@@ -73,11 +73,24 @@ def create_isolated_schema(db_url: str, schema_name: str, dimension: int | None 
 
 
 def drop_schema(db_url: str, schema_name: str):
-    """Drop an isolated schema."""
+    """Drop an isolated schema.
+
+    Retries once on InternalError (e.g. 'could not open relation with OID')
+    which can happen when pg0 has concurrent connections referencing the schema.
+    """
     engine = create_engine(db_url)
-    with engine.connect() as conn:
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE"))
-        conn.commit()
+    for attempt in range(2):
+        try:
+            with engine.connect() as conn:
+                conn.execute(text(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE"))
+                conn.commit()
+            return
+        except Exception:
+            if attempt == 0:
+                import time
+
+                time.sleep(0.5)
+            # Best-effort teardown — don't fail the test over cleanup issues
 
 
 def get_column_dimension(db_url: str, schema: str = "public", table: str = "memory_units") -> int | None:

--- a/hindsight-api-slim/tests/test_openrouter_null_content.py
+++ b/hindsight-api-slim/tests/test_openrouter_null_content.py
@@ -10,13 +10,12 @@ retry hits the same unhandled error so the entire retry budget is wasted.
 See https://github.com/vectorize-io/hindsight/issues/1334.
 """
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
 
-from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM, ProviderResponseError
 
 
 class _Response(BaseModel):
@@ -33,25 +32,38 @@ def _make_llm() -> OpenAICompatibleLLM:
 
 
 def _make_chat_response(content: str | None) -> MagicMock:
+    """Build a mock that matches the shape expected by _first_choice_or_error.
+
+    Key fields that must be explicitly set (not left as auto-MagicMock):
+    - response.error = None          (otherwise truthy MagicMock triggers error path)
+    - response.model_dump()          (returns dict without 'error' key)
+    - choice.message.tool_calls/refusal  (otherwise truthy MagicMock in error msg)
+    """
+    choice = MagicMock()
+    choice.finish_reason = "stop"
+    choice.message.content = content
+    choice.message.tool_calls = None
+    choice.message.refusal = None
+
     response = MagicMock()
+    response.error = None
+    response.model_dump.return_value = {}
     response.usage.prompt_tokens = 10
     response.usage.completion_tokens = 0 if content is None else 5
     response.usage.total_tokens = 10 if content is None else 15
-    response.choices[0].finish_reason = "stop"
-    response.choices[0].message.content = content
-    response.choices[0].message.tool_calls = None
+    response.choices = [choice]
     return response
 
 
 @pytest.mark.asyncio
 async def test_null_content_raises_after_retries_exhausted():
-    """All retries return null content -> JSONDecodeError, not TypeError."""
+    """All retries return null content -> ProviderResponseError, not TypeError."""
     llm = _make_llm()
 
     with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
         mock_create.return_value = _make_chat_response(None)
 
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(ProviderResponseError, match="empty message content"):
             await llm.call(
                 messages=[{"role": "user", "content": "extract facts"}],
                 response_format=_Response,

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -56,13 +56,15 @@ async def pool(backend):
 
 @pytest_asyncio.fixture
 async def clean_operations(pool):
-    """Clean up async_operations table before and after tests."""
-    # Clean before test - covers both 'test-worker-' and 'test_worker_recovery' patterns
-    await pool.execute(
-        "DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%' OR bank_id LIKE 'test_worker_%'"
-    )
+    """Clean up async_operations table before and after tests.
+
+    We must clean ALL pending operations (not just test-worker-* prefixed ones)
+    because WorkerPoller.claim_batch scans the entire schema for pending tasks.
+    Stale operations left by other tests (e.g. consolidation) cause spurious
+    failures when the poller picks them up unexpectedly.
+    """
+    await pool.execute("DELETE FROM async_operations WHERE status = 'pending'")
     yield
-    # Clean after test
     await pool.execute(
         "DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%' OR bank_id LIKE 'test_worker_%'"
     )


### PR DESCRIPTION
## Summary
- Merge divergent alembic migration heads that caused `test_single_head` to fail
- Fix openrouter null-content mock tests — MagicMock auto-truthy `.error` attribute triggered wrong code path; update expected exception to `ProviderResponseError`
- Fix worker test isolation — `clean_operations` now cleans all pending ops, not just `test-worker-*` prefixed ones, preventing cross-test contamination via `claim_batch`
- Add retry to custom embedding dimension schema teardown to handle pg0 race conditions under xdist

## Test plan
- [x] `test_alembic_dag::test_single_head` passes locally
- [x] `test_openrouter_null_content` both tests pass locally
- [x] Lint passes
- [ ] CI `test-api` should go from 4 failed + 2 errors → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)