### PR TITLE
fix(providers): strip JSON-Schema numeric constraints for Bedrock

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -13,6 +13,7 @@ is handled automatically by LiteLLM.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import time
@@ -24,6 +25,40 @@ from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
+
+# Providers whose tool-use / structured-output APIs reject JSON-Schema numeric
+# constraints (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`).
+# Bedrock's Claude tool-use API surfaces this as:
+#     BedrockException - {"message":"The model returned the following errors:
+#     For 'number' type, properties maximum, minimum are not supported"}
+# Pydantic's `Field(ge=..., le=...)` emits these constraints, so structured
+# output / tool calls fail on every retain when the underlying model is
+# bound through Bedrock. We strip them before the request; the response is
+# still validated server-side by Pydantic, so there is no loss of safety.
+_PROVIDERS_REQUIRING_NUMERIC_CONSTRAINT_STRIP = frozenset({"bedrock"})
+
+_NUMERIC_CONSTRAINT_KEYS = (
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+)
+
+
+def _strip_numeric_constraints(node: Any) -> Any:
+    """Recursively remove unsupported numeric constraint keys from a JSON-Schema node.
+
+    Mutates `node` in place AND returns it for chained-call ergonomics.
+    """
+    if isinstance(node, dict):
+        for k in _NUMERIC_CONSTRAINT_KEYS:
+            node.pop(k, None)
+        for v in node.values():
+            _strip_numeric_constraints(v)
+    elif isinstance(node, list):
+        for v in node:
+            _strip_numeric_constraints(v)
+    return node
 
 
 class LiteLLMLLM(LLMInterface):
@@ -130,6 +165,8 @@ class LiteLLMLLM(LLMInterface):
         # Add JSON schema response format if provided
         if response_format is not None and hasattr(response_format, "model_json_schema"):
             schema = response_format.model_json_schema()
+            if self.provider in _PROVIDERS_REQUIRING_NUMERIC_CONSTRAINT_STRIP:
+                _strip_numeric_constraints(schema)
             call_kwargs["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
@@ -281,6 +318,8 @@ class LiteLLMLLM(LLMInterface):
         start_time = time.time()
 
         call_kwargs = self._build_common_kwargs(messages, max_completion_tokens, temperature)
+        if self.provider in _PROVIDERS_REQUIRING_NUMERIC_CONSTRAINT_STRIP:
+            tools = [_strip_numeric_constraints(copy.deepcopy(t)) for t in tools]
         call_kwargs["tools"] = tools
         call_kwargs["tool_choice"] = tool_choice
 

--- a/hindsight-api-slim/tests/test_litellm_bedrock_schema_strip.py
+++ b/hindsight-api-slim/tests/test_litellm_bedrock_schema_strip.py
@@ -1,0 +1,128 @@
+"""Unit tests for LiteLLMLLM's Bedrock JSON-Schema constraint stripping.
+
+Bedrock's Claude tool-use API rejects `minimum`/`maximum` (and the
+`exclusive*` variants) on number/integer schema nodes, but Pydantic's
+`Field(ge=..., le=...)` emits them. The provider strips these for the
+`bedrock` provider only; for every other provider the schema is sent
+through unchanged.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from hindsight_api.engine.providers.litellm_llm import (
+    _NUMERIC_CONSTRAINT_KEYS,
+    _strip_numeric_constraints,
+)
+
+
+def _has_numeric_constraints(node: Any) -> bool:
+    """True if `node` (anywhere recursively) contains any numeric-constraint key."""
+    if isinstance(node, dict):
+        if any(k in node for k in _NUMERIC_CONSTRAINT_KEYS):
+            return True
+        return any(_has_numeric_constraints(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_numeric_constraints(v) for v in node)
+    return False
+
+
+def test_strip_numeric_constraints_removes_top_level_keys():
+    schema = {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 5,
+        "description": "score",
+    }
+    _strip_numeric_constraints(schema)
+    assert "minimum" not in schema
+    assert "maximum" not in schema
+    assert schema["type"] == "integer"
+    assert schema["description"] == "score"
+
+
+def test_strip_numeric_constraints_removes_exclusive_variants():
+    schema = {"type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1}
+    _strip_numeric_constraints(schema)
+    assert "exclusiveMinimum" not in schema
+    assert "exclusiveMaximum" not in schema
+
+
+def test_strip_numeric_constraints_recurses_into_nested_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "skepticism": {"type": "integer", "minimum": 1, "maximum": 5},
+            "literalism": {"type": "integer", "minimum": 1, "maximum": 5},
+            "name": {"type": "string"},
+        },
+        "required": ["skepticism"],
+    }
+    _strip_numeric_constraints(schema)
+    assert not _has_numeric_constraints(schema)
+    # untouched siblings preserved
+    assert schema["properties"]["skepticism"]["type"] == "integer"
+    assert schema["properties"]["name"] == {"type": "string"}
+    assert schema["required"] == ["skepticism"]
+
+
+def test_strip_numeric_constraints_recurses_into_arrays():
+    schema = {
+        "type": "array",
+        "items": {"type": "integer", "minimum": 0, "maximum": 100},
+    }
+    _strip_numeric_constraints(schema)
+    assert not _has_numeric_constraints(schema)
+    assert schema["items"]["type"] == "integer"
+
+
+def test_strip_numeric_constraints_handles_anyof_oneof():
+    schema = {
+        "anyOf": [
+            {"type": "integer", "minimum": 1},
+            {"type": "string"},
+        ],
+    }
+    _strip_numeric_constraints(schema)
+    assert not _has_numeric_constraints(schema)
+
+
+def test_strip_numeric_constraints_returns_node_for_chaining():
+    schema = {"type": "integer", "minimum": 0}
+    result = _strip_numeric_constraints(schema)
+    assert result is schema
+
+
+def test_strip_numeric_constraints_noop_on_clean_schema():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+    }
+    before = copy.deepcopy(schema)
+    _strip_numeric_constraints(schema)
+    assert schema == before
+
+
+def test_strip_numeric_constraints_noop_on_non_dict_non_list():
+    # Should not raise for primitives
+    assert _strip_numeric_constraints("string") == "string"
+    assert _strip_numeric_constraints(42) == 42
+    assert _strip_numeric_constraints(None) is None
+
+
+def test_strip_numeric_constraints_pydantic_field_constraints():
+    """Mirror the Pydantic-emitted shape that triggers the Bedrock rejection."""
+    from pydantic import BaseModel, Field
+
+    class Disposition(BaseModel):
+        skepticism: int = Field(ge=1, le=5)
+        literalism: int = Field(ge=1, le=5)
+        empathy: int = Field(ge=1, le=5)
+
+    schema = Disposition.model_json_schema()
+    # Pydantic emits the constraints by default
+    assert _has_numeric_constraints(schema)
+    _strip_numeric_constraints(schema)
+    assert not _has_numeric_constraints(schema)


### PR DESCRIPTION
## Summary

Bedrock's Claude tool-use API rejects `minimum`/`maximum` (and the `exclusiveMinimum`/`exclusiveMaximum` variants) on number/integer JSON-Schema nodes:

```
BedrockException - {"message":"The model returned the following errors:
For 'number' type, properties maximum, minimum are not supported"}
```

Pydantic's `Field(ge=..., le=...)` emits these constraints. Result: any structured-output / tool call whose schema contains a constrained `int` field — e.g. the bank disposition's `skepticism`/`literalism`/`empathy: int = Field(ge=1, le=5)` in `engine/response_models.py` — fails the `llm.bedrock.retain_extract_facts` stage with `BadRequestError`. The retain loop retries 3× and gives up with `0 facts, 0 chunks`. Documents accumulate in the bank but are never extracted into nodes/observations.

This PR walks the schema (and the `tools` list, for `call_with_tools`) and removes the four numeric-constraint keys before sending. Gated on `provider == "bedrock"` so other providers see zero behavior change. Pydantic still validates response shape on the Hindsight side after the call, so the constraints are not load-bearing at the wire.

## Reproduction

Running 0.5.4 against `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`, before the fix:

```
RETAIN_BATCH START: <bank>
Batch size: 1 content items, 195 chars
  Extract facts: 0 facts, 0 chunks from 1 contents in 6.5s
STREAMING RETAIN COMPLETE: 0 units across 1 batches in 6.5s
```

After:

```
  Extract facts: 3 facts, 1 chunks from 1 contents in 10.2s
  Insert facts: 3 units in 0.000s
  Insert unit_entities: 8 pairs in 0.004s
  Temporal links: 12 / Semantic links: 5 / Entity links: 6
STREAMING RETAIN COMPLETE: 3 units across 1 batches in 10.3s
```

Bank stats moved from `total_nodes: 0, total_links: 0` to `total_nodes: 6, total_links: 17` after a single retain.

## Tests

Adds `tests/test_litellm_bedrock_schema_strip.py` (9 tests, no network):

- top-level key removal
- exclusive variants
- nested object properties
- arrays
- `anyOf` / `oneOf`
- chained-call return-self
- no-op on clean schemas
- no-op on primitives
- end-to-end check on a Pydantic model with `Field(ge=, le=)` (mirrors the real failure case)

```
============================== 9 passed in 1.96s ==============================
```

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_litellm_bedrock_schema_strip.py`)
- [x] `ruff check` and `ruff format` clean
- [ ] Reviewer: confirm `provider` value at the call site matches what `_PROVIDERS_REQUIRING_NUMERIC_CONSTRAINT_STRIP` checks (just `"bedrock"`)
- [ ] Reviewer: consider whether other Bedrock-fronted providers (e.g. `bedrock_converse`) need to be added to the set