### PR TITLE
feat(cli): add --strategy flag to memory retain-files

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -269,6 +269,7 @@ impl ApiClient {
         bank_id: &str,
         files: Vec<(String, Vec<u8>)>,
         context: Option<String>,
+        strategy: Option<String>,
         verbose: bool,
     ) -> Result<FileRetainResult> {
         self.runtime.block_on(async {
@@ -283,6 +284,9 @@ impl ApiClient {
                     let mut meta = serde_json::json!({});
                     if let Some(ctx) = &context {
                         meta["context"] = serde_json::Value::String(ctx.clone());
+                    }
+                    if let Some(strat) = &strategy {
+                        meta["strategy"] = serde_json::Value::String(strat.clone());
                     }
                     // Use filename stem as document_id for deduplication
                     if let Some(stem) = std::path::Path::new(name)

--- a/hindsight-cli/src/commands/memory.rs
+++ b/hindsight-cli/src/commands/memory.rs
@@ -498,6 +498,7 @@ pub fn retain(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn retain_files(
     client: &ApiClient,
     agent_id: &str,
@@ -505,6 +506,7 @@ pub fn retain_files(
     recursive: bool,
     context: Option<String>,
     r#async: bool,
+    strategy: Option<String>,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -567,7 +569,8 @@ pub fn retain_files(
             pb.inc(1);
         }
 
-        let result = client.file_retain(agent_id, file_data, context.clone(), verbose)?;
+        let result =
+            client.file_retain(agent_id, file_data, context.clone(), strategy.clone(), verbose)?;
         all_operation_ids.extend(result.operation_ids);
     }
 

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -619,6 +619,10 @@ enum MemoryCommands {
         /// Queue for background processing
         #[arg(long)]
         r#async: bool,
+
+        /// Named retain strategy to use for these files (overrides the bank's default strategy)
+        #[arg(short = 's', long)]
+        strategy: Option<String>,
     },
 
     /// Delete a memory unit
@@ -1449,6 +1453,7 @@ fn run() -> Result<()> {
                 recursive,
                 context,
                 r#async,
+                strategy,
             } => commands::memory::retain_files(
                 &client,
                 &bank_id,
@@ -1456,6 +1461,7 @@ fn run() -> Result<()> {
                 recursive,
                 context,
                 r#async,
+                strategy,
                 verbose,
                 output_format,
             ),


### PR DESCRIPTION
## Summary
- Adds a `--strategy` / `-s` flag to `hindsight memory retain-files`, letting callers pick a named retain strategy at the CLI per [#1492](https://github.com/vectorize-io/hindsight/issues/1492).
- Threads the value through `commands::memory::retain_files` and `ApiClient::file_retain` into each `files_metadata` entry in the multipart payload.
- Server side already accepts per-file `strategy` in `FileRetainMetadata`, so no API or generated-client changes are required.

## Test plan
- [x] `cargo build` (hindsight-cli) — clean
- [x] `cargo test --bin hindsight commands::memory` — 9 passed
- [x] `./scripts/hooks/lint.sh` — clean
- [x] `hindsight memory retain-files --help` — shows new `-s, --strategy <STRATEGY>` flag
- [ ] Manual end-to-end: ingest files into a bank that has a non-default `retain_strategies` map and confirm the named strategy is applied

Closes #1492