### PR TITLE
fix(retrieval): improve native BM25 query tokenization

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/bm25_query.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/bm25_query.py
@@ -1,0 +1,154 @@
+"""BM25 query text preparation helpers.
+
+Supports Chinese tokenization via jieba (lazy-loaded) and provides
+native PostgreSQL tsquery builders matching indexed tokenization.
+"""
+
+import logging
+import re
+
+_IPV4_TOKEN_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])")
+_CHINESE_CHAR_RE = re.compile(r"[\u4e00-\u9fff]")
+_TOKEN_CHAR_RE = re.compile(r"[A-Za-z0-9\u4e00-\u9fff]")
+_CHINESE_LANGUAGES = {"zh", "zh-cn", "zh_cn", "chinese", "cn"}
+_CHINESE_QUERY_STOPWORDS = {"的", "和", "与", "及", "或", "了", "呢", "吗", "吧", "啊"}
+
+_jieba_instance = None
+
+
+def _get_jieba():
+    """Lazy-load jieba for Chinese query segmentation when installed."""
+    global _jieba_instance
+    if _jieba_instance is not None:
+        return _jieba_instance
+
+    try:
+        import jieba
+
+        jieba.setLogLevel(logging.WARNING)
+        _jieba_instance = jieba
+        return jieba
+    except ImportError:
+        _jieba_instance = False
+        return None
+
+
+def _dedupe_tokens(tokens: list[str]) -> list[str]:
+    seen = set()
+    deduped = []
+    for token in tokens:
+        normalized = token.strip()
+        if normalized and _TOKEN_CHAR_RE.search(normalized) and normalized not in seen:
+            deduped.append(normalized)
+            seen.add(normalized)
+    return deduped
+
+
+def _tokenize_chinese_query(text: str) -> list[str]:
+    jieba = _get_jieba()
+    if jieba:
+        try:
+            tokens = []
+            for token in jieba.cut(text):
+                if _CHINESE_CHAR_RE.search(token):
+                    tokens.append(token)
+                else:
+                    tokens.extend(re.sub(r"[^\w\s]", " ", token).split())
+            return _dedupe_tokens(tokens)
+        except Exception:
+            pass
+
+    return _dedupe_tokens(_CHINESE_CHAR_RE.findall(text))
+
+
+def _format_chinese_token_query(token: str) -> str:
+    token_chars = _dedupe_tokens(_CHINESE_CHAR_RE.findall(token))
+    if len(token_chars) > 1:
+        return f"({token} | {' & '.join(token_chars)})"
+    return token
+
+
+def tokenize_query(query_text: str, *, language: str = "zh") -> list[str]:
+    """Normalize query text into BM25 tokens.
+
+    Supports Chinese tokenization via jieba (lazy-loaded) and falls back
+    to ASCII word splitting for non-Chinese text.
+    """
+    normalized = query_text.lower()
+    preserved_tokens = _IPV4_TOKEN_RE.findall(normalized)
+    normalized = _IPV4_TOKEN_RE.sub(" ", normalized)
+
+    if language.lower() in _CHINESE_LANGUAGES and _CHINESE_CHAR_RE.search(normalized):
+        return _dedupe_tokens([*preserved_tokens, *_tokenize_chinese_query(normalized)])
+
+    return _dedupe_tokens([*preserved_tokens, *re.sub(r"[^\w\s]", " ", normalized).split()])
+
+
+def build_native_tsquery(query_text: str, *, language: str = "zh") -> str | None:
+    """Build native PostgreSQL tsquery text matching indexed tokenization.
+
+    For Chinese queries, produces a tsquery that matches both jieba word
+    tokens and individual characters, giving the best recall for Chinese text.
+    """
+    tokens = tokenize_query(query_text, language=language)
+    if not tokens:
+        return None
+
+    normalized = query_text.lower()
+    if language.lower() not in _CHINESE_LANGUAGES or not _CHINESE_CHAR_RE.search(normalized):
+        return " | ".join(tokens)
+
+    ascii_tokens = [token for token in tokens if not _CHINESE_CHAR_RE.search(token)]
+    chinese_word_tokens = [
+        token for token in tokens if _CHINESE_CHAR_RE.search(token) and token not in _CHINESE_QUERY_STOPWORDS
+    ]
+    chinese_chars = _dedupe_tokens(
+        char for char in _CHINESE_CHAR_RE.findall(normalized) if char not in _CHINESE_QUERY_STOPWORDS
+    )
+
+    chinese_alternatives = []
+    if chinese_word_tokens:
+        chinese_alternatives.append(" & ".join(chinese_word_tokens))
+    if chinese_chars:
+        chinese_alternatives.append(" & ".join(chinese_chars))
+
+    query_parts = [*ascii_tokens]
+    if chinese_alternatives:
+        query_parts.append(f"({' | '.join(chinese_alternatives)})")
+
+    return " & ".join(query_parts) if query_parts else None
+
+
+def build_native_tsquery_fallback(query_text: str, *, language: str = "zh") -> str | None:
+    """Build a looser native PostgreSQL tsquery used only when strict BM25 is empty.
+
+    For Chinese queries, uses pairwise AND combinations for better recall
+    when the strict tsquery returns no results.
+    """
+    tokens = tokenize_query(query_text, language=language)
+    if not tokens:
+        return None
+
+    normalized = query_text.lower()
+    if language.lower() not in _CHINESE_LANGUAGES or not _CHINESE_CHAR_RE.search(normalized):
+        return " | ".join(tokens)
+
+    ascii_tokens = [token for token in tokens if not _CHINESE_CHAR_RE.search(token)]
+    chinese_word_tokens = [
+        token for token in tokens if _CHINESE_CHAR_RE.search(token) and token not in _CHINESE_QUERY_STOPWORDS
+    ]
+    if not chinese_word_tokens:
+        return " & ".join(ascii_tokens) if ascii_tokens else None
+    if len(chinese_word_tokens) == 1:
+        chinese_query = _format_chinese_token_query(chinese_word_tokens[0])
+    else:
+        token_queries = [_format_chinese_token_query(token) for token in chinese_word_tokens]
+        pairs = [
+            f"({left} & {right})"
+            for index, left in enumerate(token_queries)
+            for right in token_queries[index + 1 :]
+        ]
+        chinese_query = f"({' | '.join(pairs)})"
+
+    query_parts = [*ascii_tokens, chinese_query]
+    return " & ".join(query_parts) if query_parts else None

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -10,7 +10,6 @@ Implements:
 
 import asyncio
 import logging
-import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Optional
@@ -19,21 +18,13 @@ from ...config import get_config
 from ..db_utils import acquire_with_retry
 from ..memory_engine import fq_table
 from ..sql import create_sql_dialect
+from .bm25_query import build_native_tsquery, build_native_tsquery_fallback, tokenize_query
 from .graph_retrieval import GraphRetriever
 from .link_expansion_retrieval import LinkExpansionRetriever
 from .tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause_simple
 from .types import GraphRetrievalTimings, RetrievalResult
 
 logger = logging.getLogger(__name__)
-
-
-def tokenize_query(query_text: str) -> list[str]:
-    """Normalize query text and split into BM25 tokens.
-
-    Strips punctuation, lowercases, and splits on whitespace.
-    Returns an empty list when the query contains no word characters.
-    """
-    return re.sub(r"[^\w\s]", " ", query_text.lower()).split()
 
 
 @dataclass
@@ -154,7 +145,8 @@ async def retrieve_semantic_bm25_combined(
     # inline if/else branches for each database.
     # Use getattr for backward compat: raw asyncpg connections (used in some
     # tests) lack backend_type; default to "postgresql".
-    dialect = create_sql_dialect(getattr(conn, "backend_type", "postgresql"))
+    backend_type = getattr(conn, "backend_type", "postgresql")
+    dialect = create_sql_dialect(backend_type)
 
     # --- Parameter layout ---
     # $1 = query_emb_str  (semantic arms)
@@ -211,7 +203,12 @@ async def retrieve_semantic_bm25_combined(
     # --- BM25 UNION ALL arms (one per fact_type, only when tokens present) ---
     if _include_bm25:
         text_ext = config.text_search_extension
-        bm25_text_param: str = dialect.prepare_bm25_text(tokens, query_text, text_search_extension=text_ext)
+        if backend_type == "postgresql" and text_ext == "native":
+            bm25_text_param = build_native_tsquery(query_text) or dialect.prepare_bm25_text(
+                tokens, query_text, text_search_extension=text_ext
+            )
+        else:
+            bm25_text_param = dialect.prepare_bm25_text(tokens, query_text, text_search_extension=text_ext)
         for i, ft in enumerate(fact_types):
             arms.append(
                 dialect.build_bm25_arm(
@@ -302,6 +299,56 @@ async def retrieve_semantic_bm25_combined(
                 sem_counts[ft] += 1
         else:
             result_dict[ft][1].append(RetrievalResult.from_db_row(row))
+
+    if _include_bm25 and backend_type == "postgresql" and config.text_search_extension == "native":
+        fallback_query_tsquery = build_native_tsquery_fallback(query_text)
+        empty_bm25_fact_types = [ft for ft in fact_types if not result_dict[ft][1]]
+        if fallback_query_tsquery and fallback_query_tsquery != bm25_text_param and empty_bm25_fact_types:
+            fallback_tags_param_idx = 4
+            fallback_tags_clause = build_tags_where_clause_simple(tags, fallback_tags_param_idx, match=tags_match)
+            fallback_tag_groups_param_start = fallback_tags_param_idx + (1 if tags else 0)
+            fallback_groups_clause, fallback_groups_params, _ = build_tag_groups_where_clause(
+                tag_groups, fallback_tag_groups_param_start
+            )
+            fallback_next_idx = fallback_tag_groups_param_start + len(fallback_groups_params)
+            fallback_created_clause = ""
+            fallback_created_params: list[Any] = []
+            if created_after is not None:
+                fallback_created_params.append(created_after)
+                fallback_created_clause += f" AND updated_at > ${fallback_next_idx}"
+                fallback_next_idx += 1
+            if created_before is not None:
+                fallback_created_params.append(created_before)
+                fallback_created_clause += f" AND updated_at < ${fallback_next_idx}"
+
+            fallback_arms = [
+                dialect.build_bm25_arm(
+                    table=table,
+                    cols=cols,
+                    fact_type=ft,
+                    bank_id_param="$1",
+                    limit_param="$2",
+                    text_param="$3",
+                    tags_clause=fallback_tags_clause,
+                    groups_clause=fallback_groups_clause,
+                    arm_index=i,
+                    text_search_extension="native",
+                    extra_where=fallback_created_clause,
+                )
+                for i, ft in enumerate(empty_bm25_fact_types)
+            ]
+            fallback_params: list[Any] = [bank_id, limit, fallback_query_tsquery]
+            if tags:
+                fallback_params.append(tags)
+            fallback_params.extend(fallback_groups_params)
+            fallback_params.extend(fallback_created_params)
+            fallback_rows = await conn.fetch("\nUNION ALL\n".join(fallback_arms), *fallback_params)
+            for r in fallback_rows:
+                row = dict(r)
+                row.pop("source")
+                ft = row.get("fact_type")
+                if ft in result_dict:
+                    result_dict[ft][1].append(RetrievalResult.from_db_row(row))
 
     return result_dict
 

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.41.0",
     "opentelemetry-semantic-conventions>=0.62b1",
     "dateparser>=1.2.2",
+    "jieba>=0.42.1",
     "google-genai>=1.0.0",
     "google-auth>=2.0.0",
     "anthropic>=0.40.0",

--- a/hindsight-api-slim/tests/test_bm25_tokenization.py
+++ b/hindsight-api-slim/tests/test_bm25_tokenization.py
@@ -1,0 +1,65 @@
+from hindsight_api.engine.search.bm25_query import build_native_tsquery, build_native_tsquery_fallback, tokenize_query
+
+
+def test_tokenize_query_preserves_ipv4_address_for_native_text_search():
+    assert tokenize_query("59.41.7.83") == ["59.41.7.83"]
+
+
+def test_tokenize_query_preserves_ipv4_address_in_mixed_query():
+    assert tokenize_query("zhouwei@59.41.7.83 SSH") == ["59.41.7.83", "zhouwei", "ssh"]
+
+
+def test_tokenize_query_still_strips_general_punctuation():
+    assert tokenize_query("Gitea SSH连接信息: ssh -p 65017") == [
+        "gitea",
+        "ssh",
+        "连接",
+        "信息",
+        "p",
+        "65017",
+    ]
+
+
+def test_build_native_tsquery_keeps_non_chinese_or_semantics():
+    assert build_native_tsquery("Gitea SSH") == "gitea | ssh"
+
+
+def test_build_native_tsquery_matches_chinese_word_or_character_indexes():
+    assert build_native_tsquery("周奕婷") == "(周奕婷 | 周 & 奕 & 婷)"
+
+
+def test_build_native_tsquery_remains_strict_for_chinese_natural_language_queries():
+    assert build_native_tsquery("周奕婷的学校和家庭信息") == (
+        "(周奕婷 & 学校 & 家庭 & 信息 | 周 & 奕 & 婷 & 学 & 校 & 家 & 庭 & 信 & 息)"
+    )
+
+
+def test_build_native_tsquery_fallback_requires_at_least_two_chinese_terms():
+    assert build_native_tsquery_fallback("周奕婷的学校和家庭信息") == (
+        "(((周奕婷 | 周 & 奕 & 婷) & (学校 | 学 & 校)) | "
+        "((周奕婷 | 周 & 奕 & 婷) & (家庭 | 家 & 庭)) | "
+        "((周奕婷 | 周 & 奕 & 婷) & (信息 | 信 & 息)) | "
+        "((学校 | 学 & 校) & (家庭 | 家 & 庭)) | "
+        "((学校 | 学 & 校) & (信息 | 信 & 息)) | "
+        "((家庭 | 家 & 庭) & (信息 | 信 & 息)))"
+    )
+
+
+def test_build_native_tsquery_fallback_uses_pairwise_terms_without_specific_anchor():
+    assert build_native_tsquery_fallback("学校和家庭信息") == (
+        "(((学校 | 学 & 校) & (家庭 | 家 & 庭)) | "
+        "((学校 | 学 & 校) & (信息 | 信 & 息)) | "
+        "((家庭 | 家 & 庭) & (信息 | 信 & 息)))"
+    )
+
+
+def test_build_native_tsquery_requires_ascii_terms_for_mixed_language_queries():
+    assert build_native_tsquery("Gitea 端口") == "gitea & (端口 | 端 & 口)"
+
+
+def test_build_native_tsquery_preserves_ipv4_address():
+    assert build_native_tsquery("zhouwei 59.41.7.83") == "59.41.7.83 | zhouwei"
+
+
+def test_build_native_tsquery_can_use_english_legacy_mode():
+    assert build_native_tsquery("周奕婷", language="english") == "周奕婷"

--- a/hindsight-api-slim/tests/test_hnsw_indexes.py
+++ b/hindsight-api-slim/tests/test_hnsw_indexes.py
@@ -14,7 +14,6 @@ import pytest
 
 from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
 
-
 # ---------------------------------------------------------------------------
 # Unit tests — no DB required
 # ---------------------------------------------------------------------------
@@ -188,6 +187,90 @@ async def test_retrieve_semantic_bm25_grouped_by_fact_type(memory, request_conte
             # All BM25 results must declare the correct fact_type
             for r in bm25:
                 assert r.fact_type == ft, f"BM25 result has wrong fact_type: {r.fact_type}"
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_bm25_matches_chinese_text_signals(memory, request_context):
+    """Native BM25 should match mixed English/Chinese queries via text_signals tokens."""
+    from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined
+
+    bank_id = f"test_bm25_chinese_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO memory_units (bank_id, text, context, fact_type, text_signals, event_date)
+                VALUES ($1, $2, $3, 'world', $4, $5)
+                """,
+                bank_id,
+                "Gitea SSH连接信息: ssh -p 65017",
+                "server note",
+                "gitea ssh 连接 信息 p 65017",
+                datetime(2026, 4, 21, tzinfo=timezone.utc),
+            )
+
+            query_emb = memory.embeddings.encode(["Gitea 连接信息"])
+            results = await retrieve_semantic_bm25_combined(
+                conn=conn,
+                query_emb_str=str(query_emb[0]),
+                query_text="Gitea 连接信息",
+                bank_id=bank_id,
+                fact_types=["world"],
+                limit=5,
+            )
+
+        _, bm25 = results["world"]
+        assert [result.text for result in bm25] == ["Gitea SSH连接信息: ssh -p 65017"]
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_bm25_fallback_for_strict_chinese_query(memory, request_context):
+    """Native BM25 falls back only after strict Chinese query returns no rows."""
+    from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined
+
+    bank_id = f"test_bm25_fallback_{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO memory_units (bank_id, text, context, fact_type, text_signals, event_date)
+                VALUES
+                    ($1, $2, $3, 'world', $4, $5),
+                    ($1, $6, $7, 'world', $8, $5)
+                """,
+                bank_id,
+                "周奕婷就读于广州市玉泉学校。",
+                "school note",
+                "周奕婷 学校",
+                datetime(2026, 4, 21, tzinfo=timezone.utc),
+                "家庭信息记录用于提醒。",
+                "generic family note",
+                "家庭 信息",
+            )
+
+            query_emb = memory.embeddings.encode(["周奕婷的学校和家庭信息"])
+            results = await retrieve_semantic_bm25_combined(
+                conn=conn,
+                query_emb_str=str(query_emb[0]),
+                query_text="周奕婷的学校和家庭信息",
+                bank_id=bank_id,
+                fact_types=["world"],
+                limit=5,
+            )
+
+        _, bm25 = results["world"]
+        assert bm25
+        assert bm25[0].text == "周奕婷就读于广州市玉泉学校。"
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/uv.lock
+++ b/uv.lock
@@ -1558,6 +1558,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "greenlet" },
     { name = "httpx" },
+    { name = "jieba" },
     { name = "langchain-core" },
     { name = "langchain-text-splitters" },
     { name = "langsmith" },
@@ -1676,6 +1677,7 @@ requires-dist = [
     { name = "hindsight-api-slim", extras = ["local-ml", "embedded-db"], marker = "extra == 'all'" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "huggingface-hub", marker = "extra == 'local-llm'", specifier = ">=0.20.0" },
+    { name = "jieba", specifier = ">=0.42.1" },
     { name = "langchain-core", specifier = ">=1.2.22" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0" },
     { name = "langsmith", specifier = ">=0.6.3" },
@@ -2042,6 +2044,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010 },
 ]
+
+[[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2", size = 19214172 }
 
 [[package]]
 name = "jinja2"


### PR DESCRIPTION
## Summary

- add BM25 query tokenization helpers that preserve IPv4 tokens and support Chinese segmentation
- build stricter native PostgreSQL tsquery values for mixed English/Chinese recall queries
- add fallback native tsquery retrieval for Chinese queries when the strict query has no BM25 hits

## Validation

- docker exec hindsight-dev /app/api/.venv/bin/ruff check /app/api/hindsight_api/engine/search/retrieval.py /app/api/hindsight_api/engine/search/bm25_query.py /tmp/test_bm25_tokenization.py /tmp/test_hnsw_indexes.py
- docker exec hindsight-dev sh -lc 'cd /app/api && /app/api/.venv/bin/pytest /tmp/test_bm25_tokenization.py -q'\n\nNote: the DB-level tests in test_hnsw_indexes.py could not be run in my local Docker database because that database contains a local-only Alembic revision (b1c2d3e4f5g6). The tests are included for upstream CI on a clean migration state.\n