### PR TITLE
chore: fix formatting in llm_wrapper.py to pass verify-generated-files

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -288,7 +288,17 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
-    elif provider_lower in ("openai", "groq", "ollama", "lmstudio", "minimax", "deepseek", "volcano", "openrouter", "zai"):
+    elif provider_lower in (
+        "openai",
+        "groq",
+        "ollama",
+        "lmstudio",
+        "minimax",
+        "deepseek",
+        "volcano",
+        "openrouter",
+        "zai",
+    ):
         return OpenAICompatibleLLM(
             provider=provider,
             api_key=api_key,

--- a/hindsight-integrations/n8n/test/node-execute.test.ts
+++ b/hindsight-integrations/n8n/test/node-execute.test.ts
@@ -35,8 +35,9 @@ function createMockExecuteFunctions(
 }
 
 function getRequestMock(fns: IExecuteFunctions): ReturnType<typeof vi.fn> {
-  return (fns as unknown as { helpers: { httpRequestWithAuthentication: ReturnType<typeof vi.fn> } })
-    .helpers.httpRequestWithAuthentication;
+  return (
+    fns as unknown as { helpers: { httpRequestWithAuthentication: ReturnType<typeof vi.fn> } }
+  ).helpers.httpRequestWithAuthentication;
 }
 
 describe("Hindsight node execute()", () => {

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -158,6 +158,11 @@
         "description": "When true (default) and retainFormat is 'json', each message's content is an Anthropic-shaped array of typed blocks including tool_use (agent tool calls) and tool_result (truncated at 2000 chars). Operational MCP tools — Hindsight's own recall/retain/search — are filtered out to avoid feedback loops. Set to false to retain text-only content, one string per message.",
         "default": true
       },
+      "includeSenderContext": {
+        "type": "boolean",
+        "description": "When true (default), prepend a session context block (sender, channel, provider) to retained transcripts so similarity search can distinguish memories by speaker even when dynamicBankGranularity does not include 'user'. Set false to omit.",
+        "default": true
+      },
       "retainEveryNTurns": {
         "type": "integer",
         "description": "Retain every Nth turn instead of every turn. 1 = every turn (default). Values > 1 enable chunked retention with a sliding window.",
@@ -404,6 +409,10 @@
     "retainToolCalls": {
       "label": "Retain Tool Calls",
       "placeholder": "true (default) — include tool_use / tool_result blocks in retained JSON"
+    },
+    "includeSenderContext": {
+      "label": "Include Sender Context",
+      "placeholder": "true (default) — prepend sender/channel/provider context to retained content"
     },
     "retainEveryNTurns": {
       "label": "Retain Every N Turns",

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -814,8 +814,7 @@ describe("prepareRetentionTranscript", () => {
     const parsed = JSON.parse(result!.transcript);
     expect(parsed[0]).toEqual({
       role: "system",
-      content:
-        "[context]\nsender: U7JAF258R\nchannel: C04L6E0H3SQ\nprovider: slack\n[/context]",
+      content: "[context]\nsender: U7JAF258R\nchannel: C04L6E0H3SQ\nprovider: slack\n[/context]",
     });
     expect(parsed[1]).toEqual({ role: "user", content: "What's MIN-123 status?" });
     expect(result?.messageCount).toBe(2);

--- a/hindsight-integrations/openclaw/src/setup.ts
+++ b/hindsight-integrations/openclaw/src/setup.ts
@@ -294,10 +294,7 @@ function assertNotCancelled<T>(value: T | symbol): asserts value is T {
 // of forcing the user to paste it again on every wizard rerun. Skipped when
 // the existing value is a SecretRef object (env-var reference) or absent —
 // SecretRefs aren't pasteable here so the regular prompt path handles them.
-async function promptInlineSecretWithReuse(
-  message: string,
-  existing: unknown
-): Promise<string> {
+async function promptInlineSecretWithReuse(message: string, existing: unknown): Promise<string> {
   if (typeof existing === "string" && existing.trim().length > 0) {
     const reuse = await p.confirm({
       message: `Reuse the existing token (ends in …${maskSecret(existing).slice(-8)})?`,
@@ -315,9 +312,10 @@ async function promptInlineSecretWithReuse(
 }
 
 async function promptCloud(pluginConfig: Record<string, unknown>): Promise<string> {
-  const existingUrl = typeof pluginConfig.hindsightApiUrl === "string"
-    ? (pluginConfig.hindsightApiUrl as string).trim()
-    : "";
+  const existingUrl =
+    typeof pluginConfig.hindsightApiUrl === "string"
+      ? (pluginConfig.hindsightApiUrl as string).trim()
+      : "";
   const currentUrl = existingUrl || HINDSIGHT_CLOUD_URL;
   const useCurrentUrl = await p.confirm({
     message:
@@ -352,9 +350,10 @@ async function promptCloud(pluginConfig: Record<string, unknown>): Promise<strin
 }
 
 async function promptApi(pluginConfig: Record<string, unknown>): Promise<string> {
-  const existingUrl = typeof pluginConfig.hindsightApiUrl === "string"
-    ? (pluginConfig.hindsightApiUrl as string).trim()
-    : "";
+  const existingUrl =
+    typeof pluginConfig.hindsightApiUrl === "string"
+      ? (pluginConfig.hindsightApiUrl as string).trim()
+      : "";
   const apiUrl = await p.text({
     message: "Hindsight API URL",
     placeholder: "https://mcp.hindsight.example.com",
@@ -363,8 +362,9 @@ async function promptApi(pluginConfig: Record<string, unknown>): Promise<string>
   });
   assertNotCancelled(apiUrl);
 
-  const hasExistingToken = typeof pluginConfig.hindsightApiToken === "string"
-    && (pluginConfig.hindsightApiToken as string).trim().length > 0;
+  const hasExistingToken =
+    typeof pluginConfig.hindsightApiToken === "string" &&
+    (pluginConfig.hindsightApiToken as string).trim().length > 0;
   const needsToken = await p.confirm({
     message: "Does this API require an auth token?",
     initialValue: hasExistingToken,


### PR DESCRIPTION
## Summary

- Fix line-too-long formatting in `llm_wrapper.py` that was causing `verify-generated-files` CI to fail (the z.ai provider PR added a long tuple line that the linter reformats)

## Test plan

- [ ] `verify-generated-files` CI job passes