### PR TITLE
feat: add z.ai as LLM provider

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -288,7 +288,7 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
-    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "deepseek", "volcano", "openrouter"):
+    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "deepseek", "volcano", "openrouter", "zai"):
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,
@@ -386,6 +386,7 @@ class LLMProvider:
             "bedrock",
             "volcano",
             "openrouter",
+            "zai",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")
@@ -404,6 +405,8 @@ class LLMProvider:
                 self.base_url = "https://api.deepseek.com"
             elif self.provider == "openrouter":
                 self.base_url = "https://openrouter.ai/api/v1"
+            elif self.provider == "zai":
+                self.base_url = "https://api.z.ai/api/coding/paas/v4"
 
         # Prepare Vertex AI config (if applicable)
         vertexai_project_id = None

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -273,6 +273,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "deepseek",
             "volcano",
             "openrouter",
+            "zai",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
@@ -291,13 +292,15 @@ class OpenAICompatibleLLM(LLMInterface):
                 self.base_url = "https://api.deepseek.com"
             elif self.provider == "openrouter":
                 self.base_url = "https://openrouter.ai/api/v1"
+            elif self.provider == "zai":
+                self.base_url = "https://api.z.ai/api/coding/paas/v4"
 
         # For ollama/lmstudio, use dummy key if not provided
         if self.provider in ("ollama", "lmstudio") and not self.api_key:
             self.api_key = "local"
 
         # Validate API key for cloud providers
-        if self.provider in ("openai", "groq", "minimax", "deepseek", "openrouter") and not self.api_key:
+        if self.provider in ("openai", "groq", "minimax", "deepseek", "openrouter", "zai") and not self.api_key:
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)


### PR DESCRIPTION
## Summary

Add [z.ai](https://open.bigmodel.cn/) as a supported LLM provider, following the existing pattern used by deepseek, minimax, and openrouter.

## Changes

### `openai_compatible_llm.py` (+3)
- Add `"zai"` to `valid_providers`
- Add default base_url: `https://api.z.ai/api/coding/paas/v4`
- Add `"zai"` to API key required check

### `llm_wrapper.py` (+4)
- Add `"zai"` to `create_llm_provider()` routing
- Add `"zai"` to `LLMConfig.valid_providers`
- Add default base_url for zai in `LLMConfig`

## Testing

Tested in Docker with `hindsight:gpu` image, volume-mounting the two modified files:
- **Retain**: `glm-4.5-air` — 3276 input / 922 output tokens, fact extraction successful
- **Recall**: Returns stored memories with correct entities (zai provider, glm-4.5-air)
- **Verification**: Intermittent `finish_reason=length` empty responses from z.ai API (same issue occurs with `provider=openai` + z.ai base_url override — not a code issue)

## Notes

- z.ai is one of the largest LLM providers in China (GLM series models)
- Uses OpenAI-compatible API, so no custom provider class needed
- No changes to `_max_tokens_param_name()` — falls through to default `max_tokens`