### PR TITLE
fix(openclaw): write hooks.allowConversationAccess in setup wizard

### DIFF
--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -10,6 +10,17 @@
       ]
     }
   },
+  "contracts": {
+    "tools": [
+      "agent_knowledge_list_pages",
+      "agent_knowledge_get_page",
+      "agent_knowledge_create_page",
+      "agent_knowledge_update_page",
+      "agent_knowledge_delete_page",
+      "agent_knowledge_recall",
+      "agent_knowledge_ingest"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "properties": {

--- a/hindsight-integrations/openclaw/src/setup-lib.test.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.test.ts
@@ -56,7 +56,11 @@ describe("ensurePluginConfig", () => {
   it("initializes the hindsight-openclaw entry on an empty config", () => {
     const cfg: OpenClawConfigShape = {};
     const pc = ensurePluginConfig(cfg);
-    expect(cfg.plugins?.entries?.[PLUGIN_ID]).toEqual({ enabled: true, config: {} });
+    expect(cfg.plugins?.entries?.[PLUGIN_ID]).toEqual({
+      enabled: true,
+      hooks: { allowConversationAccess: true },
+      config: {},
+    });
     expect(pc).toBe(cfg.plugins?.entries?.[PLUGIN_ID]?.config);
   });
 
@@ -74,6 +78,68 @@ describe("ensurePluginConfig", () => {
     const pc = ensurePluginConfig(cfg);
     expect(cfg.plugins?.entries?.[PLUGIN_ID]?.enabled).toBe(true);
     expect(pc.llmProvider).toBe("openai");
+  });
+
+  // Regression: openclaw 2026.4.24+ silently drops conversation hooks
+  // (e.g. agent_end → retain) for non-bundled plugins unless this flag is set.
+  describe("hooks.allowConversationAccess", () => {
+    it("sets allowConversationAccess=true on a fresh config", () => {
+      const cfg: OpenClawConfigShape = {};
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.entries?.[PLUGIN_ID]?.hooks?.allowConversationAccess).toBe(true);
+    });
+
+    it("backfills the flag on an existing entry that was configured before the gate landed", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: {
+          entries: {
+            [PLUGIN_ID]: {
+              enabled: true,
+              config: { hindsightApiUrl: "https://api.hindsight.vectorize.io" },
+            },
+          },
+        },
+      };
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.entries?.[PLUGIN_ID]?.hooks?.allowConversationAccess).toBe(true);
+      expect(cfg.plugins?.entries?.[PLUGIN_ID]?.config?.hindsightApiUrl).toBe(
+        "https://api.hindsight.vectorize.io"
+      );
+    });
+
+    it("never overrides an explicit allowConversationAccess=false", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: {
+          entries: {
+            [PLUGIN_ID]: {
+              enabled: true,
+              hooks: { allowConversationAccess: false },
+              config: {},
+            },
+          },
+        },
+      };
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.entries?.[PLUGIN_ID]?.hooks?.allowConversationAccess).toBe(false);
+    });
+
+    it("preserves other fields under hooks", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: {
+          entries: {
+            [PLUGIN_ID]: {
+              enabled: true,
+              hooks: { someOtherFutureFlag: "value" },
+              config: {},
+            },
+          },
+        },
+      };
+      ensurePluginConfig(cfg);
+      const hooks = cfg.plugins?.entries?.[PLUGIN_ID]?.hooks as Record<string, unknown>;
+      expect(hooks.allowConversationAccess).toBe(true);
+      expect(hooks.someOtherFutureFlag).toBe("value");
+    });
   });
 });
 

--- a/hindsight-integrations/openclaw/src/setup-lib.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.ts
@@ -29,6 +29,10 @@ export interface SecretRef {
 
 export interface PluginEntry {
   enabled?: boolean;
+  hooks?: {
+    allowConversationAccess?: boolean;
+    [key: string]: unknown;
+  };
   config?: Record<string, unknown>;
 }
 
@@ -70,12 +74,25 @@ export async function saveConfig(path: string, cfg: OpenClawConfigShape): Promis
  * Ensure a `plugins.entries["hindsight-openclaw"].config` object exists, set
  * `enabled: true`, and return the mutable config record. Idempotent — safe to
  * call against a fresh or already-configured OpenClaw config.
+ *
+ * Also writes `hooks.allowConversationAccess: true` when the field is unset.
+ * OpenClaw 2026.4.24+ blocks "conversation hooks" (e.g. `agent_end`, which
+ * triggers retain) for non-bundled plugins unless this flag is explicitly
+ * present in user config — silent failure: the plugin appears to load but the
+ * hook is dropped, so memories are never retained. Setting it on every wizard
+ * run unblocks both fresh installs and existing users who pre-date the gate.
+ * We never override an explicit `false` — that's a deliberate user choice to
+ * disable conversation access. See openclaw#71221 (released 2026.4.24).
  */
 export function ensurePluginConfig(cfg: OpenClawConfigShape): Record<string, unknown> {
   const plugins = (cfg.plugins ??= {});
   const entries = (plugins.entries ??= {});
   const entry = (entries[PLUGIN_ID] ??= { enabled: true });
   entry.enabled = true;
+  const hooks = (entry.hooks ??= {});
+  if (hooks.allowConversationAccess === undefined) {
+    hooks.allowConversationAccess = true;
+  }
   return (entry.config ??= {});
 }
 


### PR DESCRIPTION
## Summary
- OpenClaw 2026.4.24 (openclaw/openclaw#71221) silently drops conversation hooks like \`agent_end\` for non-bundled plugins unless the user explicitly sets \`plugins.entries.<id>.hooks.allowConversationAccess: true\`. The plugin still appears to register, but retain never fires — banks stay empty.
- Surfaced from a colleague's box running openclaw 2026.5.6 + hindsight-openclaw 0.7.3 reporting "no memories landing in my org". Gateway log line: \`typed hook "agent_end" blocked because non-bundled plugins must set ... allowConversationAccess=true\`.

## Fix
- \`ensurePluginConfig\` (the helper every wizard mode calls before \`saveConfig\`) now backfills \`hooks.allowConversationAccess: true\` when the field is undefined. Re-running the wizard fixes existing configs that pre-date the gate. Never overrides an explicit \`false\` — deliberate user override.
- Extends \`PluginEntry\` shape to include \`hooks\`.
- Four new regression tests: fresh / backfill-existing / preserve-explicit-false / preserve-foreign-hook-keys.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 219 tests pass (+4 new)
- [x] Live: simulated the colleague's config in node → \`ensurePluginConfig\` produces the expected \`hooks: { allowConversationAccess: true }\` block while preserving \`hindsightApiUrl\` / \`hindsightApiToken\`.

## Notes
- Forwards-compatible with openclaw < 2026.4.24 — older versions silently ignore unknown config keys (zod schema is permissive). My local box is 2026.4.9 and unaffected.
- SDA's \`hindsight-openclaw-setup\` invocation hits this same code path, so the SDA install flow gets the fix automatically once 0.7.5 publishes.