### PR TITLE
fix(packaging): hard-pin meta packages to matching hindsight-api-slim

### DIFF
--- a/hindsight-all-slim/pyproject.toml
+++ b/hindsight-all-slim/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hindsight: Agent Memory That Works Like Human Memory - Slim All-i
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "hindsight-api-slim>=0.4.17",
+    "hindsight-api-slim==0.6.0",
     "hindsight-client>=0.0.7",
     "hindsight-embed>=0.1.0",
 ]

--- a/hindsight-all/pyproject.toml
+++ b/hindsight-all/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hindsight: Agent Memory That Works Like Human Memory - All-in-One
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "hindsight-api-slim[all]>=0.4.17",
+    "hindsight-api-slim[all]==0.6.0",
     "hindsight-client>=0.0.7",
     "hindsight-embed>=0.1.0",
 ]
@@ -21,7 +21,7 @@ hindsight-embed = { workspace = true }
 
 [project.optional-dependencies]
 local-llm = [
-    "hindsight-api-slim[local-llm]>=0.4.17",
+    "hindsight-api-slim[local-llm]==0.6.0",
 ]
 test = [
     "pytest>=7.0.0",

--- a/hindsight-api/pyproject.toml
+++ b/hindsight-api/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hindsight: Agent Memory That Works Like Human Memory"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "hindsight-api-slim[all]>=0.4.17",
+    "hindsight-api-slim[all]==0.6.0",
 ]
 
 [tool.uv.sources]

--- a/hindsight-dev/pyproject.toml
+++ b/hindsight-dev/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.6.0"
 description = "Development utilities for Hindsight"
 requires-python = ">=3.11"
 dependencies = [
-    "hindsight-api",
+    "hindsight-api==0.6.0",
     "python-fasthtml>=0.12.33",
     "streamlit>=1.54.0",
     "openai>=1.0.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,6 +77,27 @@ for package in "${PYTHON_PACKAGES[@]}"; do
     fi
 done
 
+# Re-pin meta-package -> slim/api dependencies. The meta packages are pure
+# shims and must pull the matching slim/api version; otherwise `pip install -U`
+# leaves an older slim in place and the server reports the stale __version__.
+META_PIN_FILES=("hindsight-api/pyproject.toml" "hindsight-all/pyproject.toml" "hindsight-all-slim/pyproject.toml")
+for pin_file in "${META_PIN_FILES[@]}"; do
+    if [ -f "$pin_file" ]; then
+        print_info "Repinning hindsight-api-slim in $pin_file"
+        sed -i.bak -E "s/(\"hindsight-api-slim(\[[^]]+\])?)==[0-9]+\.[0-9]+\.[0-9]+\"/\1==$VERSION\"/g" "$pin_file"
+        rm "${pin_file}.bak"
+    else
+        print_warn "File $pin_file not found, skipping"
+    fi
+done
+
+DEV_PYPROJECT="hindsight-dev/pyproject.toml"
+if [ -f "$DEV_PYPROJECT" ]; then
+    print_info "Repinning hindsight-api in $DEV_PYPROJECT"
+    sed -i.bak -E "s/\"hindsight-api==[0-9]+\.[0-9]+\.[0-9]+\"/\"hindsight-api==$VERSION\"/" "$DEV_PYPROJECT"
+    rm "${DEV_PYPROJECT}.bak"
+fi
+
 # Update __version__ in Python __init__.py files
 PYTHON_INIT_FILES=(
     "hindsight-api-slim/hindsight_api/__init__.py"


### PR DESCRIPTION
## Summary

- A user reported that `hindsight-api==0.6.0` still shows `Version: v0.5.4` on the startup banner even though `pip show hindsight-api` reports 0.6.0. Root cause: the meta packages (`hindsight-api`, `hindsight-all`, `hindsight-all-slim`, `hindsight-dev`) are pure entry-point shims — all real code, including `__version__`, lives in `hindsight-api-slim`. Their dependency on slim was a stale floor (`hindsight-api-slim>=0.4.17`), so `pip install -U hindsight-api==0.6.0` was satisfied by whatever older slim was already installed and didn't pull a new one.
- Hard-pin every meta package's slim/api dependency to the current release (`==0.6.0`).
- Teach `scripts/release.sh` to rewrite those pins on each release alongside the existing `version = "..."` bumps so future releases stay in sync.

## User-facing remediation

Existing users on a stale slim can recover with: `pip install -U "hindsight-api-slim==0.6.0"` (or simply reinstall the meta package after this fix lands and the next release goes out).

## Test plan

- [x] `./scripts/hooks/lint.sh` passes
- [x] `uv sync --directory hindsight-api-slim/` resolves with no lockfile changes (workspace-internal pin)
- [x] Dry-run the new `release.sh` sed against all four pyprojects with a fake `VERSION=0.7.0` — produces the expected `==0.7.0` rewrites in every file
- [ ] Next release run executes the new pin-rewrite step and the resulting wheels actually upgrade slim on `pip install -U`