### PR TITLE
fix(search): correct vchord BM25 score direction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -185,8 +185,9 @@ class PostgreSQLDialect(SQLDialect):
         extra_where: str = "",
     ) -> str:
         if text_search_extension == "vchord":
+            # <&> returns a distance (lower = more relevant), negate for score
             bm25_score_expr = (
-                f"search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2'))"
+                f"-(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2')))"
             )
             bm25_order_by = f"{bm25_score_expr} DESC"
             bm25_where_filter = ""


### PR DESCRIPTION
## Summary
- Negate vchord's `<&>` BM25 distance operator so that higher scores mean higher relevance, matching pg_textsearch behavior

The `<&>` operator returns a distance metric (lower = more relevant), but the code used `DESC` ordering, causing the least relevant results to appear first.

## Test plan
- [ ] Configure `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=vchord`
- [ ] Run a recall query and verify relevant results appear first
- [ ] Switch to `pg_textsearch` and verify ordering remains correct