### PR TITLE
fix(typescript-client): derive CLIENT_VERSION from package.json

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -27,6 +27,7 @@
 
 import { createClient, createConfig } from "../generated/client";
 import type { Client } from "../generated/client";
+import pkg from "../package.json";
 import * as sdk from "../generated/sdk.gen";
 import type {
   RetainRequest,
@@ -53,7 +54,7 @@ import type {
   TagGroupNotInput,
 } from "../generated/types.gen";
 
-export const CLIENT_VERSION = "0.5.1";
+export const CLIENT_VERSION: string = pkg.version;
 export const DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;
 
 export interface HindsightClientOptions {


### PR DESCRIPTION
## What

`hindsight-clients/typescript/src/index.ts` exports a `CLIENT_VERSION` constant that's been hardcoded as `"0.5.1"` since 0.5.1 was released, even though the npm package itself has shipped 0.5.6, 0.5.7, and 0.6.0 since. This PR derives the constant from `package.json` at build time so it can't drift again.

## Why this is a bug

```ts
// hindsight-clients/typescript/src/index.ts (current main)
export const CLIENT_VERSION = "0.5.1";
export const DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;
```

```bash
$ npm install @vectorize-io/hindsight-client@0.6.0
$ node -e 'import("@vectorize-io/hindsight-client").then(m => console.log({version: m.CLIENT_VERSION, ua: m.DEFAULT_USER_AGENT}))'
{ version: '0.5.1', ua: 'hindsight-client-typescript/0.5.1' }

$ node -e 'console.log(require("@vectorize-io/hindsight-client/package.json").version)'
0.6.0
```

Concrete consequences today:
- **Server-side telemetry mis-attribution.** Every 0.6.0 client request shows up in API logs / dashboards as if it came from a 0.5.1 client.
- **No reliable client-side feature gating.** Consumers can't check the constant to enable behavior that depends on a specific client version (e.g. methods added in 0.6.0 like `AbortSignal` support).

The constant has lagged across at least three releases, so this looks like a missed step in the release process rather than a one-off — fixing it at the source is more durable than a one-time bump.

## How

```ts
import pkg from "../package.json";

export const CLIENT_VERSION: string = pkg.version;
export const DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;
```

`tsconfig.json` already sets `resolveJsonModule: true`, and `tsup.config.ts` has `bundle: true`, so the JSON is inlined into the dist outputs at build time — no runtime `require` of `package.json`, no extra runtime overhead.

## Verified locally

```text
$ npm run build
CJS dist/index.js     55.99 KB
ESM dist/index.mjs    54.87 KB
DTS dist/index.d.ts  170.86 KB
✓ Build success

$ grep CLIENT_VERSION dist/index.js
var CLIENT_VERSION = package_default.version;   # references inlined { version: "0.6.0", ... }
var DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;

$ npx jest tests/prompt_formatting.test.ts
PASS  tests/prompt_formatting.test.ts (9/9)
```

`tests/main_operations.test.ts` was not exercised locally — it requires a running Hindsight API server.

## One small caveat

This widens the public TS type of `CLIENT_VERSION` from the literal `"0.5.1"` to `string`. Strictly a type-only change — runtime semantics are unaffected — and the constant is intended as a runtime utility (User-Agent strings, telemetry), so consumers shouldn't depend on the literal type. Happy to add a `as const`-style narrowing if you'd prefer to preserve the literal type at the cost of needing to annotate it manually each release, but I'd argue against it.