### PR TITLE
perf(locomo): scope CI to a 3-conversation curated subset

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -25,10 +25,10 @@ on:
           - recall-with-observations
           - consolidation
         default: ""
-      locomo_max_conversations:
-        description: "LoComo max conversations (0 = skip, blank = all)"
-        type: number
-        default: 0
+      locomo_conversations:
+        description: "LoComo conversation IDs (space-separated). Blank = curated set (conv-26 conv-30 conv-43)."
+        type: string
+        default: ""
       locomo_skip:
         description: "Skip LoComo job"
         type: boolean
@@ -169,14 +169,20 @@ jobs:
         cd hindsight-dev && uv sync --frozen --all-extras --index-strategy unsafe-best-match
 
     - name: Run LoComo benchmark
+      # Curated 3-conversation subset (best/middle/worst by accuracy on the
+      # last successful full run): conv-26 (best), conv-30 (middle), conv-43
+      # (worst). Excludes conv-44, the bank with the largest unconsolidated
+      # set that has been pushing scheduled runs over the per-bank
+      # _wait_for_consolidation timeout. Override via workflow_dispatch with
+      # the locomo_conversations input.
       run: |
-        MAX_CONV_ARG=""
-        if [ "${{ inputs.locomo_max_conversations }}" != "0" ] && [ -n "${{ inputs.locomo_max_conversations }}" ]; then
-          MAX_CONV_ARG="--max-conversations ${{ inputs.locomo_max_conversations }}"
+        CONVERSATIONS="${{ inputs.locomo_conversations }}"
+        if [ -z "$CONVERSATIONS" ]; then
+          CONVERSATIONS="conv-26 conv-30 conv-43"
         fi
         uv run python hindsight-dev/benchmarks/locomo/locomo_benchmark.py \
           --wait-consolidation \
-          $MAX_CONV_ARG
+          --conversation $CONVERSATIONS
 
     - name: Upload LoComo results
       if: always()

--- a/hindsight-dev/benchmarks/common/benchmark_runner.py
+++ b/hindsight-dev/benchmarks/common/benchmark_runner.py
@@ -24,7 +24,7 @@ import os
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import pydantic
 from hindsight_api import MemoryEngine
@@ -983,7 +983,7 @@ class BenchmarkRunner:
         max_concurrent_questions: int = 1,  # Default to 1 for sequential processing
         eval_semaphore_size: int = 8,
         clear_agent_per_item: bool = False,
-        specific_item: Optional[str] = None,
+        specific_item: Optional[Union[str, Iterable[str]]] = None,
         separate_ingestion_phase: bool = False,
         filln: bool = False,
         max_concurrent_items: int = 1,  # Max concurrent items (conversations) to process in parallel
@@ -1024,13 +1024,14 @@ class BenchmarkRunner:
         console.print(f"\n[1] Loading dataset from {dataset_path}...")
         items = self.dataset.load(dataset_path, max_items)
 
-        # Filter for specific item if requested
+        # Filter for specific item(s) if requested
         if specific_item is not None:
-            items = [item for item in items if self.dataset.get_item_id(item) == specific_item]
+            target_ids = {specific_item} if isinstance(specific_item, str) else set(specific_item)
+            items = [item for item in items if self.dataset.get_item_id(item) in target_ids]
             if not items:
-                console.print(f"    [red]✗[/red] No item found with ID: {specific_item}")
-                raise ValueError(f"Item with ID '{specific_item}' not found in dataset")
-            console.print(f"    [green]✓[/green] Filtering to specific item: {specific_item}")
+                console.print(f"    [red]✗[/red] No item found with ID(s): {sorted(target_ids)}")
+                raise ValueError(f"No items matching ID(s) {sorted(target_ids)} found in dataset")
+            console.print(f"    [green]✓[/green] Filtering to {len(items)} item(s): {sorted(target_ids)}")
 
         console.print(f"    [green]✓[/green] Loaded {len(items)} items")
 

--- a/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
+++ b/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
@@ -299,7 +299,7 @@ async def run_benchmark(
     max_questions_per_conv: int = None,
     skip_ingestion: bool = False,
     use_reflect: bool = False,
-    conversation: str = None,
+    conversation: list[str] | None = None,
     api_url: str = None,
     max_concurrent_questions_override: int = None,
     only_failed: bool = False,
@@ -316,7 +316,7 @@ async def run_benchmark(
         max_questions_per_conv: Maximum questions per conversation (None for all)
         skip_ingestion: Whether to skip ingestion and use existing data
         use_reflect: Whether to use the reflect API instead of search + LLM
-        conversation: Specific conversation ID to run (e.g., "conv-26")
+        conversation: One or more conversation IDs to run (e.g., ["conv-26", "conv-30"])
         api_url: Optional API URL to connect to (default: use local memory)
         only_failed: If True, only run conversations that have failed questions (is_correct=False)
         only_invalid: If True, only run conversations that have invalid questions (is_invalid=True)
@@ -575,7 +575,11 @@ if __name__ == "__main__":
     parser.add_argument("--skip-ingestion", action="store_true", help="Skip ingestion and use existing data")
     parser.add_argument("--use-reflect", action="store_true", help="Use reflect API instead of search + LLM")
     parser.add_argument(
-        "--conversation", type=str, default=None, help='Run only specific conversation (e.g., "conv-26")'
+        "--conversation",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Run only the listed conversations (e.g., --conversation conv-26 conv-30)",
     )
     parser.add_argument(
         "--api-url",


### PR DESCRIPTION
## Summary

- Locomo CI has been failing on most scheduled runs with `TimeoutError: Consolidation did not complete within 3000.0s`. `locomo_conv-44` (largest bank, ~463 unconsolidated items at peak) regularly grazes the hardcoded 50-min `_wait_for_consolidation` budget under CI load, and the dashboard-publish step is gated on `success()` — so every failure drops the entire run from the dashboard. As a result, **no LoComo metrics have been published** since the dashboard launched.
- Rather than bump the timeout, scope the scheduled run to three conversations that bracket the accuracy spread on the last clean full run (May 5):
  - `conv-26` — best (90.79%)
  - `conv-30` — middle (86.42%)
  - `conv-43` — worst (82.02%)
- Deliberately omits `conv-44` — it sits at median accuracy but carries the largest unconsolidated set in the dataset and is the bank that's been pushing scheduled runs over the per-bank timeout.

## What changed

- `--conversation` is now `nargs="+"` and accepts a list of IDs (single-ID form still works).
- `BenchmarkRunner.run`'s `specific_item` widens to `str | Iterable[str]`; longmemeval's single-string usage is unaffected.
- Workflow input `locomo_max_conversations` is replaced with `locomo_conversations` (space-separated string), defaulting to the curated set.

## Test plan

- [x] `./scripts/hooks/lint.sh` clean
- [x] `uv run python benchmarks/locomo/locomo_benchmark.py --help` shows `--conversation CONVERSATION [CONVERSATION ...]`
- [ ] Next scheduled `Performance Tests` run publishes LoComo to the dashboard at https://vectorize-io.github.io/hindsight-continuous-performance-monitor/
- [ ] Verify `locomo_conversations` workflow_dispatch input lets you override the curated set