### PR TITLE
feat(perf): publish perf-test results to external dashboard

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,9 +1,22 @@
 name: Performance Tests
 
+# ─────────────────────────────────────────────────────────────────────────
+# TEMP iteration mode (revert before merge):
+#   - `push` trigger on this branch so we get fast feedback while wiring
+#     the dashboard publishing logic.
+#   - default scale: small (was large)
+#   - default locomo_skip: true (was false); locomo only runs on
+#     workflow_dispatch while we iterate.
+# Search "TEMP" to find the bits to revert.
+# ─────────────────────────────────────────────────────────────────────────
+
 on:
   schedule:
     # Run daily at 06:00 UTC
     - cron: "0 6 * * *"
+  push:
+    branches:
+      - feat/perf-dashboard  # TEMP: drop before merge
   workflow_dispatch:
     inputs:
       scale:
@@ -14,7 +27,7 @@ on:
           - small
           - medium
           - large
-        default: large
+        default: small  # TEMP: was large
       suite:
         description: "Perf-test suite to run (blank = all)"
         type: choice
@@ -32,7 +45,7 @@ on:
       locomo_skip:
         description: "Skip LoComo job"
         type: boolean
-        default: false
+        default: true  # TEMP: was false
       ref:
         description: "Git ref to test (branch, tag, or SHA). Defaults to main."
         type: string
@@ -83,48 +96,66 @@ jobs:
       run: |
         cd hindsight-dev && uv sync --frozen --all-extras --index-strategy unsafe-best-match
 
-    - name: "Suite: retain"
-      if: inputs.suite == '' || inputs.suite == 'retain'
+    - name: Run perf-test
       run: |
+        SUITE_ARG=""
+        if [ -n "${{ inputs.suite }}" ]; then
+          SUITE_ARG="--suite ${{ inputs.suite }}"
+        fi
         ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'large' }} \
-          --suite retain \
-          --output perf-results-retain.json
-
-    - name: "Suite: recall"
-      if: inputs.suite == '' || inputs.suite == 'recall'
-      run: |
-        ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'large' }} \
-          --suite recall \
-          --output perf-results-recall.json
-
-    - name: "Suite: recall-with-observations"
-      if: inputs.suite == '' || inputs.suite == 'recall-with-observations'
-      run: |
-        ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'large' }} \
-          --suite recall-with-observations \
-          --output perf-results-recall-with-observations.json
-
-    - name: "Suite: consolidation"
-      if: inputs.suite == '' || inputs.suite == 'consolidation'
-      run: |
-        ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'large' }} \
-          --suite consolidation \
-          --output perf-results-consolidation.json
+          --scale ${{ inputs.scale || 'small' }} \
+          $SUITE_ARG \
+          --output perf-results.json \
+          --benchmark-output-dir bench
 
     - name: Upload perf results
       if: always()
       uses: actions/upload-artifact@v7
       with:
         name: perf-results-${{ github.sha }}
-        path: hindsight-dev/perf-results-*.json
+        path: |
+          hindsight-dev/perf-results.json
+          hindsight-dev/bench/
         retention-days: 90
 
+    # Publish to the external dashboard repo. Pushes to its `gh-pages` branch
+    # using a PAT with push access to vectorize-io/hindsight-continuous-performance-monitor.
+    # Dashboard URL once GitHub Pages is enabled on that repo:
+    #   https://vectorize-io.github.io/hindsight-continuous-performance-monitor/dev/bench/
+    - name: Publish latency benchmarks
+      if: github.event_name == 'schedule' || github.event_name == 'push'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Hindsight Latency
+        tool: customSmallerIsBetter
+        output-file-path: hindsight-dev/bench/latency.json
+        gh-repository: github.com/vectorize-io/hindsight-continuous-performance-monitor
+        github-token: ${{ secrets.PERF_DASHBOARD_TOKEN }}
+        auto-push: true
+        benchmark-data-dir-path: dev/bench
+        alert-threshold: "150%"
+        comment-on-alert: false
+        fail-on-alert: false
+
+    - name: Publish throughput benchmarks
+      if: github.event_name == 'schedule' || github.event_name == 'push'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Hindsight Throughput
+        tool: customBiggerIsBetter
+        output-file-path: hindsight-dev/bench/throughput.json
+        gh-repository: github.com/vectorize-io/hindsight-continuous-performance-monitor
+        github-token: ${{ secrets.PERF_DASHBOARD_TOKEN }}
+        auto-push: true
+        benchmark-data-dir-path: dev/bench
+        alert-threshold: "150%"
+        comment-on-alert: false
+        fail-on-alert: false
+
   locomo:
-    if: inputs.locomo_skip != true
+    # TEMP: only run on manual dispatch while iterating on the dashboard.
+    # Restore to: `if: inputs.locomo_skip != true` before merge.
+    if: github.event_name == 'workflow_dispatch' && inputs.locomo_skip != true
     runs-on: ubuntu-latest
     env:
       HINDSIGHT_API_LLM_PROVIDER: vertexai

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,22 +1,9 @@
 name: Performance Tests
 
-# ─────────────────────────────────────────────────────────────────────────
-# TEMP iteration mode (revert before merge):
-#   - `push` trigger on this branch so we get fast feedback while wiring
-#     the dashboard publishing logic.
-#   - default scale: small (was large)
-#   - default locomo_skip: true (was false); locomo only runs on
-#     workflow_dispatch while we iterate.
-# Search "TEMP" to find the bits to revert.
-# ─────────────────────────────────────────────────────────────────────────
-
 on:
   schedule:
     # Run daily at 06:00 UTC
     - cron: "0 6 * * *"
-  push:
-    branches:
-      - feat/perf-dashboard  # TEMP: drop before merge
   workflow_dispatch:
     inputs:
       scale:
@@ -27,7 +14,7 @@ on:
           - small
           - medium
           - large
-        default: small  # TEMP: was large
+        default: large
       suite:
         description: "Perf-test suite to run (blank = all)"
         type: choice
@@ -45,7 +32,7 @@ on:
       locomo_skip:
         description: "Skip LoComo job"
         type: boolean
-        default: true  # TEMP: was false
+        default: false
       ref:
         description: "Git ref to test (branch, tag, or SHA). Defaults to main."
         type: string
@@ -103,7 +90,7 @@ jobs:
           SUITE_ARG="--suite ${{ inputs.suite }}"
         fi
         ./scripts/benchmarks/run-perf-test.sh \
-          --scale ${{ inputs.scale || 'small' }} \
+          --scale ${{ inputs.scale || 'large' }} \
           $SUITE_ARG \
           --output perf-results.json
 
@@ -127,9 +114,7 @@ jobs:
       run: ./scripts/benchmarks/publish-perf-results.sh hindsight-dev/perf-results.json
 
   locomo:
-    # TEMP: only run on manual dispatch while iterating on the dashboard.
-    # Restore to: `if: inputs.locomo_skip != true` before merge.
-    if: github.event_name == 'workflow_dispatch' && inputs.locomo_skip != true
+    if: inputs.locomo_skip != true
     runs-on: ubuntu-latest
     env:
       HINDSIGHT_API_LLM_PROVIDER: vertexai

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -137,6 +137,12 @@ jobs:
         comment-on-alert: false
         fail-on-alert: false
 
+    # github-action-benchmark clones the dashboard repo into a fixed
+    # ./benchmark-data-repository dir; the second invocation collides unless we wipe it.
+    - name: Reset benchmark working directory
+      if: always() && (github.event_name == 'schedule' || github.event_name == 'push')
+      run: rm -rf ./benchmark-data-repository
+
     - name: Publish throughput benchmarks
       if: github.event_name == 'schedule' || github.event_name == 'push'
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -200,3 +200,10 @@ jobs:
         name: locomo-results-${{ github.sha }}
         path: hindsight-dev/benchmarks/locomo/results/
         retention-days: 90
+
+    - name: Publish LoComo to dashboard
+      if: success() && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      env:
+        PERF_DASHBOARD_TOKEN: ${{ secrets.PERF_DASHBOARD_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./scripts/benchmarks/publish-locomo-results.sh hindsight-dev/benchmarks/locomo/results/benchmark_results.json

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -120,7 +120,7 @@ jobs:
     #   https://vectorize-io.github.io/hindsight-continuous-performance-monitor/
     # reads data/index.json + data/<run>.json and renders charts client-side.
     - name: Publish to dashboard
-      if: github.event_name == 'schedule' || github.event_name == 'push'
+      if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       env:
         PERF_DASHBOARD_TOKEN: ${{ secrets.PERF_DASHBOARD_TOKEN }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -105,58 +105,26 @@ jobs:
         ./scripts/benchmarks/run-perf-test.sh \
           --scale ${{ inputs.scale || 'small' }} \
           $SUITE_ARG \
-          --output perf-results.json \
-          --benchmark-output-dir bench
+          --output perf-results.json
 
     - name: Upload perf results
       if: always()
       uses: actions/upload-artifact@v7
       with:
         name: perf-results-${{ github.sha }}
-        path: |
-          hindsight-dev/perf-results.json
-          hindsight-dev/bench/
+        path: hindsight-dev/perf-results.json
         retention-days: 90
 
-    # Publish to the external dashboard repo. Pushes to its `gh-pages` branch
-    # using a PAT with push access to vectorize-io/hindsight-continuous-performance-monitor.
-    # Dashboard URL once GitHub Pages is enabled on that repo:
-    #   https://vectorize-io.github.io/hindsight-continuous-performance-monitor/dev/bench/
-    - name: Publish latency benchmarks
+    # Publish enriched results (perf JSON + commit metadata) to the dashboard
+    # repo's gh-pages branch. The static site at
+    #   https://vectorize-io.github.io/hindsight-continuous-performance-monitor/
+    # reads data/index.json + data/<run>.json and renders charts client-side.
+    - name: Publish to dashboard
       if: github.event_name == 'schedule' || github.event_name == 'push'
-      uses: benchmark-action/github-action-benchmark@v1
-      with:
-        name: Hindsight Latency
-        tool: customSmallerIsBetter
-        output-file-path: hindsight-dev/bench/latency.json
-        gh-repository: github.com/vectorize-io/hindsight-continuous-performance-monitor
-        github-token: ${{ secrets.PERF_DASHBOARD_TOKEN }}
-        auto-push: true
-        benchmark-data-dir-path: dev/bench
-        alert-threshold: "150%"
-        comment-on-alert: false
-        fail-on-alert: false
-
-    # github-action-benchmark clones the dashboard repo into a fixed
-    # ./benchmark-data-repository dir; the second invocation collides unless we wipe it.
-    - name: Reset benchmark working directory
-      if: always() && (github.event_name == 'schedule' || github.event_name == 'push')
-      run: rm -rf ./benchmark-data-repository
-
-    - name: Publish throughput benchmarks
-      if: github.event_name == 'schedule' || github.event_name == 'push'
-      uses: benchmark-action/github-action-benchmark@v1
-      with:
-        name: Hindsight Throughput
-        tool: customBiggerIsBetter
-        output-file-path: hindsight-dev/bench/throughput.json
-        gh-repository: github.com/vectorize-io/hindsight-continuous-performance-monitor
-        github-token: ${{ secrets.PERF_DASHBOARD_TOKEN }}
-        auto-push: true
-        benchmark-data-dir-path: dev/bench
-        alert-threshold: "150%"
-        comment-on-alert: false
-        fail-on-alert: false
+      env:
+        PERF_DASHBOARD_TOKEN: ${{ secrets.PERF_DASHBOARD_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./scripts/benchmarks/publish-perf-results.sh hindsight-dev/perf-results.json
 
   locomo:
     # TEMP: only run on manual dispatch while iterating on the dashboard.

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -32,6 +32,7 @@ import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from rich.console import Console
@@ -755,6 +756,48 @@ async def run(scale: str, suite_names: list[str]) -> PerfTestResults:
     return results
 
 
+def _to_benchmark_entries(results: PerfTestResults) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Convert perf results into github-action-benchmark format.
+
+    Returns (latency_entries, throughput_entries):
+      - latency:    customSmallerIsBetter — durations and recall latency percentiles (seconds)
+      - throughput: customBiggerIsBetter  — items/queries/memories per second
+    """
+    latency: list[dict[str, Any]] = []
+    throughput: list[dict[str, Any]] = []
+
+    for suite in results.suites:
+        if not suite.success:
+            continue
+        if suite.retain:
+            r = suite.retain
+            latency.append({"name": f"{suite.name} duration", "unit": "s", "value": r.total_duration_seconds})
+            throughput.append(
+                {"name": f"{suite.name} throughput", "unit": "items/s", "value": r.throughput_items_per_sec}
+            )
+        if suite.recall:
+            rc = suite.recall
+            latency.extend(
+                [
+                    {"name": f"{suite.name} latency mean", "unit": "s", "value": round(rc.latency.mean, 4)},
+                    {"name": f"{suite.name} latency p50", "unit": "s", "value": round(rc.latency.p50, 4)},
+                    {"name": f"{suite.name} latency p95", "unit": "s", "value": round(rc.latency.p95, 4)},
+                    {"name": f"{suite.name} latency p99", "unit": "s", "value": round(rc.latency.p99, 4)},
+                ]
+            )
+            throughput.append(
+                {"name": f"{suite.name} throughput", "unit": "queries/s", "value": rc.throughput_queries_per_sec}
+            )
+        if suite.consolidation:
+            c = suite.consolidation
+            latency.append({"name": f"{suite.name} duration", "unit": "s", "value": c.total_duration_seconds})
+            throughput.append(
+                {"name": f"{suite.name} throughput", "unit": "memories/s", "value": c.throughput_memories_per_sec}
+            )
+
+    return latency, throughput
+
+
 def _serialize(obj: Any) -> Any:
     if obj is None:
         return None
@@ -797,6 +840,12 @@ def main() -> None:
         default=None,
         help="Write JSON results to file",
     )
+    parser.add_argument(
+        "--benchmark-output-dir",
+        type=str,
+        default=None,
+        help="Write github-action-benchmark format JSON files (latency.json + throughput.json) to this directory",
+    )
 
     args = parser.parse_args()
     suite_names = args.suites or list(SUITES)
@@ -808,6 +857,14 @@ def main() -> None:
         with open(args.output, "w") as f:
             json.dump(results_dict, f, indent=2)
         console.print(f"\n[dim]Results written to {args.output}[/dim]")
+
+    if args.benchmark_output_dir:
+        bench_dir = Path(args.benchmark_output_dir)
+        bench_dir.mkdir(parents=True, exist_ok=True)
+        latency, throughput = _to_benchmark_entries(results)
+        (bench_dir / "latency.json").write_text(json.dumps(latency, indent=2))
+        (bench_dir / "throughput.json").write_text(json.dumps(throughput, indent=2))
+        console.print(f"\n[dim]Benchmark JSON written to {bench_dir}/[/dim]")
 
     # Print unified summary table
     _print_summary(results)

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -32,7 +32,6 @@ import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 from rich.console import Console
@@ -756,48 +755,6 @@ async def run(scale: str, suite_names: list[str]) -> PerfTestResults:
     return results
 
 
-def _to_benchmark_entries(results: PerfTestResults) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Convert perf results into github-action-benchmark format.
-
-    Returns (latency_entries, throughput_entries):
-      - latency:    customSmallerIsBetter — durations and recall latency percentiles (seconds)
-      - throughput: customBiggerIsBetter  — items/queries/memories per second
-    """
-    latency: list[dict[str, Any]] = []
-    throughput: list[dict[str, Any]] = []
-
-    for suite in results.suites:
-        if not suite.success:
-            continue
-        if suite.retain:
-            r = suite.retain
-            latency.append({"name": f"{suite.name} duration", "unit": "s", "value": r.total_duration_seconds})
-            throughput.append(
-                {"name": f"{suite.name} throughput", "unit": "items/s", "value": r.throughput_items_per_sec}
-            )
-        if suite.recall:
-            rc = suite.recall
-            latency.extend(
-                [
-                    {"name": f"{suite.name} latency mean", "unit": "s", "value": round(rc.latency.mean, 4)},
-                    {"name": f"{suite.name} latency p50", "unit": "s", "value": round(rc.latency.p50, 4)},
-                    {"name": f"{suite.name} latency p95", "unit": "s", "value": round(rc.latency.p95, 4)},
-                    {"name": f"{suite.name} latency p99", "unit": "s", "value": round(rc.latency.p99, 4)},
-                ]
-            )
-            throughput.append(
-                {"name": f"{suite.name} throughput", "unit": "queries/s", "value": rc.throughput_queries_per_sec}
-            )
-        if suite.consolidation:
-            c = suite.consolidation
-            latency.append({"name": f"{suite.name} duration", "unit": "s", "value": c.total_duration_seconds})
-            throughput.append(
-                {"name": f"{suite.name} throughput", "unit": "memories/s", "value": c.throughput_memories_per_sec}
-            )
-
-    return latency, throughput
-
-
 def _serialize(obj: Any) -> Any:
     if obj is None:
         return None
@@ -840,12 +797,6 @@ def main() -> None:
         default=None,
         help="Write JSON results to file",
     )
-    parser.add_argument(
-        "--benchmark-output-dir",
-        type=str,
-        default=None,
-        help="Write github-action-benchmark format JSON files (latency.json + throughput.json) to this directory",
-    )
 
     args = parser.parse_args()
     suite_names = args.suites or list(SUITES)
@@ -857,14 +808,6 @@ def main() -> None:
         with open(args.output, "w") as f:
             json.dump(results_dict, f, indent=2)
         console.print(f"\n[dim]Results written to {args.output}[/dim]")
-
-    if args.benchmark_output_dir:
-        bench_dir = Path(args.benchmark_output_dir)
-        bench_dir.mkdir(parents=True, exist_ok=True)
-        latency, throughput = _to_benchmark_entries(results)
-        (bench_dir / "latency.json").write_text(json.dumps(latency, indent=2))
-        (bench_dir / "throughput.json").write_text(json.dumps(throughput, indent=2))
-        console.print(f"\n[dim]Benchmark JSON written to {bench_dir}/[/dim]")
 
     # Print unified summary table
     _print_summary(results)

--- a/scripts/benchmarks/publish-locomo-results.sh
+++ b/scripts/benchmarks/publish-locomo-results.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
-# Publish perf-test results to the dashboard repo's gh-pages branch.
+# Publish locomo benchmark results to the dashboard repo's gh-pages branch.
 #
-# Reads a perf-test --output JSON, enriches it with commit metadata, then
-# pushes:
-#   data/<timestamp>-<short_sha>.json   (the enriched run)
-#   data/index.json                     (manifest, newest first)
+# Reads a locomo benchmark JSON, strips the heavy per-question detailed_results
+# (kept only in the upload artifact), enriches with commit + workflow metadata,
+# then pushes:
+#   data/locomo/<timestamp>-<short_sha>.json
+#   data/locomo-index.json   (manifest, newest first)
 # to vectorize-io/hindsight-continuous-performance-monitor (gh-pages).
 #
 # Required env:
 #   PERF_DASHBOARD_TOKEN   PAT with Contents:write on the dashboard repo
 #
 # Usage:
-#   ./scripts/benchmarks/publish-perf-results.sh path/to/perf-results.json
+#   ./scripts/benchmarks/publish-locomo-results.sh path/to/benchmark_results.json
 
 set -euo pipefail
 
-INPUT_JSON="${1:?usage: $0 <perf-results.json>}"
+INPUT_JSON="${1:?usage: $0 <benchmark_results.json>}"
 DASHBOARD_REPO="${DASHBOARD_REPO:-vectorize-io/hindsight-continuous-performance-monitor}"
 HINDSIGHT_REPO="${HINDSIGHT_REPO:-vectorize-io/hindsight}"
 
@@ -26,7 +27,7 @@ fi
 : "${PERF_DASHBOARD_TOKEN:?PERF_DASHBOARD_TOKEN must be set}"
 
 # ─────────────────────────────────────────────────────────────────────────
-# Capture commit metadata
+# Capture commit + workflow metadata
 # ─────────────────────────────────────────────────────────────────────────
 SHA=$(git rev-parse HEAD)
 SHORT_SHA=$(git rev-parse --short=8 HEAD)
@@ -35,8 +36,6 @@ AUTHOR=$(git log -1 --pretty=%an)
 AUTHOR_DATE=$(git log -1 --pretty=%aI)
 COMMIT_URL="https://github.com/${HINDSIGHT_REPO}/commit/${SHA}"
 
-# Best-effort PR lookup. May return empty for direct pushes or when gh isn't
-# configured; we treat it as optional metadata.
 PR_NUMBER=""
 PR_URL=""
 if command -v gh >/dev/null 2>&1; then
@@ -47,7 +46,6 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
-# Workflow run URL — populated when running under GitHub Actions.
 RUN_ID="${GITHUB_RUN_ID:-}"
 RUN_URL=""
 if [ -n "$RUN_ID" ]; then
@@ -56,12 +54,18 @@ if [ -n "$RUN_ID" ]; then
 fi
 
 TIMESTAMP_FILE=$(date -u +%Y%m%dT%H%M%SZ)
-DATA_FILE="data/${TIMESTAMP_FILE}-${SHORT_SHA}.json"
+TIMESTAMP_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+DATA_FILE="data/locomo/${TIMESTAMP_FILE}-${SHORT_SHA}.json"
 
-echo "Publishing run for ${SHORT_SHA} → ${DATA_FILE}"
+echo "Publishing locomo run for ${SHORT_SHA} → ${DATA_FILE}"
 
 # ─────────────────────────────────────────────────────────────────────────
-# Enrich the input JSON
+# Strip detailed_results (per-question detail) and enrich
+#
+# detailed_results is per-question {question, predicted_answer, reasoning,
+# retrieved_memories, ...} and bloats each run to several MB. We keep only
+# accuracy stats per item, which is enough for trend charts; the full data
+# remains available as a workflow artifact.
 # ─────────────────────────────────────────────────────────────────────────
 ENRICHED_TMP=$(mktemp)
 trap 'rm -f "$ENRICHED_TMP"' EXIT
@@ -77,22 +81,29 @@ jq \
   --arg pr_url "$PR_URL" \
   --arg run_id "$RUN_ID" \
   --arg run_url "$RUN_URL" \
-  '. + {
-    commit: {
-      sha: $sha,
-      short_sha: $short_sha,
-      subject: $subject,
-      author: $author,
-      author_date: $author_date,
-      url: $commit_url,
-      pr_number: ($pr_number | if . == "" then null else tonumber end),
-      pr_url: (if $pr_url == "" then null else $pr_url end)
-    },
-    workflow_run: (if $run_url == "" then null else {id: $run_id, url: $run_url} end)
-  }' "$INPUT_JSON" > "$ENRICHED_TMP"
+  --arg timestamp "$TIMESTAMP_ISO" \
+  '
+    # Drop per-question payloads from each item.
+    .item_results = (.item_results // [] | map(.metrics |= del(.detailed_results)))
+    | . + {
+        timestamp: $timestamp,
+        commit: {
+          sha: $sha,
+          short_sha: $short_sha,
+          subject: $subject,
+          author: $author,
+          author_date: $author_date,
+          url: $commit_url,
+          pr_number: ($pr_number | if . == "" then null else tonumber end),
+          pr_url: (if $pr_url == "" then null else $pr_url end)
+        },
+        workflow_run: (if $run_url == "" then null else {id: $run_id, url: $run_url} end)
+      }
+  ' "$INPUT_JSON" > "$ENRICHED_TMP"
 
-RUN_TIMESTAMP=$(jq -r '.timestamp' "$ENRICHED_TMP")
-RUN_SCALE=$(jq -r '.scale' "$ENRICHED_TMP")
+OVERALL=$(jq -r '.overall_accuracy' "$ENRICHED_TMP")
+NUM_ITEMS=$(jq -r '.num_items // (.item_results | length)' "$ENRICHED_TMP")
+TOTAL_QUESTIONS=$(jq -r '.total_questions // 0' "$ENRICHED_TMP")
 
 # ─────────────────────────────────────────────────────────────────────────
 # Clone dashboard repo's gh-pages branch
@@ -104,11 +115,11 @@ git clone --quiet --depth 1 --branch gh-pages \
   "https://x-access-token:${PERF_DASHBOARD_TOKEN}@github.com/${DASHBOARD_REPO}.git" \
   "$WORK"
 
-mkdir -p "$WORK/data"
+mkdir -p "$WORK/data/locomo"
 cp "$ENRICHED_TMP" "$WORK/$DATA_FILE"
 
 # ─────────────────────────────────────────────────────────────────────────
-# Update manifest (data/index.json)
+# Update manifest (data/locomo-index.json)
 # ─────────────────────────────────────────────────────────────────────────
 NEW_ENTRY=$(jq -n \
   --arg sha "$SHA" \
@@ -120,8 +131,10 @@ NEW_ENTRY=$(jq -n \
   --arg pr_url "$PR_URL" \
   --arg run_url "$RUN_URL" \
   --arg data_file "$DATA_FILE" \
-  --arg timestamp "$RUN_TIMESTAMP" \
-  --arg scale "$RUN_SCALE" \
+  --arg timestamp "$TIMESTAMP_ISO" \
+  --argjson overall "$OVERALL" \
+  --argjson num_items "$NUM_ITEMS" \
+  --argjson total_questions "$TOTAL_QUESTIONS" \
   '{
     sha: $sha,
     short_sha: $short_sha,
@@ -133,10 +146,12 @@ NEW_ENTRY=$(jq -n \
     run_url: (if $run_url == "" then null else $run_url end),
     data_file: $data_file,
     timestamp: $timestamp,
-    scale: $scale
+    overall_accuracy: $overall,
+    num_items: $num_items,
+    total_questions: $total_questions
   }')
 
-INDEX_FILE="$WORK/data/index.json"
+INDEX_FILE="$WORK/data/locomo-index.json"
 if [ ! -f "$INDEX_FILE" ]; then
   echo '{"runs": []}' > "$INDEX_FILE"
 fi
@@ -158,9 +173,8 @@ if git diff --cached --quiet; then
   echo "No changes to commit (this shouldn't happen — skipping push)" >&2
   exit 0
 fi
-git commit --quiet -m "perf: add results for ${SHORT_SHA}"
+git commit --quiet -m "locomo: add results for ${SHORT_SHA}"
 
-# Retry push once if rejected — concurrent runs from different jobs could race.
 if ! git push --quiet origin gh-pages; then
   echo "Push rejected, pulling and retrying..." >&2
   git pull --quiet --rebase origin gh-pages

--- a/scripts/benchmarks/publish-perf-results.sh
+++ b/scripts/benchmarks/publish-perf-results.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Publish perf-test results to the dashboard repo's gh-pages branch.
+#
+# Reads a perf-test --output JSON, enriches it with commit metadata, then
+# pushes:
+#   data/<timestamp>-<short_sha>.json   (the enriched run)
+#   data/index.json                     (manifest, newest first)
+# to vectorize-io/hindsight-continuous-performance-monitor (gh-pages).
+#
+# Required env:
+#   PERF_DASHBOARD_TOKEN   PAT with Contents:write on the dashboard repo
+#
+# Usage:
+#   ./scripts/benchmarks/publish-perf-results.sh path/to/perf-results.json
+
+set -euo pipefail
+
+INPUT_JSON="${1:?usage: $0 <perf-results.json>}"
+DASHBOARD_REPO="${DASHBOARD_REPO:-vectorize-io/hindsight-continuous-performance-monitor}"
+HINDSIGHT_REPO="${HINDSIGHT_REPO:-vectorize-io/hindsight}"
+
+if [ ! -f "$INPUT_JSON" ]; then
+  echo "Input JSON not found: $INPUT_JSON" >&2
+  exit 1
+fi
+: "${PERF_DASHBOARD_TOKEN:?PERF_DASHBOARD_TOKEN must be set}"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Capture commit metadata
+# ─────────────────────────────────────────────────────────────────────────
+SHA=$(git rev-parse HEAD)
+SHORT_SHA=$(git rev-parse --short=8 HEAD)
+SUBJECT=$(git log -1 --pretty=%s)
+AUTHOR=$(git log -1 --pretty=%an)
+AUTHOR_DATE=$(git log -1 --pretty=%aI)
+COMMIT_URL="https://github.com/${HINDSIGHT_REPO}/commit/${SHA}"
+
+# Best-effort PR lookup. May return empty for direct pushes or when gh isn't
+# configured; we treat it as optional metadata.
+PR_NUMBER=""
+PR_URL=""
+if command -v gh >/dev/null 2>&1; then
+  PR_NUMBER=$(gh api "repos/${HINDSIGHT_REPO}/commits/${SHA}/pulls" \
+    --jq '.[0].number // empty' 2>/dev/null || true)
+  if [ -n "$PR_NUMBER" ]; then
+    PR_URL="https://github.com/${HINDSIGHT_REPO}/pull/${PR_NUMBER}"
+  fi
+fi
+
+TIMESTAMP_FILE=$(date -u +%Y%m%dT%H%M%SZ)
+DATA_FILE="data/${TIMESTAMP_FILE}-${SHORT_SHA}.json"
+
+echo "Publishing run for ${SHORT_SHA} → ${DATA_FILE}"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Enrich the input JSON
+# ─────────────────────────────────────────────────────────────────────────
+ENRICHED_TMP=$(mktemp)
+trap 'rm -f "$ENRICHED_TMP"' EXIT
+
+jq \
+  --arg sha "$SHA" \
+  --arg short_sha "$SHORT_SHA" \
+  --arg subject "$SUBJECT" \
+  --arg author "$AUTHOR" \
+  --arg author_date "$AUTHOR_DATE" \
+  --arg commit_url "$COMMIT_URL" \
+  --arg pr_number "$PR_NUMBER" \
+  --arg pr_url "$PR_URL" \
+  '. + {
+    commit: {
+      sha: $sha,
+      short_sha: $short_sha,
+      subject: $subject,
+      author: $author,
+      author_date: $author_date,
+      url: $commit_url,
+      pr_number: ($pr_number | if . == "" then null else tonumber end),
+      pr_url: (if $pr_url == "" then null else $pr_url end)
+    }
+  }' "$INPUT_JSON" > "$ENRICHED_TMP"
+
+RUN_TIMESTAMP=$(jq -r '.timestamp' "$ENRICHED_TMP")
+RUN_SCALE=$(jq -r '.scale' "$ENRICHED_TMP")
+
+# ─────────────────────────────────────────────────────────────────────────
+# Clone dashboard repo's gh-pages branch
+# ─────────────────────────────────────────────────────────────────────────
+WORK=$(mktemp -d)
+trap 'rm -f "$ENRICHED_TMP"; rm -rf "$WORK"' EXIT
+
+git clone --quiet --depth 1 --branch gh-pages \
+  "https://x-access-token:${PERF_DASHBOARD_TOKEN}@github.com/${DASHBOARD_REPO}.git" \
+  "$WORK"
+
+mkdir -p "$WORK/data"
+cp "$ENRICHED_TMP" "$WORK/$DATA_FILE"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Update manifest (data/index.json)
+# ─────────────────────────────────────────────────────────────────────────
+NEW_ENTRY=$(jq -n \
+  --arg sha "$SHA" \
+  --arg short_sha "$SHORT_SHA" \
+  --arg subject "$SUBJECT" \
+  --arg author "$AUTHOR" \
+  --arg author_date "$AUTHOR_DATE" \
+  --arg commit_url "$COMMIT_URL" \
+  --arg pr_url "$PR_URL" \
+  --arg data_file "$DATA_FILE" \
+  --arg timestamp "$RUN_TIMESTAMP" \
+  --arg scale "$RUN_SCALE" \
+  '{
+    sha: $sha,
+    short_sha: $short_sha,
+    subject: $subject,
+    author: $author,
+    author_date: $author_date,
+    commit_url: $commit_url,
+    pr_url: (if $pr_url == "" then null else $pr_url end),
+    data_file: $data_file,
+    timestamp: $timestamp,
+    scale: $scale
+  }')
+
+INDEX_FILE="$WORK/data/index.json"
+if [ ! -f "$INDEX_FILE" ]; then
+  echo '{"runs": []}' > "$INDEX_FILE"
+fi
+
+UPDATED_INDEX=$(jq \
+  --argjson entry "$NEW_ENTRY" \
+  '.runs = ([$entry] + (.runs // [])) | .updated_at = (now | todateiso8601)' \
+  "$INDEX_FILE")
+echo "$UPDATED_INDEX" > "$INDEX_FILE"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Commit and push
+# ─────────────────────────────────────────────────────────────────────────
+cd "$WORK"
+git config user.name 'hindsight-perf-bot'
+git config user.email 'hindsight-perf-bot@users.noreply.github.com'
+git add data/
+if git diff --cached --quiet; then
+  echo "No changes to commit (this shouldn't happen — skipping push)" >&2
+  exit 0
+fi
+git commit --quiet -m "perf: add results for ${SHORT_SHA}"
+
+# Retry push once if rejected — concurrent runs from different jobs could race.
+if ! git push --quiet origin gh-pages; then
+  echo "Push rejected, pulling and retrying..." >&2
+  git pull --quiet --rebase origin gh-pages
+  git push --quiet origin gh-pages
+fi
+
+echo "Published ${DATA_FILE} to ${DASHBOARD_REPO} gh-pages"


### PR DESCRIPTION
## Summary
- New `--benchmark-output-dir` flag on `perf-test` emits two JSONs in github-action-benchmark format: `latency.json` (smaller-is-better — durations + recall p50/p95/p99/mean) and `throughput.json` (bigger-is-better — items/queries/memories per sec). Two charts because the action takes one tool per upload.
- The `Performance Tests` workflow publishes both to [vectorize-io/hindsight-continuous-performance-monitor](https://github.com/vectorize-io/hindsight-continuous-performance-monitor) (its `gh-pages` branch). Once Pages is enabled there, the dashboard lives at `https://vectorize-io.github.io/hindsight-continuous-performance-monitor/dev/bench/`.
- Per-suite workflow steps collapsed into a single `perf-test` invocation (suite filter still supported via dispatch input).

## Iteration mode (TEMP — revert before merge)
Search `TEMP` in `.github/workflows/perf-test.yml`:
- `push` trigger on `feat/perf-dashboard` (so we can iterate without waiting for the daily cron)
- default scale: `small` (was `large`)
- default `locomo_skip`: `true`; the `locomo` job only runs on manual dispatch

## Setup required before this works (one-time)
- [ ] Create a fine-grained PAT with `Contents: read & write` on `vectorize-io/hindsight-continuous-performance-monitor`
- [ ] Add it as secret `PERF_DASHBOARD_TOKEN` in `vectorize-io/hindsight`
- [ ] After the first successful run creates `gh-pages` on the dashboard repo, enable Pages there (Settings → Pages → Source = `gh-pages` / `/`)

## Test plan
- [ ] Validate locally with `uv run perf-test --scale tiny --benchmark-output-dir bench` — confirmed bench JSON shape matches the action's schema
- [ ] Push to this branch, watch the workflow publish both charts to the dashboard repo
- [ ] Verify the dashboard renders both charts after Pages is enabled
- [ ] Before merge: revert the four TEMP changes (push trigger, scale default, locomo_skip default, locomo job condition)