### PR TITLE
fix(openclaw): backfill plugins.allow with hindsight-openclaw in setup wizard

### DIFF
--- a/hindsight-integrations/openclaw/src/setup-lib.test.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.test.ts
@@ -167,6 +167,42 @@ describe("ensurePluginConfig", () => {
       expect(hooks.someOtherFutureFlag).toBe("value");
     });
   });
+
+  // openclaw 2026.2.19+ logs a startup WARN when plugins.allow is empty and
+  // non-bundled plugins are discovered. The plugin still loads, but the warning
+  // is noisy on every gateway start. We add ourselves to the allowlist to
+  // silence it — without clobbering a user-curated list.
+  describe("plugins.allow trust list", () => {
+    it("creates plugins.allow with our id when undefined", () => {
+      const cfg: OpenClawConfigShape = {};
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.allow).toEqual([PLUGIN_ID]);
+    });
+
+    it("appends our id to an existing user-curated allow list", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: { allow: ["some-other-plugin"], entries: {} },
+      };
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.allow).toEqual(["some-other-plugin", PLUGIN_ID]);
+    });
+
+    it("is idempotent when our id is already in the list", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: { allow: ["some-other-plugin", PLUGIN_ID], entries: {} },
+      };
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.allow).toEqual(["some-other-plugin", PLUGIN_ID]);
+    });
+
+    it("leaves a non-array allow value alone (don't second-guess deliberate weirdness)", () => {
+      const cfg: OpenClawConfigShape = {
+        plugins: { allow: "weird-string-value" as unknown as string[], entries: {} },
+      };
+      ensurePluginConfig(cfg);
+      expect(cfg.plugins?.allow).toEqual("weird-string-value");
+    });
+  });
 });
 
 describe("applyCloudMode — direct token value", () => {

--- a/hindsight-integrations/openclaw/src/setup-lib.ts
+++ b/hindsight-integrations/openclaw/src/setup-lib.ts
@@ -39,6 +39,7 @@ export interface PluginEntry {
 export interface OpenClawConfigShape {
   plugins?: {
     entries?: Record<string, PluginEntry>;
+    allow?: unknown;
     [key: string]: unknown;
   };
   [key: string]: unknown;
@@ -92,6 +93,18 @@ export function ensurePluginConfig(cfg: OpenClawConfigShape): Record<string, unk
   const hooks = (entry.hooks ??= {});
   if (hooks.allowConversationAccess === undefined) {
     hooks.allowConversationAccess = true;
+  }
+  // OpenClaw 2026.2.19+ warns at startup when `plugins.allow` is empty and
+  // non-bundled plugins are discovered: "plugins.allow is empty; discovered
+  // non-bundled plugins may auto-load: hindsight-openclaw". Cosmetic only — the
+  // plugin still loads — but noisy on every gateway start. Add ourselves to the
+  // allowlist so the warning goes away. Never clobber a user-curated allowlist:
+  // if `plugins.allow` is already an array, just append our id when missing.
+  // If it's set to something non-array (deliberate strange value), leave it.
+  if (plugins.allow === undefined) {
+    plugins.allow = [PLUGIN_ID];
+  } else if (Array.isArray(plugins.allow) && !plugins.allow.includes(PLUGIN_ID)) {
+    plugins.allow = [...plugins.allow, PLUGIN_ID];
   }
   return (entry.config ??= {});
 }


### PR DESCRIPTION
## Summary
OpenClaw 2026.2.19+ logs a WARN at every gateway startup when \`plugins.allow\` is empty and non-bundled plugins are discovered:

\`\`\`
[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: hindsight-openclaw (...).
          Set plugins.allow to explicit trusted ids.
\`\`\`

Cosmetic — the plugin still loads — but the warning fires on every gateway start and users (rightly) ask about it. Surfaced after walking a colleague through the post-0.7.6 setup: hooks/contracts fixes worked, but this warning was still in his log.

## Fix
\`ensurePluginConfig\` now adds \`hindsight-openclaw\` to \`plugins.allow\`:

- Undefined → set to \`["hindsight-openclaw"]\`.
- Existing array → append our id only when missing (idempotent).
- Already contains our id → no-op.
- Non-array value (deliberate weirdness) → left alone.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 226 tests pass (+4 new)
- [ ] Live: re-run \`hindsight-openclaw-setup\` on the colleague's box → his \`plugins.allow\` should pick up \`hindsight-openclaw\`, gateway restart should drop the WARN

## Notes
- Pure setup-wizard config write — no plugin runtime change. SDA users get the same fix automatically since the SDA CLI delegates to the same wizard.