### PR TITLE
ci: cosign-sign published GHCR images (manual workflow)

### DIFF
--- a/.github/workflows/sign-images.yml
+++ b/.github/workflows/sign-images.yml
@@ -1,0 +1,71 @@
+name: Sign published images
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to sign (without leading v, e.g. 0.6.0)'
+        required: true
+        type: string
+        default: '0.6.0'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  sign:
+    name: Sign ${{ matrix.image }}:${{ inputs.version }}${{ matrix.suffix }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: hindsight-api, suffix: '' }
+          - { image: hindsight-api, suffix: '-slim' }
+          - { image: hindsight-control-plane, suffix: '' }
+          - { image: hindsight, suffix: '' }
+          - { image: hindsight, suffix: '-slim' }
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Resolve image digest
+        id: resolve
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          TAG: ${{ inputs.version }}${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [[ -z "${DIGEST}" || "${DIGEST}" != sha256:* ]]; then
+            echo "Failed to resolve digest for ${IMAGE}:${TAG} (got: ${DIGEST})" >&2
+            exit 1
+          fi
+          echo "Resolved ${IMAGE}:${TAG} -> ${DIGEST}"
+          echo "ref=${IMAGE}@${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign image
+        env:
+          REF: ${{ steps.resolve.outputs.ref }}
+        run: cosign sign --yes "${REF}"
+
+      - name: Verify signature
+        env:
+          REF: ${{ steps.resolve.outputs.ref }}
+        run: |
+          cosign verify "${REF}" \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/sign-images\.yml@.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sign-images.yml`, a manual `workflow_dispatch` workflow that resolves each published image tag to its manifest digest, signs it with keyless OIDC via cosign, and verifies the signature in the same job.
- Decoupled from `release.yml` so we can backfill **v0.6.0** (and prior versions) without coupling supply-chain signing to the next release cut.
- Once we have a green run + a successful local `cosign verify`, a follow-up PR will fold the same `cosign sign` step into `release.yml` so future releases sign automatically.

Refs #1484.

## Why a separate workflow first?
Inline signing in `release.yml` would only be exercisable by cutting a real release, and a green run with `continue-on-error` doesn't actually prove the signature is verifiable. This standalone path lets us:
- Backfill signatures for already-published images (starting with v0.6.0).
- Iterate on the cosign / OIDC / cert-identity wiring without risking a release.

## Design notes
- **Sign by digest, not by tag.** `docker buildx imagetools inspect` resolves the tag to its content-addressed digest; `cosign sign` runs against `image@sha256:…`. Tags are mutable; digests are not.
- **Matrix mirrors `release.yml`** — `hindsight-api`, `hindsight-api:-slim`, `hindsight-control-plane`, `hindsight`, `hindsight:-slim`. `fail-fast: false` so one bad image doesn't kill the others.
- **Cert identity pinned to this workflow path** in the verify step, so a green run proves end-to-end verifiability — not just that `cosign sign` exited 0.
- **Permissions:** `id-token: write` for the OIDC token, `packages: write` to push signature artifacts to GHCR.

## Test plan
- [ ] Trigger workflow manually against `ci/cosign-sign-images` with `version=0.6.0`. Confirm all 5 matrix jobs pass.
- [ ] From a local machine (not a runner), run `cosign verify ghcr.io/vectorize-io/hindsight@<digest> --certificate-identity-regexp '^https://github\.com/vectorize-io/hindsight/\.github/workflows/sign-images\.yml@.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com` against each of the 5 signed images and confirm verification succeeds.
- [ ] Confirm signature artifacts are visible in GHCR alongside the image (look for `sha256-<digest>.sig` tags).
- [ ] Open follow-up PR adding the same sign step inline in `release.yml` for future releases, plus a docs update on `hindsight.vectorize.io` documenting the verification command.