### PR TITLE
fix(daemon): replace os.fork() with subprocess.Popen to fix MPS on macOS

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -496,7 +496,7 @@ DEFAULT_LLM_GEMINI_SAFETY_SETTINGS = None  # None = use Gemini default safety se
 
 DEFAULT_EMBEDDINGS_PROVIDER = "local"
 DEFAULT_EMBEDDINGS_LOCAL_MODEL = "BAAI/bge-small-en-v1.5"
-DEFAULT_EMBEDDINGS_LOCAL_FORCE_CPU = False  # Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS)
+DEFAULT_EMBEDDINGS_LOCAL_FORCE_CPU = False  # Force CPU mode for local embeddings
 DEFAULT_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE = False  # Security: disabled by default, required for some models
 DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
@@ -507,7 +507,7 @@ DEFAULT_EMBEDDING_DIMENSION = 384
 
 DEFAULT_RERANKER_PROVIDER = "local"
 DEFAULT_RERANKER_LOCAL_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
-DEFAULT_RERANKER_LOCAL_FORCE_CPU = False  # Force CPU mode for local reranker (avoids MPS/XPC issues on macOS)
+DEFAULT_RERANKER_LOCAL_FORCE_CPU = False  # Force CPU mode for local reranker
 DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT = 4  # Limit concurrent CPU-bound reranking to prevent thrashing
 DEFAULT_RERANKER_LOCAL_TRUST_REMOTE_CODE = (
     False  # Security: disabled by default, required for some models like jina-reranker-v2

--- a/hindsight-api-slim/hindsight_api/daemon.py
+++ b/hindsight-api-slim/hindsight_api/daemon.py
@@ -4,12 +4,20 @@ Daemon mode support for Hindsight API.
 Provides idle timeout for running as a background daemon.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
+import platform
+import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import IO
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +27,12 @@ DEFAULT_IDLE_TIMEOUT = 0  # 0 = no auto-exit (hindsight-embed passes its own tim
 
 # Allow override via environment variable for profile-specific logs
 DAEMON_LOG_PATH = Path(os.getenv("HINDSIGHT_API_DAEMON_LOG", str(Path.home() / ".hindsight" / "daemon.log")))
+
+# Internal env var: set by daemonize() in the re-exec'd child so the child
+# skips re-exec and just redirects stdio.  Also set by hindsight-embed's
+# DaemonEmbedManager so the daemon launched via Popen skips re-exec entirely
+# (hindsight-embed's Popen already provides a clean, detached process).
+ENV_DAEMON_CHILD = "_HINDSIGHT_DAEMON_CHILD"
 
 
 class IdleTimeoutMiddleware:
@@ -58,55 +72,103 @@ class IdleTimeoutMiddleware:
                 os.kill(os.getpid(), signal.SIGTERM)
 
 
-def daemonize():
+def _detach_popen_kwargs(log_handle: "IO[bytes]") -> dict:
+    """Cross-platform kwargs to spawn a subprocess detached from the caller.
+
+    On POSIX, ``start_new_session=True`` calls ``setsid(2)`` so the child
+    survives the parent's terminal.  On Windows we use
+    ``DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP``.
+
+    ``log_handle`` receives the child's stdout/stderr so output never leaks
+    into the parent's terminal.
     """
-    Fork the current process into a background daemon.
+    if platform.system() == "Windows":
+        detached_process = getattr(subprocess, "DETACHED_PROCESS", 0)
+        create_new_process_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        return {
+            "creationflags": detached_process | create_new_process_group,
+            "stdin": subprocess.DEVNULL,
+            "stdout": log_handle,
+            "stderr": subprocess.STDOUT,
+            "close_fds": True,
+        }
+    return {
+        "start_new_session": True,
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_handle,
+        "stderr": log_handle,
+    }
 
-    Uses double-fork technique to properly detach from terminal.
 
-    On Windows there is no fork model: the spawning parent is expected to
-    detach us via `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS` and to
-    redirect stdout/stderr to HINDSIGHT_API_DAEMON_LOG before exec. We
-    still ensure the log directory exists so that any file handlers set
-    up by the calling app have a valid target.
+def _redirect_stdio_to_log() -> None:
+    """Redirect stdin/stdout/stderr to the daemon log file.
+
+    Called in the daemon child process after re-exec.
     """
-    if sys.platform == "win32":
-        DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        return
-
-    # First fork - detach from parent
-    try:
-        pid = os.fork()
-        if pid > 0:
-            sys.exit(0)
-    except OSError as e:
-        sys.stderr.write(f"fork #1 failed: {e}\n")
-        sys.exit(1)
-
-    # Decouple from parent environment
-    os.chdir("/")
-    os.setsid()
-    os.umask(0)
-
-    # Second fork - prevent zombie
-    pid = os.fork()
-    if pid > 0:
-        sys.exit(0)
-
-    # Redirect standard file descriptors to log file
     DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
     sys.stdout.flush()
     sys.stderr.flush()
 
-    # Redirect stdin to /dev/null
-    with open("/dev/null", "r") as devnull:
+    with open(os.devnull, "r") as devnull:
         os.dup2(devnull.fileno(), sys.stdin.fileno())
 
-    # Redirect stdout/stderr to log file
     log_fd = open(DAEMON_LOG_PATH, "a")
     os.dup2(log_fd.fileno(), sys.stdout.fileno())
     os.dup2(log_fd.fileno(), sys.stderr.fileno())
+
+
+def daemonize():
+    """Detach the current process into a background daemon.
+
+    Uses ``subprocess.Popen`` (which maps to ``posix_spawn`` on macOS) to
+    re-exec the current command in a detached session.  This replaces the
+    traditional double-fork pattern because ``os.fork()`` without ``exec()``
+    corrupts Apple framework state (XPC, Metal/MPS, ObjC runtime) on macOS,
+    causing SIGBUS crashes when PyTorch uses the MPS backend.
+
+    The function has two code paths controlled by the ``_HINDSIGHT_DAEMON_CHILD``
+    environment variable:
+
+    * **Parent** (env var not set): re-exec the same command via Popen with
+      ``start_new_session=True``, stripping ``--daemon`` from argv and setting
+      ``_HINDSIGHT_DAEMON_CHILD=1``.  Then ``sys.exit(0)``.
+    * **Child** (env var set): redirect stdio to the daemon log file and return.
+      No fork, no re-exec.
+
+    On Windows there is no fork model: the spawning parent is expected to
+    detach us via ``CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`` and to
+    redirect stdout/stderr to ``HINDSIGHT_API_DAEMON_LOG`` before exec.
+    We still ensure the log directory exists.
+    """
+    if sys.platform == "win32":
+        DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        return
+
+    # If we are already the daemon child (re-exec'd by a previous daemonize()
+    # call, or launched by hindsight-embed with the env var set), just redirect
+    # stdio and return — no re-exec needed.
+    if os.environ.get(ENV_DAEMON_CHILD) == "1":
+        _redirect_stdio_to_log()
+        return
+
+    # --- Parent path: re-exec ourselves as a detached background process ---
+
+    # Build child command: same Python, same module entry point, all args
+    # except --daemon (replaced by the env var).
+    child_args = [a for a in sys.argv[1:] if a != "--daemon"]
+    cmd = [sys.executable, "-m", "hindsight_api.main"] + child_args
+
+    env = os.environ.copy()
+    env[ENV_DAEMON_CHILD] = "1"
+    env["HINDSIGHT_API_DAEMON_LOG"] = str(DAEMON_LOG_PATH)
+
+    DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(DAEMON_LOG_PATH, "ab") as log_handle:
+        subprocess.Popen(cmd, env=env, **_detach_popen_kwargs(log_handle))
+
+    sys.exit(0)
 
 
 def check_daemon_running(port: int = DEFAULT_DAEMON_PORT) -> bool:

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -133,7 +133,7 @@ class LocalSTCrossEncoder(CrossEncoderModel):
                        Default: cross-encoder/ms-marco-MiniLM-L-6-v2
             max_concurrent: Maximum concurrent reranking calls (default: 2).
                            Higher values may cause CPU thrashing under load.
-            force_cpu: Force CPU mode (avoids MPS/XPC issues on macOS in daemon mode).
+            force_cpu: Force CPU mode for local inference.
                       Default: False
             trust_remote_code: Allow loading models with custom code (security risk).
                               Required for some models like jina-reranker-v2-base-multilingual.

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -104,7 +104,7 @@ class LocalSTEmbeddings(Embeddings):
         Args:
             model_name: Name of the SentenceTransformer model to use.
                        Default: BAAI/bge-small-en-v1.5
-            force_cpu: Force CPU mode (avoids MPS/XPC issues on macOS in daemon mode).
+            force_cpu: Force CPU mode for local inference.
                       Default: False
             trust_remote_code: Allow loading models with custom code (security risk).
                               Required for some models with custom architectures.

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -28,6 +28,7 @@ from .config import DEFAULT_WORKERS, ENV_HOST, ENV_WORKERS, HindsightConfig, _ge
 from .daemon import (
     DEFAULT_DAEMON_PORT,
     DEFAULT_IDLE_TIMEOUT,
+    ENV_DAEMON_CHILD,
     IdleTimeoutMiddleware,
     daemonize,
 )
@@ -150,8 +151,15 @@ def main():
 
     args = parser.parse_args()
 
-    # Daemon mode handling
-    if args.daemon:
+    # Daemon mode handling.
+    # is_daemon_child is True when we are the re-exec'd child spawned by
+    # daemonize() or by hindsight-embed's DaemonEmbedManager.  The child
+    # does not have --daemon in its argv, but must still behave as a daemon
+    # (resolve host/port, enable idle timeout, suppress banner, etc.).
+    is_daemon_child = os.environ.get(ENV_DAEMON_CHILD) == "1"
+    is_daemon = args.daemon or is_daemon_child
+
+    if is_daemon:
         args.host, args.port = resolve_daemon_host_port(
             args_host=args.host,
             args_port=args.port,
@@ -159,12 +167,13 @@ def main():
             config_port=config.port,
         )
 
-        # Fork into background
-        # No lockfile needed - port binding prevents duplicate daemons
+        # Detach into background (parent re-execs and exits; child redirects
+        # stdio to log file).  No lockfile needed — port binding prevents
+        # duplicate daemons.
         daemonize()
 
     # Print banner (not in daemon mode)
-    if not args.daemon:
+    if not is_daemon:
         print()
         print_banner()
 
@@ -173,7 +182,7 @@ def main():
     if args.log_level != config.log_level:
         config = dataclasses.replace(config, host=args.host, port=args.port, log_level=args.log_level)
     config.configure_logging()
-    if not args.daemon:
+    if not is_daemon:
         config.log_config()
 
     # Register cleanup handlers
@@ -222,7 +231,7 @@ def main():
 
     # Wrap with idle timeout middleware in daemon mode
     idle_middleware = None
-    if args.daemon:
+    if is_daemon:
         idle_middleware = IdleTimeoutMiddleware(app, idle_timeout=args.idle_timeout)
         app = idle_middleware
 
@@ -277,7 +286,7 @@ def main():
         uvicorn_config["ssl_certfile"] = args.ssl_certfile
 
     # Print startup info (not in daemon mode)
-    if not args.daemon:
+    if not is_daemon:
         from .banner import print_startup_info
 
         print_startup_info(

--- a/hindsight-api-slim/tests/test_daemonize.py
+++ b/hindsight-api-slim/tests/test_daemonize.py
@@ -1,0 +1,88 @@
+"""Tests for daemonize() — subprocess.Popen re-exec instead of os.fork()."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_daemonize_parent_reexecs_via_popen(monkeypatch, tmp_path):
+    """Parent path: daemonize() must spawn a child via subprocess.Popen and exit."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("_HINDSIGHT_DAEMON_CHILD", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hindsight-api", "--daemon", "--port", "9999"])
+
+    log_path = tmp_path / "daemon.log"
+    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+
+    captured: dict = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+        proc.pid = 99999
+        return proc
+
+    with (
+        patch("hindsight_api.daemon.subprocess.Popen", side_effect=fake_popen),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        from hindsight_api.daemon import daemonize
+
+        daemonize()
+
+    assert exc_info.value.code == 0
+
+    # Verify child command does NOT contain --daemon
+    assert "--daemon" not in captured["cmd"]
+    # Verify it uses the module entry point
+    assert "-m" in captured["cmd"]
+    assert "hindsight_api.main" in captured["cmd"]
+    # Verify remaining args are preserved
+    assert "--port" in captured["cmd"]
+    assert "9999" in captured["cmd"]
+
+    # Verify env has the daemon child marker
+    env = captured["kwargs"]["env"]
+    assert env["_HINDSIGHT_DAEMON_CHILD"] == "1"
+
+    # Verify detach kwargs
+    kwargs = captured["kwargs"]
+    assert kwargs.get("start_new_session") is True
+
+
+def test_daemonize_child_does_not_reexec(monkeypatch, tmp_path):
+    """Child path: when _HINDSIGHT_DAEMON_CHILD=1, daemonize() does NOT call
+    Popen — it only redirects stdio."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("_HINDSIGHT_DAEMON_CHILD", "1")
+
+    log_path = tmp_path / "daemon.log"
+    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+
+    with (
+        patch("hindsight_api.daemon.subprocess.Popen") as mock_popen,
+        patch("hindsight_api.daemon._redirect_stdio_to_log") as mock_redirect,
+    ):
+        from hindsight_api.daemon import daemonize
+
+        daemonize()
+        mock_popen.assert_not_called()
+        mock_redirect.assert_called_once()
+
+
+def test_daemonize_windows_noop(monkeypatch, tmp_path):
+    """On Windows, daemonize() just creates the log directory."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    log_path = tmp_path / "subdir" / "daemon.log"
+    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+
+    with patch("hindsight_api.daemon.subprocess.Popen") as mock_popen:
+        from hindsight_api.daemon import daemonize
+
+        daemonize()
+        mock_popen.assert_not_called()
+
+    assert log_path.parent.exists()

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -251,15 +251,6 @@ def _do_configure_from_env():
         if api_key:
             f.write(f"HINDSIGHT_API_LLM_API_KEY={api_key}\n")
 
-        # Force CPU mode for embeddings/reranker on macOS to avoid MPS/XPC crashes in daemon mode
-        # On Linux, users can set these to 0 to use CUDA if available
-        import platform
-
-        if platform.system() == "Darwin":  # macOS
-            f.write("\n# Daemon settings (macOS: force CPU to avoid MPS/XPC issues)\n")
-            f.write("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=1\n")
-            f.write("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=1\n")
-
     CONFIG_FILE.chmod(0o600)
 
     print()
@@ -436,13 +427,6 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         config_dict["HINDSIGHT_API_LLM_MODEL"] = model
     if api_key:
         config_dict["HINDSIGHT_API_LLM_API_KEY"] = api_key
-
-    # Force CPU mode for embeddings/reranker on macOS to avoid MPS/XPC crashes in daemon mode
-    import platform
-
-    if platform.system() == "Darwin":  # macOS
-        config_dict["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
-        config_dict["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
 
     if profile_name:
         # Create named profile

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -371,14 +371,9 @@ class DaemonEmbedManager(EmbedManager):
         if "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT" not in env:
             env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(DEFAULT_DAEMON_IDLE_TIMEOUT)
 
-        # On macOS, force CPU for local embeddings/reranker to avoid MPS/XPC
-        # hangs during sentence-transformers init in daemon mode (issue #962).
-        # Users can opt back into MPS by explicitly setting these to "0".
-        if platform.system() == "Darwin":
-            if "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU" not in env:
-                env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
-            if "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU" not in env:
-                env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
+        # Tell the daemon child it was already launched in a detached session
+        # (via our Popen below) so daemonize() skips the redundant re-exec.
+        env["_HINDSIGHT_DAEMON_CHILD"] = "1"
 
         # Get idle timeout from env
         idle_timeout = int(env.get("HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT", str(DEFAULT_DAEMON_IDLE_TIMEOUT)))

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -229,59 +229,6 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
     assert config["bank_id"] == "production-bank", "Should use profile's bank_id"
 
 
-def test_macos_forces_cpu_for_local_embeddings_and_reranker(temp_home, monkeypatch):
-    """Regression test for issue #962.
-
-    On macOS, the daemon must force CPU for local embeddings/reranker by default to
-    avoid sentence-transformers selecting MPS and hanging during startup. PR #933
-    removed this default when adding the llamacpp provider; this test guards against
-    that regression.
-    """
-    from unittest.mock import MagicMock, patch
-
-    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
-
-    # Clear any caller-supplied force-cpu env so we test the default behavior.
-    monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", raising=False)
-    monkeypatch.delenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", raising=False)
-
-    manager = DaemonEmbedManager()
-
-    captured: dict[str, dict[str, str]] = {}
-    popen_called = [False]
-
-    def fake_popen(cmd, env, **kwargs):
-        captured["env"] = env
-        popen_called[0] = True
-        proc = MagicMock()
-        proc.pid = 12345
-        return proc
-
-    # is_running must return False before Popen (so _start_daemon and
-    # _start_daemon_locked don't short-circuit on the pre-Popen checks added
-    # in #1016) and True after Popen (so the readiness wait loop breaks
-    # immediately). Tying it to popen_called gives us both for free.
-    def fake_is_running(profile=""):
-        return popen_called[0]
-
-    with (
-        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
-        patch("hindsight_embed.daemon_embed_manager.time.sleep"),  # skip 2s stability wait
-        patch.object(manager, "_clear_port", return_value=True),
-        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
-        patch.object(manager, "is_running", side_effect=fake_is_running),
-        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
-    ):
-        manager._start_daemon(
-            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
-            profile="",
-        )
-
-    env = captured["env"]
-    assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "1"
-    assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "1"
-
-
 def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, monkeypatch):
     """Regression test: HINDSIGHT_* keys in profile .env must reach the daemon subprocess env.
 
@@ -361,14 +308,12 @@ def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, mo
     assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "1"
 
 
-def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
-    """Users who explicitly disable FORCE_CPU (e.g. to use MPS) must not be overridden."""
+def test_daemon_child_env_var_set_in_daemon_env(temp_home, monkeypatch):
+    """hindsight-embed must set _HINDSIGHT_DAEMON_CHILD=1 so the daemon child
+    skips the redundant re-exec in daemonize()."""
     from unittest.mock import MagicMock, patch
 
     from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
-
-    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", "0")
-    monkeypatch.setenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", "0")
 
     manager = DaemonEmbedManager()
     captured: dict[str, dict[str, str]] = {}
@@ -390,7 +335,6 @@ def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
         patch.object(manager, "_clear_port", return_value=True),
         patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
         patch.object(manager, "is_running", side_effect=fake_is_running),
-        patch("hindsight_embed.daemon_embed_manager.platform.system", return_value="Darwin"),
     ):
         manager._start_daemon(
             config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
@@ -398,8 +342,7 @@ def test_macos_force_cpu_respects_explicit_override(temp_home, monkeypatch):
         )
 
     env = captured["env"]
-    assert env.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") == "0"
-    assert env.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") == "0"
+    assert env.get("_HINDSIGHT_DAEMON_CHILD") == "1"
 
 
 def test_windows_popen_uses_detached_process_flags(temp_home, monkeypatch):


### PR DESCRIPTION
## Summary

- Replace `os.fork()` double-fork in `daemonize()` with `subprocess.Popen` re-exec (uses `posix_spawn` on macOS), giving the daemon a clean process where MPS/Metal works
- Remove the macOS `FORCE_CPU=1` workaround from `hindsight-embed` — MPS now works natively in daemon mode
- Add `_HINDSIGHT_DAEMON_CHILD` env var protocol so `hindsight-embed`'s Popen launch skips redundant re-exec

## Root cause

`os.fork()` without `exec()` corrupts Apple framework state (XPC connections, Metal/MPS, ObjC runtime). When the daemon auto-selects MPS for torch models, the first GPU operation hits a dead XPC connection → `SIGBUS` / `XPC_ERROR_CONNECTION_INVALID`. This was the root cause behind #270, #1394, and #1497.

`subprocess.Popen` with `start_new_session=True` uses `posix_spawn` on macOS, which gives the child a completely clean process — valid XPC connections, working MPS backend.

## Test plan

- [x] `hindsight-api-slim` tests pass (`test_daemonize.py` + existing)
- [x] `hindsight-embed` tests pass (updated `test_profile_daemon_config.py`)
- [x] Lint passes
- [x] Verified MPS works in Popen-spawned child (embeddings + reranker on `mps:0`)
- [x] Verified `os.fork()` crashes with same setup (control test)

Fixes #270, #1394, #1497