### PR TITLE
fix(embed): default Apple Silicon reranker to RRF

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -380,6 +380,23 @@ class DaemonEmbedManager(EmbedManager):
             if "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU" not in env:
                 env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
 
+            # On Apple Silicon, forcing the local SentenceTransformers
+            # cross-encoder to CPU avoids MPS startup hangs but does not avoid
+            # SIGBUS crashes seen during local reranker inference in embedded
+            # daemon mode (notably during consolidation recall/rerank). The
+            # crash is a native PyTorch/SentenceTransformers failure and cannot
+            # be caught by Python exception handling, so prefer the RRF
+            # passthrough reranker unless the user explicitly opts into another
+            # provider.
+            if platform.machine().lower() in {"arm64", "aarch64"} and "HINDSIGHT_API_RERANKER_PROVIDER" not in env:
+                env["HINDSIGHT_API_RERANKER_PROVIDER"] = "rrf"
+                logger.warning(
+                    "Apple Silicon embedded daemon detected; defaulting "
+                    "HINDSIGHT_API_RERANKER_PROVIDER=rrf to avoid local "
+                    "cross-encoder SIGBUS crashes. Set "
+                    "HINDSIGHT_API_RERANKER_PROVIDER explicitly to override."
+                )
+
         # Get idle timeout from env
         idle_timeout = int(env.get("HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT", str(DEFAULT_DAEMON_IDLE_TIMEOUT)))
 

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -282,6 +282,89 @@ def test_macos_forces_cpu_for_local_embeddings_and_reranker(temp_home, monkeypat
     assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "1"
 
 
+def test_macos_arm64_defaults_reranker_to_rrf(temp_home, monkeypatch):
+    """Apple Silicon embedded daemons should avoid the local cross-encoder by default.
+
+    FORCE_CPU avoids MPS startup hangs, but local SentenceTransformers reranker
+    inference can still SIGBUS the embedded daemon on macOS ARM64. Default to
+    the RRF passthrough reranker unless the user explicitly selects a provider.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.delenv("HINDSIGHT_API_RERANKER_PROVIDER", raising=False)
+
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+        patch("hindsight_embed.daemon_embed_manager.platform.machine", return_value="arm64"),
+    ):
+        manager._start_daemon(
+            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
+            profile="",
+        )
+
+    assert captured["env"].get("HINDSIGHT_API_RERANKER_PROVIDER") == "rrf"
+
+
+def test_macos_arm64_reranker_default_respects_explicit_provider(temp_home, monkeypatch):
+    """Users can explicitly opt back into local or select a remote reranker."""
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.setenv("HINDSIGHT_API_RERANKER_PROVIDER", "local")
+
+    manager = DaemonEmbedManager()
+    captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
+        patch("hindsight_embed.daemon_embed_manager.platform.machine", return_value="arm64"),
+    ):
+        manager._start_daemon(
+            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
+            profile="",
+        )
+
+    assert captured["env"].get("HINDSIGHT_API_RERANKER_PROVIDER") == "local"
+
+
 def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, monkeypatch):
     """Regression test: HINDSIGHT_* keys in profile .env must reach the daemon subprocess env.
 


### PR DESCRIPTION
## Summary

- Default Apple Silicon embedded daemons to `HINDSIGHT_API_RERANKER_PROVIDER=rrf` when the user has not explicitly selected a reranker provider.
- Keep existing macOS force-CPU defaults for local embeddings/reranker.
- Add regression tests for the Apple Silicon RRF default and for respecting an explicit reranker provider override.

## Why

On macOS ARM64, the local SentenceTransformers cross-encoder reranker can hard-crash the embedded daemon with `Fatal Python error: Bus error` during consolidation recall/rerank. This is a native PyTorch/SentenceTransformers crash, so it cannot be handled as a normal Python exception inside the worker task.

In an isolated local embedded repro:

- `HINDSIGHT_API_LAZY_RERANKER=true` did not prevent the crash once local reranker inference was reached.
- `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=1` did not prevent the crash.
- `HINDSIGHT_API_RERANKER_PROVIDER=rrf` avoided the crash in the same overlapping retain/consolidation scenario and recall succeeded.

This mitigation is limited to Apple Silicon embedded daemons and only applies when the user has not explicitly configured a reranker provider. Users can still opt back into local reranking or select a remote reranker by setting `HINDSIGHT_API_RERANKER_PROVIDER`.

## Test Plan

```bash
cd hindsight-embed
uv run pytest tests/test_profile_daemon_config.py -q
uv run ruff check hindsight_embed/daemon_embed_manager.py tests/test_profile_daemon_config.py
uv run ruff format --check hindsight_embed/daemon_embed_manager.py tests/test_profile_daemon_config.py
```

Results locally:

```text
14 passed in 0.20s
All checks passed!
2 files already formatted
```

## Related

- Related to #270
- Related to #1394
- RRF passthrough ranking behavior is related to #957


Fixes #1497
