### PR TITLE
docs(self-driving-agents): list `claude` harness in install README

### DIFF
--- a/hindsight-tools/self-driving-agents/README.md
+++ b/hindsight-tools/self-driving-agents/README.md
@@ -29,7 +29,7 @@ Agent name defaults to the directory name. Override with `--agent <name>`.
 ```
 npx @vectorize-io/self-driving-agents install <dir> --harness <harness> [options]
 
---harness <h>      Required. openclaw | nemoclaw | hermes | claude-code
+--harness <h>      Required. openclaw | nemoclaw | hermes | claude | claude-code
 --sandbox <name>   NemoClaw sandbox name (required when --harness nemoclaw; auto-detected if only one sandbox exists)
 --agent <name>     Agent name (defaults to directory name)
 --api-url <url>    Override Hindsight API URL


### PR DESCRIPTION
## Summary

`hindsight-tools/self-driving-agents/README.md` lists 4 harnesses in the `--harness` option (`openclaw | nemoclaw | hermes | claude-code`), but `cli.ts` actually accepts 5 — the `claude` harness (Claude Chat / Cowork) added in #1427 is missing from the README.

The `cli.ts` `--help` block (line ~763), the validation error message (line ~789), and the dispatch branches (lines 905, 910) all list `openclaw | nemoclaw | hermes | claude | claude-code`. The README is the only place still showing the pre-#1427 list.

## Diff

```diff
- --harness <h>      Required. openclaw | nemoclaw | hermes | claude-code
+ --harness <h>      Required. openclaw | nemoclaw | hermes | claude | claude-code
```

## Test plan
- [x] `cli.ts` lines 763, 789, 905, 910 confirm `claude` is a supported harness value
- [x] cross-checked against PR #1427 (Claude Chat/Cowork harness) which is the source
