### PR TITLE
feat: add map-type entity labels for structured entity extraction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
@@ -6,7 +6,7 @@ Defines a controlled vocabulary of key:value classification labels
 at retain time and stored as entities.
 """
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, create_model
 
@@ -18,15 +18,28 @@ class LabelValue(BaseModel):
     description: str = ""
 
 
+class MapField(BaseModel):
+    """A field within a map-type entity label group. Supports recursion via type='map'."""
+
+    type: Literal["text", "value", "multi-values", "map"] = "text"
+    description: str = ""
+    values: list[LabelValue] = []
+    fields: dict[str, "MapField"] = {}
+
+
+MapField.model_rebuild()
+
+
 class LabelGroup(BaseModel):
     """A label group (dimension) with its type and allowed values."""
 
     key: str
     description: str = ""
-    type: Literal["value", "multi-values", "text"] = "value"
+    type: Literal["value", "multi-values", "text", "map"] = "value"
     optional: bool = True
     tag: bool = False
     values: list[LabelValue] = []
+    fields: dict[str, MapField] = {}
 
 
 class EntityLabelsConfig(BaseModel):
@@ -91,6 +104,71 @@ def _migrate_label_group(raw: dict) -> dict:
     return patched
 
 
+def _build_map_fields_model(fields: dict[str, MapField], model_name: str) -> type[BaseModel] | None:
+    """
+    Build a dynamic Pydantic model for a set of map fields (recursive).
+
+    Each field becomes a typed Pydantic field based on its type:
+    - text         → str | None
+    - value        → Literal[...] | None
+    - multi-values → list[Literal[...]]
+    - map          → list[NestedModel] (recursive)
+
+    Returns:
+        Dynamic Pydantic model class, or None if no fields defined
+    """
+    if not fields:
+        return None
+    model_fields: dict[str, Any] = {}
+    for field_name, map_field in fields.items():
+        description = map_field.description or field_name
+
+        if map_field.type == "map":
+            nested = _build_map_fields_model(map_field.fields, model_name + field_name.capitalize())
+            if nested is not None:
+                model_fields[field_name] = (
+                    list[nested],  # type: ignore[valid-type]
+                    Field(default_factory=list, description=description),
+                )
+        elif map_field.type == "text":
+            model_fields[field_name] = (str | None, Field(default=None, description=description))
+        else:
+            # value / multi-values — enum-constrained
+            if not map_field.values:
+                model_fields[field_name] = (str | None, Field(default=None, description=description))
+                continue
+            values = tuple(v.value for v in map_field.values if v.value)
+            if not values:
+                model_fields[field_name] = (str | None, Field(default=None, description=description))
+                continue
+            literal_type = Literal[values]  # type: ignore[valid-type]
+            if map_field.type == "multi-values":
+                model_fields[field_name] = (
+                    list[literal_type],  # type: ignore[valid-type]
+                    Field(default_factory=list, description=description),
+                )
+            else:
+                model_fields[field_name] = (
+                    literal_type | None,  # type: ignore[valid-type]
+                    Field(default=None, description=description),
+                )
+
+    if not model_fields:
+        return None
+    return create_model(model_name, **model_fields)
+
+
+def _build_map_entity_model(group: LabelGroup) -> type[BaseModel] | None:
+    """
+    Build a dynamic Pydantic model for a map-type entity label group.
+
+    Delegates to ``_build_map_fields_model`` which handles recursion.
+    """
+    # Capitalize group key for the model name (e.g., "person" → "Person")
+    model_name = group.key.capitalize() + "Entity"
+    return _build_map_fields_model(group.fields, model_name)
+
+
 def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None:
     """
     Build a dynamic Pydantic model for structured label extraction.
@@ -100,6 +178,7 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
     - type="value",   optional=True      → Literal["v1","v2"] | None
     - type="value",   optional=False     → Literal["v1","v2"]  (required)
     - type="multi-values"                → list[Literal["v1","v2"]]
+    - type="map"                         → list[MapModel]  (structured entity)
 
     Args:
         labels_cfg: Parsed EntityLabelsConfig
@@ -113,7 +192,14 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
             continue
         description = group.description or group.key
 
-        if group.type == "text":
+        if group.type == "map":
+            map_model = _build_map_entity_model(group)
+            if map_model is not None:
+                fields[group.key] = (
+                    list[map_model],  # type: ignore[valid-type]
+                    Field(default_factory=list, description=description),
+                )
+        elif group.type == "text":
             # Free-form: any string value accepted, always optional
             fields[group.key] = (str | None, Field(default=None, description=description))
         else:
@@ -147,18 +233,35 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
     return create_model("Labels", **fields)
 
 
+def _is_map_label_entity(text_lower: str, prefix: str, fields: dict[str, MapField]) -> bool:
+    """Recursively check if text matches a map field path (e.g. 'person:address:city:...')."""
+    for field_name, map_field in fields.items():
+        field_prefix = f"{prefix}{field_name.lower()}:"
+        if map_field.type == "map" and map_field.fields:
+            if _is_map_label_entity(text_lower, field_prefix, map_field.fields):
+                return True
+        elif text_lower.startswith(field_prefix):
+            return True
+    return False
+
+
 def is_label_entity(text: str, labels_cfg: EntityLabelsConfig, labels_lookup: set[str]) -> bool:
     """
     Return True if entity text belongs to any configured label group.
 
     For enum groups: checks the pre-built lookup set.
     For text groups: checks that the text starts with a known key prefix.
+    For map groups: recursively checks ``key:field:...:value`` patterns.
     """
     if text.lower() in labels_lookup:
         return True
     for group in labels_cfg.attributes:
         if group.type == "text" and group.key and text.lower().startswith(f"{group.key.lower()}:"):
             return True
+        if group.type == "map" and group.key and group.fields:
+            prefix = f"{group.key.lower()}:"
+            if _is_map_label_entity(text.lower(), prefix, group.fields):
+                return True
     return False
 
 
@@ -186,8 +289,8 @@ def build_labels_lookup(labels_cfg: EntityLabelsConfig | list | None) -> set[str
 
     valid = set()
     for group in labels_cfg.attributes:
-        if group.type == "text":
-            continue  # No fixed vocabulary — all values accepted in post-processing
+        if group.type in ("text", "map"):
+            continue  # text: no fixed vocabulary; map: uses three-level key:field:value strings
         for v in group.values:
             if group.key and v.value:
                 valid.add(f"{group.key}:{v.value}".lower())

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -19,11 +19,55 @@ from ..llm_wrapper import LLMConfig, OutputTooLongError, sanitize_llm_output
 from ..response_models import TokenUsage
 from .entity_labels import (
     EntityLabelsConfig,
+    MapField,
     build_labels_lookup,
     build_labels_model,
     is_label_entity,
     parse_entity_labels,
 )
+
+
+def _extract_map_entities(
+    entity_obj: dict,
+    fields: dict[str, MapField],
+    prefix: str,
+    validated_entities: "list[Entity]",
+    existing_texts_lower: set[str],
+) -> None:
+    """Recursively extract key:field:value entity strings from a map entity dict."""
+    for field_name, map_field in fields.items():
+        field_val = entity_obj.get(field_name)
+        if field_val is None or field_val == "":
+            continue
+        if map_field.type == "map" and map_field.fields:
+            # Nested map: recurse into each sub-entity
+            sub_list = field_val if isinstance(field_val, list) else [field_val]
+            for sub_obj in sub_list:
+                if isinstance(sub_obj, dict):
+                    _extract_map_entities(
+                        sub_obj,
+                        map_field.fields,
+                        f"{prefix}{field_name}:",
+                        validated_entities,
+                        existing_texts_lower,
+                    )
+        elif map_field.type == "multi-values":
+            vals = field_val if isinstance(field_val, list) else [field_val]
+            for v in vals:
+                if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
+                    continue
+                label_str = f"{prefix}{field_name}:{v.strip()}"
+                if label_str.lower() not in existing_texts_lower:
+                    validated_entities.append(Entity(text=label_str))
+                    existing_texts_lower.add(label_str.lower())
+        else:
+            # text or value — single string
+            if not isinstance(field_val, str) or not field_val.strip() or field_val.lower() in ("none", "null", "n/a"):
+                continue
+            label_str = f"{prefix}{field_name}:{field_val.strip()}"
+            if label_str.lower() not in existing_texts_lower:
+                validated_entities.append(Entity(text=label_str))
+                existing_texts_lower.add(label_str.lower())
 
 
 def _infer_temporal_date(fact_text: str, event_date: datetime | None) -> str | None:
@@ -731,6 +775,25 @@ Example: "Lost job → couldn't pay rent → moved apartment"
 - Fact 2: Moved apartment, causal_relations: [{target_index: 1, relation_type: "caused_by"}]"""
 
 
+def _append_map_fields_prompt(fields: dict[str, "MapField"], lines: list[str], indent: int = 4) -> None:
+    """Recursively append map field descriptions to the prompt lines."""
+    pad = " " * indent
+    for field_name, map_field in fields.items():
+        field_desc = f": {map_field.description}" if map_field.description else ""
+        if map_field.type == "map" and map_field.fields:
+            lines.append(f"{pad}• {field_name} (object){field_desc}")
+            _append_map_fields_prompt(map_field.fields, lines, indent + 4)
+        elif map_field.type == "multi-values":
+            vals = ", ".join(v.value for v in map_field.values if v.value)
+            type_hint = f"multi-values: {vals}" if vals else "multi-values"
+            lines.append(f"{pad}• {field_name} ({type_hint}){field_desc}")
+        elif map_field.type == "value" and map_field.values:
+            vals = ", ".join(v.value for v in map_field.values if v.value)
+            lines.append(f"{pad}• {field_name} (one of: {vals}){field_desc}")
+        else:
+            lines.append(f"{pad}• {field_name} (text){field_desc}")
+
+
 def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, free_form_entities: bool = True) -> str:
     """Build the entity labels classification section for the extraction prompt."""
     if labels_cfg is None:
@@ -763,7 +826,14 @@ def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, f
         "",
     ]
 
+    has_classification_attrs = False
+    has_map_attrs = False
+
     for attr in labels_cfg.attributes:
+        if attr.type == "map":
+            has_map_attrs = True
+            continue
+        has_classification_attrs = True
         if attr.type == "text":
             # Free-text: no predefined values — LLM writes any relevant string or null
             lines.append(f"- {attr.key} (free text or null): {attr.description}")
@@ -775,7 +845,31 @@ def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, f
                 lines.append(f'    • "{v.value}"{desc}')
         lines.append("")
 
-    lines.append("Only assign labels when clearly applicable. Leave null/empty if the fact does not match.")
+    if has_classification_attrs:
+        lines.append("Only assign labels when clearly applicable. Leave null/empty if the fact does not match.")
+        lines.append("")
+
+    # Add structured entity types (map groups)
+    if has_map_attrs:
+        lines.append("")
+        lines.append("══════════════════════════════════════════════════════════════════════════")
+        lines.append("STRUCTURED ENTITY TYPES")
+        lines.append("══════════════════════════════════════════════════════════════════════════")
+        lines.append("")
+        lines.append("For each fact, extract structured entities into the corresponding list field in 'labels'.")
+        lines.append("Each structured entity type has defined fields. Return a list of objects, one per entity found.")
+        lines.append("")
+        for attr in labels_cfg.attributes:
+            if attr.type != "map" or not attr.fields:
+                continue
+            desc = f": {attr.description}" if attr.description else ""
+            lines.append(f"- {attr.key}{desc}")
+            _append_map_fields_prompt(attr.fields, lines, indent=4)
+            lines.append("")
+        lines.append(
+            "Only extract structured entities when clearly present in the text. Leave the list empty if none found."
+        )
+
     return "\n".join(lines)
 
 
@@ -1163,6 +1257,19 @@ async def _extract_facts_from_chunk(
                         for group in labels_cfg.attributes:
                             value = labels_data.get(group.key)
                             if not value:
+                                continue
+                            # Map-type groups: recursively extract key:field:value strings
+                            if group.type == "map" and group.fields:
+                                entities_list = value if isinstance(value, list) else [value]
+                                for entity_obj in entities_list:
+                                    if isinstance(entity_obj, dict):
+                                        _extract_map_entities(
+                                            entity_obj,
+                                            group.fields,
+                                            f"{group.key}:",
+                                            validated_entities,
+                                            existing_texts_lower,
+                                        )
                                 continue
                             values_list = value if isinstance(value, list) else [value]
                             for v in values_list:
@@ -1862,6 +1969,19 @@ async def extract_facts_from_contents_batch_api(
                     for group in labels_cfg_batch.attributes:
                         value = labels_data.get(group.key)
                         if not value:
+                            continue
+                        # Map-type groups: recursively extract key:field:value strings
+                        if group.type == "map" and group.fields:
+                            entities_list = value if isinstance(value, list) else [value]
+                            for entity_obj in entities_list:
+                                if isinstance(entity_obj, dict):
+                                    _extract_map_entities(
+                                        entity_obj,
+                                        group.fields,
+                                        f"{group.key}:",
+                                        validated_entities,
+                                        existing_texts_lower,
+                                    )
                             continue
                         values_list = value if isinstance(value, list) else [value]
                         for v in values_list:

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -17,7 +17,10 @@ from hindsight_api.engine.retain.entity_labels import (
     EntityLabelsConfig,
     LabelGroup,
     LabelValue,
+    MapField,
     build_labels_lookup,
+    build_labels_model,
+    is_label_entity,
     parse_entity_labels,
 )
 
@@ -1118,3 +1121,776 @@ async def test_retain_extracts_free_values_label(memory, request_context):
         )
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_retain_extracts_map_type_entities(memory, request_context):
+    """
+    End-to-end: retain content with a map-type entity_labels group.
+    Verify that structured entity fields are extracted as key:field:value entity strings.
+    """
+    from hindsight_api.engine.memory_engine import fq_table
+
+    bank_id = f"test-labels-map-{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        # Configure a map-type entity label
+        await memory._config_resolver.update_bank_config(
+            bank_id=bank_id,
+            updates={
+                "entity_labels": [
+                    {
+                        "key": "person",
+                        "type": "map",
+                        "description": "A person mentioned in the text",
+                        "fields": {
+                            "name": {"type": "text", "description": "Full name of the person"},
+                            "role": {"type": "text", "description": "Job title or role"},
+                            "organization": {"type": "text", "description": "Company or organization"},
+                        },
+                    }
+                ],
+                "entities_allow_free_form": False,  # map entities only
+            },
+            context=request_context,
+        )
+
+        unit_ids = await memory.retain_async(
+            bank_id=bank_id,
+            content=(
+                "Alice Johnson is a Senior Software Engineer at Google. "
+                "She leads the search infrastructure team and has been with the company for 5 years."
+            ),
+            request_context=request_context,
+        )
+
+        assert len(unit_ids) > 0, "Should have extracted at least one fact"
+
+        async with memory._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT e.canonical_name
+                FROM {fq_table("unit_entities")} ue
+                JOIN {fq_table("entities")} e ON e.id = ue.entity_id
+                WHERE ue.unit_id = ANY($1::uuid[])
+                """,
+                [u for u in unit_ids],
+            )
+
+        entity_names = {r["canonical_name"].lower() for r in rows}
+        # Should have person:name:* entity
+        name_entities = {n for n in entity_names if n.startswith("person:name:")}
+        assert len(name_entities) > 0, (
+            f"Expected at least one person:name:* entity. Got: {entity_names}"
+        )
+        # Name should contain "alice" somewhere
+        assert any("alice" in n for n in name_entities), (
+            f"Expected person:name entity containing 'alice'. Got: {name_entities}"
+        )
+        # Should have person:organization:* entity mentioning google
+        org_entities = {n for n in entity_names if n.startswith("person:organization:")}
+        assert len(org_entities) > 0, (
+            f"Expected at least one person:organization:* entity. Got: {entity_names}"
+        )
+        assert any("google" in n for n in org_entities), (
+            f"Expected person:organization entity containing 'google'. Got: {org_entities}"
+        )
+        # In labels-only mode, free-form entities should be absent
+        non_person_entities = {n for n in entity_names if not n.startswith("person:")}
+        assert len(non_person_entities) == 0, (
+            f"Free-form entities should not appear in labels-only mode. Got: {non_person_entities}"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ─── map-type entity labels ──────────────────────────────────────────────────
+
+
+def test_parse_entity_labels_map_type():
+    """Map-type label group with fields is parsed correctly."""
+    raw = [
+        {
+            "key": "person",
+            "type": "map",
+            "description": "A person entity",
+            "fields": {
+                "name": {"type": "text", "description": "Full name"},
+                "role": {"type": "text", "description": "Job title"},
+                "organization": {"type": "text", "description": "Company"},
+            },
+        }
+    ]
+    result = parse_entity_labels(raw)
+    assert result is not None
+    assert len(result.attributes) == 1
+    group = result.attributes[0]
+    assert group.key == "person"
+    assert group.type == "map"
+    assert len(group.fields) == 3
+    assert "name" in group.fields
+    assert group.fields["name"].description == "Full name"
+
+
+def test_parse_entity_labels_map_type_dict_format():
+    """Map-type label group via dict format."""
+    raw = {
+        "attributes": [
+            {
+                "key": "company",
+                "type": "map",
+                "fields": {
+                    "name": {"type": "text"},
+                    "industry": {"type": "text"},
+                },
+            }
+        ]
+    }
+    result = parse_entity_labels(raw)
+    assert result is not None
+    assert result.attributes[0].type == "map"
+    assert len(result.attributes[0].fields) == 2
+
+
+def test_build_labels_model_map_type():
+    """Map-type groups produce list[MapModel] fields in the Labels model."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person",
+                fields={
+                    "name": MapField(description="Full name"),
+                    "role": MapField(description="Job title"),
+                },
+            ),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is not None
+    schema = model.model_json_schema()
+    assert "person" in schema["properties"]
+    # Should be an array of objects
+    person_prop = schema["properties"]["person"]
+    assert person_prop["type"] == "array"
+
+
+def test_build_labels_model_mixed_map_and_value():
+    """Both map-type and value-type groups coexist in the same Labels model."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person",
+                fields={
+                    "name": MapField(description="Full name"),
+                },
+            ),
+            LabelGroup(
+                key="topic",
+                type="value",
+                values=[LabelValue(value="math"), LabelValue(value="science")],
+            ),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is not None
+    schema = model.model_json_schema()
+    assert "person" in schema["properties"]
+    assert "topic" in schema["properties"]
+
+
+def test_build_labels_model_map_type_no_fields():
+    """Map-type group with no fields produces no field in the model."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(key="empty", type="map", fields={}),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is None
+
+
+def test_build_labels_lookup_skips_map_type():
+    """Map-type groups should not contribute to the two-level lookup set."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={"name": MapField()},
+            ),
+            LabelGroup(
+                key="topic",
+                type="value",
+                values=[LabelValue(value="math")],
+            ),
+        ]
+    )
+    lookup = build_labels_lookup(labels_cfg)
+    assert "topic:math" in lookup
+    # No map-type entries in the lookup
+    assert not any("person" in v for v in lookup)
+
+
+def test_is_label_entity_map_type():
+    """Three-level key:field:value strings are recognized as label entities."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(),
+                    "role": MapField(),
+                },
+            ),
+        ]
+    )
+    lookup = build_labels_lookup(labels_cfg)
+    assert is_label_entity("person:name:Alice", labels_cfg, lookup)
+    assert is_label_entity("person:role:Engineer", labels_cfg, lookup)
+    assert is_label_entity("Person:Name:Alice", labels_cfg, lookup)  # case insensitive
+    assert not is_label_entity("person:unknown_field:value", labels_cfg, lookup)
+    assert not is_label_entity("person:Alice", labels_cfg, lookup)  # two-level, not map
+    assert not is_label_entity("Alice", labels_cfg, lookup)
+
+
+def test_build_labels_prompt_section_map_type():
+    """Map-type groups appear in the STRUCTURED ENTITY TYPES prompt section."""
+    from hindsight_api.engine.retain.fact_extraction import _build_labels_prompt_section
+
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person entity",
+                fields={
+                    "name": MapField(description="Full name"),
+                    "role": MapField(description="Job title"),
+                },
+            ),
+        ]
+    )
+    result = _build_labels_prompt_section(labels_cfg)
+    assert "STRUCTURED ENTITY TYPES" in result
+    assert "person" in result
+    assert "name" in result
+    assert "role" in result
+    assert "Full name" in result
+
+
+def test_build_labels_prompt_section_mixed():
+    """Mixed map-type and value-type groups both appear in the prompt."""
+    from hindsight_api.engine.retain.fact_extraction import _build_labels_prompt_section
+
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="topic",
+                type="value",
+                description="Subject area",
+                values=[LabelValue(value="math")],
+            ),
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person",
+                fields={"name": MapField(description="Full name")},
+            ),
+        ]
+    )
+    result = _build_labels_prompt_section(labels_cfg)
+    assert "CLASSIFICATION ATTRIBUTES" in result
+    assert "topic" in result
+    assert "STRUCTURED ENTITY TYPES" in result
+    assert "person" in result
+
+
+def test_map_entity_post_processing():
+    """Map-type labels are converted to key:field:value entity strings."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "role": MapField(type="text"),
+        "organization": MapField(type="text"),
+    }
+    entity_obj = {"name": "Alice", "role": "Senior Engineer", "organization": "Acme Corp"}
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Alice" in texts
+    assert "person:role:Senior Engineer" in texts
+    assert "person:organization:Acme Corp" in texts
+
+
+def test_map_entity_post_processing_null_fields_skipped():
+    """Null/empty fields in map entities are skipped."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "role": MapField(type="text"),
+    }
+    entity_obj = {"name": "Bob", "role": None}
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Bob" in texts
+    assert len(texts) == 1  # role was null, so only name
+
+
+def test_map_entity_post_processing_multiple_entities():
+    """Multiple map entities in a single fact produce separate entity strings."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "role": MapField(type="text"),
+    }
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities({"name": "Alice", "role": "Engineer"}, fields, "person:", validated, existing)
+    _extract_map_entities({"name": "Bob", "role": "Manager"}, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Alice" in texts
+    assert "person:role:Engineer" in texts
+    assert "person:name:Bob" in texts
+    assert "person:role:Manager" in texts
+    assert len(texts) == 4
+
+
+# ─── recursive map-type entity labels ────────────────────────────────────────
+
+
+def test_parse_entity_labels_recursive_map():
+    """Nested map fields parse correctly."""
+    raw = [
+        {
+            "key": "person",
+            "type": "map",
+            "fields": {
+                "name": {"type": "text"},
+                "address": {
+                    "type": "map",
+                    "fields": {
+                        "city": {"type": "text", "description": "City name"},
+                        "country": {"type": "text"},
+                    },
+                },
+            },
+        }
+    ]
+    result = parse_entity_labels(raw)
+    assert result is not None
+    group = result.attributes[0]
+    assert group.fields["address"].type == "map"
+    assert "city" in group.fields["address"].fields
+    assert group.fields["address"].fields["city"].description == "City name"
+
+
+def test_build_labels_model_recursive_map():
+    """Nested map fields produce nested list[Model] in the schema."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(type="text"),
+                    "address": MapField(
+                        type="map",
+                        fields={
+                            "city": MapField(type="text"),
+                            "country": MapField(type="text"),
+                        },
+                    ),
+                },
+            ),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is not None
+    schema = model.model_json_schema()
+    person_prop = schema["properties"]["person"]
+    assert person_prop["type"] == "array"
+
+
+def test_is_label_entity_recursive_map():
+    """Deeply nested key:field:subfield:value strings are recognized."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(type="text"),
+                    "address": MapField(
+                        type="map",
+                        fields={
+                            "city": MapField(type="text"),
+                            "country": MapField(type="text"),
+                        },
+                    ),
+                },
+            ),
+        ]
+    )
+    lookup = build_labels_lookup(labels_cfg)
+    assert is_label_entity("person:name:Alice", labels_cfg, lookup)
+    assert is_label_entity("person:address:city:New York", labels_cfg, lookup)
+    assert is_label_entity("person:address:country:US", labels_cfg, lookup)
+    assert not is_label_entity("person:address:zip:12345", labels_cfg, lookup)
+    assert not is_label_entity("person:address:New York", labels_cfg, lookup)
+
+
+def test_recursive_map_post_processing():
+    """Nested map entities produce deeply-joined key:field:subfield:value strings."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "address": MapField(
+            type="map",
+            fields={
+                "city": MapField(type="text"),
+                "country": MapField(type="text"),
+            },
+        ),
+    }
+
+    entity_obj = {
+        "name": "Alice",
+        "address": [{"city": "New York", "country": "US"}],
+    }
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Alice" in texts
+    assert "person:address:city:New York" in texts
+    assert "person:address:country:US" in texts
+    assert len(texts) == 3
+
+
+def test_map_field_with_enum_values():
+    """Map fields with value/multi-values types constrain extraction."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(type="text"),
+                    "department": MapField(
+                        type="value",
+                        values=[LabelValue(value="engineering"), LabelValue(value="sales")],
+                    ),
+                },
+            ),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is not None
+    schema = model.model_json_schema()
+    # The model should exist and have the person field
+    assert "person" in schema["properties"]
+
+
+def test_build_labels_prompt_section_recursive_map():
+    """Nested map fields appear indented in the prompt."""
+    from hindsight_api.engine.retain.fact_extraction import _build_labels_prompt_section
+
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person",
+                fields={
+                    "name": MapField(type="text", description="Full name"),
+                    "address": MapField(
+                        type="map",
+                        description="Home address",
+                        fields={
+                            "city": MapField(type="text", description="City name"),
+                        },
+                    ),
+                },
+            ),
+        ]
+    )
+    result = _build_labels_prompt_section(labels_cfg)
+    assert "name (text)" in result
+    assert "address (object)" in result
+    assert "city (text)" in result
+
+
+# ─── map fields with value/multi-values types ────────────────────────────────
+
+
+def test_map_field_value_post_processing():
+    """Map field with type='value' extracts a single enum entity string."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "department": MapField(
+            type="value",
+            values=[LabelValue(value="engineering"), LabelValue(value="sales")],
+        ),
+    }
+    entity_obj = {"name": "Alice", "department": "engineering"}
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Alice" in texts
+    assert "person:department:engineering" in texts
+    assert len(texts) == 2
+
+
+def test_map_field_multi_values_post_processing():
+    """Map field with type='multi-values' extracts one entity per value."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "skills": MapField(
+            type="multi-values",
+            values=[LabelValue(value="python"), LabelValue(value="go"), LabelValue(value="rust")],
+        ),
+    }
+    entity_obj = {"name": "Alice", "skills": ["python", "rust"]}
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Alice" in texts
+    assert "person:skills:python" in texts
+    assert "person:skills:rust" in texts
+    assert "person:skills:go" not in texts
+    assert len(texts) == 3
+
+
+def test_map_field_multi_values_null_skipped():
+    """Null/sentinel values in multi-values are skipped."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "tags": MapField(type="multi-values"),
+    }
+    entity_obj = {"tags": ["valid", "none", "null", "", "  ", "n/a", "also_valid"]}
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "item:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "item:tags:valid" in texts
+    assert "item:tags:also_valid" in texts
+    assert len(texts) == 2
+
+
+def test_nested_map_with_enum_fields_post_processing():
+    """Nested map containing value/multi-values fields produces correct paths."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+        "job": MapField(
+            type="map",
+            fields={
+                "title": MapField(type="text"),
+                "level": MapField(
+                    type="value",
+                    values=[LabelValue(value="junior"), LabelValue(value="senior")],
+                ),
+                "languages": MapField(
+                    type="multi-values",
+                    values=[LabelValue(value="python"), LabelValue(value="java")],
+                ),
+            },
+        ),
+    }
+    entity_obj = {
+        "name": "Bob",
+        "job": [{"title": "Engineer", "level": "senior", "languages": ["python", "java"]}],
+    }
+
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities(entity_obj, fields, "person:", validated, existing)
+
+    texts = {e.text for e in validated}
+    assert "person:name:Bob" in texts
+    assert "person:job:title:Engineer" in texts
+    assert "person:job:level:senior" in texts
+    assert "person:job:languages:python" in texts
+    assert "person:job:languages:java" in texts
+    assert len(texts) == 5
+
+
+def test_is_label_entity_map_with_enum_fields():
+    """Entity strings from map fields with value/multi-values types are recognized."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(type="text"),
+                    "department": MapField(
+                        type="value",
+                        values=[LabelValue(value="engineering")],
+                    ),
+                    "skills": MapField(type="multi-values"),
+                },
+            ),
+        ]
+    )
+    lookup = build_labels_lookup(labels_cfg)
+    assert is_label_entity("person:name:Alice", labels_cfg, lookup)
+    assert is_label_entity("person:department:engineering", labels_cfg, lookup)
+    assert is_label_entity("person:skills:python", labels_cfg, lookup)
+    assert not is_label_entity("person:unknown:value", labels_cfg, lookup)
+
+
+def test_is_label_entity_nested_map_with_enum():
+    """Deeply nested paths with value/multi-values fields are recognized."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "job": MapField(
+                        type="map",
+                        fields={
+                            "level": MapField(type="value"),
+                            "languages": MapField(type="multi-values"),
+                        },
+                    ),
+                },
+            ),
+        ]
+    )
+    lookup = build_labels_lookup(labels_cfg)
+    assert is_label_entity("person:job:level:senior", labels_cfg, lookup)
+    assert is_label_entity("person:job:languages:python", labels_cfg, lookup)
+    assert not is_label_entity("person:job:salary:100k", labels_cfg, lookup)
+
+
+def test_map_field_enum_schema_generation():
+    """Map fields with value/multi-values generate correct JSON schema constraints."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                fields={
+                    "name": MapField(type="text"),
+                    "department": MapField(
+                        type="value",
+                        values=[LabelValue(value="engineering"), LabelValue(value="sales")],
+                    ),
+                    "skills": MapField(
+                        type="multi-values",
+                        values=[LabelValue(value="python"), LabelValue(value="go")],
+                    ),
+                },
+            ),
+        ]
+    )
+    model = build_labels_model(labels_cfg)
+    assert model is not None
+    schema = model.model_json_schema()
+    # Resolve $defs to find the person entity schema
+    person_ref = schema["properties"]["person"]["items"]
+    if "$ref" in person_ref:
+        ref_name = person_ref["$ref"].split("/")[-1]
+        person_schema = schema["$defs"][ref_name]
+    else:
+        person_schema = person_ref
+    props = person_schema["properties"]
+    # department should be an enum
+    assert "department" in props
+    assert "enum" in props["department"] or "anyOf" in props["department"]
+    # skills should be an array
+    assert "skills" in props
+    assert props["skills"]["type"] == "array"
+
+
+def test_prompt_section_map_with_all_field_types():
+    """Prompt includes correct type hints for value/multi-values/map fields."""
+    from hindsight_api.engine.retain.fact_extraction import _build_labels_prompt_section
+
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(
+                key="person",
+                type="map",
+                description="A person",
+                fields={
+                    "name": MapField(type="text", description="Full name"),
+                    "department": MapField(
+                        type="value",
+                        description="Department",
+                        values=[LabelValue(value="eng"), LabelValue(value="sales")],
+                    ),
+                    "skills": MapField(
+                        type="multi-values",
+                        description="Skills list",
+                        values=[LabelValue(value="python"), LabelValue(value="go")],
+                    ),
+                    "address": MapField(
+                        type="map",
+                        description="Home address",
+                        fields={"city": MapField(type="text")},
+                    ),
+                },
+            ),
+        ]
+    )
+    result = _build_labels_prompt_section(labels_cfg)
+    assert "name (text)" in result
+    assert "one of: eng, sales" in result
+    assert "multi-values: python, go" in result
+    assert "address (object)" in result
+    assert "city (text)" in result
+
+
+def test_duplicate_entity_strings_deduplicated():
+    """Same entity string from multiple nested objects is only added once."""
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    fields = {
+        "name": MapField(type="text"),
+    }
+    # Two entities with the same name
+    validated: list[Entity] = []
+    existing: set[str] = set()
+    _extract_map_entities({"name": "Alice"}, fields, "person:", validated, existing)
+    _extract_map_entities({"name": "Alice"}, fields, "person:", validated, existing)
+
+    texts = [e.text for e in validated]
+    assert texts == ["person:name:Alice"]  # only once

--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -64,13 +64,20 @@ type ObservationsEdits = {
 };
 
 type LabelValue = { value: string; description: string };
+type MapField = {
+  type: "text" | "value" | "multi-values" | "map";
+  description: string;
+  values?: LabelValue[];
+  fields?: Record<string, MapField>;
+};
 type LabelGroup = {
   key: string;
   description: string;
-  type: "value" | "multi-values" | "text";
+  type: "value" | "multi-values" | "text" | "map";
   optional: boolean;
   tag: boolean;
   values: LabelValue[];
+  fields: Record<string, MapField>;
 };
 
 type MCPEdits = {
@@ -1295,6 +1302,242 @@ function TraitRow({
   );
 }
 
+// ─── MapFieldsEditor (recursive) ─────────────────────────────────────────────
+
+/** Build an output-example string for the badge. */
+function exampleBadge(
+  key: string,
+  attr: { type: string; values?: LabelValue[]; fields?: Record<string, MapField> }
+): string {
+  if (attr.type === "map" && attr.fields && Object.keys(attr.fields).length > 0)
+    return `e.g. ${Object.keys(attr.fields)
+      .slice(0, 2)
+      .map((f) => `${key}:${f}:<value>`)
+      .join(", ")}`;
+  if (attr.type === "text") return `e.g. ${key}:<any text>`;
+  if ((attr.values?.length ?? 0) > 0) return `e.g. ${key}:${attr.values![0].value || "<value>"}`;
+  return `e.g. ${key}:<value>`;
+}
+
+const FIELD_TYPE_LABELS: Record<MapField["type"], string> = {
+  text: "Text",
+  value: "Single value",
+  "multi-values": "Multi-values",
+  map: "Map",
+};
+
+function MapFieldsEditor({
+  fields,
+  onChange,
+  depth,
+  extraControls,
+  examplePrefix,
+}: {
+  fields: Record<string, MapField>;
+  onChange: (fields: Record<string, MapField>) => void;
+  depth: number;
+  extraControls?: React.ReactNode;
+  examplePrefix?: string;
+}) {
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+
+  const updateField = (oldName: string, patch: Partial<MapField>) => {
+    const newFields: Record<string, MapField> = {};
+    for (const [k, v] of Object.entries(fields)) {
+      newFields[k] = k === oldName ? { ...v, ...patch } : v;
+    }
+    onChange(newFields);
+  };
+
+  const renameField = (oldName: string, newName: string) => {
+    const newFields: Record<string, MapField> = {};
+    for (const [k, v] of Object.entries(fields)) {
+      newFields[k === oldName ? newName : k] = v;
+    }
+    onChange(newFields);
+  };
+
+  const removeField = (name: string) => {
+    const newFields = { ...fields };
+    delete newFields[name];
+    onChange(newFields);
+  };
+
+  const addField = () => {
+    const newFields = { ...fields, "": { type: "text" as const, description: "" } };
+    onChange(newFields);
+  };
+
+  const isRoot = depth === 0;
+  const indent = `${(depth + 1) * 12}px`;
+
+  return (
+    <div
+      className={
+        isRoot ? "space-y-1.5 py-1" : "space-y-1.5 py-1 ml-3 border-l-2 border-border/40 pl-3"
+      }
+    >
+      {Object.keys(fields).length === 0 && (
+        <p className="text-xs text-muted-foreground italic">No fields yet.</p>
+      )}
+      {Object.entries(fields).map(([fieldName, field], fi) => {
+        const isNestedMap = field.type === "map";
+        const hasEnum = field.type === "value" || field.type === "multi-values";
+        const isOpen = expanded[fi] ?? true;
+        const hasExpandable = isNestedMap || hasEnum;
+        return (
+          <div key={fi} className="space-y-1">
+            {/* Field row */}
+            <div className="flex items-center gap-1.5">
+              {hasExpandable ? (
+                <button
+                  type="button"
+                  onClick={() => setExpanded((prev) => ({ ...prev, [fi]: !isOpen }))}
+                  className="text-muted-foreground hover:text-foreground shrink-0 p-0.5 rounded hover:bg-muted/50"
+                >
+                  {isOpen ? (
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              ) : (
+                <span className="w-[18px] shrink-0" />
+              )}
+              <Input
+                placeholder="field name"
+                value={fieldName}
+                onChange={(e) => renameField(fieldName, e.target.value)}
+                className="h-7 text-xs font-mono w-28 shrink-0"
+              />
+              <Input
+                placeholder="extractor hint: what to extract"
+                value={field.description}
+                onChange={(e) => updateField(fieldName, { description: e.target.value })}
+                className="h-7 text-xs flex-1 min-w-0"
+              />
+              <Select
+                value={field.type}
+                onValueChange={(v: MapField["type"]) =>
+                  updateField(fieldName, {
+                    type: v,
+                    ...(v === "map" ? { fields: field.fields ?? {}, values: undefined } : {}),
+                    ...(v === "text" ? { fields: undefined, values: undefined } : {}),
+                    ...(v === "value" || v === "multi-values"
+                      ? { fields: undefined, values: field.values ?? [] }
+                      : {}),
+                  })
+                }
+              >
+                <SelectTrigger className="h-7 text-xs w-[120px] shrink-0 px-2 py-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(FIELD_TYPE_LABELS).map(([val, label]) => (
+                    <SelectItem key={val} value={val} className="text-xs">
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {extraControls}
+              <button
+                type="button"
+                onClick={() => removeField(fieldName)}
+                className="text-muted-foreground hover:text-destructive shrink-0 p-0.5 rounded hover:bg-destructive/10"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
+            {/* Example badge — only at root level to avoid clutter */}
+            {isRoot && examplePrefix && fieldName && (
+              <div className="ml-[18px] pl-1.5">
+                <span className="text-[10px] font-mono text-muted-foreground/60 leading-none">
+                  {exampleBadge(examplePrefix, field)}
+                </span>
+              </div>
+            )}
+
+            {/* Nested map fields */}
+            {isOpen && isNestedMap && (
+              <MapFieldsEditor
+                fields={field.fields ?? {}}
+                onChange={(subFields) => updateField(fieldName, { fields: subFields })}
+                depth={depth + 1}
+                examplePrefix={examplePrefix ? `${examplePrefix}:${fieldName}` : undefined}
+              />
+            )}
+
+            {/* Enum values for value/multi-values fields */}
+            {isOpen && hasEnum && (
+              <div className="ml-6 space-y-0.5 py-1">
+                {(field.values ?? []).length === 0 && (
+                  <p className="text-[11px] text-muted-foreground italic">No values yet.</p>
+                )}
+                {(field.values ?? []).map((v, vi) => (
+                  <div key={vi} className="flex items-center gap-1.5 group/val">
+                    <span className="text-muted-foreground/50 text-[10px] shrink-0">&#x2022;</span>
+                    <Input
+                      placeholder="value"
+                      value={v.value}
+                      onChange={(e) => {
+                        const newValues = [...(field.values ?? [])];
+                        newValues[vi] = { ...v, value: e.target.value };
+                        updateField(fieldName, { values: newValues });
+                      }}
+                      className="h-6 text-[11px] font-mono w-24 shrink-0 border-dashed"
+                    />
+                    <Input
+                      placeholder="extractor hint: when to pick this value"
+                      value={v.description}
+                      onChange={(e) => {
+                        const newValues = [...(field.values ?? [])];
+                        newValues[vi] = { ...v, description: e.target.value };
+                        updateField(fieldName, { values: newValues });
+                      }}
+                      className="h-6 text-[11px] flex-1 min-w-0 border-dashed"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const newValues = (field.values ?? []).filter((_, i) => i !== vi);
+                        updateField(fieldName, { values: newValues });
+                      }}
+                      className="text-muted-foreground/40 hover:text-destructive shrink-0 p-0.5 rounded hover:bg-destructive/10 opacity-0 group-hover/val:opacity-100 transition-opacity"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => {
+                    const newValues = [...(field.values ?? []), { value: "", description: "" }];
+                    updateField(fieldName, { values: newValues });
+                  }}
+                  className="text-[11px] text-muted-foreground/60 hover:text-foreground inline-flex items-center gap-1 ml-2.5"
+                >
+                  <Plus className="h-2.5 w-2.5" />
+                  value
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={addField}
+        className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+      >
+        <Plus className="h-3 w-3" />
+        field
+      </button>
+    </div>
+  );
+}
+
 // ─── EntityLabelsEditor ───────────────────────────────────────────────────────
 
 function emptyAttribute(): LabelGroup {
@@ -1305,11 +1548,8 @@ function emptyAttribute(): LabelGroup {
     optional: true,
     tag: false,
     values: [],
+    fields: {},
   };
-}
-
-function emptyValue(): LabelValue {
-  return { value: "", description: "" };
 }
 
 function EntityLabelsEditor({
@@ -1319,8 +1559,6 @@ function EntityLabelsEditor({
   value: LabelGroup[];
   onChange: (attrs: LabelGroup[]) => void;
 }) {
-  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
-
   const updateAttr = (i: number, patch: Partial<LabelGroup>) => {
     const next = value.map((a, idx) => (idx === i ? { ...a, ...patch } : a));
     onChange(next);
@@ -1328,32 +1566,10 @@ function EntityLabelsEditor({
 
   const removeAttr = (i: number) => {
     onChange(value.filter((_, idx) => idx !== i));
-    setExpanded((prev) => {
-      const next = { ...prev };
-      delete next[i];
-      return next;
-    });
   };
 
   const addAttr = () => {
-    const next = [...value, emptyAttribute()];
-    onChange(next);
-    setExpanded((prev) => ({ ...prev, [next.length - 1]: true }));
-  };
-
-  const updateVal = (attrIdx: number, valIdx: number, patch: Partial<LabelValue>) => {
-    const newValues = value[attrIdx].values.map((v, vi) =>
-      vi === valIdx ? { ...v, ...patch } : v
-    );
-    updateAttr(attrIdx, { values: newValues });
-  };
-
-  const removeVal = (attrIdx: number, valIdx: number) => {
-    updateAttr(attrIdx, { values: value[attrIdx].values.filter((_, vi) => vi !== valIdx) });
-  };
-
-  const addVal = (attrIdx: number) => {
-    updateAttr(attrIdx, { values: [...value[attrIdx].values, emptyValue()] });
+    onChange([...value, emptyAttribute()]);
   };
 
   return (
@@ -1362,12 +1578,13 @@ function EntityLabelsEditor({
         <div>
           <p className="text-sm font-medium">Entity Labels</p>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Classification labels extracted at retain time. Leave empty to disable.
+            Extracted per memory at retain time. Every field is optional — only filled when clearly
+            applicable.
           </p>
         </div>
         {value.length > 0 && (
           <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full shrink-0">
-            {value.length} group{value.length !== 1 ? "s" : ""}
+            {value.length} label{value.length !== 1 ? "s" : ""}
           </span>
         )}
       </div>
@@ -1377,124 +1594,51 @@ function EntityLabelsEditor({
       )}
 
       <div className="space-y-2">
-        {value.map((attr, i) => {
-          const isOpen = expanded[i] ?? false;
-          const isText = attr.type === "text";
-          const hasValues = !isText;
-          return (
-            <div key={i} className="border border-border/50 rounded-md bg-background">
-              {/* Attribute header */}
-              <div className="flex items-center gap-2 px-3 py-2">
-                <button
-                  type="button"
-                  onClick={() => setExpanded((prev) => ({ ...prev, [i]: !isOpen }))}
-                  className="text-muted-foreground hover:text-foreground shrink-0"
-                  disabled={isText}
+        {value.map((attr, i) => (
+          <div key={i} className="border border-border/50 rounded-md bg-background">
+            {/* Rendered via MapFieldsEditor as a single-field editor */}
+            <MapFieldsEditor
+              fields={{
+                [attr.key]: {
+                  type: attr.type as MapField["type"],
+                  description: attr.description,
+                  values: attr.values,
+                  fields: attr.fields,
+                },
+              }}
+              onChange={(updated) => {
+                const entries = Object.entries(updated);
+                if (entries.length === 0) {
+                  removeAttr(i);
+                } else {
+                  const [newKey, newField] = entries[0];
+                  updateAttr(i, {
+                    key: newKey,
+                    type: newField.type as LabelGroup["type"],
+                    description: newField.description,
+                    values: newField.values ?? [],
+                    fields: newField.fields ?? {},
+                  });
+                }
+              }}
+              depth={0}
+              extraControls={
+                <label
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0 cursor-pointer select-none"
+                  title="Also store extracted values as tags on the memory (not just entities)"
                 >
-                  {isOpen && hasValues ? (
-                    <ChevronDown className="h-4 w-4" />
-                  ) : (
-                    <ChevronRight className={`h-4 w-4 ${isText ? "opacity-30" : ""}`} />
-                  )}
-                </button>
-                <Input
-                  placeholder="key (e.g. pedagogy)"
-                  value={attr.key}
-                  onChange={(e) => updateAttr(i, { key: e.target.value })}
-                  className="h-8 text-xs font-mono w-36 shrink-0"
-                />
-                <Input
-                  placeholder={isText ? "description / examples" : "description"}
-                  value={attr.description}
-                  onChange={(e) => updateAttr(i, { description: e.target.value })}
-                  className="h-8 text-xs flex-1 min-w-0"
-                />
-                {/* Type dropdown */}
-                <Select
-                  value={attr.type}
-                  onValueChange={(v: "value" | "multi-values" | "text") =>
-                    updateAttr(i, {
-                      type: v,
-                      // reset values when switching to free text
-                      ...(v === "text" ? { values: [] } : {}),
-                    })
-                  }
-                >
-                  <SelectTrigger className="h-8 text-xs w-32 shrink-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="value" className="text-xs">
-                      Single value
-                    </SelectItem>
-                    <SelectItem value="multi-values" className="text-xs">
-                      Multi-values
-                    </SelectItem>
-                    <SelectItem value="text" className="text-xs">
-                      Free text
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {/* Tag checkbox — also write extracted labels as tags */}
-                <label className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0 cursor-pointer select-none">
                   <Checkbox
                     checked={attr.tag}
                     onCheckedChange={(checked) => updateAttr(i, { tag: !!checked })}
                     className="h-4 w-4"
                   />
-                  tag
+                  + tag
                 </label>
-                <button
-                  type="button"
-                  onClick={() => removeAttr(i)}
-                  className="text-muted-foreground hover:text-destructive shrink-0"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </div>
-
-              {/* Values list — enum and multi-values only */}
-              {isOpen && hasValues && (
-                <div className="px-3 pb-3 space-y-1 border-t border-border/30 pt-2">
-                  {attr.values.length === 0 && (
-                    <p className="text-xs text-muted-foreground italic pl-5">No values yet.</p>
-                  )}
-                  {attr.values.map((v, vi) => (
-                    <div key={vi} className="flex items-center gap-2 pl-5">
-                      <Input
-                        placeholder="value"
-                        value={v.value}
-                        onChange={(e) => updateVal(i, vi, { value: e.target.value })}
-                        className="h-8 text-xs font-mono w-32 shrink-0"
-                      />
-                      <Input
-                        placeholder="description"
-                        value={v.description}
-                        onChange={(e) => updateVal(i, vi, { description: e.target.value })}
-                        className="h-8 text-xs flex-1 min-w-0"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => removeVal(i, vi)}
-                        className="text-muted-foreground hover:text-destructive shrink-0"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => addVal(i)}
-                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground pl-5 mt-1"
-                  >
-                    <Plus className="h-3 w-3" />
-                    Add value
-                  </button>
-                </div>
-              )}
-            </div>
-          );
-        })}
+              }
+              examplePrefix={attr.key}
+            />
+          </div>
+        ))}
       </div>
 
       <button
@@ -1503,7 +1647,7 @@ function EntityLabelsEditor({
         className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
       >
         <Plus className="h-3.5 w-3.5" />
-        Add attribute
+        Add label
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds `type="map"` to entity_labels allowing users to define structured entity types with named fields (e.g., Person with name, role, organization)
- Each field is stored as a flat `key:field:value` entity string (e.g., `person:name:Alice`), reusing existing entity storage with no DB changes
- Fields support all types recursively: text, value, multi-values, and nested map
- Control plane UI updated with a shared recursive `MapFieldsEditor` component with tree-style visual nesting

Closes #1370

## Test plan
- [x] 25+ unit tests for map config parsing, model building, lookup, prompt generation, post-processing (all field type combinations)
- [x] LLM integration test (`test_retain_extracts_map_type_entities`) verifies end-to-end extraction with real Gemini
- [x] All existing entity label tests pass (no regressions)
- [x] TypeScript compiles cleanly
- [ ] Manual test: configure map-type labels in control plane UI, retain content, verify entities