### PR TITLE
docs(openclaw): document hooks.allowConversationAccess + plugins.allow setup-wizard backfills (#1514, #1521)

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -169,6 +169,30 @@ The setup wizard sets this for you. If you edit `~/.openclaw/openclaw.json` by h
 
 If retain isn't writing facts, check the gateway log — the diagnostic line is `typed hook "agent_end" blocked because non-bundled plugins must set ... allowConversationAccess=true`. Adding the field above (or re-running `hindsight-openclaw-setup` so the wizard backfills it) unblocks retain.
 
+### Plugin allowlist
+
+Since OpenClaw 2026.2.19, the gateway logs a `WARN` at every startup when `plugins.allow` is empty and non-bundled plugins are auto-loaded:
+
+```
+[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: hindsight-openclaw (...).
+          Set plugins.allow to explicit trusted ids.
+```
+
+The plugin still loads under the legacy empty-allowlist auto-discover behavior, but the warning fires on every gateway start until you set explicit trusted plugin ids. The setup wizard adds `hindsight-openclaw` to `plugins.allow` for you. If you edit `~/.openclaw/openclaw.json` by hand, add it to the allowlist:
+
+```json
+{
+  "plugins": {
+    "allow": ["hindsight-openclaw"],
+    "entries": {
+      "hindsight-openclaw": { "enabled": true }
+    }
+  }
+}
+```
+
+If you already curate `plugins.allow` for other plugins, append our id rather than replacing the list. When `plugins.allow` is an array, `hindsight-openclaw-setup` appends `hindsight-openclaw` if missing (idempotent) and leaves existing entries untouched. If `plugins.allow` is set to a non-array value, the wizard leaves it alone — normalize it to an array of plugin ids by hand.
+
 
 ### Memory Isolation
 

--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -143,6 +143,33 @@ Optional settings in `~/.openclaw/openclaw.json`:
 - `retainOverlapTurns` - Extra prior turns included when chunked retention fires (default: `0`).
 - `debug` - Enable debug logging (default: `false`).
 
+### Plugin hooks
+
+Since OpenClaw 2026.4.24, non-bundled plugins must explicitly opt in to register typed conversation hooks (e.g. `agent_end`, used by retain). Without this opt-in the gateway blocks the hook and `retain` never fires — banks stay empty.
+
+The setup wizard sets this for you. If you edit `~/.openclaw/openclaw.json` by hand, add `hooks.allowConversationAccess: true` to the plugin entry:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "hindsight-openclaw": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
+        "config": {
+          "...": "..."
+        }
+      }
+    }
+  }
+}
+```
+
+If retain isn't writing facts, check the gateway log — the diagnostic line is `typed hook "agent_end" blocked because non-bundled plugins must set ... allowConversationAccess=true`. Adding the field above (or re-running `hindsight-openclaw-setup` so the wizard backfills it) unblocks retain.
+
+
 ### Memory Isolation
 
 The plugin creates separate memory banks based on conversation context. By default, banks are derived from the `agent`, `channel`, and `user` fields — so each unique combination gets its own isolated memory store.


### PR DESCRIPTION
## Summary

Document two related setup-wizard backfills as new subsections in `hindsight-docs/docs-integrations/openclaw.md`:

1. **`hooks.allowConversationAccess`** (OpenClaw 2026.4.24+, surfaced in #1514) — without this opt-in the gateway blocks `agent_end` and retain never fires, so banks stay empty.
2. **`plugins.allow`** (OpenClaw 2026.2.19+, surfaced in #1521) — empty allowlist auto-loads non-bundled plugins under legacy permissive behavior, but the gateway logs a WARN every startup until you set explicit trusted plugin ids.

Both fields are populated automatically by `hindsight-openclaw-setup`; manual `~/.openclaw/openclaw.json` editors currently have no doc-level guidance. Adding both to the Optional settings area between "Plugin Settings" and "Memory Isolation".

## Source-of-truth

- `hindsight-integrations/openclaw/src/setup-lib.ts` L30-33 — `PluginEntry.hooks?: { allowConversationAccess?: boolean }` shape
- `hindsight-integrations/openclaw/src/setup-lib.ts` L79-95 — backfill rationale comment for `allowConversationAccess` ("OpenClaw 2026.4.24+ blocks conversation hooks (e.g. `agent_end`)…")
- `hindsight-integrations/openclaw/src/setup-lib.ts` (same file, post #1521) — `ensurePluginConfig` `plugins.allow` handling: undefined → `[PLUGIN_ID]`; existing array → append our id when missing (idempotent); non-array value → left alone
- #1514 PR description — observed gateway log line `typed hook "agent_end" blocked because non-bundled plugins must set ... allowConversationAccess=true` and "no memories landing in my org" symptom
- #1521 PR description — observed startup WARN `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: hindsight-openclaw (...). Set plugins.allow to explicit trusted ids.`

## Whats added

Two additive subsections (~50 LOC total) between "Plugin Settings" and "Memory Isolation":

1. **### Plugin hooks** — paragraph + sample JSON for `hooks.allowConversationAccess: true` + diagnostic log line + unblock paths.
2. **### Plugin allowlist** — paragraph + sample JSON for `plugins.allow: ["hindsight-openclaw"]` + WARN log block + explicit asymmetry note: when `plugins.allow` is an array the wizard appends idempotently, when it is non-array the wizard leaves it untouched and the user must normalize manually.

No changes to existing JSON examples in the doc — both are standalone new subsections so users searching for the symptom or the field name find them directly.

## Test plan

- [x] Verified PluginEntry shape against `setup-lib.ts` (hooks at top of plugin entry alongside `enabled` / `config`)
- [x] Verified `plugins.allow` is at `plugins.allow` level (sibling of `plugins.entries`), not nested per-entry
- [x] Diagnostic log line copied verbatim from #1514 PR description
- [x] WARN log block copied verbatim from #1521 PR description
- [x] `~/.openclaw/openclaw.json` manual-edit paths match the wizards `ensurePluginConfig` backfill behavior
- [x] Asymmetry note (array vs non-array) matches the explicit code branches in `ensurePluginConfig`

## Codex adversarial review

Codex round 1 (gpt-5.5 xhigh): flagged 0.88 confidence — initial wording "appends idempotently and never clobbers a user-curated allowlist" misled users with non-array `plugins.allow` value because the wizard intentionally leaves non-arrays alone. Reworked to explicit array-vs-non-array asymmetry note.

Codex round 2: flagged 0.78 confidence — calling the WARN "cosmetic" understated the security/legacy-permissive meaning of an empty allowlist. Reworked to "legacy empty-allowlist auto-discover behavior" + explicit "until you set explicit trusted plugin ids".

If something already landed via a different path (the wizard side is in #1514 / #1521), please feel free to close and mark accordingly.
