### PR TITLE
docs(entity-labels): document type="map" structured entity groups

### DIFF
--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -127,10 +127,11 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `key` | — | Label group identifier. Becomes the prefix in `key:value` entities. |
+| `key` | — | Label group identifier. Becomes the prefix in `key:value` entities (or `key:field:value` for `"map"`). |
 | `description` | `""` | Shown to the LLM to guide label assignment. |
-| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string. |
-| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"`. |
+| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"map"` → structured group with named fields. |
+| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"` and `"map"`. |
+| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
 | `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` groups (always optional). |
 | `tag` | `false` | When `true`, extracted `key:value` labels are also written as tags on the memory unit, enabling filtering via `tags`/`tags_match` in recall/reflect. |
 
@@ -145,6 +146,21 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
   "type": "text",
   "optional": true,
   "values": []
+}
+```
+
+**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
+
+```json
+{
+  "key": "person",
+  "description": "A person mentioned in the text",
+  "type": "map",
+  "fields": {
+    "name":         { "type": "text", "description": "Full name of the person" },
+    "role":         { "type": "text", "description": "Job title or role" },
+    "organization": { "type": "text", "description": "Company or organization" }
+  }
 }
 ```
 

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -120,10 +120,11 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `key` | — | Label group identifier. Becomes the prefix in `key:value` entities. |
+| `key` | — | Label group identifier. Becomes the prefix in `key:value` entities (or `key:field:value` for `"map"`). |
 | `description` | `""` | Shown to the LLM to guide label assignment. |
-| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string. |
-| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"`. |
+| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"map"` → structured group with named fields. |
+| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"` and `"map"`. |
+| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
 | `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` groups (always optional). |
 | `tag` | `false` | When `true`, extracted `key:value` labels are also written as tags on the memory unit, enabling filtering via `tags`/`tags_match` in recall/reflect. |
 
@@ -138,6 +139,21 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
   "type": "text",
   "optional": true,
   "values": []
+}
+```
+
+**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
+
+```json
+{
+  "key": "person",
+  "description": "A person mentioned in the text",
+  "type": "map",
+  "fields": {
+    "name":         { "type": "text", "description": "Full name of the person" },
+    "role":         { "type": "text", "description": "Job title or role" },
+    "organization": { "type": "text", "description": "Company or organization" }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

#1505 (just merged 2026-05-07T11:32Z) added `type="map"` to entity_labels, allowing users to define structured entity types with named fields (e.g., a `person` group with `name`, `role`, `organization` sub-fields). Each field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing existing entity storage with no DB changes. Closes #1370.

The bank-config docs only enumerate `value` / `multi-values` / `text` types and don't mention `fields`, so SDK developers reading the API reference cannot discover the new primitive — they have to find it via control-plane UI or read the source.

This PR documents the new `"map"` type in both:

- `hindsight-docs/docs/developer/api/memory-banks.mdx` (Field table + new "Map groups" subsection)
- `skills/hindsight-docs/references/developer/api/memory-banks.md` (sidecar mirror)

## Changes

- Field table: extend `type` enum description with `"map"`, extend `values` description (also ignored for map), add new `fields` row.
- Update `key` row description: prefix becomes `key:field:value` for `"map"` (matches storage format from `entity_labels.py:_is_map_label_entity`).
- Add **Map groups** subsection with the canonical `person` example from `tests/test_entity_labels.py::test_retain_extracts_map_type_entities` (name / role / organization), and a sentence explaining the `key:field:value` storage convention and that nesting + recursion are supported.

Byte-for-byte identical edit between mdx and sidecar mirror to keep the dual-doc pair consistent.

## Test plan

- [x] No code change — pure markdown.
- [x] Schema details (`type` enum values, `fields` semantics, recursion) verified against `LabelGroup` / `MapField` in `hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py` (post-#1505).
- [x] Storage convention `key:field:value` verified against `_is_map_label_entity` and `is_label_entity` in same file.
- [x] Example payload verified against `tests/test_entity_labels.py::test_retain_extracts_map_type_entities`.