### PR TITLE
fix(worker): propagate child error_message to failed batch_retain parent

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1654,11 +1654,16 @@ class MemoryEngine(MemoryEngineInterface):
                 # Parent doesn't exist (shouldn't happen)
                 return
 
-            # Get all sibling operations (including this one)
-            # This query runs in the same transaction, so it sees the current child's updated status
+            # Get all sibling operations (including this one).
+            # This query runs in the same transaction, so it sees the current
+            # child's updated status. Pull error_message too so a parent that
+            # fails can inherit a representative child reason -- otherwise
+            # downstream consumers (dashboards, alert filters) lose the actual
+            # cause once a batch has children. See the worker poller's
+            # _summarise_child_error_messages for the propagation rationale.
             siblings = await conn.fetch(
                 f"""
-                SELECT status
+                SELECT status, error_message
                 FROM {fq_table("async_operations")}
                 WHERE bank_id = $1
                 AND result_metadata::jsonb @> $2::jsonb
@@ -1682,7 +1687,12 @@ class MemoryEngine(MemoryEngineInterface):
             # All siblings are done - update parent status
             if any_failed:
                 new_status = "failed"
-                # Set parent error message to indicate child failure
+                # Set parent error message to indicate child failure. Inherit
+                # the most-common failed-child error_message rather than a
+                # generic string so downstream filters can attribute the
+                # cause correctly.
+                from hindsight_api.worker.poller import _summarise_child_error_messages
+
                 await conn.execute(
                     f"""
                     UPDATE {fq_table("async_operations")}
@@ -1691,7 +1701,7 @@ class MemoryEngine(MemoryEngineInterface):
                     """,
                     uuid.UUID(parent_operation_id),
                     new_status,
-                    "One or more sub-batches failed",
+                    _summarise_child_error_messages(siblings),
                 )
             elif all_completed:
                 new_status = "completed"

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -14,7 +14,8 @@ import json
 import logging
 import time
 import traceback
-from collections.abc import Awaitable, Callable
+from collections import Counter
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,36 @@ PROGRESS_LOG_INTERVAL = 30
 # per threshold it crosses (5min, 10min, 20min, 40min, 80min...).
 STUCK_STACK_INITIAL_THRESHOLD_S = 300
 STUCK_STACK_MAX_THRESHOLD_S = 3600 * 6  # cap doubling at 6h
+
+
+def _summarise_child_error_messages(siblings: "Iterable[Any]") -> str:
+    """Pick a representative error message for a parent whose children failed.
+
+    Used when a batch_retain parent transitions to 'failed' because at least
+    one child sub-batch failed. Without this, the parent gets a generic
+    "One or more sub-batches failed" string and any consumer that reasons
+    about errors via error_message (dashboards, alert filters, log
+    aggregators) loses the actual cause -- a class of failures that all
+    share the same root reason at the child level becomes indistinguishable
+    at the parent level.
+
+    Strategy: pick the most common non-empty error_message among failed
+    siblings. If they all failed for the same reason (the common case), the
+    parent inherits that reason verbatim. If they vary, the most-common one
+    is still a useful representative. Falls back to the legacy generic
+    string when no failed sibling carries an error_message at all.
+    """
+    failed_errors: list[str] = []
+    for s in siblings:
+        if s["status"] != "failed":
+            continue
+        msg = (s["error_message"] or "").strip()
+        if msg:
+            failed_errors.append(msg)
+    if not failed_errors:
+        return "One or more sub-batches failed"
+    most_common, _count = Counter(failed_errors).most_common(1)[0]
+    return most_common
 
 
 @dataclass
@@ -495,10 +526,14 @@ class WorkerPoller:
             if not parent_row:
                 return
 
-            # Check whether all siblings are done
+            # Check whether all siblings are done. Pull error_message too so a
+            # parent that fails can inherit a representative child reason --
+            # otherwise the parent's error_message is generic ("One or more
+            # sub-batches failed") and downstream consumers (dashboards, alerts,
+            # filters) lose the actual cause once a batch has children.
             siblings = await conn.fetch(
                 f"""
-                SELECT status FROM {table}
+                SELECT status, error_message FROM {table}
                 WHERE bank_id = $1
                   AND result_metadata::jsonb @> $2::jsonb
                 """,
@@ -517,7 +552,7 @@ class WorkerPoller:
                     WHERE operation_id = $1
                     """,
                     uuid.UUID(parent_operation_id),
-                    "One or more sub-batches failed",
+                    _summarise_child_error_messages(siblings),
                 )
             else:
                 await conn.execute(

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2394,6 +2394,75 @@ async def test_pending_breakdown_explains_unclaimable_rows(pool, backend, clean_
     assert buckets["consolidation"]["claimable"] >= 1
 
 
+class TestSummariseChildErrorMessages:
+    """Pure unit tests for the _summarise_child_error_messages helper.
+
+    The helper picks a representative error message for a parent whose
+    children failed. The integration tests above exercise the full path
+    through _mark_failed; these tests focus on the choice itself.
+    """
+
+    def _sib(self, status: str, error_message: str | None = None) -> dict:
+        return {"status": status, "error_message": error_message}
+
+    def test_all_failed_with_same_message_inherits_that_message(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("failed", "boom"),
+            self._sib("failed", "boom"),
+            self._sib("failed", "boom"),
+        ]
+        assert _summarise_child_error_messages(siblings) == "boom"
+
+    def test_mixed_failed_messages_picks_most_common(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("failed", "common cause"),
+            self._sib("failed", "common cause"),
+            self._sib("failed", "rare cause"),
+        ]
+        assert _summarise_child_error_messages(siblings) == "common cause"
+
+    def test_completed_siblings_ignored(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("completed", None),
+            self._sib("completed", None),
+            self._sib("failed", "the one real failure"),
+        ]
+        assert _summarise_child_error_messages(siblings) == "the one real failure"
+
+    def test_no_failed_siblings_falls_back_to_generic(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("completed", None),
+            self._sib("completed", None),
+        ]
+        assert _summarise_child_error_messages(siblings) == "One or more sub-batches failed"
+
+    def test_failed_siblings_with_no_error_message_falls_back_to_generic(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("failed", None),
+            self._sib("failed", ""),
+        ]
+        assert _summarise_child_error_messages(siblings) == "One or more sub-batches failed"
+
+    def test_whitespace_only_messages_treated_as_empty(self):
+        from hindsight_api.worker.poller import _summarise_child_error_messages
+
+        siblings = [
+            self._sib("failed", "   "),
+            self._sib("failed", "actual error"),
+        ]
+        assert _summarise_child_error_messages(siblings) == "actual error"
+
+
 class TestMarkFailedParentPropagation:
     """Tests for _mark_failed parent propagation in WorkerPoller.
 
@@ -2473,9 +2542,20 @@ class TestMarkFailedParentPropagation:
         assert "DB constraint violation" in child2_row["error_message"]
 
         # parent must now be failed (all siblings done, at least one failed)
-        parent_row = await pool.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", parent_id)
+        parent_row = await pool.fetchrow(
+            "SELECT status, error_message FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
         assert parent_row["status"] == "failed", (
             f"Parent should be 'failed' when last sibling fails, got '{parent_row['status']}'"
+        )
+        # Parent error_message must propagate the child's actual error reason,
+        # not the legacy generic "One or more sub-batches failed". Without this,
+        # downstream filters that classify failures by error_message lose all
+        # signal once a batch has children.
+        assert "DB constraint violation" in (parent_row["error_message"] or ""), (
+            f"Parent error_message should inherit child's reason, "
+            f"got: {parent_row['error_message']!r}"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When a \`batch_retain\` parent transitions to \`failed\` because at least one child sub-batch failed, the parent's \`error_message\` was hardcoded to the generic string \`"One or more sub-batches failed"\`. Any consumer that classifies failures by \`error_message\` (dashboards, alert filters, log aggregators) loses signal once a batch grows children — a class of failures that all share the same root reason at the child level becomes indistinguishable at the parent level.

## Fix

Pull \`error_message\` in the siblings query and pick the most-common non-empty failed-child message as the parent's \`error_message\`. When all siblings failed for the same reason (the common case) the parent inherits that reason verbatim; when reasons vary the most-common one is still a useful representative. Falls back to the legacy generic string only when no failed sibling carries an \`error_message\` at all, preserving backward compat for that edge case.

Same change applied to both:
- the worker poller's fallback path (\`worker/poller.py:_maybe_update_parent_operation\`)
- the memory engine's in-transaction path (\`engine/memory_engine.py:_maybe_update_parent_operation\`)

so the propagation behavior is consistent regardless of which surface finalises the parent.

## Behavior change

| Before | After |
|---|---|
| Parent error_message: \`\"One or more sub-batches failed\"\` | Parent error_message: \`<most-common failed child's error_message>\` |
| Generic-fallback when no children have errors | Same (preserved for backward compat) |

## Test plan

- [x] 6 new pure unit tests for \`_summarise_child_error_messages\` covering: same-message inheritance, mixed-message most-common selection, completed-sibling skip, no-failed fallback, no-error-message fallback, whitespace-only-message fallback
- [x] Existing integration test \`test_mark_failed_finalises_parent_when_last_sibling_fails\` extended with an assertion that the parent \`error_message\` contains the child's reason
- [x] Full \`TestMarkFailedParentPropagation\` + \`TestSummariseChildErrorMessages\` suite (11 tests) passes locally
- [x] No tests asserted on the legacy generic string anywhere in the repo