### PR TITLE
docs(readme): document bind-mount UID requirement in Docker quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 
 You can modify the LLM provider by setting `HINDSIGHT_API_LLM_PROVIDER`. Valid options are `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `lmstudio`, and `minimax`. The documentation provides more details on [supported models](https://hindsight.vectorize.io/developer/models).
 
+> **Bind-mount permissions.** The container runs as UID 1000, so the host directory must be writable by UID 1000 — otherwise the embedded PostgreSQL fails to start with `Permission denied (os error 13)`. On macOS Docker Desktop and most Linux setups where `$HOME` isn't owned by UID 1000, pre-create and chown the directory:
+> ```bash
+> mkdir -p $HOME/.hindsight-docker && sudo chown -R 1000:1000 $HOME/.hindsight-docker
+> ```
+> Or run the container as your host user instead by adding `--user $(id -u):$(id -g)` to the `docker run` command (and chown the host directory to your own UID). If you don't need the data on a host path, you can also use a named volume: `-v hindsight-data:/home/hindsight/.pg0`.
+
 
 
 ### Docker (external PostgreSQL)


### PR DESCRIPTION
## Summary
- Adds a callout under the Docker quickstart explaining that the container runs as UID 1000 and the bind-mounted host directory must be writable by UID 1000, otherwise embedded PostgreSQL fails to start with `Permission denied (os error 13)`.
- Documents both fixes contributors are most likely to reach for: pre-creating the host dir and `chown -R 1000:1000`, or running the container as the host user via `--user $(id -u):$(id -g)`. The `--user` path already works thanks to #1493 (chmod 755 /home/hindsight).
- Mentions named volumes (`-v hindsight-data:/home/hindsight/.pg0`) as a no-chown option for users who don't need data on a host path.
- Keeps the existing bind-mount default in the example so existing users copy-pasting the README continue to work.

Closes #1483

## Test plan
- [ ] Fresh macOS Docker Desktop run with `chown 1000:1000 \$HOME/.hindsight-docker` succeeds and serves http://localhost:8888
- [ ] Fresh run with `--user \$(id -u):\$(id -g)` and host-UID-owned dir succeeds
- [ ] Fresh run with named volume (`-v hindsight-data:/home/hindsight/.pg0`) succeeds
- [ ] Without any of the above, the original failure (`Permission denied (os error 13)`) reproduces — confirming the callout addresses a real foot-gun