### PR TITLE
feat(openclaw): prepend session-context block to retained transcripts

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -799,6 +799,68 @@ describe("prepareRetentionTranscript", () => {
     // The middle message becomes empty after tag stripping, so messageCount should be 2
     expect(result?.messageCount).toBe(2);
   });
+
+  it("prepends a session-context system message when sessionContext is provided (json)", () => {
+    const config: PluginConfig = { ...baseConfig, retainToolCalls: false };
+    const messages = [{ role: "user", content: "What's MIN-123 status?" }];
+    const result = prepareRetentionTranscript(messages, config, false, {
+      senderId: "U7JAF258R",
+      channelId: "C04L6E0H3SQ",
+      provider: "slack",
+    });
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!.transcript);
+    expect(parsed[0]).toEqual({
+      role: "system",
+      content:
+        "[context]\nsender: U7JAF258R\nchannel: C04L6E0H3SQ\nprovider: slack\n[/context]",
+    });
+    expect(parsed[1]).toEqual({ role: "user", content: "What's MIN-123 status?" });
+    expect(result?.messageCount).toBe(2);
+  });
+
+  it("prepends a session-context block when sessionContext is provided (text format)", () => {
+    const config: PluginConfig = { ...baseConfig, retainFormat: "text" };
+    const messages = [{ role: "user", content: "ping" }];
+    const result = prepareRetentionTranscript(messages, config, false, {
+      senderId: "U7JAF258R",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.transcript.startsWith("[context]\nsender: U7JAF258R\n[/context]\n\n")).toBe(
+      true
+    );
+    expect(result!.transcript).toContain("[role: user]\nping\n[user:end]");
+  });
+
+  it("omits the context header when includeSenderContext is explicitly disabled", () => {
+    const config: PluginConfig = {
+      ...baseConfig,
+      retainFormat: "text",
+      includeSenderContext: false,
+    };
+    const messages = [{ role: "user", content: "ping" }];
+    const result = prepareRetentionTranscript(messages, config, false, {
+      senderId: "U7JAF258R",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.transcript).not.toContain("[context]");
+    expect(result!.transcript.startsWith("[role: user]")).toBe(true);
+  });
+
+  it("omits the context header when sessionContext has no usable fields", () => {
+    const config: PluginConfig = { ...baseConfig, retainFormat: "text" };
+    const messages = [{ role: "user", content: "ping" }];
+    const result = prepareRetentionTranscript(messages, config, false, {});
+    expect(result).not.toBeNull();
+    expect(result!.transcript).not.toContain("[context]");
+  });
+
+  it("falls back gracefully when sessionContext is omitted", () => {
+    const messages = [{ role: "user", content: "ping" }];
+    const result = prepareRetentionTranscript(messages, baseConfig);
+    expect(result).not.toBeNull();
+    expect(result!.transcript).not.toContain("[context]");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -2287,7 +2287,12 @@ ${memoriesFormatted}
         const retention = prepareRetentionTranscript(
           messagesToRetain,
           pluginConfig,
-          retainFullWindow
+          retainFullWindow,
+          {
+            senderId: resolvedCtxForRetain?.senderId,
+            channelId: effectiveCtxForRetain?.channelId,
+            provider: effectiveCtxForRetain?.messageProvider,
+          }
         );
         if (!retention) {
           debug("[Hindsight Hook] No messages to retain (filtered/short/no-user)");
@@ -2509,10 +2514,36 @@ export function buildRetainRequest(
   };
 }
 
+export interface RetentionSessionContext {
+  senderId?: string;
+  channelId?: string;
+  provider?: string;
+}
+
+/**
+ * Build a session-context block describing who is speaking, on which channel,
+ * via which provider. Prepending this to retained transcripts lets similarity
+ * search distinguish memories by speaker without requiring per-user banks
+ * (`dynamicBankGranularity: ["agent", "user"]`). Returns null when no usable
+ * fields are available.
+ */
+export function formatRetentionSessionContext(
+  ctx: RetentionSessionContext | null | undefined
+): string | null {
+  if (!ctx) return null;
+  const lines: string[] = [];
+  if (ctx.senderId) lines.push(`sender: ${ctx.senderId}`);
+  if (ctx.channelId) lines.push(`channel: ${ctx.channelId}`);
+  if (ctx.provider) lines.push(`provider: ${ctx.provider}`);
+  if (lines.length === 0) return null;
+  return ["[context]", ...lines, "[/context]"].join("\n");
+}
+
 export function prepareRetentionTranscript(
   messages: any[],
   pluginConfig: PluginConfig,
-  retainFullWindow = false
+  retainFullWindow = false,
+  sessionContext?: RetentionSessionContext | null
 ): { transcript: string; messageCount: number } | null {
   if (!messages || messages.length === 0) {
     return null;
@@ -2539,13 +2570,22 @@ export function prepareRetentionTranscript(
 
   const format = pluginConfig.retainFormat ?? "json";
   const includeToolCalls = format === "json" && pluginConfig.retainToolCalls !== false;
+  const contextHeader =
+    pluginConfig.includeSenderContext === false
+      ? null
+      : formatRetentionSessionContext(sessionContext);
 
   if (includeToolCalls) {
     const structured = buildAnthropicStructuredMessages(targetMessages, pluginConfig);
     if (structured.length === 0) return null;
-    const transcript = JSON.stringify(structured);
+    // Prepend session context as a system-role message so similarity search
+    // and downstream LLM consumers can attribute the conversation to a speaker.
+    const withContext = contextHeader
+      ? [{ role: "system", content: contextHeader }, ...structured]
+      : structured;
+    const transcript = JSON.stringify(withContext);
     if (!transcript.trim() || transcript.length < 10) return null;
-    return { transcript, messageCount: structured.length };
+    return { transcript, messageCount: withContext.length };
   }
 
   // Role filtering (text-only path)
@@ -2583,16 +2623,25 @@ export function prepareRetentionTranscript(
 
   if (normalized.length === 0) return null;
 
-  const transcript =
-    format === "text"
-      ? normalized
-          .map(({ role, content }) => `[role: ${role}]\n${content}\n[${role}:end]`)
-          .join("\n\n")
-      : JSON.stringify(normalized);
+  let transcript: string;
+  let messageCount: number;
+  if (format === "text") {
+    const body = normalized
+      .map(({ role, content }) => `[role: ${role}]\n${content}\n[${role}:end]`)
+      .join("\n\n");
+    transcript = contextHeader ? `${contextHeader}\n\n${body}` : body;
+    messageCount = normalized.length;
+  } else {
+    const withContext = contextHeader
+      ? [{ role: "system", content: contextHeader }, ...normalized]
+      : normalized;
+    transcript = JSON.stringify(withContext);
+    messageCount = withContext.length;
+  }
 
   if (!transcript.trim() || transcript.length < 10) return null;
 
-  return { transcript, messageCount: normalized.length };
+  return { transcript, messageCount };
 }
 
 // MCP tool name suffixes that are operational (recall/retain/search/CRUD) and

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -92,6 +92,7 @@ export interface PluginConfig {
   recallMaxTokens?: number; // Max tokens for recall response. Default: 1024
   recallTypes?: Array<"world" | "experience" | "observation">; // Memory types to recall. Default: ['world', 'experience']
   recallRoles?: Array<"user" | "assistant" | "system" | "tool">; // Roles to include when composing contextual recall query. Default: ['user', 'assistant']
+  includeSenderContext?: boolean; // When true (default), prepend a session context block (sender, channel, provider) to retained transcripts so similarity search can distinguish memories by speaker even when dynamicBankGranularity does not include 'user'. Set false to omit.
   retainDocumentScope?: "session" | "turn"; // Granularity of the retained document_id. 'session' (default) groups all retains under a single document per OpenClaw session (`openclaw:{sessionKey}`). 'turn' produces a new document per retain (`openclaw:{sessionKey}:turn:NNNNNN` / `:window:NNNNNN`).
   retainEveryNTurns?: number; // Retain every Nth turn (1 = every turn, default: 1). Values > 1 enable chunked retention.
   retainOverlapTurns?: number; // Extra prior turns included when chunked retention fires (default: 0). Window = retainEveryNTurns + retainOverlapTurns.


### PR DESCRIPTION
## Problem

When `dynamicBankGranularity` doesn't include `"user"`, every speaker in an agent's bank ends up indistinguishable to vector recall. Two different users (say _John_ and _Peter_) chatting with the same agent in the same channel produce transcripts that are byte-for-byte structurally identical:

```
[role: user]
What's the status of MIN-123?
[user:end]
…
```

`stripMetadataEnvelopes` removes OpenClaw's inbound `[meta]` blocks before the transcript reaches `client.retain(...)`, so the stored content has no signal that lets similarity search separate one speaker's memories from another's.

The escape hatch today is `dynamicBankGranularity: ["agent", "user"]`, but that's not always the right tradeoff — for sprint-ops / shared-team bots, fragmenting the bank per user forfeits cross-user shared context, and you still want a single agent-level memory pool.

## Change

* Add a `RetentionSessionContext` shape (`senderId`, `channelId`, `provider`) and a `formatRetentionSessionContext(ctx)` helper that returns either a `[context] … [/context]` block or `null` when nothing useful is set.
* Extend `prepareRetentionTranscript(messages, pluginConfig, retainFullWindow, sessionContext?)` so it can prepend that block:
  * **JSON / Anthropic-structured formats** → first message is `{ role: "system", content: "[context]\nsender: …\nchannel: …\nprovider: …\n[/context]" }`.
  * **Text format** → the same block is prepended literally before `[role: user]…`.
* Pull `senderId` from the already-resolved retain ctx (`resolvedCtxForRetain`) at the call site so the value matches what `deriveBankId` uses, including the per-session sender cache populated during `before_prompt_build`.
* New `includeSenderContext?: boolean` config flag (default `true`) so operators can opt out.

The header is intentionally tiny and provider-agnostic — just enough signal for vector recall to disambiguate without forcing a schema change on Hindsight or the LLM consumer.

## Why this design

* **Backward-compatible**: `sessionContext` is optional; old callers and the existing `text`/`json` shapes still work. Without context, no header is emitted.
* **Format-aware**: in JSON mode the header is a real system message (so structured consumers see it), in text mode it's a `[context]` block matching the rest of the transcript style.
* **No bank-shape impact**: nothing about `deriveBankId` changes — operators keep whatever granularity they chose.
* **Filtered out cleanly**: `formatRetentionSessionContext` returns `null` for `undefined`/empty fields, so e.g. cron and identity-skipped sessions don't get spurious `sender: anonymous` headers.

## Tests

`prepareRetentionTranscript` got 5 new cases:

* JSON format prepends a system-role context message
* Text format prepends a literal `[context]` block
* `includeSenderContext: false` suppresses the header
* `sessionContext: {}` (no usable fields) — nothing prepended
* Missing `sessionContext` argument — unchanged from current behavior

All 21 existing `prepareRetentionTranscript` tests still pass; full unit suite is green except for one pre-existing `backfill.test.ts` symlink case that fails on `main` itself in this sandbox (unrelated to this change).

## Operator example

```ts
plugins.entries["hindsight-openclaw"].config = {
  // single bank for the agent — old behavior
  dynamicBankGranularity: ["agent"],
  // new: speaker info still flows into the transcript so recall can rank by user
  includeSenderContext: true, // default
};
```

After this, a memory retained from John ends up tagged as

```
{
  "role": "system",
  "content": "[context]\nsender: U7JAF258R\nchannel: C04L6E0H3SQ\nprovider: slack\n[/context]"
}
```

and similarity search can naturally weight retrieval by the active speaker without changing the bank scheme.