### PR TITLE
follow-up to #1459: AlloyDB ScaNN docs + review-nit cleanups

### DIFF
--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -4,9 +4,21 @@ from __future__ import annotations
 
 import logging
 
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
 logger = logging.getLogger(__name__)
 
-VALID_EXTENSIONS = ("pgvector", "pgvectorscale", "vchord", "scann")
+# Extensions a user can set via HINDSIGHT_API_VECTOR_EXTENSION.
+CONFIGURABLE_EXTENSIONS = ("pgvector", "pgvectorscale", "vchord", "scann")
+
+# Extensions detect_vector_extension() can return. pg_diskann is a runtime-only
+# resolution from a configured "pgvectorscale" backend on Azure (uses a different
+# WITH clause), never a value the user sets directly.
+RESOLVED_EXTENSIONS = (*CONFIGURABLE_EXTENSIONS, "pg_diskann")
+
+# Backwards-compatible alias for older imports.
+VALID_EXTENSIONS = CONFIGURABLE_EXTENSIONS
 
 SCANN_MIN_ROWS_FOR_AUTO_INDEX = 10_000
 
@@ -56,11 +68,24 @@ _INSTALL_HINTS = {
 
 
 def validate_extension(name: str) -> str:
-    """Return a normalized vector extension name or raise for unsupported input."""
+    """Return a normalized configurable vector extension name or raise.
+
+    Used at the user-facing config boundary; pg_diskann is rejected here because
+    it is a detection-time alias, never a value the user sets directly.
+    """
     ext = name.lower()
-    if ext not in VALID_EXTENSIONS:
-        valid = ", ".join(VALID_EXTENSIONS)
+    if ext not in CONFIGURABLE_EXTENSIONS:
+        valid = ", ".join(CONFIGURABLE_EXTENSIONS)
         raise ValueError(f"Invalid vector_extension: {name}. Must be one of: {valid}")
+    return ext
+
+
+def _normalize_resolved(name: str) -> str:
+    """Normalize either a user-configurable or detect-time extension name."""
+    ext = name.lower()
+    if ext not in RESOLVED_EXTENSIONS:
+        valid = ", ".join(RESOLVED_EXTENSIONS)
+        raise ValueError(f"Unknown vector extension: {name}. Must be one of: {valid}")
     return ext
 
 
@@ -71,26 +96,17 @@ def pg_extension_name(ext: str) -> str:
 
 def index_using_clause(ext: str) -> str:
     """Return the CREATE INDEX USING clause for the vector backend."""
-    normalized = ext.lower()
-    if normalized == "pg_diskann":
-        return _INDEX_USING_CLAUSES[normalized]
-    return _INDEX_USING_CLAUSES[validate_extension(normalized)]
+    return _INDEX_USING_CLAUSES[_normalize_resolved(ext)]
 
 
 def index_type_keyword(ext: str) -> str:
     """Return the keyword that identifies this index type in pg_indexes.indexdef."""
-    normalized = ext.lower()
-    if normalized == "pg_diskann":
-        return _INDEX_TYPE_KEYWORDS[normalized]
-    return _INDEX_TYPE_KEYWORDS[validate_extension(normalized)]
+    return _INDEX_TYPE_KEYWORDS[_normalize_resolved(ext)]
 
 
 def minimum_rows_for_index(ext: str) -> int:
     """Return the minimum populated embedding rows before creating this index type."""
-    normalized = ext.lower()
-    if normalized == "pg_diskann":
-        return 0
-    return SCANN_MIN_ROWS_FOR_AUTO_INDEX if validate_extension(normalized) == "scann" else 0
+    return SCANN_MIN_ROWS_FOR_AUTO_INDEX if _normalize_resolved(ext) == "scann" else 0
 
 
 def should_defer_index_creation(ext: str, row_count: int) -> bool:
@@ -101,25 +117,19 @@ def should_defer_index_creation(ext: str, row_count: int) -> bool:
 
 def uses_per_bank_vector_indexes(ext: str) -> bool:
     """Return whether the backend should create per-bank partial vector indexes."""
-    normalized = ext.lower()
-    if normalized == "pg_diskann":
-        return True
-    return validate_extension(normalized) != "scann"
+    return _normalize_resolved(ext) != "scann"
 
 
-def bootstrap_extension(conn, ext: str) -> None:
+def bootstrap_extension(conn: Connection, ext: str) -> None:
     """Install the configured vector extension and any prerequisites if possible."""
-    from sqlalchemy import text
-
     normalized = validate_extension(ext)
     for statement in _EXTENSION_INSTALL_SQL[normalized]:
         conn.execute(text(statement))
 
 
-def detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
+def detect_vector_extension(conn: Connection, vector_extension: str = "pgvector") -> str:
     """Validate the configured vector extension exists and return the index backend."""
     configured_ext = validate_extension(vector_extension)
-    from sqlalchemy import text
 
     if configured_ext == "pgvectorscale":
         pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -70,6 +70,7 @@ def _drop_per_bank_vector_indexes(conn: Connection, schema_name: str) -> None:
         """),
         {"schema_name": schema_name},
     ).fetchall()
+    # DDL identifiers cannot be passed as bound parameters, so escape inline.
     safe_schema = schema_name.replace('"', '""')
     for row in rows:
         safe_index = row[0].replace('"', '""')

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -75,7 +75,7 @@ def test_scann_does_not_use_per_bank_partial_indexes():
 
 
 def test_alembic_vector_migrations_freeze_vector_sql_locally():
-    migration_dir = Path("hindsight_api/alembic/versions")
+    migration_dir = Path(__file__).resolve().parent.parent / "hindsight_api/alembic/versions"
     changed_migrations = [
         "5a366d414dce_initial_schema.py",
         "a4b5c6d7e8f9_fix_per_bank_vector_index_type.py",

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -68,9 +68,9 @@ hindsight-admin run-db-migration --schema tenant_acme
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_VECTOR_EXTENSION` | Vector index algorithm: `pgvector`, `vchord`, or `pgvectorscale` | `pgvector` |
+| `HINDSIGHT_API_VECTOR_EXTENSION` | Vector index algorithm: `pgvector`, `vchord`, `pgvectorscale`, or `scann` | `pgvector` |
 
-Hindsight supports three PostgreSQL vector extensions:
+Hindsight supports four PostgreSQL vector extensions:
 
 #### **pgvector** (HNSW - default)
 - In-memory index using Hierarchical Navigable Small World algorithm
@@ -96,6 +96,13 @@ Hindsight supports three PostgreSQL vector extensions:
 - Includes integrated BM25 search capabilities
 - Requires `vchord` extension
 
+#### **scann** (AlloyDB ScaNN)
+- Google's ScaNN index, available on **AlloyDB** and **AlloyDB Omni**
+- Uses a single global vector index in `AUTO` mode (per-bank partial indexes are not used)
+- **Installation:** `CREATE EXTENSION vector; CREATE EXTENSION alloydb_scann CASCADE;`
+- **Index build is deferred** until a table reaches **10,000 populated embedding rows** — AlloyDB cannot build a ScaNN AUTO index on a near-empty table. Until that threshold is crossed, recall falls back to a sequential scan; the global index is built on the next API startup once enough rows exist.
+- A ready-to-use Docker Compose stack is provided at [`docker/docker-compose/alloydb/docker-compose.yaml`](https://github.com/vectorize-io/hindsight/blob/main/docker/docker-compose/alloydb/docker-compose.yaml) for running Hindsight against AlloyDB Omni locally.
+
 **When to use pgvectorscale (DiskANN):**
 - Large datasets (10M+ vectors) ⭐
 - Complex filtering requirements
@@ -114,11 +121,15 @@ Hindsight supports three PostgreSQL vector extensions:
 - Want integrated BM25 search
 - Already using vchord for text search
 
+**When to use scann:**
+- Running on Google **AlloyDB** or **AlloyDB Omni**
+- Want managed ScaNN with `AUTO` mode tuning
+
 **Switching extensions:**
 
 If you need to switch from one extension to another:
-1. Set `HINDSIGHT_API_VECTOR_EXTENSION` to your desired extension (`pgvector`, `vchord`, or `pgvectorscale`)
-2. If your database has existing data, you'll get an error with migration instructions
+1. Set `HINDSIGHT_API_VECTOR_EXTENSION` to your desired extension (`pgvector`, `vchord`, `pgvectorscale`, or `scann`)
+2. If your database has existing data, you'll get an error with migration instructions (note: switching **to** `scann` is allowed even with data — the existing index is dropped and rebuilt as ScaNN once the table has at least 10,000 embedding rows)
 3. For empty databases, indexes will be automatically recreated on startup
 
 **Learn more:**

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -29,6 +29,7 @@ Hindsight requires PostgreSQL 14+ with a vector extension for similarity search.
 - **pgvector** (default)
 - **pgvectorscale**
 - **vchord**
+- **scann** (AlloyDB)
 
 Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configuration](./configuration) for details.
 
@@ -38,6 +39,7 @@ Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configura
 - **Supabase** — Managed PostgreSQL with pgvector built-in
 - **Neon** — Serverless PostgreSQL with pgvector
 - **Azure Database for PostgreSQL** — With pgvector and pgvectorscale support
+- **Google AlloyDB** / **AlloyDB Omni** — With pgvector and ScaNN support
 - **AWS RDS** / **Cloud SQL** — With pgvector extension enabled
 - **Self-hosted** — PostgreSQL 14+ with your preferred vector extension
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -68,9 +68,9 @@ hindsight-admin run-db-migration --schema tenant_acme
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_VECTOR_EXTENSION` | Vector index algorithm: `pgvector`, `vchord`, or `pgvectorscale` | `pgvector` |
+| `HINDSIGHT_API_VECTOR_EXTENSION` | Vector index algorithm: `pgvector`, `vchord`, `pgvectorscale`, or `scann` | `pgvector` |
 
-Hindsight supports three PostgreSQL vector extensions:
+Hindsight supports four PostgreSQL vector extensions:
 
 #### **pgvector** (HNSW - default)
 - In-memory index using Hierarchical Navigable Small World algorithm
@@ -96,6 +96,13 @@ Hindsight supports three PostgreSQL vector extensions:
 - Includes integrated BM25 search capabilities
 - Requires `vchord` extension
 
+#### **scann** (AlloyDB ScaNN)
+- Google's ScaNN index, available on **AlloyDB** and **AlloyDB Omni**
+- Uses a single global vector index in `AUTO` mode (per-bank partial indexes are not used)
+- **Installation:** `CREATE EXTENSION vector; CREATE EXTENSION alloydb_scann CASCADE;`
+- **Index build is deferred** until a table reaches **10,000 populated embedding rows** — AlloyDB cannot build a ScaNN AUTO index on a near-empty table. Until that threshold is crossed, recall falls back to a sequential scan; the global index is built on the next API startup once enough rows exist.
+- A ready-to-use Docker Compose stack is provided at [`docker/docker-compose/alloydb/docker-compose.yaml`](https://github.com/vectorize-io/hindsight/blob/main/docker/docker-compose/alloydb/docker-compose.yaml) for running Hindsight against AlloyDB Omni locally.
+
 **When to use pgvectorscale (DiskANN):**
 - Large datasets (10M+ vectors) ⭐
 - Complex filtering requirements
@@ -114,11 +121,15 @@ Hindsight supports three PostgreSQL vector extensions:
 - Want integrated BM25 search
 - Already using vchord for text search
 
+**When to use scann:**
+- Running on Google **AlloyDB** or **AlloyDB Omni**
+- Want managed ScaNN with `AUTO` mode tuning
+
 **Switching extensions:**
 
 If you need to switch from one extension to another:
-1. Set `HINDSIGHT_API_VECTOR_EXTENSION` to your desired extension (`pgvector`, `vchord`, or `pgvectorscale`)
-2. If your database has existing data, you'll get an error with migration instructions
+1. Set `HINDSIGHT_API_VECTOR_EXTENSION` to your desired extension (`pgvector`, `vchord`, `pgvectorscale`, or `scann`)
+2. If your database has existing data, you'll get an error with migration instructions (note: switching **to** `scann` is allowed even with data — the existing index is dropped and rebuilt as ScaNN once the table has at least 10,000 embedding rows)
 3. For empty databases, indexes will be automatically recreated on startup
 
 **Learn more:**

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -29,6 +29,7 @@ Hindsight requires PostgreSQL 14+ with a vector extension for similarity search.
 - **pgvector** (default)
 - **pgvectorscale**
 - **vchord**
+- **scann** (AlloyDB)
 
 Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configuration](./configuration) for details.
 
@@ -38,6 +39,7 @@ Configure which one to use with `HINDSIGHT_API_VECTOR_EXTENSION`. See [Configura
 - **Supabase** — Managed PostgreSQL with pgvector built-in
 - **Neon** — Serverless PostgreSQL with pgvector
 - **Azure Database for PostgreSQL** — With pgvector and pgvectorscale support
+- **Google AlloyDB** / **AlloyDB Omni** — With pgvector and ScaNN support
 - **AWS RDS** / **Cloud SQL** — With pgvector extension enabled
 - **Self-hosted** — PostgreSQL 14+ with your preferred vector extension
 


### PR DESCRIPTION
## Summary
Follow-up to #1459. Two commits:

**1. Docs** (045d4f12)
- Add `scann` to the supported-extensions list in `installation.md` and list Google AlloyDB / AlloyDB Omni among recommended production deployments.
- New **scann (AlloyDB ScaNN)** section in `configuration.md`: install SQL, the global-index lifecycle, and the **10,000-row deferred-build caveat** (recall falls back to seq scan until the threshold is crossed; the global index is built on the next API startup once enough rows exist).
- Link the new `docker/docker-compose/alloydb/docker-compose.yaml` stack as the AlloyDB Omni quickstart.
- Note that switching **to** `scann` is allowed even with existing data.
- Pre-commit auto-regenerated `skills/hindsight-docs/references/...` mirror.

**2. Review-nit cleanups in `_vector_index.py`** (bcc6dbbf) — addresses the design nits flagged on the parent PR review:
- Lift `from sqlalchemy import text` (and add `Connection`) to module top; both helpers now have proper type hints (`bootstrap_extension(conn: Connection, ...)`, `detect_vector_extension(conn: Connection, ...)`).
- Make `pg_diskann` first-class via a new `RESOLVED_EXTENSIONS` tuple and a `_normalize_resolved` helper. The user-config boundary stays strict (`validate_extension` rejects `pg_diskann`); the resolved helpers (`index_using_clause`, `index_type_keyword`, `minimum_rows_for_index`, `uses_per_bank_vector_indexes`) accept it without per-call `if normalized == "pg_diskann":` branches. Behavior is identical.
- Harden `test_alembic_vector_migrations_freeze_vector_sql_locally` to resolve the migrations dir from `__file__` instead of the working directory.
- One-liner comment in `_drop_per_bank_vector_indexes` explaining why DDL identifiers are escaped inline rather than bound.

## Test plan
- [x] `uv run pytest tests/test_vector_index.py` — 10 passed
- [x] `uv run pytest tests/test_migration_shape.py tests/test_migrations_thread_safety.py` — 64 passed
- [x] `./scripts/hooks/lint.sh` — all lints passed
- [x] `uv run ty check hindsight_api/_vector_index.py hindsight_api/migrations.py` — all checks passed
- [ ] Render the docs site locally and confirm the new ScaNN section renders with the inline link.