### PR TITLE
ci(release): add --provenance to npm publish (required for n8n Verified)

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -117,7 +117,7 @@ jobs:
       working-directory: ./hindsight-integrations/${{ steps.info.outputs.integration }}
       run: |
         set +e
-        OUTPUT=$(npm publish --access public 2>&1)
+        OUTPUT=$(npm publish --access public --provenance 2>&1)
         EXIT_CODE=$?
         echo "$OUTPUT"
         if [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary

Adds \`--provenance\` to the \`npm publish\` step in \`release-integration.yml\` so TypeScript integration packages — specifically \`@vectorize-io/n8n-nodes-hindsight\` — are published with build provenance attestations.

## Why

n8n's policy [as of 2026-05-01](https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/) only accepts community nodes for **Verified** status (the gate to n8n Cloud distribution) when they are published from GitHub Actions with provenance statements. Locally-published packages are rejected.

Without this flag, our first attempt to submit \`@vectorize-io/n8n-nodes-hindsight\` for Verified review will be auto-rejected.

## Pre-conditions (already met)

- Job already declares \`permissions: id-token: write\` (was added for PyPI trusted publishing — also required for npm provenance via \`NODE_AUTH_TOKEN\`).
- Node 22 setup, registry-url, NPM_TOKEN — all already wired.

## Test plan

- [ ] Cut a TS integration release tag (e.g. \`integrations/n8n/v0.1.1\`) once merged → confirm the published package on npmjs.com has the "Provenance" badge in its sidebar.
- [ ] Submit to n8n Creator Portal for Verified review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)