### PR TITLE
feat(engine): optional read-only backend for recall queries

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -122,6 +122,8 @@ def normalize_config_dict(config: dict[str, Any]) -> dict[str, Any]:
 ENV_DATABASE_BACKEND = "HINDSIGHT_API_DATABASE_BACKEND"
 ENV_DATABASE_URL = "HINDSIGHT_API_DATABASE_URL"
 ENV_READ_DATABASE_URL = "HINDSIGHT_API_READ_DATABASE_URL"
+ENV_READ_DB_POOL_MIN_SIZE = "HINDSIGHT_API_READ_DB_POOL_MIN_SIZE"
+ENV_READ_DB_POOL_MAX_SIZE = "HINDSIGHT_API_READ_DB_POOL_MAX_SIZE"
 ENV_MIGRATION_DATABASE_URL = "HINDSIGHT_API_MIGRATION_DATABASE_URL"
 ENV_DATABASE_SCHEMA = "HINDSIGHT_API_DATABASE_SCHEMA"
 ENV_LLM_PROVIDER = "HINDSIGHT_API_LLM_PROVIDER"
@@ -832,13 +834,11 @@ class HindsightConfig:
     # Database
     database_backend: Literal["postgresql", "oracle"]
     database_url: str
-    # Optional separate URL for read-only heavy queries (e.g. recall vector
-    # similarity). When set, the engine opens a second connection pool against
-    # this URL and routes the recall retrieval queries through it; everything
-    # else (writes, queue management, transactional reads) keeps using
-    # database_url. Intended for fronting a read-replica via a pgbouncer-style
-    # pooler. Leaving this unset preserves single-pool behaviour bit-for-bit.
+    # Optional read-replica URL for recall queries. When set, the engine opens
+    # a second pool and routes recall SELECTs through it.
     read_database_url: str | None
+    read_db_pool_min_size: int
+    read_db_pool_max_size: int
     migration_database_url: str | None
     database_schema: str
     vector_extension: str  # "pgvector" or "vchord"
@@ -1368,6 +1368,8 @@ class HindsightConfig:
             database_backend=os.getenv(ENV_DATABASE_BACKEND, DEFAULT_DATABASE_BACKEND).lower(),
             database_url=os.getenv(ENV_DATABASE_URL, DEFAULT_DATABASE_URL),
             read_database_url=os.getenv(ENV_READ_DATABASE_URL) or None,
+            read_db_pool_min_size=int(os.getenv(ENV_READ_DB_POOL_MIN_SIZE, str(DEFAULT_DB_POOL_MIN_SIZE))),
+            read_db_pool_max_size=int(os.getenv(ENV_READ_DB_POOL_MAX_SIZE, str(DEFAULT_DB_POOL_MAX_SIZE))),
             migration_database_url=os.getenv(ENV_MIGRATION_DATABASE_URL) or None,
             database_schema=os.getenv(ENV_DATABASE_SCHEMA, DEFAULT_DATABASE_SCHEMA),
             vector_extension=os.getenv(ENV_VECTOR_EXTENSION, DEFAULT_VECTOR_EXTENSION).lower(),

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -121,6 +121,7 @@ def normalize_config_dict(config: dict[str, Any]) -> dict[str, Any]:
 # Environment variable names
 ENV_DATABASE_BACKEND = "HINDSIGHT_API_DATABASE_BACKEND"
 ENV_DATABASE_URL = "HINDSIGHT_API_DATABASE_URL"
+ENV_READ_DATABASE_URL = "HINDSIGHT_API_READ_DATABASE_URL"
 ENV_MIGRATION_DATABASE_URL = "HINDSIGHT_API_MIGRATION_DATABASE_URL"
 ENV_DATABASE_SCHEMA = "HINDSIGHT_API_DATABASE_SCHEMA"
 ENV_LLM_PROVIDER = "HINDSIGHT_API_LLM_PROVIDER"
@@ -831,6 +832,13 @@ class HindsightConfig:
     # Database
     database_backend: Literal["postgresql", "oracle"]
     database_url: str
+    # Optional separate URL for read-only heavy queries (e.g. recall vector
+    # similarity). When set, the engine opens a second connection pool against
+    # this URL and routes the recall retrieval queries through it; everything
+    # else (writes, queue management, transactional reads) keeps using
+    # database_url. Intended for fronting a read-replica via a pgbouncer-style
+    # pooler. Leaving this unset preserves single-pool behaviour bit-for-bit.
+    read_database_url: str | None
     migration_database_url: str | None
     database_schema: str
     vector_extension: str  # "pgvector" or "vchord"
@@ -1359,6 +1367,7 @@ class HindsightConfig:
             # Database
             database_backend=os.getenv(ENV_DATABASE_BACKEND, DEFAULT_DATABASE_BACKEND).lower(),
             database_url=os.getenv(ENV_DATABASE_URL, DEFAULT_DATABASE_URL),
+            read_database_url=os.getenv(ENV_READ_DATABASE_URL) or None,
             migration_database_url=os.getenv(ENV_MIGRATION_DATABASE_URL) or None,
             database_schema=os.getenv(ENV_DATABASE_SCHEMA, DEFAULT_DATABASE_SCHEMA),
             vector_extension=os.getenv(ENV_VECTOR_EXTENSION, DEFAULT_VECTOR_EXTENSION).lower(),
@@ -1888,6 +1897,8 @@ class HindsightConfig:
     def log_config(self) -> None:
         """Log the current configuration (without sensitive values)."""
         logger.info(f"Database: {mask_network_location(self.database_url)} (schema: {self.database_schema})")
+        if self.read_database_url:
+            logger.info(f"Read database (recall queries only): {mask_network_location(self.read_database_url)}")
         if self.migration_database_url:
             logger.info(f"Migration database: {mask_network_location(self.migration_database_url)}")
         logger.info(f"LLM: provider={self.llm_provider}, model={self.llm_model}")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -502,14 +502,15 @@ class MemoryEngine(MemoryEngineInterface):
         self._dialect: SQLDialect | None = None
         # Connection pool — set from backend.get_pool() for backward compatibility
         self._pool = None
-        # Optional second backend for read-only heavy queries (e.g. recall
-        # vector search). Populated in initialize() when
-        # config.read_database_url is set; otherwise aliased to self._backend
-        # so call sites are unconditional.
         self._read_backend: DatabaseBackend | None = None
+        self._read_database_url: str | None = (
+            config.read_database_url if self._database_backend_type == "postgresql" else None
+        )
         self._initialized = False
         self._pool_min_size = pool_min_size if pool_min_size is not None else config.db_pool_min_size
         self._pool_max_size = pool_max_size if pool_max_size is not None else config.db_pool_max_size
+        self._read_pool_min_size = config.read_db_pool_min_size
+        self._read_pool_max_size = config.read_db_pool_max_size
         self._db_command_timeout = db_command_timeout if db_command_timeout is not None else config.db_command_timeout
         self._db_acquire_timeout = db_acquire_timeout if db_acquire_timeout is not None else config.db_acquire_timeout
         self._db_statement_timeout = config.db_statement_timeout
@@ -1934,25 +1935,15 @@ class MemoryEngine(MemoryEngineInterface):
         # These will be migrated to use self._backend.acquire() over time.
         self._pool = self._backend.get_pool()
 
-        # Optional second backend for heavy recall queries — typically
-        # pointed at a read-replica fronted by a pgbouncer-style pooler.
-        # PostgreSQL-only; on Oracle the abstraction layer does not yet
-        # model a second pool, so we silently fall back to the primary
-        # backend. When the env var is unset (or backend is Oracle),
-        # _read_backend aliases to _backend so call sites stay
-        # unconditional and behaviour is bit-identical to before.
-        # Re-read config here because the only earlier `config = get_config()`
-        # in this method lives inside `if self._run_migrations`, which is
-        # skipped in tests and pre-migrated deployments.
-        runtime_config = get_config()
-        read_url = runtime_config.read_database_url if self._database_backend_type == "postgresql" else None
-        if read_url:
-            logger.info(f"Opening read backend against {mask_network_location(read_url)} for recall queries")
+        if self._read_database_url:
+            logger.info(
+                f"Opening read backend against {mask_network_location(self._read_database_url)} for recall queries"
+            )
             self._read_backend = create_database_backend(self._database_backend_type)
             await self._read_backend.initialize(
-                read_url,
-                min_size=self._pool_min_size,
-                max_size=self._pool_max_size,
+                self._read_database_url,
+                min_size=self._read_pool_min_size,
+                max_size=self._read_pool_max_size,
                 command_timeout=self._db_command_timeout,
                 acquire_timeout=self._db_acquire_timeout,
                 statement_cache_size=0,
@@ -2050,17 +2041,9 @@ class MemoryEngine(MemoryEngineInterface):
         return self._pool
 
     async def _get_read_backend(self) -> DatabaseBackend:
-        """Get the read-only database backend, intended for heavy SELECT
-        queries that can tolerate slight replication lag (e.g. recall's
-        vector search).
+        """Get the read-only backend (replica when configured, otherwise primary).
 
-        When ``HINDSIGHT_API_READ_DATABASE_URL`` is set, this returns a
-        dedicated backend against that URL — typically a read-replica
-        fronted by a pgbouncer-style pooler. When unset, this returns the
-        primary backend, so callers are safe regardless of configuration.
-
-        Writes MUST NOT be issued through this backend — there is no
-        guarantee the underlying server is the primary.
+        Writes MUST NOT be issued through this backend.
         """
         if not self._initialized:
             await self.initialize()
@@ -2122,9 +2105,6 @@ class MemoryEngine(MemoryEngineInterface):
             await self._http_client.aclose()
             self._http_client = None
 
-        # Close read backend first if it was a distinct backend (when
-        # read_database_url was set). When it aliases to _backend, leave it
-        # alone — _backend.shutdown() below covers it.
         if self._read_backend is not None and self._read_backend is not self._backend:
             await self._read_backend.shutdown()
         self._read_backend = None
@@ -2974,10 +2954,6 @@ class MemoryEngine(MemoryEngineInterface):
         if tracer:
             tracer.start()
 
-        # Use the read backend (replica when HINDSIGHT_API_READ_DATABASE_URL
-        # is set, otherwise the primary). Recall's vector / BM25 / graph /
-        # temporal queries are pure SELECTs and tolerate the small
-        # replication lag of an asynchronous standby.
         backend = await self._get_read_backend()
         recall_start = time.time()
 
@@ -3047,9 +3023,6 @@ class MemoryEngine(MemoryEngineInterface):
                     max_connections=effective_connection_budget,
                     operation_id=f"recall-{recall_id}",
                 ) as op:
-                    # Wrap the read backend (resolved above) — when a read
-                    # replica URL is configured, this offloads recall's heavy
-                    # SELECT traffic from the primary.
                     budgeted_pool = op.wrap_pool(backend)
                     parallel_start = time.time()
                     multi_result = await retrieve_all_fact_types_parallel(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -502,6 +502,11 @@ class MemoryEngine(MemoryEngineInterface):
         self._dialect: SQLDialect | None = None
         # Connection pool — set from backend.get_pool() for backward compatibility
         self._pool = None
+        # Optional second backend for read-only heavy queries (e.g. recall
+        # vector search). Populated in initialize() when
+        # config.read_database_url is set; otherwise aliased to self._backend
+        # so call sites are unconditional.
+        self._read_backend: DatabaseBackend | None = None
         self._initialized = False
         self._pool_min_size = pool_min_size if pool_min_size is not None else config.db_pool_min_size
         self._pool_max_size = pool_max_size if pool_max_size is not None else config.db_pool_max_size
@@ -1929,6 +1934,33 @@ class MemoryEngine(MemoryEngineInterface):
         # These will be migrated to use self._backend.acquire() over time.
         self._pool = self._backend.get_pool()
 
+        # Optional second backend for heavy recall queries — typically
+        # pointed at a read-replica fronted by a pgbouncer-style pooler.
+        # PostgreSQL-only; on Oracle the abstraction layer does not yet
+        # model a second pool, so we silently fall back to the primary
+        # backend. When the env var is unset (or backend is Oracle),
+        # _read_backend aliases to _backend so call sites stay
+        # unconditional and behaviour is bit-identical to before.
+        # Re-read config here because the only earlier `config = get_config()`
+        # in this method lives inside `if self._run_migrations`, which is
+        # skipped in tests and pre-migrated deployments.
+        runtime_config = get_config()
+        read_url = runtime_config.read_database_url if self._database_backend_type == "postgresql" else None
+        if read_url:
+            logger.info(f"Opening read backend against {mask_network_location(read_url)} for recall queries")
+            self._read_backend = create_database_backend(self._database_backend_type)
+            await self._read_backend.initialize(
+                read_url,
+                min_size=self._pool_min_size,
+                max_size=self._pool_max_size,
+                command_timeout=self._db_command_timeout,
+                acquire_timeout=self._db_acquire_timeout,
+                statement_cache_size=0,
+                init_callback=_init_connection,
+            )
+        else:
+            self._read_backend = self._backend
+
         # Initialize entity resolver with pool and configured lookup strategy
         self.entity_resolver = EntityResolver(
             self._backend,
@@ -2017,6 +2049,23 @@ class MemoryEngine(MemoryEngineInterface):
             await self.initialize()
         return self._pool
 
+    async def _get_read_backend(self) -> DatabaseBackend:
+        """Get the read-only database backend, intended for heavy SELECT
+        queries that can tolerate slight replication lag (e.g. recall's
+        vector search).
+
+        When ``HINDSIGHT_API_READ_DATABASE_URL`` is set, this returns a
+        dedicated backend against that URL — typically a read-replica
+        fronted by a pgbouncer-style pooler. When unset, this returns the
+        primary backend, so callers are safe regardless of configuration.
+
+        Writes MUST NOT be issued through this backend — there is no
+        guarantee the underlying server is the primary.
+        """
+        if not self._initialized:
+            await self.initialize()
+        return self._read_backend
+
     async def _get_backend(self) -> DatabaseBackend:
         """Get the database backend, auto-initializing if needed."""
         if not self._initialized:
@@ -2073,7 +2122,14 @@ class MemoryEngine(MemoryEngineInterface):
             await self._http_client.aclose()
             self._http_client = None
 
-        # Close database backend (shuts down pool)
+        # Close read backend first if it was a distinct backend (when
+        # read_database_url was set). When it aliases to _backend, leave it
+        # alone — _backend.shutdown() below covers it.
+        if self._read_backend is not None and self._read_backend is not self._backend:
+            await self._read_backend.shutdown()
+        self._read_backend = None
+
+        # Close primary database backend (shuts down pool)
         if self._backend is not None:
             await self._backend.shutdown()
             self._backend = None
@@ -2918,7 +2974,11 @@ class MemoryEngine(MemoryEngineInterface):
         if tracer:
             tracer.start()
 
-        backend = await self._get_backend()
+        # Use the read backend (replica when HINDSIGHT_API_READ_DATABASE_URL
+        # is set, otherwise the primary). Recall's vector / BM25 / graph /
+        # temporal queries are pure SELECTs and tolerate the small
+        # replication lag of an asynchronous standby.
+        backend = await self._get_read_backend()
         recall_start = time.time()
 
         # Buffer logs for clean output in concurrent scenarios.
@@ -2987,7 +3047,10 @@ class MemoryEngine(MemoryEngineInterface):
                     max_connections=effective_connection_budget,
                     operation_id=f"recall-{recall_id}",
                 ) as op:
-                    budgeted_pool = op.wrap_pool(self._backend)
+                    # Wrap the read backend (resolved above) — when a read
+                    # replica URL is configured, this offloads recall's heavy
+                    # SELECT traffic from the primary.
+                    budgeted_pool = op.wrap_pool(backend)
                     parallel_start = time.time()
                     multi_result = await retrieve_all_fact_types_parallel(
                         budgeted_pool,

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -172,17 +172,17 @@ def test_read_database_url_empty_string_is_treated_as_unset(monkeypatch):
     assert config.read_database_url is None
 
 
-def test_log_config_masks_read_database_url(caplog):
+def test_log_config_masks_read_database_url(monkeypatch, caplog):
     """Read-replica URL credentials must be masked in startup logs, same as
     the primary URL.
     """
     from hindsight_api.config import HindsightConfig
 
-    os.environ["HINDSIGHT_API_DATABASE_URL"] = "postgresql://hindsight:pw@primary:5432/db"
-    os.environ["HINDSIGHT_API_READ_DATABASE_URL"] = "postgresql://reader:replica-secret@replica:5432/db"
-    os.environ["HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS"] = "64000"
-    os.environ["HINDSIGHT_API_RETAIN_CHUNK_SIZE"] = "3000"
-    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    monkeypatch.setenv("HINDSIGHT_API_DATABASE_URL", "postgresql://hindsight:pw@primary:5432/db")
+    monkeypatch.setenv("HINDSIGHT_API_READ_DATABASE_URL", "postgresql://reader:replica-secret@replica:5432/db")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", "64000")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_CHUNK_SIZE", "3000")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
 
     caplog.set_level(logging.INFO, logger="hindsight_api.config")
 

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -128,6 +128,74 @@ def test_log_config_masks_database_urls(caplog):
     assert "postgresql://***:***@db-admin:5432/hindsight_db" in log_output
 
 
+def test_read_database_url_defaults_to_none_when_unset(monkeypatch):
+    """Without HINDSIGHT_API_READ_DATABASE_URL, the field is None — engine
+    will alias the read backend to the primary, preserving today's
+    single-pool behaviour byte-for-bit. This is the most important guarantee
+    of the change: zero-config means zero behaviour change.
+    """
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.delenv("HINDSIGHT_API_READ_DATABASE_URL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.read_database_url is None
+
+
+def test_read_database_url_is_loaded_when_set(monkeypatch):
+    """When HINDSIGHT_API_READ_DATABASE_URL is set, the value flows into
+    config so MemoryEngine.initialize() will open a second backend against
+    that URL for recall queries.
+    """
+    from hindsight_api.config import HindsightConfig
+
+    read_url = "postgresql://reader:secret@replica.example:5432/hindsight"
+    monkeypatch.setenv("HINDSIGHT_API_READ_DATABASE_URL", read_url)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.read_database_url == read_url
+
+
+def test_read_database_url_empty_string_is_treated_as_unset(monkeypatch):
+    """Helm sometimes renders an unset env var as the empty string. Treat it
+    the same as unset so deployments that conditionally set the var don't
+    accidentally try to open a pool against `''`.
+    """
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_READ_DATABASE_URL", "")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.read_database_url is None
+
+
+def test_log_config_masks_read_database_url(caplog):
+    """Read-replica URL credentials must be masked in startup logs, same as
+    the primary URL.
+    """
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_DATABASE_URL"] = "postgresql://hindsight:pw@primary:5432/db"
+    os.environ["HINDSIGHT_API_READ_DATABASE_URL"] = "postgresql://reader:replica-secret@replica:5432/db"
+    os.environ["HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS"] = "64000"
+    os.environ["HINDSIGHT_API_RETAIN_CHUNK_SIZE"] = "3000"
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+
+    caplog.set_level(logging.INFO, logger="hindsight_api.config")
+
+    config = HindsightConfig.from_env()
+    config.log_config()
+
+    log_output = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reader" not in log_output
+    assert "replica-secret" not in log_output
+    assert "Read database" in log_output
+    assert "postgresql://***:***@replica:5432/db" in log_output
+
+
 # Note: The BadRequestError wrapping is implemented in fact_extraction.py
 # but requires a complex integration test setup. The functionality is
 # straightforward: when a BadRequestError containing keywords like

--- a/hindsight-api-slim/tests/test_read_backend.py
+++ b/hindsight-api-slim/tests/test_read_backend.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 import pytest_asyncio
 

--- a/hindsight-api-slim/tests/test_read_backend.py
+++ b/hindsight-api-slim/tests/test_read_backend.py
@@ -1,0 +1,158 @@
+"""Tests for the optional read-only backend used to route heavy recall queries
+off the primary.
+
+The contract this test enforces:
+
+1. When ``HINDSIGHT_API_READ_DATABASE_URL`` is unset, ``MemoryEngine._read_backend``
+   IS the same object as ``MemoryEngine._backend`` — call sites see no
+   behavioural difference from before this feature existed. This is the
+   most important guarantee: zero-config = zero behaviour change.
+
+2. When the env var is set, a distinct backend instance is created and
+   wired as ``_read_backend``. Recall queries flow through it; writes
+   continue to flow through the primary backend.
+
+3. The recall path (``_search_with_retries``) acquires the read backend,
+   not the primary backend.
+
+Tests use the ``pg0_db_url`` fixture (a real embedded postgres) so the
+backend lifecycle is exercised end-to-end. Pointing both URLs at the same
+DB is fine for this test — we only need to verify the engine creates two
+separate backend objects, not that they live on different servers.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine
+from hindsight_api.engine.task_backend import SyncTaskBackend
+
+
+def _make_engine(pg0_db_url: str, embeddings, cross_encoder, query_analyzer) -> MemoryEngine:
+    """Build a MemoryEngine for a single test. Tiny pool, no migrations,
+    SyncTaskBackend so async tasks resolve inline. Mirrors conftest's
+    ``memory`` fixture but lets each test build its own with custom env.
+    """
+    return MemoryEngine(
+        db_url=pg0_db_url,
+        memory_llm_provider="none",  # No LLM calls in these tests
+        memory_llm_api_key="unused",
+        memory_llm_model="unused",
+        embeddings=embeddings,
+        cross_encoder=cross_encoder,
+        query_analyzer=query_analyzer,
+        pool_min_size=1,
+        pool_max_size=2,
+        run_migrations=False,
+        task_backend=SyncTaskBackend(),
+    )
+
+
+@pytest_asyncio.fixture
+async def engine_no_read_url(monkeypatch, pg0_db_url, embeddings, cross_encoder, query_analyzer):
+    """Engine built with READ_DATABASE_URL explicitly unset."""
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.delenv("HINDSIGHT_API_READ_DATABASE_URL", raising=False)
+    clear_config_cache()
+
+    mem = _make_engine(pg0_db_url, embeddings, cross_encoder, query_analyzer)
+    await mem.initialize()
+    yield mem
+    try:
+        await mem.close()
+    except Exception:
+        pass
+    clear_config_cache()
+
+
+@pytest_asyncio.fixture
+async def engine_with_read_url(monkeypatch, pg0_db_url, embeddings, cross_encoder, query_analyzer):
+    """Engine built with READ_DATABASE_URL set to the same DB. The engine
+    can't tell it's the same server — it just sees a second URL and opens
+    a second backend, which is what we want to verify.
+    """
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_READ_DATABASE_URL", pg0_db_url)
+    clear_config_cache()
+
+    mem = _make_engine(pg0_db_url, embeddings, cross_encoder, query_analyzer)
+    await mem.initialize()
+    yield mem
+    try:
+        await mem.close()
+    except Exception:
+        pass
+    clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_read_backend_aliases_primary_when_url_unset(engine_no_read_url):
+    """Without HINDSIGHT_API_READ_DATABASE_URL, _read_backend is _backend.
+    This is the back-compat invariant — every call site that uses
+    _get_read_backend() resolves to the same object _get_backend() returns,
+    so nothing observable changes.
+    """
+    assert engine_no_read_url._read_backend is engine_no_read_url._backend
+
+
+@pytest.mark.asyncio
+async def test_read_backend_is_separate_instance_when_url_set(engine_with_read_url):
+    """With HINDSIGHT_API_READ_DATABASE_URL set, a SECOND backend object is
+    created. Even if both URLs point at the same DB (as in this test), the
+    two backends own independent connection pools — connections taken from
+    one don't drain the other, and shutting one down doesn't close the
+    other's pool.
+    """
+    primary = engine_with_read_url._backend
+    read = engine_with_read_url._read_backend
+    assert read is not primary
+    # Both backends are independently initialized (each owns a pool)
+    assert primary.get_pool() is not None
+    assert read.get_pool() is not None
+    assert primary.get_pool() is not read.get_pool()
+
+
+@pytest.mark.asyncio
+async def test_get_read_backend_returns_read_backend(engine_with_read_url):
+    """The accessor used by recall (`_get_read_backend`) returns the dedicated
+    read backend, not the primary. Without this, the env var would have no
+    effect.
+    """
+    backend = await engine_with_read_url._get_read_backend()
+    assert backend is engine_with_read_url._read_backend
+    assert backend is not engine_with_read_url._backend
+
+
+@pytest.mark.asyncio
+async def test_get_read_backend_returns_primary_when_unset(engine_no_read_url):
+    """The accessor falls through to the primary when no read URL is set,
+    so callers don't need to handle a None case.
+    """
+    backend = await engine_no_read_url._get_read_backend()
+    assert backend is engine_no_read_url._backend
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_distinct_read_backend(engine_with_read_url):
+    """When the read backend is distinct, close() must shut it down too,
+    not just the primary. Otherwise we leak the read pool when the engine
+    is recycled (e.g. across pytest sessions or in app shutdown).
+    """
+    primary_before = engine_with_read_url._backend
+    read_before = engine_with_read_url._read_backend
+    assert read_before is not primary_before
+
+    await engine_with_read_url.close()
+
+    # Both backends should be cleared on close. The exact post-close state
+    # is "primary _backend cleared, _read_backend cleared". The shutdown
+    # method on the read backend is called — we verify by checking the
+    # engine no longer references either.
+    assert engine_with_read_url._backend is None
+    assert engine_with_read_url._read_backend is None

--- a/hindsight-api-slim/tests/test_read_backend.py
+++ b/hindsight-api-slim/tests/test_read_backend.py
@@ -1,25 +1,4 @@
-"""Tests for the optional read-only backend used to route heavy recall queries
-off the primary.
-
-The contract this test enforces:
-
-1. When ``HINDSIGHT_API_READ_DATABASE_URL`` is unset, ``MemoryEngine._read_backend``
-   IS the same object as ``MemoryEngine._backend`` — call sites see no
-   behavioural difference from before this feature existed. This is the
-   most important guarantee: zero-config = zero behaviour change.
-
-2. When the env var is set, a distinct backend instance is created and
-   wired as ``_read_backend``. Recall queries flow through it; writes
-   continue to flow through the primary backend.
-
-3. The recall path (``_search_with_retries``) acquires the read backend,
-   not the primary backend.
-
-Tests use the ``pg0_db_url`` fixture (a real embedded postgres) so the
-backend lifecycle is exercised end-to-end. Pointing both URLs at the same
-DB is fine for this test — we only need to verify the engine creates two
-separate backend objects, not that they live on different servers.
-"""
+"""Tests for the optional read-only backend for recall queries."""
 
 from __future__ import annotations
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -20,6 +20,7 @@ The API service handles all memory operations (retain, recall, reflect).
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_DATABASE_URL` | PostgreSQL connection string | `pg0` (embedded) |
+| `HINDSIGHT_API_READ_DATABASE_URL` | Optional read-replica PostgreSQL URL. When set, recall queries (semantic, BM25, graph, temporal) are routed through a separate connection pool against this URL, offloading the primary. Typically points to a read-only endpoint (e.g., CNPG's `<cluster>-ro` service or Aurora reader endpoint). | Unset (uses primary) |
 | `HINDSIGHT_API_MIGRATION_DATABASE_URL` | Direct PostgreSQL URL for running migrations, bypassing connection poolers (e.g. PgBouncer). When set, advisory locks and Alembic migrations use this URL instead of `DATABASE_URL`. | Falls back to `DATABASE_URL` |
 | `HINDSIGHT_API_DATABASE_SCHEMA` | PostgreSQL schema name for tables | `public` |
 | `HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP` | Run database migrations on API startup | `true` |
@@ -43,8 +44,10 @@ Migrations will automatically create the schema if it doesn't exist and create a
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_DB_POOL_MIN_SIZE` | Minimum connections in the pool | `5` |
-| `HINDSIGHT_API_DB_POOL_MAX_SIZE` | Maximum connections in the pool | `100` |
+| `HINDSIGHT_API_DB_POOL_MIN_SIZE` | Minimum connections in the primary pool | `5` |
+| `HINDSIGHT_API_DB_POOL_MAX_SIZE` | Maximum connections in the primary pool | `100` |
+| `HINDSIGHT_API_READ_DB_POOL_MIN_SIZE` | Minimum connections in the read-replica pool (only used when `READ_DATABASE_URL` is set) | Falls back to `DB_POOL_MIN_SIZE` |
+| `HINDSIGHT_API_READ_DB_POOL_MAX_SIZE` | Maximum connections in the read-replica pool (only used when `READ_DATABASE_URL` is set) | Falls back to `DB_POOL_MAX_SIZE` |
 | `HINDSIGHT_API_DB_COMMAND_TIMEOUT` | PostgreSQL command timeout in seconds (asyncpg client-side) | `60` |
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -20,6 +20,7 @@ The API service handles all memory operations (retain, recall, reflect).
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_DATABASE_URL` | PostgreSQL connection string | `pg0` (embedded) |
+| `HINDSIGHT_API_READ_DATABASE_URL` | Optional read-replica PostgreSQL URL. When set, recall queries (semantic, BM25, graph, temporal) are routed through a separate connection pool against this URL, offloading the primary. Typically points to a read-only endpoint (e.g., CNPG's `<cluster>-ro` service or Aurora reader endpoint). | Unset (uses primary) |
 | `HINDSIGHT_API_MIGRATION_DATABASE_URL` | Direct PostgreSQL URL for running migrations, bypassing connection poolers (e.g. PgBouncer). When set, advisory locks and Alembic migrations use this URL instead of `DATABASE_URL`. | Falls back to `DATABASE_URL` |
 | `HINDSIGHT_API_DATABASE_SCHEMA` | PostgreSQL schema name for tables | `public` |
 | `HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP` | Run database migrations on API startup | `true` |
@@ -43,8 +44,10 @@ Migrations will automatically create the schema if it doesn't exist and create a
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_DB_POOL_MIN_SIZE` | Minimum connections in the pool | `5` |
-| `HINDSIGHT_API_DB_POOL_MAX_SIZE` | Maximum connections in the pool | `100` |
+| `HINDSIGHT_API_DB_POOL_MIN_SIZE` | Minimum connections in the primary pool | `5` |
+| `HINDSIGHT_API_DB_POOL_MAX_SIZE` | Maximum connections in the primary pool | `100` |
+| `HINDSIGHT_API_READ_DB_POOL_MIN_SIZE` | Minimum connections in the read-replica pool (only used when `READ_DATABASE_URL` is set) | Falls back to `DB_POOL_MIN_SIZE` |
+| `HINDSIGHT_API_READ_DB_POOL_MAX_SIZE` | Maximum connections in the read-replica pool (only used when `READ_DATABASE_URL` is set) | Falls back to `DB_POOL_MAX_SIZE` |
 | `HINDSIGHT_API_DB_COMMAND_TIMEOUT` | PostgreSQL command timeout in seconds (asyncpg client-side) | `60` |
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.5.6"
+    "version": "0.6.0"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
## Summary

Adds an optional second `DatabaseBackend` (`MemoryEngine._read_backend`) wired only into the recall search path. When operators set the new \`HINDSIGHT_API_READ_DATABASE_URL\` env var, the heavy SELECTs that drive `recall_async` flow through this backend; everything else (writes, queue management, transactional reads) continues to use the primary backend. When the env var is unset, the read backend aliases to the primary — call sites are unconditional and behaviour is bit-identical to today.

## Why

\`_search_with_retries\` is recall's hot path: it runs four parallel retrievers (semantic vector + BM25 + graph + temporal) over `memory_units` and aggregates them. For workloads with a meaningful read/write split, that's a large fraction of database CPU. Today, all of it lands on whatever pool `_get_pool()` resolves — the same pool used for writes, queue-management updates, and migration coordination.

For deployments that already run a primary-replica setup, the existing pool can't take advantage of the replicas. There's no way for the engine to distinguish "this is a SELECT that's safe to send to a standby" from "this is a write that must hit the primary" — they all share the pool.

This change introduces that distinction at the connection boundary instead of at the query boundary: callers explicitly opt in to the read pool by calling `_get_read_backend()`. Today only `_search_with_retries` uses it, but the surface is intentionally minimal so other read-only call sites (`get_chunk`, `get_mental_model`, `list_memory_units`, etc.) can be moved later as needed.

## How it works

- New env var \`HINDSIGHT_API_READ_DATABASE_URL\` (optional; defaults to None / unset).
- New field \`HindsightConfig.read_database_url: str | None\`.
- In \`MemoryEngine.initialize()\`, after creating the primary backend, conditionally create a second `DatabaseBackend` against the read URL and assign to `self._read_backend`. When unset (or when running on the Oracle backend, which doesn't yet model a second pool), `_read_backend` is the same object as `_backend`.
- New accessor \`MemoryEngine._get_read_backend()\` mirrors \`_get_backend()\`.
- One-line edit in \`_search_with_retries\`: change \`backend = await self._get_backend()\` → \`backend = await self._get_read_backend()\`. The existing \`op.wrap_pool(backend)\` call already accepts the backend through `BudgetedPool`, so the budgeted-recall machinery is unchanged.
- \`MemoryEngine.close()\` shuts down the read backend only when it's a distinct object — the alias case isn't double-closed.

## Constraints

- **PostgreSQL backend only.** The Oracle backend's abstraction layer doesn't yet model a second pool, so when `database_backend=oracle` the engine silently falls back to the primary backend even if the read URL is set.
- **Must not be used for writes.** There's no guarantee the underlying server is the primary. Only the recall retrieval pipeline is wired to use it. All other call sites continue to use `_backend` / `_get_backend()`.
- **Replication lag.** When pointed at an asynchronous standby, recall reads may lag behind recent writes by milliseconds. For most workloads this is fine (recall queries aren't required to see writes from the same millisecond). Operators who need read-after-write semantics should leave the env var unset for the affected pods (e.g. set on background workers but not on synchronous request handlers).

## Reflect benefits transparently

`reflect_async` doesn't touch `_get_pool()` or `_get_backend()` directly. It composes recall via its agent-loop tools (\`recall\`, \`lookup\`, \`expand\`, \`learn\`). When recall offloads to the read backend, every reflect call inherits that behaviour automatically — no separate change needed.

## Tests

\`\`\`
hindsight-api-slim/tests/test_config_validation.py
  test_read_database_url_defaults_to_none_when_unset
  test_read_database_url_is_loaded_when_set
  test_read_database_url_empty_string_is_treated_as_unset
  test_log_config_masks_read_database_url

hindsight-api-slim/tests/test_read_backend.py
  test_read_backend_aliases_primary_when_url_unset
  test_read_backend_is_separate_instance_when_url_set
  test_get_read_backend_returns_read_backend
  test_get_read_backend_returns_primary_when_unset
  test_close_terminates_distinct_read_backend
\`\`\`

The most important test is the first engine test: with no env var set, `_read_backend is _backend` — proves zero-config = zero behaviour change. All 5 engine tests use a real embedded postgres (via the existing `pg0_db_url` fixture); no mocking of the backend layer.

## Local verification

- \`uv run ruff check\` — clean
- \`uv run ruff format\` — clean
- \`uv run ty check hindsight_api/config.py hindsight_api/engine/memory_engine.py\` — clean
- 9 new tests pass; existing config tests still pass
- Diff: +303 / -3 across 4 files

## Test plan

- [x] Unit tests for config + engine init (above)
- [x] ruff + ty clean on changed files
- [ ] CI passes
- [ ] After merge: deployments wanting to enable this set `HINDSIGHT_API_READ_DATABASE_URL` on the relevant pods and verify recall queries land on the read endpoint via `pg_stat_activity` / `application_name`