### PR TITLE
docs(env): document HINDSIGHT_API_READ_DATABASE_URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 
 # Database (Optional - uses embedded pg0 by default)
 # HINDSIGHT_API_DATABASE_URL=postgresql://user:pass@host:5432/db
+# HINDSIGHT_API_READ_DATABASE_URL=  # Optional read-replica URL. When set, recall queries (semantic, BM25, graph, temporal) flow through a separate pool against this URL, offloading the primary. Typically points to a read-only endpoint (CNPG's <cluster>-ro service or Aurora reader endpoint).
 # HINDSIGHT_API_MIGRATION_DATABASE_URL=  # Direct PostgreSQL URL for migrations (bypasses PgBouncer). Falls back to DATABASE_URL.
 # HINDSIGHT_API_DATABASE_SCHEMA=public  # PostgreSQL schema name (default: public)
 


### PR DESCRIPTION
## Summary

PR #1460 (cdbartholomew, merged 2026-05-06 by @nicoloboschi) added an optional read-only database backend wired through three new env vars:
- `HINDSIGHT_API_READ_DATABASE_URL`
- `HINDSIGHT_API_READ_DB_POOL_MIN_SIZE`
- `HINDSIGHT_API_READ_DB_POOL_MAX_SIZE`

The authoritative reference (`hindsight-docs/docs/developer/configuration.md`) was updated in the same PR. `.env.example`, however, still lists only `DATABASE_URL` / `MIGRATION_DATABASE_URL` / `DATABASE_SCHEMA` in the **Database** section — anyone copying that file as their starting point misses the new read-replica knob.

## Change

One commented line added to the **Database** section of `.env.example`, mirroring the new operator-facing var:

```
# HINDSIGHT_API_READ_DATABASE_URL=  # Optional read-replica URL. When set, recall queries (semantic, BM25, graph, temporal) flow through a separate pool against this URL, offloading the primary. Typically points to a read-only endpoint (CNPG's <cluster>-ro service or Aurora reader endpoint).
```

The two read-pool sizing vars are intentionally **not** added — `.env.example`'s current Database section only documents the user-facing connection knobs (it doesn't list `DB_POOL_MIN_SIZE` / `DB_POOL_MAX_SIZE` either), so adding only their READ-replica counterparts would be inconsistent. They remain documented in `hindsight-docs/docs/developer/configuration.md`.

Phrasing pulled verbatim from the config-doc table to keep the two sources byte-aligned.