### PR TITLE
fix(retain): prevent runaway structured extraction retries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -957,6 +957,12 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
     return request_body
 
 
+def _retain_llm_attempts(config) -> int:
+    """Return the retain extraction retry budget as a bounded attempt count."""
+    configured = config.retain_llm_max_retries if config.retain_llm_max_retries is not None else config.llm_max_retries
+    return max(1, int(configured))
+
+
 async def _extract_facts_from_chunk(
     chunk: str,
     chunk_index: int,
@@ -992,13 +998,11 @@ async def _extract_facts_from_chunk(
 
     # Retry logic for JSON validation errors
     # Use retain-specific overrides if set, otherwise fall back to global LLM config
-    llm_max_retries = (
-        config.retain_llm_max_retries if config.retain_llm_max_retries is not None else config.llm_max_retries
-    )
+    llm_attempts = _retain_llm_attempts(config)
     last_error: Exception | None = None
 
     usage = TokenUsage()  # Track cumulative usage across retries
-    for attempt in range(llm_max_retries):
+    for attempt in range(llm_attempts):
         try:
             initial_backoff = (
                 config.retain_llm_initial_backoff
@@ -1015,7 +1019,10 @@ async def _extract_facts_from_chunk(
                 scope="retain_extract_facts",
                 temperature=0.1,
                 max_completion_tokens=config.retain_max_completion_tokens,
-                max_retries=llm_max_retries,
+                # The retain extraction loop owns the schema/content retry
+                # budget. Passing the same budget into provider-level structured
+                # retries multiplies LLM calls for every chunk.
+                max_retries=0,
                 initial_backoff=initial_backoff,
                 max_backoff=max_backoff,
                 skip_validation=True,  # Get raw JSON, we'll validate leniently
@@ -1029,14 +1036,14 @@ async def _extract_facts_from_chunk(
 
             # Handle malformed LLM responses
             if not isinstance(extraction_response_json, dict):
-                if attempt < llm_max_retries - 1:
+                if attempt < llm_attempts - 1:
                     logger.warning(
-                        f"LLM returned non-dict JSON on attempt {attempt + 1}/{llm_max_retries}: {type(extraction_response_json).__name__}. Retrying..."
+                        f"LLM returned non-dict JSON on attempt {attempt + 1}/{llm_attempts}: {type(extraction_response_json).__name__}. Retrying..."
                     )
                     continue
                 else:
                     logger.warning(
-                        f"LLM returned non-dict JSON after {llm_max_retries} attempts: {type(extraction_response_json).__name__}. "
+                        f"LLM returned non-dict JSON after {llm_attempts} attempts: {type(extraction_response_json).__name__}. "
                         f"Raw: {str(extraction_response_json)[:500]}"
                     )
                     return [], usage
@@ -1242,9 +1249,9 @@ async def _extract_facts_from_chunk(
                     continue
 
             # If we got malformed facts and haven't exhausted retries, try again
-            if has_malformed_facts and len(chunk_facts) < len(raw_facts) * 0.8 and attempt < llm_max_retries - 1:
+            if has_malformed_facts and len(chunk_facts) < len(raw_facts) * 0.8 and attempt < llm_attempts - 1:
                 logger.warning(
-                    f"Got {len(raw_facts) - len(chunk_facts)} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{llm_max_retries}. Retrying..."
+                    f"Got {len(raw_facts) - len(chunk_facts)} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{llm_attempts}. Retrying..."
                 )
                 continue
 
@@ -1277,9 +1284,9 @@ async def _extract_facts_from_chunk(
 
             if "json_validate_failed" in str(e):
                 logger.warning(
-                    f"          [1.3.{chunk_index + 1}] Attempt {attempt + 1}/{llm_max_retries} failed with JSON validation error: {e}"
+                    f"          [1.3.{chunk_index + 1}] Attempt {attempt + 1}/{llm_attempts} failed with JSON validation error: {e}"
                 )
-                if attempt < llm_max_retries - 1:
+                if attempt < llm_attempts - 1:
                     logger.info(f"          [1.3.{chunk_index + 1}] Retrying...")
                     continue
             # If it's not a JSON validation error or we're out of retries, re-raise
@@ -1288,7 +1295,7 @@ async def _extract_facts_from_chunk(
     # If we exhausted all retries, raise the last error or a descriptive fallback
     if last_error is not None:
         raise last_error
-    raise RuntimeError(f"Fact extraction failed after {llm_max_retries} attempts: LLM did not return valid JSON")
+    raise RuntimeError(f"Fact extraction failed after {llm_attempts} attempts: LLM did not return valid JSON")
 
 
 async def _extract_facts_with_auto_split(
@@ -1455,17 +1462,19 @@ async def extract_facts_from_text(
             f"chunk_size={config.retain_chunk_size:,}) - starting parallel LLM extraction"
         )
 
-    # Per-chunk retry wrapper: each chunk gets up to MAX_CHUNK_RETRIES attempts.
+    # Per-chunk retry wrapper: each chunk gets up to the configured retain LLM
+    # attempt budget. This keeps chunk-level retries aligned with the operator's
+    # retry cap instead of multiplying it by a hardcoded constant.
     # This handles transient LLM failures (timeouts, rate limits, malformed responses)
     # without discarding the entire batch. If a chunk still fails after all retries,
     # the ENTIRE retain fails — we do not accept partial extraction.
-    MAX_CHUNK_RETRIES = 3
+    max_chunk_attempts = _retain_llm_attempts(config)
     CHUNK_RETRY_BASE_DELAY = 2.0  # seconds, doubles each retry
 
     async def _extract_chunk_with_retry(chunk: str, chunk_index: int) -> tuple:
         """Extract facts from a single chunk with retries on failure."""
         last_exception = None
-        for attempt in range(MAX_CHUNK_RETRIES):
+        for attempt in range(max_chunk_attempts):
             try:
                 return await _extract_facts_with_auto_split(
                     chunk=chunk,
@@ -1480,18 +1489,18 @@ async def extract_facts_from_text(
                 )
             except Exception as e:
                 last_exception = e
-                if attempt < MAX_CHUNK_RETRIES - 1:
+                if attempt < max_chunk_attempts - 1:
                     delay = CHUNK_RETRY_BASE_DELAY * (2**attempt)
                     logger.warning(
                         f"Chunk {chunk_index}/{len(chunks)} extraction failed "
-                        f"(attempt {attempt + 1}/{MAX_CHUNK_RETRIES}): "
+                        f"(attempt {attempt + 1}/{max_chunk_attempts}): "
                         f"{type(e).__name__}. Retrying in {delay:.0f}s..."
                     )
                     await asyncio.sleep(delay)
                 else:
                     logger.error(
                         f"Chunk {chunk_index}/{len(chunks)} extraction failed after "
-                        f"{MAX_CHUNK_RETRIES} attempts: {type(e).__name__}: {e}"
+                        f"{max_chunk_attempts} attempts: {type(e).__name__}: {e}"
                     )
         raise last_exception
 
@@ -1522,7 +1531,7 @@ async def extract_facts_from_text(
         failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}" for idx, err in failed_chunks[:5])
         raise RuntimeError(
             f"Fact extraction failed: {len(failed_chunks)}/{len(chunks)} chunks failed "
-            f"after {MAX_CHUNK_RETRIES} retries each. First failures: {failed_summary}"
+            f"after {max_chunk_attempts} attempts each. First failures: {failed_summary}"
         )
 
     return all_facts, chunk_metadata, total_usage

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -24,6 +24,7 @@ def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = 
     cfg.retain_llm_max_backoff = None
     cfg.llm_max_backoff = 0.0
     cfg.retain_max_completion_tokens = 8192
+    cfg.retain_chunk_size = 3000
     cfg.retain_extraction_mode = "concise"
     cfg.retain_extract_causal_links = False
     cfg.retain_mission = None
@@ -139,6 +140,201 @@ async def test_retain_llm_max_retries_overrides_global():
     assert facts == []
     # Verify it retried exactly retain_llm_max_retries times
     assert llm_config.call.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_retain_extraction_owns_structured_retry_budget():
+    """
+    Retain fact extraction has its own validation/retry loop. It should not pass
+    the same retry budget down to the provider, otherwise structured-output
+    validation failures are multiplied across nested retry layers.
+    """
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=3)
+    llm_config = _make_llm_config(mock_response=[{"invalid": "response"}])
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris in 2023.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert facts == []
+    assert llm_config.call.call_count == 3
+    assert {call.kwargs["max_retries"] for call in llm_config.call.await_args_list} == {0}
+
+
+@pytest.mark.asyncio
+async def test_chunk_retry_wrapper_respects_retain_retry_budget():
+    """
+    Chunk-level retries should use the retain LLM retry budget instead of a
+    hardcoded retry count. Otherwise a user who lowers retain_llm_max_retries
+    still gets repeated structured extraction attempts for each chunk.
+    """
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=1)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with (
+        patch(
+            "hindsight_api.engine.retain.fact_extraction._extract_facts_with_auto_split",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("schema validation failed"),
+        ) as extract_chunk,
+        patch("hindsight_api.engine.retain.fact_extraction.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(RuntimeError, match="Fact extraction failed"):
+            await extract_facts_from_text(
+                text="Alice visited Paris in 2023.",
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                llm_config=llm_config,
+                agent_name="test-agent",
+                config=config,
+                context="travel notes",
+            )
+
+    assert extract_chunk.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chunk_retry_wrapper_falls_back_to_global_retry_budget():
+    """When retain_llm_max_retries is unset, chunk retries use llm_max_retries."""
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+
+    config = _make_config(llm_max_retries=2, retain_llm_max_retries=None)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with (
+        patch(
+            "hindsight_api.engine.retain.fact_extraction._extract_facts_with_auto_split",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("upstream unavailable"),
+        ) as extract_chunk,
+        patch("hindsight_api.engine.retain.fact_extraction.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(RuntimeError, match="Fact extraction failed"):
+            await extract_facts_from_text(
+                text="Alice visited Paris in 2023.",
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                llm_config=llm_config,
+                agent_name="test-agent",
+                config=config,
+                context="travel notes",
+            )
+
+    assert extract_chunk.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_zero_retain_retry_budget_still_allows_one_attempt():
+    """A zero retry budget should mean no retries, not zero total attempts."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response={
+        "facts": [
+            {
+                "what": "Alice visited Paris",
+                "when": "2023",
+                "who": "Alice",
+                "why": "vacation",
+            }
+        ]
+    })
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris in 2023.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert llm_config.call.call_count == 1
+    assert llm_config.call.await_args.kwargs["max_retries"] == 0
+
+
+@pytest.mark.asyncio
+async def test_multi_chunk_retry_budget_is_bounded_per_chunk():
+    """Total failed chunk attempts are bounded by chunk_count * retry budget."""
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=2)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with (
+        patch("hindsight_api.engine.retain.fact_extraction.chunk_text", return_value=["chunk one", "chunk two"]),
+        patch(
+            "hindsight_api.engine.retain.fact_extraction._extract_facts_with_auto_split",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("schema validation failed"),
+        ) as extract_chunk,
+        patch("hindsight_api.engine.retain.fact_extraction.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(RuntimeError, match="2/2 chunks failed after 2 attempts each"):
+            await extract_facts_from_text(
+                text="long text split into two chunks",
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                llm_config=llm_config,
+                agent_name="test-agent",
+                config=config,
+                context="travel notes",
+            )
+
+    assert extract_chunk.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_chunk_retry_still_recovers_from_transient_failure():
+    """The retry cap is bounded, but a transient chunk failure can still recover."""
+    from hindsight_api.engine.response_models import TokenUsage
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=2)
+    llm_config = _make_llm_config(mock_response={"facts": []})
+
+    with (
+        patch(
+            "hindsight_api.engine.retain.fact_extraction._extract_facts_with_auto_split",
+            new_callable=AsyncMock,
+            side_effect=[
+                RuntimeError("temporary provider failure"),
+                ([], TokenUsage()),
+            ],
+        ) as extract_chunk,
+        patch("hindsight_api.engine.retain.fact_extraction.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        facts, chunks, usage = await extract_facts_from_text(
+            text="Alice visited Paris in 2023.",
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            llm_config=llm_config,
+            agent_name="test-agent",
+            config=config,
+            context="travel notes",
+        )
+
+    assert facts == []
+    assert chunks == [("Alice visited Paris in 2023.", 0)]
+    assert extract_chunk.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Prevents retain fact extraction from multiplying structured-output retry attempts across nested retry layers.

The retain path now owns the structured extraction attempt budget directly, while provider-level retries are disabled for each retain extraction call. The per-chunk retry wrapper also uses the configured retain/global LLM budget instead of a hardcoded 3 attempts.

## Why

In issue #1412, operators observed workers stuck in `retain_extract_facts+structured` even after their configured retry budget appeared exhausted. The retain pipeline had more than one retry layer:

- provider-level structured JSON retry
- retain fact validation retry
- chunk-level retry with a hardcoded 3 attempts

That made the effective number of LLM calls higher than the configured `HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES` suggested, especially for multi-chunk inputs.

## Changes

- Adds a small `_retain_llm_attempts()` helper for retain retry budget resolution.
- Uses `retain_llm_max_retries` when set, otherwise falls back to `llm_max_retries`.
- Treats `0` as "no retries, but still make one attempt".
- Sets provider-level `max_retries=0` inside retain fact extraction so the retain loop owns structured validation retries.
- Replaces the hardcoded chunk retry count with the same configured retain attempt budget.
- Expands regression coverage for explicit retain budget, global fallback, zero-budget semantics, multi-chunk bounding, and transient recovery.

## Test Plan

```bash
uv run --directory hindsight-api-slim pytest tests/test_fact_extraction_retry.py tests/test_consolidation_retry_budget.py -q
uv run --directory hindsight-api-slim ruff check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_retry.py
git diff --check
```

All passed locally.

## Risk

This is scoped to retain fact extraction. It intentionally preserves chunk-level retry recovery, but makes the configured retry budget the source of truth so failure cases stop sooner instead of being multiplied by nested retry loops.

I left consolidation unchanged in this PR because that path already has a separate documented outer/inner retry model and tests. This PR focuses on the retain path surfaced by the stuck `retain_extract_facts` logs.

## Related Issue

Addresses the retain extraction retry amplification described in #1412.
