### PR TITLE
feat(recall): add configurable relevance thresholds

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -250,6 +250,8 @@ ENV_RERANKER_TEI_BATCH_SIZE = "HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE"
 ENV_RERANKER_TEI_MAX_CONCURRENT = "HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT"
 ENV_RERANKER_TEI_HTTP_TIMEOUT = "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT"
 ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
+ENV_RERANKER_THRESHOLD = "HINDSIGHT_API_RERANKER_THRESHOLD"
+ENV_SEMANTIC_THRESHOLD = "HINDSIGHT_API_SEMANTIC_THRESHOLD"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
 ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA = "HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA"
@@ -515,6 +517,8 @@ DEFAULT_RERANKER_TEI_BATCH_SIZE = 128
 DEFAULT_RERANKER_TEI_MAX_CONCURRENT = 8
 DEFAULT_RERANKER_TEI_HTTP_TIMEOUT = 30.0  # HTTP timeout for TEI reranker requests (seconds)
 DEFAULT_RERANKER_MAX_CANDIDATES = 300
+DEFAULT_RERANKER_THRESHOLD = 0.01
+DEFAULT_SEMANTIC_THRESHOLD = 0.3
 DEFAULT_RERANKER_FLASHRANK_MODEL = "ms-marco-MiniLM-L-12-v2"  # Best balance of speed and quality
 DEFAULT_RERANKER_FLASHRANK_CACHE_DIR = None  # Use default cache directory
 DEFAULT_RERANKER_FLASHRANK_CPU_MEM_ARENA = False  # Disable ONNX CPU memory arena to bound RSS
@@ -946,6 +950,8 @@ class HindsightConfig:
     reranker_tei_max_concurrent: int
     reranker_tei_http_timeout: float
     reranker_max_candidates: int
+    reranker_threshold: float | None
+    semantic_threshold: float
     reranker_cohere_api_key: str | None
     reranker_cohere_model: str
     reranker_cohere_base_url: str | None
@@ -1290,6 +1296,9 @@ class HindsightConfig:
                 f"Invalid text_search_extension: {self.text_search_extension}. Must be one of: {', '.join(valid_text_search)}"
             )
 
+        if not 0.0 <= self.semantic_threshold <= 1.0:
+            raise ValueError(f"Invalid semantic_threshold: {self.semantic_threshold}. Must be between 0.0 and 1.0")
+
         # When LLM provider is "none", force chunks-only mode and disable LLM-dependent features
         if self.llm_provider == "none":
             self.retain_extraction_mode = "chunks"
@@ -1561,6 +1570,10 @@ class HindsightConfig:
                 os.getenv(ENV_RERANKER_TEI_HTTP_TIMEOUT, str(DEFAULT_RERANKER_TEI_HTTP_TIMEOUT))
             ),
             reranker_max_candidates=int(os.getenv(ENV_RERANKER_MAX_CANDIDATES, str(DEFAULT_RERANKER_MAX_CANDIDATES))),
+            reranker_threshold=(
+                float(v) if (v := os.getenv(ENV_RERANKER_THRESHOLD)) else DEFAULT_RERANKER_THRESHOLD
+            ),
+            semantic_threshold=float(os.getenv(ENV_SEMANTIC_THRESHOLD, str(DEFAULT_SEMANTIC_THRESHOLD))),
             # Cohere reranker (with backward-compatible fallback to shared API key)
             reranker_cohere_api_key=os.getenv(ENV_RERANKER_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),
             reranker_cohere_model=os.getenv(ENV_RERANKER_COHERE_MODEL, DEFAULT_RERANKER_COHERE_MODEL),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -203,7 +203,7 @@ from .response_models import RecallResult as RecallResultModel
 from .retain import bank_utils, embedding_utils
 from .retain.types import RetainContentDict
 from .search import think_utils
-from .search.reranking import CrossEncoderReranker, apply_combined_scoring
+from .search.reranking import CrossEncoderReranker, apply_combined_scoring, filter_by_reranker_threshold
 from .search.tags import TagGroup, TagsMatch, build_tags_where_clause
 from .task_backend import TaskBackend
 
@@ -3279,6 +3279,17 @@ class MemoryEngine(MemoryEngineInterface):
                 apply_combined_scoring(scored_results, now=utcnow(), is_passthrough_reranker=is_passthrough)
                 scored_results.sort(key=lambda x: x.weight, reverse=True)
                 log_buffer.append("  [4.6] Combined scoring: ce * recency_boost(0.2) * temporal_boost(0.2)")
+
+                threshold = get_config().reranker_threshold
+                if threshold is not None and not is_passthrough:
+                    original_count = len(scored_results)
+                    scored_results = filter_by_reranker_threshold(scored_results, threshold)
+                    filtered_count = original_count - len(scored_results)
+                    if filtered_count > 0:
+                        log_buffer.append(
+                            f"  [4.7] Threshold filtering (raw_ce >= {threshold:.2f}): "
+                            f"{original_count} -> {len(scored_results)} results"
+                        )
 
             # Add reranked results to tracer AFTER combined scoring (so normalized values are included)
             if tracer:

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -130,6 +130,23 @@ def apply_combined_scoring(
         sr.weight = sr.combined_score
 
 
+def filter_by_reranker_threshold(
+    scored_results: list[ScoredResult],
+    threshold: float | None,
+    *,
+    enabled: bool = True,
+) -> list[ScoredResult]:
+    """Filter scored results using the raw cross-encoder score."""
+    if not enabled or threshold is None:
+        return scored_results
+
+    return [
+        sr
+        for sr in scored_results
+        if not math.isnan(sr.cross_encoder_score) and sr.cross_encoder_score >= threshold
+    ]
+
+
 class CrossEncoderReranker:
     """
     Neural reranking using a cross-encoder model.

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -137,6 +137,8 @@ async def retrieve_semantic_bm25_combined(
     """
     result_dict: dict[str, tuple[list[RetrievalResult], list[RetrievalResult]]] = {ft: ([], []) for ft in fact_types}
 
+    config = get_config()
+    semantic_threshold = config.semantic_threshold
     tokens = tokenize_query(query_text)
 
     # Over-fetch for HNSW approximation; semantic results trimmed to limit in Python.
@@ -147,8 +149,6 @@ async def retrieve_semantic_bm25_combined(
         "fact_type, document_id, chunk_id, tags, metadata, proof_count"
     )
     table = fq_table("memory_units")
-
-    config = get_config()
 
     # Use the SQL dialect to build backend-specific query arms, avoiding
     # inline if/else branches for each database.
@@ -201,6 +201,7 @@ async def retrieve_semantic_bm25_combined(
             embedding_param="$1",
             bank_id_param="$2",
             fetch_limit=hnsw_fetch,
+            semantic_threshold=semantic_threshold,
             tags_clause=tags_clause,
             groups_clause=groups_clause,
             extra_where=created_range_clause,
@@ -272,6 +273,7 @@ async def retrieve_semantic_bm25_combined(
                     embedding_param="$1",
                     bank_id_param="$2",
                     fetch_limit=hnsw_fetch,
+                    semantic_threshold=semantic_threshold,
                     tags_clause=fb_tags_clause,
                     groups_clause=fb_groups_clause,
                     extra_where=fb_created_clause,

--- a/hindsight-api-slim/hindsight_api/engine/sql/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/base.py
@@ -371,6 +371,7 @@ class SQLDialect(ABC):
         embedding_param: str,
         bank_id_param: str,
         fetch_limit: int,
+        semantic_threshold: float,
         tags_clause: str = "",
         groups_clause: str = "",
         extra_where: str = "",
@@ -387,6 +388,7 @@ class SQLDialect(ABC):
             embedding_param: Parameter placeholder for query embedding.
             bank_id_param: Parameter placeholder for bank_id.
             fetch_limit: Max rows to fetch (over-fetched for HNSW approximation).
+            semantic_threshold: Minimum vector similarity to include.
             tags_clause: Optional WHERE clause fragment for tag filtering.
             groups_clause: Optional WHERE clause fragment for tag group filtering.
             extra_where: Optional additional WHERE clause fragment (e.g. time range filter).

--- a/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
@@ -234,6 +234,7 @@ class OracleDialect(SQLDialect):
         embedding_param: str,
         bank_id_param: str,
         fetch_limit: int,
+        semantic_threshold: float,
         tags_clause: str = "",
         groups_clause: str = "",
         extra_where: str = "",
@@ -249,7 +250,7 @@ class OracleDialect(SQLDialect):
             f" WHERE bank_id = {bank_id_param}"
             f"   AND fact_type = '{fact_type}'"
             f"   AND embedding IS NOT NULL"
-            f"   AND (1 - VECTOR_DISTANCE(embedding, {embedding_param}, COSINE)) >= 0.3"
+            f"   AND (1 - VECTOR_DISTANCE(embedding, {embedding_param}, COSINE)) >= {semantic_threshold}"
             f"   {tags_clause}"
             f"   {groups_clause}"
             f"   {extra_where}"

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -148,6 +148,7 @@ class PostgreSQLDialect(SQLDialect):
         embedding_param: str,
         bank_id_param: str,
         fetch_limit: int,
+        semantic_threshold: float,
         tags_clause: str = "",
         groups_clause: str = "",
         extra_where: str = "",
@@ -161,7 +162,7 @@ class PostgreSQLDialect(SQLDialect):
             f" WHERE bank_id = {bank_id_param}"
             f"   AND fact_type = '{fact_type}'"
             f"   AND embedding IS NOT NULL"
-            f"   AND (1 - (embedding <=> {embedding_param}::vector)) >= 0.3"
+            f"   AND (1 - (embedding <=> {embedding_param}::vector)) >= {semantic_threshold}"
             f"   {tags_clause}"
             f"   {groups_clause}"
             f"   {extra_where}"

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -21,6 +21,7 @@ def setup_test_env():
         "HINDSIGHT_API_RETAIN_CHUNK_SIZE",
         "HINDSIGHT_API_LLM_PROVIDER",
         "HINDSIGHT_API_LLM_MODEL",
+        "HINDSIGHT_API_SEMANTIC_THRESHOLD",
         "HINDSIGHT_API_DATABASE_URL",
         "HINDSIGHT_API_MIGRATION_DATABASE_URL",
     ]
@@ -100,6 +101,26 @@ def test_valid_retain_config_succeeds():
     config = HindsightConfig.from_env()
     assert config.retain_max_completion_tokens == 64000
     assert config.retain_chunk_size == 3000
+
+
+def test_semantic_threshold_reads_from_env():
+    """Test that semantic retrieval threshold can be configured."""
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_SEMANTIC_THRESHOLD"] = "0.58"
+
+    config = HindsightConfig.from_env()
+    assert config.semantic_threshold == 0.58
+
+
+def test_semantic_threshold_must_be_between_zero_and_one():
+    """Test that invalid semantic threshold values fail fast."""
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_SEMANTIC_THRESHOLD"] = "1.5"
+
+    with pytest.raises(ValueError, match="semantic_threshold"):
+        HindsightConfig.from_env()
 
 
 def test_log_config_masks_database_urls(caplog):

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -4,8 +4,7 @@ Unit tests that verify the abstraction interfaces work correctly
 without requiring a live database connection.
 """
 
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -194,9 +193,10 @@ class TestPostgreSQLDialect:
     def test_build_semantic_arm(self, d):
         arm = d.build_semantic_arm(
             table="schema.memory_units", cols="id, text", fact_type="world",
-            embedding_param="$1", bank_id_param="$2", fetch_limit=100,
+            embedding_param="$1", bank_id_param="$2", fetch_limit=100, semantic_threshold=0.58,
         )
         assert "1 - (embedding <=> $1::vector)" in arm
+        assert ">= 0.58" in arm
         assert "fact_type = 'world'" in arm
         assert "LIMIT 100" in arm
         assert "'semantic' AS source" in arm
@@ -275,9 +275,10 @@ class TestOracleDialect:
     def test_build_semantic_arm(self, d):
         arm = d.build_semantic_arm(
             table="memory_units", cols="id, text", fact_type="world",
-            embedding_param=":1", bank_id_param=":2", fetch_limit=100,
+            embedding_param=":1", bank_id_param=":2", fetch_limit=100, semantic_threshold=0.58,
         )
         assert "VECTOR_DISTANCE" in arm
+        assert ">= 0.58" in arm
         assert "fact_type = 'world'" in arm
         assert "FETCH FIRST 100 ROWS ONLY" in arm
         assert "'semantic' AS source" in arm

--- a/hindsight-api-slim/tests/test_reranker_threshold.py
+++ b/hindsight-api-slim/tests/test_reranker_threshold.py
@@ -1,0 +1,124 @@
+"""Tests for raw cross-encoder threshold filtering."""
+
+import math
+from datetime import datetime, timezone
+
+from hindsight_api.config import (
+    DEFAULT_RERANKER_THRESHOLD,
+    ENV_RERANKER_THRESHOLD,
+    HindsightConfig,
+)
+from hindsight_api.engine.search.reranking import apply_combined_scoring, filter_by_reranker_threshold
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult, ScoredResult
+
+UTC = timezone.utc
+NOW = datetime(2026, 4, 21, tzinfo=UTC)
+
+
+def _make_result(
+    result_id: str,
+    raw_ce: float,
+    *,
+    ce_norm: float = 0.5,
+    occurred_start: datetime | None = None,
+) -> ScoredResult:
+    retrieval = RetrievalResult(
+        id=result_id,
+        text=f"fact {result_id}",
+        fact_type="world",
+        occurred_start=occurred_start,
+    )
+    candidate = MergedCandidate(
+        retrieval=retrieval,
+        rrf_score=0.1,
+    )
+    return ScoredResult(
+        candidate=candidate,
+        cross_encoder_score=raw_ce,
+        cross_encoder_score_normalized=ce_norm,
+        weight=ce_norm,
+    )
+
+
+def test_filters_results_below_raw_cross_encoder_threshold():
+    high = _make_result("high", 0.86)
+    low = _make_result("low", 0.0002)
+
+    filtered = filter_by_reranker_threshold([high, low], 0.01)
+
+    assert [sr.id for sr in filtered] == ["high"]
+
+
+def test_threshold_uses_raw_score_not_normalized_score():
+    low_raw_high_norm = _make_result("low-raw", 0.0002, ce_norm=0.99)
+    high_raw_low_norm = _make_result("high-raw", 0.86, ce_norm=0.51)
+
+    filtered = filter_by_reranker_threshold([low_raw_high_norm, high_raw_low_norm], 0.01)
+
+    assert [sr.id for sr in filtered] == ["high-raw"]
+
+
+def test_threshold_allows_empty_results():
+    results = [
+        _make_result("noise-1", 0.00002),
+        _make_result("noise-2", 0.00016),
+    ]
+
+    assert filter_by_reranker_threshold(results, 0.01) == []
+
+
+def test_threshold_none_and_disabled_return_original_list():
+    results = [_make_result("low", 0.0002)]
+
+    assert filter_by_reranker_threshold(results, None) is results
+    assert filter_by_reranker_threshold(results, 0.01, enabled=False) is results
+
+
+def test_threshold_drops_nan_when_enabled():
+    nan_result = _make_result("nan", math.nan)
+    high = _make_result("high", 0.95)
+
+    filtered = filter_by_reranker_threshold([nan_result, high], 0.01)
+
+    assert [sr.id for sr in filtered] == ["high"]
+
+
+def test_threshold_filters_after_combined_scoring_without_recency_leaking_noise():
+    high_relevance_old = _make_result("relevant", 0.96, ce_norm=0.72, occurred_start=NOW.replace(year=2025))
+    low_relevance_recent = _make_result("noise", 0.0001, ce_norm=0.5, occurred_start=NOW)
+
+    apply_combined_scoring([high_relevance_old, low_relevance_recent], now=NOW)
+    scored = sorted([high_relevance_old, low_relevance_recent], key=lambda sr: sr.weight, reverse=True)
+
+    filtered = filter_by_reranker_threshold(scored, 0.01)
+
+    assert [sr.id for sr in filtered] == ["relevant"]
+
+
+def test_low_threshold_preserves_weak_but_nontrivial_relevance():
+    weak_match = _make_result("weak-match", 0.02)
+    noise = _make_result("noise", 0.0002)
+
+    filtered = filter_by_reranker_threshold([weak_match, noise], 0.01)
+
+    assert [sr.id for sr in filtered] == ["weak-match"]
+
+
+def test_config_reads_reranker_threshold_from_env(monkeypatch):
+    monkeypatch.setenv(ENV_RERANKER_THRESHOLD, "0.01")
+
+    config = HindsightConfig.from_env()
+
+    assert config.reranker_threshold == 0.01
+
+
+def test_config_defaults_reranker_threshold(monkeypatch):
+    monkeypatch.delenv(ENV_RERANKER_THRESHOLD, raising=False)
+
+    config = HindsightConfig.from_env()
+
+    assert config.reranker_threshold == DEFAULT_RERANKER_THRESHOLD
+
+
+def test_reranker_threshold_is_static_server_config():
+    assert "reranker_threshold" not in HindsightConfig.get_configurable_fields()


### PR DESCRIPTION
## Summary

- add server-level semantic and raw reranker threshold configuration
- pass semantic threshold through SQLDialect retrieval arms for PostgreSQL and Oracle
- filter reranked recall results by raw cross-encoder score, skipping RRF passthrough

## Validation

- docker exec hindsight-dev /app/api/.venv/bin/ruff check /app/api/hindsight_api/config.py /app/api/hindsight_api/engine/memory_engine.py /app/api/hindsight_api/engine/search/reranking.py /app/api/hindsight_api/engine/search/retrieval.py /app/api/hindsight_api/engine/sql/base.py /app/api/hindsight_api/engine/sql/postgresql.py /app/api/hindsight_api/engine/sql/oracle.py /tmp/test_config_validation.py /tmp/test_db_abstraction.py /tmp/test_reranker_threshold.py
- docker exec hindsight-dev sh -lc 'cd /app/api && /app/api/.venv/bin/pytest /tmp/test_config_validation.py /tmp/test_db_abstraction.py /tmp/test_reranker_threshold.py -q'\n