### PR TITLE
fix(openclaw): reuse existing token + URL when re-running setup wizard

### DIFF
--- a/hindsight-integrations/openclaw/src/setup-lib.test.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.test.ts
@@ -52,6 +52,32 @@ describe("envSecretRef", () => {
   });
 });
 
+describe("maskSecret", () => {
+  // Used by the wizard's reuse-existing-token prompt — show enough of the secret
+  // to hint identity without leaking it onto the user's terminal scrollback.
+  // We grab maskSecret out of setup-lib so the test doesn't need a TTY.
+  it("masks all but the last 4 chars for a typical token", async () => {
+    const { maskSecret } = await import("./setup-lib.js");
+    const token = "mypwd-1234";
+    const masked = maskSecret(token);
+    expect(masked).toHaveLength(token.length);
+    expect(masked.endsWith("1234")).toBe(true);
+    expect(masked.slice(0, -4)).toMatch(/^\*+$/);
+  });
+
+  it("returns all stars for very short values (≤ 4 chars)", async () => {
+    const { maskSecret } = await import("./setup-lib.js");
+    expect(maskSecret("abcd")).toEqual("****");
+    expect(maskSecret("ab")).toEqual("**");
+    expect(maskSecret("")).toEqual("");
+  });
+
+  it("trims surrounding whitespace before masking", async () => {
+    const { maskSecret } = await import("./setup-lib.js");
+    expect(maskSecret("  abc12345  ")).toEqual("****2345");
+  });
+});
+
 describe("ensurePluginConfig", () => {
   it("initializes the hindsight-openclaw entry on an empty config", () => {
     const cfg: OpenClawConfigShape = {};

--- a/hindsight-integrations/openclaw/src/setup-lib.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.ts
@@ -123,6 +123,17 @@ export function defaultApiKeyEnvVar(provider: string): string {
 }
 
 /**
+ * Mask all but the last 4 chars of a secret so we can hint "yes, this is your
+ * configured token" without leaking the secret onto the user's terminal
+ * scrollback. Used by the wizard's reuse-existing-token prompt.
+ */
+export function maskSecret(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 4) return "*".repeat(trimmed.length);
+  return `${"*".repeat(Math.max(4, trimmed.length - 4))}${trimmed.slice(-4)}`;
+}
+
+/**
  * Cloud mode credential: either a direct token value (stored inline as a
  * plaintext string in openclaw.json) or an env var name (stored as a
  * SecretRef that OpenClaw resolves from `process.env` at startup).

--- a/hindsight-integrations/openclaw/src/setup.ts
+++ b/hindsight-integrations/openclaw/src/setup.ts
@@ -34,6 +34,7 @@ import {
   ensurePluginConfig,
   isValidEnvVarName,
   loadConfig,
+  maskSecret,
   saveConfig,
   summarizeApi,
   summarizeCloud,
@@ -289,15 +290,46 @@ function assertNotCancelled<T>(value: T | symbol): asserts value is T {
   }
 }
 
+// When an inline secret is already in pluginConfig, offer to reuse it instead
+// of forcing the user to paste it again on every wizard rerun. Skipped when
+// the existing value is a SecretRef object (env-var reference) or absent —
+// SecretRefs aren't pasteable here so the regular prompt path handles them.
+async function promptInlineSecretWithReuse(
+  message: string,
+  existing: unknown
+): Promise<string> {
+  if (typeof existing === "string" && existing.trim().length > 0) {
+    const reuse = await p.confirm({
+      message: `Reuse the existing token (ends in …${maskSecret(existing).slice(-8)})?`,
+      initialValue: true,
+    });
+    assertNotCancelled(reuse);
+    if (reuse) return existing.trim();
+  }
+  const value = await p.password({
+    message,
+    validate: validateRequired("Token is required"),
+  });
+  assertNotCancelled(value);
+  return value as string;
+}
+
 async function promptCloud(pluginConfig: Record<string, unknown>): Promise<string> {
-  const useDefaultUrl = await p.confirm({
-    message: `Use the default Hindsight Cloud URL (${HINDSIGHT_CLOUD_URL})?`,
+  const existingUrl = typeof pluginConfig.hindsightApiUrl === "string"
+    ? (pluginConfig.hindsightApiUrl as string).trim()
+    : "";
+  const currentUrl = existingUrl || HINDSIGHT_CLOUD_URL;
+  const useCurrentUrl = await p.confirm({
+    message:
+      existingUrl && existingUrl !== HINDSIGHT_CLOUD_URL
+        ? `Reuse the configured Cloud URL (${currentUrl})?`
+        : `Use the default Hindsight Cloud URL (${HINDSIGHT_CLOUD_URL})?`,
     initialValue: true,
   });
-  assertNotCancelled(useDefaultUrl);
+  assertNotCancelled(useCurrentUrl);
 
   let apiUrl: string | undefined;
-  if (!useDefaultUrl) {
+  if (!useCurrentUrl) {
     const custom = await p.text({
       message: "Hindsight Cloud URL",
       placeholder: HINDSIGHT_CLOUD_URL,
@@ -305,13 +337,14 @@ async function promptCloud(pluginConfig: Record<string, unknown>): Promise<strin
     });
     assertNotCancelled(custom);
     apiUrl = custom;
+  } else if (existingUrl) {
+    apiUrl = existingUrl;
   }
 
-  const token = await p.password({
-    message: "Hindsight Cloud API token (paste the value, it will be masked)",
-    validate: validateRequired("Token is required"),
-  });
-  assertNotCancelled(token);
+  const token = await promptInlineSecretWithReuse(
+    "Hindsight Cloud API token (paste the value, it will be masked)",
+    pluginConfig.hindsightApiToken
+  );
 
   const input = { apiUrl, token };
   applyCloudMode(pluginConfig, input);
@@ -319,30 +352,34 @@ async function promptCloud(pluginConfig: Record<string, unknown>): Promise<strin
 }
 
 async function promptApi(pluginConfig: Record<string, unknown>): Promise<string> {
+  const existingUrl = typeof pluginConfig.hindsightApiUrl === "string"
+    ? (pluginConfig.hindsightApiUrl as string).trim()
+    : "";
   const apiUrl = await p.text({
     message: "Hindsight API URL",
     placeholder: "https://mcp.hindsight.example.com",
+    initialValue: existingUrl || undefined,
     validate: validateRequired("URL is required"),
   });
   assertNotCancelled(apiUrl);
 
+  const hasExistingToken = typeof pluginConfig.hindsightApiToken === "string"
+    && (pluginConfig.hindsightApiToken as string).trim().length > 0;
   const needsToken = await p.confirm({
     message: "Does this API require an auth token?",
-    initialValue: false,
+    initialValue: hasExistingToken,
   });
   assertNotCancelled(needsToken);
 
   let token: string | undefined;
   if (needsToken) {
-    const value = await p.password({
-      message: "API token (paste the value, it will be masked)",
-      validate: validateRequired("Token is required"),
-    });
-    assertNotCancelled(value);
-    token = value;
+    token = await promptInlineSecretWithReuse(
+      "API token (paste the value, it will be masked)",
+      pluginConfig.hindsightApiToken
+    );
   }
 
-  const input = { apiUrl, token };
+  const input = { apiUrl: apiUrl as string, token };
   applyApiMode(pluginConfig, input);
   return summarizeApi(input);
 }
@@ -373,12 +410,10 @@ async function promptEmbedded(pluginConfig: Record<string, unknown>): Promise<st
 
   let apiKey: string | undefined;
   if (!NO_KEY_PROVIDERS.has(llmProvider)) {
-    const value = await p.password({
-      message: `${llmProvider} API key (paste the value, it will be masked)`,
-      validate: validateRequired("API key is required"),
-    });
-    assertNotCancelled(value);
-    apiKey = value;
+    apiKey = await promptInlineSecretWithReuse(
+      `${llmProvider} API key (paste the value, it will be masked)`,
+      pluginConfig.llmApiKey
+    );
   }
 
   const overrideModel = await p.confirm({


### PR DESCRIPTION
## Summary
The wizard re-prompted for the API token / API key on every run even when one was already stored in openclaw.json — confusing for users (re-typing a long secret) and wasteful when running setup just to backfill new fields like \`hooks.allowConversationAccess\`.

## Behavior
- **Cloud / API / Embedded**: if pluginConfig has an inline string secret (cloud token, api token, llm api key), the wizard now offers to reuse it. The prompt shows the last 4 chars masked, e.g. \`Reuse the existing token (ends in …***1234)?\`. Saying yes keeps the existing secret; saying no falls back to the masked password prompt as before. SecretRef objects (env-var refs) aren't pasteable so they keep the previous prompt path.
- **Cloud URL**: prompt label adapts to \`Reuse the configured Cloud URL X?\` when a non-default URL is configured (vs the existing \`Use the default Hindsight Cloud URL?\` for the empty/default case). Reuses the existing URL on confirm.
- **API URL**: text prompt seeded with the existing URL via \`initialValue\` so the user can press enter to accept.
- **API token confirm**: defaults to "yes, needs token" when one is already configured (was always defaulting to no, contradicting the existing config).

## Plumbing
- Pure \`maskSecret\` helper added to setup-lib.ts (testable without a TTY) — masks all but the last 4 chars, preserves length.
- Three regression tests for maskSecret: long token / very-short input / surrounding whitespace.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 222 tests pass (+3 new)
- [ ] Live: re-run \`hindsight-openclaw-setup\` on a box with an existing config → wizard should offer reuse instead of re-prompting

## Notes
- Useful for any wizard rerun, but particularly relevant right now: 0.7.5 added \`hooks.allowConversationAccess\` backfill — without this PR, users have to re-type their token every time they run the wizard to pick up that fix.