### PR TITLE
chore: stabilize CI — docs-skill pre-commit hook + retain dict-mutation fix

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -18,7 +18,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import asyncpg
 import httpx
@@ -2297,6 +2297,12 @@ class MemoryEngine(MemoryEngineInterface):
             result = await self._validate_operation(self._operation_validator.validate_retain(ctx))
             if result and result.contents is not None:
                 contents = result.contents
+
+        # Engine-owned copy: the orchestrator clears per-item "content" strings
+        # after building the document's combined text (memory pressure
+        # optimization, see retain/orchestrator.py). Without an internal copy
+        # those mutations leak back to the caller's dicts.
+        contents = cast(list[RetainContentDict], [dict(c) for c in contents])
 
         # Apply batch-level document_id to contents that don't have their own (backwards compatibility)
         if document_id:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1056,6 +1056,9 @@ async def _streaming_retain_batch(
         is_last: bool,
     ) -> None:
         """Run Phase 1 + Phase 2 + Phase 3 for a batch of pre-extracted chunks."""
+        # Allow clearing combined_content after the no-facts skip path runs
+        # doc tracking — see the assignment further below.
+        nonlocal combined_content
         # Combine results from individual chunk extractions
         batch_contents: list[RetainContent] = []
         batch_extracted: list = []
@@ -1127,6 +1130,10 @@ async def _streaming_retain_batch(
                                 ops=pool.ops,
                             )
                         doc_tracking_done[0] = True
+                        # Memory: combined_content has been persisted; release
+                        # it now so the rest of the consumer loop doesn't pin
+                        # a multi-MB string. Nothing reads it after tracking.
+                        combined_content = ""
                         log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (0 facts in first batch)")
             log_buffer.append(
                 f"[streaming] Consumer batch {consumer_batch_idx + 1}: "
@@ -1140,6 +1147,9 @@ async def _streaming_retain_batch(
         )
 
         async def _run_mini_batch_db_work() -> None:
+            # Allow clearing combined_content after the doc-tracking call so
+            # subsequent batches don't carry the per-document text in memory.
+            nonlocal combined_content
             entity_resolver.discard_pending_stats()
             mb_start = time.time()
 
@@ -1231,6 +1241,10 @@ async def _streaming_retain_batch(
                             )
                             log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (full content)")
                         doc_tracking_done[0] = True
+                        # Memory: combined_content is no longer needed after
+                        # this first-batch tracking call. Release it so the
+                        # remaining consumer batches don't pin the string.
+                        combined_content = ""
                     else:
                         # --- Later batches: verify we still own the document ---
                         # If another request took over (cascade-deleted our doc and
@@ -1405,6 +1419,9 @@ async def _streaming_retain_batch(
                             ops=pool.ops,
                         )
                     doc_tracking_done[0] = True
+                    # Memory: combined_content has been persisted and won't be
+                    # read again — release the per-document text now.
+                    combined_content = ""
                     log_buffer.append(f"[streaming] Document {effective_doc_id} tracked (no facts extracted)")
 
         # Mark facts as committed in operation metadata (crash recovery checkpoint)

--- a/scripts/hooks/generate-docs-skill.sh
+++ b/scripts/hooks/generate-docs-skill.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Pre-commit hook: keep skills/hindsight-docs/ in sync with hindsight-docs/
+# sources. CI's verify-generated-files job regenerates and fails the build on
+# drift; this hook catches it locally first so PR authors don't ship a commit
+# that needs a follow-up "regenerate docs skill" patch.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+"$REPO_ROOT/scripts/generate-docs-skill.sh" >/dev/null
+
+if ! git diff --quiet -- skills/hindsight-docs/; then
+    echo ""
+    echo "  ❌ skills/hindsight-docs/ was out of sync with hindsight-docs/ sources."
+    echo "     The generator just refreshed it — stage the regen and re-commit:"
+    echo "       git add skills/hindsight-docs/"
+    echo ""
+    git diff --stat -- skills/hindsight-docs/ | sed 's/^/         /'
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
Two unrelated CI-stability fixes bundled together since they came out of the same investigation.

## 1. Pre-commit hook for `generate-docs-skill.sh`

Background: the `verify-generated-files` CI job has been failing on **9 of the last 11 main runs (~82%)** because PRs touch `hindsight-docs/src/pages/changelog/` or `hindsight-docs/static/openapi.json` without re-running `./scripts/generate-docs-skill.sh`. The committed copy under `skills/hindsight-docs/references/` falls out of sync.

The fix is a tiny pre-commit hook (`scripts/hooks/generate-docs-skill.sh`) that the existing `.githooks/pre-commit` dispatcher picks up automatically. It regenerates the skill on every commit and fails the commit if drift is detected, with a message pointing the author at `git add skills/hindsight-docs/`. Verified locally: clean tree passes; staged-source-without-skill-regen drift fails with a clear diff stat.

## 2. Stop mutating caller-provided content dicts in `retain_batch_async`

Background: PR #1398 (`fix(retain): reduce memory pressure by clearing content references after use`) added this to `_streaming_retain_batch`:

```python
combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
for d in contents_dicts:
    d.pop("content", None)
```

The intent is correct — `combined_content` holds the canonical document, so per-item content refs are redundant in the engine. The bug is that `contents_dicts` *is the caller's list of dicts* (forwarded all the way from `memory_engine.retain_batch_async` through `_retain_batch_async_internal` into `orchestrator.retain_batch(contents_dicts=contents)`). So the pop reaches back and strips `"content"` from the caller's input. Any caller that still references its `contents` list after the call hits `KeyError: 'content'`.

This is what made `test_extensions.py::TestOperationHooksParameters::test_retain_pre_hook_receives_all_parameters` fail intermittently — the streaming path hits the pop, non-streaming paths don't, hence ~27% flake rate.

### Fix

- **`memory_engine.py`:** take an engine-owned shallow copy after the validator hook (`contents = cast(list[RetainContentDict], [dict(c) for c in contents])`). Adds ~150 bytes per item; strings are shared by reference, so no actual content duplication.
- **`orchestrator.py`:** clear `combined_content` immediately after each `handle_document_tracking` / `upsert_document_metadata` call in `_streaming_retain_batch` (three first-batch sites: no-facts skip, mini-batch DB work, post-loop fallback). Once tracking writes the document, nothing reads `combined_content` again. `nonlocal` declarations needed because Python infers `combined_content` as local when any branch assigns to it.

### Memory profile

| Caller shape | PR #1398 (buggy) | After this fix |
|---|---|---|
| Benchmark (caller releases reference at call time) | 1.3x sustained | 1.3x sustained + brief 2x peak before tracking completes |
| HTTP / FastAPI (request body alive through handler) | no real saving (strings live through request anyway) | identical to before |

All other PR #1398 optimizations (chunks, batch lists, `sanitized_content`, RetainContent.content) are unaffected — they operate on engine-owned data.

## Test plan

- [x] Locally: target test `TestOperationHooksParameters::test_retain_pre_hook_receives_all_parameters` passes (was flaking on main).
- [x] Locally: 28/29 of `test_extensions.py` (excluding `not hs_llm_mat`) passes; the single remaining failure (`test_retain_post_hook_receives_all_parameters_and_result` asserting `llm_input_tokens > 0`) is a pre-existing flake in mock-LLM environments — confirmed identical failure on bare `main`.
- [x] Locally: pre-commit hook fires correctly on simulated drift; clean tree passes.
- [ ] CI green (or only flakes on the known unrelated jobs: bedrock LLM acceptance, vertexai LLM acceptance, test-typescript-client-oracle Oracle listener race).