### PR TITLE
fix: regenerate docs skill to sync with removed config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1164,7 +1164,7 @@ jobs:
             model: openai/gpt-oss-20b
             api_key_secret: GROQ_API_KEY
           - provider: bedrock
-            model: us.amazon.nova-2-lite-v1:0
+            model: us.amazon.nova-2-pro-v1:0
     name: LLM acceptance (${{ matrix.provider }}/${{ matrix.model }})
     env:
       HINDSIGHT_API_LLM_PROVIDER: ${{ matrix.provider }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1164,7 +1164,7 @@ jobs:
             model: openai/gpt-oss-20b
             api_key_secret: GROQ_API_KEY
           - provider: bedrock
-            model: us.amazon.nova-2-pro-v1:0
+            model: us.amazon.nova-2-lite-v1:0
     name: LLM acceptance (${{ matrix.provider }}/${{ matrix.model }})
     env:
       HINDSIGHT_API_LLM_PROVIDER: ${{ matrix.provider }}

--- a/deno.lock
+++ b/deno.lock
@@ -42,6 +42,16 @@
   },
   "workspace": {
     "members": {
+      "hindsight-all-npm": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@types/node@22",
+            "npm:tsup@^8.5.1",
+            "npm:typescript@^5.7.0",
+            "npm:vitest@^4.1.2"
+          ]
+        }
+      },
       "hindsight-clients/typescript": {
         "packageJson": {
           "dependencies": [
@@ -58,6 +68,7 @@
       "hindsight-control-plane": {
         "packageJson": {
           "dependencies": [
+            "npm:@chenglou/pretext@^0.0.3",
             "npm:@eslint/eslintrc@^3.3.3",
             "npm:@eslint/js@^9.39.2",
             "npm:@radix-ui/react-alert-dialog@^1.1.15",
@@ -91,11 +102,12 @@
             "npm:eslint@^9.39.1",
             "npm:lucide-react@0.553",
             "npm:next-themes@~0.4.6",
-            "npm:next@^16.1.6",
+            "npm:next@^16.1.7",
             "npm:postcss@^8.5.6",
             "npm:prettier@^3.7.4",
             "npm:react-chrono@^2.9.1",
             "npm:react-dom@^19.2.0",
+            "npm:react-is@^19.2.4",
             "npm:react-markdown@^10.1.0",
             "npm:react18-json-view@~0.2.9",
             "npm:react@^19.2.0",
@@ -131,6 +143,26 @@
             "npm:react@19",
             "npm:redocusaurus@^2.5.0",
             "npm:typescript@~5.6.2"
+          ]
+        }
+      },
+      "hindsight-tools/hindsight-agent-sdk": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@vectorize-io/hindsight-client@~0.5.6",
+            "npm:typescript@^5.4.0",
+            "npm:vitest@^4.1.2"
+          ]
+        }
+      },
+      "hindsight-tools/self-driving-agents": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@clack/prompts@^1.2.0",
+            "npm:@vectorize-io/hindsight-client@~0.5.6",
+            "npm:picocolors@^1.1.0",
+            "npm:typescript@^5.4.0",
+            "npm:vitest@^4.1.2"
           ]
         }
       }

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -186,9 +186,7 @@ class PostgreSQLDialect(SQLDialect):
     ) -> str:
         if text_search_extension == "vchord":
             # <&> returns a distance (lower = more relevant), negate for score
-            bm25_score_expr = (
-                f"-(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2')))"
-            )
+            bm25_score_expr = f"-(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2')))"
             bm25_order_by = f"{bm25_score_expr} DESC"
             bm25_where_filter = ""
         elif text_search_extension == "pg_textsearch":

--- a/hindsight-integrations/n8n/README.md
+++ b/hindsight-integrations/n8n/README.md
@@ -37,31 +37,31 @@ Restart n8n and the **Hindsight** node appears in the node panel.
 
 ### Retain — store content in a bank
 
-| Field | Description |
-|---|---|
-| Bank ID | The memory bank to store in (auto-created on first use) |
+| Field   | Description                                                             |
+| ------- | ----------------------------------------------------------------------- |
+| Bank ID | The memory bank to store in (auto-created on first use)                 |
 | Content | Free text to retain. Hindsight extracts structured facts asynchronously |
-| Tags | Comma-separated tags applied to the stored memory |
+| Tags    | Comma-separated tags applied to the stored memory                       |
 
 ### Recall — search a bank
 
-| Field | Description |
-|---|---|
-| Bank ID | Memory bank to search |
-| Query | Natural-language query |
-| Budget | `low` / `mid` / `high` — controls retrieval depth |
-| Max Tokens | Cap on returned memory tokens |
-| Tags Filter | Filter memories by tag |
+| Field       | Description                                       |
+| ----------- | ------------------------------------------------- |
+| Bank ID     | Memory bank to search                             |
+| Query       | Natural-language query                            |
+| Budget      | `low` / `mid` / `high` — controls retrieval depth |
+| Max Tokens  | Cap on returned memory tokens                     |
+| Tags Filter | Filter memories by tag                            |
 
 Returns: `{ results: [{ text, score, ... }, ...] }`
 
 ### Reflect — LLM-synthesized answer
 
-| Field | Description |
-|---|---|
+| Field   | Description               |
+| ------- | ------------------------- |
 | Bank ID | Memory bank to reflect on |
-| Query | Question to answer |
-| Budget | `low` / `mid` / `high` |
+| Query   | Question to answer        |
+| Budget  | `low` / `mid` / `high`    |
 
 Returns: `{ text: "...", citations: [...] }`
 

--- a/hindsight-integrations/n8n/credentials/HindsightApi.credentials.ts
+++ b/hindsight-integrations/n8n/credentials/HindsightApi.credentials.ts
@@ -1,9 +1,9 @@
 import type {
-	IAuthenticateGeneric,
-	ICredentialTestRequest,
-	ICredentialType,
-	INodeProperties,
-} from 'n8n-workflow';
+  IAuthenticateGeneric,
+  ICredentialTestRequest,
+  ICredentialType,
+  INodeProperties,
+} from "n8n-workflow";
 
 /**
  * Credentials for the Hindsight memory API.
@@ -12,45 +12,45 @@ import type {
  * to your deployment (e.g. http://localhost:8888).
  */
 export class HindsightApi implements ICredentialType {
-	name = 'hindsightApi';
-	displayName = 'Hindsight API';
-	documentationUrl = 'https://hindsight.vectorize.io/developer/api/quickstart';
-	properties: INodeProperties[] = [
-		{
-			displayName: 'API URL',
-			name: 'apiUrl',
-			type: 'string',
-			default: 'https://api.hindsight.vectorize.io',
-			description:
-				'Base URL of the Hindsight API. Defaults to Hindsight Cloud; change for self-hosted instances.',
-			required: true,
-		},
-		{
-			displayName: 'API Key',
-			name: 'apiKey',
-			type: 'string',
-			typeOptions: { password: true },
-			default: '',
-			description:
-				'API key for Hindsight Cloud (begins with "hsk_"). Leave blank for unauthenticated self-hosted instances.',
-		},
-	];
+  name = "hindsightApi";
+  displayName = "Hindsight API";
+  documentationUrl = "https://hindsight.vectorize.io/developer/api/quickstart";
+  properties: INodeProperties[] = [
+    {
+      displayName: "API URL",
+      name: "apiUrl",
+      type: "string",
+      default: "https://api.hindsight.vectorize.io",
+      description:
+        "Base URL of the Hindsight API. Defaults to Hindsight Cloud; change for self-hosted instances.",
+      required: true,
+    },
+    {
+      displayName: "API Key",
+      name: "apiKey",
+      type: "string",
+      typeOptions: { password: true },
+      default: "",
+      description:
+        'API key for Hindsight Cloud (begins with "hsk_"). Leave blank for unauthenticated self-hosted instances.',
+    },
+  ];
 
-	authenticate: IAuthenticateGeneric = {
-		type: 'generic',
-		properties: {
-			headers: {
-				Authorization: '={{ $credentials.apiKey ? "Bearer " + $credentials.apiKey : "" }}',
-			},
-		},
-	};
+  authenticate: IAuthenticateGeneric = {
+    type: "generic",
+    properties: {
+      headers: {
+        Authorization: '={{ $credentials.apiKey ? "Bearer " + $credentials.apiKey : "" }}',
+      },
+    },
+  };
 
-	// Test against /health — works for both Cloud and self-hosted
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: '={{ $credentials.apiUrl }}',
-			url: '/health',
-			method: 'GET',
-		},
-	};
+  // Test against /health — works for both Cloud and self-hosted
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: "={{ $credentials.apiUrl }}",
+      url: "/health",
+      method: "GET",
+    },
+  };
 }

--- a/hindsight-integrations/n8n/index.ts
+++ b/hindsight-integrations/n8n/index.ts
@@ -1,2 +1,2 @@
-export { Hindsight } from './nodes/Hindsight/Hindsight.node';
-export { HindsightApi } from './credentials/HindsightApi.credentials';
+export { Hindsight } from "./nodes/Hindsight/Hindsight.node";
+export { HindsightApi } from "./credentials/HindsightApi.credentials";

--- a/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
+++ b/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
@@ -1,17 +1,17 @@
 import type {
-	IDataObject,
-	IExecuteFunctions,
-	INodeExecutionData,
-	INodeType,
-	INodeTypeDescription,
-} from 'n8n-workflow';
-import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+  IDataObject,
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeType,
+  INodeTypeDescription,
+} from "n8n-workflow";
+import { NodeConnectionTypes, NodeOperationError } from "n8n-workflow";
 
-import { HindsightClient, type Budget } from '@vectorize-io/hindsight-client';
+import { HindsightClient, type Budget } from "@vectorize-io/hindsight-client";
 
 interface HindsightCredentials {
-	apiUrl: string;
-	apiKey?: string;
+  apiUrl: string;
+  apiKey?: string;
 }
 
 /**
@@ -24,262 +24,266 @@ interface HindsightCredentials {
  *  - Reflect: Get an LLM-synthesized answer using the bank's memories
  */
 export class Hindsight implements INodeType {
-	description: INodeTypeDescription = {
-		displayName: 'Hindsight',
-		name: 'hindsight',
-		icon: 'file:hindsight.svg',
-		group: ['transform'],
-		version: 1,
-		subtitle: '={{$parameter["operation"]}}',
-		description: 'Retain, recall, and reflect on long-term memory',
-		defaults: {
-			name: 'Hindsight',
-		},
-		inputs: [NodeConnectionTypes.Main],
-		outputs: [NodeConnectionTypes.Main],
-		credentials: [
-			{
-				name: 'hindsightApi',
-				required: true,
-			},
-		],
-		properties: [
-			{
-				displayName: 'Operation',
-				name: 'operation',
-				type: 'options',
-				noDataExpression: true,
-				options: [
-					{
-						name: 'Retain',
-						value: 'retain',
-						description: 'Store content in a memory bank',
-						action: 'Retain content to a memory bank',
-					},
-					{
-						name: 'Recall',
-						value: 'recall',
-						description: 'Search a memory bank for relevant memories',
-						action: 'Recall memories from a bank',
-					},
-					{
-						name: 'Reflect',
-						value: 'reflect',
-						description: 'Get an LLM-synthesized answer using the bank',
-						action: 'Reflect on memories in a bank',
-					},
-				],
-				default: 'retain',
-			},
+  description: INodeTypeDescription = {
+    displayName: "Hindsight",
+    name: "hindsight",
+    icon: "file:hindsight.svg",
+    group: ["transform"],
+    version: 1,
+    subtitle: '={{$parameter["operation"]}}',
+    description: "Retain, recall, and reflect on long-term memory",
+    defaults: {
+      name: "Hindsight",
+    },
+    inputs: [NodeConnectionTypes.Main],
+    outputs: [NodeConnectionTypes.Main],
+    credentials: [
+      {
+        name: "hindsightApi",
+        required: true,
+      },
+    ],
+    properties: [
+      {
+        displayName: "Operation",
+        name: "operation",
+        type: "options",
+        noDataExpression: true,
+        options: [
+          {
+            name: "Retain",
+            value: "retain",
+            description: "Store content in a memory bank",
+            action: "Retain content to a memory bank",
+          },
+          {
+            name: "Recall",
+            value: "recall",
+            description: "Search a memory bank for relevant memories",
+            action: "Recall memories from a bank",
+          },
+          {
+            name: "Reflect",
+            value: "reflect",
+            description: "Get an LLM-synthesized answer using the bank",
+            action: "Reflect on memories in a bank",
+          },
+        ],
+        default: "retain",
+      },
 
-			// Bank ID — common to all operations
-			{
-				displayName: 'Bank ID',
-				name: 'bankId',
-				type: 'string',
-				default: '',
-				required: true,
-				description:
-					'The Hindsight memory bank to operate on. A bank is created on first use if it does not exist.',
-				placeholder: 'user-123',
-			},
+      // Bank ID — common to all operations
+      {
+        displayName: "Bank ID",
+        name: "bankId",
+        type: "string",
+        default: "",
+        required: true,
+        description:
+          "The Hindsight memory bank to operate on. A bank is created on first use if it does not exist.",
+        placeholder: "user-123",
+      },
 
-			// === RETAIN ===
-			{
-				displayName: 'Content',
-				name: 'content',
-				type: 'string',
-				typeOptions: {
-					rows: 4,
-				},
-				default: '',
-				required: true,
-				description: 'The text to store in memory. Hindsight extracts facts asynchronously after retain.',
-				displayOptions: {
-					show: {
-						operation: ['retain'],
-					},
-				},
-			},
-			{
-				displayName: 'Tags',
-				name: 'retainTags',
-				type: 'string',
-				default: '',
-				description: 'Comma-separated tags applied to the stored memory (e.g. "user:alex,scope:profile")',
-				displayOptions: {
-					show: {
-						operation: ['retain'],
-					},
-				},
-			},
+      // === RETAIN ===
+      {
+        displayName: "Content",
+        name: "content",
+        type: "string",
+        typeOptions: {
+          rows: 4,
+        },
+        default: "",
+        required: true,
+        description:
+          "The text to store in memory. Hindsight extracts facts asynchronously after retain.",
+        displayOptions: {
+          show: {
+            operation: ["retain"],
+          },
+        },
+      },
+      {
+        displayName: "Tags",
+        name: "retainTags",
+        type: "string",
+        default: "",
+        description:
+          'Comma-separated tags applied to the stored memory (e.g. "user:alex,scope:profile")',
+        displayOptions: {
+          show: {
+            operation: ["retain"],
+          },
+        },
+      },
 
-			// === RECALL ===
-			{
-				displayName: 'Query',
-				name: 'recallQuery',
-				type: 'string',
-				default: '',
-				required: true,
-				description: 'Natural-language query to search memories with',
-				displayOptions: {
-					show: {
-						operation: ['recall'],
-					},
-				},
-			},
-			{
-				displayName: 'Budget',
-				name: 'recallBudget',
-				type: 'options',
-				options: [
-					{ name: 'Low', value: 'low' },
-					{ name: 'Mid', value: 'mid' },
-					{ name: 'High', value: 'high' },
-				],
-				default: 'mid',
-				description: 'Recall budget level — controls how exhaustive the retrieval is',
-				displayOptions: {
-					show: {
-						operation: ['recall'],
-					},
-				},
-			},
-			{
-				displayName: 'Max Tokens',
-				name: 'recallMaxTokens',
-				type: 'number',
-				default: 4096,
-				description: 'Maximum tokens of memory to return',
-				displayOptions: {
-					show: {
-						operation: ['recall'],
-					},
-				},
-			},
-			{
-				displayName: 'Tags Filter',
-				name: 'recallTags',
-				type: 'string',
-				default: '',
-				description: 'Comma-separated tags to filter recall (leave blank for no filter)',
-				displayOptions: {
-					show: {
-						operation: ['recall'],
-					},
-				},
-			},
+      // === RECALL ===
+      {
+        displayName: "Query",
+        name: "recallQuery",
+        type: "string",
+        default: "",
+        required: true,
+        description: "Natural-language query to search memories with",
+        displayOptions: {
+          show: {
+            operation: ["recall"],
+          },
+        },
+      },
+      {
+        displayName: "Budget",
+        name: "recallBudget",
+        type: "options",
+        options: [
+          { name: "Low", value: "low" },
+          { name: "Mid", value: "mid" },
+          { name: "High", value: "high" },
+        ],
+        default: "mid",
+        description: "Recall budget level — controls how exhaustive the retrieval is",
+        displayOptions: {
+          show: {
+            operation: ["recall"],
+          },
+        },
+      },
+      {
+        displayName: "Max Tokens",
+        name: "recallMaxTokens",
+        type: "number",
+        default: 4096,
+        description: "Maximum tokens of memory to return",
+        displayOptions: {
+          show: {
+            operation: ["recall"],
+          },
+        },
+      },
+      {
+        displayName: "Tags Filter",
+        name: "recallTags",
+        type: "string",
+        default: "",
+        description: "Comma-separated tags to filter recall (leave blank for no filter)",
+        displayOptions: {
+          show: {
+            operation: ["recall"],
+          },
+        },
+      },
 
-			// === REFLECT ===
-			{
-				displayName: 'Query',
-				name: 'reflectQuery',
-				type: 'string',
-				default: '',
-				required: true,
-				description: 'Question to answer using the bank\'s memories',
-				displayOptions: {
-					show: {
-						operation: ['reflect'],
-					},
-				},
-			},
-			{
-				displayName: 'Budget',
-				name: 'reflectBudget',
-				type: 'options',
-				options: [
-					{ name: 'Low', value: 'low' },
-					{ name: 'Mid', value: 'mid' },
-					{ name: 'High', value: 'high' },
-				],
-				default: 'mid',
-				description: 'Reflect budget level',
-				displayOptions: {
-					show: {
-						operation: ['reflect'],
-					},
-				},
-			},
-		],
-	};
+      // === REFLECT ===
+      {
+        displayName: "Query",
+        name: "reflectQuery",
+        type: "string",
+        default: "",
+        required: true,
+        description: "Question to answer using the bank's memories",
+        displayOptions: {
+          show: {
+            operation: ["reflect"],
+          },
+        },
+      },
+      {
+        displayName: "Budget",
+        name: "reflectBudget",
+        type: "options",
+        options: [
+          { name: "Low", value: "low" },
+          { name: "Mid", value: "mid" },
+          { name: "High", value: "high" },
+        ],
+        default: "mid",
+        description: "Reflect budget level",
+        displayOptions: {
+          show: {
+            operation: ["reflect"],
+          },
+        },
+      },
+    ],
+  };
 
-	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const items = this.getInputData();
-		const returnData: INodeExecutionData[] = [];
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
 
-		const credentials = (await this.getCredentials('hindsightApi')) as unknown as HindsightCredentials;
-		const client = new HindsightClient({
-			baseUrl: credentials.apiUrl,
-			apiKey: credentials.apiKey || undefined,
-		});
+    const credentials = (await this.getCredentials(
+      "hindsightApi"
+    )) as unknown as HindsightCredentials;
+    const client = new HindsightClient({
+      baseUrl: credentials.apiUrl,
+      apiKey: credentials.apiKey || undefined,
+    });
 
-		for (let i = 0; i < items.length; i++) {
-			try {
-				const operation = this.getNodeParameter('operation', i) as string;
-				const bankId = this.getNodeParameter('bankId', i) as string;
+    for (let i = 0; i < items.length; i++) {
+      try {
+        const operation = this.getNodeParameter("operation", i) as string;
+        const bankId = this.getNodeParameter("bankId", i) as string;
 
-				if (!bankId) {
-					throw new NodeOperationError(this.getNode(), 'bankId is required', { itemIndex: i });
-				}
+        if (!bankId) {
+          throw new NodeOperationError(this.getNode(), "bankId is required", { itemIndex: i });
+        }
 
-				let result: IDataObject;
+        let result: IDataObject;
 
-				if (operation === 'retain') {
-					const content = this.getNodeParameter('content', i) as string;
-					const tagsRaw = this.getNodeParameter('retainTags', i, '') as string;
-					const tags = parseTags(tagsRaw);
+        if (operation === "retain") {
+          const content = this.getNodeParameter("content", i) as string;
+          const tagsRaw = this.getNodeParameter("retainTags", i, "") as string;
+          const tags = parseTags(tagsRaw);
 
-					const response = await client.retain(bankId, content, tags.length ? { tags } : undefined);
-					result = response as unknown as IDataObject;
-				} else if (operation === 'recall') {
-					const query = this.getNodeParameter('recallQuery', i) as string;
-					const budget = this.getNodeParameter('recallBudget', i, 'mid') as string;
-					const maxTokens = this.getNodeParameter('recallMaxTokens', i, 4096) as number;
-					const tagsRaw = this.getNodeParameter('recallTags', i, '') as string;
-					const tags = parseTags(tagsRaw);
+          const response = await client.retain(bankId, content, tags.length ? { tags } : undefined);
+          result = response as unknown as IDataObject;
+        } else if (operation === "recall") {
+          const query = this.getNodeParameter("recallQuery", i) as string;
+          const budget = this.getNodeParameter("recallBudget", i, "mid") as string;
+          const maxTokens = this.getNodeParameter("recallMaxTokens", i, 4096) as number;
+          const tagsRaw = this.getNodeParameter("recallTags", i, "") as string;
+          const tags = parseTags(tagsRaw);
 
-					const response = await client.recall(bankId, query, {
-						budget: budget as Budget,
-						maxTokens,
-						...(tags.length ? { tags } : {}),
-					});
-					result = response as unknown as IDataObject;
-				} else if (operation === 'reflect') {
-					const query = this.getNodeParameter('reflectQuery', i) as string;
-					const budget = this.getNodeParameter('reflectBudget', i, 'mid') as string;
+          const response = await client.recall(bankId, query, {
+            budget: budget as Budget,
+            maxTokens,
+            ...(tags.length ? { tags } : {}),
+          });
+          result = response as unknown as IDataObject;
+        } else if (operation === "reflect") {
+          const query = this.getNodeParameter("reflectQuery", i) as string;
+          const budget = this.getNodeParameter("reflectBudget", i, "mid") as string;
 
-					const response = await client.reflect(bankId, query, {
-						budget: budget as Budget,
-					});
-					result = response as unknown as IDataObject;
-				} else {
-					throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, {
-						itemIndex: i,
-					});
-				}
+          const response = await client.reflect(bankId, query, {
+            budget: budget as Budget,
+          });
+          result = response as unknown as IDataObject;
+        } else {
+          throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, {
+            itemIndex: i,
+          });
+        }
 
-				returnData.push({ json: result, pairedItem: { item: i } });
-			} catch (error) {
-				if (this.continueOnFail()) {
-					returnData.push({
-						json: { error: (error as Error).message },
-						pairedItem: { item: i },
-					});
-					continue;
-				}
-				throw error;
-			}
-		}
+        returnData.push({ json: result, pairedItem: { item: i } });
+      } catch (error) {
+        if (this.continueOnFail()) {
+          returnData.push({
+            json: { error: (error as Error).message },
+            pairedItem: { item: i },
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
 
-		return [returnData];
-	}
+    return [returnData];
+  }
 }
 
 function parseTags(raw: string): string[] {
-	if (!raw) return [];
-	return raw
-		.split(',')
-		.map((t) => t.trim())
-		.filter(Boolean);
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
 }

--- a/hindsight-integrations/n8n/test/credentials.test.ts
+++ b/hindsight-integrations/n8n/test/credentials.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { HindsightApi } from '../credentials/HindsightApi.credentials';
+import { HindsightApi } from "../credentials/HindsightApi.credentials";
 
-describe('HindsightApi credentials', () => {
-	const cred = new HindsightApi();
+describe("HindsightApi credentials", () => {
+  const cred = new HindsightApi();
 
-	it('declares the expected name and displayName', () => {
-		expect(cred.name).toBe('hindsightApi');
-		expect(cred.displayName).toBe('Hindsight API');
-	});
+  it("declares the expected name and displayName", () => {
+    expect(cred.name).toBe("hindsightApi");
+    expect(cred.displayName).toBe("Hindsight API");
+  });
 
-	it('exposes apiUrl and apiKey properties', () => {
-		const propNames = cred.properties.map((p) => p.name);
-		expect(propNames).toContain('apiUrl');
-		expect(propNames).toContain('apiKey');
-	});
+  it("exposes apiUrl and apiKey properties", () => {
+    const propNames = cred.properties.map((p) => p.name);
+    expect(propNames).toContain("apiUrl");
+    expect(propNames).toContain("apiKey");
+  });
 
-	it('defaults apiUrl to Hindsight Cloud', () => {
-		const apiUrlProp = cred.properties.find((p) => p.name === 'apiUrl');
-		expect(apiUrlProp?.default).toBe('https://api.hindsight.vectorize.io');
-	});
+  it("defaults apiUrl to Hindsight Cloud", () => {
+    const apiUrlProp = cred.properties.find((p) => p.name === "apiUrl");
+    expect(apiUrlProp?.default).toBe("https://api.hindsight.vectorize.io");
+  });
 
-	it('marks apiKey as a password field', () => {
-		const apiKeyProp = cred.properties.find((p) => p.name === 'apiKey');
-		expect(apiKeyProp?.typeOptions?.password).toBe(true);
-	});
+  it("marks apiKey as a password field", () => {
+    const apiKeyProp = cred.properties.find((p) => p.name === "apiKey");
+    expect(apiKeyProp?.typeOptions?.password).toBe(true);
+  });
 
-	it('uses a generic Bearer-token auth scheme', () => {
-		expect(cred.authenticate.type).toBe('generic');
-		const props = cred.authenticate.properties as { headers?: Record<string, string> };
-		expect(props.headers?.Authorization).toContain('Bearer');
-	});
+  it("uses a generic Bearer-token auth scheme", () => {
+    expect(cred.authenticate.type).toBe("generic");
+    const props = cred.authenticate.properties as { headers?: Record<string, string> };
+    expect(props.headers?.Authorization).toContain("Bearer");
+  });
 
-	it('tests against /health', () => {
-		expect(cred.test.request.url).toBe('/health');
-		expect(cred.test.request.method).toBe('GET');
-	});
+  it("tests against /health", () => {
+    expect(cred.test.request.url).toBe("/health");
+    expect(cred.test.request.method).toBe("GET");
+  });
 });

--- a/hindsight-integrations/n8n/test/node-execute.test.ts
+++ b/hindsight-integrations/n8n/test/node-execute.test.ts
@@ -1,192 +1,194 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { IExecuteFunctions, INodeExecutionData } from "n8n-workflow";
 
 const mockRetain = vi.fn();
 const mockRecall = vi.fn();
 const mockReflect = vi.fn();
 
-vi.mock('@vectorize-io/hindsight-client', () => {
-	return {
-		HindsightClient: class {
-			constructor(public options: unknown) {}
-			retain = mockRetain;
-			recall = mockRecall;
-			reflect = mockReflect;
-		},
-	};
+vi.mock("@vectorize-io/hindsight-client", () => {
+  return {
+    HindsightClient: class {
+      constructor(public options: unknown) {}
+      retain = mockRetain;
+      recall = mockRecall;
+      reflect = mockReflect;
+    },
+  };
 });
 
-import { Hindsight } from '../nodes/Hindsight/Hindsight.node';
+import { Hindsight } from "../nodes/Hindsight/Hindsight.node";
 
 function createMockExecuteFunctions(params: Record<string, unknown>): IExecuteFunctions {
-	return {
-		getInputData: () => [{ json: {} }] as INodeExecutionData[],
-		getCredentials: vi.fn().mockResolvedValue({
-			apiUrl: 'https://api.example.com',
-			apiKey: 'hsk_test123',
-		}),
-		getNodeParameter: vi.fn().mockImplementation((name: string, _index: number, fallback?: unknown) => {
-			return params[name] ?? fallback;
-		}),
-		getNode: vi.fn().mockReturnValue({ name: 'Hindsight' }),
-		continueOnFail: vi.fn().mockReturnValue(false),
-	} as unknown as IExecuteFunctions;
+  return {
+    getInputData: () => [{ json: {} }] as INodeExecutionData[],
+    getCredentials: vi.fn().mockResolvedValue({
+      apiUrl: "https://api.example.com",
+      apiKey: "hsk_test123",
+    }),
+    getNodeParameter: vi
+      .fn()
+      .mockImplementation((name: string, _index: number, fallback?: unknown) => {
+        return params[name] ?? fallback;
+      }),
+    getNode: vi.fn().mockReturnValue({ name: "Hindsight" }),
+    continueOnFail: vi.fn().mockReturnValue(false),
+  } as unknown as IExecuteFunctions;
 }
 
-describe('Hindsight node execute()', () => {
-	const node = new Hindsight();
+describe("Hindsight node execute()", () => {
+  const node = new Hindsight();
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-	it('calls client.retain with correct arguments', async () => {
-		mockRetain.mockResolvedValue({ operation_id: 'op-1', status: 'accepted' });
+  it("calls client.retain with correct arguments", async () => {
+    mockRetain.mockResolvedValue({ operation_id: "op-1", status: "accepted" });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'retain',
-			bankId: 'bank-1',
-			content: 'User prefers dark mode',
-			retainTags: 'pref,ui',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "retain",
+      bankId: "bank-1",
+      content: "User prefers dark mode",
+      retainTags: "pref,ui",
+    });
 
-		const result = await node.execute.call(mockFns);
+    const result = await node.execute.call(mockFns);
 
-		// Client was instantiated (verified by the successful retain call)
-		expect(mockRetain).toHaveBeenCalledWith('bank-1', 'User prefers dark mode', {
-			tags: ['pref', 'ui'],
-		});
-		expect(result[0][0].json).toEqual({ operation_id: 'op-1', status: 'accepted' });
-	});
+    // Client was instantiated (verified by the successful retain call)
+    expect(mockRetain).toHaveBeenCalledWith("bank-1", "User prefers dark mode", {
+      tags: ["pref", "ui"],
+    });
+    expect(result[0][0].json).toEqual({ operation_id: "op-1", status: "accepted" });
+  });
 
-	it('calls client.retain without tags when tags is empty', async () => {
-		mockRetain.mockResolvedValue({ operation_id: 'op-2', status: 'accepted' });
+  it("calls client.retain without tags when tags is empty", async () => {
+    mockRetain.mockResolvedValue({ operation_id: "op-2", status: "accepted" });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'retain',
-			bankId: 'bank-1',
-			content: 'Hello world',
-			retainTags: '',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "retain",
+      bankId: "bank-1",
+      content: "Hello world",
+      retainTags: "",
+    });
 
-		await node.execute.call(mockFns);
+    await node.execute.call(mockFns);
 
-		expect(mockRetain).toHaveBeenCalledWith('bank-1', 'Hello world', undefined);
-	});
+    expect(mockRetain).toHaveBeenCalledWith("bank-1", "Hello world", undefined);
+  });
 
-	it('calls client.recall with correct arguments', async () => {
-		mockRecall.mockResolvedValue({
-			results: [{ text: 'User prefers dark mode', score: 0.95 }],
-		});
+  it("calls client.recall with correct arguments", async () => {
+    mockRecall.mockResolvedValue({
+      results: [{ text: "User prefers dark mode", score: 0.95 }],
+    });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'recall',
-			bankId: 'bank-1',
-			recallQuery: 'what are user preferences?',
-			recallBudget: 'high',
-			recallMaxTokens: 2048,
-			recallTags: 'pref',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "recall",
+      bankId: "bank-1",
+      recallQuery: "what are user preferences?",
+      recallBudget: "high",
+      recallMaxTokens: 2048,
+      recallTags: "pref",
+    });
 
-		const result = await node.execute.call(mockFns);
+    const result = await node.execute.call(mockFns);
 
-		expect(mockRecall).toHaveBeenCalledWith('bank-1', 'what are user preferences?', {
-			budget: 'high',
-			maxTokens: 2048,
-			tags: ['pref'],
-		});
-		expect(result[0][0].json).toEqual({
-			results: [{ text: 'User prefers dark mode', score: 0.95 }],
-		});
-	});
+    expect(mockRecall).toHaveBeenCalledWith("bank-1", "what are user preferences?", {
+      budget: "high",
+      maxTokens: 2048,
+      tags: ["pref"],
+    });
+    expect(result[0][0].json).toEqual({
+      results: [{ text: "User prefers dark mode", score: 0.95 }],
+    });
+  });
 
-	it('calls client.recall without tags when tags filter is empty', async () => {
-		mockRecall.mockResolvedValue({ results: [] });
+  it("calls client.recall without tags when tags filter is empty", async () => {
+    mockRecall.mockResolvedValue({ results: [] });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'recall',
-			bankId: 'bank-1',
-			recallQuery: 'hello',
-			recallBudget: 'mid',
-			recallMaxTokens: 4096,
-			recallTags: '',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "recall",
+      bankId: "bank-1",
+      recallQuery: "hello",
+      recallBudget: "mid",
+      recallMaxTokens: 4096,
+      recallTags: "",
+    });
 
-		await node.execute.call(mockFns);
+    await node.execute.call(mockFns);
 
-		expect(mockRecall).toHaveBeenCalledWith('bank-1', 'hello', {
-			budget: 'mid',
-			maxTokens: 4096,
-		});
-	});
+    expect(mockRecall).toHaveBeenCalledWith("bank-1", "hello", {
+      budget: "mid",
+      maxTokens: 4096,
+    });
+  });
 
-	it('calls client.reflect with correct arguments', async () => {
-		mockReflect.mockResolvedValue({
-			text: 'The user prefers dark mode and minimal UI.',
-			citations: [],
-		});
+  it("calls client.reflect with correct arguments", async () => {
+    mockReflect.mockResolvedValue({
+      text: "The user prefers dark mode and minimal UI.",
+      citations: [],
+    });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'reflect',
-			bankId: 'bank-1',
-			reflectQuery: 'summarize user preferences',
-			reflectBudget: 'low',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "reflect",
+      bankId: "bank-1",
+      reflectQuery: "summarize user preferences",
+      reflectBudget: "low",
+    });
 
-		const result = await node.execute.call(mockFns);
+    const result = await node.execute.call(mockFns);
 
-		expect(mockReflect).toHaveBeenCalledWith('bank-1', 'summarize user preferences', {
-			budget: 'low',
-		});
-		expect(result[0][0].json).toEqual({
-			text: 'The user prefers dark mode and minimal UI.',
-			citations: [],
-		});
-	});
+    expect(mockReflect).toHaveBeenCalledWith("bank-1", "summarize user preferences", {
+      budget: "low",
+    });
+    expect(result[0][0].json).toEqual({
+      text: "The user prefers dark mode and minimal UI.",
+      citations: [],
+    });
+  });
 
-	it('throws NodeOperationError when bankId is empty', async () => {
-		const mockFns = createMockExecuteFunctions({
-			operation: 'retain',
-			bankId: '',
-			content: 'test',
-			retainTags: '',
-		});
+  it("throws NodeOperationError when bankId is empty", async () => {
+    const mockFns = createMockExecuteFunctions({
+      operation: "retain",
+      bankId: "",
+      content: "test",
+      retainTags: "",
+    });
 
-		await expect(node.execute.call(mockFns)).rejects.toThrow('bankId is required');
-	});
+    await expect(node.execute.call(mockFns)).rejects.toThrow("bankId is required");
+  });
 
-	it('returns error json when continueOnFail is true and client throws', async () => {
-		mockRetain.mockRejectedValue(new Error('Network error'));
+  it("returns error json when continueOnFail is true and client throws", async () => {
+    mockRetain.mockRejectedValue(new Error("Network error"));
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'retain',
-			bankId: 'bank-1',
-			content: 'test',
-			retainTags: '',
-		});
-		(mockFns.continueOnFail as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const mockFns = createMockExecuteFunctions({
+      operation: "retain",
+      bankId: "bank-1",
+      content: "test",
+      retainTags: "",
+    });
+    (mockFns.continueOnFail as ReturnType<typeof vi.fn>).mockReturnValue(true);
 
-		const result = await node.execute.call(mockFns);
+    const result = await node.execute.call(mockFns);
 
-		expect(result[0][0].json).toEqual({ error: 'Network error' });
-	});
+    expect(result[0][0].json).toEqual({ error: "Network error" });
+  });
 
-	it('omits apiKey from client when credential has no key', async () => {
-		mockRetain.mockResolvedValue({ operation_id: 'op-3', status: 'accepted' });
+  it("omits apiKey from client when credential has no key", async () => {
+    mockRetain.mockResolvedValue({ operation_id: "op-3", status: "accepted" });
 
-		const mockFns = createMockExecuteFunctions({
-			operation: 'retain',
-			bankId: 'bank-1',
-			content: 'test',
-			retainTags: '',
-		});
-		(mockFns.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
-			apiUrl: 'http://localhost:8888',
-			apiKey: '',
-		});
+    const mockFns = createMockExecuteFunctions({
+      operation: "retain",
+      bankId: "bank-1",
+      content: "test",
+      retainTags: "",
+    });
+    (mockFns.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
+      apiUrl: "http://localhost:8888",
+      apiKey: "",
+    });
 
-		await node.execute.call(mockFns);
+    await node.execute.call(mockFns);
 
-		// Verified by the successful retain call with empty apiKey credential
-	});
+    // Verified by the successful retain call with empty apiKey credential
+  });
 });

--- a/hindsight-integrations/n8n/test/node.test.ts
+++ b/hindsight-integrations/n8n/test/node.test.ts
@@ -1,58 +1,58 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { Hindsight } from '../nodes/Hindsight/Hindsight.node';
+import { Hindsight } from "../nodes/Hindsight/Hindsight.node";
 
-describe('Hindsight node', () => {
-	const node = new Hindsight();
+describe("Hindsight node", () => {
+  const node = new Hindsight();
 
-	it('declares the expected node metadata', () => {
-		expect(node.description.name).toBe('hindsight');
-		expect(node.description.displayName).toBe('Hindsight');
-		expect(node.description.version).toBe(1);
-	});
+  it("declares the expected node metadata", () => {
+    expect(node.description.name).toBe("hindsight");
+    expect(node.description.displayName).toBe("Hindsight");
+    expect(node.description.version).toBe(1);
+  });
 
-	it('requires the hindsightApi credential', () => {
-		const cred = node.description.credentials?.[0];
-		expect(cred?.name).toBe('hindsightApi');
-		expect(cred?.required).toBe(true);
-	});
+  it("requires the hindsightApi credential", () => {
+    const cred = node.description.credentials?.[0];
+    expect(cred?.name).toBe("hindsightApi");
+    expect(cred?.required).toBe(true);
+  });
 
-	it('exposes retain / recall / reflect operations', () => {
-		const operationProp = node.description.properties.find((p) => p.name === 'operation');
-		expect(operationProp).toBeDefined();
-		const values = (operationProp?.options as Array<{ value: string }>).map((o) => o.value);
-		expect(values).toEqual(['retain', 'recall', 'reflect']);
-	});
+  it("exposes retain / recall / reflect operations", () => {
+    const operationProp = node.description.properties.find((p) => p.name === "operation");
+    expect(operationProp).toBeDefined();
+    const values = (operationProp?.options as Array<{ value: string }>).map((o) => o.value);
+    expect(values).toEqual(["retain", "recall", "reflect"]);
+  });
 
-	it('requires a bankId for every operation', () => {
-		const bankIdProp = node.description.properties.find((p) => p.name === 'bankId');
-		expect(bankIdProp).toBeDefined();
-		expect(bankIdProp?.required).toBe(true);
-		// No displayOptions = visible for every operation
-		expect(bankIdProp?.displayOptions).toBeUndefined();
-	});
+  it("requires a bankId for every operation", () => {
+    const bankIdProp = node.description.properties.find((p) => p.name === "bankId");
+    expect(bankIdProp).toBeDefined();
+    expect(bankIdProp?.required).toBe(true);
+    // No displayOptions = visible for every operation
+    expect(bankIdProp?.displayOptions).toBeUndefined();
+  });
 
-	it('shows content only for retain', () => {
-		const contentProp = node.description.properties.find((p) => p.name === 'content');
-		expect(contentProp?.displayOptions?.show?.operation).toEqual(['retain']);
-	});
+  it("shows content only for retain", () => {
+    const contentProp = node.description.properties.find((p) => p.name === "content");
+    expect(contentProp?.displayOptions?.show?.operation).toEqual(["retain"]);
+  });
 
-	it('shows recall query only for recall', () => {
-		const queryProp = node.description.properties.find((p) => p.name === 'recallQuery');
-		expect(queryProp?.displayOptions?.show?.operation).toEqual(['recall']);
-	});
+  it("shows recall query only for recall", () => {
+    const queryProp = node.description.properties.find((p) => p.name === "recallQuery");
+    expect(queryProp?.displayOptions?.show?.operation).toEqual(["recall"]);
+  });
 
-	it('shows reflect query only for reflect', () => {
-		const queryProp = node.description.properties.find((p) => p.name === 'reflectQuery');
-		expect(queryProp?.displayOptions?.show?.operation).toEqual(['reflect']);
-	});
+  it("shows reflect query only for reflect", () => {
+    const queryProp = node.description.properties.find((p) => p.name === "reflectQuery");
+    expect(queryProp?.displayOptions?.show?.operation).toEqual(["reflect"]);
+  });
 
-	it('exposes budget options low/mid/high for recall and reflect', () => {
-		for (const propName of ['recallBudget', 'reflectBudget']) {
-			const prop = node.description.properties.find((p) => p.name === propName);
-			expect(prop).toBeDefined();
-			const values = (prop?.options as Array<{ value: string }>).map((o) => o.value);
-			expect(values).toEqual(['low', 'mid', 'high']);
-		}
-	});
+  it("exposes budget options low/mid/high for recall and reflect", () => {
+    for (const propName of ["recallBudget", "reflectBudget"]) {
+      const prop = node.description.properties.find((p) => p.name === propName);
+      expect(prop).toBeDefined();
+      const values = (prop?.options as Array<{ value: string }>).map((o) => o.value);
+      expect(values).toEqual(["low", "mid", "high"]);
+    }
+  });
 });

--- a/hindsight-integrations/n8n/vitest.config.ts
+++ b/hindsight-integrations/n8n/vitest.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	test: {
-		include: ['test/**/*.test.ts'],
-		environment: 'node',
-		globals: false,
-	},
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
 });


### PR DESCRIPTION
## Summary
- Regenerated `skills/hindsight-docs/references/developer/configuration.md` to remove the `HINDSIGHT_API_LLM_DEFAULT_HEADERS` entry that was already removed from source docs
- Fixes the `verify-generated-files` CI check

## Test plan
- [ ] `verify-generated-files` CI job passes