### PR TITLE
feat(control-plane): enrich bank dropdown with memory stats

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -997,7 +997,7 @@ class BackgroundResponse(BaseModel):
 
 
 class BankListItem(BaseModel):
-    """Bank list item with profile summary."""
+    """Bank list item with profile summary and stats."""
 
     bank_id: str
     name: str | None = None
@@ -1005,6 +1005,8 @@ class BankListItem(BaseModel):
     mission: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
+    fact_count: int = 0
+    last_document_at: str | None = None
 
 
 class BankListResponse(BaseModel):
@@ -1021,6 +1023,8 @@ class BankListResponse(BaseModel):
                         "mission": "I am a software engineer helping my team ship quality code",
                         "created_at": "2024-01-15T10:30:00Z",
                         "updated_at": "2024-01-16T14:20:00Z",
+                        "fact_count": 156,
+                        "last_document_at": "2024-01-16T14:20:00Z",
                     }
                 ]
             }

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -368,29 +368,48 @@ Merged mission:"""
 
 async def list_banks(pool) -> list:
     """
-    List all banks in the system.
+    List all banks in the system with summary stats.
 
     Args:
         pool: Database connection pool
 
     Returns:
-        List of dicts with bank_id, name, disposition, mission, created_at, updated_at
+        List of dicts with bank info and stats (document_count, fact_count, last_event_at)
     """
+    banks_table = fq_table("banks")
+    docs_table = fq_table("documents")
+    mu_table = fq_table("memory_units")
+
     async with acquire_with_retry(pool) as conn:
         rows = await conn.fetch(
             f"""
-            SELECT bank_id, name, disposition, mission, created_at, updated_at
-            FROM {fq_table("banks")}
-            ORDER BY updated_at DESC
+            SELECT
+                b.bank_id, b.name, b.disposition, b.mission,
+                b.created_at, b.updated_at,
+                COALESCE(m.fact_count, 0) AS fact_count,
+                d.last_document_at
+            FROM {banks_table} b
+            LEFT JOIN (
+                SELECT bank_id, MAX(created_at) AS last_document_at
+                FROM {docs_table}
+                GROUP BY bank_id
+            ) d ON d.bank_id = b.bank_id
+            LEFT JOIN (
+                SELECT bank_id, COUNT(*) AS fact_count
+                FROM {mu_table}
+                GROUP BY bank_id
+            ) m ON m.bank_id = b.bank_id
+            ORDER BY d.last_document_at DESC NULLS LAST, b.updated_at DESC
             """
         )
 
         result = []
         for row in rows:
-            # asyncpg returns JSONB as a string, so parse it
             disposition_data = row["disposition"]
             if isinstance(disposition_data, str):
                 disposition_data = json.loads(disposition_data)
+
+            last_doc = row["last_document_at"]
 
             result.append(
                 {
@@ -400,6 +419,8 @@ async def list_banks(pool) -> list:
                     "mission": row["mission"] or "",
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
+                    "fact_count": row["fact_count"],
+                    "last_document_at": last_doc.isoformat() if last_doc else None,
                 }
             )
 

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -158,6 +158,14 @@ async def test_full_api_workflow(api_client, test_bank_id):
     assert "total_nodes" in stats
     assert stats["total_nodes"] > 0
 
+    # Verify bank list returns stats (fact_count, last_document_at)
+    response = await api_client.get("/v1/default/banks")
+    assert response.status_code == 200
+    banks_after = response.json()["banks"]
+    our_bank = next(b for b in banks_after if b["bank_id"] == test_bank_id)
+    assert our_bank["fact_count"] > 0, "fact_count should reflect retained memories"
+    assert our_bank["last_document_at"] is not None, "last_document_at should be set after retain"
+
     # List memory units
     response = await api_client.get(
         f"/v1/default/banks/{test_bank_id}/memories/list",

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3666,7 +3666,7 @@ components:
       - updates
       title: BankConfigUpdate
     BankListItem:
-      description: Bank list item with profile summary.
+      description: Bank list item with profile summary and stats.
       properties:
         bank_id:
           title: Bank Id
@@ -3685,6 +3685,13 @@ components:
         updated_at:
           nullable: true
           type: string
+        fact_count:
+          default: 0
+          title: Fact Count
+          type: integer
+        last_document_at:
+          nullable: true
+          type: string
       required:
       - bank_id
       - disposition
@@ -3699,6 +3706,8 @@ components:
             empathy: 3
             literalism: 3
             skepticism: 3
+          fact_count: 156
+          last_document_at: 2024-01-16T14:20:00Z
           mission: I am a software engineer helping my team ship quality code
           name: Alice
           updated_at: 2024-01-16T14:20:00Z

--- a/hindsight-clients/go/model_bank_list_item.go
+++ b/hindsight-clients/go/model_bank_list_item.go
@@ -19,7 +19,7 @@ import (
 // checks if the BankListItem type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &BankListItem{}
 
-// BankListItem Bank list item with profile summary.
+// BankListItem Bank list item with profile summary and stats.
 type BankListItem struct {
 	BankId string `json:"bank_id"`
 	Name NullableString `json:"name,omitempty"`
@@ -27,6 +27,8 @@ type BankListItem struct {
 	Mission NullableString `json:"mission,omitempty"`
 	CreatedAt NullableString `json:"created_at,omitempty"`
 	UpdatedAt NullableString `json:"updated_at,omitempty"`
+	FactCount *int32 `json:"fact_count,omitempty"`
+	LastDocumentAt NullableString `json:"last_document_at,omitempty"`
 }
 
 type _BankListItem BankListItem
@@ -39,6 +41,8 @@ func NewBankListItem(bankId string, disposition DispositionTraits) *BankListItem
 	this := BankListItem{}
 	this.BankId = bankId
 	this.Disposition = disposition
+	var factCount int32 = 0
+	this.FactCount = &factCount
 	return &this
 }
 
@@ -47,6 +51,8 @@ func NewBankListItem(bankId string, disposition DispositionTraits) *BankListItem
 // but it doesn't guarantee that properties required by API are set
 func NewBankListItemWithDefaults() *BankListItem {
 	this := BankListItem{}
+	var factCount int32 = 0
+	this.FactCount = &factCount
 	return &this
 }
 
@@ -266,6 +272,80 @@ func (o *BankListItem) UnsetUpdatedAt() {
 	o.UpdatedAt.Unset()
 }
 
+// GetFactCount returns the FactCount field value if set, zero value otherwise.
+func (o *BankListItem) GetFactCount() int32 {
+	if o == nil || IsNil(o.FactCount) {
+		var ret int32
+		return ret
+	}
+	return *o.FactCount
+}
+
+// GetFactCountOk returns a tuple with the FactCount field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *BankListItem) GetFactCountOk() (*int32, bool) {
+	if o == nil || IsNil(o.FactCount) {
+		return nil, false
+	}
+	return o.FactCount, true
+}
+
+// HasFactCount returns a boolean if a field has been set.
+func (o *BankListItem) HasFactCount() bool {
+	if o != nil && !IsNil(o.FactCount) {
+		return true
+	}
+
+	return false
+}
+
+// SetFactCount gets a reference to the given int32 and assigns it to the FactCount field.
+func (o *BankListItem) SetFactCount(v int32) {
+	o.FactCount = &v
+}
+
+// GetLastDocumentAt returns the LastDocumentAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *BankListItem) GetLastDocumentAt() string {
+	if o == nil || IsNil(o.LastDocumentAt.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.LastDocumentAt.Get()
+}
+
+// GetLastDocumentAtOk returns a tuple with the LastDocumentAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *BankListItem) GetLastDocumentAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.LastDocumentAt.Get(), o.LastDocumentAt.IsSet()
+}
+
+// HasLastDocumentAt returns a boolean if a field has been set.
+func (o *BankListItem) HasLastDocumentAt() bool {
+	if o != nil && o.LastDocumentAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetLastDocumentAt gets a reference to the given NullableString and assigns it to the LastDocumentAt field.
+func (o *BankListItem) SetLastDocumentAt(v string) {
+	o.LastDocumentAt.Set(&v)
+}
+// SetLastDocumentAtNil sets the value for LastDocumentAt to be an explicit nil
+func (o *BankListItem) SetLastDocumentAtNil() {
+	o.LastDocumentAt.Set(nil)
+}
+
+// UnsetLastDocumentAt ensures that no value is present for LastDocumentAt, not even an explicit nil
+func (o *BankListItem) UnsetLastDocumentAt() {
+	o.LastDocumentAt.Unset()
+}
+
 func (o BankListItem) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -289,6 +369,12 @@ func (o BankListItem) ToMap() (map[string]interface{}, error) {
 	}
 	if o.UpdatedAt.IsSet() {
 		toSerialize["updated_at"] = o.UpdatedAt.Get()
+	}
+	if !IsNil(o.FactCount) {
+		toSerialize["fact_count"] = o.FactCount
+	}
+	if o.LastDocumentAt.IsSet() {
+		toSerialize["last_document_at"] = o.LastDocumentAt.Get()
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/bank_list_item.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from hindsight_client_api.models.disposition_traits import DispositionTraits
 from typing import Optional, Set
@@ -25,7 +25,7 @@ from typing_extensions import Self
 
 class BankListItem(BaseModel):
     """
-    Bank list item with profile summary.
+    Bank list item with profile summary and stats.
     """ # noqa: E501
     bank_id: StrictStr
     name: Optional[StrictStr] = None
@@ -33,7 +33,9 @@ class BankListItem(BaseModel):
     mission: Optional[StrictStr] = None
     created_at: Optional[StrictStr] = None
     updated_at: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["bank_id", "name", "disposition", "mission", "created_at", "updated_at"]
+    fact_count: Optional[StrictInt] = 0
+    last_document_at: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["bank_id", "name", "disposition", "mission", "created_at", "updated_at", "fact_count", "last_document_at"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +99,11 @@ class BankListItem(BaseModel):
         if self.updated_at is None and "updated_at" in self.model_fields_set:
             _dict['updated_at'] = None
 
+        # set to None if last_document_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_document_at is None and "last_document_at" in self.model_fields_set:
+            _dict['last_document_at'] = None
+
         return _dict
 
     @classmethod
@@ -114,7 +121,9 @@ class BankListItem(BaseModel):
             "disposition": DispositionTraits.from_dict(obj["disposition"]) if obj.get("disposition") is not None else None,
             "mission": obj.get("mission"),
             "created_at": obj.get("created_at"),
-            "updated_at": obj.get("updated_at")
+            "updated_at": obj.get("updated_at"),
+            "fact_count": obj.get("fact_count") if obj.get("fact_count") is not None else 0,
+            "last_document_at": obj.get("last_document_at")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -242,7 +242,7 @@ export type BankConfigUpdate = {
 /**
  * BankListItem
  *
- * Bank list item with profile summary.
+ * Bank list item with profile summary and stats.
  */
 export type BankListItem = {
   /**
@@ -266,6 +266,14 @@ export type BankListItem = {
    * Updated At
    */
   updated_at?: string | null;
+  /**
+   * Fact Count
+   */
+  fact_count?: number;
+  /**
+   * Last Document At
+   */
+  last_document_at?: string | null;
 };
 
 /**

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -52,11 +52,33 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import type { BankInfo } from "@/lib/bank-context";
+
+function formatCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return n.toString();
+}
+
+function formatTimeAgo(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
 
 function BankSelectorInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { currentBank, setCurrentBank, banks, loadBanks } = useBank();
+  const { currentBank, setCurrentBank, banks, bankInfos, loadBanks } = useBank();
   const { theme, toggleTheme } = useTheme();
   const [open, setOpen] = React.useState(false);
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false);
@@ -134,8 +156,18 @@ function BankSelectorInner() {
   }, []);
 
   const sortedBanks = React.useMemo(() => {
-    return [...banks].sort((a, b) => a.localeCompare(b));
-  }, [banks]);
+    // Sort by last document inserted descending, then by created_at
+    return [...bankInfos].sort((a, b) => {
+      const aTime = a.last_document_at || a.created_at || "";
+      const bTime = b.last_document_at || b.created_at || "";
+      return bTime.localeCompare(aTime);
+    });
+  }, [bankInfos]);
+
+  const maxFactCount = React.useMemo(
+    () => Math.max(1, ...sortedBanks.map((b) => b.fact_count)),
+    [sortedBanks]
+  );
 
   const handleCreateBank = async () => {
     if (!newBankId.trim()) return;
@@ -446,37 +478,64 @@ function BankSelectorInner() {
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="w-[250px] p-0">
+          <PopoverContent className="w-[420px] p-0" align="start">
             <Command>
               {sortedBanks.length > 0 && <CommandInput placeholder="Search memory banks..." />}
               <CommandList>
                 <CommandEmpty>No memory banks yet.</CommandEmpty>
                 <CommandGroup>
-                  {sortedBanks.map((bank) => (
-                    <CommandItem
-                      key={bank}
-                      value={bank}
-                      onSelect={(value) => {
-                        setCurrentBank(value);
-                        setOpen(false);
-                        // Preserve current view and subTab when switching banks
-                        const view = searchParams.get("view") || "data";
-                        const subTab = searchParams.get("subTab");
-                        const queryString = subTab
-                          ? `?view=${view}&subTab=${subTab}`
-                          : `?view=${view}`;
-                        router.push(bankRoute(value, queryString));
-                      }}
-                    >
-                      <Check
-                        className={cn(
-                          "mr-2 h-4 w-4",
-                          currentBank === bank ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                      {bank}
-                    </CommandItem>
-                  ))}
+                  {sortedBanks.map((bank) => {
+                    const barPct = (bank.fact_count / maxFactCount) * 100;
+                    const isSelected = currentBank === bank.bank_id;
+                    return (
+                      <CommandItem
+                        key={bank.bank_id}
+                        value={bank.bank_id}
+                        onSelect={(value) => {
+                          setCurrentBank(value);
+                          setOpen(false);
+                          const view = searchParams.get("view") || "data";
+                          const subTab = searchParams.get("subTab");
+                          const queryString = subTab
+                            ? `?view=${view}&subTab=${subTab}`
+                            : `?view=${view}`;
+                          router.push(bankRoute(value, queryString));
+                        }}
+                        className="relative overflow-hidden py-2.5 mb-0.5"
+                      >
+                        {/* Background bar — proportional to memory count */}
+                        <div
+                          className="absolute inset-y-0 left-0 bg-primary/15 dark:bg-primary/20 rounded-[inherit] transition-all"
+                          style={{ width: `${barPct}%` }}
+                        />
+                        <div className="relative flex items-center w-full gap-2">
+                          <Check
+                            className={cn(
+                              "h-4 w-4 shrink-0",
+                              isSelected ? "opacity-100" : "opacity-0"
+                            )}
+                          />
+                          <span className="truncate flex-1 font-medium" title={bank.bank_id}>
+                            {bank.bank_id}
+                          </span>
+                          <span className="shrink-0 tabular-nums text-[11px] text-muted-foreground/70">
+                            {bank.fact_count > 0 ? (
+                              <>
+                                {formatCompact(bank.fact_count)}
+                                <span className="ml-1.5 text-muted-foreground/40">
+                                  {bank.last_document_at
+                                    ? formatTimeAgo(bank.last_document_at)
+                                    : ""}
+                                </span>
+                              </>
+                            ) : (
+                              <span className="italic text-muted-foreground/40">empty</span>
+                            )}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
                 </CommandGroup>
               </CommandList>
               {/* Footer: Create new bank */}

--- a/hindsight-control-plane/src/components/ui/popover.tsx
+++ b/hindsight-control-plane/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-50 w-72 rounded-md border border-border/50 bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
         className
       )}
       {...props}

--- a/hindsight-control-plane/src/lib/bank-context.tsx
+++ b/hindsight-control-plane/src/lib/bank-context.tsx
@@ -4,10 +4,21 @@ import React, { createContext, useContext, useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { client } from "./api";
 
+export interface BankInfo {
+  bank_id: string;
+  name: string | null;
+  mission: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  fact_count: number;
+  last_document_at: string | null;
+}
+
 interface BankContextType {
   currentBank: string | null;
   setCurrentBank: (bank: string | null) => void;
   banks: string[];
+  bankInfos: BankInfo[];
   loadBanks: () => Promise<void>;
 }
 
@@ -16,18 +27,29 @@ const BankContext = createContext<BankContextType | undefined>(undefined);
 export function BankProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [currentBank, setCurrentBank] = useState<string | null>(null);
-  const [banks, setBanks] = useState<string[]>([]);
+  const [bankInfos, setBankInfos] = useState<BankInfo[]>([]);
 
   const loadBanks = async () => {
     try {
       const response = await client.listBanks();
-      // Extract bank_id from each bank object
-      const bankIds = response.banks?.map((bank: any) => bank.bank_id) || [];
-      setBanks(bankIds);
+      const infos: BankInfo[] =
+        response.banks?.map((bank: any) => ({
+          bank_id: bank.bank_id,
+          name: bank.name ?? null,
+          mission: bank.mission ?? null,
+          created_at: bank.created_at ?? null,
+          updated_at: bank.updated_at ?? null,
+          fact_count: bank.fact_count ?? 0,
+          last_document_at: bank.last_document_at ?? null,
+        })) || [];
+      setBankInfos(infos);
     } catch (error) {
       console.error("Error loading banks:", error);
     }
   };
+
+  // Derive bank IDs for backwards compatibility
+  const banks = bankInfos.map((b) => b.bank_id);
 
   // Initialize bank from URL on mount
   useEffect(() => {
@@ -42,7 +64,7 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <BankContext.Provider value={{ currentBank, setCurrentBank, banks, loadBanks }}>
+    <BankContext.Provider value={{ currentBank, setCurrentBank, banks, bankInfos, loadBanks }}>
       {children}
     </BankContext.Provider>
   );

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -5333,6 +5333,22 @@
               }
             ],
             "title": "Updated At"
+          },
+          "fact_count": {
+            "type": "integer",
+            "title": "Fact Count",
+            "default": 0
+          },
+          "last_document_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Document At"
           }
         },
         "type": "object",
@@ -5341,7 +5357,7 @@
           "disposition"
         ],
         "title": "BankListItem",
-        "description": "Bank list item with profile summary."
+        "description": "Bank list item with profile summary and stats."
       },
       "BankListResponse": {
         "properties": {
@@ -5369,6 +5385,8 @@
                 "literalism": 3,
                 "skepticism": 3
               },
+              "fact_count": 156,
+              "last_document_at": "2024-01-16T14:20:00Z",
               "mission": "I am a software engineer helping my team ship quality code",
               "name": "Alice",
               "updated_at": "2024-01-16T14:20:00Z"


### PR DESCRIPTION
## Summary
- Add `fact_count` and `last_document_at` to the bank list API response (replacing `document_count` and `last_event_at`)
- Bank dropdown now shows a proportional background bar for relative memory volume, compact count (1.5k, 2.1M), and time since last document ingestion
- Banks sorted by most recently active first, empty banks at bottom
- Full bank name visible on hover (title tooltip)
- Popover border color softened globally (`border-border/50`)

## Test plan
- [ ] Open control plane, verify bank dropdown shows stats and background bars
- [ ] Verify hover on truncated bank name shows full name
- [ ] Verify empty banks show "empty" label and no bar
- [ ] Verify `GET /v1/default/banks` returns `fact_count` and `last_document_at` fields
- [ ] CI passes