### PR TITLE
fix(worker): liveness-gate orphaned processing rows in bank-serialization

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -739,7 +739,9 @@ class PostgreSQLOps(DataAccessOps):
                 busy_banks = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    WHERE operation_type = 'consolidation'
+                      AND status = 'processing'
+                      AND updated_at > NOW() - INTERVAL '1 hour'
                     """,
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
@@ -844,7 +846,9 @@ class PostgreSQLOps(DataAccessOps):
                 busy_banks_2 = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    WHERE operation_type = 'consolidation'
+                      AND status = 'processing'
+                      AND updated_at > NOW() - INTERVAL '1 hour'
                     """,
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -707,7 +707,12 @@ class WorkerPoller:
                         f"""
                         UPDATE {table}
                         SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
-                        WHERE status = 'processing' AND worker_id = $1 AND result_metadata->>'batch_id' IS NULL
+                        WHERE status = 'processing'
+                          AND result_metadata->>'batch_id' IS NULL
+                          AND (
+                            worker_id = $1
+                            OR updated_at < NOW() - INTERVAL '1 hour'
+                          )
                         """,
                         self._worker_id,
                     )

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3102,3 +3102,208 @@ class TestWorkerStatus:
         )
 
         assert len(rows) == 0
+
+
+class TestOrphanedProcessingRowLiveness:
+    """Regression tests for the orphaned-processing-row bug (issue #1470).
+
+    When a worker dies mid-consolidation (container restart, OOM), the
+    async_operations row can be left in status='processing' indefinitely.
+    The bank-serialization filter in claim_tasks() must treat such stale rows
+    as non-live (>1 hour since updated_at) so the bank becomes claimable again.
+    Similarly, _recover_orphaned_tasks() on startup must reset stale rows even
+    when they were owned by a different worker_id.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stale_processing_row_does_not_block_claim(self, pool, backend, clean_operations):
+        """A consolidation row stuck in processing for >1h must not block claim.
+
+        Scenario: worker_A died mid-consolidation; its row has status='processing'
+        and updated_at=2 hours ago. A new worker (worker_B) should be able to
+        claim pending consolidation tasks for the same bank.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # Simulate the orphaned row left by dead worker_A: processing, updated 2h ago.
+        orphan_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'dead-worker-A', now(), now() - INTERVAL '2 hours')
+            """,
+            orphan_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(orphan_id)}),
+        )
+
+        # The pending task that should be claimed by worker_B.
+        pending_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            pending_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(pending_id)}),
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        claimed = await poller.claim_batch()
+        claimed_ids = {c.operation_id for c in claimed}
+
+        assert str(pending_id) in claimed_ids, (
+            "Worker should claim the pending consolidation task when the only "
+            "blocking processing row is stale (>1h). "
+            "Regression: orphaned row from dead worker must not block claim forever."
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_processing_row_still_blocks_claim(self, pool, backend, clean_operations):
+        """A consolidation row in processing with a recent updated_at must still block claim.
+
+        Ensures the liveness gate does not break the actual bank-serialization
+        invariant: two live workers must not consolidate the same bank concurrently.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # A live processing row: updated_at = just now (active worker).
+        live_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'live-worker-A', now(), now())
+            """,
+            live_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(live_id)}),
+        )
+
+        # Pending task for the same bank.
+        pending_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            pending_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(pending_id)}),
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        claimed = await poller.claim_batch()
+        claimed_ids = {c.operation_id for c in claimed}
+
+        assert str(pending_id) not in claimed_ids, (
+            "Worker must NOT claim a consolidation task while a live (recently updated) "
+            "processing row exists for the same bank. Bank-serialization invariant must hold."
+        )
+
+    @pytest.mark.asyncio
+    async def test_recover_orphaned_tasks_resets_cross_worker_stale_rows(self, pool, backend, clean_operations):
+        """_recover_orphaned_tasks must reset stale processing rows from other workers.
+
+        Scenario: worker_A died; its row is >1h stale. Worker_B starts up and calls
+        _recover_orphaned_tasks. The row must be reset to pending so it can be claimed.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test_worker_recovery_{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # Orphaned row from dead worker_A, updated 2h ago.
+        orphan_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', NULL, 'dead-worker-A', now(), now() - INTERVAL '2 hours')
+            """,
+            orphan_id,
+            bank_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        recovered = await poller._recover_orphaned_tasks()
+
+        row = await pool.fetchrow(
+            "SELECT status, worker_id FROM async_operations WHERE operation_id = $1",
+            orphan_id,
+        )
+
+        assert row["status"] == "pending", (
+            "_recover_orphaned_tasks must reset stale cross-worker processing rows to pending. "
+            "Regression: worker_id filter was too strict (only matched own worker_id)."
+        )
+        assert row["worker_id"] is None
+        assert recovered >= 1
+
+    @pytest.mark.asyncio
+    async def test_recover_orphaned_tasks_does_not_reset_fresh_cross_worker_rows(
+        self, pool, backend, clean_operations
+    ):
+        """_recover_orphaned_tasks must NOT reset a fresh processing row from another worker.
+
+        A row from a different worker that was updated <1h ago is assumed to be live.
+        Resetting it would cause duplicate consolidation runs.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test_worker_recovery_{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        fresh_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', NULL, 'live-worker-A', now(), now() - INTERVAL '5 minutes')
+            """,
+            fresh_id,
+            bank_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        await poller._recover_orphaned_tasks()
+
+        row = await pool.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            fresh_id,
+        )
+
+        assert row["status"] == "processing", (
+            "_recover_orphaned_tasks must not disturb a recently-updated processing row "
+            "belonging to another worker (could be a live worker's task)."
+        )


### PR DESCRIPTION
## Why

When a worker dies mid-consolidation (container restart, OOM), its `async_operations` row stays in `status='processing'` indefinitely. The current bank-serialization filter in `claim_tasks()` has no liveness check — it treats that orphaned row as a live lock and excludes the bank from all subsequent claim queries. Result: free reserved slot + `claimable=N` but zero tasks ever claimed, surviving container restarts, forever.

Reported in #1470 with a 5-day reproduction on a single-tenant 0.5.6 deployment.

## Root cause

Two-part chain:

**1. `ops_postgresql.py` — no liveness check on `busy_banks`**

Both the Phase 1 reserved-pool query (line 739) and Phase 2b shared-pool query (line 844) build a `busy_bank_ids` list from:

```sql
SELECT DISTINCT bank_id FROM {table}
WHERE operation_type = 'consolidation' AND status = 'processing'
```

No `updated_at` guard. A row stuck in `processing` for days matches identically to one a live worker is actively touching.

**2. `poller.py` `_recover_orphaned_tasks()` — `worker_id = $1` predicate**

Startup recovery resets rows with `worker_id = $1` (own worker only). A container restart gives the new worker a fresh `worker_id`, so the orphaned row from the old worker is never reset and survives restarts indefinitely.

The `[PENDING_BREAKDOWN]` logger doesn't apply the bank-busy filter — it only checks `payload_null`/`retry_blocked`/`assigned` — so it kept reporting `claimable=5` while the claim path silently excluded the bank. The mismatch is what made the symptom look paradoxical.

## Fix

**A. `ops_postgresql.py` (runtime self-healing)** — add a liveness gate to both `busy_banks` queries:

```sql
AND updated_at > NOW() - INTERVAL '1 hour'
```

A `processing` row untouched for >1h is treated as dead and stops blocking the bank. Threshold is intentionally conservative: real consolidation jobs complete in seconds to a few minutes; 1h gives headroom for legitimate slow runs while recovering without any restart.

**B. `poller.py` (startup recovery)** — broaden `_recover_orphaned_tasks()` to also reset stale cross-worker rows:

```sql
WHERE status = 'processing'
  AND result_metadata->>'batch_id' IS NULL
  AND (
    worker_id = $1
    OR updated_at < NOW() - INTERVAL '1 hour'
  )
```

Catches the container-restart case on the very next startup.

No migration required — `updated_at` is present in the initial schema (`5a366d414dce`) and is written on every claim/update transition (confirmed at `ops_postgresql.py:935`).

## Test plan

Four new tests in `TestOrphanedProcessingRowLiveness` (`tests/test_worker.py`):

- `test_stale_processing_row_does_not_block_claim` — pending task is claimed when the only blocking row is >1h stale (primary regression case)
- `test_fresh_processing_row_still_blocks_claim` — bank-serialization invariant preserved for recently-updated processing rows (no regression on the happy path)
- `test_recover_orphaned_tasks_resets_cross_worker_stale_rows` — startup recovery resets stale rows from other workers
- `test_recover_orphaned_tasks_does_not_reset_fresh_cross_worker_rows` — startup recovery leaves recently-updated cross-worker rows alone

All four pass locally. Run with:
```bash
cd hindsight-api-slim && uv run pytest tests/test_worker.py::TestOrphanedProcessingRowLiveness -v
```

Fixes #1470