### PR TITLE
fix(reflect): read document metadata from retain params

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -7,6 +7,7 @@ Implements hierarchical retrieval:
 3. recall - Raw facts as ground truth
 """
 
+import json
 import logging
 import uuid
 from dataclasses import replace
@@ -20,6 +21,21 @@ if TYPE_CHECKING:
     from ..memory_engine import MemoryEngine
 
 logger = logging.getLogger(__name__)
+
+
+def _document_metadata_from_retain_params(retain_params: Any) -> dict[str, Any] | None:
+    """Return document metadata stored under retain_params.metadata."""
+    if isinstance(retain_params, str):
+        try:
+            retain_params = json.loads(retain_params)
+        except json.JSONDecodeError:
+            return None
+
+    if not isinstance(retain_params, dict):
+        return None
+
+    metadata = retain_params.get("metadata")
+    return metadata if isinstance(metadata, dict) else None
 
 
 async def tool_search_mental_models(
@@ -350,7 +366,7 @@ async def tool_expand(
     if all_doc_ids:
         docs = await conn.fetch(
             f"""
-            SELECT id, original_text, metadata, retain_params
+            SELECT id, original_text, retain_params
             FROM {fq_table("documents")}
             WHERE id = ANY($1) AND bank_id = $2
             """,
@@ -396,7 +412,7 @@ async def tool_expand(
                 item["document"] = {
                     "id": doc["id"],
                     "full_text": doc["original_text"],
-                    "metadata": doc["metadata"],
+                    "metadata": _document_metadata_from_retain_params(doc["retain_params"]),
                     "retain_params": doc["retain_params"],
                 }
         elif memory["document_id"] and depth == "document" and memory["document_id"] in doc_map:
@@ -405,7 +421,7 @@ async def tool_expand(
             item["document"] = {
                 "id": doc["id"],
                 "full_text": doc["original_text"],
-                "metadata": doc["metadata"],
+                "metadata": _document_metadata_from_retain_params(doc["retain_params"]),
                 "retain_params": doc["retain_params"],
             }
 

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -1,0 +1,120 @@
+"""Regression tests for reflect tool helpers."""
+
+import re
+import uuid
+
+import pytest
+
+from hindsight_api.engine.reflect.tools import _document_metadata_from_retain_params, tool_expand
+
+
+class _FakeReflectConnection:
+    """Tiny asyncpg-like connection for tool_expand query behavior."""
+
+    def __init__(self, bank_id: str, memory_id: uuid.UUID, document_id: str, chunk_id: str | None) -> None:
+        self.bank_id = bank_id
+        self.memory_id = memory_id
+        self.document_id = document_id
+        self.chunk_id = chunk_id
+
+    async def fetch(self, query: str, *args):
+        normalized_query = re.sub(r"\s+", " ", query).strip()
+
+        if "FROM public.memory_units" in normalized_query:
+            return [
+                {
+                    "id": self.memory_id,
+                    "text": "The user prefers test-first bug fixes.",
+                    "chunk_id": self.chunk_id,
+                    "document_id": self.document_id,
+                    "fact_type": "experience",
+                    "context": "preference",
+                }
+            ]
+
+        if "FROM public.chunks" in normalized_query:
+            if self.chunk_id is None:
+                return []
+            return [
+                {
+                    "chunk_id": self.chunk_id,
+                    "chunk_text": "The user prefers test-first bug fixes.",
+                    "chunk_index": 0,
+                    "document_id": self.document_id,
+                }
+            ]
+
+        if "FROM public.documents" in normalized_query:
+            select_clause = normalized_query.split(" FROM ", 1)[0]
+            assert " metadata," not in f" {select_clause},", (
+                "tool_expand must not query documents.metadata; that column was removed and "
+                "document metadata now lives in retain_params.metadata"
+            )
+            return [
+                {
+                    "id": self.document_id,
+                    "original_text": "The user prefers test-first bug fixes.",
+                    "retain_params": {"metadata": {"source": "regression-test"}},
+                }
+            ]
+
+        raise AssertionError(f"Unexpected query: {normalized_query}")
+
+
+@pytest.mark.asyncio
+async def test_tool_expand_document_depth_reads_metadata_from_retain_params() -> None:
+    """Document expansion must work after documents.metadata has been dropped."""
+    bank_id = "test-reflect-expand-retain-params-metadata"
+    memory_id = uuid.uuid4()
+    document_id = "doc-reflect-expand"
+    chunk_id = "chunk-reflect-expand"
+    conn = _FakeReflectConnection(bank_id, memory_id, document_id, chunk_id)
+
+    result = await tool_expand(
+        conn=conn,
+        bank_id=bank_id,
+        memory_ids=[str(memory_id)],
+        depth="document",
+    )
+
+    assert result["count"] == 1
+    document = result["results"][0]["document"]
+    assert document["metadata"] == {"source": "regression-test"}
+    assert document["retain_params"] == {"metadata": {"source": "regression-test"}}
+
+
+@pytest.mark.asyncio
+async def test_tool_expand_document_depth_without_chunk_reads_metadata_from_retain_params() -> None:
+    """Direct document expansion follows the same metadata source contract."""
+    bank_id = "test-reflect-expand-direct-retain-params-metadata"
+    memory_id = uuid.uuid4()
+    document_id = "doc-reflect-expand-direct"
+    conn = _FakeReflectConnection(bank_id, memory_id, document_id, chunk_id=None)
+
+    result = await tool_expand(
+        conn=conn,
+        bank_id=bank_id,
+        memory_ids=[str(memory_id)],
+        depth="document",
+    )
+
+    assert result["count"] == 1
+    document = result["results"][0]["document"]
+    assert document["metadata"] == {"source": "regression-test"}
+    assert document["retain_params"] == {"metadata": {"source": "regression-test"}}
+
+
+def test_document_metadata_from_retain_params_accepts_json_strings() -> None:
+    """asyncpg JSONB codecs may return retain_params as a dict or JSON string."""
+    retain_params = '{"metadata": {"source": "json-string"}}'
+
+    assert _document_metadata_from_retain_params(retain_params) == {"source": "json-string"}
+
+
+@pytest.mark.parametrize(
+    "retain_params",
+    [None, [], "not json", {"metadata": ["not", "a", "dict"]}],
+)
+def test_document_metadata_from_retain_params_ignores_invalid_values(retain_params) -> None:
+    """Malformed retain_params should not break reflect expansion."""
+    assert _document_metadata_from_retain_params(retain_params) is None


### PR DESCRIPTION
## Bug Description

`tool_expand(depth="document")` still queried `documents.metadata`, but the `d6e7f8a9b0c1_drop_documents_metadata_column` migration intentionally removed that column. On migrated databases this causes reflect/document expansion to fail with:

```text
column "metadata" does not exist
```

## Root Cause

The migration documents that document metadata is stored in `documents.retain_params.metadata`, but the reflect expansion path was still selecting and returning the removed `documents.metadata` column.

## Fix

- Stop selecting `documents.metadata` in `tool_expand()`.
- Preserve the public response shape by returning `document["metadata"]` from `retain_params.metadata`.
- Accept `retain_params` as either a decoded JSON object or a JSON string.
- Treat malformed/non-object metadata as absent instead of breaking reflect expansion.
- Add focused regression coverage for both document expansion branches.

## How to Verify

1. Run `uv run pytest tests/test_reflect_tools.py -q`.
2. Run `uv run ruff check hindsight_api/engine/reflect/tools.py tests/test_reflect_tools.py`.
3. Run `uv run ty check hindsight_api/engine/reflect/tools.py`.

## Test Plan

- [x] Added regression tests for this bug.
- [x] Verified the new regression test failed before the implementation change because `tool_expand()` selected `documents.metadata`.
- [x] `uv run pytest tests/test_reflect_tools.py -q` — 7 passed.
- [x] `uv run ruff format hindsight_api/engine/reflect/tools.py tests/test_reflect_tools.py`.
- [x] `uv run ruff check hindsight_api/engine/reflect/tools.py tests/test_reflect_tools.py`.
- [x] `uv run ty check hindsight_api/engine/reflect/tools.py`.

## Risk Assessment

Low — this is scoped to reflect document expansion. It aligns `tool_expand()` with the existing schema migration and existing document API behavior while preserving the returned `document["metadata"]` field.

## Notes

This PR intentionally does not add a migration. The schema is already correct; the bug is stale application code querying a removed column.
