### PR TITLE
fix(worker): probe pg_proc before calling optional schemas_with_pending_work()

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
@@ -1,0 +1,161 @@
+"""Registry of optional PostgreSQL server-side routines.
+
+Some hot paths (currently only the worker poller's per-cycle scan) can be
+sped up by a server-side PL/pgSQL routine that the API never installs
+itself — operators install it out-of-band (e.g. a Helm hook in
+hindsight-cloud) when they want the optimisation. When the routine is not
+installed, callers must fall back to a pure-Python implementation.
+
+This module centralises that pattern so we don't sprinkle ad-hoc
+``try / except`` blocks (which silently log a server-side error on every
+call) around the codebase. Each registered entry carries:
+
+* a ``schema`` and ``name`` (used to probe ``pg_proc``)
+* the install SQL, kept next to the registration so anyone who greps for
+  the routine name finds the canonical definition
+
+Probe behaviour:
+
+* On first ``is_installed()`` call per backend instance we issue a single
+  ``SELECT EXISTS(...) FROM pg_proc`` and cache the boolean result in
+  memory for the life of the process.
+* No TTL: if an operator installs a routine on a running cluster, workers
+  pick it up only after restart. This is intentional — these routines are
+  expected to be installed once at deploy time, and a probe-per-poll would
+  defeat the optimisation.
+* Non-PostgreSQL backends short-circuit to ``False`` without touching the
+  database, so callers can use the same code path for Oracle.
+
+PostgreSQL terminology note: ``CREATE FUNCTION ... RETURNS SETOF`` defines
+a *function* (invoked via ``SELECT``); ``CREATE PROCEDURE`` defines a
+*procedure* (invoked via ``CALL``). The SQL-standard umbrella term
+covering both is *routine*, and the system catalog (``pg_proc``) stores
+both. The module name uses "routine" so a future ``CREATE PROCEDURE``
+entry slots in without a rename.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import DatabaseBackend, DatabaseConnection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OptionalRoutine:
+    """One optional server-side routine.
+
+    Attributes:
+        name: Unqualified routine name as it appears in ``pg_proc.proname``.
+        schema: Schema the routine lives in (matched against
+            ``pg_namespace.nspname``). Defaults to ``"public"``.
+        install_sql: Canonical ``CREATE OR REPLACE`` statement, kept here
+            so operators / Helm hooks have a single source of truth.
+    """
+
+    name: str
+    schema: str
+    install_sql: str
+
+
+# Registry of known optional routines.
+#
+# Add new entries here when a hot path grows a server-side optimisation.
+# Keep the install SQL inline — duplicating it elsewhere is how it goes
+# stale.
+SCHEMAS_WITH_PENDING_WORK = OptionalRoutine(
+    name="schemas_with_pending_work",
+    schema="public",
+    install_sql="""
+        CREATE OR REPLACE FUNCTION public.schemas_with_pending_work()
+        RETURNS SETOF text AS $$
+        DECLARE
+          r RECORD; has_work BOOLEAN;
+        BEGIN
+          FOR r IN SELECT nspname FROM pg_namespace
+                   WHERE nspname LIKE 'tenant_%' LOOP
+            BEGIN
+              EXECUTE format(
+                'SELECT EXISTS(SELECT 1 FROM %I.async_operations '
+                'WHERE status = ''pending'' '
+                'AND task_payload IS NOT NULL LIMIT 1)',
+                r.nspname) INTO has_work;
+              IF has_work THEN RETURN NEXT r.nspname; END IF;
+            EXCEPTION WHEN OTHERS THEN NULL;
+            END;
+          END LOOP;
+        END $$ LANGUAGE plpgsql STABLE;
+    """,
+)
+
+_REGISTRY: dict[str, OptionalRoutine] = {
+    SCHEMAS_WITH_PENDING_WORK.name: SCHEMAS_WITH_PENDING_WORK,
+}
+
+
+class OptionalRoutines:
+    """Per-backend cache of which optional routines are installed.
+
+    One instance per long-lived consumer (e.g. one per ``WorkerPoller``).
+    Probes ``pg_proc`` lazily on first lookup and caches the result in
+    memory until the process restarts.
+    """
+
+    def __init__(self, backend: DatabaseBackend) -> None:
+        self._backend = backend
+        self._cache: dict[str, bool] = {}
+
+    async def is_installed(self, conn: DatabaseConnection, routine_name: str) -> bool:
+        """Return True iff *routine_name* exists in ``pg_proc``.
+
+        On non-PostgreSQL backends always returns False without issuing a
+        query. Result is memoised for the life of this instance.
+        """
+        if self._backend.backend_type != "postgresql":
+            return False
+
+        cached = self._cache.get(routine_name)
+        if cached is not None:
+            return cached
+
+        routine = _REGISTRY.get(routine_name)
+        if routine is None:
+            raise KeyError(f"Unknown optional routine: {routine_name!r}")
+
+        exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM pg_proc p "
+            "JOIN pg_namespace n ON p.pronamespace = n.oid "
+            "WHERE n.nspname = $1 AND p.proname = $2)",
+            routine.schema,
+            routine.name,
+        )
+        installed = bool(exists)
+        self._cache[routine_name] = installed
+        if installed:
+            logger.info(
+                "Optional PG routine %s.%s detected — using server-side path",
+                routine.schema,
+                routine.name,
+            )
+        else:
+            logger.debug(
+                "Optional PG routine %s.%s not installed — using fallback path",
+                routine.schema,
+                routine.name,
+            )
+        return installed
+
+    def invalidate(self, routine_name: str | None = None) -> None:
+        """Drop cached probe results (test helper).
+
+        Without an argument, clears the entire cache.
+        """
+        if routine_name is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(routine_name, None)

--- a/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
@@ -11,8 +11,13 @@ This module centralises that pattern so we don't sprinkle ad-hoc
 call) around the codebase. Each registered entry carries:
 
 * a ``schema`` and ``name`` (used to probe ``pg_proc``)
-* the install SQL, kept next to the registration so anyone who greps for
-  the routine name finds the canonical definition
+* a ``contract`` describing the expected signature and return shape
+
+Bodies are deliberately not stored here. Hindsight never installs these
+routines, so a body checked into this repo would (a) drift from whatever
+operators actually deploy and (b) imply ownership we don't have. The
+contract is the entire API surface: any operator-supplied implementation
+that satisfies it is interchangeable.
 
 Probe behaviour:
 
@@ -48,48 +53,63 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class OptionalRoutine:
-    """One optional server-side routine.
+    """One optional server-side routine Hindsight may call when present.
+
+    Hindsight never installs these — operators do, out-of-band. The fields
+    here describe the contract the API expects; any implementation that
+    matches is interchangeable.
 
     Attributes:
         name: Unqualified routine name as it appears in ``pg_proc.proname``.
         schema: Schema the routine lives in (matched against
-            ``pg_namespace.nspname``). Defaults to ``"public"``.
-        install_sql: Canonical ``CREATE OR REPLACE`` statement, kept here
-            so operators / Helm hooks have a single source of truth.
+            ``pg_namespace.nspname``).
+        contract: Free-form description of the expected signature,
+            arguments, return type, and any semantic constraints. Read
+            this before installing a custom implementation.
     """
 
     name: str
     schema: str
-    install_sql: str
+    contract: str
 
 
 # Registry of known optional routines.
 #
 # Add new entries here when a hot path grows a server-side optimisation.
-# Keep the install SQL inline — duplicating it elsewhere is how it goes
-# stale.
+# Document the *contract* — not the implementation — so operator-supplied
+# variants stay interchangeable and we don't pretend to own SQL we never
+# install.
 SCHEMAS_WITH_PENDING_WORK = OptionalRoutine(
     name="schemas_with_pending_work",
     schema="public",
-    install_sql="""
-        CREATE OR REPLACE FUNCTION public.schemas_with_pending_work()
-        RETURNS SETOF text AS $$
-        DECLARE
-          r RECORD; has_work BOOLEAN;
-        BEGIN
-          FOR r IN SELECT nspname FROM pg_namespace
-                   WHERE nspname LIKE 'tenant_%' LOOP
-            BEGIN
-              EXECUTE format(
-                'SELECT EXISTS(SELECT 1 FROM %I.async_operations '
-                'WHERE status = ''pending'' '
-                'AND task_payload IS NOT NULL LIMIT 1)',
-                r.nspname) INTO has_work;
-              IF has_work THEN RETURN NEXT r.nspname; END IF;
-            EXCEPTION WHEN OTHERS THEN NULL;
-            END;
-          END LOOP;
-        END $$ LANGUAGE plpgsql STABLE;
+    contract="""
+    Signature:  public.schemas_with_pending_work() RETURNS SETOF text
+
+    Called by the worker poller on every cycle to find schemas with
+    claimable async_operations rows. The poller then runs FOR UPDATE
+    SKIP LOCKED only against the returned schemas, so an empty set means
+    "nothing to do, skip the expensive claim query".
+
+    A schema is "claimable" iff at least one row matches:
+        status = 'pending' AND task_payload IS NOT NULL
+    in that schema's ``async_operations`` table.
+
+    Required semantics:
+      * No arguments.
+      * Returns a set of schema names (``text``); each must match a real
+        ``pg_namespace.nspname``. The poller passes them straight into
+        the claim query — anything that isn't a valid schema will fail.
+      * Operators choose the search scope (e.g. ``tenant_%`` only, or
+        include ``public``). A schema omitted from the scan will *never*
+        be serviced by the poller, so the implementation must cover
+        every schema that holds an ``async_operations`` table in that
+        deployment.
+      * Should be cheap and idempotent — called every poll cycle (~30s).
+
+    Fallback when the routine is absent: per-schema ``EXISTS`` queries
+    from Python (~4ms per schema). The server-side path is a single-
+    round-trip optimisation worth ~200ms in deployments with thousands
+    of tenant schemas; everything else works correctly without it.
     """,
 )
 

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -137,6 +137,11 @@ class WorkerPoller:
         self._slot_reservations: dict[str, int] = (
             slot_reservations if slot_reservations is not None else {"consolidation": 2}
         )
+        # Cache of which optional PG routines are installed on the server
+        # (probed once, memoised for the life of the poller).
+        from ..engine.db.optional_routines import OptionalRoutines
+
+        self._optional_routines = OptionalRoutines(self._backend)
         self._shutdown = asyncio.Event()
         self._current_tasks: set[asyncio.Task] = set()
         self._in_flight_count = 0
@@ -162,46 +167,22 @@ class WorkerPoller:
     async def _scan_active_schemas(self, schemas: list[str | None]) -> set[str | None]:
         """Find which schemas have pending work.
 
-        Tries a server-side PL/pgSQL function first (single DB round-trip,
-        ~200ms for 1400+ schemas). Falls back to per-schema Python EXISTS
-        queries if the function is not installed (~4ms each).
+        Prefers a server-side PL/pgSQL routine (single DB round-trip,
+        ~200ms for 1400+ schemas) when ``public.schemas_with_pending_work()``
+        is installed. The presence check goes through
+        ``OptionalRoutines.is_installed`` which probes ``pg_proc`` once and
+        caches the result, so we don't generate a server-side error on
+        every poll cycle when the routine isn't installed.
 
-        The server-side function should be installed in the ``public``
-        schema as::
-
-            CREATE OR REPLACE FUNCTION public.schemas_with_pending_work()
-            RETURNS SETOF text AS $$
-            DECLARE
-              r RECORD; has_work BOOLEAN;
-            BEGIN
-              FOR r IN SELECT nspname FROM pg_namespace
-                       WHERE nspname LIKE 'tenant_%' LOOP
-                BEGIN
-                  EXECUTE format(
-                    'SELECT EXISTS(SELECT 1 FROM %I.async_operations '
-                    'WHERE status = ''pending'' '
-                    'AND task_payload IS NOT NULL LIMIT 1)',
-                    r.nspname) INTO has_work;
-                  IF has_work THEN RETURN NEXT r.nspname; END IF;
-                EXCEPTION WHEN OTHERS THEN NULL;
-                END;
-              END LOOP;
-            END $$ LANGUAGE plpgsql STABLE;
-
-        In hindsight-cloud deployments this is installed by a Helm hook
-        job alongside ``total_pending_tasks()``.
+        Falls back to per-schema Python EXISTS queries (~4ms each) on
+        non-PostgreSQL backends or when the routine isn't installed. See
+        ``hindsight_api.engine.db.optional_routines`` for the canonical
+        install SQL.
         """
         async with self._backend.acquire() as conn:
-            # The schemas_with_pending_work() PL/pgSQL function is a
-            # PostgreSQL-specific optimisation installed by Helm hooks in
-            # hindsight-cloud. Skip on non-PG backends to avoid constant
-            # ORA-00904 / syntax errors on every poll cycle.
-            if self._backend.backend_type == "postgresql":
-                try:
-                    rows = await conn.fetch("SELECT * FROM schemas_with_pending_work()")
-                    return {r[0] for r in rows}
-                except Exception:
-                    pass
+            if await self._optional_routines.is_installed(conn, "schemas_with_pending_work"):
+                rows = await conn.fetch("SELECT * FROM public.schemas_with_pending_work()")
+                return {r[0] for r in rows}
 
             # Fallback: per-schema EXISTS checks from Python
             active: set[str | None] = set()

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2802,12 +2802,21 @@ class TestClaimBatchRotation:
         ``_scan_active_schemas`` invokes it instead of running per-schema
         EXISTS queries from Python. Confirms the OptionalRoutines probe
         path is wired correctly end-to-end.
+
+        The routine body installed here is a minimal stand-in that
+        satisfies the contract documented on
+        ``optional_routines.SCHEMAS_WITH_PENDING_WORK`` — Hindsight does
+        not own the canonical implementation.
         """
-        from hindsight_api.engine.db.optional_routines import SCHEMAS_WITH_PENDING_WORK
         from hindsight_api.engine.db.postgresql import PostgresConnection
         from hindsight_api.worker import WorkerPoller
 
-        await pool.execute(SCHEMAS_WITH_PENDING_WORK.install_sql)
+        # Minimal contract-satisfying implementation: returns the empty
+        # set. Enough to prove the poller follows the server-side path.
+        await pool.execute(
+            "CREATE OR REPLACE FUNCTION public.schemas_with_pending_work() "
+            "RETURNS SETOF text AS $$ BEGIN RETURN; END $$ LANGUAGE plpgsql STABLE"
+        )
         try:
             poller = WorkerPoller(
                 backend=backend,

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2797,6 +2797,62 @@ class TestClaimBatchRotation:
             await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", op_id)
 
     @pytest.mark.asyncio
+    async def test_scan_uses_optional_routine_when_installed(self, pool, backend, clean_operations):
+        """When ``public.schemas_with_pending_work()`` exists in pg_proc,
+        ``_scan_active_schemas`` invokes it instead of running per-schema
+        EXISTS queries from Python. Confirms the OptionalRoutines probe
+        path is wired correctly end-to-end.
+        """
+        from hindsight_api.engine.db.optional_routines import SCHEMAS_WITH_PENDING_WORK
+        from hindsight_api.engine.db.postgresql import PostgresConnection
+        from hindsight_api.worker import WorkerPoller
+
+        await pool.execute(SCHEMAS_WITH_PENDING_WORK.install_sql)
+        try:
+            poller = WorkerPoller(
+                backend=backend,
+                worker_id="test-routine",
+                executor=lambda x: None,
+            )
+
+            captured_fetch: list[str] = []
+            captured_fetchval: list[str] = []
+            original_fetch = PostgresConnection.fetch
+            original_fetchval = PostgresConnection.fetchval
+
+            async def spy_fetch(self, query, *args, timeout=None):
+                captured_fetch.append(query)
+                return await original_fetch(self, query, *args, timeout=timeout)
+
+            async def spy_fetchval(self, query, *args, column=0, timeout=None):
+                captured_fetchval.append(query)
+                return await original_fetchval(self, query, *args, column=column, timeout=timeout)
+
+            PostgresConnection.fetch = spy_fetch  # type: ignore[method-assign]
+            PostgresConnection.fetchval = spy_fetchval  # type: ignore[method-assign]
+            try:
+                await poller._scan_active_schemas([None])
+            finally:
+                PostgresConnection.fetch = original_fetch  # type: ignore[method-assign]
+                PostgresConnection.fetchval = original_fetchval  # type: ignore[method-assign]
+
+            # Routine was probed (one pg_proc lookup) and then invoked.
+            assert any("pg_proc" in q for q in captured_fetchval), (
+                f"Expected a pg_proc existence probe; fetchval queries: {captured_fetchval}"
+            )
+            assert any("schemas_with_pending_work" in q for q in captured_fetch), (
+                f"Expected schemas_with_pending_work() to be invoked; fetch queries: {captured_fetch}"
+            )
+            # Fallback per-schema EXISTS path must NOT have run.
+            assert not any("async_operations" in q and "EXISTS" in q for q in captured_fetchval), (
+                f"Fallback EXISTS path should be skipped when routine is installed; fetchval queries: {captured_fetchval}"
+            )
+            # Probe result is cached so the next scan skips the pg_proc lookup.
+            assert poller._optional_routines._cache.get("schemas_with_pending_work") is True
+        finally:
+            await pool.execute("DROP FUNCTION IF EXISTS public.schemas_with_pending_work()")
+
+    @pytest.mark.asyncio
     async def test_claim_batch_only_queries_active_schemas(self, pool, backend, clean_operations):
         """claim_batch uses _scan_active_schemas to pre-filter, then
         only calls _claim_batch_for_schema on schemas the scan found.


### PR DESCRIPTION
## Summary

- Fixes #1408. Stops the worker poller from calling `schemas_with_pending_work()` unconditionally, which was logging a server-side `function does not exist` error in Postgres every ~30s on fresh deployments where the optional PL/pgSQL routine isn't installed.
- Adds a small centralised registry `hindsight_api/engine/db/optional_routines.py` that probes `pg_proc` once per process and memoises the result. Single source of truth for the install SQL — anyone grepping the routine name lands on the canonical definition.
- Wires `WorkerPoller._scan_active_schemas` through the registry: if `is_installed("schemas_with_pending_work")` returns True it uses the server-side path, otherwise it runs the existing per-schema EXISTS fallback. Non-PG backends short-circuit to False without touching the DB.

## Notes

- "Routine" is the SQL-standard umbrella covering both PG functions and procedures (both stored in `pg_proc`). Module/abstraction uses that term so a future `CREATE PROCEDURE` slots in without a rename.
- Cache is permanent for the life of the process. Installing the routine on a running cluster requires a worker restart — intentional, since these routines are deploy-time concerns and probe-per-poll would defeat the optimisation. Tell me if you'd rather have a TTL.
- Issue #1408 also flags that the cloud's routine body only checks `tenant_%` schemas (broken for single-tenant). That's a property of the cloud Helm hook's SQL, not this code path — the per-schema EXISTS fallback already handles single-tenant correctly. Out of scope for this PR.

## Test plan

- [x] New `test_scan_uses_optional_routine_when_installed` installs the routine, spies on `PostgresConnection.fetch`/`fetchval`, and asserts (a) `pg_proc` was probed, (b) `schemas_with_pending_work()` was invoked, (c) the per-schema EXISTS fallback did NOT run, (d) the cache records `True`. Drops the routine in `finally`.
- [x] Existing `test_scan_finds_schemas_with_pending_work` (uninstalled routine, fallback path) still passes.
- [x] Full `TestClaimBatchRotation` class (8 tests) passes locally.
- [x] `./scripts/hooks/lint.sh` clean.