### PR TITLE
fix(claude-code): use detail=metadata for agent_knowledge_list_pages

### DIFF
--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -78,7 +78,16 @@ def agent_knowledge_get_current_bank() -> str:
 @mcp.tool()
 def agent_knowledge_list_pages() -> str:
     """List all your knowledge pages (IDs and names only). Use agent_knowledge_get_page to read the full content of a specific page."""
-    resp = _client.request("GET", f"/v1/default/banks/{_encode_bank(_default_bank_id)}/mental-models", timeout=10)
+    # The API defaults to detail=full, which returns synthesized content +
+    # reflect_response for every page. The docstring above promises "IDs and
+    # names only", so request the metadata projection explicitly. This keeps
+    # list_pages payloads small at realistic agent scales (tens of pages,
+    # each up to ~100 KB content).
+    resp = _client.request(
+        "GET",
+        f"/v1/default/banks/{_encode_bank(_default_bank_id)}/mental-models?detail=metadata",
+        timeout=10,
+    )
     return json.dumps(resp, indent=2)
 
 

--- a/hindsight-integrations/claude-code/tests/test_mcp_server.py
+++ b/hindsight-integrations/claude-code/tests/test_mcp_server.py
@@ -1,0 +1,44 @@
+"""Regression tests for mcp_server.py.
+
+The MCP server runs as a stdio subprocess; the Claude Code MCP client buffers
+up to 16 MB looking for a JSON-RPC message boundary (newline) and disconnects
+if a single response exceeds that ceiling. The /mental-models LIST endpoint
+defaults to detail=full, which returns synthesized content + reflect_response
+for every page in the bank — at realistic agent scales (tens of pages with
+~100 KB content each) this exceeds 16 MB in a single response and triggers a
+deterministic disconnect during agent_knowledge_list_pages. The fix is to
+request detail=metadata, which the API supports specifically for this use case
+(see the upstream PR that added the parameter: "reduces payload for agent
+boot flows and MCP clients where context budget is limited").
+"""
+
+import os
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+
+
+def _read_mcp_server_source() -> str:
+    return open(os.path.join(SCRIPTS_DIR, "mcp_server.py"), encoding="utf-8").read()
+
+
+class TestListPagesUsesMetadataProjection:
+    """`agent_knowledge_list_pages` must request the API's metadata projection.
+
+    The /mental-models endpoint accepts a `detail` query parameter with values
+    `metadata` / `content` / `full`, defaulting to `full`. The full projection
+    returns synthesized content + reflect_response for every page in the bank,
+    which has caused real disconnects (>16 MB single JSON-RPC response). The
+    docstring promises "IDs and names only", so the request must pin
+    `detail=metadata`.
+    """
+
+    def test_list_pages_request_uses_detail_metadata(self):
+        src = _read_mcp_server_source()
+        assert "/mental-models?detail=metadata" in src, (
+            "list_pages must request detail=metadata; the API defaults to full"
+        )
+        list_pages_def = src.find("def agent_knowledge_list_pages")
+        next_def = src.find("def agent_knowledge_get_page")
+        assert list_pages_def > 0 and next_def > list_pages_def
+        list_pages_body = src[list_pages_def:next_def]
+        assert "detail=metadata" in list_pages_body


### PR DESCRIPTION
## Summary

`agent_knowledge_list_pages` was hitting `GET /mental-models` with no `detail` parameter, so the API returned its default (`detail=full`) — synthesized content + `reflect_response` for every page in the bank. On a bank with many pages this produces a single JSON-RPC response that exceeds the Claude Code MCP client's 16 MB without-newline-boundary buffer ceiling and triggers a deterministic disconnect during the first `list_pages` call of a session.

The disconnect manifests in client logs as:

> `wrote >16MB to stdout without a JSON-RPC message boundary. The server is likely writing logs or other non-protocol data to stdout instead of stderr.`

The "logs to stdout" hint is a misleading client heuristic — the bytes are a single valid JSON-RPC response, just one that's too large to fit in the framing buffer.

## Root cause verification

Driving the MCP server end-to-end against a real bank:

| | Bytes on stdout | JSON-RPC messages | Result |
|---|---|---|---|
| Unpatched (`detail=full` default) | **20,054,285** | 1 (single oversized) | 16 MB ceiling tripped → disconnect |
| Patched (`detail=metadata`) | **44,987** | 2 | clean |

That's a ~445× reduction in payload size for the list call.

## Why this is safe

The plugin tool's docstring already promises *"IDs and names only. Use `agent_knowledge_get_page` to read the full content of a specific page."* — so this aligns the wire call with the documented contract. The change is plugin-internal:

- `agent_knowledge_list_pages` is the only place in the plugin that calls the list endpoint.
- No hook, session-start handler, or other plugin code consumes the response.
- `agent_knowledge_get_page` continues to use `detail=full` and is unaffected.
- The API endpoint itself is unchanged — only this client opts into the existing `detail=metadata` projection that #846 added specifically for "agent boot flows and MCP clients where context budget is limited."

I also audited the other 23 plugin integrations (openclaw, codex, opencode, langgraph, dify, crewai, agentcore, llamaindex, pipecat, openai-agents, chat, strands, ag2, agno, ai-sdk, autogen, cloudflare-oauth-proxy, n8n, nemoclaw, paperclip, pydantic-ai, smolagents, litellm) — none of them call the list endpoint, so this bug is unique to the claude-code plugin.

## Test plan

- [x] New regression test: `tests/test_mcp_server.py::TestListPagesUsesMetadataProjection` — pins the metadata projection on the wire URL.
- [x] Full plugin test suite passes locally (169 passed).
- [x] End-to-end repro: drove the patched MCP server against a real bank, captured stdout bytes, confirmed single-message size dropped from 20 MB to 45 KB.
- [ ] Smoke-tested by reconnecting after install and calling `list_pages` against a populated bank.