### PR TITLE
docs: surface stable worker_id guidance and zombie-operation recovery

### DIFF
--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -245,6 +245,44 @@ hindsight-admin worker-status --schema tenant_acme
 
 ---
 
+## Recovering stuck or zombie operations
+
+A "zombie" operation is one stuck in `processing` indefinitely because the worker that claimed it is gone. The most common cause is an unstable `HINDSIGHT_API_WORKER_ID`: when it defaults to the container hostname, a Docker restart produces a new container ID, the new worker doesn't recognize the old worker's claims as its own, and those tasks are stranded.
+
+**How to spot them:**
+
+```bash
+# List processing tasks grouped by worker — workers with a growing last_update_ago are dead
+hindsight-admin worker-status
+
+# Bank-level counters; pending_consolidation that never decreases is the usual symptom
+curl -s http://localhost:8888/v1/default/banks/<bank_id>/stats
+```
+
+**How to recover:**
+
+```bash
+# You know which worker is dead (e.g. from worker-status):
+hindsight-admin decommission-worker <old-worker-id>
+
+# You don't know — release every processing task across the fleet:
+hindsight-admin decommission-workers
+```
+
+Both commands reset `processing` rows back to `pending` so a live worker can claim them on the next poll.
+
+**How to prevent it:**
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value so worker identity survives restarts:
+
+- **Docker**: pass `-e HINDSIGHT_API_WORKER_ID=hindsight-prod` (or per-replica names if running multiple containers)
+- **Kubernetes (Helm)**: the chart's StatefulSet uses the pod name automatically — no extra config needed
+- **Bare metal / pip**: pass `--worker-id <name>` or set the env var per process
+
+See [Installation - Docker](./installation#docker) and [Configuration - Distributed Workers](./configuration#distributed-workers).
+
+---
+
 ## Environment Variables
 
 The admin CLI uses the same environment variables as the API service. The most important one is:

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -87,6 +87,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 All published images are [signed with Cosign](#verifying-image-signatures) — verification is optional.
 
+:::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
+The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_ID=hindsight-prod`) so the worker keeps the same identity across restarts. This is recommended even for single-container deployments. For diagnosis and recovery commands, see [Admin CLI - Recovering stuck operations](./admin-cli#recovering-stuck-or-zombie-operations).
+:::
+
 ### Docker Image Variants
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
@@ -169,6 +175,8 @@ helm install hindsight oci://ghcr.io/vectorize-io/charts/hindsight \
   --set worker.enabled=true \
   --set worker.replicaCount=3
 ```
+
+The chart deploys workers as a StatefulSet, so each pod gets a stable name (e.g. `hindsight-worker-0`) that the worker uses as its `HINDSIGHT_API_WORKER_ID`. Tasks claimed by a pod are recognized as its own across restarts. If you swap the chart for a plain Deployment, set `HINDSIGHT_API_WORKER_ID` explicitly per replica — otherwise hostnames are randomized and previously-claimed tasks become orphaned. See [Admin CLI - Recovering stuck operations](./admin-cli#recovering-stuck-or-zombie-operations) for diagnosis.
 
 See [Services - Worker Service](./services#worker-service) for configuration details and architecture.
 

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -15,6 +15,7 @@ import PageHero from '@site/src/components/PageHero';
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
 - [Hosting and system requirements](#do-i-need-to-host-my-own-infrastructure)
+- [What are "zombie" operations and how do I recover them?](#what-are-zombie-operations-and-how-do-i-recover-them)
 - [How do I isolate user data?](#how-do-i-isolate-user-data)
 - [Retain, recall, and reflect — what's the difference?](#whats-the-difference-between-retain-recall-and-reflect)
 - [When should I use recall vs reflect?](#when-should-i-use-recall-vs-reflect)
@@ -107,6 +108,28 @@ For running the Hindsight API server locally:
 - LLM API key (OpenAI, Anthropic, etc.) or local LLM setup
 
 See [Installation](/developer/installation) for setup instructions.
+
+---
+
+### What are "zombie" operations and how do I recover them?
+
+A **zombie operation** is a background task stuck in `processing` indefinitely because the worker that claimed it is gone — typically after a Docker container restart. The symptom is a `pending_consolidation` (or similar) counter that never decreases on `/banks/{bank_id}/stats`, even though the worker logs show plenty of free slots.
+
+The root cause is almost always an unstable `HINDSIGHT_API_WORKER_ID`. By default the worker uses the container hostname as its identity, and Docker rotates that on every restart — so the new container has a different ID and won't recognize the old worker's claims as its own.
+
+**Recover** with the admin CLI:
+
+```bash
+# If you know which worker is dead:
+hindsight-admin decommission-worker <old-worker-id>
+
+# Or, fleet-wide release across all workers:
+hindsight-admin decommission-workers
+```
+
+**Prevent it** by setting `HINDSIGHT_API_WORKER_ID` to a stable value (Docker `-e HINDSIGHT_API_WORKER_ID=...`, or `--worker-id` on bare metal). The Helm chart already handles this — its StatefulSet wires the pod name automatically.
+
+See [Admin CLI — Recovering stuck operations](/developer/admin-cli#recovering-stuck-or-zombie-operations) for the full diagnosis and recovery flow.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -245,6 +245,44 @@ hindsight-admin worker-status --schema tenant_acme
 
 ---
 
+## Recovering stuck or zombie operations
+
+A "zombie" operation is one stuck in `processing` indefinitely because the worker that claimed it is gone. The most common cause is an unstable `HINDSIGHT_API_WORKER_ID`: when it defaults to the container hostname, a Docker restart produces a new container ID, the new worker doesn't recognize the old worker's claims as its own, and those tasks are stranded.
+
+**How to spot them:**
+
+```bash
+# List processing tasks grouped by worker — workers with a growing last_update_ago are dead
+hindsight-admin worker-status
+
+# Bank-level counters; pending_consolidation that never decreases is the usual symptom
+curl -s http://localhost:8888/v1/default/banks/<bank_id>/stats
+```
+
+**How to recover:**
+
+```bash
+# You know which worker is dead (e.g. from worker-status):
+hindsight-admin decommission-worker <old-worker-id>
+
+# You don't know — release every processing task across the fleet:
+hindsight-admin decommission-workers
+```
+
+Both commands reset `processing` rows back to `pending` so a live worker can claim them on the next poll.
+
+**How to prevent it:**
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value so worker identity survives restarts:
+
+- **Docker**: pass `-e HINDSIGHT_API_WORKER_ID=hindsight-prod` (or per-replica names if running multiple containers)
+- **Kubernetes (Helm)**: the chart's StatefulSet uses the pod name automatically — no extra config needed
+- **Bare metal / pip**: pass `--worker-id <name>` or set the env var per process
+
+See [Installation - Docker](./installation#docker) and [Configuration - Distributed Workers](./configuration#distributed-workers).
+
+---
+
 ## Environment Variables
 
 The admin CLI uses the same environment variables as the API service. The most important one is:

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -87,6 +87,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 All published images are [signed with Cosign](#verifying-image-signatures) — verification is optional.
 
+:::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
+The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_ID=hindsight-prod`) so the worker keeps the same identity across restarts. This is recommended even for single-container deployments. For diagnosis and recovery commands, see [Admin CLI - Recovering stuck operations](./admin-cli#recovering-stuck-or-zombie-operations).
+:::
+
 ### Docker Image Variants
 
 | Variant | Size (AMD64) | Size (ARM64) | When to use |
@@ -169,6 +175,8 @@ helm install hindsight oci://ghcr.io/vectorize-io/charts/hindsight \
   --set worker.enabled=true \
   --set worker.replicaCount=3
 ```
+
+The chart deploys workers as a StatefulSet, so each pod gets a stable name (e.g. `hindsight-worker-0`) that the worker uses as its `HINDSIGHT_API_WORKER_ID`. Tasks claimed by a pod are recognized as its own across restarts. If you swap the chart for a plain Deployment, set `HINDSIGHT_API_WORKER_ID` explicitly per replica — otherwise hostnames are randomized and previously-claimed tasks become orphaned. See [Admin CLI - Recovering stuck operations](./admin-cli#recovering-stuck-or-zombie-operations) for diagnosis.
 
 See [Services - Worker Service](./services#worker-service) for configuration details and architecture.
 

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -8,6 +8,7 @@
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
 - [Hosting and system requirements](#do-i-need-to-host-my-own-infrastructure)
+- [What are "zombie" operations and how do I recover them?](#what-are-zombie-operations-and-how-do-i-recover-them)
 - [How do I isolate user data?](#how-do-i-isolate-user-data)
 - [Retain, recall, and reflect — what's the difference?](#whats-the-difference-between-retain-recall-and-reflect)
 - [When should I use recall vs reflect?](#when-should-i-use-recall-vs-reflect)
@@ -115,6 +116,28 @@ For running the Hindsight API server locally:
 - LLM API key (OpenAI, Anthropic, etc.) or local LLM setup
 
 See [Installation](developer/installation.md) for setup instructions.
+
+---
+
+### What are "zombie" operations and how do I recover them?
+
+A **zombie operation** is a background task stuck in `processing` indefinitely because the worker that claimed it is gone — typically after a Docker container restart. The symptom is a `pending_consolidation` (or similar) counter that never decreases on `/banks/{bank_id}/stats`, even though the worker logs show plenty of free slots.
+
+The root cause is almost always an unstable `HINDSIGHT_API_WORKER_ID`. By default the worker uses the container hostname as its identity, and Docker rotates that on every restart — so the new container has a different ID and won't recognize the old worker's claims as its own.
+
+**Recover** with the admin CLI:
+
+```bash
+# If you know which worker is dead:
+hindsight-admin decommission-worker <old-worker-id>
+
+# Or, fleet-wide release across all workers:
+hindsight-admin decommission-workers
+```
+
+**Prevent it** by setting `HINDSIGHT_API_WORKER_ID` to a stable value (Docker `-e HINDSIGHT_API_WORKER_ID=...`, or `--worker-id` on bare metal). The Helm chart already handles this — its StatefulSet wires the pod name automatically.
+
+See [Admin CLI — Recovering stuck operations](developer/admin-cli.md#recovering-stuck-or-zombie-operations) for the full diagnosis and recovery flow.
 
 ---
 


### PR DESCRIPTION
## Summary

Worker identity defaults to the container hostname, which Docker rotates on every restart. When that happens, tasks the previous container claimed are orphaned — the new container has a different ID and won't recognize them as its own. Several real deployments have hit this (issue #1470, plus the related closed tickets #991 / #696 / #624).

The mitigation — set `HINDSIGHT_API_WORKER_ID` to a stable value — was previously only documented as a row in the configuration reference table, where it tends to get read **after** the bug has bitten. This PR moves the guidance to where deployers actually look during install, and adds a recovery section next to the decommission commands.

- **`installation.md` Docker section** — callout right after the `docker run` example explaining the container-ID-as-hostname trap and recommending an explicit `HINDSIGHT_API_WORKER_ID`.
- **`installation.md` Helm Distributed Workers** — note that the chart's StatefulSet wires the pod name automatically (verified via `helm/hindsight/templates/worker-statefulset.yaml`), with a warning if you swap to a plain Deployment.
- **`admin-cli.md`** — new "Recovering stuck or zombie operations" section: spot (`worker-status`, `/stats`), recover (`decommission-worker` / `decommission-workers`), prevent (stable `WORKER_ID` per platform).

The configuration reference table is untouched — it's still the source of truth, the install path just signposts to it now.

## Test plan
- [ ] Local Docusaurus build (`./scripts/dev/start-docs.sh`) renders the new sections without anchor warnings
- [ ] Anchor links resolve: `./admin-cli#recovering-stuck-or-zombie-operations`, `./installation#docker`, `./configuration#distributed-workers`
- [ ] No new lint errors from `generate-docs-skill.sh` (regenerated `skills/hindsight-docs/` is included in the commit)