### PR TITLE
fix(docker): chmod 755 /home/hindsight for --user UID:GID support

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -172,6 +172,10 @@ USER hindsight
 # "Permission denied" error when mounting a fresh root-owned volume.
 RUN mkdir -p /home/hindsight/.pg0
 
+# Make /home/hindsight traversable when running with --user UID:GID overrides
+# (default 0700 blocks traversal by non-owner UIDs needed for bind-mount ownership matching)
+RUN chmod 755 /home/hindsight
+
 ENV PATH="/app/api/.venv/bin:${PATH}"
 
 # Pre-download tiktoken encoding (ALWAYS - required for token counting even in air-gapped envs)
@@ -327,6 +331,10 @@ USER hindsight
 # volumes with correct ownership (UID 1000) on first use, avoiding the
 # "Permission denied" error when mounting a fresh root-owned volume.
 RUN mkdir -p /home/hindsight/.pg0
+
+# Make /home/hindsight traversable when running with --user UID:GID overrides
+# (default 0700 blocks traversal by non-owner UIDs needed for bind-mount ownership matching)
+RUN chmod 755 /home/hindsight
 
 ENV PATH="/app/api/.venv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Adds `chmod 755 /home/hindsight` in both `api-only` and `standalone` Dockerfile stages
- Fixes permission denied when running with `--user UID:GID` for bind-mount ownership matching
- No-op for users running as the default `hindsight` user (uid 1000)

Closes #1481

## Test plan
- [ ] Build image: `docker build -t hindsight-test -f docker/standalone/Dockerfile .`
- [ ] Verify default user still works: `docker run --rm hindsight-test ls /home/hindsight`
- [ ] Verify custom UID works: `docker run --rm --user 1001:1001 hindsight-test ls /home/hindsight`