### PR TITLE
ci: cosign-sign release images + document verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,6 +314,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       matrix:
         include:
@@ -410,6 +411,7 @@ jobs:
 
     # Build multi-platform and push to release tags
     - name: Build and push release images
+      id: build
       uses: docker/build-push-action@v7
       with:
         context: .
@@ -420,6 +422,31 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v3
+
+    - name: Sign published images
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        set -euo pipefail
+        refs=()
+        while IFS= read -r tag; do
+          [[ -z "${tag}" ]] && continue
+          refs+=("${tag}@${DIGEST}")
+        done <<< "${TAGS}"
+        cosign sign --yes "${refs[@]}"
+
+    - name: Verify signature on primary tag
+      env:
+        IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        cosign verify "${IMAGE}@${DIGEST}" \
+          --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yml@.*" \
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
   release-helm-chart:
     runs-on: ubuntu-latest

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -83,6 +83,8 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
+All published images are [signed with Cosign](#verifying-image-signatures) — verification is optional.
+
 ### Docker Image Variants
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
@@ -111,17 +113,13 @@ ghcr.io/vectorize-io/hindsight-control-plane:latest
 
 ### Verifying image signatures
 
-Hindsight images published to GHCR are signed with [Sigstore Cosign](https://docs.sigstore.dev/cosign/signing/overview/) using keyless OIDC from the release workflow. Verification is optional — pulling and running images works without it — but recommended for production deployments that want to confirm an image was built by Vectorize from the published source.
-
-Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/), then verify any tag:
+Images are signed with [Cosign](https://docs.sigstore.dev/cosign/signing/overview/) keyless OIDC. To verify any tag:
 
 ```bash
 cosign verify ghcr.io/vectorize-io/hindsight:<tag> \
   --certificate-identity-regexp '^https://github\.com/vectorize-io/hindsight/\.github/workflows/(sign-images|release)\.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
-
-A successful run prints the signature payload and exits 0. The same command works for `hindsight-api` and `hindsight-control-plane` images. Signatures are tied to the image content (digest), not the tag — verifying a moved tag re-checks the new digest's signature automatically.
 
 ---
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -109,6 +109,20 @@ ghcr.io/vectorize-io/hindsight-api:latest-slim
 ghcr.io/vectorize-io/hindsight-control-plane:latest
 ```
 
+### Verifying image signatures
+
+Hindsight images published to GHCR are signed with [Sigstore Cosign](https://docs.sigstore.dev/cosign/signing/overview/) using keyless OIDC from the release workflow. Verification is optional — pulling and running images works without it — but recommended for production deployments that want to confirm an image was built by Vectorize from the published source.
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/), then verify any tag:
+
+```bash
+cosign verify ghcr.io/vectorize-io/hindsight:<tag> \
+  --certificate-identity-regexp '^https://github\.com/vectorize-io/hindsight/\.github/workflows/(sign-images|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A successful run prints the signature payload and exits 0. The same command works for `hindsight-api` and `hindsight-control-plane` images. Signatures are tied to the image content (digest), not the tag — verifying a moved tag re-checks the new digest's signature automatically.
+
 ---
 
 ## Helm / Kubernetes

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -83,6 +83,8 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 - **API Server**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
+All published images are [signed with Cosign](#verifying-image-signatures) — verification is optional.
+
 ### Docker Image Variants
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
@@ -111,17 +113,13 @@ ghcr.io/vectorize-io/hindsight-control-plane:latest
 
 ### Verifying image signatures
 
-Hindsight images published to GHCR are signed with [Sigstore Cosign](https://docs.sigstore.dev/cosign/signing/overview/) using keyless OIDC from the release workflow. Verification is optional — pulling and running images works without it — but recommended for production deployments that want to confirm an image was built by Vectorize from the published source.
-
-Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/), then verify any tag:
+Images are signed with [Cosign](https://docs.sigstore.dev/cosign/signing/overview/) keyless OIDC. To verify any tag:
 
 ```bash
 cosign verify ghcr.io/vectorize-io/hindsight:<tag> \
   --certificate-identity-regexp '^https://github\.com/vectorize-io/hindsight/\.github/workflows/(sign-images|release)\.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
-
-A successful run prints the signature payload and exits 0. The same command works for `hindsight-api` and `hindsight-control-plane` images. Signatures are tied to the image content (digest), not the tag — verifying a moved tag re-checks the new digest's signature automatically.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -109,6 +109,20 @@ ghcr.io/vectorize-io/hindsight-api:latest-slim
 ghcr.io/vectorize-io/hindsight-control-plane:latest
 ```
 
+### Verifying image signatures
+
+Hindsight images published to GHCR are signed with [Sigstore Cosign](https://docs.sigstore.dev/cosign/signing/overview/) using keyless OIDC from the release workflow. Verification is optional — pulling and running images works without it — but recommended for production deployments that want to confirm an image was built by Vectorize from the published source.
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/), then verify any tag:
+
+```bash
+cosign verify ghcr.io/vectorize-io/hindsight:<tag> \
+  --certificate-identity-regexp '^https://github\.com/vectorize-io/hindsight/\.github/workflows/(sign-images|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A successful run prints the signature payload and exits 0. The same command works for `hindsight-api` and `hindsight-control-plane` images. Signatures are tied to the image content (digest), not the tag — verifying a moved tag re-checks the new digest's signature automatically.
+
 ---
 
 ## Helm / Kubernetes


### PR DESCRIPTION
## Summary
- Folds the cosign signing flow (proven on 0.6.0 backfill via #1495 / `sign-images.yml`) into `release.yml`, so future release tags get signed automatically alongside the build.
- Adds a "Verifying image signatures" subsection to the Docker section of `docs/developer/installation.md` so downstream consumers know that signing exists and how to verify.

Closes #1484.

## What changes in `release.yml`
- Adds `id-token: write` permission on the `release-docker-images` job (needed for the keyless OIDC token).
- Adds `id: build` to the existing `docker/build-push-action` step so we can read `outputs.digest`.
- Installs cosign and signs every tag the `metadata-action` produced — by digest, not by tag — using `cosign sign --yes "${tag}@${digest}"`.
- Verifies the signature on the image as a sanity step (cert identity pinned to `release.yml` on this repo + the standard GitHub OIDC issuer). A green run proves end-to-end verifiability, not just that `sign` exited 0.

The `helm-chart` job is intentionally **not** modified here — Helm OCI signing has its own quirks (digest comes from `helm push` stderr, not a step output) and is better isolated in its own PR.

## What changes in the docs
A new subsection inside the Docker section of `installation.md` (and the mirrored `skills/hindsight-docs/`):
- Explains that signing exists and is opt-in for verification.
- Gives the exact `cosign verify` command with the right `--certificate-identity-regexp` and `--certificate-oidc-issuer`.
- The regex accepts both `sign-images.yml` (the backfill workflow used for 0.6.0) and `release.yml` (future releases), so a single documented command works for all signed tags.

## Test plan
- [ ] CI green on this PR.
- [ ] Next release tag triggers `release.yml`; confirm the "Sign published images" step succeeds for all 5 matrix jobs.
- [ ] After release, run `cosign verify` from a local machine against one of the new tags using exactly the command from the docs page; expect success.
- [ ] Reload the published docs site and confirm the new "Verifying image signatures" subsection renders correctly under the Docker section.
- [ ] Close #1484 once the next release ships and verification is confirmed end-to-end.