### PR TITLE
fix(n8n): drop hindsight-client runtime dep, inline HTTP calls

### DIFF
--- a/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
+++ b/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
@@ -7,7 +7,7 @@ import type {
 } from "n8n-workflow";
 import { NodeConnectionTypes, NodeOperationError } from "n8n-workflow";
 
-import { HindsightClient, type Budget } from "@vectorize-io/hindsight-client";
+type Budget = "low" | "mid" | "high";
 
 interface HindsightCredentials {
   apiUrl: string;
@@ -22,6 +22,11 @@ interface HindsightCredentials {
  *  - Retain: Store a piece of content in a memory bank
  *  - Recall: Search a bank for memories relevant to a query
  *  - Reflect: Get an LLM-synthesized answer using the bank's memories
+ *
+ * HTTP calls go through n8n's built-in `requestWithAuthentication` helper
+ * so the package ships with zero runtime dependencies (required for n8n
+ * Cloud verified-node distribution). The Bearer header is applied
+ * automatically from the configured Hindsight API credential.
  */
 export class Hindsight implements INodeType {
   description: INodeTypeDescription = {
@@ -213,10 +218,7 @@ export class Hindsight implements INodeType {
     const credentials = (await this.getCredentials(
       "hindsightApi"
     )) as unknown as HindsightCredentials;
-    const client = new HindsightClient({
-      baseUrl: credentials.apiUrl,
-      apiKey: credentials.apiKey || undefined,
-    });
+    const baseUrl = (credentials.apiUrl || "").replace(/\/$/, "");
 
     for (let i = 0; i < items.length; i++) {
       try {
@@ -234,29 +236,75 @@ export class Hindsight implements INodeType {
           const tagsRaw = this.getNodeParameter("retainTags", i, "") as string;
           const tags = parseTags(tagsRaw);
 
-          const response = await client.retain(bankId, content, tags.length ? { tags } : undefined);
-          result = response as unknown as IDataObject;
+          // Retain: POST /v1/default/banks/{bank_id}/memories
+          // Body matches HindsightClient.retain() shape: { items: [{ content, tags? }] }
+          const item: IDataObject = { content };
+          if (tags.length) {
+            item.tags = tags;
+          }
+
+          const response = (await this.helpers.requestWithAuthentication.call(
+            this,
+            "hindsightApi",
+            {
+              method: "POST",
+              url: `${baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}/memories`,
+              body: { items: [item] },
+              json: true,
+            }
+          )) as IDataObject;
+          result = response;
         } else if (operation === "recall") {
           const query = this.getNodeParameter("recallQuery", i) as string;
-          const budget = this.getNodeParameter("recallBudget", i, "mid") as string;
+          const budget = this.getNodeParameter("recallBudget", i, "mid") as Budget;
           const maxTokens = this.getNodeParameter("recallMaxTokens", i, 4096) as number;
           const tagsRaw = this.getNodeParameter("recallTags", i, "") as string;
           const tags = parseTags(tagsRaw);
 
-          const response = await client.recall(bankId, query, {
-            budget: budget as Budget,
-            maxTokens,
-            ...(tags.length ? { tags } : {}),
-          });
-          result = response as unknown as IDataObject;
+          // Recall: POST /v1/default/banks/{bank_id}/memories/recall
+          // Body matches HindsightClient.recall() shape
+          const body: IDataObject = {
+            query,
+            max_tokens: maxTokens,
+            budget,
+          };
+          if (tags.length) {
+            body.tags = tags;
+          }
+
+          const response = (await this.helpers.requestWithAuthentication.call(
+            this,
+            "hindsightApi",
+            {
+              method: "POST",
+              url: `${baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}/memories/recall`,
+              body,
+              json: true,
+            }
+          )) as IDataObject;
+          result = response;
         } else if (operation === "reflect") {
           const query = this.getNodeParameter("reflectQuery", i) as string;
-          const budget = this.getNodeParameter("reflectBudget", i, "mid") as string;
+          const budget = this.getNodeParameter("reflectBudget", i, "mid") as Budget;
 
-          const response = await client.reflect(bankId, query, {
-            budget: budget as Budget,
-          });
-          result = response as unknown as IDataObject;
+          // Reflect: POST /v1/default/banks/{bank_id}/reflect
+          // Body matches HindsightClient.reflect() shape
+          const body: IDataObject = {
+            query,
+            budget,
+          };
+
+          const response = (await this.helpers.requestWithAuthentication.call(
+            this,
+            "hindsightApi",
+            {
+              method: "POST",
+              url: `${baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}/reflect`,
+              body,
+              json: true,
+            }
+          )) as IDataObject;
+          result = response;
         } else {
           throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, {
             itemIndex: i,

--- a/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
+++ b/hindsight-integrations/n8n/nodes/Hindsight/Hindsight.node.ts
@@ -23,7 +23,7 @@ interface HindsightCredentials {
  *  - Recall: Search a bank for memories relevant to a query
  *  - Reflect: Get an LLM-synthesized answer using the bank's memories
  *
- * HTTP calls go through n8n's built-in `requestWithAuthentication` helper
+ * HTTP calls go through n8n's built-in `httpRequestWithAuthentication` helper
  * so the package ships with zero runtime dependencies (required for n8n
  * Cloud verified-node distribution). The Bearer header is applied
  * automatically from the configured Hindsight API credential.
@@ -243,7 +243,7 @@ export class Hindsight implements INodeType {
             item.tags = tags;
           }
 
-          const response = (await this.helpers.requestWithAuthentication.call(
+          const response = (await this.helpers.httpRequestWithAuthentication.call(
             this,
             "hindsightApi",
             {
@@ -272,7 +272,7 @@ export class Hindsight implements INodeType {
             body.tags = tags;
           }
 
-          const response = (await this.helpers.requestWithAuthentication.call(
+          const response = (await this.helpers.httpRequestWithAuthentication.call(
             this,
             "hindsightApi",
             {
@@ -294,7 +294,7 @@ export class Hindsight implements INodeType {
             budget,
           };
 
-          const response = (await this.helpers.requestWithAuthentication.call(
+          const response = (await this.helpers.httpRequestWithAuthentication.call(
             this,
             "hindsightApi",
             {

--- a/hindsight-integrations/n8n/package-lock.json
+++ b/hindsight-integrations/n8n/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@vectorize-io/n8n-nodes-hindsight",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/n8n-nodes-hindsight",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
-      "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.5.6"
-      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "n8n-workflow": "^1.82.0",
@@ -122,9 +119,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -132,9 +129,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +146,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
       "cpu": [
         "arm64"
       ],
@@ -166,9 +163,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
       "cpu": [
         "x64"
       ],
@@ -183,9 +180,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
       "cpu": [
         "x64"
       ],
@@ -200,9 +197,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
       "cpu": [
         "arm"
       ],
@@ -217,9 +214,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
       "cpu": [
         "arm64"
       ],
@@ -234,9 +231,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
       "cpu": [
         "arm64"
       ],
@@ -251,9 +248,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
       "cpu": [
         "ppc64"
       ],
@@ -268,9 +265,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
       "cpu": [
         "s390x"
       ],
@@ -285,9 +282,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +299,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
       "cpu": [
         "x64"
       ],
@@ -319,9 +316,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
       "cpu": [
         "arm64"
       ],
@@ -336,9 +333,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
       "cpu": [
         "wasm32"
       ],
@@ -355,9 +352,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
       "cpu": [
         "arm64"
       ],
@@ -372,9 +369,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
       "cpu": [
         "x64"
       ],
@@ -389,9 +386,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
       "dev": true,
       "license": "MIT"
     },
@@ -403,9 +400,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -432,9 +429,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -447,12 +444,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
-      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
-      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -1706,9 +1697,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1821,9 +1812,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -1890,14 +1881,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1906,21 +1897,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
       }
     },
     "node_modules/safe-regex-test": {
@@ -2152,16 +2143,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -2178,7 +2169,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/hindsight-integrations/n8n/package-lock.json
+++ b/hindsight-integrations/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/n8n-nodes-hindsight",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/n8n-nodes-hindsight",
-      "version": "0.1.3",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/hindsight-integrations/n8n/package-lock.json
+++ b/hindsight-integrations/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/n8n-nodes-hindsight",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/n8n-nodes-hindsight",
-      "version": "0.1.2",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/hindsight-integrations/n8n/package.json
+++ b/hindsight-integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectorize-io/n8n-nodes-hindsight",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "n8n community nodes for Hindsight - persistent memory for any n8n workflow",
   "license": "MIT",
   "homepage": "https://hindsight.vectorize.io",

--- a/hindsight-integrations/n8n/package.json
+++ b/hindsight-integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectorize-io/n8n-nodes-hindsight",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "n8n community nodes for Hindsight - persistent memory for any n8n workflow",
   "license": "MIT",
   "homepage": "https://hindsight.vectorize.io",
@@ -46,9 +46,6 @@
     "llm",
     "long-term-memory"
   ],
-  "dependencies": {
-    "@vectorize-io/hindsight-client": "^0.5.6"
-  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "n8n-workflow": "^1.82.0",

--- a/hindsight-integrations/n8n/test/node-execute.test.ts
+++ b/hindsight-integrations/n8n/test/node-execute.test.ts
@@ -1,29 +1,24 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { IExecuteFunctions, INodeExecutionData } from "n8n-workflow";
 
-const mockRetain = vi.fn();
-const mockRecall = vi.fn();
-const mockReflect = vi.fn();
-
-vi.mock("@vectorize-io/hindsight-client", () => {
-  return {
-    HindsightClient: class {
-      constructor(public options: unknown) {}
-      retain = mockRetain;
-      recall = mockRecall;
-      reflect = mockReflect;
-    },
-  };
-});
-
 import { Hindsight } from "../nodes/Hindsight/Hindsight.node";
 
-function createMockExecuteFunctions(params: Record<string, unknown>): IExecuteFunctions {
-  return {
+const API_URL = "https://api.example.com";
+
+function createMockExecuteFunctions(
+  params: Record<string, unknown>,
+  options: {
+    apiUrl?: string;
+    apiKey?: string;
+    requestImpl?: (...args: unknown[]) => unknown;
+  } = {}
+): IExecuteFunctions {
+  const requestWithAuthentication = vi.fn(options.requestImpl ?? (() => ({})));
+  const fns = {
     getInputData: () => [{ json: {} }] as INodeExecutionData[],
     getCredentials: vi.fn().mockResolvedValue({
-      apiUrl: "https://api.example.com",
-      apiKey: "hsk_test123",
+      apiUrl: options.apiUrl ?? API_URL,
+      apiKey: options.apiKey ?? "hsk_test123",
     }),
     getNodeParameter: vi
       .fn()
@@ -32,7 +27,16 @@ function createMockExecuteFunctions(params: Record<string, unknown>): IExecuteFu
       }),
     getNode: vi.fn().mockReturnValue({ name: "Hindsight" }),
     continueOnFail: vi.fn().mockReturnValue(false),
-  } as unknown as IExecuteFunctions;
+    helpers: {
+      requestWithAuthentication,
+    },
+  };
+  return fns as unknown as IExecuteFunctions;
+}
+
+function getRequestMock(fns: IExecuteFunctions): ReturnType<typeof vi.fn> {
+  return (fns as unknown as { helpers: { requestWithAuthentication: ReturnType<typeof vi.fn> } })
+    .helpers.requestWithAuthentication;
 }
 
 describe("Hindsight node execute()", () => {
@@ -42,103 +46,149 @@ describe("Hindsight node execute()", () => {
     vi.clearAllMocks();
   });
 
-  it("calls client.retain with correct arguments", async () => {
-    mockRetain.mockResolvedValue({ operation_id: "op-1", status: "accepted" });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "retain",
-      bankId: "bank-1",
-      content: "User prefers dark mode",
-      retainTags: "pref,ui",
-    });
+  it("calls retain endpoint with correct URL and body", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "retain",
+        bankId: "bank-1",
+        content: "User prefers dark mode",
+        retainTags: "pref,ui",
+      },
+      {
+        requestImpl: () => ({ operation_id: "op-1", status: "accepted" }),
+      }
+    );
 
     const result = await node.execute.call(mockFns);
 
-    // Client was instantiated (verified by the successful retain call)
-    expect(mockRetain).toHaveBeenCalledWith("bank-1", "User prefers dark mode", {
-      tags: ["pref", "ui"],
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledTimes(1);
+    expect(req).toHaveBeenCalledWith("hindsightApi", {
+      method: "POST",
+      url: `${API_URL}/v1/default/banks/bank-1/memories`,
+      body: { items: [{ content: "User prefers dark mode", tags: ["pref", "ui"] }] },
+      json: true,
     });
     expect(result[0][0].json).toEqual({ operation_id: "op-1", status: "accepted" });
   });
 
-  it("calls client.retain without tags when tags is empty", async () => {
-    mockRetain.mockResolvedValue({ operation_id: "op-2", status: "accepted" });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "retain",
-      bankId: "bank-1",
-      content: "Hello world",
-      retainTags: "",
-    });
+  it("retain omits tags from item when tags is empty", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "retain",
+        bankId: "bank-1",
+        content: "Hello world",
+        retainTags: "",
+      },
+      {
+        requestImpl: () => ({ operation_id: "op-2", status: "accepted" }),
+      }
+    );
 
     await node.execute.call(mockFns);
 
-    expect(mockRetain).toHaveBeenCalledWith("bank-1", "Hello world", undefined);
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledWith("hindsightApi", {
+      method: "POST",
+      url: `${API_URL}/v1/default/banks/bank-1/memories`,
+      body: { items: [{ content: "Hello world" }] },
+      json: true,
+    });
   });
 
-  it("calls client.recall with correct arguments", async () => {
-    mockRecall.mockResolvedValue({
-      results: [{ text: "User prefers dark mode", score: 0.95 }],
-    });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "recall",
-      bankId: "bank-1",
-      recallQuery: "what are user preferences?",
-      recallBudget: "high",
-      recallMaxTokens: 2048,
-      recallTags: "pref",
-    });
+  it("calls recall endpoint with correct URL and body", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "recall",
+        bankId: "bank-1",
+        recallQuery: "what are user preferences?",
+        recallBudget: "high",
+        recallMaxTokens: 2048,
+        recallTags: "pref",
+      },
+      {
+        requestImpl: () => ({
+          results: [{ text: "User prefers dark mode", score: 0.95 }],
+        }),
+      }
+    );
 
     const result = await node.execute.call(mockFns);
 
-    expect(mockRecall).toHaveBeenCalledWith("bank-1", "what are user preferences?", {
-      budget: "high",
-      maxTokens: 2048,
-      tags: ["pref"],
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledWith("hindsightApi", {
+      method: "POST",
+      url: `${API_URL}/v1/default/banks/bank-1/memories/recall`,
+      body: {
+        query: "what are user preferences?",
+        max_tokens: 2048,
+        budget: "high",
+        tags: ["pref"],
+      },
+      json: true,
     });
     expect(result[0][0].json).toEqual({
       results: [{ text: "User prefers dark mode", score: 0.95 }],
     });
   });
 
-  it("calls client.recall without tags when tags filter is empty", async () => {
-    mockRecall.mockResolvedValue({ results: [] });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "recall",
-      bankId: "bank-1",
-      recallQuery: "hello",
-      recallBudget: "mid",
-      recallMaxTokens: 4096,
-      recallTags: "",
-    });
+  it("recall omits tags from body when tags filter is empty", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "recall",
+        bankId: "bank-1",
+        recallQuery: "hello",
+        recallBudget: "mid",
+        recallMaxTokens: 4096,
+        recallTags: "",
+      },
+      {
+        requestImpl: () => ({ results: [] }),
+      }
+    );
 
     await node.execute.call(mockFns);
 
-    expect(mockRecall).toHaveBeenCalledWith("bank-1", "hello", {
-      budget: "mid",
-      maxTokens: 4096,
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledWith("hindsightApi", {
+      method: "POST",
+      url: `${API_URL}/v1/default/banks/bank-1/memories/recall`,
+      body: {
+        query: "hello",
+        max_tokens: 4096,
+        budget: "mid",
+      },
+      json: true,
     });
   });
 
-  it("calls client.reflect with correct arguments", async () => {
-    mockReflect.mockResolvedValue({
-      text: "The user prefers dark mode and minimal UI.",
-      citations: [],
-    });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "reflect",
-      bankId: "bank-1",
-      reflectQuery: "summarize user preferences",
-      reflectBudget: "low",
-    });
+  it("calls reflect endpoint with correct URL and body", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "reflect",
+        bankId: "bank-1",
+        reflectQuery: "summarize user preferences",
+        reflectBudget: "low",
+      },
+      {
+        requestImpl: () => ({
+          text: "The user prefers dark mode and minimal UI.",
+          citations: [],
+        }),
+      }
+    );
 
     const result = await node.execute.call(mockFns);
 
-    expect(mockReflect).toHaveBeenCalledWith("bank-1", "summarize user preferences", {
-      budget: "low",
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledWith("hindsightApi", {
+      method: "POST",
+      url: `${API_URL}/v1/default/banks/bank-1/reflect`,
+      body: {
+        query: "summarize user preferences",
+        budget: "low",
+      },
+      json: true,
     });
     expect(result[0][0].json).toEqual({
       text: "The user prefers dark mode and minimal UI.",
@@ -157,15 +207,20 @@ describe("Hindsight node execute()", () => {
     await expect(node.execute.call(mockFns)).rejects.toThrow("bankId is required");
   });
 
-  it("returns error json when continueOnFail is true and client throws", async () => {
-    mockRetain.mockRejectedValue(new Error("Network error"));
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "retain",
-      bankId: "bank-1",
-      content: "test",
-      retainTags: "",
-    });
+  it("returns error json when continueOnFail is true and request throws", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "retain",
+        bankId: "bank-1",
+        content: "test",
+        retainTags: "",
+      },
+      {
+        requestImpl: () => {
+          throw new Error("Network error");
+        },
+      }
+    );
     (mockFns.continueOnFail as ReturnType<typeof vi.fn>).mockReturnValue(true);
 
     const result = await node.execute.call(mockFns);
@@ -173,22 +228,29 @@ describe("Hindsight node execute()", () => {
     expect(result[0][0].json).toEqual({ error: "Network error" });
   });
 
-  it("omits apiKey from client when credential has no key", async () => {
-    mockRetain.mockResolvedValue({ operation_id: "op-3", status: "accepted" });
-
-    const mockFns = createMockExecuteFunctions({
-      operation: "retain",
-      bankId: "bank-1",
-      content: "test",
-      retainTags: "",
-    });
-    (mockFns.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
-      apiUrl: "http://localhost:8888",
-      apiKey: "",
-    });
+  it("strips trailing slash from apiUrl when building request URL", async () => {
+    const mockFns = createMockExecuteFunctions(
+      {
+        operation: "retain",
+        bankId: "bank-1",
+        content: "test",
+        retainTags: "",
+      },
+      {
+        apiUrl: "http://localhost:8888/",
+        apiKey: "",
+        requestImpl: () => ({ operation_id: "op-3", status: "accepted" }),
+      }
+    );
 
     await node.execute.call(mockFns);
 
-    // Verified by the successful retain call with empty apiKey credential
+    const req = getRequestMock(mockFns);
+    expect(req).toHaveBeenCalledWith(
+      "hindsightApi",
+      expect.objectContaining({
+        url: "http://localhost:8888/v1/default/banks/bank-1/memories",
+      })
+    );
   });
 });

--- a/hindsight-integrations/n8n/test/node-execute.test.ts
+++ b/hindsight-integrations/n8n/test/node-execute.test.ts
@@ -13,7 +13,7 @@ function createMockExecuteFunctions(
     requestImpl?: (...args: unknown[]) => unknown;
   } = {}
 ): IExecuteFunctions {
-  const requestWithAuthentication = vi.fn(options.requestImpl ?? (() => ({})));
+  const httpRequestWithAuthentication = vi.fn(options.requestImpl ?? (() => ({})));
   const fns = {
     getInputData: () => [{ json: {} }] as INodeExecutionData[],
     getCredentials: vi.fn().mockResolvedValue({
@@ -28,15 +28,15 @@ function createMockExecuteFunctions(
     getNode: vi.fn().mockReturnValue({ name: "Hindsight" }),
     continueOnFail: vi.fn().mockReturnValue(false),
     helpers: {
-      requestWithAuthentication,
+      httpRequestWithAuthentication,
     },
   };
   return fns as unknown as IExecuteFunctions;
 }
 
 function getRequestMock(fns: IExecuteFunctions): ReturnType<typeof vi.fn> {
-  return (fns as unknown as { helpers: { requestWithAuthentication: ReturnType<typeof vi.fn> } })
-    .helpers.requestWithAuthentication;
+  return (fns as unknown as { helpers: { httpRequestWithAuthentication: ReturnType<typeof vi.fn> } })
+    .helpers.httpRequestWithAuthentication;
 }
 
 describe("Hindsight node execute()", () => {


### PR DESCRIPTION
## Summary
n8n's verified-node review auto-rejects packages with runtime dependencies via the \`@n8n/community-nodes/no-restricted-imports\` ESLint rule. \`@vectorize-io/n8n-nodes-hindsight@0.1.2\` failed today's scan with:

\`\`\`
dist/nodes/Hindsight/Hindsight.node.js
  5:28  error  Require of '@vectorize-io/hindsight-client' is not allowed.
              n8n Cloud does not allow community nodes with dependencies
\`\`\`

This PR replaces the SDK calls with direct HTTP via n8n's built-in \`requestWithAuthentication\` helper. The package now ships with **zero runtime dependencies**, unblocking the n8n Verified Node submission.

## Behavior

Identical. The Bearer header is applied automatically from the existing \`IAuthenticateGeneric\` credential. Body shapes match \`HindsightClient.retain/recall/reflect\` line-for-line, so the server sees the same requests.

Endpoints used:

| Operation | Method + URL | Body |
|---|---|---|
| Retain | \`POST {apiUrl}/v1/default/banks/{bank_id}/memories\` | \`{ items: [{ content, tags? }] }\` |
| Recall | \`POST {apiUrl}/v1/default/banks/{bank_id}/memories/recall\` | \`{ query, max_tokens, budget, tags? }\` |
| Reflect | \`POST {apiUrl}/v1/default/banks/{bank_id}/reflect\` | \`{ query, budget }\` |

## Tests

All 22 vitest tests pass (8 in \`node-execute.test.ts\`, 14 elsewhere). The execute tests now mock \`helpers.requestWithAuthentication\` instead of mocking \`@vectorize-io/hindsight-client\`. Added one new test asserting trailing-slash \`apiUrl\` is stripped before URL concatenation.

## Package
- Dropped \`@vectorize-io/hindsight-client\` from \`dependencies\`
- Bumped \`0.1.2\` → \`0.1.3\`

## Post-merge action plan
1. Run \`./scripts/release-integration.sh n8n 0.1.3\` to tag and publish with provenance
2. Verify with \`npx @n8n/scan-community-package @vectorize-io/n8n-nodes-hindsight@0.1.3\` — should pass clean
3. Submit at https://creators.n8n.io for Verified Node review

## Test plan
- [x] \`npm install && npm run build\` succeeds (TypeScript + icon copy)
- [x] \`npm test\` — all 22 tests green
- [x] \`grep -r "@vectorize-io/hindsight-client" dist/\` — zero matches in compiled output
- [ ] Post-publish: \`npx @n8n/scan-community-package @vectorize-io/n8n-nodes-hindsight@0.1.3\` exits 0
- [ ] Manual smoke test: install in fresh n8n, run Manual Trigger → Retain → Recall against local Hindsight

🤖 Generated with [Claude Code](https://claude.com/claude-code)