### PR TITLE
fix(worker): liveness-gate busy_banks for stuck processing rows (runtime, scoped from #1488)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -736,10 +736,21 @@ class PostgreSQLOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
+                # Liveness gate: a `processing` row whose `updated_at` is
+                # older than 1 hour is treated as dead and stops blocking
+                # the bank. Real consolidation jobs complete in seconds to
+                # a few minutes; 1 hour gives headroom for legitimate slow
+                # runs while recovering from worker-stuck cases that
+                # `_recover_orphaned_tasks` cannot (orphans owned by a
+                # worker_id that no longer exists, e.g. after OOM, scale-
+                # down, or any non-graceful exit). See vectorize-io/
+                # hindsight#1470 for two independent reproductions.
                 busy_banks = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    WHERE operation_type = 'consolidation'
+                      AND status = 'processing'
+                      AND updated_at > NOW() - INTERVAL '1 hour'
                     """,
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
@@ -840,11 +851,14 @@ class PostgreSQLOps(DataAccessOps):
             remaining_shared -= len(rows)
 
             # 2b. Consolidation tasks (with bank-serialization)
+            # Same liveness gate as Phase 1 — see comment above for rationale.
             if remaining_shared > 0:
                 busy_banks_2 = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
-                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    WHERE operation_type = 'consolidation'
+                      AND status = 'processing'
+                      AND updated_at > NOW() - INTERVAL '1 hour'
                     """,
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3103,6 +3103,131 @@ class TestWorkerStatus:
         assert len(worker_x_rows) == 2
         assert len(worker_y_rows) == 1
 
+
+class TestBusyBankLivenessGate:
+    """Regression tests for orphaned-processing-row bug — runtime path only.
+
+    Issue #1470 reports: when a worker dies mid-consolidation (OOM, SIGKILL,
+    upstream LLM failure that prevents progress, container OOM-kill, etc.),
+    the async_operations row is left in status='processing' with a stale
+    updated_at and a worker_id that no longer exists. The bank-serialization
+    filter in claim_tasks() then permanently excludes the bank from claim,
+    even though no live worker is actually processing the row.
+
+    The maintainer's recommendation (set HINDSIGHT_API_WORKER_ID to a stable
+    value) covers planned graceful restarts but not the worker-stuck class.
+    These tests pin the runtime liveness gate (>1h stale processing rows
+    are skipped by the busy_banks filter) without touching the startup
+    recovery path — that path is unchanged and continues to be controlled
+    by HINDSIGHT_API_WORKER_ID.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stale_processing_row_does_not_block_claim(self, pool, backend, clean_operations):
+        """A consolidation row stuck in processing for >1h must not block claim.
+
+        Scenario: worker_A died mid-consolidation; its row has status='processing'
+        and updated_at=2 hours ago. A new worker (worker_B) should be able to
+        claim pending consolidation tasks for the same bank.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # Simulate the orphaned row left by dead worker_A: processing, updated 2h ago.
+        orphan_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'dead-worker-A', now(), now() - INTERVAL '2 hours')
+            """,
+            orphan_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(orphan_id)}),
+        )
+
+        # The pending task that should be claimed by worker_B.
+        pending_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            pending_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(pending_id)}),
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        claimed = await poller.claim_batch()
+        claimed_ids = {c.operation_id for c in claimed}
+
+        assert str(pending_id) in claimed_ids, (
+            "Worker should claim the pending consolidation task when the only "
+            "blocking processing row is stale (>1h). "
+            "Regression: orphaned row from dead worker must not block claim forever."
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_processing_row_still_blocks_claim(self, pool, backend, clean_operations):
+        """A consolidation row in processing with a recent updated_at must still block claim.
+
+        Ensures the liveness gate does not break the actual bank-serialization
+        invariant: two live workers must not consolidate the same bank concurrently.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        # A live processing row: updated_at = just now (active worker).
+        live_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'live-worker-A', now(), now())
+            """,
+            live_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(live_id)}),
+        )
+
+        # Pending task for the same bank.
+        pending_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+              (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            pending_id,
+            bank_id,
+            json.dumps({"type": "consolidation", "bank_id": bank_id, "operation_id": str(pending_id)}),
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="worker-B",
+            executor=lambda x: None,
+        )
+
+        claimed = await poller.claim_batch()
+        claimed_ids = {c.operation_id for c in claimed}
+
+        assert str(pending_id) not in claimed_ids, (
+            "Worker must NOT claim a consolidation task while a live (recently updated) "
+            "processing row exists for the same bank. Bank-serialization invariant must hold."
+        )
+
     @pytest.mark.asyncio
     async def test_worker_status_excludes_non_processing(self, pool, clean_operations):
         """Test that worker status only shows processing tasks, not pending/completed/failed."""


### PR DESCRIPTION
## Why (smaller-scope follow-up after #1488 closure)

Closing #1488 redirected to setting `HINDSIGHT_API_WORKER_ID` to a stable value as the canonical fix (#1470). That covers planned graceful restarts cleanly. It doesn't cover the cases where *the worker can't process the task it already claimed*, which is the second-reporter scenario [@descention raised](https://github.com/vectorize-io/hindsight/issues/1470#issuecomment-4396697812):

> I'm running Hindsight in podman. My llama-cpp instance had recently been updated with a different model name, so hindsight was getting 400's from llama-cpp. A consolidation task was queued. Worker `b6627cebef89` picked it up but obviously couldn't process it. I updated my container's configuration and restarted.

In their case stable `WORKER_ID` doesn't help — they restarted with a config fix, but the orphan row is still owned by `b6627cebef89` and `_recover_orphaned_tasks()` only resets rows owned by the current `worker_id`.

We hit the same chain in our deployment via different cause (worker died mid-OOM, no graceful exit). The stuck `processing` rows on `agent:cortex` had 8 different historical worker UUIDs across multiple container restarts — none matched the current worker, so the recovery query was a no-op every cycle. We unstuck it manually via `UPDATE async_operations SET status='pending', worker_id=NULL WHERE status='processing'` (48 rows reset, bank started draining within 20 seconds).

## What this PR does (smaller than #1488)

Adds `AND updated_at > NOW() - INTERVAL '1 hour'` to both `busy_banks` queries in `claim_tasks()` (Phase 1 reservation at line 739, Phase 2b shared pool at line 844). A `processing` row not touched for >1 hour is treated as dead and no longer blocks the bank from being claimed.

Scope is intentionally **smaller than #1488**:

| Path                          | #1488 | This PR | Owner               |
|-------------------------------|-------|---------|---------------------|
| `busy_banks` runtime gate     | ✅     | ✅       | Self-healing        |
| `_recover_orphaned_tasks()` startup recovery broaden | ✅     | ❌       | `HINDSIGHT_API_WORKER_ID` covers it |

The startup-recovery side is left untouched. Operators continue to set `HINDSIGHT_API_WORKER_ID` to a stable value (the documented contract); this PR is a runtime backstop for the worker-stuck cases that stable id alone cannot reach.

## Threshold rationale

1 hour is intentionally conservative. Real consolidation jobs complete in seconds to minutes (consistent with `STUCK_STACK_INITIAL_THRESHOLD_S` × 12 = 1h elsewhere in the codebase). The threshold could be made configurable via env var if you'd like; not added in this PR to keep the diff minimal.

## No migration

`updated_at` is in the initial schema (`5a366d414dce`) and is written on every claim/update transition. Confirmed `ops_postgresql.py:935` writes it on every status flip.

## Tests

`TestBusyBankLivenessGate` (`tests/test_worker.py`):

- `test_stale_processing_row_does_not_block_claim` — pending task is claimed when the only blocking row is >1h stale (primary regression case from #1470)
- `test_fresh_processing_row_still_blocks_claim` — bank-serialization invariant preserved for recently-updated processing rows

Run with:

```bash
cd hindsight-api-slim && uv run pytest tests/test_worker.py::TestBusyBankLivenessGate -v
```

Both pass against current `main`.

Refs #1470, scoped-down successor to closed #1488.