### PR TITLE
docs(installation): bake custom models into image instead of PVC

### DIFF
--- a/docker/docker-compose/custom-models/Dockerfile
+++ b/docker/docker-compose/custom-models/Dockerfile
@@ -11,8 +11,12 @@ FROM ghcr.io/vectorize-io/hindsight:latest-slim
 
 # Install the local-ml deps required to load sentence-transformers /
 # cross-encoder models at runtime. Pinned ranges mirror hindsight-api-slim's
-# `local-ml` extra in hindsight-api-slim/pyproject.toml.
-RUN pip install --no-cache-dir \
+# `local-ml` extra in hindsight-api-slim/pyproject.toml. Use `uv pip
+# install` against the image's venv explicitly: the slim image's venv was
+# created by `uv sync` and does not ship its own `pip`, so a bare
+# `pip install` would fall back to user site-packages and not be visible
+# to the runtime python.
+RUN uv pip install --python /app/api/.venv/bin/python --no-cache \
     'sentence-transformers>=3.3.0' \
     'transformers>=4.53.0' \
     'torch>=2.6.0'

--- a/docker/docker-compose/custom-models/Dockerfile
+++ b/docker/docker-compose/custom-models/Dockerfile
@@ -1,0 +1,30 @@
+# Example: custom Hindsight image with non-default local models baked in.
+#
+# Use this pattern in production when you run a non-default embedder or
+# reranker. Baking models into the image removes the runtime dependency on
+# HuggingFace and lets the container registry handle caching per node, so
+# you don't need a model-cache PVC.
+#
+# Built on top of the slim image so only the deps and models you actually
+# use end up in the final image.
+FROM ghcr.io/vectorize-io/hindsight:latest-slim
+
+# Install the local-ml deps required to load sentence-transformers /
+# cross-encoder models at runtime. Pinned ranges mirror hindsight-api-slim's
+# `local-ml` extra in hindsight-api-slim/pyproject.toml.
+RUN pip install --no-cache-dir \
+    'sentence-transformers>=3.3.0' \
+    'transformers>=4.53.0' \
+    'torch>=2.6.0'
+
+# Pre-download the models you want to use. Replace these with your own.
+# The defaults bundled in the full image are BAAI/bge-small-en-v1.5 and
+# cross-encoder/ms-marco-MiniLM-L-6-v2; here we pick multilingual variants
+# as a concrete non-default example.
+ARG EMBEDDER=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+ARG RERANKER=cross-encoder/mmarco-mMiniLMv2-L12-H384-v1
+ENV HF_HUB_DOWNLOAD_TIMEOUT=600
+RUN python -c "\
+from sentence_transformers import SentenceTransformer, CrossEncoder; \
+SentenceTransformer('${EMBEDDER}'); \
+CrossEncoder('${RERANKER}')"

--- a/docker/docker-compose/custom-models/README.md
+++ b/docker/docker-compose/custom-models/README.md
@@ -1,0 +1,81 @@
+# Hindsight with Custom Local Models
+
+Example Docker Compose setup that builds a Hindsight image with **non-default
+local embedder and reranker models baked in at build time**.
+
+This is the recommended pattern for production when you use a non-default
+local model: the container registry caches model layers per node, pod
+startup is deterministic, and you don't need a model-cache PVC (or any
+runtime dependency on HuggingFace).
+
+## When to use this
+
+- You override `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` or
+  `HINDSIGHT_API_RERANKER_LOCAL_MODEL` to a non-default model.
+- You want pod startup to be deterministic and offline-capable.
+- You'd otherwise reach for a Helm `modelCache` PVC just to avoid
+  re-downloading models.
+
+If you're using the **default** local models, the published full image
+(`ghcr.io/vectorize-io/hindsight:latest`) already bakes them in — you don't
+need this example.
+
+If you're using **external** providers (TEI, OpenAI, Cohere, ...) for
+embeddings and reranking, use the slim image directly — no models are
+needed in the image.
+
+## Quick start
+
+```bash
+export OPENAI_API_KEY=sk-xxx
+
+docker compose -f docker/docker-compose/custom-models/docker-compose.yaml up --build
+```
+
+- API: http://localhost:8888
+- Control Plane: http://localhost:9999
+
+## Using your own models
+
+Override the build args to bake different models:
+
+```bash
+docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build \
+  --build-arg EMBEDDER=your-org/your-embedder \
+  --build-arg RERANKER=your-org/your-reranker
+```
+
+Then update the matching `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` and
+`HINDSIGHT_API_RERANKER_LOCAL_MODEL` values in `docker-compose.yaml` so the
+runtime points at the same model IDs.
+
+## Verifying the models are baked in
+
+`docker-compose.yaml` sets `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1`
+so that any attempt to download a model at runtime fails loudly instead of
+silently re-downloading. If the container starts and serves recall queries
+with these set, the models are correctly baked in.
+
+You can also inspect the image directly:
+
+```bash
+docker run --rm --entrypoint sh hindsight-custom-models-hindsight \
+  -c 'ls ~/.cache/huggingface/hub/'
+```
+
+## Why not a model-cache PVC?
+
+The Helm chart exposes an optional `api.persistence.modelCache` PVC for
+caching downloaded models across pod restarts. Compared to baking models
+into the image:
+
+- A PVC adds storage cost — one PVC per worker replica with
+  `volumeClaimTemplates`.
+- `ReadWriteOnce` (the default) pins pods to a node.
+- The PVC needs lifecycle management on `helm uninstall` / `helm upgrade`
+  — without `helm.sh/resource-policy: keep` it is deleted on uninstall;
+  with it, storage keeps billing forever until manually cleaned up.
+- Pod startup still depends on HuggingFace being reachable on first run.
+
+Image layers, by contrast, are pulled once per node and cached for free by
+the container runtime, with no orphaned-storage cleanup story.

--- a/docker/docker-compose/custom-models/docker-compose.yaml
+++ b/docker/docker-compose/custom-models/docker-compose.yaml
@@ -1,0 +1,44 @@
+name: hindsight-custom-models
+# Example: run a custom Hindsight image with non-default local models baked
+# in at build time, so pod startup does not depend on HuggingFace at runtime.
+#
+# Quick start:
+#   export OPENAI_API_KEY=sk-xxx
+#   docker compose -f docker/docker-compose/custom-models/docker-compose.yaml up --build
+#
+# Required environment variables:
+# - OPENAI_API_KEY (or configure another LLM provider via HINDSIGHT_API_LLM_*)
+
+services:
+  hindsight:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # Override at build time to bake different models:
+      #   docker compose build --build-arg EMBEDDER=your-org/your-embedder
+      args:
+        EMBEDDER: sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+        RERANKER: cross-encoder/mmarco-mMiniLMv2-L12-H384-v1
+    container_name: hindsight-custom-models
+    ports:
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      HINDSIGHT_API_LLM_PROVIDER: ${HINDSIGHT_API_LLM_PROVIDER:-openai}
+      HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:-your-api-key}
+
+      # Point Hindsight at the models baked into the image above.
+      HINDSIGHT_API_EMBEDDINGS_PROVIDER: local
+      HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL: sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+      HINDSIGHT_API_RERANKER_PROVIDER: local
+      HINDSIGHT_API_RERANKER_LOCAL_MODEL: cross-encoder/mmarco-mMiniLMv2-L12-H384-v1
+
+      # Fail fast if a model is missing from the image instead of silently
+      # falling back to a HuggingFace download at runtime.
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+    volumes:
+      - pg_data:/home/hindsight/.pg0
+
+volumes:
+  pg_data:

--- a/helm/hindsight/values.yaml
+++ b/helm/hindsight/values.yaml
@@ -70,6 +70,12 @@ api:
   # Persistent volume for local model cache (reranker, embeddings)
   # Models are downloaded to /home/hindsight/.cache on first use.
   # Without persistence, models are re-downloaded on every pod restart.
+  #
+  # For production, prefer baking models into a custom image instead of
+  # enabling this PVC: image layers are pulled once per node and cached
+  # for free, while a PVC adds storage cost, pins pods to a node
+  # (ReadWriteOnce), and needs lifecycle management on uninstall/upgrade.
+  # See docs: developer/installation#bundling-custom-models-in-a-custom-image
   persistence:
     modelCache:
       enabled: false
@@ -168,7 +174,10 @@ worker:
   # affinity: {}
 
   # Persistent volume for local model cache (reranker, embeddings)
-  # Uses volumeClaimTemplates since worker is a StatefulSet.
+  # Uses volumeClaimTemplates since worker is a StatefulSet — one PVC per
+  # replica. For production, prefer baking models into a custom image; see
+  # api.persistence.modelCache above and docs:
+  # developer/installation#bundling-custom-models-in-a-custom-image
   persistence:
     modelCache:
       enabled: false

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -92,6 +92,24 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
 
+### Bundling Custom Models in a Custom Image
+
+The full image bakes the **default** embedder (`BAAI/bge-small-en-v1.5`) and reranker (`cross-encoder/ms-marco-MiniLM-L-6-v2`) into the image at build time, so the default deployment has no runtime dependency on HuggingFace. If you use a **non-default** local model, the recommended pattern for production is to extend the slim image and pre-download the models you need at build time, rather than relying on a runtime model cache (or a `modelCache` PVC).
+
+A complete, runnable example lives in [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) — a `Dockerfile` that bakes two configurable models into the slim image, plus a `docker-compose.yaml` that runs it with `HF_HUB_OFFLINE=1` so any missed download fails loudly.
+
+```bash
+docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build \
+  --build-arg EMBEDDER=your-org/your-embedder \
+  --build-arg RERANKER=your-org/your-reranker
+```
+
+This makes pod startup deterministic: the container registry caches the model layers per node, and you never depend on HuggingFace at runtime.
+
+:::tip Prefer this over a model-cache PVC
+The Helm chart exposes an optional `api.persistence.modelCache` PVC for caching downloaded models across pod restarts. For production, baking models into the image is generally preferable — image layers are pulled once per node and cached for free, while a PVC adds storage cost (one per replica with `volumeClaimTemplates`), pins pods to a node (`ReadWriteOnce`), and needs lifecycle management on `helm uninstall`/`upgrade`.
+:::
+
 ### Available Tags
 
 ```bash

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -94,20 +94,8 @@ The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip pa
 
 ### Bundling Custom Models in a Custom Image
 
-The full image bakes the **default** embedder (`BAAI/bge-small-en-v1.5`) and reranker (`cross-encoder/ms-marco-MiniLM-L-6-v2`) into the image at build time, so the default deployment has no runtime dependency on HuggingFace. If you use a **non-default** local model, the recommended pattern for production is to extend the slim image and pre-download the models you need at build time, rather than relying on a runtime model cache (or a `modelCache` PVC).
-
-A complete, runnable example lives in [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) — a `Dockerfile` that bakes two configurable models into the slim image, plus a `docker-compose.yaml` that runs it with `HF_HUB_OFFLINE=1` so any missed download fails loudly.
-
-```bash
-docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build \
-  --build-arg EMBEDDER=your-org/your-embedder \
-  --build-arg RERANKER=your-org/your-reranker
-```
-
-This makes pod startup deterministic: the container registry caches the model layers per node, and you never depend on HuggingFace at runtime.
-
-:::tip Prefer this over a model-cache PVC
-The Helm chart exposes an optional `api.persistence.modelCache` PVC for caching downloaded models across pod restarts. For production, baking models into the image is generally preferable — image layers are pulled once per node and cached for free, while a PVC adds storage cost (one per replica with `volumeClaimTemplates`), pins pods to a node (`ReadWriteOnce`), and needs lifecycle management on `helm uninstall`/`upgrade`.
+:::tip Production deployments with non-default local models
+If you use a non-default local embedder or reranker, bake the models into a custom image at build time rather than enabling the Helm `modelCache` PVC. See [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) for a runnable example.
 :::
 
 ### Available Tags

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -92,6 +92,24 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip package. See [Configuration](./configuration#embeddings) for external provider options.
 
+### Bundling Custom Models in a Custom Image
+
+The full image bakes the **default** embedder (`BAAI/bge-small-en-v1.5`) and reranker (`cross-encoder/ms-marco-MiniLM-L-6-v2`) into the image at build time, so the default deployment has no runtime dependency on HuggingFace. If you use a **non-default** local model, the recommended pattern for production is to extend the slim image and pre-download the models you need at build time, rather than relying on a runtime model cache (or a `modelCache` PVC).
+
+A complete, runnable example lives in [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) — a `Dockerfile` that bakes two configurable models into the slim image, plus a `docker-compose.yaml` that runs it with `HF_HUB_OFFLINE=1` so any missed download fails loudly.
+
+```bash
+docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build \
+  --build-arg EMBEDDER=your-org/your-embedder \
+  --build-arg RERANKER=your-org/your-reranker
+```
+
+This makes pod startup deterministic: the container registry caches the model layers per node, and you never depend on HuggingFace at runtime.
+
+:::tip Prefer this over a model-cache PVC
+The Helm chart exposes an optional `api.persistence.modelCache` PVC for caching downloaded models across pod restarts. For production, baking models into the image is generally preferable — image layers are pulled once per node and cached for free, while a PVC adds storage cost (one per replica with `volumeClaimTemplates`), pins pods to a node (`ReadWriteOnce`), and needs lifecycle management on `helm uninstall`/`upgrade`.
+:::
+
 ### Available Tags
 
 ```bash

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -94,20 +94,8 @@ The slim image corresponds to the [`hindsight-api-slim`](#bare-metal-pip) pip pa
 
 ### Bundling Custom Models in a Custom Image
 
-The full image bakes the **default** embedder (`BAAI/bge-small-en-v1.5`) and reranker (`cross-encoder/ms-marco-MiniLM-L-6-v2`) into the image at build time, so the default deployment has no runtime dependency on HuggingFace. If you use a **non-default** local model, the recommended pattern for production is to extend the slim image and pre-download the models you need at build time, rather than relying on a runtime model cache (or a `modelCache` PVC).
-
-A complete, runnable example lives in [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) — a `Dockerfile` that bakes two configurable models into the slim image, plus a `docker-compose.yaml` that runs it with `HF_HUB_OFFLINE=1` so any missed download fails loudly.
-
-```bash
-docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build \
-  --build-arg EMBEDDER=your-org/your-embedder \
-  --build-arg RERANKER=your-org/your-reranker
-```
-
-This makes pod startup deterministic: the container registry caches the model layers per node, and you never depend on HuggingFace at runtime.
-
-:::tip Prefer this over a model-cache PVC
-The Helm chart exposes an optional `api.persistence.modelCache` PVC for caching downloaded models across pod restarts. For production, baking models into the image is generally preferable — image layers are pulled once per node and cached for free, while a PVC adds storage cost (one per replica with `volumeClaimTemplates`), pins pods to a node (`ReadWriteOnce`), and needs lifecycle management on `helm uninstall`/`upgrade`.
+:::tip Production deployments with non-default local models
+If you use a non-default local embedder or reranker, bake the models into a custom image at build time rather than enabling the Helm `modelCache` PVC. See [`docker/docker-compose/custom-models/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/custom-models) for a runnable example.
 :::
 
 ### Available Tags


### PR DESCRIPTION
## Summary

- Add a runnable example under `docker/docker-compose/custom-models/` (Dockerfile + compose + README) that extends the slim image and pre-downloads non-default embedder/reranker models at build time.
- Document this in `installation.md` as the recommended pattern for production when running non-default local models, instead of enabling the Helm `modelCache` PVC.
- Add pointers from the api/worker `modelCache` values in `helm/hindsight/values.yaml` to the new section.

## Why

Refs #1383. That issue proposes defaulting `helm.sh/resource-policy: keep` on the model-cache PVC so models survive `helm uninstall`. The PVC isn't the right tool for "models that never change at runtime" — image layers already cache per node for free, no orphaned-storage cleanup story, and the registry is the right cache layer for immutable artifacts. Baking models into a custom image based on slim is the cleaner production pattern; documenting it gives users a concrete path that doesn't depend on PVC lifecycle tuning.

The chart's PVC stays available as a fallback (no behavior change), but the values comments and the docs steer users toward the image-layer pattern first.

## Test plan

- [ ] `docker compose -f docker/docker-compose/custom-models/docker-compose.yaml build` succeeds
- [ ] Container starts with `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` set, and recall queries work end-to-end (proves the baked-in models are wired up)
- [ ] Doc renders correctly in Docusaurus preview