### PR TITLE
Add AlloyDB ScaNN vector index support

### DIFF
--- a/docker/docker-compose/alloydb/docker-compose.yaml
+++ b/docker/docker-compose/alloydb/docker-compose.yaml
@@ -1,0 +1,90 @@
+name: hindsight
+# Docker Compose file for Hindsight with AlloyDB Omni and ScaNN
+# Uses Google's free AlloyDB Omni container image: https://hub.docker.com/r/google/alloydbomni
+#
+# Usage:
+# docker compose -f docker/docker-compose/alloydb/docker-compose.yaml up -d
+#
+# Make sure to set the required environment variables before running:
+# - HINDSIGHT_DB_PASSWORD: password for the AlloyDB Omni/PostgreSQL user
+# - Configure LLM provider variables as needed (see the hindsight service below)
+#
+# Optional environment variables with defaults:
+# - HINDSIGHT_VERSION: Hindsight application version (default: latest)
+# - HINDSIGHT_DB_VERSION: AlloyDB Omni image tag (default: 17)
+# - HINDSIGHT_DB_USER: database user (default: hindsight_user)
+# - HINDSIGHT_DB_NAME: database name (default: hindsight_db)
+
+services:
+  db:
+    image: google/alloydbomni:${HINDSIGHT_DB_VERSION:-17}
+    container_name: hindsight-db-alloydb
+    restart: always
+    ports:
+      - "5438:5432"
+    environment:
+      POSTGRES_USER: ${HINDSIGHT_DB_USER:-hindsight_user}
+      POSTGRES_PASSWORD: ${HINDSIGHT_DB_PASSWORD:-hindsight_password}
+      POSTGRES_DB: ${HINDSIGHT_DB_NAME:-hindsight_db}
+    volumes:
+      - alloydb_data:/var/lib/postgresql/data
+    networks:
+      - hindsight-net
+
+  alloydb-init:
+    image: google/alloydbomni:${HINDSIGHT_DB_VERSION:-17}
+    depends_on:
+      - db
+    environment:
+      - PGPASSWORD=${HINDSIGHT_DB_PASSWORD:-hindsight_password}
+    command:
+      - bash
+      - -c
+      - |
+        echo 'Waiting for AlloyDB Omni to be ready...'
+        until pg_isready -h hindsight-db-alloydb -p 5432 -U ${HINDSIGHT_DB_USER:-hindsight_user}; do
+          echo 'AlloyDB Omni is unavailable - sleeping'
+          sleep 2
+        done
+        echo 'AlloyDB Omni is ready - creating ${HINDSIGHT_DB_NAME:-hindsight_db} database'
+        psql -h hindsight-db-alloydb -p 5432 -U ${HINDSIGHT_DB_USER:-hindsight_user} -c 'CREATE DATABASE ${HINDSIGHT_DB_NAME:-hindsight_db};' 2>/dev/null || echo 'Database already exists'
+        echo 'Creating vector and alloydb_scann extensions'
+        psql -h hindsight-db-alloydb -p 5432 -U ${HINDSIGHT_DB_USER:-hindsight_user} -d ${HINDSIGHT_DB_NAME:-hindsight_db} -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+        psql -h hindsight-db-alloydb -p 5432 -U ${HINDSIGHT_DB_USER:-hindsight_user} -d ${HINDSIGHT_DB_NAME:-hindsight_db} -c 'CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE;'
+        echo 'Database and extensions created successfully'
+    restart: "no"
+    networks:
+      - hindsight-net
+
+  hindsight:
+    image: ghcr.io/vectorize-io/hindsight:${HINDSIGHT_VERSION:-latest}
+    container_name: hindsight-app
+    ports:
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      # LLM Configuration
+      HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
+      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+
+      # Database Configuration
+      HINDSIGHT_API_DATABASE_URL: postgresql://${HINDSIGHT_DB_USER:-hindsight_user}:${HINDSIGHT_DB_PASSWORD:-hindsight_password}@db:5432/${HINDSIGHT_DB_NAME:-hindsight_db}
+
+      # Vector and Text Search Extensions
+      HINDSIGHT_API_VECTOR_EXTENSION: scann
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION: native
+
+    depends_on:
+      db:
+        condition: service_started
+      alloydb-init:
+        condition: service_completed_successfully
+    networks:
+      - hindsight-net
+
+networks:
+  hindsight-net:
+    driver: bridge
+
+volumes:
+  alloydb_data:

--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -8,6 +8,9 @@ logger = logging.getLogger(__name__)
 
 VALID_EXTENSIONS = ("pgvector", "pgvectorscale", "vchord", "scann")
 
+SCANN_MIN_ROWS_FOR_AUTO_INDEX = 10_000
+
+
 _EXTENSION_NAMES = {
     "pgvector": "vector",
     "pgvectorscale": "vectorscale",
@@ -80,6 +83,28 @@ def index_type_keyword(ext: str) -> str:
     if normalized == "pg_diskann":
         return _INDEX_TYPE_KEYWORDS[normalized]
     return _INDEX_TYPE_KEYWORDS[validate_extension(normalized)]
+
+
+def minimum_rows_for_index(ext: str) -> int:
+    """Return the minimum populated embedding rows before creating this index type."""
+    normalized = ext.lower()
+    if normalized == "pg_diskann":
+        return 0
+    return SCANN_MIN_ROWS_FOR_AUTO_INDEX if validate_extension(normalized) == "scann" else 0
+
+
+def should_defer_index_creation(ext: str, row_count: int) -> bool:
+    """Return True when index creation should wait for more embeddings."""
+    minimum_rows = minimum_rows_for_index(ext)
+    return minimum_rows > 0 and row_count < minimum_rows
+
+
+def uses_per_bank_vector_indexes(ext: str) -> bool:
+    """Return whether the backend should create per-bank partial vector indexes."""
+    normalized = ext.lower()
+    if normalized == "pg_diskann":
+        return True
+    return validate_extension(normalized) != "scann"
 
 
 def bootstrap_extension(conn, ext: str) -> None:

--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -1,0 +1,135 @@
+"""Shared PostgreSQL vector-extension dispatch helpers."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+VALID_EXTENSIONS = ("pgvector", "pgvectorscale", "vchord", "scann")
+
+_EXTENSION_NAMES = {
+    "pgvector": "vector",
+    "pgvectorscale": "vectorscale",
+    "vchord": "vchord",
+    "scann": "alloydb_scann",
+}
+
+_INDEX_USING_CLAUSES = {
+    "pgvector": "USING hnsw (embedding vector_cosine_ops)",
+    "pgvectorscale": "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)",
+    "pg_diskann": "USING diskann (embedding vector_cosine_ops) WITH (max_neighbors = 50)",
+    "vchord": "USING vchordrq (embedding vector_l2_ops)",
+    "scann": "USING scann (embedding cosine) WITH (mode = 'AUTO')",
+}
+
+_INDEX_TYPE_KEYWORDS = {
+    "pgvector": "hnsw",
+    "pgvectorscale": "diskann",
+    "pg_diskann": "diskann",
+    "vchord": "vchordrq",
+    "scann": "scann",
+}
+
+_EXTENSION_INSTALL_SQL = {
+    "pgvector": ("CREATE EXTENSION IF NOT EXISTS vector",),
+    "pgvectorscale": (
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        "CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE",
+    ),
+    "vchord": ("CREATE EXTENSION IF NOT EXISTS vchord CASCADE",),
+    "scann": (
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
+    ),
+}
+
+_INSTALL_HINTS = {
+    "pgvector": "CREATE EXTENSION vector;",
+    "pgvectorscale": "CREATE EXTENSION vector; then CREATE EXTENSION vectorscale CASCADE; (or pg_diskann on Azure)",
+    "vchord": "CREATE EXTENSION vchord CASCADE;",
+    "scann": "CREATE EXTENSION vector; then CREATE EXTENSION alloydb_scann CASCADE;",
+}
+
+
+def validate_extension(name: str) -> str:
+    """Return a normalized vector extension name or raise for unsupported input."""
+    ext = name.lower()
+    if ext not in VALID_EXTENSIONS:
+        valid = ", ".join(VALID_EXTENSIONS)
+        raise ValueError(f"Invalid vector_extension: {name}. Must be one of: {valid}")
+    return ext
+
+
+def pg_extension_name(ext: str) -> str:
+    """Return the PostgreSQL extension name for a configured vector backend."""
+    return _EXTENSION_NAMES[validate_extension(ext)]
+
+
+def index_using_clause(ext: str) -> str:
+    """Return the CREATE INDEX USING clause for the vector backend."""
+    normalized = ext.lower()
+    if normalized == "pg_diskann":
+        return _INDEX_USING_CLAUSES[normalized]
+    return _INDEX_USING_CLAUSES[validate_extension(normalized)]
+
+
+def index_type_keyword(ext: str) -> str:
+    """Return the keyword that identifies this index type in pg_indexes.indexdef."""
+    normalized = ext.lower()
+    if normalized == "pg_diskann":
+        return _INDEX_TYPE_KEYWORDS[normalized]
+    return _INDEX_TYPE_KEYWORDS[validate_extension(normalized)]
+
+
+def bootstrap_extension(conn, ext: str) -> None:
+    """Install the configured vector extension and any prerequisites if possible."""
+    from sqlalchemy import text
+
+    normalized = validate_extension(ext)
+    for statement in _EXTENSION_INSTALL_SQL[normalized]:
+        conn.execute(text(statement))
+
+
+def detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
+    """Validate the configured vector extension exists and return the index backend."""
+    configured_ext = validate_extension(vector_extension)
+    from sqlalchemy import text
+
+    if configured_ext == "pgvectorscale":
+        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+        if not pgvector_check:
+            raise RuntimeError(
+                "DiskANN (pgvectorscale/pg_diskann) requires pgvector to be installed. "
+                f"Install it with: {_INSTALL_HINTS['pgvectorscale']}"
+            )
+
+        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
+        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
+
+        if vectorscale_check:
+            logger.debug("Using vector extension: pgvectorscale (DiskANN)")
+            return "pgvectorscale"
+        if pg_diskann_check:
+            logger.debug("Using vector extension: pg_diskann (Azure DiskANN)")
+            return "pg_diskann"
+
+        raise RuntimeError(
+            "Configured vector extension 'pgvectorscale' not found. Install either:\n"
+            "  - pgvectorscale (open source): CREATE EXTENSION vectorscale CASCADE;\n"
+            "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
+        )
+
+    extension_name = pg_extension_name(configured_ext)
+    extension_check = conn.execute(
+        text("SELECT 1 FROM pg_extension WHERE extname = :extension_name"),
+        {"extension_name": extension_name},
+    ).scalar()
+    if not extension_check:
+        raise RuntimeError(
+            f"Configured vector extension '{configured_ext}' not found. "
+            f"Install it with: {_INSTALL_HINTS[configured_ext]}"
+        )
+
+    logger.debug("Using configured vector extension: %s", configured_ext)
+    return configured_ext

--- a/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
@@ -15,6 +15,7 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 
+from hindsight_api._vector_index import detect_vector_extension, index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -22,56 +23,6 @@ revision: str = "5a366d414dce"
 down_revision: str | Sequence[str] | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
-
-
-def _detect_vector_extension() -> str:
-    """
-    Detect or validate vector extension: 'pgvector', 'vchord', or 'pgvectorscale'.
-    Respects HINDSIGHT_API_VECTOR_EXTENSION env var if set.
-    """
-    conn = op.get_bind()
-    vector_extension = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-
-    # Validate configured extension is installed
-    if vector_extension == "pgvectorscale":
-        # pgvectorscale/DiskANN requires pgvector
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "DiskANN requires pgvector. Install with: CREATE EXTENSION vector; then vectorscale or pg_diskann CASCADE;"
-            )
-        # Check for either vectorscale (open source) or pg_diskann (Azure)
-        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
-        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
-
-        if vectorscale_check:
-            return "pgvectorscale"
-        elif pg_diskann_check:
-            return "pg_diskann"
-        else:
-            raise RuntimeError(
-                "Configured vector extension 'pgvectorscale' not found. Install either:\n"
-                "  - pgvectorscale: CREATE EXTENSION vectorscale CASCADE;\n"
-                "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
-            )
-    elif vector_extension == "vchord":
-        vchord_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vchord'")).scalar()
-        if not vchord_check:
-            raise RuntimeError(
-                "Configured vector extension 'vchord' not found. Install it with: CREATE EXTENSION vchord CASCADE;"
-            )
-        return "vchord"
-    elif vector_extension == "pgvector":
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "Configured vector extension 'pgvector' not found. Install it with: CREATE EXTENSION vector;"
-            )
-        return "pgvector"
-    else:
-        raise ValueError(
-            f"Invalid HINDSIGHT_API_VECTOR_EXTENSION: {vector_extension}. Must be 'pgvector', 'vchord', or 'pgvectorscale'"
-        )
 
 
 def _detect_text_search_extension() -> str:
@@ -312,37 +263,11 @@ def _pg_upgrade() -> None:
         postgresql_where=sa.text("fact_type = 'observation'"),
     )
     # Create vector index - conditional based on available extension
-    vector_ext = _detect_vector_extension()
-
-    if vector_ext == "pgvectorscale":
-        # Use DiskANN index for pgvectorscale (disk-based, scalable)
-        op.execute("""
-            CREATE INDEX idx_memory_units_embedding ON memory_units
-            USING diskann (embedding vector_cosine_ops)
-            WITH (num_neighbors = 50)
-        """)
-    elif vector_ext == "pg_diskann":
-        # Use DiskANN index for pg_diskann (Azure)
-        op.execute("""
-            CREATE INDEX idx_memory_units_embedding ON memory_units
-            USING diskann (embedding vector_cosine_ops)
-            WITH (max_neighbors = 50)
-        """)
-    elif vector_ext == "vchord":
-        # Use vchordrq index for vchord (supports high-dimensional embeddings)
-        op.execute("""
-            CREATE INDEX idx_memory_units_embedding ON memory_units
-            USING vchordrq (embedding vector_l2_ops)
-        """)
-    else:  # pgvector
-        # Use HNSW index for pgvector
-        op.create_index(
-            "idx_memory_units_embedding",
-            "memory_units",
-            ["embedding"],
-            postgresql_using="hnsw",
-            postgresql_ops={"embedding": "vector_cosine_ops"},
-        )
+    vector_ext = detect_vector_extension(op.get_bind(), os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    op.execute(f"""
+        CREATE INDEX idx_memory_units_embedding ON memory_units
+        {index_using_clause(vector_ext)}
+    """)
 
     # Create full-text search index on search_vector
     # Index type depends on text search backend

--- a/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
@@ -15,7 +15,6 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 
-from hindsight_api._vector_index import detect_vector_extension, index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -23,6 +22,71 @@ revision: str = "5a366d414dce"
 down_revision: str | Sequence[str] | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+
+def _detect_vector_extension() -> str:
+    """
+    Detect or validate vector extension for this immutable migration revision.
+    Respects HINDSIGHT_API_VECTOR_EXTENSION env var if set.
+    """
+    conn = op.get_bind()
+    vector_extension = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
+
+    if vector_extension == "pgvectorscale":
+        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+        if not pgvector_check:
+            raise RuntimeError(
+                "DiskANN requires pgvector. Install with: CREATE EXTENSION vector; then vectorscale or pg_diskann CASCADE;"
+            )
+        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
+        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
+
+        if vectorscale_check:
+            return "pgvectorscale"
+        if pg_diskann_check:
+            return "pg_diskann"
+        raise RuntimeError(
+            "Configured vector extension 'pgvectorscale' not found. Install either:\n"
+            "  - pgvectorscale: CREATE EXTENSION vectorscale CASCADE;\n"
+            "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
+        )
+    if vector_extension == "vchord":
+        vchord_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vchord'")).scalar()
+        if not vchord_check:
+            raise RuntimeError(
+                "Configured vector extension 'vchord' not found. Install it with: CREATE EXTENSION vchord CASCADE;"
+            )
+        return "vchord"
+    if vector_extension == "scann":
+        scann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'alloydb_scann'")).scalar()
+        if not scann_check:
+            raise RuntimeError(
+                "Configured vector extension 'scann' not found. Install it with: CREATE EXTENSION alloydb_scann CASCADE;"
+            )
+        return "scann"
+    if vector_extension == "pgvector":
+        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+        if not pgvector_check:
+            raise RuntimeError(
+                "Configured vector extension 'pgvector' not found. Install it with: CREATE EXTENSION vector;"
+            )
+        return "pgvector"
+    raise ValueError(
+        "Invalid HINDSIGHT_API_VECTOR_EXTENSION: "
+        f"{vector_extension}. Must be 'pgvector', 'vchord', 'pgvectorscale', or 'scann'"
+    )
+
+
+def _vector_index_using_clause(ext: str) -> str:
+    if ext == "pgvectorscale":
+        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
+    if ext == "pg_diskann":
+        return "USING diskann (embedding vector_cosine_ops) WITH (max_neighbors = 50)"
+    if ext == "vchord":
+        return "USING vchordrq (embedding vector_l2_ops)"
+    if ext == "scann":
+        return "USING scann (embedding cosine) WITH (mode = 'AUTO')"
+    return "USING hnsw (embedding vector_cosine_ops)"
 
 
 def _detect_text_search_extension() -> str:
@@ -263,11 +327,12 @@ def _pg_upgrade() -> None:
         postgresql_where=sa.text("fact_type = 'observation'"),
     )
     # Create vector index - conditional based on available extension
-    vector_ext = detect_vector_extension(op.get_bind(), os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
-    op.execute(f"""
-        CREATE INDEX idx_memory_units_embedding ON memory_units
-        {index_using_clause(vector_ext)}
-    """)
+    vector_ext = _detect_vector_extension()
+    if vector_ext != "scann":
+        op.execute(f"""
+            CREATE INDEX idx_memory_units_embedding ON memory_units
+            {_vector_index_using_clause(vector_ext)}
+        """)
 
     # Create full-text search index on search_vector
     # Index type depends on text search backend

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
@@ -6,12 +6,13 @@ Create Date: 2026-04-01
 
 Migration d5e6f7a8b9c0 hardcoded HNSW when creating per-bank partial vector
 indexes, ignoring HINDSIGHT_API_VECTOR_EXTENSION. Banks that existed when that
-migration ran got HNSW indexes even when pgvectorscale (DiskANN), vchord,
-or ScaNN was configured.
+migration ran got HNSW indexes even when pgvectorscale (DiskANN) or vchord
+was configured.
 
 This migration detects the mismatch and recreates the affected indexes with
 the correct type. Skipped entirely when the configured extension is pgvector
-(the default), since those indexes are already correct.
+(the default) or scann. ScaNN uses global vector indexes because empty or tiny
+per-bank indexes cannot be built safely on AlloyDB.
 """
 
 import os
@@ -20,7 +21,6 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
-from hindsight_api._vector_index import index_type_keyword, index_using_clause, validate_extension
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "a4b5c6d7e8f9"
@@ -40,19 +40,47 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
+def _validate_extension(name: str) -> str:
+    ext = name.lower()
+    if ext not in {"pgvector", "pgvectorscale", "vchord", "scann"}:
+        raise ValueError(
+            f"Invalid HINDSIGHT_API_VECTOR_EXTENSION: {ext}. Must be 'pgvector', 'vchord', 'pgvectorscale', or 'scann'"
+        )
+    return ext
+
+
+def _index_type_keyword(ext: str) -> str:
+    if ext == "pgvectorscale":
+        return "diskann"
+    if ext == "vchord":
+        return "vchordrq"
+    if ext == "scann":
+        return "scann"
+    return "hnsw"
+
+
+def _vector_index_using_clause(ext: str) -> str:
+    if ext == "pgvectorscale":
+        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
+    if ext == "vchord":
+        return "USING vchordrq (embedding vector_l2_ops)"
+    if ext == "scann":
+        return "USING scann (embedding cosine) WITH (mode = 'AUTO')"
+    return "USING hnsw (embedding vector_cosine_ops)"
+
+
 def _pg_upgrade() -> None:
-    ext = validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
-    if ext == "pgvector":
-        # pgvector — indexes are already HNSW, nothing to fix
+    ext = _validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    if ext in {"pgvector", "scann"}:
         return
-    target = index_type_keyword(ext)
+    target = _index_type_keyword(ext)
 
     bind = op.get_bind()
     schema_name = context.config.get_main_option("target_schema")
     schema = _get_schema_prefix()
     table_ref = f'"{schema_name}".memory_units' if schema_name else "memory_units"
     banks_ref = f'"{schema_name}".banks' if schema_name else "banks"
-    using_clause = index_using_clause(ext)
+    using_clause = _vector_index_using_clause(ext)
     pg_schema = schema_name or "public"
 
     rows = bind.execute(text(f"SELECT bank_id, internal_id FROM {banks_ref}")).fetchall()  # noqa: S608
@@ -98,8 +126,8 @@ def _pg_upgrade() -> None:
 
 def _pg_downgrade() -> None:
     # Downgrade recreates indexes as HNSW (the original hardcoded behavior)
-    ext = validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
-    if ext == "pgvector":
+    ext = _validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    if ext in {"pgvector", "scann"}:
         return
 
     bind = op.get_bind()

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a4b5c6d7e8f9_fix_per_bank_vector_index_type.py
@@ -6,8 +6,8 @@ Create Date: 2026-04-01
 
 Migration d5e6f7a8b9c0 hardcoded HNSW when creating per-bank partial vector
 indexes, ignoring HINDSIGHT_API_VECTOR_EXTENSION. Banks that existed when that
-migration ran got HNSW indexes even when pgvectorscale (DiskANN) or vchord
-was configured.
+migration ran got HNSW indexes even when pgvectorscale (DiskANN), vchord,
+or ScaNN was configured.
 
 This migration detects the mismatch and recreates the affected indexes with
 the correct type. Skipped entirely when the configured extension is pgvector
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
+from hindsight_api._vector_index import index_type_keyword, index_using_clause, validate_extension
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "a4b5c6d7e8f9"
@@ -39,39 +40,19 @@ def _get_schema_prefix() -> str:
     return f'"{schema}".' if schema else ""
 
 
-def _target_index_type() -> str | None:
-    """Return the target index type, or None if pgvector (no fix needed)."""
-    ext = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-    if ext == "pgvectorscale":
-        return "diskann"
-    elif ext == "vchord":
-        return "vchordrq"
-    return None
-
-
-def _vector_index_using_clause() -> str:
-    """Return the USING clause based on the configured vector extension."""
-    ext = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-    if ext == "pgvectorscale":
-        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
-    elif ext == "vchord":
-        return "USING vchordrq (embedding vector_l2_ops)"
-    else:
-        return "USING hnsw (embedding vector_cosine_ops)"
-
-
 def _pg_upgrade() -> None:
-    target = _target_index_type()
-    if target is None:
+    ext = validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    if ext == "pgvector":
         # pgvector — indexes are already HNSW, nothing to fix
         return
+    target = index_type_keyword(ext)
 
     bind = op.get_bind()
     schema_name = context.config.get_main_option("target_schema")
     schema = _get_schema_prefix()
     table_ref = f'"{schema_name}".memory_units' if schema_name else "memory_units"
     banks_ref = f'"{schema_name}".banks' if schema_name else "banks"
-    using_clause = _vector_index_using_clause()
+    using_clause = index_using_clause(ext)
     pg_schema = schema_name or "public"
 
     rows = bind.execute(text(f"SELECT bank_id, internal_id FROM {banks_ref}")).fetchall()  # noqa: S608
@@ -117,8 +98,8 @@ def _pg_upgrade() -> None:
 
 def _pg_downgrade() -> None:
     # Downgrade recreates indexes as HNSW (the original hardcoded behavior)
-    target = _target_index_type()
-    if target is None:
+    ext = validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    if ext == "pgvector":
         return
 
     bind = op.get_bind()

--- a/hindsight-api-slim/hindsight_api/alembic/versions/d5e6f7a8b9c0_add_bank_internal_id_and_per_bank_hnsw.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d5e6f7a8b9c0_add_bank_internal_id_and_per_bank_hnsw.py
@@ -9,7 +9,7 @@ This migration:
 2. Drops the global vector index (competes with per-bank partial indexes)
 3. Creates per-(bank_id, fact_type) partial vector indexes for all existing banks
    using the configured vector extension (HNSW for pgvector, DiskANN for
-   pgvectorscale, vchordrq for vchord).
+   pgvectorscale, vchordrq for vchord, ScaNN for AlloyDB).
    (new banks get indexes created at bank-creation time via bank_utils.create_bank_vector_indexes)
 
 Why per-(bank, fact_type) indexes:
@@ -25,6 +25,7 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
+from hindsight_api._vector_index import index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "d5e6f7a8b9c0"
@@ -42,17 +43,6 @@ _FACT_TYPES: dict[str, str] = {
 def _get_schema_prefix() -> str:
     schema = context.config.get_main_option("target_schema")
     return f'"{schema}".' if schema else ""
-
-
-def _vector_index_using_clause() -> str:
-    """Return the USING clause based on the configured vector extension."""
-    ext = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-    if ext == "pgvectorscale":
-        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
-    elif ext == "vchord":
-        return "USING vchordrq (embedding vector_l2_ops)"
-    else:
-        return "USING hnsw (embedding vector_cosine_ops)"
 
 
 def _pg_upgrade() -> None:
@@ -74,12 +64,12 @@ def _pg_upgrade() -> None:
     op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_embedding")
 
     # 5. Create per-(bank, fact_type) partial vector indexes for all existing banks
-    #    using the configured extension (HNSW / DiskANN / vchordrq)
+    #    using the configured extension (HNSW / DiskANN / vchordrq / ScaNN)
     bind = op.get_bind()
     schema_name = context.config.get_main_option("target_schema")
     table_ref = f'"{schema_name}".memory_units' if schema_name else "memory_units"
     banks_ref = f'"{schema_name}".banks' if schema_name else "banks"
-    using_clause = _vector_index_using_clause()
+    using_clause = index_using_clause(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
 
     rows = bind.execute(text(f"SELECT bank_id, internal_id FROM {banks_ref}")).fetchall()  # noqa: S608
     for row in rows:
@@ -109,7 +99,7 @@ def _pg_downgrade() -> None:
     rows = bind.execute(text(f"SELECT internal_id FROM {banks_ref}")).fetchall()  # noqa: S608
     for row in rows:
         internal_id = str(row[0]).replace("-", "")[:16]
-        for ft_short in _HNSW_FACT_TYPES.values():
+        for ft_short in _FACT_TYPES.values():
             idx_name = f"idx_mu_emb_{ft_short}_{internal_id}"
             bind.execute(text(f"DROP INDEX IF EXISTS {schema}{idx_name}"))
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/d5e6f7a8b9c0_add_bank_internal_id_and_per_bank_hnsw.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/d5e6f7a8b9c0_add_bank_internal_id_and_per_bank_hnsw.py
@@ -6,10 +6,11 @@ Create Date: 2026-03-11
 
 This migration:
 1. Adds internal_id UUID column to banks (stable identifier for index naming)
-2. Drops the global vector index (competes with per-bank partial indexes)
-3. Creates per-(bank_id, fact_type) partial vector indexes for all existing banks
-   using the configured vector extension (HNSW for pgvector, DiskANN for
-   pgvectorscale, vchordrq for vchord, ScaNN for AlloyDB).
+2. For non-ScaNN backends, drops the global vector index (competes with
+   per-bank partial indexes)
+3. For non-ScaNN backends, creates per-(bank_id, fact_type) partial vector
+   indexes for all existing banks using the configured vector extension
+   (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord).
    (new banks get indexes created at bank-creation time via bank_utils.create_bank_vector_indexes)
 
 Why per-(bank, fact_type) indexes:
@@ -17,6 +18,8 @@ Why per-(bank, fact_type) indexes:
   clause, because the idx_memory_units_bank_id B-tree index always wins at planning time.
 - Per-(bank, fact_type) partial indexes have both predicates matching → planner selects them.
 - The global vector index competes for larger partitions (world, observation) and must be dropped.
+- AlloyDB ScaNN uses global vector indexes with filtered vector search instead
+  because empty or tiny per-bank indexes cannot be built safely.
 """
 
 import os
@@ -25,7 +28,6 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
-from hindsight_api._vector_index import index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "d5e6f7a8b9c0"
@@ -38,6 +40,25 @@ _FACT_TYPES: dict[str, str] = {
     "experience": "expr",
     "observation": "obsv",
 }
+
+
+def _configured_vector_extension() -> str:
+    ext = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
+    if ext not in {"pgvector", "pgvectorscale", "vchord", "scann"}:
+        raise ValueError(
+            f"Invalid HINDSIGHT_API_VECTOR_EXTENSION: {ext}. Must be 'pgvector', 'vchord', 'pgvectorscale', or 'scann'"
+        )
+    return ext
+
+
+def _vector_index_using_clause(ext: str) -> str:
+    if ext == "pgvectorscale":
+        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
+    if ext == "vchord":
+        return "USING vchordrq (embedding vector_l2_ops)"
+    if ext == "scann":
+        return "USING scann (embedding cosine) WITH (mode = 'AUTO')"
+    return "USING hnsw (embedding vector_cosine_ops)"
 
 
 def _get_schema_prefix() -> str:
@@ -54,6 +75,14 @@ def _pg_upgrade() -> None:
     )
     op.execute(f"ALTER TABLE {schema}banks ADD CONSTRAINT banks_internal_id_unique UNIQUE (internal_id)")
 
+    ext = _configured_vector_extension()
+    if ext == "scann":
+        # ScaNN should keep/use a global vector index. Per-bank partial indexes
+        # are created while banks are empty and can fail AlloyDB's ScaNN build
+        # requirements, so this migration leaves vector index reconciliation to
+        # runtime ensure_vector_extension once enough rows exist.
+        return
+
     # 2. Drop any fact_type-only partial indexes that may exist from prior migrations
     #    (bank_id B-tree always wins over them when bank_id is in the WHERE clause)
     op.execute(f"DROP INDEX IF EXISTS {schema}idx_mu_emb_world")
@@ -64,12 +93,12 @@ def _pg_upgrade() -> None:
     op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_embedding")
 
     # 5. Create per-(bank, fact_type) partial vector indexes for all existing banks
-    #    using the configured extension (HNSW / DiskANN / vchordrq / ScaNN)
+    #    using the configured extension (HNSW / DiskANN / vchordrq)
     bind = op.get_bind()
     schema_name = context.config.get_main_option("target_schema")
     table_ref = f'"{schema_name}".memory_units' if schema_name else "memory_units"
     banks_ref = f'"{schema_name}".banks' if schema_name else "banks"
-    using_clause = index_using_clause(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    using_clause = _vector_index_using_clause(ext)
 
     rows = bind.execute(text(f"SELECT bank_id, internal_id FROM {banks_ref}")).fetchall()  # noqa: S608
     for row in rows:

--- a/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
@@ -16,6 +16,7 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
+from hindsight_api._vector_index import detect_vector_extension, index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -29,56 +30,6 @@ def _get_schema_prefix() -> str:
     """Get schema prefix for table names (required for multi-tenant support)."""
     schema = context.config.get_main_option("target_schema")
     return f'"{schema}".' if schema else ""
-
-
-def _detect_vector_extension() -> str:
-    """
-    Detect or validate vector extension: 'pgvector', 'vchord', or 'pgvectorscale'.
-    Respects HINDSIGHT_API_VECTOR_EXTENSION env var if set.
-    """
-    conn = op.get_bind()
-    vector_extension = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-
-    # Validate configured extension is installed
-    if vector_extension == "pgvectorscale":
-        # pgvectorscale/DiskANN requires pgvector
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "DiskANN requires pgvector. Install with: CREATE EXTENSION vector; then vectorscale or pg_diskann CASCADE;"
-            )
-        # Check for either vectorscale (open source) or pg_diskann (Azure)
-        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
-        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
-
-        if vectorscale_check:
-            return "pgvectorscale"
-        elif pg_diskann_check:
-            return "pg_diskann"
-        else:
-            raise RuntimeError(
-                "Configured vector extension 'pgvectorscale' not found. Install either:\n"
-                "  - pgvectorscale: CREATE EXTENSION vectorscale CASCADE;\n"
-                "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
-            )
-    elif vector_extension == "vchord":
-        vchord_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vchord'")).scalar()
-        if not vchord_check:
-            raise RuntimeError(
-                "Configured vector extension 'vchord' not found. Install it with: CREATE EXTENSION vchord CASCADE;"
-            )
-        return "vchord"
-    elif vector_extension == "pgvector":
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "Configured vector extension 'pgvector' not found. Install it with: CREATE EXTENSION vector;"
-            )
-        return "pgvector"
-    else:
-        raise ValueError(
-            f"Invalid HINDSIGHT_API_VECTOR_EXTENSION: {vector_extension}. Must be 'pgvector', 'vchord', or 'pgvectorscale'"
-        )
 
 
 def _detect_text_search_extension() -> str:
@@ -126,7 +77,7 @@ def _pg_upgrade() -> None:
     schema = _get_schema_prefix()
 
     # Detect which vector extension is available
-    vector_ext = _detect_vector_extension()
+    vector_ext = detect_vector_extension(op.get_bind(), os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
 
     # Detect which text search extension to use
     text_search_ext = _detect_text_search_extension()
@@ -159,28 +110,10 @@ def _pg_upgrade() -> None:
     op.execute(f"CREATE INDEX idx_learnings_bank_id ON {schema}learnings(bank_id)")
 
     # Create vector index based on detected extension
-    if vector_ext == "pgvectorscale":
-        op.execute(f"""
-            CREATE INDEX idx_learnings_embedding ON {schema}learnings
-            USING diskann (embedding vector_cosine_ops)
-            WITH (num_neighbors = 50)
-        """)
-    elif vector_ext == "pg_diskann":
-        op.execute(f"""
-            CREATE INDEX idx_learnings_embedding ON {schema}learnings
-            USING diskann (embedding vector_cosine_ops)
-            WITH (max_neighbors = 50)
-        """)
-    elif vector_ext == "vchord":
-        op.execute(f"""
-            CREATE INDEX idx_learnings_embedding ON {schema}learnings
-            USING vchordrq (embedding vector_l2_ops)
-        """)
-    else:  # pgvector
-        op.execute(f"""
-            CREATE INDEX idx_learnings_embedding ON {schema}learnings
-            USING hnsw (embedding vector_cosine_ops)
-        """)
+    op.execute(f"""
+        CREATE INDEX idx_learnings_embedding ON {schema}learnings
+        {index_using_clause(vector_ext)}
+    """)
 
     op.execute(f"CREATE INDEX idx_learnings_tags ON {schema}learnings USING GIN(tags)")
 
@@ -238,28 +171,10 @@ def _pg_upgrade() -> None:
     op.execute(f"CREATE INDEX idx_pinned_reflections_bank_id ON {schema}pinned_reflections(bank_id)")
 
     # Create vector index based on detected extension
-    if vector_ext == "pgvectorscale":
-        op.execute(f"""
-            CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
-            USING diskann (embedding vector_cosine_ops)
-            WITH (num_neighbors = 50)
-        """)
-    elif vector_ext == "pg_diskann":
-        op.execute(f"""
-            CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
-            USING diskann (embedding vector_cosine_ops)
-            WITH (max_neighbors = 50)
-        """)
-    elif vector_ext == "vchord":
-        op.execute(f"""
-            CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
-            USING vchordrq (embedding vector_l2_ops)
-        """)
-    else:  # pgvector
-        op.execute(f"""
-            CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
-            USING hnsw (embedding vector_cosine_ops)
-        """)
+    op.execute(f"""
+        CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
+        {index_using_clause(vector_ext)}
+    """)
 
     op.execute(f"CREATE INDEX idx_pinned_reflections_tags ON {schema}pinned_reflections USING GIN(tags)")
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
@@ -16,7 +16,6 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
-from hindsight_api._vector_index import detect_vector_extension, index_using_clause
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -30,6 +29,68 @@ def _get_schema_prefix() -> str:
     """Get schema prefix for table names (required for multi-tenant support)."""
     schema = context.config.get_main_option("target_schema")
     return f'"{schema}".' if schema else ""
+
+
+def _detect_vector_extension() -> str:
+    """Detect or validate vector extension for this immutable migration revision."""
+    conn = op.get_bind()
+    vector_extension = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
+
+    if vector_extension == "pgvectorscale":
+        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+        if not pgvector_check:
+            raise RuntimeError(
+                "DiskANN requires pgvector. Install with: CREATE EXTENSION vector; then vectorscale or pg_diskann CASCADE;"
+            )
+        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
+        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
+
+        if vectorscale_check:
+            return "pgvectorscale"
+        if pg_diskann_check:
+            return "pg_diskann"
+        raise RuntimeError(
+            "Configured vector extension 'pgvectorscale' not found. Install either:\n"
+            "  - pgvectorscale: CREATE EXTENSION vectorscale CASCADE;\n"
+            "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
+        )
+    if vector_extension == "vchord":
+        vchord_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vchord'")).scalar()
+        if not vchord_check:
+            raise RuntimeError(
+                "Configured vector extension 'vchord' not found. Install it with: CREATE EXTENSION vchord CASCADE;"
+            )
+        return "vchord"
+    if vector_extension == "scann":
+        scann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'alloydb_scann'")).scalar()
+        if not scann_check:
+            raise RuntimeError(
+                "Configured vector extension 'scann' not found. Install it with: CREATE EXTENSION alloydb_scann CASCADE;"
+            )
+        return "scann"
+    if vector_extension == "pgvector":
+        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
+        if not pgvector_check:
+            raise RuntimeError(
+                "Configured vector extension 'pgvector' not found. Install it with: CREATE EXTENSION vector;"
+            )
+        return "pgvector"
+    raise ValueError(
+        "Invalid HINDSIGHT_API_VECTOR_EXTENSION: "
+        f"{vector_extension}. Must be 'pgvector', 'vchord', 'pgvectorscale', or 'scann'"
+    )
+
+
+def _vector_index_using_clause(ext: str) -> str:
+    if ext == "pgvectorscale":
+        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
+    if ext == "pg_diskann":
+        return "USING diskann (embedding vector_cosine_ops) WITH (max_neighbors = 50)"
+    if ext == "vchord":
+        return "USING vchordrq (embedding vector_l2_ops)"
+    if ext == "scann":
+        return "USING scann (embedding cosine) WITH (mode = 'AUTO')"
+    return "USING hnsw (embedding vector_cosine_ops)"
 
 
 def _detect_text_search_extension() -> str:
@@ -77,7 +138,7 @@ def _pg_upgrade() -> None:
     schema = _get_schema_prefix()
 
     # Detect which vector extension is available
-    vector_ext = detect_vector_extension(op.get_bind(), os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    vector_ext = _detect_vector_extension()
 
     # Detect which text search extension to use
     text_search_ext = _detect_text_search_extension()
@@ -109,11 +170,13 @@ def _pg_upgrade() -> None:
     # Indexes for learnings
     op.execute(f"CREATE INDEX idx_learnings_bank_id ON {schema}learnings(bank_id)")
 
-    # Create vector index based on detected extension
-    op.execute(f"""
-        CREATE INDEX idx_learnings_embedding ON {schema}learnings
-        {index_using_clause(vector_ext)}
-    """)
+    # Create vector index based on detected extension. ScaNN is deferred because
+    # this table is empty during migration and AlloyDB rejects empty ScaNN builds.
+    if vector_ext != "scann":
+        op.execute(f"""
+            CREATE INDEX idx_learnings_embedding ON {schema}learnings
+            {_vector_index_using_clause(vector_ext)}
+        """)
 
     op.execute(f"CREATE INDEX idx_learnings_tags ON {schema}learnings USING GIN(tags)")
 
@@ -170,11 +233,13 @@ def _pg_upgrade() -> None:
     # Indexes for pinned_reflections
     op.execute(f"CREATE INDEX idx_pinned_reflections_bank_id ON {schema}pinned_reflections(bank_id)")
 
-    # Create vector index based on detected extension
-    op.execute(f"""
-        CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
-        {index_using_clause(vector_ext)}
-    """)
+    # Create vector index based on detected extension. ScaNN is deferred because
+    # this table is empty during migration and AlloyDB rejects empty ScaNN builds.
+    if vector_ext != "scann":
+        op.execute(f"""
+            CREATE INDEX idx_pinned_reflections_embedding ON {schema}pinned_reflections
+            {_vector_index_using_clause(vector_ext)}
+        """)
 
     op.execute(f"CREATE INDEX idx_pinned_reflections_tags ON {schema}pinned_reflections USING GIN(tags)")
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -14,6 +14,7 @@ from typing import Any, Literal
 
 from dotenv import find_dotenv, load_dotenv
 
+from ._vector_index import validate_extension
 from .utils import mask_network_location
 
 # Load .env file, searching current and parent directories (overrides existing env vars)
@@ -536,8 +537,8 @@ DEFAULT_RERANKER_SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
 
 DEFAULT_RERANKER_GOOGLE_MODEL = "semantic-ranker-default-004"
 
-# Vector extension (pgvector, vchord, or pgvectorscale)
-DEFAULT_VECTOR_EXTENSION = "pgvector"  # Options: "pgvector", "vchord", "pgvectorscale"
+# Vector extension (pgvector, vchord, pgvectorscale, or AlloyDB ScaNN)
+DEFAULT_VECTOR_EXTENSION = "pgvector"  # Options: "pgvector", "vchord", "pgvectorscale", "scann"
 
 # Text search extension (native PostgreSQL, vchord BM25, or Timescale pg_textsearch)
 DEFAULT_TEXT_SEARCH_EXTENSION = "native"  # Options: "native", "vchord", "pg_textsearch"
@@ -841,7 +842,7 @@ class HindsightConfig:
     read_db_pool_max_size: int
     migration_database_url: str | None
     database_schema: str
-    vector_extension: str  # "pgvector" or "vchord"
+    vector_extension: str  # "pgvector", "vchord", "pgvectorscale", or "scann"
     text_search_extension: str  # "native" or "vchord"
 
     # LLM (default, used as fallback for per-operation config)
@@ -1285,11 +1286,7 @@ class HindsightConfig:
     def validate(self) -> None:
         """Validate configuration values and raise errors for invalid combinations."""
         # Validate vector_extension
-        valid_extensions = ("pgvector", "vchord", "pgvectorscale")
-        if self.vector_extension not in valid_extensions:
-            raise ValueError(
-                f"Invalid vector_extension: {self.vector_extension}. Must be one of: {', '.join(valid_extensions)}"
-            )
+        validate_extension(self.vector_extension)
 
         # Validate text_search_extension
         valid_text_search = ("native", "vchord", "pg_textsearch")

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -10,7 +10,7 @@ from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
-from ..._vector_index import index_using_clause
+from ..._vector_index import index_using_clause, uses_per_bank_vector_indexes
 from ...config import get_config
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table, get_current_schema
@@ -36,31 +36,40 @@ def _bank_index_name(ft: str, internal_id: str) -> str:
     return f"idx_mu_emb_{_BANK_INDEX_FACT_TYPES[ft]}_{uid}"
 
 
-def _vector_index_clause() -> str:
-    """Return the USING clause for vector index creation based on the configured extension."""
-    return index_using_clause(get_config().vector_extension)
+def _vector_index_clause() -> str | None:
+    """Return the USING clause for per-bank vector indexes, if this backend uses them."""
+    ext = get_config().vector_extension
+    if not uses_per_bank_vector_indexes(ext):
+        return None
+    return index_using_clause(ext)
 
 
 async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, ops=None) -> None:
     """Create per-(bank, fact_type) partial vector indexes for a newly created bank.
 
     Respects the HINDSIGHT_API_VECTOR_EXTENSION config to use the appropriate
-    index type (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord, ScaNN for AlloyDB).
+    index type (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord).
 
-    Called immediately after the bank row is first inserted. Safe on empty banks
-    (index build is instant). Idempotent via CREATE INDEX IF NOT EXISTS.
+    AlloyDB ScaNN uses global vector indexes with filtered vector search; it
+    cannot safely create per-bank indexes at bank-creation time because new
+    banks have no embedding rows.
     bank_id is escaped for SQL literal safety (apostrophes doubled).
 
     On Oracle 23ai, this is a no-op — Oracle uses a single global vector index
     created during migrations. Partial indexes (WHERE clause) are not supported
     for Oracle vector indexes.
     """
+    index_clause = _vector_index_clause()
+    if index_clause is None:
+        logger.debug("Skipping per-bank vector indexes for configured backend")
+        return
+
     await ops.create_bank_vector_indexes(
         conn,
         fq_table("memory_units"),
         bank_id,
         internal_id,
-        _vector_index_clause(),
+        index_clause,
         _BANK_INDEX_FACT_TYPES,
     )
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
+from ..._vector_index import index_using_clause
 from ...config import get_config
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table, get_current_schema
@@ -37,20 +38,14 @@ def _bank_index_name(ft: str, internal_id: str) -> str:
 
 def _vector_index_clause() -> str:
     """Return the USING clause for vector index creation based on the configured extension."""
-    ext = get_config().vector_extension
-    if ext == "pgvectorscale":
-        return "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)"
-    elif ext == "vchord":
-        return "USING vchordrq (embedding vector_l2_ops)"
-    else:  # pgvector (default)
-        return "USING hnsw (embedding vector_cosine_ops)"
+    return index_using_clause(get_config().vector_extension)
 
 
 async def create_bank_vector_indexes(conn, bank_id: str, internal_id: str, ops=None) -> None:
     """Create per-(bank, fact_type) partial vector indexes for a newly created bank.
 
     Respects the HINDSIGHT_API_VECTOR_EXTENSION config to use the appropriate
-    index type (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord).
+    index type (HNSW for pgvector, DiskANN for pgvectorscale, vchordrq for vchord, ScaNN for AlloyDB).
 
     Called immediately after the bank row is first inserted. Safe on empty banks
     (index build is instant). Idempotent via CREATE INDEX IF NOT EXISTS.

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -27,6 +27,7 @@ from alembic.config import Config
 from alembic.script.revision import ResolutionError
 from sqlalchemy import Connection, create_engine, text
 
+from ._vector_index import bootstrap_extension, detect_vector_extension, index_type_keyword, index_using_clause
 from .db_url import is_oracle_url, to_libpq_url
 from .utils import mask_network_location
 
@@ -44,66 +45,8 @@ _alembic_lock = threading.Lock()
 
 
 def _detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
-    """
-    Validate vector extension: 'pgvector', 'vchord', or 'pgvectorscale'.
-
-    Args:
-        conn: SQLAlchemy connection object
-        vector_extension: Configured extension ("pgvector", "vchord", or "pgvectorscale")
-
-    Returns:
-        "pgvector", "vchord", "pgvectorscale", or "pg_diskann"
-
-    Raises:
-        RuntimeError: If configured extension is not installed
-    """
-    # Verify the configured extension is installed
-    if vector_extension == "pgvectorscale":
-        # pgvectorscale/DiskANN requires pgvector to be installed first
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "DiskANN (pgvectorscale/pg_diskann) requires pgvector to be installed. "
-                "Install it with: CREATE EXTENSION vector; then CREATE EXTENSION vectorscale CASCADE; (or pg_diskann on Azure)"
-            )
-
-        # Check for either vectorscale (open source) or pg_diskann (Azure)
-        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
-        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
-
-        if vectorscale_check:
-            logger.debug("Using vector extension: pgvectorscale (DiskANN)")
-            return "pgvectorscale"
-        elif pg_diskann_check:
-            logger.debug("Using vector extension: pg_diskann (Azure DiskANN)")
-            return "pg_diskann"  # Return distinct name for parameter handling
-        else:
-            raise RuntimeError(
-                "Configured vector extension 'pgvectorscale' not found. "
-                "Install either:\n"
-                "  - pgvectorscale (open source): CREATE EXTENSION vectorscale CASCADE;\n"
-                "  - pg_diskann (Azure): CREATE EXTENSION pg_diskann CASCADE;"
-            )
-    elif vector_extension == "vchord":
-        vchord_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vchord'")).scalar()
-        if not vchord_check:
-            raise RuntimeError(
-                "Configured vector extension 'vchord' not found. Install it with: CREATE EXTENSION vchord CASCADE;"
-            )
-        logger.debug("Using configured vector extension: vchord")
-        return "vchord"
-    elif vector_extension == "pgvector":
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
-            raise RuntimeError(
-                "Configured vector extension 'pgvector' not found. Install it with: CREATE EXTENSION vector;"
-            )
-        logger.debug("Using configured vector extension: pgvector")
-        return "pgvector"
-    else:
-        raise ValueError(
-            f"Invalid vector_extension: {vector_extension}. Must be 'pgvector', 'vchord', or 'pgvectorscale'"
-        )
+    """Validate configured vector extension and preserve Azure DiskANN detection."""
+    return detect_vector_extension(conn, vector_extension)
 
 
 def _get_schema_lock_id(schema: str) -> int:
@@ -364,47 +307,8 @@ def run_migrations(
                                 "Please install it with: CREATE EXTENSION vector;"
                             ) from e
 
-                # If using pgvectorscale, ensure vectorscale extension is also installed
                 vector_extension = os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector").lower()
-                if vector_extension == "pgvectorscale":
-                    logger.debug("Checking pgvectorscale (vectorscale) extension availability...")
-
-                    vectorscale_check = conn.execute(
-                        text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")
-                    ).scalar()
-
-                    if vectorscale_check:
-                        logger.info("pgvectorscale extension already installed")
-                    else:
-                        # Extension doesn't exist - try to install
-                        logger.info("pgvectorscale extension not found, attempting to install...")
-                        try:
-                            conn.execute(text("CREATE EXTENSION vectorscale CASCADE"))
-                            conn.commit()
-                            logger.info("pgvectorscale extension installed successfully")
-                        except Exception as e:
-                            # Installation failed - check one more time in case another process installed it
-                            conn.rollback()
-                            vectorscale_recheck = conn.execute(
-                                text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")
-                            ).fetchone()
-
-                            if vectorscale_recheck:
-                                logger.warning(
-                                    "Could not install pgvectorscale extension (permission denied?), "
-                                    "but extension exists. Continuing..."
-                                )
-                            else:
-                                # Extension truly doesn't exist and we can't install it
-                                logger.error(
-                                    f"pgvectorscale extension is not installed and cannot be installed: {e}. "
-                                    f"Please ensure pgvectorscale is installed by a database administrator. "
-                                    f"See: https://github.com/timescale/pgvectorscale#installation"
-                                )
-                                raise RuntimeError(
-                                    "pgvectorscale extension is required but not installed. "
-                                    "Please install it with: CREATE EXTENSION vectorscale CASCADE;"
-                                ) from e
+                bootstrap_extension(conn, vector_extension)
 
                 # Commit any pending transaction on the advisory-lock connection
                 # before running migrations.  Some code paths above (e.g., the
@@ -545,7 +449,7 @@ def _migrate_table_embedding_dimension(
 
     logger.info(f"Altering {table_name}.embedding column dimension from {current_dim} to {required_dimension}")
 
-    # Drop existing vector index (works for both HNSW and vchordrq)
+    # Drop existing vector index (works for HNSW, DiskANN, vchordrq, and ScaNN)
     conn.execute(
         text(f"""
             DO $$
@@ -555,7 +459,7 @@ def _migrate_table_embedding_dimension(
                     SELECT indexname FROM pg_indexes
                     WHERE schemaname = '{schema_name}'
                       AND tablename = '{table_name}'
-                      AND (indexdef LIKE '%hnsw%' OR indexdef LIKE '%vchordrq%' OR indexdef LIKE '%diskann%')
+                      AND (indexdef LIKE '%hnsw%' OR indexdef LIKE '%vchordrq%' OR indexdef LIKE '%diskann%' OR indexdef LIKE '%scann%')
                       AND indexdef LIKE '%embedding%'
                 LOOP
                     EXECUTE 'DROP INDEX IF EXISTS {schema_name}.' || idx_name;
@@ -570,41 +474,22 @@ def _migrate_table_embedding_dimension(
     conn.commit()
 
     # Recreate index with appropriate type based on detected extension
-    if vector_ext == "pgvectorscale":
-        conn.execute(
-            text(f"""
-                CREATE INDEX IF NOT EXISTS idx_{table_name}_embedding_diskann
-                ON {schema_name}.{table_name}
-                USING diskann (embedding vector_cosine_ops)
-                WITH (num_neighbors = 50)
-            """)
+    if vector_ext == "pgvector" and required_dimension > 2000:
+        raise RuntimeError(
+            f"Embedding dimension {required_dimension} exceeds pgvector HNSW index limit of 2000. "
+            f"Use an embedding model with <= 2000 dimensions, or switch to a vector extension "
+            f"that supports higher dimensions (e.g., pgvectorscale/DiskANN or AlloyDB ScaNN)."
         )
-        logger.info(f"Created DiskANN index on {table_name} for {required_dimension}-dimensional embeddings")
-    elif vector_ext == "vchord":
-        conn.execute(
-            text(f"""
-                CREATE INDEX IF NOT EXISTS idx_{table_name}_embedding_vchordrq
-                ON {schema_name}.{table_name}
-                USING vchordrq (embedding vector_l2_ops)
-            """)
-        )
-        logger.info(f"Created vchordrq index on {table_name} for {required_dimension}-dimensional embeddings")
-    else:  # pgvector
-        if required_dimension > 2000:
-            raise RuntimeError(
-                f"Embedding dimension {required_dimension} exceeds pgvector HNSW index limit of 2000. "
-                f"Use an embedding model with <= 2000 dimensions, or switch to a vector extension "
-                f"that supports higher dimensions (e.g., pgvectorscale/DiskANN)."
-            )
-        conn.execute(
-            text(f"""
-                CREATE INDEX IF NOT EXISTS idx_{table_name}_embedding_hnsw
-                ON {schema_name}.{table_name}
-                USING hnsw (embedding vector_cosine_ops)
-                WITH (m = 16, ef_construction = 64)
-            """)
-        )
-        logger.info(f"Created HNSW index on {table_name} for {required_dimension}-dimensional embeddings")
+
+    index_type = index_type_keyword(vector_ext)
+    conn.execute(
+        text(f"""
+            CREATE INDEX IF NOT EXISTS idx_{table_name}_embedding_{index_type}
+            ON {schema_name}.{table_name}
+            {index_using_clause(vector_ext)}
+        """)
+    )
+    logger.info(f"Created {index_type} index on {table_name} for {required_dimension}-dimensional embeddings")
     conn.commit()
 
     logger.info(f"Successfully changed {table_name}.embedding dimension to {required_dimension}")
@@ -628,7 +513,7 @@ def ensure_embedding_dimension(
         database_url: SQLAlchemy database URL
         required_dimension: The embedding dimension required by the model
         schema: Target PostgreSQL schema name (None for public)
-        vector_extension: Configured vector extension ("pgvector" or "vchord")
+        vector_extension: Configured vector extension ("pgvector", "vchord", "pgvectorscale", or "scann")
 
     Raises:
         RuntimeError: If dimension mismatch with existing data
@@ -676,7 +561,7 @@ def ensure_vector_extension(
 
     Args:
         database_url: SQLAlchemy database URL
-        vector_extension: Configured vector extension ("pgvector" or "vchord")
+        vector_extension: Configured vector extension ("pgvector", "vchord", "pgvectorscale", or "scann")
         schema: Target PostgreSQL schema name (None for public)
 
     Raises:
@@ -697,13 +582,7 @@ def ensure_vector_extension(
             ("pinned_reflections", "idx_pinned_reflections_embedding"),
         ]
 
-        # Determine target index type
-        if target_ext in ("pgvectorscale", "pg_diskann"):
-            target_index_type = "diskann"
-        elif target_ext == "vchord":
-            target_index_type = "vchordrq"
-        else:
-            target_index_type = "hnsw"
+        target_index_type = index_type_keyword(target_ext)
 
         mismatched_tables = []
         tables_with_data = []
@@ -737,7 +616,7 @@ def ensure_vector_extension(
             ).fetchone()
 
             if not current_index_info:
-                # Check whether per-bank partial HNSW indexes already cover this table
+                # Check whether per-bank partial vector indexes already cover this table
                 # (created by the bank_utils lifecycle — no global index needed in that case)
                 per_bank_index_count = conn.execute(
                     text("""
@@ -752,7 +631,7 @@ def ensure_vector_extension(
                 if per_bank_index_count and per_bank_index_count > 0:
                     logger.debug(
                         f"No global embedding index on {table_name}, but {per_bank_index_count} "
-                        f"per-bank partial HNSW indexes exist — skipping global index creation"
+                        f"per-bank partial vector indexes exist — skipping global index creation"
                     )
                     continue
                 logger.warning(f"No embedding index found for {table_name}, will create it")
@@ -760,7 +639,9 @@ def ensure_vector_extension(
                 continue
 
             indexdef = current_index_info[0].lower()
-            if "diskann" in indexdef:
+            if "scann" in indexdef:
+                current_index_type = "scann"
+            elif "diskann" in indexdef:
                 current_index_type = "diskann"
             elif "vchordrq" in indexdef:
                 current_index_type = "vchordrq"
@@ -783,7 +664,7 @@ def ensure_vector_extension(
                 ).scalar()
 
                 if row_count > 0:
-                    tables_with_data.append((table_name, row_count))
+                    tables_with_data.append((table_name, row_count, current_index_type))
             else:
                 logger.debug(f"Index type OK for {table_name}: {current_index_type}")
 
@@ -794,11 +675,15 @@ def ensure_vector_extension(
 
         # If there's data in any mismatched table, raise error
         if tables_with_data:
-            table_list = ", ".join([f"{table}({count} rows)" for table, count in tables_with_data])
+            table_list = ", ".join([f"{table}({count} rows)" for table, count, _ in tables_with_data])
+            current_index_type = tables_with_data[0][2]
             # Map index type back to extension name for error message
-            current_ext_name = {"diskann": "pgvectorscale", "vchordrq": "vchord", "hnsw": "pgvector"}.get(
-                current_index_type, current_index_type
-            )
+            current_ext_name = {
+                "diskann": "pgvectorscale",
+                "vchordrq": "vchord",
+                "hnsw": "pgvector",
+                "scann": "scann",
+            }.get(current_index_type, current_index_type)
 
             raise RuntimeError(
                 f"Cannot change vector extension from {current_index_type} to {target_index_type}: "
@@ -819,36 +704,7 @@ def ensure_vector_extension(
                 conn.execute(text(f"DROP INDEX IF EXISTS {schema_name}.{index_name}"))
 
             # Create new index with appropriate type
-            if target_ext == "pgvectorscale":
-                logger.info(f"Creating DiskANN index on {table_name} (pgvectorscale)")
-                conn.execute(
-                    text(f"""
-                        CREATE INDEX IF NOT EXISTS {index_name}
-                        ON {schema_name}.{table_name}
-                        USING diskann (embedding vector_cosine_ops)
-                        WITH (num_neighbors = 50)
-                    """)
-                )
-            elif target_ext == "pg_diskann":
-                logger.info(f"Creating DiskANN index on {table_name} (pg_diskann/Azure)")
-                conn.execute(
-                    text(f"""
-                        CREATE INDEX IF NOT EXISTS {index_name}
-                        ON {schema_name}.{table_name}
-                        USING diskann (embedding vector_cosine_ops)
-                        WITH (max_neighbors = 50)
-                    """)
-                )
-            elif target_ext == "vchord":
-                logger.info(f"Creating vchordrq index on {table_name}")
-                conn.execute(
-                    text(f"""
-                        CREATE INDEX IF NOT EXISTS {index_name}
-                        ON {schema_name}.{table_name}
-                        USING vchordrq (embedding vector_l2_ops)
-                    """)
-                )
-            else:  # pgvector
+            if target_ext == "pgvector":
                 # Check embedding dimension — pgvector HNSW indexes only support up to 2000 dims
                 embed_dim = conn.execute(
                     text("""
@@ -865,17 +721,17 @@ def ensure_vector_extension(
                     raise RuntimeError(
                         f"Embedding dimension {embed_dim} on {table_name} exceeds pgvector HNSW index limit of 2000. "
                         f"Use an embedding model with <= 2000 dimensions, or switch to a vector extension "
-                        f"that supports higher dimensions (e.g., pgvectorscale/DiskANN)."
+                        f"that supports higher dimensions (e.g., pgvectorscale/DiskANN or AlloyDB ScaNN)."
                     )
-                logger.info(f"Creating HNSW index on {table_name}")
-                conn.execute(
-                    text(f"""
-                        CREATE INDEX IF NOT EXISTS {index_name}
-                        ON {schema_name}.{table_name}
-                        USING hnsw (embedding vector_cosine_ops)
-                        WITH (m = 16, ef_construction = 64)
-                    """)
-                )
+
+            logger.info(f"Creating {target_index_type} index on {table_name}")
+            conn.execute(
+                text(f"""
+                    CREATE INDEX IF NOT EXISTS {index_name}
+                    ON {schema_name}.{table_name}
+                    {index_using_clause(target_ext)}
+                """)
+            )
 
         conn.commit()
         logger.info(f"Successfully migrated vector indexes to {target_ext}")

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -27,7 +27,15 @@ from alembic.config import Config
 from alembic.script.revision import ResolutionError
 from sqlalchemy import Connection, create_engine, text
 
-from ._vector_index import bootstrap_extension, detect_vector_extension, index_type_keyword, index_using_clause
+from ._vector_index import (
+    bootstrap_extension,
+    detect_vector_extension,
+    index_type_keyword,
+    index_using_clause,
+    minimum_rows_for_index,
+    should_defer_index_creation,
+    uses_per_bank_vector_indexes,
+)
 from .db_url import is_oracle_url, to_libpq_url
 from .utils import mask_network_location
 
@@ -47,6 +55,25 @@ _alembic_lock = threading.Lock()
 def _detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
     """Validate configured vector extension and preserve Azure DiskANN detection."""
     return detect_vector_extension(conn, vector_extension)
+
+
+def _drop_per_bank_vector_indexes(conn: Connection, schema_name: str) -> None:
+    """Drop per-bank partial memory_units vector indexes after global ScaNN is ready."""
+    rows = conn.execute(
+        text("""
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = :schema_name
+              AND tablename = 'memory_units'
+              AND indexname LIKE 'idx_mu_emb_%'
+              AND indexdef LIKE '%embedding%'
+        """),
+        {"schema_name": schema_name},
+    ).fetchall()
+    safe_schema = schema_name.replace('"', '""')
+    for row in rows:
+        safe_index = row[0].replace('"', '""')
+        conn.execute(text(f'DROP INDEX IF EXISTS "{safe_schema}"."{safe_index}"'))
 
 
 def _get_schema_lock_id(schema: str) -> int:
@@ -482,6 +509,18 @@ def _migrate_table_embedding_dimension(
         )
 
     index_type = index_type_keyword(vector_ext)
+    if should_defer_index_creation(vector_ext, row_count):
+        minimum_rows = minimum_rows_for_index(vector_ext)
+        logger.warning(
+            "Skipping %s index recreation on %s: AlloyDB ScaNN AUTO indexes need at least %s populated "
+            "embedding rows; table currently has %s",
+            vector_ext,
+            table_name,
+            minimum_rows,
+            row_count,
+        )
+        return
+
     conn.execute(
         text(f"""
             CREATE INDEX IF NOT EXISTS idx_{table_name}_embedding_{index_type}
@@ -603,6 +642,10 @@ def ensure_vector_extension(
                 logger.debug(f"Table {table_name} does not exist in schema '{schema_name}', skipping")
                 continue
 
+            row_count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {schema_name}.{table_name} WHERE embedding IS NOT NULL")
+            ).scalar()
+
             # Check current index type by querying pg_indexes
             current_index_info = conn.execute(
                 text("""
@@ -616,26 +659,27 @@ def ensure_vector_extension(
             ).fetchone()
 
             if not current_index_info:
-                # Check whether per-bank partial vector indexes already cover this table
-                # (created by the bank_utils lifecycle — no global index needed in that case)
-                per_bank_index_count = conn.execute(
-                    text("""
-                        SELECT COUNT(*)
-                        FROM pg_indexes
-                        WHERE schemaname = :schema
-                          AND tablename = :table_name
-                          AND indexname LIKE 'idx_mu_emb_%'
-                    """),
-                    {"schema": schema_name, "table_name": table_name},
-                ).scalar()
-                if per_bank_index_count and per_bank_index_count > 0:
-                    logger.debug(
-                        f"No global embedding index on {table_name}, but {per_bank_index_count} "
-                        f"per-bank partial vector indexes exist — skipping global index creation"
-                    )
-                    continue
-                logger.warning(f"No embedding index found for {table_name}, will create it")
-                mismatched_tables.append((table_name, index_name, None))
+                if table_name == "memory_units" and uses_per_bank_vector_indexes(target_ext):
+                    # Check whether per-bank partial vector indexes already cover this table
+                    # (created by the bank_utils lifecycle — no global index needed in that case)
+                    per_bank_index_count = conn.execute(
+                        text("""
+                            SELECT COUNT(*)
+                            FROM pg_indexes
+                            WHERE schemaname = :schema
+                              AND tablename = :table_name
+                              AND indexname LIKE 'idx_mu_emb_%'
+                        """),
+                        {"schema": schema_name, "table_name": table_name},
+                    ).scalar()
+                    if per_bank_index_count and per_bank_index_count > 0:
+                        logger.debug(
+                            f"No global embedding index on {table_name}, but {per_bank_index_count} "
+                            f"per-bank partial vector indexes exist — skipping global index creation"
+                        )
+                        continue
+                logger.warning(f"No embedding index found for {table_name}, will create it if safe")
+                mismatched_tables.append((table_name, index_name, None, row_count))
                 continue
 
             indexdef = current_index_info[0].lower()
@@ -656,24 +700,22 @@ def ensure_vector_extension(
                 logger.info(
                     f"Index type mismatch on {table_name}: current={current_index_type}, target={target_index_type}"
                 )
-                mismatched_tables.append((table_name, index_name, current_index_type))
+                mismatched_tables.append((table_name, index_name, current_index_type, row_count))
 
-                # Check if table has data
-                row_count = conn.execute(
-                    text(f"SELECT COUNT(*) FROM {schema_name}.{table_name} WHERE embedding IS NOT NULL")
-                ).scalar()
-
-                if row_count > 0:
+                if row_count > 0 and target_ext != "scann":
                     tables_with_data.append((table_name, row_count, current_index_type))
             else:
                 logger.debug(f"Index type OK for {table_name}: {current_index_type}")
+                if target_ext == "scann" and table_name == "memory_units":
+                    _drop_per_bank_vector_indexes(conn, schema_name)
+                    conn.commit()
 
         # If no mismatches, we're done
         if not mismatched_tables:
             logger.debug(f"All vector indexes match configured extension: {target_ext}")
             return
 
-        # If there's data in any mismatched table, raise error
+        # If there's data in any non-ScaNN mismatched table, raise error
         if tables_with_data:
             table_list = ", ".join([f"{table}({count} rows)" for table, count, _ in tables_with_data])
             current_index_type = tables_with_data[0][2]
@@ -694,10 +736,21 @@ def ensure_vector_extension(
                 f"  2. Use the current vector extension (set HINDSIGHT_API_VECTOR_EXTENSION='{current_ext_name}')"
             )
 
-        # Tables are empty, safe to recreate indexes
-        logger.info(f"Recreating vector indexes for {target_ext}")
+        logger.info(f"Reconciling vector indexes for {target_ext}")
 
-        for table_name, index_name, current_type in mismatched_tables:
+        for table_name, index_name, current_type, row_count in mismatched_tables:
+            if should_defer_index_creation(target_ext, row_count):
+                minimum_rows = minimum_rows_for_index(target_ext)
+                logger.warning(
+                    "Skipping %s index creation on %s: AlloyDB ScaNN AUTO indexes need at least %s populated "
+                    "embedding rows; table currently has %s",
+                    target_ext,
+                    table_name,
+                    minimum_rows,
+                    row_count,
+                )
+                continue
+
             # Drop existing index if it exists
             if current_type:
                 logger.info(f"Dropping {current_type} index on {table_name}")
@@ -732,9 +785,11 @@ def ensure_vector_extension(
                     {index_using_clause(target_ext)}
                 """)
             )
+            if target_ext == "scann" and table_name == "memory_units":
+                _drop_per_bank_vector_indexes(conn, schema_name)
 
         conn.commit()
-        logger.info(f"Successfully migrated vector indexes to {target_ext}")
+        logger.info(f"Successfully reconciled vector indexes for {target_ext}")
 
 
 def ensure_text_search_extension(

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -1,10 +1,16 @@
+from pathlib import Path
+
 from hindsight_api._vector_index import (
+    SCANN_MIN_ROWS_FOR_AUTO_INDEX,
     bootstrap_extension,
     index_type_keyword,
     index_using_clause,
     pg_extension_name,
+    should_defer_index_creation,
+    uses_per_bank_vector_indexes,
     validate_extension,
 )
+from hindsight_api.engine.retain import bank_utils
 
 
 class RecordingConn:
@@ -52,3 +58,52 @@ def test_bootstrap_extension_scann_installs_vector_before_alloydb_scann():
         "CREATE EXTENSION IF NOT EXISTS vector",
         "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
     ]
+
+
+def test_scann_index_creation_defers_until_table_is_large_enough():
+    assert should_defer_index_creation("scann", 0)
+    assert should_defer_index_creation("scann", SCANN_MIN_ROWS_FOR_AUTO_INDEX - 1)
+    assert not should_defer_index_creation("scann", SCANN_MIN_ROWS_FOR_AUTO_INDEX)
+    assert not should_defer_index_creation("pgvector", 0)
+
+
+def test_scann_does_not_use_per_bank_partial_indexes():
+    assert not uses_per_bank_vector_indexes("scann")
+    assert uses_per_bank_vector_indexes("pgvector")
+    assert uses_per_bank_vector_indexes("pgvectorscale")
+    assert uses_per_bank_vector_indexes("vchord")
+
+
+def test_alembic_vector_migrations_freeze_vector_sql_locally():
+    migration_dir = Path("hindsight_api/alembic/versions")
+    changed_migrations = [
+        "5a366d414dce_initial_schema.py",
+        "a4b5c6d7e8f9_fix_per_bank_vector_index_type.py",
+        "d5e6f7a8b9c0_add_bank_internal_id_and_per_bank_hnsw.py",
+        "n9i0j1k2l3m4_learnings_and_pinned_reflections.py",
+    ]
+
+    for migration in changed_migrations:
+        text = (migration_dir / migration).read_text()
+        assert "hindsight_api._vector_index" not in text
+
+
+class RecordingOps:
+    def __init__(self):
+        self.called = False
+
+    async def create_bank_vector_indexes(self, *args, **kwargs):
+        self.called = True
+
+
+class ScannConfig:
+    vector_extension = "scann"
+
+
+async def test_create_bank_vector_indexes_skips_scann(monkeypatch):
+    monkeypatch.setattr(bank_utils, "get_config", lambda: ScannConfig())
+    ops = RecordingOps()
+
+    await bank_utils.create_bank_vector_indexes(None, "bank", "00000000-0000-0000-0000-000000000000", ops=ops)
+
+    assert not ops.called

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -1,0 +1,54 @@
+from hindsight_api._vector_index import (
+    bootstrap_extension,
+    index_type_keyword,
+    index_using_clause,
+    pg_extension_name,
+    validate_extension,
+)
+
+
+class RecordingConn:
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, statement, *args, **kwargs):
+        self.statements.append(str(statement))
+
+
+def test_validate_extension_accepts_scann():
+    assert validate_extension("scann") == "scann"
+    assert validate_extension("ScaNN") == "scann"
+
+
+def test_pg_extension_name_maps_scann_to_alloydb_extension():
+    assert pg_extension_name("scann") == "alloydb_scann"
+
+
+def test_index_using_clause_scann_uses_cosine_auto_mode():
+    clause = index_using_clause("scann")
+
+    assert "USING scann (embedding cosine)" in clause
+    assert "mode = 'AUTO'" in clause
+
+
+def test_index_using_clause_pgvector_matches_existing_clause():
+    assert index_using_clause("pgvector") == "USING hnsw (embedding vector_cosine_ops)"
+
+
+def test_index_type_keyword_scann_round_trips_pg_indexes_indexdef():
+    keyword = index_type_keyword("scann")
+    indexdef = "CREATE INDEX idx ON memory_units USING scann (embedding cosine) WITH (mode='AUTO')"
+
+    assert keyword == "scann"
+    assert keyword in indexdef.lower()
+
+
+def test_bootstrap_extension_scann_installs_vector_before_alloydb_scann():
+    conn = RecordingConn()
+
+    bootstrap_extension(conn, "scann")
+
+    assert conn.statements == [
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
+    ]


### PR DESCRIPTION
## What changed

Adds `scann` as a supported `HINDSIGHT_API_VECTOR_EXTENSION` value for AlloyDB.

The vector-index branching was getting copied across migrations and runtime code, so this moves it into a shared helper first. ScaNN then plugs into the same paths as pgvector, pgvectorscale, and vchord.

A few details worth calling out:

- `scann` maps to the AlloyDB extension name `alloydb_scann`
- ScaNN indexes use `USING scann (embedding cosine) WITH (mode = 'AUTO')`
- bootstrap creates `vector` before `alloydb_scann`
- the per-bank index repair migration now picks up ScaNN automatically, so existing empty HNSW per-bank indexes get recreated as ScaNN when configured

## Checked

- `uv run ruff check ...`
- `uv run python -m py_compile ...`
- `uv run pytest hindsight-api-slim/tests/test_vector_index.py`
- `uv run pytest hindsight-api-slim/tests/test_migration_shape.py hindsight-api-slim/tests/test_migrations_thread_safety.py`

I also tried the full `hindsight-api-slim/tests` suite locally, but this checkout has no `.env` / `HINDSIGHT_API_LLM_API_KEY`, so the broader suite fails during test setup before reaching this change.