### PR TITLE
docs(sdks): document AbortSignal cancellation on TypeScript client per #1198

### DIFF
--- a/hindsight-docs/docs/sdks/nodejs.md
+++ b/hindsight-docs/docs/sdks/nodejs.md
@@ -110,6 +110,32 @@ const answer = await client.reflect('my-bank', 'What should I know about Alice?'
 console.log(answer.text);       // Generated response
 ```
 
+## Cancellation
+
+All `HindsightClient` methods accept an optional `AbortSignal` via `options.signal` to cancel in-flight requests. This is useful when an agent's per-call time budget for memory operations expires before the next LLM invocation:
+
+```typescript
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), 500);
+
+try {
+    const response = await client.recall('my-bank', 'What does Alice do?', {
+        signal: controller.signal,
+    });
+    console.log(response.results);
+} catch (err) {
+    if ((err as Error).name === 'AbortError') {
+        // Best-effort recall exceeded budget — proceed without memory
+    } else {
+        throw err;
+    }
+} finally {
+    clearTimeout(timer);
+}
+```
+
+Supported on `retain`, `retainBatch`, `retainFiles`, `recall`, `reflect`, `listMemories`, and bank/document operations.
+
 ## Bank Management
 
 ### Create Bank

--- a/skills/hindsight-docs/references/sdks/nodejs.md
+++ b/skills/hindsight-docs/references/sdks/nodejs.md
@@ -110,6 +110,32 @@ const answer = await client.reflect('my-bank', 'What should I know about Alice?'
 console.log(answer.text);       // Generated response
 ```
 
+## Cancellation
+
+All `HindsightClient` methods accept an optional `AbortSignal` via `options.signal` to cancel in-flight requests. This is useful when an agent's per-call time budget for memory operations expires before the next LLM invocation:
+
+```typescript
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), 500);
+
+try {
+    const response = await client.recall('my-bank', 'What does Alice do?', {
+        signal: controller.signal,
+    });
+    console.log(response.results);
+} catch (err) {
+    if ((err as Error).name === 'AbortError') {
+        // Best-effort recall exceeded budget — proceed without memory
+    } else {
+        throw err;
+    }
+} finally {
+    clearTimeout(timer);
+}
+```
+
+Supported on `retain`, `retainBatch`, `retainFiles`, `recall`, `reflect`, `listMemories`, and bank/document operations.
+
 ## Bank Management
 
 ### Create Bank


### PR DESCRIPTION
## Summary

Documents the per-method `AbortSignal` cancellation support added to `HindsightClient` in #1198 (merged 2026-05-04, also called out in the v0.6.0 release blog post and changelog). The TypeScript SDK reference (`hindsight-docs/docs/sdks/nodejs.md`) didn't show how to use it — readers see the announcement but can't find a usage example.

## Why

`HindsightClient.{retain,retainBatch,retainFiles,recall,reflect,listMemories, ...}` all accept `options.signal?: AbortSignal` and pass it through to the generated SDK. The release blog says "All `HindsightClient` methods accept an `AbortSignal` for request cancellation" — adding a small `## Cancellation` section between Core Operations and Bank Management gives readers a working example (with `try/finally` cleanup so the timeout doesn't leak on unrelated rejections).

## Changes

- `hindsight-docs/docs/sdks/nodejs.md` — new `## Cancellation` section (~25 LOC)
- `skills/hindsight-docs/references/sdks/nodejs.md` — byte-identical mirror

Pure docs, no logic change.