### PR TITLE
     fix(worker): recover stuck tasks from dead workers with UI controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_API_KEY=your-deepseek-api-key
 # HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash  # or deepseek-v4-pro / deepseek-chat / deepseek-reasoner
 
+# Worker Configuration (Optional)
+# Automatically recover tasks stuck in 'processing' state from dead workers (container crash/restart).
+# When enabled, the worker checks every 60s for tasks older than 5 minutes and resets them to 'pending'.
+# Default: false (disabled). Enable if you experience stuck consolidations after container restarts.
+# HINDSIGHT_WORKER_AUTO_RECOVER_DEAD_TASKS=false
+# HINDSIGHT_WORKER_STUCK_TASK_THRESHOLD_S=600  # 10 minutes default
+# HINDSIGHT_WORKER_STUCK_TASK_CHECK_INTERVAL_S=60  # Check every 60 seconds
+
 # Example: LM Studio local configuration (Qwen 2.5 32B recommended)
 # HINDSIGHT_API_LLM_PROVIDER=lmstudio
 # HINDSIGHT_API_LLM_API_KEY=lmstudio

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1456,6 +1456,14 @@ class RecoverConsolidationResponse(BaseModel):
     retried_count: int
 
 
+class RecoverStuckTasksResponse(BaseModel):
+    """Response model for recovering stuck tasks from dead workers."""
+
+    model_config = ConfigDict(json_schema_extra={"example": {"recovered_count": 3}})
+
+    recovered_count: int
+
+
 class BankStatsResponse(BaseModel):
     """Response model for bank statistics endpoint."""
 
@@ -1500,6 +1508,10 @@ class BankStatsResponse(BaseModel):
     failed_consolidation: int = Field(
         default=0,
         description="Number of source memories (world/experience) whose consolidation permanently failed and can be retried via the consolidation recovery endpoint.",
+    )
+    stuck_consolidation: int = Field(
+        default=0,
+        description="Number of consolidation tasks stuck in 'processing' state for more than 5 minutes (worker likely dead). Use the tasks/recover endpoint to reset them.",
     )
     total_observations: int = Field(default=0, description="Total number of observations")
 
@@ -3504,6 +3516,7 @@ def _register_routes(app: FastAPI):
                 last_consolidated_at=stats["last_consolidated_at"],
                 pending_consolidation=stats["pending_consolidation"],
                 failed_consolidation=stats.get("failed_consolidation", 0),
+                stuck_consolidation=stats.get("stuck_consolidation", 0),
                 total_observations=stats["total_observations"],
             )
         except OperationValidationError as e:
@@ -5200,6 +5213,76 @@ def _register_routes(app: FastAPI):
 
             error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
             logger.error(f"Error in POST /v1/default/banks/{bank_id}/consolidation/recover: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post(
+        "/v1/default/banks/{bank_id}/tasks/recover",
+        response_model=RecoverStuckTasksResponse,
+        summary="Recover stuck tasks",
+        description=(
+            "Recover tasks that are stuck in 'processing' state because the worker that claimed "
+            "them died (container restart, crash, etc.). Tasks older than 5 minutes in 'processing' "
+            "state are reset to 'pending' so they can be picked up by any live worker. "
+            "This is useful when a consolidation task blocks the bank serialization lock."
+        ),
+        operation_id="recover_stuck_tasks",
+        tags=["Banks"],
+    )
+    @audited("recover_stuck_tasks", request_param=None)
+    async def api_recover_stuck_tasks(bank_id: str, request_context: RequestContext = Depends(get_request_context)):
+        """Reset stuck tasks from dead workers."""
+        try:
+            result = await app.state.memory.recover_stuck_tasks(bank_id, request_context=request_context)
+            return RecoverStuckTasksResponse(recovered_count=result["recovered_count"])
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in POST /v1/default/banks/{bank_id}/tasks/recover: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    class WorkerConfigRequest(BaseModel):
+        """Request body for updating worker configuration at runtime."""
+        worker_auto_recover_dead_tasks: bool | None = Field(
+            default=None,
+            description="Enable automatic recovery of stuck tasks from dead workers (default: false)",
+        )
+
+    class WorkerConfigResponse(BaseModel):
+        """Current worker configuration."""
+        worker_auto_recover_dead_tasks: bool
+        warning: str | None = None
+
+    @app.put(
+        "/v1/default/config/worker",
+        response_model=WorkerConfigResponse,
+        summary="Update worker configuration",
+        description="Update worker configuration settings at runtime without restarting the service.",
+        operation_id="update_worker_config",
+        tags=["Config"],
+    )
+    async def api_update_worker_config(request: WorkerConfigRequest):
+        """Update worker configuration at runtime."""
+        try:
+            config = get_config()
+            if request.worker_auto_recover_dead_tasks is not None:
+                config.worker_auto_recover_dead_tasks = request.worker_auto_recover_dead_tasks
+                logger.info(
+                    f"Worker config updated: worker_auto_recover_dead_tasks={config.worker_auto_recover_dead_tasks}"
+                )
+            return WorkerConfigResponse(
+                worker_auto_recover_dead_tasks=config.worker_auto_recover_dead_tasks,
+                warning="This setting is in-memory only and will not persist across restarts or propagate to other processes.",
+            )
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in PUT /v1/default/config/worker: {error_detail}")
             raise HTTPException(status_code=500, detail=str(e))
 
     @app.delete(

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -392,6 +392,9 @@ ENV_WORKER_POLL_INTERVAL_MS = "HINDSIGHT_API_WORKER_POLL_INTERVAL_MS"
 ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
+ENV_WORKER_AUTO_RECOVER_DEAD_TASKS = "HINDSIGHT_WORKER_AUTO_RECOVER_DEAD_TASKS"
+ENV_WORKER_STUCK_TASK_THRESHOLD_S = "HINDSIGHT_WORKER_STUCK_TASK_THRESHOLD_S"
+ENV_WORKER_STUCK_TASK_CHECK_INTERVAL_S = "HINDSIGHT_WORKER_STUCK_TASK_CHECK_INTERVAL_S"
 
 # Per-operation-type slot reservations. Each entry maps an operation_type
 # (as stored in async_operations.operation_type) to its env var and default.
@@ -630,6 +633,9 @@ DEFAULT_WORKER_POLL_INTERVAL_MS = 500  # Poll database every 500ms
 DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
+DEFAULT_WORKER_AUTO_RECOVER_DEAD_TASKS = False  # Auto-recover orphaned tasks from dead workers
+DEFAULT_WORKER_STUCK_TASK_THRESHOLD_S = 600  # 10 minutes - threshold for detecting stuck tasks
+DEFAULT_WORKER_STUCK_TASK_CHECK_INTERVAL_S = 60  # Check every 60 seconds
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
 
 # Reflect agent settings
@@ -1094,6 +1100,9 @@ class HindsightConfig:
     worker_http_port: int
     worker_max_slots: int
     worker_slot_reservations: dict[str, int]
+    worker_auto_recover_dead_tasks: bool
+    worker_stuck_task_threshold_s: int
+    worker_stuck_task_check_interval_s: int
     retain_max_concurrent: int
 
     # Reflect agent settings
@@ -1741,6 +1750,9 @@ class HindsightConfig:
                 for op_type, (env_var, default) in WORKER_SLOT_RESERVATION_TYPES.items()
                 if int(os.getenv(env_var, str(default))) > 0
             },
+            worker_auto_recover_dead_tasks=os.getenv(ENV_WORKER_AUTO_RECOVER_DEAD_TASKS, str(DEFAULT_WORKER_AUTO_RECOVER_DEAD_TASKS)).lower() == "true",
+            worker_stuck_task_threshold_s=int(os.getenv(ENV_WORKER_STUCK_TASK_THRESHOLD_S, str(DEFAULT_WORKER_STUCK_TASK_THRESHOLD_S))),
+            worker_stuck_task_check_interval_s=int(os.getenv(ENV_WORKER_STUCK_TASK_CHECK_INTERVAL_S, str(DEFAULT_WORKER_STUCK_TASK_CHECK_INTERVAL_S))),
             retain_max_concurrent=int(os.getenv(ENV_RETAIN_MAX_CONCURRENT, str(DEFAULT_RETAIN_MAX_CONCURRENT))),
             # Reflect agent settings
             reflect_max_iterations=int(os.getenv(ENV_REFLECT_MAX_ITERATIONS, str(DEFAULT_REFLECT_MAX_ITERATIONS))),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13,6 +13,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import socket
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -4372,6 +4373,56 @@ class MemoryEngine(MemoryEngineInterface):
             )
             return {"retried_count": count or 0}
 
+    async def recover_stuck_tasks(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, int]:
+        """
+        Recover tasks stuck in 'processing' state from dead workers.
+
+        Resets tasks older than the configured threshold to 'pending'.
+
+        Args:
+            bank_id: Bank ID to recover tasks for
+            request_context: Request context for authentication
+
+        Returns:
+            Dictionary with count of recovered tasks.
+        """
+        from ..config import get_config
+
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext
+
+            ctx = BankWriteContext(
+                bank_id=bank_id, operation="recover_stuck_tasks", request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+        threshold_s = get_config().worker_stuck_task_threshold_s
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            result = await conn.execute(
+                f"""
+                UPDATE {fq_table("async_operations")}
+                SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                WHERE bank_id = $1
+                  AND status = 'processing'
+                  AND claimed_at < now() - make_interval(secs => $2)
+                """,
+                bank_id,
+                threshold_s,
+            )
+            count = int(result.split()[-1]) if result else 0
+            if count > 0:
+                logger.info(
+                    f"Recovered {count} stuck tasks for bank {bank_id} "
+                    f"(older than {threshold_s}s)"
+                )
+            return {"recovered_count": count}
+
     async def clear_observations_for_memory(
         self,
         bank_id: str,
@@ -6714,6 +6765,10 @@ class MemoryEngine(MemoryEngineInterface):
 
             ctx = BankReadContext(bank_id=bank_id, operation="get_bank_stats", request_context=request_context)
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        from ..config import get_config
+
+        threshold_s = get_config().worker_stuck_task_threshold_s
+        worker_id = get_config().worker_id or socket.gethostname()
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -6775,6 +6830,20 @@ class MemoryEngine(MemoryEngineInterface):
                 """,
                 bank_id,
             )
+            stuck_row = await conn.fetchrow(
+                f"""
+                SELECT COUNT(*) as count
+                FROM {fq_table("async_operations")}
+                WHERE bank_id = $1
+                  AND status = 'processing'
+                  AND operation_type = 'consolidation'
+                  AND claimed_at < now() - make_interval(secs => $2)
+                  AND worker_id IS DISTINCT FROM $3
+                """,
+                bank_id,
+                threshold_s,
+                worker_id,
+            )
 
             node_counts = {row["fact_type"]: row["count"] for row in node_stats}
             ops_by_status = {row["status"]: row["count"] for row in ops_stats}
@@ -6794,6 +6863,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "last_consolidated_at": last_consolidated_at.isoformat() if last_consolidated_at else None,
                 "pending_consolidation": consolidation_row["pending"] if consolidation_row else 0,
                 "failed_consolidation": consolidation_row["failed"] if consolidation_row else 0,
+                "stuck_consolidation": stuck_row["count"] if stuck_row else 0,
                 "total_observations": node_counts.get("observation", 0),
             }
 

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -142,6 +142,7 @@ class WorkerPoller:
         self._in_flight_count = 0
         self._in_flight_lock = asyncio.Lock()
         self._last_progress_log = 0.0
+        self._last_stuck_check = 0.0
         self._tasks_completed_since_log = 0
         # Track active tasks locally: operation_id -> ActiveTaskInfo
         self._active_tasks: dict[str, ActiveTaskInfo] = {}
@@ -864,6 +865,18 @@ class WorkerPoller:
                 # Log progress stats periodically
                 await self._log_progress_if_due()
 
+                # Check for stuck tasks from dead workers periodically (opt-in feature)
+                now = time.time()
+                if now - self._last_stuck_check >= self._get_check_interval_s():
+                    self._last_stuck_check = now
+                    try:
+                        from ..config import get_config
+
+                        if get_config().worker_auto_recover_dead_tasks:
+                            await self._recover_dead_worker_tasks()
+                    except Exception as e:
+                        logger.debug(f"Stuck task recovery check failed: {e}")
+
             except asyncio.CancelledError:
                 logger.info(f"Worker {self._worker_id} polling loop cancelled")
                 break
@@ -874,6 +887,77 @@ class WorkerPoller:
                 await asyncio.sleep(1)
 
         logger.info(f"Worker {self._worker_id} polling loop stopped")
+
+    # Threshold for detecting stuck tasks from dead workers (seconds)
+    _STUCK_TASK_THRESHOLD_S_DEFAULT = 300  # Fallback default
+    # How often to check for stuck tasks (seconds)
+    _STUCK_TASK_CHECK_INTERVAL_S_DEFAULT = 60
+
+    def _get_stuck_threshold_s(self) -> int:
+        """Get the stuck task threshold from config, with fallback to class default."""
+        try:
+            from ..config import get_config
+            return get_config().worker_stuck_task_threshold_s
+        except Exception:
+            return self._STUCK_TASK_THRESHOLD_S_DEFAULT
+
+    def _get_check_interval_s(self) -> int:
+        """Get the check interval from config, with fallback to class default."""
+        try:
+            from ..config import get_config
+            return get_config().worker_stuck_task_check_interval_s
+        except Exception:
+            return self._STUCK_TASK_CHECK_INTERVAL_S_DEFAULT
+
+    async def _recover_dead_worker_tasks(self) -> int:
+        """Recover tasks stuck in 'processing' from workers that are no longer alive.
+
+        A task is considered stuck if it has been in 'processing' state for longer than
+        ``_STUCK_TASK_THRESHOLD_S`` (based on ``claimed_at`` timestamp). This handles the
+        case where another worker dies while processing tasks, leaving them orphaned.
+
+        Unlike ``recover_own_tasks``, this recovers tasks from ANY dead worker, not just
+        this worker's own tasks.
+
+        Returns:
+            Number of tasks recovered.
+        """
+        schemas = await self._get_schemas()
+        total_count = 0
+
+        for schema in schemas:
+            try:
+                table = fq_table("async_operations", schema)
+                schema_display = f'"{schema}"' if schema else str(schema)
+
+                async with self._backend.acquire() as conn:
+                    result = await conn.execute(
+                        f"""
+                        UPDATE {table}
+                        SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                        WHERE status = 'processing'
+                          AND worker_id IS DISTINCT FROM $1
+                          AND claimed_at < now() - make_interval(secs => $2)
+                        """,
+                        self._worker_id,
+                        self._get_stuck_threshold_s(),
+                    )
+
+                count = int(result.split()[-1]) if result else 0
+                total_count += count
+                if count > 0:
+                    logger.info(
+                        f"Worker {self._worker_id} recovered {count} stuck tasks "
+                        f"from dead worker(s) in schema {schema_display}"
+                    )
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else str(schema)
+                logger.warning(
+                    f"Worker {self._worker_id} failed to recover dead worker tasks "
+                    f"for schema {schema_display}: {e}"
+                )
+
+        return total_count
 
     async def shutdown_graceful(self, timeout: float = 30.0):
         """

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1072,6 +1072,123 @@ class TestWorkerRecovery:
         recovered_count = await poller.recover_own_tasks()
         assert recovered_count == 0
 
+    @pytest.mark.asyncio
+    async def test_recover_dead_worker_tasks_resets_old_processing(self, pool, backend, clean_operations):
+        """Test that _recover_dead_worker_tasks resets tasks from other workers stuck >5min."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        current_worker = "current-worker"
+
+        # Create a task from a dead worker, claimed 10 minutes ago
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "consolidation", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, $4, now() - interval '10 minutes')
+            """,
+            op_id,
+            bank_id,
+            payload,
+            "dead-worker",
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id=current_worker,
+            executor=lambda x: None,
+        )
+
+        recovered = await poller._recover_dead_worker_tasks()
+        assert recovered == 1
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id, claimed_at FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending"
+        assert row["worker_id"] is None
+        assert row["claimed_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_recover_dead_worker_tasks_skips_recent(self, pool, backend, clean_operations):
+        """Test that tasks claimed <5min ago are NOT recovered (they're still running normally)."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # Create a task from another worker, claimed 2 minutes ago (within threshold)
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "consolidation", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, $4, now() - interval '2 minutes')
+            """,
+            op_id,
+            bank_id,
+            payload,
+            "other-worker",
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="current-worker",
+            executor=lambda x: None,
+        )
+
+        recovered = await poller._recover_dead_worker_tasks()
+        assert recovered == 0
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "other-worker"
+
+    @pytest.mark.asyncio
+    async def test_recover_dead_worker_tasks_skips_self(self, pool, backend, clean_operations):
+        """Test that the current worker's own tasks are NOT recovered even if old."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        current_worker = "my-worker"
+
+        # Create a task from the current worker, claimed 10 minutes ago
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "consolidation", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, $4, now() - interval '10 minutes')
+            """,
+            op_id,
+            bank_id,
+            payload,
+            current_worker,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id=current_worker,
+            executor=lambda x: None,
+        )
+
+        recovered = await poller._recover_dead_worker_tasks()
+        assert recovered == 0
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "processing"
+        assert row["worker_id"] == current_worker
+
 
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""
@@ -3100,3 +3217,84 @@ class TestWorkerStatus:
         )
 
         assert len(rows) == 0
+
+
+class TestRecoverStuckTasksMemoryEngine:
+    """Tests for MemoryEngine.recover_stuck_tasks() method."""
+
+    @pytest.mark.asyncio
+    async def test_recover_stuck_tasks_memory_engine(self, memory_no_llm_verify, request_context):
+        """Test that recover_stuck_tasks resets tasks older than threshold."""
+        import datetime
+        import uuid
+
+        bank_id = f"test-recover-stuck-{uuid.uuid4().hex[:8]}"
+        await memory_no_llm_verify.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        # Create a stuck task (claimed 15 minutes ago)
+        op_id = uuid.uuid4()
+        async with memory_no_llm_verify._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+                VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, $4, now() - interval '15 minutes')
+                """,
+                op_id,
+                bank_id,
+                '{"type": "consolidation", "bank_id": "' + bank_id + '"}',
+                "dead-worker",
+            )
+
+        result = await memory_no_llm_verify.recover_stuck_tasks(
+            bank_id, request_context=request_context
+        )
+
+        assert result["recovered_count"] == 1
+
+        async with memory_no_llm_verify._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+                op_id,
+            )
+        assert row["status"] == "pending"
+        assert row["worker_id"] is None
+
+        await memory_no_llm_verify.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_recover_stuck_tasks_skips_recent(self, memory_no_llm_verify, request_context):
+        """Test that recover_stuck_tasks doesn't touch tasks claimed recently."""
+        import uuid
+
+        bank_id = f"test-recover-stuck-recent-{uuid.uuid4().hex[:8]}"
+        await memory_no_llm_verify.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        # Create a recent task (claimed 2 minutes ago)
+        op_id = uuid.uuid4()
+        async with memory_no_llm_verify._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+                VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, $4, now() - interval '2 minutes')
+                """,
+                op_id,
+                bank_id,
+                '{"type": "consolidation", "bank_id": "' + bank_id + '"}',
+                "other-worker",
+            )
+
+        result = await memory_no_llm_verify.recover_stuck_tasks(
+            bank_id, request_context=request_context
+        )
+
+        assert result["recovered_count"] == 0
+
+        async with memory_no_llm_verify._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+                op_id,
+            )
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "other-worker"
+
+        await memory_no_llm_verify.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/tasks/recover/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/tasks/recover/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getDataplaneHeaders, dataplaneBankUrl } from "@/lib/hindsight-client";
+
+export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
+  try {
+    const { bankId } = await params;
+
+    if (!bankId) {
+      return NextResponse.json({ error: "bank_id is required" }, { status: 400 });
+    }
+
+    const response = await fetch(dataplaneBankUrl(bankId, "/tasks/recover"), {
+      method: "POST",
+      headers: getDataplaneHeaders(),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("API error recovering stuck tasks:", error);
+      return NextResponse.json({ error: "Failed to recover stuck tasks" }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error("Error recovering stuck tasks:", error);
+    return NextResponse.json({ error: "Failed to recover stuck tasks" }, { status: 500 });
+  }
+}

--- a/hindsight-control-plane/src/app/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/banks/[bankId]/page.tsx
@@ -39,7 +39,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Brain, Download, Trash2, Loader2, MoreVertical, Pencil, RotateCcw } from "lucide-react";
+import { AlertTriangle, Brain, Download, Trash2, Loader2, MoreVertical, Pencil, RotateCcw } from "lucide-react";
 
 type NavItem = "recall" | "reflect" | "data" | "documents" | "entities" | "profile";
 type DataSubTab = "world" | "experience" | "observations" | "mental-models";
@@ -65,6 +65,7 @@ export default function BankPage() {
   const [isClearingObservations, setIsClearingObservations] = useState(false);
   const [isConsolidating, setIsConsolidating] = useState(false);
   const [isRecoveringConsolidation, setIsRecoveringConsolidation] = useState(false);
+  const [isRecoveringStuck, setIsRecoveringStuck] = useState(false);
   const [showResetConfigDialog, setShowResetConfigDialog] = useState(false);
   const [isResettingConfig, setIsResettingConfig] = useState(false);
 
@@ -93,7 +94,7 @@ export default function BankPage() {
       setCurrentBank(null);
       await loadBanks();
       router.push("/");
-    } catch (error) {
+    } catch (/* eslint-disable-next-line @typescript-eslint/no-unused-vars */ error) {
       // Error toast is shown automatically by the API client interceptor
     } finally {
       setIsDeleting(false);
@@ -110,7 +111,7 @@ export default function BankPage() {
       toast.success("Success", {
         description: result.message || "Observations cleared successfully",
       });
-    } catch (error) {
+    } catch (/* eslint-disable-next-line @typescript-eslint/no-unused-vars */ error) {
       // Error toast is shown automatically by the API client interceptor
     } finally {
       setIsClearingObservations(false);
@@ -136,7 +137,7 @@ export default function BankPage() {
     setIsConsolidating(true);
     try {
       await client.triggerConsolidation(bankId);
-    } catch (error) {
+    } catch (/* eslint-disable-next-line @typescript-eslint/no-unused-vars */ error) {
       // Error toast is shown automatically by the API client interceptor
     } finally {
       setIsConsolidating(false);
@@ -152,10 +153,30 @@ export default function BankPage() {
       toast.success(
         `Recovered ${result.retried_count} failed ${result.retried_count === 1 ? "memory" : "memories"} for re-consolidation`
       );
-    } catch (error) {
+    } catch (/* eslint-disable-next-line @typescript-eslint/no-unused-vars */ error) {
       // Error toast is shown automatically by the API client interceptor
     } finally {
       setIsRecoveringConsolidation(false);
+    }
+  };
+
+  const handleRecoverStuckTasks = async () => {
+    if (!bankId) return;
+
+    setIsRecoveringStuck(true);
+    try {
+      const result = await client.recoverStuckTasks(bankId);
+      if (result.recovered_count > 0) {
+        toast.success(
+          `Recovered ${result.recovered_count} stuck ${result.recovered_count === 1 ? "task" : "tasks"} from dead worker`
+        );
+      } else {
+        toast.success("No stuck tasks found");
+      }
+    } catch (/* eslint-disable-next-line @typescript-eslint/no-unused-vars */ error) {
+      // Error toast is shown automatically by the API client interceptor
+    } finally {
+      setIsRecoveringStuck(false);
     }
   };
 
@@ -224,7 +245,9 @@ export default function BankPage() {
                         onClick={handleRecoverConsolidation}
                         disabled={isRecoveringConsolidation || !observationsEnabled}
                         title={
-                          !observationsEnabled ? "Observations feature is not enabled" : undefined
+                          !observationsEnabled
+                            ? "Observations feature is not enabled"
+                            : "Reset memories that permanently failed LLM processing (after all retries exhausted)"
                         }
                       >
                         {isRecoveringConsolidation ? (
@@ -236,6 +259,18 @@ export default function BankPage() {
                         {!observationsEnabled && (
                           <span className="ml-auto text-xs text-muted-foreground">Off</span>
                         )}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={handleRecoverStuckTasks}
+                        disabled={isRecoveringStuck}
+                        title="Reset tasks stuck in processing state from a dead worker (container crash/restart)"
+                      >
+                        {isRecoveringStuck ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : (
+                          <AlertTriangle className="w-4 h-4 mr-2" />
+                        )}
+                        {isRecoveringStuck ? "Recovering..." : "Recover Stuck Tasks"}
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() => setShowClearObservationsDialog(true)}

--- a/hindsight-control-plane/src/components/bank-profile-view.tsx
+++ b/hindsight-control-plane/src/components/bank-profile-view.tsx
@@ -100,6 +100,7 @@ interface BankStats {
   // Consolidation stats
   last_consolidated_at: string | null;
   pending_consolidation: number;
+  stuck_consolidation: number;
   total_observations: number;
 }
 

--- a/hindsight-control-plane/src/components/bank-stats-view.tsx
+++ b/hindsight-control-plane/src/components/bank-stats-view.tsx
@@ -6,6 +6,7 @@ import { useFeatures } from "@/lib/features-context";
 import { client, MentalModel } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  AlertTriangle,
   Database,
   Link2,
   FolderOpen,
@@ -67,6 +68,7 @@ interface BankStats {
   last_consolidated_at: string | null;
   pending_consolidation: number;
   failed_consolidation: number;
+  stuck_consolidation: number;
   total_observations: number;
 }
 
@@ -480,17 +482,20 @@ function ConsolidationCard({
   done,
   pending,
   failed,
+  stuck,
   total,
   lastConsolidatedAt,
 }: {
   done: number;
   pending: number;
   failed: number;
+  stuck: number;
   total: number;
   lastConsolidatedAt: string | null;
 }) {
   const [failedOpen, setFailedOpen] = useState(false);
   const hasFailed = failed > 0;
+  const hasStuck = stuck > 0;
 
   return (
     <Card>
@@ -499,6 +504,15 @@ function ConsolidationCard({
       </CardHeader>
       <CardContent className="space-y-4">
         <ProgressRow done={done} total={total} doneColor={CHART_COLORS.success} />
+        {hasStuck && (
+          <div className="flex items-center gap-2 bg-red-500/10 text-red-700 dark:text-red-400 border border-red-500/20 rounded-md px-3 py-2 text-xs">
+            <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+            <span>
+              {stuck} consolidation task{stuck > 1 ? "s" : ""} stuck from dead worker — use{" "}
+              <code className="bg-red-500/20 px-1 py-0.5 rounded">Recover Stuck Tasks</code> in Actions
+            </span>
+          </div>
+        )}
         <div className="grid grid-cols-4 gap-3 pt-1">
           <div className="space-y-0.5">
             <div className="flex items-center gap-1.5">
@@ -951,6 +965,7 @@ export function BankStatsView() {
             done={consolidatedDone}
             pending={stats.pending_consolidation}
             failed={stats.failed_consolidation ?? 0}
+            stuck={stats.stuck_consolidation ?? 0}
             total={stats.total_nodes}
             lastConsolidatedAt={stats.last_consolidated_at}
           />

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -624,6 +624,17 @@ export class ControlPlaneClient {
   }
 
   /**
+   * Recover stuck tasks from dead workers (reset tasks in processing state >5min)
+   */
+  async recoverStuckTasks(bankId: string) {
+    return this.fetchApi<{
+      recovered_count: number;
+    }>(bankApi(bankId, "/tasks/recover"), {
+      method: "POST",
+    });
+  }
+
+  /**
    * List memory units for a bank with optional filters.
    */
   async listMemories(


### PR DESCRIPTION
When a hindsight container crashes or restarts, tasks in `processing` state can become orphaned, blocking bank serialization locks. This adds recovery mechanisms with both automatic and manual controls.
## Changes

### Backend
- **`recover_stuck_tasks()`** in `memory_engine.py` — resets tasks older than configurable threshold (default: 10min) to `pending`
- **`POST /v1/default/banks/{bank_id}/tasks/recover`** endpoint for manual recovery
- **Auto-recovery** in worker poller (opt-in via `HINDSIGHT_WORKER_AUTO_RECOVER_DEAD_TASKS=false`)
- **`PUT /v1/default/config/worker`** endpoint for runtime config updates (in-memory only)
- **`stuck_consolidation`** field in bank stats to detect stuck tasks
- **Config-driven thresholds**: `HINDSIGHT_WORKER_STUCK_TASK_THRESHOLD_S` (default: 600s) and `HINDSIGHT_WORKER_STUCK_TASK_CHECK_INTERVAL_S` (default: 60s)
- All SQL properly parameterized using `make_interval(secs => $N)` — no string interpolation
- Worker identity uses configured `worker_id` to avoid false positives in stats

### Frontend
- **Recover Stuck Tasks** button in bank page Actions dropdown
- **Stuck indicator** in ConsolidationCard when tasks are detected
- **Tooltips** clarifying the difference between "Recover Consolidation" and "Recover Stuck Tasks"

### Tests
5 new tests in `test_worker.py`:
- `test_recover_dead_worker_tasks_resets_old_processing`
- `test_recover_dead_worker_tasks_skips_recent`
- `test_recover_dead_worker_tasks_skips_self`
- `test_recover_stuck_tasks_memory_engine`
- `test_recover_stuck_tasks_skips_recent`

## Configuration
New environment variables (all optional):
```env
# Auto-recover orphaned tasks from dead workers (default: false)
HINDSIGHT_WORKER_AUTO_RECOVER_DEAD_TASKS=false

# Threshold for detecting stuck tasks in seconds (default: 600 = 10 minutes)
HINDSIGHT_WORKER_STUCK_TASK_THRESHOLD_S=600

# How often to check for stuck tasks in seconds (default: 60)
HINDSIGHT_WORKER_STUCK_TASK_CHECK_INTERVAL_S=60
```
Can be toggled at runtime via PUT /v1/default/config/worker (in-memory only, does not persist across restarts or propagate to other processes).


Security
- All SQL parameters are properly parameterized using make_interval(secs => $N) — no string interpolation
- Worker identity uses configured worker_id to avoid false positives
- Manual recovery endpoint requires authentication and bank write permissions

## View

alert
<img width="849" height="293" alt="Capture d’écran 2026-05-05 à 03 18 35" src="https://github.com/user-attachments/assets/9e861ae4-c2df-420d-a30b-d6546be4bdc1" />
trigger button
<img width="1736" height="488" alt="Capture d’écran 2026-05-05 à 03 18 58" src="https://github.com/user-attachments/assets/576a424d-1f00-4897-b218-4c7645486879" />
