### PR TITLE
docs(cli): document --strategy flag for memory retain-files

### DIFF
--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -104,6 +104,9 @@ hindsight memory retain-files <bank_id> ./documents/
 # With context
 hindsight memory retain-files <bank_id> meeting-notes.txt --context "team meeting"
 
+# With a named retain strategy (see retain_strategies in bank config)
+hindsight memory retain-files <bank_id> ./documents/ --strategy conversations
+
 # Background processing
 hindsight memory retain-files <bank_id> ./data/ --async
 ```

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -104,6 +104,9 @@ hindsight memory retain-files <bank_id> ./documents/
 # With context
 hindsight memory retain-files <bank_id> meeting-notes.txt --context "team meeting"
 
+# With a named retain strategy (see retain_strategies in bank config)
+hindsight memory retain-files <bank_id> ./documents/ --strategy conversations
+
 # Background processing
 hindsight memory retain-files <bank_id> ./data/ --async
 ```


### PR DESCRIPTION
## Summary

PR #1494 added a `--strategy` / `-s` flag to `hindsight memory retain-files`, but `hindsight-docs/docs/sdks/cli.md` and the dual-doc mirror in `skills/hindsight-docs/references/sdks/cli.md` still only show `--context` and `--async` examples. This PR adds the missing `--strategy` example so callers can discover the new flag without running `--help`.

The example uses `--strategy conversations` to match the named strategy already documented as `retain_default_strategy: "conversations"` in the retain_strategies bank-config docs.

## Test plan
- [x] Diff is dual-doc mirrored (two identical 3-line additions)
- [x] Cross-checked example against retain_strategies docs in `developer/configuration.md`
- [x] Cross-checked CLI flag exists in `hindsight-cli/src/main.rs` (PR #1494, commit landed 2026-05-06)