### PR TITLE
fix(cp): improve access-key auth UX and harden middleware

### DIFF
--- a/hindsight-control-plane/src/app/api/auth/login/route.ts
+++ b/hindsight-control-plane/src/app/api/auth/login/route.ts
@@ -7,10 +7,7 @@ export async function POST(request: NextRequest) {
 
   // If no access key is configured, return 503
   if (!accessKey) {
-    return NextResponse.json(
-      { error: "Access key not configured" },
-      { status: 503 }
-    );
+    return NextResponse.json({ error: "Access key not configured" }, { status: 503 });
   }
 
   let body: { key?: string };

--- a/hindsight-control-plane/src/app/api/version/route.ts
+++ b/hindsight-control-plane/src/app/api/version/route.ts
@@ -12,7 +12,12 @@ export async function GET() {
       return NextResponse.json({ error: "Failed to get version" }, { status: 500 });
     }
 
-    return NextResponse.json(response.data, { status: 200 });
+    const data = response.data as Record<string, unknown>;
+    const features = (data.features ?? {}) as Record<string, boolean>;
+    features.access_key_auth = !!process.env.HINDSIGHT_CP_ACCESS_KEY;
+    data.features = features;
+
+    return NextResponse.json(data, { status: 200 });
   } catch (error) {
     console.error("Error getting version:", error);
     return NextResponse.json({ error: "Failed to get version" }, { status: 500 });

--- a/hindsight-control-plane/src/app/dashboard/page.tsx
+++ b/hindsight-control-plane/src/app/dashboard/page.tsx
@@ -1,24 +1,14 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { BankSelector } from "@/components/bank-selector";
 import { useBank } from "@/lib/bank-context";
 import { bankRoute } from "@/lib/bank-url";
-import { Button } from "@/components/ui/button";
-import { LogOut } from "lucide-react";
 
 export default function DashboardPage() {
   const router = useRouter();
   const { currentBank } = useBank();
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await fetch("/api/auth/logout", { method: "POST" });
-    } finally {
-      window.location.href = "/login";
-    }
-  }, []);
 
   // Redirect to bank page if a bank is selected
   useEffect(() => {
@@ -29,25 +19,14 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border">
-        <div className="text-sm text-muted-foreground">Hindsight Control Plane</div>
-        <Button variant="ghost" size="sm" onClick={handleLogout}>
-          <LogOut className="w-4 h-4" />
-        </Button>
-      </div>
-
       <div className="flex-1 flex flex-col">
         <BankSelector />
 
         <div className="flex items-center justify-center h-[calc(100vh-80px)] bg-muted/20">
           <div className="text-center p-10 bg-card rounded-lg border-2 border-border shadow-lg max-w-md">
             <h3 className="text-2xl font-bold mb-3 text-card-foreground">Welcome to Hindsight</h3>
-            <p className="text-muted-foreground mb-4">
+            <p className="text-muted-foreground">
               Select a memory bank from the dropdown above to get started.
-            </p>
-            <div className="text-6xl mb-4">🧠</div>
-            <p className="text-sm text-muted-foreground">
-              The sidebar will appear once you select a memory bank.
             </p>
           </div>
         </div>

--- a/hindsight-control-plane/src/app/login/page.tsx
+++ b/hindsight-control-plane/src/app/login/page.tsx
@@ -4,9 +4,8 @@ import { useState, FormEvent, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import Image from "next/image";
 
 export default function LoginPage() {
   const [key, setKey] = useState("");
@@ -55,14 +54,19 @@ export default function LoginPage() {
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <div className="text-4xl mb-2">🧠</div>
-          <CardTitle>Hindsight</CardTitle>
+          <Image
+            src="/logo.png"
+            alt="Hindsight"
+            width={160}
+            height={160}
+            className="mx-auto"
+            unoptimized
+          />
           <CardDescription>Enter your access key to continue</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="access-key">Access Key</Label>
+            <div>
               <Input
                 id="access-key"
                 type="password"
@@ -73,11 +77,7 @@ export default function LoginPage() {
               />
             </div>
 
-            {error && (
-              <Alert variant="destructive">
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+            {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
             <Button type="submit" className="w-full" disabled={loading || !key}>
               {loading ? "Signing in..." : "Sign In"}

--- a/hindsight-control-plane/src/app/login/page.tsx
+++ b/hindsight-control-plane/src/app/login/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, FormEvent, useEffect } from "react";
+import { Suspense, useState, FormEvent, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import Image from "next/image";
 
-export default function LoginPage() {
+function LoginForm() {
   const [key, setKey] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -86,5 +86,13 @@ export default function LoginPage() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -37,8 +37,10 @@ import {
   Lock,
   ChevronDown,
   ChevronRight,
+  LogOut,
 } from "lucide-react";
 import { useTheme } from "@/lib/theme-context";
+import { useFeatures } from "@/lib/features-context";
 import Image from "next/image";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -78,8 +80,9 @@ function formatTimeAgo(isoDate: string): string {
 function BankSelectorInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { currentBank, setCurrentBank, banks, bankInfos, loadBanks } = useBank();
+  const { currentBank, setCurrentBank, banks, bankInfos, banksLoading, loadBanks } = useBank();
   const { theme, toggleTheme } = useTheme();
+  const { features } = useFeatures();
   const [open, setOpen] = React.useState(false);
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false);
   const [newBankId, setNewBankId] = React.useState("");
@@ -482,7 +485,16 @@ function BankSelectorInner() {
             <Command>
               {sortedBanks.length > 0 && <CommandInput placeholder="Search memory banks..." />}
               <CommandList>
-                <CommandEmpty>No memory banks yet.</CommandEmpty>
+                <CommandEmpty>
+                  {banksLoading ? (
+                    <div className="flex items-center justify-center gap-2 py-2">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                      <span>Loading banks...</span>
+                    </div>
+                  ) : (
+                    "No memory banks yet."
+                  )}
+                </CommandEmpty>
                 <CommandGroup>
                   {sortedBanks.map((bank) => {
                     const barPct = (bank.fact_count / maxFactCount) * 100;
@@ -601,6 +613,27 @@ function BankSelectorInner() {
         >
           {theme === "light" ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
         </Button>
+
+        {features?.access_key_auth && (
+          <>
+            <div className="h-8 w-px bg-border" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9"
+              title="Logout"
+              onClick={async () => {
+                try {
+                  await fetch("/api/auth/logout", { method: "POST" });
+                } finally {
+                  window.location.href = "/login";
+                }
+              }}
+            >
+              <LogOut className="h-5 w-5" />
+            </Button>
+          </>
+        )}
 
         <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
           <DialogContent className="sm:max-w-[550px]">

--- a/hindsight-control-plane/src/components/sidebar.tsx
+++ b/hindsight-control-plane/src/components/sidebar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { useBank } from "@/lib/bank-context";
 import { bankRoute } from "@/lib/bank-url";
-import { useFeatures } from "@/lib/features-context";
 import {
   Search,
   Sparkles,
@@ -13,7 +12,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Settings,
-  LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
@@ -27,17 +25,7 @@ interface SidebarProps {
 
 export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
   const { currentBank } = useBank();
-  const { features } = useFeatures();
   const [isCollapsed, setIsCollapsed] = useState(true);
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await fetch("/api/auth/logout", { method: "POST" });
-    } finally {
-      // Force a full reload to clear state and trigger middleware redirect
-      window.location.href = "/login";
-    }
-  }, []);
 
   if (!currentBank) {
     return null;
@@ -96,21 +84,6 @@ export function Sidebar({ currentTab, onTabChange }: SidebarProps) {
           })}
         </ul>
       </nav>
-
-      {/* Logout button */}
-      <div className="p-3 border-t border-border">
-        <button
-          onClick={handleLogout}
-          className={cn(
-            "w-full flex items-center gap-3 px-4 py-2 rounded-lg text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors",
-            isCollapsed && "justify-center px-0"
-          )}
-          title={isCollapsed ? "Logout" : "Logout"}
-        >
-          <LogOut className="w-5 h-5" />
-          {!isCollapsed && <span>Logout</span>}
-        </button>
-      </div>
 
       {/* Collapse/Expand button at bottom */}
       <div className="p-3 border-t border-border">

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -129,6 +129,12 @@ export class ControlPlaneClient {
       });
 
       if (!response.ok) {
+        // Redirect to login on 401 (session expired or not authenticated)
+        if (response.status === 401 && !window.location.pathname.startsWith("/login")) {
+          window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`;
+          throw new Error("Unauthorized");
+        }
+
         // Try to parse error response
         let errorMessage = `HTTP ${response.status}`;
         let errorDetails: string | undefined;

--- a/hindsight-control-plane/src/lib/bank-context.tsx
+++ b/hindsight-control-plane/src/lib/bank-context.tsx
@@ -19,6 +19,7 @@ interface BankContextType {
   setCurrentBank: (bank: string | null) => void;
   banks: string[];
   bankInfos: BankInfo[];
+  banksLoading: boolean;
   loadBanks: () => Promise<void>;
 }
 
@@ -28,8 +29,10 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [currentBank, setCurrentBank] = useState<string | null>(null);
   const [bankInfos, setBankInfos] = useState<BankInfo[]>([]);
+  const [banksLoading, setBanksLoading] = useState(true);
 
   const loadBanks = async () => {
+    setBanksLoading(true);
     try {
       const response = await client.listBanks();
       const infos: BankInfo[] =
@@ -45,6 +48,8 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
       setBankInfos(infos);
     } catch (error) {
       console.error("Error loading banks:", error);
+    } finally {
+      setBanksLoading(false);
     }
   };
 
@@ -64,7 +69,9 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <BankContext.Provider value={{ currentBank, setCurrentBank, banks, bankInfos, loadBanks }}>
+    <BankContext.Provider
+      value={{ currentBank, setCurrentBank, banks, bankInfos, banksLoading, loadBanks }}
+    >
       {children}
     </BankContext.Provider>
   );

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -8,6 +8,7 @@ interface Features {
   mcp: boolean;
   worker: boolean;
   bank_config_api: boolean;
+  access_key_auth: boolean;
 }
 
 interface FeaturesContextType {
@@ -21,6 +22,7 @@ const defaultFeatures: Features = {
   mcp: false,
   worker: false,
   bank_config_api: false,
+  access_key_auth: false,
 };
 
 const FeaturesContext = createContext<FeaturesContextType | undefined>(undefined);

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -36,7 +36,7 @@ export function FeaturesProvider({ children }: { children: React.ReactNode }) {
     const loadFeatures = async () => {
       try {
         const response = await client.getVersion();
-        setFeatures(response.features);
+        setFeatures({ ...defaultFeatures, ...response.features });
         setError(null);
       } catch (err) {
         console.error("Error loading features:", err);

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -9,6 +9,7 @@ const PUBLIC_PATTERNS = [
   "/api/auth/",
   "/api/health",
   "/api/version",
+  "/logo.png",
   "/favicon",
   "/_next",
   "/fonts",
@@ -36,6 +37,11 @@ export function middleware(request: NextRequest) {
   const isAuthenticated = request.cookies.has(ACCESS_KEY_COOKIE);
 
   if (!isAuthenticated) {
+    // For API routes, return 401 JSON instead of redirecting to HTML login page
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     // Redirect to login page
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("returnTo", pathname);

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1345,11 +1345,15 @@ The Control Plane is the web UI for managing memory banks.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
+| `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash
 # Point Control Plane to a remote API service
 export HINDSIGHT_CP_DATAPLANE_API_URL=http://api.example.com:8888
+
+# Protect the Control Plane with an access key
+export HINDSIGHT_CP_ACCESS_KEY=my-secret-key
 ```
 
 ### Hierarchical Configuration

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -250,6 +250,7 @@ This connects to your running API server and provides a visual interface for man
 | `-p, --port` | `PORT` | 9999 | Port to listen on |
 | `-H, --hostname` | `HOSTNAME` | 0.0.0.0 | Hostname to bind to |
 | `-a, --api-url` | `HINDSIGHT_CP_DATAPLANE_API_URL` | http://localhost:8888 | Hindsight API URL |
+| | `HINDSIGHT_CP_ACCESS_KEY` | *(none)* | Access key to protect the Control Plane UI. When set, users must enter this key to log in. |
 
 #### Examples
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1345,11 +1345,15 @@ The Control Plane is the web UI for managing memory banks.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
+| `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash
 # Point Control Plane to a remote API service
 export HINDSIGHT_CP_DATAPLANE_API_URL=http://api.example.com:8888
+
+# Protect the Control Plane with an access key
+export HINDSIGHT_CP_ACCESS_KEY=my-secret-key
 ```
 
 ### Hierarchical Configuration

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -250,6 +250,7 @@ This connects to your running API server and provides a visual interface for man
 | `-p, --port` | `PORT` | 9999 | Port to listen on |
 | `-H, --hostname` | `HOSTNAME` | 0.0.0.0 | Hostname to bind to |
 | `-a, --api-url` | `HINDSIGHT_CP_DATAPLANE_API_URL` | http://localhost:8888 | Hindsight API URL |
+| | `HINDSIGHT_CP_ACCESS_KEY` | *(none)* | Access key to protect the Control Plane UI. When set, users must enter this key to log in. |
 
 #### Examples
 


### PR DESCRIPTION
## Summary

Follow-up to #1530 — fixes several issues with the access-key login feature:

- **Logout button moved**: removed from sidebar and dashboard status bar, now appears next to the GitHub icon in the header bar — only when `HINDSIGHT_CP_ACCESS_KEY` is configured
- **Middleware hardened**: unauthenticated `/api/*` requests now return 401 JSON instead of redirecting to the HTML login page (which caused JSON parse errors in client code)
- **Client-side 401 handling**: `fetchApi` redirects to `/login` on 401, but skips redirect if already on the login page (prevents infinite reload loop)
- **Login page polish**: replaced brain emoji with Hindsight logo, fixed error message visibility in dark mode, removed redundant label
- **Bank selector loading state**: shows a spinner while banks are being fetched instead of "No memory banks yet"
- **Dashboard cleanup**: removed redundant status bar and brain emoji from the no-bank-selected state
- **Docs**: added `HINDSIGHT_CP_ACCESS_KEY` to configuration and installation docs

## Test plan

- [ ] Start CP without `HINDSIGHT_CP_ACCESS_KEY` — no login page, no logout button
- [ ] Start CP with `HINDSIGHT_CP_ACCESS_KEY=test` — login page shown, logout button visible after login
- [ ] Enter wrong key — error message visible in both light and dark mode
- [ ] Open `/dashboard` unauthenticated — clean redirect to `/login`, no console errors
- [ ] Verify bank selector shows spinner while loading