### PR TITLE
feat(api): add litellmrouter provider for LLM fallback chains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1191,18 +1191,18 @@ jobs:
         CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
         "
 
-    - name: Build litellmrouter chain
+    - name: Build litellmrouter config
       if: matrix.provider == 'litellmrouter'
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ROUTER_MODEL: ${{ matrix.model }}
       run: |
-        chain=$(jq -nc \
-          --arg model "$ROUTER_MODEL" \
+        cfg=$(jq -nc \
+          --arg model "openai/$ROUTER_MODEL" \
           --arg key "$OPENAI_API_KEY" \
-          '[{provider:"openai", model:$model, api_key:$key}]')
-        echo "::add-mask::$chain"
-        echo "HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN=$chain" >> "$GITHUB_ENV"
+          '{model_list: [{model_name: "default", litellm_params: {model: $model, api_key: $key}}]}')
+        echo "::add-mask::$cfg"
+        echo "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG=$cfg" >> "$GITHUB_ENV"
 
     - name: Run LLM acceptance tests
       working-directory: ./hindsight-api-slim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1203,12 +1203,6 @@ jobs:
           '{model_list: [{model_name: "default", litellm_params: {model: $model, api_key: $key}}]}')
         echo "::add-mask::$cfg"
         echo "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG=$cfg" >> "$GITHUB_ENV"
-        # gpt-4.1-nano caps completion at 32768. The openai matrix row passes because
-        # OpenAICompatibleLLM has model-specific token capping; LiteLLMLLM (and Router
-        # by inheritance) don't. Lower the retain default to fit under that cap so
-        # CI exercises the Router-backed path end-to-end instead of dying on a
-        # provider-side BadRequestError unrelated to this PR.
-        echo "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=32000" >> "$GITHUB_ENV"
 
     - name: Run LLM acceptance tests
       working-directory: ./hindsight-api-slim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1203,6 +1203,12 @@ jobs:
           '{model_list: [{model_name: "default", litellm_params: {model: $model, api_key: $key}}]}')
         echo "::add-mask::$cfg"
         echo "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG=$cfg" >> "$GITHUB_ENV"
+        # gpt-4.1-nano caps completion at 32768. The openai matrix row passes because
+        # OpenAICompatibleLLM has model-specific token capping; LiteLLMLLM (and Router
+        # by inheritance) don't. Lower the retain default to fit under that cap so
+        # CI exercises the Router-backed path end-to-end instead of dying on a
+        # provider-side BadRequestError unrelated to this PR.
+        echo "HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=32000" >> "$GITHUB_ENV"
 
     - name: Run LLM acceptance tests
       working-directory: ./hindsight-api-slim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1130,6 +1130,10 @@ jobs:
             api_key_secret: GROQ_API_KEY
           - provider: bedrock
             model: us.amazon.nova-2-lite-v1:0
+          - provider: litellmrouter
+            model: gpt-4.1-nano
+            # Single-deployment chain over OpenAI — verifies the Router-backed
+            # call path works end-to-end. Built from secrets in the step below.
     name: LLM acceptance (${{ matrix.provider }}/${{ matrix.model }})
     env:
       HINDSIGHT_API_LLM_PROVIDER: ${{ matrix.provider }}
@@ -1186,6 +1190,19 @@ jobs:
         SentenceTransformer('BAAI/bge-small-en-v1.5')
         CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
         "
+
+    - name: Build litellmrouter chain
+      if: matrix.provider == 'litellmrouter'
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ROUTER_MODEL: ${{ matrix.model }}
+      run: |
+        chain=$(jq -nc \
+          --arg model "$ROUTER_MODEL" \
+          --arg key "$OPENAI_API_KEY" \
+          '[{provider:"openai", model:$model, api_key:$key}]')
+        echo "::add-mask::$chain"
+        echo "HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN=$chain" >> "$GITHUB_ENV"
 
     - name: Run LLM acceptance tests
       working-directory: ./hindsight-api-slim

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -141,6 +141,14 @@ ENV_LLM_OPENAI_SERVICE_TIER = "HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER"
 ENV_LLM_EXTRA_BODY = "HINDSIGHT_API_LLM_EXTRA_BODY"
 ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 
+# LiteLLM Router chain — provider-specific config consumed by the "litellmrouter"
+# provider. Each entry is a deployment; the Router tries them in declared order and
+# falls back to the next on transient errors (5xx, rate-limit, timeout).
+# Provider-scoped naming mirrors other provider-specific flags (e.g. llm_groq_*,
+# llm_vertexai_*). Note the single token "LITELLMROUTER" — keeping it one word
+# disambiguates from the embeddings/reranker LITELLM_* settings.
+ENV_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN"
+
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
@@ -159,6 +167,7 @@ ENV_RETAIN_LLM_MAX_RETRIES = "HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES"
 ENV_RETAIN_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF"
 ENV_RETAIN_LLM_MAX_BACKOFF = "HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF"
 ENV_RETAIN_LLM_TIMEOUT = "HINDSIGHT_API_RETAIN_LLM_TIMEOUT"
+ENV_RETAIN_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN"
 
 ENV_REFLECT_LLM_PROVIDER = "HINDSIGHT_API_REFLECT_LLM_PROVIDER"
 ENV_REFLECT_LLM_API_KEY = "HINDSIGHT_API_REFLECT_LLM_API_KEY"
@@ -169,6 +178,7 @@ ENV_REFLECT_LLM_MAX_RETRIES = "HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES"
 ENV_REFLECT_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_REFLECT_LLM_INITIAL_BACKOFF"
 ENV_REFLECT_LLM_MAX_BACKOFF = "HINDSIGHT_API_REFLECT_LLM_MAX_BACKOFF"
 ENV_REFLECT_LLM_TIMEOUT = "HINDSIGHT_API_REFLECT_LLM_TIMEOUT"
+ENV_REFLECT_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN"
 
 ENV_CONSOLIDATION_LLM_PROVIDER = "HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER"
 ENV_CONSOLIDATION_LLM_API_KEY = "HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY"
@@ -179,6 +189,7 @@ ENV_CONSOLIDATION_LLM_MAX_RETRIES = "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES
 ENV_CONSOLIDATION_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF"
 ENV_CONSOLIDATION_LLM_MAX_BACKOFF = "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF"
 ENV_CONSOLIDATION_LLM_TIMEOUT = "HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT"
+ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN"
 
 ENV_EMBEDDINGS_PROVIDER = "HINDSIGHT_API_EMBEDDINGS_PROVIDER"
 ENV_EMBEDDINGS_LOCAL_MODEL = "HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"
@@ -809,6 +820,36 @@ def _get_default_model_for_provider(provider: str) -> str:
     return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
 
 
+_LLM_CHAIN_ENTRY_KEYS = {"provider", "model", "api_key", "base_url"}
+
+
+def _parse_llm_router_chain(env_var: str) -> list[dict] | None:
+    """
+    Parse a LiteLLM Router chain from a JSON list env var.
+
+    Each entry must contain ``provider`` and ``model``; ``api_key`` and ``base_url``
+    are optional. Returns None when the env var is unset or empty.
+    """
+    raw = os.getenv(env_var, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid {env_var}: expected a JSON list, got invalid JSON: {e}") from e
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError(f"Invalid {env_var}: expected a non-empty JSON list of deployment objects")
+    for i, entry in enumerate(parsed):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Invalid {env_var}[{i}]: expected an object, got {type(entry).__name__}")
+        if not entry.get("provider") or not entry.get("model"):
+            raise ValueError(f"Invalid {env_var}[{i}]: 'provider' and 'model' are required")
+        unknown = set(entry.keys()) - _LLM_CHAIN_ENTRY_KEYS
+        if unknown:
+            raise ValueError(f"Invalid {env_var}[{i}]: unknown keys {sorted(unknown)}")
+    return parsed
+
+
 def _parse_default_bank_template(raw: str | None) -> dict | None:
     """
     Parse HINDSIGHT_API_DEFAULT_BANK_TEMPLATE as JSON.
@@ -865,6 +906,12 @@ class HindsightConfig:
         dict | None
     )  # Custom headers passed as default_headers to provider SDK clients (e.g. {"X-Component-Id": "hindsight"} for proxies / request tracing)
 
+    # LiteLLM Router chain (provider-specific; consumed by the "litellmrouter" provider).
+    # List of deployment dicts evaluated in order with fallback on transient errors.
+    # Each entry: {"provider": str, "model": str, "api_key": str | None, "base_url": str | None}.
+    # Treated as a credential field because entries embed api keys.
+    llm_litellmrouter_chain: list[dict] | None
+
     # Vertex AI configuration
     llm_vertexai_project_id: str | None
     llm_vertexai_region: str
@@ -891,6 +938,7 @@ class HindsightConfig:
     retain_llm_initial_backoff: float | None
     retain_llm_max_backoff: float | None
     retain_llm_timeout: float | None
+    retain_llm_litellmrouter_chain: list[dict] | None
 
     reflect_llm_provider: str | None
     reflect_llm_api_key: str | None
@@ -901,6 +949,7 @@ class HindsightConfig:
     reflect_llm_initial_backoff: float | None
     reflect_llm_max_backoff: float | None
     reflect_llm_timeout: float | None
+    reflect_llm_litellmrouter_chain: list[dict] | None
 
     consolidation_llm_provider: str | None
     consolidation_llm_api_key: str | None
@@ -911,6 +960,7 @@ class HindsightConfig:
     consolidation_llm_initial_backoff: float | None
     consolidation_llm_max_backoff: float | None
     consolidation_llm_timeout: float | None
+    consolidation_llm_litellmrouter_chain: list[dict] | None
 
     # Embeddings
     embeddings_provider: str
@@ -1150,6 +1200,11 @@ class HindsightConfig:
         "retain_llm_api_key",
         "reflect_llm_api_key",
         "consolidation_llm_api_key",
+        # LiteLLM Router chains — entries embed api_keys and base_urls
+        "llm_litellmrouter_chain",
+        "retain_llm_litellmrouter_chain",
+        "reflect_llm_litellmrouter_chain",
+        "consolidation_llm_litellmrouter_chain",
         # Base URLs (could expose infrastructure)
         "llm_base_url",
         "retain_llm_base_url",
@@ -1386,6 +1441,7 @@ class HindsightConfig:
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
             llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
+            llm_litellmrouter_chain=_parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),
@@ -1424,6 +1480,7 @@ class HindsightConfig:
             if os.getenv(ENV_RETAIN_LLM_MAX_BACKOFF)
             else None,
             retain_llm_timeout=float(os.getenv(ENV_RETAIN_LLM_TIMEOUT)) if os.getenv(ENV_RETAIN_LLM_TIMEOUT) else None,
+            retain_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_RETAIN_LLM_LITELLMROUTER_CHAIN),
             reflect_llm_provider=os.getenv(ENV_REFLECT_LLM_PROVIDER) or None,
             reflect_llm_api_key=os.getenv(ENV_REFLECT_LLM_API_KEY) or None,
             reflect_llm_model=os.getenv(ENV_REFLECT_LLM_MODEL)
@@ -1448,6 +1505,7 @@ class HindsightConfig:
             reflect_llm_timeout=float(os.getenv(ENV_REFLECT_LLM_TIMEOUT))
             if os.getenv(ENV_REFLECT_LLM_TIMEOUT)
             else None,
+            reflect_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_REFLECT_LLM_LITELLMROUTER_CHAIN),
             consolidation_llm_provider=os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER) or None,
             consolidation_llm_api_key=os.getenv(ENV_CONSOLIDATION_LLM_API_KEY) or None,
             consolidation_llm_model=os.getenv(ENV_CONSOLIDATION_LLM_MODEL)
@@ -1472,6 +1530,7 @@ class HindsightConfig:
             consolidation_llm_timeout=float(os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT))
             if os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT)
             else None,
+            consolidation_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN),
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
             embeddings_local_model=os.getenv(ENV_EMBEDDINGS_LOCAL_MODEL, DEFAULT_EMBEDDINGS_LOCAL_MODEL),

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -822,34 +822,20 @@ def _get_default_model_for_provider(provider: str) -> str:
 
 def _parse_llm_router_config(env_var: str) -> dict | None:
     """
-    Parse a LiteLLM Router configuration from a JSON object env var.
+    Parse a LiteLLM Router configuration from a JSON env var.
 
-    The value is a JSON object passed verbatim to ``litellm.Router(**config)``.
-    The only Hindsight-imposed shape rule is that ``model_list`` is present
-    and non-empty and that each entry has a ``model_name``. Everything else —
-    ``fallbacks``, ``num_retries``, ``cooldown_time``, ``routing_strategy``,
-    per-deployment ``rpm``/``tpm``/``weight`` etc. — is forwarded as-is.
-
-    See https://docs.litellm.ai/docs/routing for the supported keys.
+    The value is forwarded verbatim to ``litellm.Router(**config)``. We only
+    check that it parses as JSON; LiteLLM Router is authoritative about the
+    shape (``model_list``, ``fallbacks``, ``routing_strategy``, …). See
+    https://docs.litellm.ai/docs/routing.
     """
     raw = os.getenv(env_var, "").strip()
     if not raw:
         return None
     try:
-        parsed = json.loads(raw)
+        return json.loads(raw)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid {env_var}: expected a JSON object, got invalid JSON: {e}") from e
-    if not isinstance(parsed, dict):
-        raise ValueError(f"Invalid {env_var}: expected a JSON object, got {type(parsed).__name__}")
-    model_list = parsed.get("model_list")
-    if not isinstance(model_list, list) or not model_list:
-        raise ValueError(f"Invalid {env_var}: 'model_list' must be a non-empty list")
-    for i, entry in enumerate(model_list):
-        if not isinstance(entry, dict):
-            raise ValueError(f"Invalid {env_var}.model_list[{i}]: expected an object, got {type(entry).__name__}")
-        if not entry.get("model_name"):
-            raise ValueError(f"Invalid {env_var}.model_list[{i}]: 'model_name' is required")
-    return parsed
+        raise ValueError(f"Invalid {env_var}: invalid JSON: {e}") from e
 
 
 def _parse_default_bank_template(raw: str | None) -> dict | None:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -820,15 +820,14 @@ def _get_default_model_for_provider(provider: str) -> str:
     return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
 
 
-_LLM_CHAIN_ENTRY_KEYS = {"provider", "model", "api_key", "base_url"}
-
-
 def _parse_llm_router_chain(env_var: str) -> list[dict] | None:
     """
     Parse a LiteLLM Router chain from a JSON list env var.
 
-    Each entry must contain ``provider`` and ``model``; ``api_key`` and ``base_url``
-    are optional. Returns None when the env var is unset or empty.
+    Each entry must contain ``provider`` and ``model``; everything else is
+    forwarded to LiteLLM unchanged (``api_key``, ``base_url``, plus any
+    Router/SDK knobs like ``rpm``, ``tpm``, ``weight``, ``model_info``, or a
+    nested ``litellm_params`` dict). Returns None when the env var is unset.
     """
     raw = os.getenv(env_var, "").strip()
     if not raw:
@@ -844,9 +843,6 @@ def _parse_llm_router_chain(env_var: str) -> list[dict] | None:
             raise ValueError(f"Invalid {env_var}[{i}]: expected an object, got {type(entry).__name__}")
         if not entry.get("provider") or not entry.get("model"):
             raise ValueError(f"Invalid {env_var}[{i}]: 'provider' and 'model' are required")
-        unknown = set(entry.keys()) - _LLM_CHAIN_ENTRY_KEYS
-        if unknown:
-            raise ValueError(f"Invalid {env_var}[{i}]: unknown keys {sorted(unknown)}")
     return parsed
 
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -147,7 +147,7 @@ ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 # Provider-scoped naming mirrors other provider-specific flags (e.g. llm_groq_*,
 # llm_vertexai_*). Note the single token "LITELLMROUTER" — keeping it one word
 # disambiguates from the embeddings/reranker LITELLM_* settings.
-ENV_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN"
+ENV_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG"
 
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
@@ -167,7 +167,7 @@ ENV_RETAIN_LLM_MAX_RETRIES = "HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES"
 ENV_RETAIN_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF"
 ENV_RETAIN_LLM_MAX_BACKOFF = "HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF"
 ENV_RETAIN_LLM_TIMEOUT = "HINDSIGHT_API_RETAIN_LLM_TIMEOUT"
-ENV_RETAIN_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN"
+ENV_RETAIN_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG"
 
 ENV_REFLECT_LLM_PROVIDER = "HINDSIGHT_API_REFLECT_LLM_PROVIDER"
 ENV_REFLECT_LLM_API_KEY = "HINDSIGHT_API_REFLECT_LLM_API_KEY"
@@ -178,7 +178,7 @@ ENV_REFLECT_LLM_MAX_RETRIES = "HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES"
 ENV_REFLECT_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_REFLECT_LLM_INITIAL_BACKOFF"
 ENV_REFLECT_LLM_MAX_BACKOFF = "HINDSIGHT_API_REFLECT_LLM_MAX_BACKOFF"
 ENV_REFLECT_LLM_TIMEOUT = "HINDSIGHT_API_REFLECT_LLM_TIMEOUT"
-ENV_REFLECT_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN"
+ENV_REFLECT_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CONFIG"
 
 ENV_CONSOLIDATION_LLM_PROVIDER = "HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER"
 ENV_CONSOLIDATION_LLM_API_KEY = "HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY"
@@ -189,7 +189,7 @@ ENV_CONSOLIDATION_LLM_MAX_RETRIES = "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES
 ENV_CONSOLIDATION_LLM_INITIAL_BACKOFF = "HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF"
 ENV_CONSOLIDATION_LLM_MAX_BACKOFF = "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF"
 ENV_CONSOLIDATION_LLM_TIMEOUT = "HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT"
-ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN = "HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN"
+ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG"
 
 ENV_EMBEDDINGS_PROVIDER = "HINDSIGHT_API_EMBEDDINGS_PROVIDER"
 ENV_EMBEDDINGS_LOCAL_MODEL = "HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"
@@ -820,14 +820,17 @@ def _get_default_model_for_provider(provider: str) -> str:
     return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
 
 
-def _parse_llm_router_chain(env_var: str) -> list[dict] | None:
+def _parse_llm_router_config(env_var: str) -> dict | None:
     """
-    Parse a LiteLLM Router chain from a JSON list env var.
+    Parse a LiteLLM Router configuration from a JSON object env var.
 
-    Each entry must contain ``provider`` and ``model``; everything else is
-    forwarded to LiteLLM unchanged (``api_key``, ``base_url``, plus any
-    Router/SDK knobs like ``rpm``, ``tpm``, ``weight``, ``model_info``, or a
-    nested ``litellm_params`` dict). Returns None when the env var is unset.
+    The value is a JSON object passed verbatim to ``litellm.Router(**config)``.
+    The only Hindsight-imposed shape rule is that ``model_list`` is present
+    and non-empty and that each entry has a ``model_name``. Everything else —
+    ``fallbacks``, ``num_retries``, ``cooldown_time``, ``routing_strategy``,
+    per-deployment ``rpm``/``tpm``/``weight`` etc. — is forwarded as-is.
+
+    See https://docs.litellm.ai/docs/routing for the supported keys.
     """
     raw = os.getenv(env_var, "").strip()
     if not raw:
@@ -835,14 +838,17 @@ def _parse_llm_router_chain(env_var: str) -> list[dict] | None:
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid {env_var}: expected a JSON list, got invalid JSON: {e}") from e
-    if not isinstance(parsed, list) or not parsed:
-        raise ValueError(f"Invalid {env_var}: expected a non-empty JSON list of deployment objects")
-    for i, entry in enumerate(parsed):
+        raise ValueError(f"Invalid {env_var}: expected a JSON object, got invalid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Invalid {env_var}: expected a JSON object, got {type(parsed).__name__}")
+    model_list = parsed.get("model_list")
+    if not isinstance(model_list, list) or not model_list:
+        raise ValueError(f"Invalid {env_var}: 'model_list' must be a non-empty list")
+    for i, entry in enumerate(model_list):
         if not isinstance(entry, dict):
-            raise ValueError(f"Invalid {env_var}[{i}]: expected an object, got {type(entry).__name__}")
-        if not entry.get("provider") or not entry.get("model"):
-            raise ValueError(f"Invalid {env_var}[{i}]: 'provider' and 'model' are required")
+            raise ValueError(f"Invalid {env_var}.model_list[{i}]: expected an object, got {type(entry).__name__}")
+        if not entry.get("model_name"):
+            raise ValueError(f"Invalid {env_var}.model_list[{i}]: 'model_name' is required")
     return parsed
 
 
@@ -906,7 +912,7 @@ class HindsightConfig:
     # List of deployment dicts evaluated in order with fallback on transient errors.
     # Each entry: {"provider": str, "model": str, "api_key": str | None, "base_url": str | None}.
     # Treated as a credential field because entries embed api keys.
-    llm_litellmrouter_chain: list[dict] | None
+    llm_litellmrouter_config: dict | None
 
     # Vertex AI configuration
     llm_vertexai_project_id: str | None
@@ -934,7 +940,7 @@ class HindsightConfig:
     retain_llm_initial_backoff: float | None
     retain_llm_max_backoff: float | None
     retain_llm_timeout: float | None
-    retain_llm_litellmrouter_chain: list[dict] | None
+    retain_llm_litellmrouter_config: dict | None
 
     reflect_llm_provider: str | None
     reflect_llm_api_key: str | None
@@ -945,7 +951,7 @@ class HindsightConfig:
     reflect_llm_initial_backoff: float | None
     reflect_llm_max_backoff: float | None
     reflect_llm_timeout: float | None
-    reflect_llm_litellmrouter_chain: list[dict] | None
+    reflect_llm_litellmrouter_config: dict | None
 
     consolidation_llm_provider: str | None
     consolidation_llm_api_key: str | None
@@ -956,7 +962,7 @@ class HindsightConfig:
     consolidation_llm_initial_backoff: float | None
     consolidation_llm_max_backoff: float | None
     consolidation_llm_timeout: float | None
-    consolidation_llm_litellmrouter_chain: list[dict] | None
+    consolidation_llm_litellmrouter_config: dict | None
 
     # Embeddings
     embeddings_provider: str
@@ -1197,10 +1203,10 @@ class HindsightConfig:
         "reflect_llm_api_key",
         "consolidation_llm_api_key",
         # LiteLLM Router chains — entries embed api_keys and base_urls
-        "llm_litellmrouter_chain",
-        "retain_llm_litellmrouter_chain",
-        "reflect_llm_litellmrouter_chain",
-        "consolidation_llm_litellmrouter_chain",
+        "llm_litellmrouter_config",
+        "retain_llm_litellmrouter_config",
+        "reflect_llm_litellmrouter_config",
+        "consolidation_llm_litellmrouter_config",
         # Base URLs (could expose infrastructure)
         "llm_base_url",
         "retain_llm_base_url",
@@ -1437,7 +1443,7 @@ class HindsightConfig:
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
             llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
-            llm_litellmrouter_chain=_parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN),
+            llm_litellmrouter_config=_parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG),
             # Vertex AI
             llm_vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or DEFAULT_LLM_VERTEXAI_PROJECT_ID,
             llm_vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION, DEFAULT_LLM_VERTEXAI_REGION),
@@ -1476,7 +1482,7 @@ class HindsightConfig:
             if os.getenv(ENV_RETAIN_LLM_MAX_BACKOFF)
             else None,
             retain_llm_timeout=float(os.getenv(ENV_RETAIN_LLM_TIMEOUT)) if os.getenv(ENV_RETAIN_LLM_TIMEOUT) else None,
-            retain_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_RETAIN_LLM_LITELLMROUTER_CHAIN),
+            retain_llm_litellmrouter_config=_parse_llm_router_config(ENV_RETAIN_LLM_LITELLMROUTER_CONFIG),
             reflect_llm_provider=os.getenv(ENV_REFLECT_LLM_PROVIDER) or None,
             reflect_llm_api_key=os.getenv(ENV_REFLECT_LLM_API_KEY) or None,
             reflect_llm_model=os.getenv(ENV_REFLECT_LLM_MODEL)
@@ -1501,7 +1507,7 @@ class HindsightConfig:
             reflect_llm_timeout=float(os.getenv(ENV_REFLECT_LLM_TIMEOUT))
             if os.getenv(ENV_REFLECT_LLM_TIMEOUT)
             else None,
-            reflect_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_REFLECT_LLM_LITELLMROUTER_CHAIN),
+            reflect_llm_litellmrouter_config=_parse_llm_router_config(ENV_REFLECT_LLM_LITELLMROUTER_CONFIG),
             consolidation_llm_provider=os.getenv(ENV_CONSOLIDATION_LLM_PROVIDER) or None,
             consolidation_llm_api_key=os.getenv(ENV_CONSOLIDATION_LLM_API_KEY) or None,
             consolidation_llm_model=os.getenv(ENV_CONSOLIDATION_LLM_MODEL)
@@ -1526,7 +1532,7 @@ class HindsightConfig:
             consolidation_llm_timeout=float(os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT))
             if os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT)
             else None,
-            consolidation_llm_litellmrouter_chain=_parse_llm_router_chain(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN),
+            consolidation_llm_litellmrouter_config=_parse_llm_router_config(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG),
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
             embeddings_local_model=os.getenv(ENV_EMBEDDINGS_LOCAL_MODEL, DEFAULT_EMBEDDINGS_LOCAL_MODEL),

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -129,6 +129,7 @@ _PROVIDERS_WITHOUT_API_KEY = frozenset(
         "none",
         "vertexai",
         "litellm",
+        "litellmrouter",
         "bedrock",
     }
 )
@@ -153,6 +154,7 @@ def create_llm_provider(
     vertexai_region: str | None = None,
     vertexai_credentials: Any = None,
     gemini_safety_settings: list | None = None,
+    chain: list[dict[str, Any]] | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -183,6 +185,7 @@ def create_llm_provider(
         CodexLLM,
         GeminiLLM,
         LiteLLMLLM,
+        LiteLLMRouterLLM,
         LlamaCppLLM,
         MockLLM,
         NoneLLM,
@@ -256,6 +259,22 @@ def create_llm_provider(
             api_key=api_key,
             base_url=base_url,
             model=model,
+            reasoning_effort=reasoning_effort,
+        )
+
+    elif provider_lower == "litellmrouter":
+        if not chain:
+            raise ValueError(
+                "Provider 'litellmrouter' requires a non-empty chain. "
+                "Set HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN (or the per-op variant) "
+                "to a JSON list of deployment objects."
+            )
+        return LiteLLMRouterLLM(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            chain=chain,
             reasoning_effort=reasoning_effort,
         )
 
@@ -333,6 +352,7 @@ class LLMProvider:
         gemini_safety_settings: list | None = None,
         extra_body: dict[str, Any] | None = None,
         default_headers: dict[str, str] | None = None,
+        litellmrouter_chain: list[dict[str, Any]] | None = None,
     ):
         """
         Initialize LLM provider.
@@ -351,12 +371,17 @@ class LLMProvider:
                 Used by operators routing through proxies / request-tracing middleware. Falls
                 back to ``HindsightConfig.llm_default_headers`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``)
                 when ``None``.
+            litellmrouter_chain: Provider-specific config for ``provider="litellmrouter"``.
+                List of deployment dicts evaluated in order with fallback on transient errors.
+                Ignored unless ``provider == "litellmrouter"``. When None and the provider is
+                ``litellmrouter``, falls back to ``HindsightConfig.llm_litellmrouter_chain``.
         """
         self.provider = provider.lower()
         self.api_key = api_key
         self.base_url = base_url
         self.model = model
         self.reasoning_effort = reasoning_effort
+        self.litellmrouter_chain = litellmrouter_chain
         # Service tiers from hierarchical config (not env vars)
         self.groq_service_tier = groq_service_tier
         self.openai_service_tier = openai_service_tier
@@ -393,6 +418,7 @@ class LLMProvider:
             "minimax",
             "deepseek",
             "litellm",
+            "litellmrouter",
             "bedrock",
             "volcano",
             "openrouter",
@@ -472,6 +498,19 @@ class LLMProvider:
             except Exception:
                 pass  # Config may not be initialized in test environments
 
+        # For litellmrouter: prefer an explicit chain from the caller (per-op
+        # construction in MemoryEngine threads the right chain through). If the caller
+        # didn't supply one, fall back to the global ``llm_litellmrouter_chain`` so
+        # ad-hoc constructions (e.g. ``LLMProvider.from_env()``) keep working.
+        chain: list[dict[str, Any]] | None = self.litellmrouter_chain
+        if self.provider == "litellmrouter" and chain is None:
+            from ..config import _get_raw_config
+
+            try:
+                chain = _get_raw_config().llm_litellmrouter_chain
+            except Exception:
+                chain = None
+
         # Create provider implementation using factory
         self._provider_impl = create_llm_provider(
             provider=self.provider,
@@ -487,6 +526,7 @@ class LLMProvider:
             vertexai_region=vertexai_region,
             vertexai_credentials=vertexai_credentials,
             gemini_safety_settings=self.gemini_safety_settings,
+            chain=chain,
         )
 
         # Backward compatibility: Keep mock provider properties

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -154,7 +154,7 @@ def create_llm_provider(
     vertexai_region: str | None = None,
     vertexai_credentials: Any = None,
     gemini_safety_settings: list | None = None,
-    chain: list[dict[str, Any]] | None = None,
+    litellmrouter_config: dict[str, Any] | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -263,18 +263,19 @@ def create_llm_provider(
         )
 
     elif provider_lower == "litellmrouter":
-        if not chain:
+        if not litellmrouter_config:
             raise ValueError(
-                "Provider 'litellmrouter' requires a non-empty chain. "
-                "Set HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN (or the per-op variant) "
-                "to a JSON list of deployment objects."
+                "Provider 'litellmrouter' requires a config object. "
+                "Set HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG (or the per-op variant) "
+                "to a JSON object accepted by litellm.Router. "
+                "See https://docs.litellm.ai/docs/routing."
             )
         return LiteLLMRouterLLM(
             provider=provider,
             api_key=api_key,
             base_url=base_url,
             model=model,
-            chain=chain,
+            config=litellmrouter_config,
             reasoning_effort=reasoning_effort,
         )
 
@@ -352,7 +353,7 @@ class LLMProvider:
         gemini_safety_settings: list | None = None,
         extra_body: dict[str, Any] | None = None,
         default_headers: dict[str, str] | None = None,
-        litellmrouter_chain: list[dict[str, Any]] | None = None,
+        litellmrouter_config: dict[str, Any] | None = None,
     ):
         """
         Initialize LLM provider.
@@ -371,17 +372,18 @@ class LLMProvider:
                 Used by operators routing through proxies / request-tracing middleware. Falls
                 back to ``HindsightConfig.llm_default_headers`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``)
                 when ``None``.
-            litellmrouter_chain: Provider-specific config for ``provider="litellmrouter"``.
-                List of deployment dicts evaluated in order with fallback on transient errors.
-                Ignored unless ``provider == "litellmrouter"``. When None and the provider is
-                ``litellmrouter``, falls back to ``HindsightConfig.llm_litellmrouter_chain``.
+            litellmrouter_config: Provider-specific config for ``provider="litellmrouter"``.
+                JSON object passed verbatim to ``litellm.Router(**config)`` — see
+                https://docs.litellm.ai/docs/routing. Ignored unless ``provider == "litellmrouter"``.
+                When None and the provider is ``litellmrouter``, falls back to
+                ``HindsightConfig.llm_litellmrouter_config``.
         """
         self.provider = provider.lower()
         self.api_key = api_key
         self.base_url = base_url
         self.model = model
         self.reasoning_effort = reasoning_effort
-        self.litellmrouter_chain = litellmrouter_chain
+        self.litellmrouter_config = litellmrouter_config
         # Service tiers from hierarchical config (not env vars)
         self.groq_service_tier = groq_service_tier
         self.openai_service_tier = openai_service_tier
@@ -500,16 +502,16 @@ class LLMProvider:
 
         # For litellmrouter: prefer an explicit chain from the caller (per-op
         # construction in MemoryEngine threads the right chain through). If the caller
-        # didn't supply one, fall back to the global ``llm_litellmrouter_chain`` so
+        # didn't supply one, fall back to the global ``llm_litellmrouter_config`` so
         # ad-hoc constructions (e.g. ``LLMProvider.from_env()``) keep working.
-        chain: list[dict[str, Any]] | None = self.litellmrouter_chain
-        if self.provider == "litellmrouter" and chain is None:
+        router_config: dict[str, Any] | None = self.litellmrouter_config
+        if self.provider == "litellmrouter" and router_config is None:
             from ..config import _get_raw_config
 
             try:
-                chain = _get_raw_config().llm_litellmrouter_chain
+                router_config = _get_raw_config().llm_litellmrouter_config
             except Exception:
-                chain = None
+                router_config = None
 
         # Create provider implementation using factory
         self._provider_impl = create_llm_provider(
@@ -526,7 +528,7 @@ class LLMProvider:
             vertexai_region=vertexai_region,
             vertexai_credentials=vertexai_credentials,
             gemini_safety_settings=self.gemini_safety_settings,
-            chain=chain,
+            litellmrouter_config=router_config,
         )
 
         # Backward compatibility: Keep mock provider properties

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -546,7 +546,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=memory_llm_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
-            litellmrouter_chain=config.llm_litellmrouter_chain,
+            litellmrouter_config=config.llm_litellmrouter_config,
         )
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
@@ -575,7 +575,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=retain_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
-            litellmrouter_chain=config.retain_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
+            litellmrouter_config=config.retain_llm_litellmrouter_config or config.llm_litellmrouter_config,
         )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
@@ -599,7 +599,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=reflect_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
-            litellmrouter_chain=config.reflect_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
+            litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
         )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
@@ -623,7 +623,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=consolidation_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
-            litellmrouter_chain=config.consolidation_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
+            litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -546,6 +546,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=memory_llm_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
+            litellmrouter_chain=config.llm_litellmrouter_chain,
         )
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
@@ -574,6 +575,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=retain_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
+            litellmrouter_chain=config.retain_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
         )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
@@ -597,6 +599,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=reflect_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
+            litellmrouter_chain=config.reflect_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
         )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
@@ -620,6 +623,7 @@ class MemoryEngine(MemoryEngineInterface):
             model=consolidation_model,
             extra_body=config.llm_extra_body,
             default_headers=config.llm_default_headers,
+            litellmrouter_chain=config.consolidation_llm_litellmrouter_chain or config.llm_litellmrouter_chain,
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
@@ -9,6 +9,7 @@ from .claude_code_llm import ClaudeCodeLLM
 from .codex_llm import CodexLLM
 from .gemini_llm import GeminiLLM
 from .litellm_llm import LiteLLMLLM
+from .litellm_router_llm import LiteLLMRouterLLM
 from .llamacpp_llm import LlamaCppLLM
 from .mock_llm import MockLLM
 from .none_llm import NoneLLM
@@ -21,6 +22,7 @@ __all__ = [
     "GeminiLLM",
     "LlamaCppLLM",
     "LiteLLMLLM",
+    "LiteLLMRouterLLM",
     "MockLLM",
     "NoneLLM",
     "OpenAICompatibleLLM",

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -103,11 +103,33 @@ class LiteLLMLLM(LLMInterface):
         if self.base_url:
             kwargs["api_base"] = self.base_url
         if max_completion_tokens is not None:
-            kwargs["max_completion_tokens"] = max_completion_tokens
+            kwargs["max_completion_tokens"] = self._cap_max_completion_tokens(max_completion_tokens)
         if temperature is not None:
             kwargs["temperature"] = temperature
 
         return kwargs
+
+    # ── per-model output-tokens cap (shared with Router subclass) ────────────
+    # Hindsight's defaults (e.g. retain_max_completion_tokens=64000) target
+    # high-capacity models. When a configured deployment supports fewer
+    # completion tokens (e.g. gpt-4.1-nano caps at 32768), the call would
+    # otherwise be rejected. Cap pre-emptively using LiteLLM's per-model
+    # registry so things work out of the box across the supported model set.
+
+    def _cap_max_completion_tokens(self, value: int) -> int:
+        cap = self._get_model_output_cap()
+        if cap and value > cap:
+            logger.debug("capping max_completion_tokens %d -> %d for model %s", value, cap, self.model)
+            return cap
+        return value
+
+    def _get_model_output_cap(self) -> int | None:
+        """Return the configured model's max output tokens, per LiteLLM's registry."""
+        try:
+            cap = self._litellm.get_max_tokens(self.model)
+            return int(cap) if cap else None
+        except Exception:
+            return None
 
     # ── hooks for Router-style subclasses ────────────────────────────────────
     # The retry+parse loop in call() / call_with_tools() is shared by every

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -109,6 +109,30 @@ class LiteLLMLLM(LLMInterface):
 
         return kwargs
 
+    # ── hooks for Router-style subclasses ────────────────────────────────────
+    # The retry+parse loop in call() / call_with_tools() is shared by every
+    # LiteLLM-backed provider. Subclasses override the small surface below to
+    # swap the completion fn (direct vs Router) and rename the deployment that
+    # actually answered the request.
+
+    @property
+    def _stage_label(self) -> str:
+        """Stage breadcrumb label — overridden by subclasses (e.g. ``litellmrouter``)."""
+        return "litellm"
+
+    async def _acompletion(self, **kwargs: Any) -> Any:
+        """Issue a chat completion. Subclasses override to route via ``litellm.Router``."""
+        return await self._litellm.acompletion(**kwargs)
+
+    def _resolve_completion_model(self, response: Any) -> str:
+        """
+        Return the model name to record in metrics/tracing.
+
+        For Router-backed providers this can differ from ``self.model`` — the Router
+        may pick a different deployment than the primary. Default: ``self.model``.
+        """
+        return self.model
+
     async def call(
         self,
         messages: list[dict[str, str]],
@@ -143,12 +167,13 @@ class LiteLLMLLM(LLMInterface):
 
         for attempt in range(max_retries + 1):
             if attempt > 0:
-                set_stage(f"llm.litellm.{scope}.attempt={attempt + 1}/{max_retries + 1}")
+                set_stage(f"llm.{self._stage_label}.{scope}.attempt={attempt + 1}/{max_retries + 1}")
             try:
-                response = await self._litellm.acompletion(**call_kwargs)
+                response = await self._acompletion(**call_kwargs)
 
                 content = response.choices[0].message.content or ""
                 finish_reason = response.choices[0].finish_reason
+                model_name = self._resolve_completion_model(response)
 
                 # Check for length-limited output
                 if finish_reason == "length":
@@ -184,7 +209,7 @@ class LiteLLMLLM(LLMInterface):
                 metrics = get_metrics_collector()
                 metrics.record_llm_call(
                     provider=self.provider,
-                    model=self.model,
+                    model=model_name,
                     scope=scope,
                     duration=duration,
                     input_tokens=input_tokens,
@@ -198,7 +223,7 @@ class LiteLLMLLM(LLMInterface):
                 span_recorder = get_span_recorder()
                 span_recorder.record_llm_call(
                     provider=self.provider,
-                    model=self.model,
+                    model=model_name,
                     scope=scope,
                     messages=messages,
                     response_content=_serialize_for_span(result),
@@ -211,7 +236,7 @@ class LiteLLMLLM(LLMInterface):
 
                 if duration > 10.0:
                     logger.info(
-                        f"slow llm call: scope={scope}, model={self.provider}/{self.model}, "
+                        f"slow llm call: scope={scope}, model={self.provider}/{model_name}, "
                         f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
                         f"time={duration:.3f}s"
                     )
@@ -287,13 +312,14 @@ class LiteLLMLLM(LLMInterface):
         last_exception = None
         for attempt in range(max_retries + 1):
             if attempt > 0:
-                set_stage(f"llm.litellm.tools.attempt={attempt + 1}/{max_retries + 1}")
+                set_stage(f"llm.{self._stage_label}.tools.attempt={attempt + 1}/{max_retries + 1}")
             try:
-                response = await self._litellm.acompletion(**call_kwargs)
+                response = await self._acompletion(**call_kwargs)
 
                 message = response.choices[0].message
                 content = message.content
                 finish_reason = response.choices[0].finish_reason
+                model_name = self._resolve_completion_model(response)
 
                 # Extract tool calls
                 tool_calls: list[LLMToolCall] = []
@@ -319,7 +345,7 @@ class LiteLLMLLM(LLMInterface):
                 metrics = get_metrics_collector()
                 metrics.record_llm_call(
                     provider=self.provider,
-                    model=self.model,
+                    model=model_name,
                     scope=scope,
                     duration=duration,
                     input_tokens=input_tokens,
@@ -338,7 +364,7 @@ class LiteLLMLLM(LLMInterface):
                 )
                 span_recorder.record_llm_call(
                     provider=self.provider,
-                    model=self.model,
+                    model=model_name,
                     scope=scope,
                     messages=messages,
                     response_content=content,

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -89,7 +89,30 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         # or introspect Router internals.
         self._router = Router(**config)
 
+        # Pre-compute the most conservative output-tokens cap across every configured
+        # deployment so a single max_completion_tokens value works no matter which
+        # deployment Router picks. Uses LiteLLM's own per-model registry; unknown
+        # models contribute no cap. See LiteLLMLLM._cap_max_completion_tokens.
+        self._router_output_cap = self._compute_router_output_cap(config)
+
         logger.info("LiteLLM Router initialized; entrypoint model_name=%r", _ENTRYPOINT_MODEL_NAME)
+
+    def _compute_router_output_cap(self, config: dict[str, Any]) -> int | None:
+        caps: list[int] = []
+        for deployment in (config.get("model_list") or []) if isinstance(config, dict) else []:
+            if not isinstance(deployment, dict):
+                continue
+            params = deployment.get("litellm_params") or {}
+            model_str = params.get("model") if isinstance(params, dict) else None
+            if not model_str:
+                continue
+            try:
+                cap = self._litellm.get_max_tokens(model_str)
+            except Exception:
+                cap = None
+            if cap:
+                caps.append(int(cap))
+        return min(caps) if caps else None
 
     # ── overrides for the shared retry/parse loop ───────────────────────────
 
@@ -104,6 +127,9 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         hidden = getattr(response, "_hidden_params", None) or {}
         return hidden.get("model") or _ENTRYPOINT_MODEL_NAME
 
+    def _get_model_output_cap(self) -> int | None:
+        return self._router_output_cap
+
     def _build_common_kwargs(
         self,
         messages: list[dict[str, Any]],
@@ -117,7 +143,7 @@ class LiteLLMRouterLLM(LiteLLMLLM):
             "messages": messages,
         }
         if max_completion_tokens is not None:
-            kwargs["max_completion_tokens"] = max_completion_tokens
+            kwargs["max_completion_tokens"] = self._cap_max_completion_tokens(max_completion_tokens)
         if temperature is not None:
             kwargs["temperature"] = temperature
         return kwargs

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -2,28 +2,32 @@
 LiteLLM Router LLM provider — pure pass-through to ``litellm.Router``.
 
 The full configuration object is forwarded verbatim. We do not translate model
-names, infer fallbacks, or impose defaults: whatever the user puts in the
-``HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG`` env var becomes ``Router(**config)``.
-The only Hindsight-imposed convention is that requests are issued against the
-``model_name`` of the first entry in ``model_list``; chain ordering, fallbacks,
-load-balancing, retries and cooldowns are LiteLLM Router's responsibility.
+names, infer fallbacks, validate shape, or introspect Router internals:
+whatever the user puts in ``HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG`` becomes
+``Router(**config)``. If the shape is wrong, LiteLLM Router raises.
+
+The only Hindsight-imposed convention is that one entry in ``model_list``
+must have ``model_name: "default"`` — that's the entrypoint we issue
+completions against. Everything else (ordering, fallbacks, load-balancing,
+weighted picks, rate limits, retries, cooldowns) is whatever the user
+configures via LiteLLM's own keys.
 
 See https://docs.litellm.ai/docs/routing for the supported keys (``model_list``,
 ``fallbacks``, ``context_window_fallbacks``, ``num_retries``, ``cooldown_time``,
 ``routing_strategy``, ``allowed_fails``, …).
 
-The retry/parse/metrics loop is shared with ``LiteLLMLLM`` via inheritance: this
-class only overrides the small surface that differs (the completion fn, the
-deployment kwargs, and the deployment-name resolution for metrics).
+The retry/parse/metrics loop is shared with ``LiteLLMLLM`` via inheritance:
+this class only overrides the completion fn, the call kwargs, and the model
+name reported in metrics.
 
 Example ``HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG``::
 
     {
       "model_list": [
-        {"model_name": "primary",  "litellm_params": {"model": "openai/gpt-4o-mini",       "api_key": "sk-..."}},
+        {"model_name": "default",  "litellm_params": {"model": "openai/gpt-4o-mini",       "api_key": "sk-..."}},
         {"model_name": "fallback", "litellm_params": {"model": "anthropic/claude-sonnet-4", "api_key": "sk-ant-..."}}
       ],
-      "fallbacks": [{"primary": ["fallback"]}],
+      "fallbacks": [{"default": ["fallback"]}],
       "num_retries": 0,
       "cooldown_time": 60
     }
@@ -35,6 +39,14 @@ from typing import Any
 from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
 
 logger = logging.getLogger(__name__)
+
+
+# Hindsight always issues completions against this ``model_name``. Users must
+# include at least one entry with ``model_name: "default"`` in their config's
+# ``model_list``; that entry is the entrypoint, and any other entries become
+# fallback / load-balance / weighted-pool members per the user's own
+# ``fallbacks`` / ``routing_strategy`` settings.
+_ENTRYPOINT_MODEL_NAME = "default"
 
 
 class LiteLLMRouterLLM(LiteLLMLLM):
@@ -67,25 +79,17 @@ class LiteLLMRouterLLM(LiteLLMLLM):
             timeout=timeout,
             **kwargs,
         )
-        if not isinstance(config, dict) or not config.get("model_list"):
-            raise ValueError("LiteLLMRouterLLM requires a config dict with a non-empty 'model_list'")
-        first = config["model_list"][0]
-        primary_model_name = first.get("model_name") if isinstance(first, dict) else None
-        if not primary_model_name:
-            raise ValueError("LiteLLMRouterLLM: model_list[0] must have a 'model_name'")
-
         self.config = config
-        self._primary_model_name = primary_model_name
 
         from litellm import Router
 
         logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+        # Pure pass-through: whatever the user gave goes straight to LiteLLM Router.
+        # If the shape is invalid, Router raises its own error — we don't pre-validate
+        # or introspect Router internals.
         self._router = Router(**config)
 
-        logger.info(
-            f"LiteLLM Router initialized: {len(config['model_list'])} deployment(s), "
-            f"primary model_name={primary_model_name!r}"
-        )
+        logger.info("LiteLLM Router initialized; entrypoint model_name=%r", _ENTRYPOINT_MODEL_NAME)
 
     # ── overrides for the shared retry/parse loop ───────────────────────────
 
@@ -98,7 +102,7 @@ class LiteLLMRouterLLM(LiteLLMLLM):
 
     def _resolve_completion_model(self, response: Any) -> str:
         hidden = getattr(response, "_hidden_params", None) or {}
-        return hidden.get("model") or self._primary_model_name
+        return hidden.get("model") or _ENTRYPOINT_MODEL_NAME
 
     def _build_common_kwargs(
         self,
@@ -106,10 +110,10 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         max_completion_tokens: int | None = None,
         temperature: float | None = None,
     ) -> dict[str, Any]:
-        # Always issue against the primary group; Router handles deployment selection,
+        # Always issue against the entrypoint group; Router handles deployment selection,
         # cross-group fallbacks, retries, cooldowns — whatever the user configured.
         kwargs: dict[str, Any] = {
-            "model": self._primary_model_name,
+            "model": _ENTRYPOINT_MODEL_NAME,
             "messages": messages,
         }
         if max_completion_tokens is not None:

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -1,0 +1,449 @@
+"""
+LiteLLM Router LLM provider — ordered fallback across multiple deployments.
+
+Wraps ``litellm.Router`` with a chain of deployments. Requests are tried against
+the primary deployment first; on transient errors (rate-limit, timeout, 5xx) the
+Router falls back to subsequent deployments in declared order. Chain entries are
+modelled as distinct LiteLLM ``model_name`` groups so that the ``fallbacks`` map
+expresses the linear chain explicitly — this gives deterministic fallback order
+rather than the load-balancing behaviour you get from same-group deployments.
+
+Auth-style errors (401/403) are not retried across deployments, since fallback
+on a misconfigured key would just propagate the failure.
+
+References:
+    - LiteLLM Router: https://docs.litellm.ai/docs/routing
+    - Router fallbacks: https://docs.litellm.ai/docs/routing#fallbacks
+
+Chain entry shape (matches ``HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN``)::
+
+    [
+      {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
+      {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
+    ]
+"""
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
+from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.metrics import get_metrics_collector
+from hindsight_api.worker.stage import set_stage
+
+logger = logging.getLogger(__name__)
+
+
+# Hindsight provider name → LiteLLM model prefix.
+# Providers not listed are treated as OpenAI-compatible: the configured base_url
+# carries the routing and the model is sent under the "openai/" prefix.
+_LITELLM_PROVIDER_PREFIX = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "gemini": "gemini",
+    "vertexai": "vertex_ai",
+    "groq": "groq",
+    "deepseek": "deepseek",
+    "openrouter": "openrouter",
+    "bedrock": "bedrock",
+    "ollama": "ollama_chat",
+    "litellm": None,  # caller already provided a fully-qualified model string
+}
+
+# Primary group name. All chain entries fall back to subsequent indices.
+_PRIMARY_GROUP = "hindsight-chain-0"
+
+
+def _build_litellm_model(provider: str, model: str) -> str:
+    """Translate a Hindsight (provider, model) pair into a LiteLLM model string."""
+    if "/" in model:
+        return model  # caller pre-qualified the model, respect it
+    prefix = _LITELLM_PROVIDER_PREFIX.get(provider.lower(), "openai")
+    if prefix is None:
+        return model
+    return f"{prefix}/{model}"
+
+
+def _build_model_list(chain: list[dict[str, Any]], timeout: float) -> list[dict[str, Any]]:
+    """Translate a Hindsight chain into a LiteLLM Router model_list."""
+    model_list: list[dict[str, Any]] = []
+    for i, entry in enumerate(chain):
+        provider = entry["provider"]
+        model = entry["model"]
+        litellm_params: dict[str, Any] = {
+            "model": _build_litellm_model(provider, model),
+            "timeout": timeout,
+        }
+        if entry.get("api_key"):
+            litellm_params["api_key"] = entry["api_key"]
+        if entry.get("base_url"):
+            litellm_params["api_base"] = entry["base_url"]
+        model_list.append(
+            {
+                "model_name": f"hindsight-chain-{i}",
+                "litellm_params": litellm_params,
+            }
+        )
+    return model_list
+
+
+def _build_fallbacks(chain_length: int) -> list[dict[str, list[str]]]:
+    """Map the primary group to every subsequent chain index in declared order."""
+    if chain_length <= 1:
+        return []
+    return [{_PRIMARY_GROUP: [f"hindsight-chain-{i}" for i in range(1, chain_length)]}]
+
+
+class LiteLLMRouterLLM(LLMInterface):
+    """
+    LLM provider backed by ``litellm.Router`` with ordered fallback.
+
+    Each entry in the chain becomes a distinct LiteLLM model_group; the primary
+    group is wired to fall back through the remaining groups in declared order.
+    Requests are always issued against the primary group — Router internally
+    re-issues against the fallback groups when the primary fails.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        api_key: str,
+        base_url: str,
+        model: str,
+        chain: list[dict[str, Any]],
+        reasoning_effort: str = "low",
+        timeout: float = 300.0,
+        **kwargs: Any,
+    ):
+        super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
+        if not chain:
+            raise ValueError("LiteLLMRouterLLM requires a non-empty chain")
+        self.timeout = timeout
+        self.chain = chain
+        self._litellm: Any = None
+        self._router: Any = None
+
+        try:
+            import litellm
+            from litellm import Router
+
+            self._litellm = litellm
+            litellm.suppress_debug_info = True  # type: ignore[assignment]
+            litellm.drop_params = True  # type: ignore[assignment]
+            logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+            logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+        except ImportError as e:
+            raise RuntimeError("LiteLLM SDK not installed. Run: uv add litellm or pip install litellm") from e
+
+        model_list = _build_model_list(chain, timeout=timeout)
+        fallbacks = _build_fallbacks(len(chain))
+        self._router = Router(
+            model_list=model_list,
+            fallbacks=fallbacks,
+            num_retries=0,  # outer loop in call()/call_with_tools() owns retries
+            allowed_fails=1,  # cooldown a deployment after a single failure within a window
+            cooldown_time=60,
+        )
+
+        chain_summary = ", ".join(f"{entry['provider']}/{entry['model']}" for entry in chain)
+        logger.info(f"LiteLLM Router initialized with {len(chain)} deployment(s): [{chain_summary}]")
+
+    async def verify_connection(self) -> None:
+        try:
+            await self.call(
+                messages=[{"role": "user", "content": "test"}],
+                max_completion_tokens=50,
+                temperature=0.0,
+                scope="verification",
+                max_retries=0,
+            )
+            logger.info("LiteLLM Router connection verified successfully")
+        except OutputTooLongError:
+            logger.info("LiteLLM Router connection verified successfully (response truncated)")
+        except Exception as e:
+            logger.error(f"LiteLLM Router connection verification failed: {e}")
+            raise RuntimeError(f"Failed to verify LiteLLM Router connection: {e}") from e
+
+    def _build_call_kwargs(
+        self,
+        messages: list[dict[str, Any]],
+        max_completion_tokens: int | None,
+        temperature: float | None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "model": _PRIMARY_GROUP,
+            "messages": messages,
+        }
+        if max_completion_tokens is not None:
+            kwargs["max_completion_tokens"] = max_completion_tokens
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        return kwargs
+
+    async def call(
+        self,
+        messages: list[dict[str, str]],
+        response_format: Any | None = None,
+        max_completion_tokens: int | None = None,
+        temperature: float | None = None,
+        scope: str = "memory",
+        max_retries: int = 10,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 60.0,
+        skip_validation: bool = False,
+        strict_schema: bool = False,
+        return_usage: bool = False,
+    ) -> Any:
+        start_time = time.time()
+        call_kwargs = self._build_call_kwargs(messages, max_completion_tokens, temperature)
+
+        if response_format is not None and hasattr(response_format, "model_json_schema"):
+            schema = response_format.model_json_schema()
+            call_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": getattr(response_format, "__name__", "response"),
+                    "schema": schema,
+                    "strict": strict_schema,
+                },
+            }
+
+        last_exception: Exception | None = None
+
+        for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.litellmrouter.{scope}.attempt={attempt + 1}/{max_retries + 1}")
+            try:
+                response = await self._router.acompletion(**call_kwargs)
+
+                content = response.choices[0].message.content or ""
+                finish_reason = response.choices[0].finish_reason
+                # Router exposes the deployment that actually answered via response._hidden_params.
+                deployment_model = (
+                    getattr(response, "_hidden_params", {}).get("model")
+                    if hasattr(response, "_hidden_params")
+                    else None
+                ) or call_kwargs["model"]
+
+                if finish_reason == "length":
+                    raise OutputTooLongError("LiteLLM Router response was truncated due to token limit")
+
+                if response_format is not None:
+                    clean_content = content
+                    if "```json" in content:
+                        clean_content = content.split("```json")[1].split("```")[0].strip()
+                    elif "```" in content:
+                        clean_content = content.split("```")[1].split("```")[0].strip()
+                    try:
+                        json_data = json.loads(clean_content)
+                    except json.JSONDecodeError:
+                        json_data = json.loads(content)
+                    result = json_data if skip_validation else response_format.model_validate(json_data)
+                else:
+                    result = content
+
+                input_tokens = getattr(response.usage, "prompt_tokens", 0) or 0
+                output_tokens = getattr(response.usage, "completion_tokens", 0) or 0
+                total_tokens = input_tokens + output_tokens
+
+                duration = time.time() - start_time
+                metrics = get_metrics_collector()
+                metrics.record_llm_call(
+                    provider=self.provider,
+                    model=deployment_model,
+                    scope=scope,
+                    duration=duration,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    success=True,
+                )
+
+                from hindsight_api.tracing import _serialize_for_span, get_span_recorder
+
+                span_recorder = get_span_recorder()
+                span_recorder.record_llm_call(
+                    provider=self.provider,
+                    model=deployment_model,
+                    scope=scope,
+                    messages=messages,
+                    response_content=_serialize_for_span(result),
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    duration=duration,
+                    finish_reason=finish_reason,
+                    error=None,
+                )
+
+                if duration > 10.0:
+                    logger.info(
+                        f"slow llm call: scope={scope}, model={self.provider}/{deployment_model}, "
+                        f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
+                        f"time={duration:.3f}s"
+                    )
+
+                if return_usage:
+                    return result, TokenUsage(
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        total_tokens=total_tokens,
+                    )
+                return result
+
+            except OutputTooLongError:
+                raise
+
+            except json.JSONDecodeError as e:
+                last_exception = e
+                if attempt < max_retries:
+                    logger.warning("LiteLLM Router returned invalid JSON, retrying...")
+                    backoff = min(initial_backoff * (2**attempt), max_backoff)
+                    await asyncio.sleep(backoff)
+                    continue
+                logger.error(f"LiteLLM Router returned invalid JSON after {max_retries + 1} attempts")
+                raise
+
+            except Exception as e:
+                error_str = str(e).lower()
+                if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
+                    logger.error(f"LiteLLM Router auth error, not retrying: {e}")
+                    raise
+
+                last_exception = e
+                if attempt < max_retries:
+                    is_retryable = any(
+                        keyword in error_str
+                        for keyword in ("rate", "limit", "timeout", "connection", "500", "502", "503", "529")
+                    )
+                    if is_retryable:
+                        backoff = min(initial_backoff * (2**attempt), max_backoff)
+                        jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
+                        await asyncio.sleep(backoff + jitter)
+                        continue
+
+                logger.error(f"LiteLLM Router API error after {attempt + 1} attempts: {e}")
+                raise
+
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("LiteLLM Router call failed after all retries")
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        max_completion_tokens: int | None = None,
+        temperature: float | None = None,
+        scope: str = "tools",
+        max_retries: int = 5,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 30.0,
+        tool_choice: str | dict[str, Any] = "auto",
+    ) -> LLMToolCallResult:
+        start_time = time.time()
+        call_kwargs = self._build_call_kwargs(messages, max_completion_tokens, temperature)
+        call_kwargs["tools"] = tools
+        call_kwargs["tool_choice"] = tool_choice
+
+        last_exception: Exception | None = None
+        for attempt in range(max_retries + 1):
+            if attempt > 0:
+                set_stage(f"llm.litellmrouter.tools.attempt={attempt + 1}/{max_retries + 1}")
+            try:
+                response = await self._router.acompletion(**call_kwargs)
+
+                message = response.choices[0].message
+                content = message.content
+                finish_reason = response.choices[0].finish_reason
+                deployment_model = (
+                    getattr(response, "_hidden_params", {}).get("model")
+                    if hasattr(response, "_hidden_params")
+                    else None
+                ) or call_kwargs["model"]
+
+                tool_calls: list[LLMToolCall] = []
+                if message.tool_calls:
+                    for tc in message.tool_calls:
+                        arguments = tc.function.arguments
+                        if isinstance(arguments, str):
+                            arguments = json.loads(arguments)
+                        tool_calls.append(
+                            LLMToolCall(
+                                id=tc.id,
+                                name=tc.function.name,
+                                arguments=arguments,
+                            )
+                        )
+
+                input_tokens = getattr(response.usage, "prompt_tokens", 0) or 0
+                output_tokens = getattr(response.usage, "completion_tokens", 0) or 0
+
+                duration = time.time() - start_time
+                metrics = get_metrics_collector()
+                metrics.record_llm_call(
+                    provider=self.provider,
+                    model=deployment_model,
+                    scope=scope,
+                    duration=duration,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    success=True,
+                )
+
+                from hindsight_api.tracing import get_span_recorder
+
+                span_recorder = get_span_recorder()
+                tool_calls_dict = (
+                    [{"id": tc.id, "name": tc.name, "arguments": tc.arguments} for tc in tool_calls]
+                    if tool_calls
+                    else None
+                )
+                span_recorder.record_llm_call(
+                    provider=self.provider,
+                    model=deployment_model,
+                    scope=scope,
+                    messages=messages,
+                    response_content=content,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    duration=duration,
+                    finish_reason=finish_reason,
+                    error=None,
+                    tool_calls=tool_calls_dict,
+                )
+
+                return LLMToolCallResult(
+                    content=content,
+                    tool_calls=tool_calls,
+                    finish_reason=finish_reason or ("tool_calls" if tool_calls else "stop"),
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                )
+
+            except Exception as e:
+                error_str = str(e).lower()
+                if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
+                    raise
+
+                last_exception = e
+                if attempt < max_retries:
+                    is_retryable = any(
+                        keyword in error_str
+                        for keyword in ("rate", "limit", "timeout", "connection", "500", "502", "503", "529")
+                    )
+                    if is_retryable:
+                        await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
+                        continue
+
+                logger.error(f"LiteLLM Router tool call error after {attempt + 1} attempts: {e}")
+                raise
+
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("LiteLLM Router tool call failed after all retries")
+
+    async def cleanup(self) -> None:
+        """Clean up resources."""
+        pass

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -11,6 +11,10 @@ rather than the load-balancing behaviour you get from same-group deployments.
 Auth-style errors (401/403) are not retried across deployments, since fallback
 on a misconfigured key would just propagate the failure.
 
+The retry/parse/metrics loop is shared with ``LiteLLMLLM`` via inheritance: this
+class only overrides the small surface that differs (the completion fn, the
+deployment kwargs, and the deployment-name resolution for metrics).
+
 References:
     - LiteLLM Router: https://docs.litellm.ai/docs/routing
     - Router fallbacks: https://docs.litellm.ai/docs/routing#fallbacks
@@ -21,18 +25,19 @@ Chain entry shape (matches ``HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN``)::
       {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
       {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
     ]
+
+Entries support arbitrary extra keys: anything not in
+``{provider, model, api_key, base_url, litellm_params}`` is forwarded to the
+LiteLLM Router deployment top-level (e.g. ``rpm``, ``tpm``, ``weight``,
+``model_info``). Anything inside a ``litellm_params`` sub-object is merged into
+the inner ``litellm_params`` dict (e.g. per-deployment ``temperature``,
+``extra_headers``).
 """
 
-import asyncio
-import json
 import logging
-import time
 from typing import Any
 
-from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
-from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
-from hindsight_api.metrics import get_metrics_collector
-from hindsight_api.worker.stage import set_stage
+from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
 
 logger = logging.getLogger(__name__)
 
@@ -68,25 +73,42 @@ def _build_litellm_model(provider: str, model: str) -> str:
 
 
 def _build_model_list(chain: list[dict[str, Any]], timeout: float) -> list[dict[str, Any]]:
-    """Translate a Hindsight chain into a LiteLLM Router model_list."""
+    """
+    Translate a Hindsight chain into a LiteLLM Router ``model_list``.
+
+    Known Hindsight keys (``provider``, ``model``, ``api_key``, ``base_url``) are
+    mapped onto LiteLLM's ``litellm_params``. Anything inside a ``litellm_params``
+    sub-object is merged into the inner dict (later wins). Any other top-level
+    key is forwarded verbatim to the deployment record (``rpm``, ``tpm``,
+    ``weight``, ``model_info`` …).
+    """
     model_list: list[dict[str, Any]] = []
-    for i, entry in enumerate(chain):
-        provider = entry["provider"]
-        model = entry["model"]
+    for i, raw_entry in enumerate(chain):
+        entry = dict(raw_entry)  # don't mutate caller data
+        provider = entry.pop("provider")
+        model = entry.pop("model")
+        api_key = entry.pop("api_key", None)
+        base_url = entry.pop("base_url", None)
+        nested_params = dict(entry.pop("litellm_params", {}) or {})
+
         litellm_params: dict[str, Any] = {
             "model": _build_litellm_model(provider, model),
             "timeout": timeout,
         }
-        if entry.get("api_key"):
-            litellm_params["api_key"] = entry["api_key"]
-        if entry.get("base_url"):
-            litellm_params["api_base"] = entry["base_url"]
-        model_list.append(
-            {
-                "model_name": f"hindsight-chain-{i}",
-                "litellm_params": litellm_params,
-            }
-        )
+        if api_key:
+            litellm_params["api_key"] = api_key
+        if base_url:
+            litellm_params["api_base"] = base_url
+        # Caller-supplied litellm_params win over our defaults.
+        litellm_params.update(nested_params)
+
+        deployment: dict[str, Any] = {
+            "model_name": f"hindsight-chain-{i}",
+            "litellm_params": litellm_params,
+        }
+        # Any remaining keys are Router-level deployment fields (rpm, tpm, weight, ...).
+        deployment.update(entry)
+        model_list.append(deployment)
     return model_list
 
 
@@ -97,7 +119,7 @@ def _build_fallbacks(chain_length: int) -> list[dict[str, list[str]]]:
     return [{_PRIMARY_GROUP: [f"hindsight-chain-{i}" for i in range(1, chain_length)]}]
 
 
-class LiteLLMRouterLLM(LLMInterface):
+class LiteLLMRouterLLM(LiteLLMLLM):
     """
     LLM provider backed by ``litellm.Router`` with ordered fallback.
 
@@ -105,6 +127,9 @@ class LiteLLMRouterLLM(LLMInterface):
     group is wired to fall back through the remaining groups in declared order.
     Requests are always issued against the primary group — Router internally
     re-issues against the fallback groups when the primary fails.
+
+    Inherits the retry/parse/metrics loop from ``LiteLLMLLM`` and only overrides
+    the small surface that differs.
     """
 
     def __init__(
@@ -118,25 +143,22 @@ class LiteLLMRouterLLM(LLMInterface):
         timeout: float = 300.0,
         **kwargs: Any,
     ):
-        super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
+        super().__init__(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            timeout=timeout,
+            **kwargs,
+        )
         if not chain:
             raise ValueError("LiteLLMRouterLLM requires a non-empty chain")
-        self.timeout = timeout
         self.chain = chain
-        self._litellm: Any = None
-        self._router: Any = None
 
-        try:
-            import litellm
-            from litellm import Router
+        from litellm import Router
 
-            self._litellm = litellm
-            litellm.suppress_debug_info = True  # type: ignore[assignment]
-            litellm.drop_params = True  # type: ignore[assignment]
-            logging.getLogger("LiteLLM").setLevel(logging.WARNING)
-            logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
-        except ImportError as e:
-            raise RuntimeError("LiteLLM SDK not installed. Run: uv add litellm or pip install litellm") from e
+        logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
 
         model_list = _build_model_list(chain, timeout=timeout)
         fallbacks = _build_fallbacks(len(chain))
@@ -148,10 +170,42 @@ class LiteLLMRouterLLM(LLMInterface):
             cooldown_time=60,
         )
 
-        chain_summary = ", ".join(f"{entry['provider']}/{entry['model']}" for entry in chain)
+        chain_summary = ", ".join(f"{e['provider']}/{e['model']}" for e in chain)
         logger.info(f"LiteLLM Router initialized with {len(chain)} deployment(s): [{chain_summary}]")
 
+    # ── overrides for the shared retry/parse loop ───────────────────────────
+
+    @property
+    def _stage_label(self) -> str:
+        return "litellmrouter"
+
+    async def _acompletion(self, **kwargs: Any) -> Any:
+        return await self._router.acompletion(**kwargs)
+
+    def _resolve_completion_model(self, response: Any) -> str:
+        hidden = getattr(response, "_hidden_params", None) or {}
+        return hidden.get("model") or self.model
+
+    def _build_common_kwargs(
+        self,
+        messages: list[dict[str, Any]],
+        max_completion_tokens: int | None = None,
+        temperature: float | None = None,
+    ) -> dict[str, Any]:
+        # Always issue against the primary group; Router handles deployment selection.
+        kwargs: dict[str, Any] = {
+            "model": _PRIMARY_GROUP,
+            "messages": messages,
+        }
+        if max_completion_tokens is not None:
+            kwargs["max_completion_tokens"] = max_completion_tokens
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        return kwargs
+
     async def verify_connection(self) -> None:
+        from hindsight_api.engine.llm_interface import OutputTooLongError
+
         try:
             await self.call(
                 messages=[{"role": "user", "content": "test"}],
@@ -166,284 +220,3 @@ class LiteLLMRouterLLM(LLMInterface):
         except Exception as e:
             logger.error(f"LiteLLM Router connection verification failed: {e}")
             raise RuntimeError(f"Failed to verify LiteLLM Router connection: {e}") from e
-
-    def _build_call_kwargs(
-        self,
-        messages: list[dict[str, Any]],
-        max_completion_tokens: int | None,
-        temperature: float | None,
-    ) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {
-            "model": _PRIMARY_GROUP,
-            "messages": messages,
-        }
-        if max_completion_tokens is not None:
-            kwargs["max_completion_tokens"] = max_completion_tokens
-        if temperature is not None:
-            kwargs["temperature"] = temperature
-        return kwargs
-
-    async def call(
-        self,
-        messages: list[dict[str, str]],
-        response_format: Any | None = None,
-        max_completion_tokens: int | None = None,
-        temperature: float | None = None,
-        scope: str = "memory",
-        max_retries: int = 10,
-        initial_backoff: float = 1.0,
-        max_backoff: float = 60.0,
-        skip_validation: bool = False,
-        strict_schema: bool = False,
-        return_usage: bool = False,
-    ) -> Any:
-        start_time = time.time()
-        call_kwargs = self._build_call_kwargs(messages, max_completion_tokens, temperature)
-
-        if response_format is not None and hasattr(response_format, "model_json_schema"):
-            schema = response_format.model_json_schema()
-            call_kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": getattr(response_format, "__name__", "response"),
-                    "schema": schema,
-                    "strict": strict_schema,
-                },
-            }
-
-        last_exception: Exception | None = None
-
-        for attempt in range(max_retries + 1):
-            if attempt > 0:
-                set_stage(f"llm.litellmrouter.{scope}.attempt={attempt + 1}/{max_retries + 1}")
-            try:
-                response = await self._router.acompletion(**call_kwargs)
-
-                content = response.choices[0].message.content or ""
-                finish_reason = response.choices[0].finish_reason
-                # Router exposes the deployment that actually answered via response._hidden_params.
-                deployment_model = (
-                    getattr(response, "_hidden_params", {}).get("model")
-                    if hasattr(response, "_hidden_params")
-                    else None
-                ) or call_kwargs["model"]
-
-                if finish_reason == "length":
-                    raise OutputTooLongError("LiteLLM Router response was truncated due to token limit")
-
-                if response_format is not None:
-                    clean_content = content
-                    if "```json" in content:
-                        clean_content = content.split("```json")[1].split("```")[0].strip()
-                    elif "```" in content:
-                        clean_content = content.split("```")[1].split("```")[0].strip()
-                    try:
-                        json_data = json.loads(clean_content)
-                    except json.JSONDecodeError:
-                        json_data = json.loads(content)
-                    result = json_data if skip_validation else response_format.model_validate(json_data)
-                else:
-                    result = content
-
-                input_tokens = getattr(response.usage, "prompt_tokens", 0) or 0
-                output_tokens = getattr(response.usage, "completion_tokens", 0) or 0
-                total_tokens = input_tokens + output_tokens
-
-                duration = time.time() - start_time
-                metrics = get_metrics_collector()
-                metrics.record_llm_call(
-                    provider=self.provider,
-                    model=deployment_model,
-                    scope=scope,
-                    duration=duration,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    success=True,
-                )
-
-                from hindsight_api.tracing import _serialize_for_span, get_span_recorder
-
-                span_recorder = get_span_recorder()
-                span_recorder.record_llm_call(
-                    provider=self.provider,
-                    model=deployment_model,
-                    scope=scope,
-                    messages=messages,
-                    response_content=_serialize_for_span(result),
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    duration=duration,
-                    finish_reason=finish_reason,
-                    error=None,
-                )
-
-                if duration > 10.0:
-                    logger.info(
-                        f"slow llm call: scope={scope}, model={self.provider}/{deployment_model}, "
-                        f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
-                        f"time={duration:.3f}s"
-                    )
-
-                if return_usage:
-                    return result, TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=total_tokens,
-                    )
-                return result
-
-            except OutputTooLongError:
-                raise
-
-            except json.JSONDecodeError as e:
-                last_exception = e
-                if attempt < max_retries:
-                    logger.warning("LiteLLM Router returned invalid JSON, retrying...")
-                    backoff = min(initial_backoff * (2**attempt), max_backoff)
-                    await asyncio.sleep(backoff)
-                    continue
-                logger.error(f"LiteLLM Router returned invalid JSON after {max_retries + 1} attempts")
-                raise
-
-            except Exception as e:
-                error_str = str(e).lower()
-                if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
-                    logger.error(f"LiteLLM Router auth error, not retrying: {e}")
-                    raise
-
-                last_exception = e
-                if attempt < max_retries:
-                    is_retryable = any(
-                        keyword in error_str
-                        for keyword in ("rate", "limit", "timeout", "connection", "500", "502", "503", "529")
-                    )
-                    if is_retryable:
-                        backoff = min(initial_backoff * (2**attempt), max_backoff)
-                        jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
-                        await asyncio.sleep(backoff + jitter)
-                        continue
-
-                logger.error(f"LiteLLM Router API error after {attempt + 1} attempts: {e}")
-                raise
-
-        if last_exception:
-            raise last_exception
-        raise RuntimeError("LiteLLM Router call failed after all retries")
-
-    async def call_with_tools(
-        self,
-        messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]],
-        max_completion_tokens: int | None = None,
-        temperature: float | None = None,
-        scope: str = "tools",
-        max_retries: int = 5,
-        initial_backoff: float = 1.0,
-        max_backoff: float = 30.0,
-        tool_choice: str | dict[str, Any] = "auto",
-    ) -> LLMToolCallResult:
-        start_time = time.time()
-        call_kwargs = self._build_call_kwargs(messages, max_completion_tokens, temperature)
-        call_kwargs["tools"] = tools
-        call_kwargs["tool_choice"] = tool_choice
-
-        last_exception: Exception | None = None
-        for attempt in range(max_retries + 1):
-            if attempt > 0:
-                set_stage(f"llm.litellmrouter.tools.attempt={attempt + 1}/{max_retries + 1}")
-            try:
-                response = await self._router.acompletion(**call_kwargs)
-
-                message = response.choices[0].message
-                content = message.content
-                finish_reason = response.choices[0].finish_reason
-                deployment_model = (
-                    getattr(response, "_hidden_params", {}).get("model")
-                    if hasattr(response, "_hidden_params")
-                    else None
-                ) or call_kwargs["model"]
-
-                tool_calls: list[LLMToolCall] = []
-                if message.tool_calls:
-                    for tc in message.tool_calls:
-                        arguments = tc.function.arguments
-                        if isinstance(arguments, str):
-                            arguments = json.loads(arguments)
-                        tool_calls.append(
-                            LLMToolCall(
-                                id=tc.id,
-                                name=tc.function.name,
-                                arguments=arguments,
-                            )
-                        )
-
-                input_tokens = getattr(response.usage, "prompt_tokens", 0) or 0
-                output_tokens = getattr(response.usage, "completion_tokens", 0) or 0
-
-                duration = time.time() - start_time
-                metrics = get_metrics_collector()
-                metrics.record_llm_call(
-                    provider=self.provider,
-                    model=deployment_model,
-                    scope=scope,
-                    duration=duration,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    success=True,
-                )
-
-                from hindsight_api.tracing import get_span_recorder
-
-                span_recorder = get_span_recorder()
-                tool_calls_dict = (
-                    [{"id": tc.id, "name": tc.name, "arguments": tc.arguments} for tc in tool_calls]
-                    if tool_calls
-                    else None
-                )
-                span_recorder.record_llm_call(
-                    provider=self.provider,
-                    model=deployment_model,
-                    scope=scope,
-                    messages=messages,
-                    response_content=content,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    duration=duration,
-                    finish_reason=finish_reason,
-                    error=None,
-                    tool_calls=tool_calls_dict,
-                )
-
-                return LLMToolCallResult(
-                    content=content,
-                    tool_calls=tool_calls,
-                    finish_reason=finish_reason or ("tool_calls" if tool_calls else "stop"),
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                )
-
-            except Exception as e:
-                error_str = str(e).lower()
-                if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
-                    raise
-
-                last_exception = e
-                if attempt < max_retries:
-                    is_retryable = any(
-                        keyword in error_str
-                        for keyword in ("rate", "limit", "timeout", "connection", "500", "502", "503", "529")
-                    )
-                    if is_retryable:
-                        await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
-                        continue
-
-                logger.error(f"LiteLLM Router tool call error after {attempt + 1} attempts: {e}")
-                raise
-
-        if last_exception:
-            raise last_exception
-        raise RuntimeError("LiteLLM Router tool call failed after all retries")
-
-    async def cleanup(self) -> None:
-        """Clean up resources."""
-        pass

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -1,37 +1,32 @@
 """
-LiteLLM Router LLM provider — ordered fallback across multiple deployments.
+LiteLLM Router LLM provider — pure pass-through to ``litellm.Router``.
 
-Wraps ``litellm.Router`` with a chain of deployments. Requests are tried against
-the primary deployment first; on transient errors (rate-limit, timeout, 5xx) the
-Router falls back to subsequent deployments in declared order. Chain entries are
-modelled as distinct LiteLLM ``model_name`` groups so that the ``fallbacks`` map
-expresses the linear chain explicitly — this gives deterministic fallback order
-rather than the load-balancing behaviour you get from same-group deployments.
+The full configuration object is forwarded verbatim. We do not translate model
+names, infer fallbacks, or impose defaults: whatever the user puts in the
+``HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG`` env var becomes ``Router(**config)``.
+The only Hindsight-imposed convention is that requests are issued against the
+``model_name`` of the first entry in ``model_list``; chain ordering, fallbacks,
+load-balancing, retries and cooldowns are LiteLLM Router's responsibility.
 
-Auth-style errors (401/403) are not retried across deployments, since fallback
-on a misconfigured key would just propagate the failure.
+See https://docs.litellm.ai/docs/routing for the supported keys (``model_list``,
+``fallbacks``, ``context_window_fallbacks``, ``num_retries``, ``cooldown_time``,
+``routing_strategy``, ``allowed_fails``, …).
 
 The retry/parse/metrics loop is shared with ``LiteLLMLLM`` via inheritance: this
 class only overrides the small surface that differs (the completion fn, the
 deployment kwargs, and the deployment-name resolution for metrics).
 
-References:
-    - LiteLLM Router: https://docs.litellm.ai/docs/routing
-    - Router fallbacks: https://docs.litellm.ai/docs/routing#fallbacks
+Example ``HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG``::
 
-Chain entry shape (matches ``HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN``)::
-
-    [
-      {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
-      {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
-    ]
-
-Entries support arbitrary extra keys: anything not in
-``{provider, model, api_key, base_url, litellm_params}`` is forwarded to the
-LiteLLM Router deployment top-level (e.g. ``rpm``, ``tpm``, ``weight``,
-``model_info``). Anything inside a ``litellm_params`` sub-object is merged into
-the inner ``litellm_params`` dict (e.g. per-deployment ``temperature``,
-``extra_headers``).
+    {
+      "model_list": [
+        {"model_name": "primary",  "litellm_params": {"model": "openai/gpt-4o-mini",       "api_key": "sk-..."}},
+        {"model_name": "fallback", "litellm_params": {"model": "anthropic/claude-sonnet-4", "api_key": "sk-ant-..."}}
+      ],
+      "fallbacks": [{"primary": ["fallback"]}],
+      "num_retries": 0,
+      "cooldown_time": 60
+    }
 """
 
 import logging
@@ -42,94 +37,14 @@ from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
 logger = logging.getLogger(__name__)
 
 
-# Hindsight provider name → LiteLLM model prefix.
-# Providers not listed are treated as OpenAI-compatible: the configured base_url
-# carries the routing and the model is sent under the "openai/" prefix.
-_LITELLM_PROVIDER_PREFIX = {
-    "openai": "openai",
-    "anthropic": "anthropic",
-    "gemini": "gemini",
-    "vertexai": "vertex_ai",
-    "groq": "groq",
-    "deepseek": "deepseek",
-    "openrouter": "openrouter",
-    "bedrock": "bedrock",
-    "ollama": "ollama_chat",
-    "litellm": None,  # caller already provided a fully-qualified model string
-}
-
-# Primary group name. All chain entries fall back to subsequent indices.
-_PRIMARY_GROUP = "hindsight-chain-0"
-
-
-def _build_litellm_model(provider: str, model: str) -> str:
-    """Translate a Hindsight (provider, model) pair into a LiteLLM model string."""
-    if "/" in model:
-        return model  # caller pre-qualified the model, respect it
-    prefix = _LITELLM_PROVIDER_PREFIX.get(provider.lower(), "openai")
-    if prefix is None:
-        return model
-    return f"{prefix}/{model}"
-
-
-def _build_model_list(chain: list[dict[str, Any]], timeout: float) -> list[dict[str, Any]]:
-    """
-    Translate a Hindsight chain into a LiteLLM Router ``model_list``.
-
-    Known Hindsight keys (``provider``, ``model``, ``api_key``, ``base_url``) are
-    mapped onto LiteLLM's ``litellm_params``. Anything inside a ``litellm_params``
-    sub-object is merged into the inner dict (later wins). Any other top-level
-    key is forwarded verbatim to the deployment record (``rpm``, ``tpm``,
-    ``weight``, ``model_info`` …).
-    """
-    model_list: list[dict[str, Any]] = []
-    for i, raw_entry in enumerate(chain):
-        entry = dict(raw_entry)  # don't mutate caller data
-        provider = entry.pop("provider")
-        model = entry.pop("model")
-        api_key = entry.pop("api_key", None)
-        base_url = entry.pop("base_url", None)
-        nested_params = dict(entry.pop("litellm_params", {}) or {})
-
-        litellm_params: dict[str, Any] = {
-            "model": _build_litellm_model(provider, model),
-            "timeout": timeout,
-        }
-        if api_key:
-            litellm_params["api_key"] = api_key
-        if base_url:
-            litellm_params["api_base"] = base_url
-        # Caller-supplied litellm_params win over our defaults.
-        litellm_params.update(nested_params)
-
-        deployment: dict[str, Any] = {
-            "model_name": f"hindsight-chain-{i}",
-            "litellm_params": litellm_params,
-        }
-        # Any remaining keys are Router-level deployment fields (rpm, tpm, weight, ...).
-        deployment.update(entry)
-        model_list.append(deployment)
-    return model_list
-
-
-def _build_fallbacks(chain_length: int) -> list[dict[str, list[str]]]:
-    """Map the primary group to every subsequent chain index in declared order."""
-    if chain_length <= 1:
-        return []
-    return [{_PRIMARY_GROUP: [f"hindsight-chain-{i}" for i in range(1, chain_length)]}]
-
-
 class LiteLLMRouterLLM(LiteLLMLLM):
     """
-    LLM provider backed by ``litellm.Router`` with ordered fallback.
+    LLM provider backed by ``litellm.Router``.
 
-    Each entry in the chain becomes a distinct LiteLLM model_group; the primary
-    group is wired to fall back through the remaining groups in declared order.
-    Requests are always issued against the primary group — Router internally
-    re-issues against the fallback groups when the primary fails.
-
-    Inherits the retry/parse/metrics loop from ``LiteLLMLLM`` and only overrides
-    the small surface that differs.
+    The full Router config is supplied by the caller. We pass it verbatim to
+    ``Router(**config)`` and route requests against the first ``model_list``
+    entry's ``model_name``. Inherits the retry/parse/metrics loop from
+    ``LiteLLMLLM``; only the completion fn and the call kwargs differ.
     """
 
     def __init__(
@@ -138,7 +53,7 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         api_key: str,
         base_url: str,
         model: str,
-        chain: list[dict[str, Any]],
+        config: dict[str, Any],
         reasoning_effort: str = "low",
         timeout: float = 300.0,
         **kwargs: Any,
@@ -152,26 +67,25 @@ class LiteLLMRouterLLM(LiteLLMLLM):
             timeout=timeout,
             **kwargs,
         )
-        if not chain:
-            raise ValueError("LiteLLMRouterLLM requires a non-empty chain")
-        self.chain = chain
+        if not isinstance(config, dict) or not config.get("model_list"):
+            raise ValueError("LiteLLMRouterLLM requires a config dict with a non-empty 'model_list'")
+        first = config["model_list"][0]
+        primary_model_name = first.get("model_name") if isinstance(first, dict) else None
+        if not primary_model_name:
+            raise ValueError("LiteLLMRouterLLM: model_list[0] must have a 'model_name'")
+
+        self.config = config
+        self._primary_model_name = primary_model_name
 
         from litellm import Router
 
         logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+        self._router = Router(**config)
 
-        model_list = _build_model_list(chain, timeout=timeout)
-        fallbacks = _build_fallbacks(len(chain))
-        self._router = Router(
-            model_list=model_list,
-            fallbacks=fallbacks,
-            num_retries=0,  # outer loop in call()/call_with_tools() owns retries
-            allowed_fails=1,  # cooldown a deployment after a single failure within a window
-            cooldown_time=60,
+        logger.info(
+            f"LiteLLM Router initialized: {len(config['model_list'])} deployment(s), "
+            f"primary model_name={primary_model_name!r}"
         )
-
-        chain_summary = ", ".join(f"{e['provider']}/{e['model']}" for e in chain)
-        logger.info(f"LiteLLM Router initialized with {len(chain)} deployment(s): [{chain_summary}]")
 
     # ── overrides for the shared retry/parse loop ───────────────────────────
 
@@ -184,7 +98,7 @@ class LiteLLMRouterLLM(LiteLLMLLM):
 
     def _resolve_completion_model(self, response: Any) -> str:
         hidden = getattr(response, "_hidden_params", None) or {}
-        return hidden.get("model") or self.model
+        return hidden.get("model") or self._primary_model_name
 
     def _build_common_kwargs(
         self,
@@ -192,9 +106,10 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         max_completion_tokens: int | None = None,
         temperature: float | None = None,
     ) -> dict[str, Any]:
-        # Always issue against the primary group; Router handles deployment selection.
+        # Always issue against the primary group; Router handles deployment selection,
+        # cross-group fallbacks, retries, cooldowns — whatever the user configured.
         kwargs: dict[str, Any] = {
-            "model": _PRIMARY_GROUP,
+            "model": self._primary_model_name,
             "messages": messages,
         }
         if max_completion_tokens is not None:

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -1,0 +1,368 @@
+"""
+Tests for the LiteLLM Router LLM provider — chain config parsing, factory
+dispatch, and the Router-backed call paths (plain text, structured output,
+tool calls, retry on transient failure).
+"""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.config import (
+    ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN,
+    ENV_LLM_LITELLMROUTER_CHAIN,
+    ENV_LLM_PROVIDER,
+    ENV_REFLECT_LLM_LITELLMROUTER_CHAIN,
+    ENV_RETAIN_LLM_LITELLMROUTER_CHAIN,
+    HindsightConfig,
+    _parse_llm_router_chain,
+)
+from hindsight_api.engine.llm_wrapper import create_llm_provider
+from hindsight_api.engine.providers.litellm_router_llm import (
+    LiteLLMRouterLLM,
+    _build_fallbacks,
+    _build_litellm_model,
+    _build_model_list,
+)
+
+
+@pytest.fixture
+def two_step_chain() -> list[dict[str, Any]]:
+    return [
+        {
+            "provider": "openai",
+            "model": "MiniMax-M2.7",
+            "api_key": "sk-primary",
+            "base_url": "https://api.minimax.io/v1",
+        },
+        {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-fallback", "base_url": None},
+    ]
+
+
+@pytest.fixture
+def mock_router_response() -> MagicMock:
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "ok"
+    choice.message.tool_calls = None
+    choice.finish_reason = "stop"
+    response.choices = [choice]
+    response.usage.prompt_tokens = 12
+    response.usage.completion_tokens = 3
+    response._hidden_params = {"model": "openai/gpt-4o-mini"}
+    return response
+
+
+# --- chain parsing -----------------------------------------------------------
+
+
+class TestParseLLMRouterChain:
+    def test_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CHAIN, raising=False)
+        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) is None
+
+    def test_empty_string_returns_none(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "  ")
+        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) is None
+
+    def test_valid_chain(self, monkeypatch):
+        chain = [
+            {"provider": "openai", "model": "gpt-4o-mini", "api_key": "k1"},
+            {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "k2"},
+        ]
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps(chain))
+        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) == chain
+
+    def test_invalid_json(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "{not json")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+
+    def test_not_a_list(self, monkeypatch):
+        monkeypatch.setenv(
+            ENV_LLM_LITELLMROUTER_CHAIN,
+            json.dumps({"provider": "openai", "model": "x"}),
+        )
+        with pytest.raises(ValueError, match="non-empty JSON list"):
+            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+
+    def test_empty_list(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "[]")
+        with pytest.raises(ValueError, match="non-empty JSON list"):
+            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+
+    def test_missing_required_keys(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps([{"provider": "openai"}]))
+        with pytest.raises(ValueError, match="'provider' and 'model' are required"):
+            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+
+    def test_unknown_keys_rejected(self, monkeypatch):
+        monkeypatch.setenv(
+            ENV_LLM_LITELLMROUTER_CHAIN,
+            json.dumps([{"provider": "openai", "model": "gpt-4o", "weight": 5}]),
+        )
+        with pytest.raises(ValueError, match="unknown keys"):
+            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+
+
+class TestFromEnvLoadsChains:
+    def test_chain_loaded_when_provider_is_litellmrouter(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_PROVIDER, "litellmrouter")
+        monkeypatch.setenv(
+            ENV_LLM_LITELLMROUTER_CHAIN,
+            json.dumps(
+                [
+                    {"provider": "openai", "model": "gpt-4o-mini", "api_key": "k1"},
+                    {"provider": "openai", "model": "gpt-4o", "api_key": "k2"},
+                ]
+            ),
+        )
+        cfg = HindsightConfig.from_env()
+        # Provider name is whatever the user set — no auto-promotion.
+        assert cfg.llm_provider == "litellmrouter"
+        assert cfg.llm_litellmrouter_chain is not None
+        assert len(cfg.llm_litellmrouter_chain) == 2
+
+    def test_chain_unset_keeps_default_provider(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_PROVIDER, "openai")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-primary")
+        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CHAIN, raising=False)
+        cfg = HindsightConfig.from_env()
+        assert cfg.llm_provider == "openai"
+        assert cfg.llm_litellmrouter_chain is None
+
+    def test_per_op_chains_independent(self, monkeypatch):
+        """Per-op chain env vars populate per-op fields without affecting the default."""
+        monkeypatch.setenv(ENV_LLM_PROVIDER, "openai")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-primary")
+        monkeypatch.setenv(
+            ENV_RETAIN_LLM_LITELLMROUTER_CHAIN,
+            json.dumps([{"provider": "openai", "model": "retain-1", "api_key": "rk"}]),
+        )
+        monkeypatch.setenv(
+            ENV_REFLECT_LLM_LITELLMROUTER_CHAIN,
+            json.dumps([{"provider": "anthropic", "model": "claude", "api_key": "ak"}]),
+        )
+        monkeypatch.setenv(
+            ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN,
+            json.dumps([{"provider": "openai", "model": "consol-1", "api_key": "ck"}]),
+        )
+        cfg = HindsightConfig.from_env()
+        assert cfg.llm_litellmrouter_chain is None
+        assert cfg.retain_llm_litellmrouter_chain == [{"provider": "openai", "model": "retain-1", "api_key": "rk"}]
+        assert cfg.reflect_llm_litellmrouter_chain == [{"provider": "anthropic", "model": "claude", "api_key": "ak"}]
+        assert cfg.consolidation_llm_litellmrouter_chain == [
+            {"provider": "openai", "model": "consol-1", "api_key": "ck"}
+        ]
+
+
+# --- helper translation ------------------------------------------------------
+
+
+class TestModelTranslation:
+    def test_known_provider_prefixes(self):
+        assert _build_litellm_model("openai", "gpt-4o-mini") == "openai/gpt-4o-mini"
+        assert _build_litellm_model("anthropic", "claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
+        assert _build_litellm_model("gemini", "gemini-2.5-flash") == "gemini/gemini-2.5-flash"
+        assert _build_litellm_model("vertexai", "gemini-2.5-flash") == "vertex_ai/gemini-2.5-flash"
+
+    def test_unknown_provider_falls_back_to_openai(self):
+        # OpenAI-compatible providers (lmstudio, custom, etc.) route via openai/ + base_url
+        assert _build_litellm_model("lmstudio", "qwen3") == "openai/qwen3"
+        assert _build_litellm_model("minimax", "MiniMax-M2.7") == "openai/MiniMax-M2.7"
+
+    def test_pre_qualified_model_passes_through(self):
+        assert _build_litellm_model("openai", "anthropic/claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
+
+    def test_litellm_provider_uses_raw_model(self):
+        assert _build_litellm_model("litellm", "bedrock/anthropic.claude-3-5-sonnet") == (
+            "bedrock/anthropic.claude-3-5-sonnet"
+        )
+
+
+class TestModelListBuilder:
+    def test_builds_one_group_per_chain_entry(self, two_step_chain):
+        ml = _build_model_list(two_step_chain, timeout=30.0)
+        assert [d["model_name"] for d in ml] == ["hindsight-chain-0", "hindsight-chain-1"]
+        assert ml[0]["litellm_params"]["model"] == "openai/MiniMax-M2.7"
+        assert ml[0]["litellm_params"]["api_key"] == "sk-primary"
+        assert ml[0]["litellm_params"]["api_base"] == "https://api.minimax.io/v1"
+        assert ml[1]["litellm_params"]["model"] == "openai/gpt-4o-mini"
+        assert "api_base" not in ml[1]["litellm_params"]  # base_url=None should be omitted
+
+    def test_fallbacks_wired_in_order(self):
+        assert _build_fallbacks(1) == []
+        assert _build_fallbacks(2) == [{"hindsight-chain-0": ["hindsight-chain-1"]}]
+        assert _build_fallbacks(3) == [{"hindsight-chain-0": ["hindsight-chain-1", "hindsight-chain-2"]}]
+
+
+# --- factory dispatch --------------------------------------------------------
+
+
+class TestFactoryDispatch:
+    def test_router_provider_requires_chain(self):
+        with pytest.raises(ValueError, match="non-empty chain"):
+            create_llm_provider(
+                provider="litellmrouter",
+                api_key="",
+                base_url="",
+                model="unused",
+                reasoning_effort="low",
+                chain=None,
+            )
+
+    def test_router_provider_returns_router_impl(self, two_step_chain):
+        with patch.dict("sys.modules", {"litellm": MagicMock(), "litellm.Router": MagicMock()}):
+            with patch(
+                "hindsight_api.engine.providers.litellm_router_llm.LiteLLMRouterLLM.__init__",
+                return_value=None,
+            ) as mock_init:
+                impl = create_llm_provider(
+                    provider="litellmrouter",
+                    api_key="",
+                    base_url="",
+                    model="unused",
+                    reasoning_effort="low",
+                    chain=two_step_chain,
+                )
+                assert isinstance(impl, LiteLLMRouterLLM)
+                mock_init.assert_called_once()
+                _, kwargs = mock_init.call_args
+                assert kwargs["chain"] == two_step_chain
+
+
+# --- Router-backed call paths ------------------------------------------------
+
+
+def _make_router_provider(chain: list[dict[str, Any]], mock_router: Any) -> LiteLLMRouterLLM:
+    """Construct a LiteLLMRouterLLM with the inner Router replaced by a mock."""
+    fake_litellm = MagicMock()
+    fake_router_cls = MagicMock(return_value=mock_router)
+    fake_litellm.Router = fake_router_cls
+    with patch.dict("sys.modules", {"litellm": fake_litellm}):
+        with patch(
+            "hindsight_api.engine.providers.litellm_router_llm.Router",
+            fake_router_cls,
+            create=True,
+        ):
+            # Bypass the import inside __init__ by injecting directly via attribute swap.
+            provider = LiteLLMRouterLLM.__new__(LiteLLMRouterLLM)
+            # Initialise the LLMInterface base attrs without invoking the heavy ctor.
+            provider.provider = "litellmrouter"
+            provider.api_key = ""
+            provider.base_url = ""
+            provider.model = "unused"
+            provider.reasoning_effort = "low"
+            provider.timeout = 300.0
+            provider.chain = chain
+            provider._litellm = fake_litellm
+            provider._router = mock_router
+            return provider
+
+
+class TestRouterCall:
+    @pytest.mark.asyncio
+    async def test_plain_text_call(self, two_step_chain, mock_router_response):
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(return_value=mock_router_response)
+        provider = _make_router_provider(two_step_chain, mock_router)
+
+        result = await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_completion_tokens=50,
+            max_retries=0,
+        )
+        assert result == "ok"
+        # Always invoked against the primary group; Router handles fallback internally.
+        kwargs = mock_router.acompletion.await_args.kwargs
+        assert kwargs["model"] == "hindsight-chain-0"
+
+    @pytest.mark.asyncio
+    async def test_structured_output(self, two_step_chain):
+        class MySchema(BaseModel):
+            answer: str
+
+        response = MagicMock()
+        choice = MagicMock()
+        choice.message.content = '{"answer": "42"}'
+        choice.message.tool_calls = None
+        choice.finish_reason = "stop"
+        response.choices = [choice]
+        response.usage.prompt_tokens = 5
+        response.usage.completion_tokens = 5
+        response._hidden_params = {"model": "openai/gpt-4o-mini"}
+
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(return_value=response)
+        provider = _make_router_provider(two_step_chain, mock_router)
+
+        result = await provider.call(
+            messages=[{"role": "user", "content": "q"}],
+            response_format=MySchema,
+            max_retries=0,
+        )
+        assert isinstance(result, MySchema)
+        assert result.answer == "42"
+
+    @pytest.mark.asyncio
+    async def test_retry_on_transient_then_success(self, two_step_chain, mock_router_response):
+        mock_router = MagicMock()
+        # First call raises a 503-style error, second call returns ok.
+        mock_router.acompletion = AsyncMock(side_effect=[Exception("503 Service Unavailable"), mock_router_response])
+        provider = _make_router_provider(two_step_chain, mock_router)
+
+        result = await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=2,
+            initial_backoff=0.0,  # no real sleep in tests
+            max_backoff=0.0,
+        )
+        assert result == "ok"
+        assert mock_router.acompletion.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_auth_error_does_not_retry(self, two_step_chain):
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(side_effect=Exception("401 Unauthorized: bad key"))
+        provider = _make_router_provider(two_step_chain, mock_router)
+
+        with pytest.raises(Exception, match="401"):
+            await provider.call(
+                messages=[{"role": "user", "content": "hi"}],
+                max_retries=5,
+                initial_backoff=0.0,
+            )
+        assert mock_router.acompletion.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_call_with_tools(self, two_step_chain):
+        response = MagicMock()
+        choice = MagicMock()
+        choice.message.content = None
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function.name = "lookup"
+        tool_call.function.arguments = '{"q": "x"}'
+        choice.message.tool_calls = [tool_call]
+        choice.finish_reason = "tool_calls"
+        response.choices = [choice]
+        response.usage.prompt_tokens = 5
+        response.usage.completion_tokens = 2
+        response._hidden_params = {"model": "openai/gpt-4o-mini"}
+
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(return_value=response)
+        provider = _make_router_provider(two_step_chain, mock_router)
+
+        result = await provider.call_with_tools(
+            messages=[{"role": "user", "content": "use tool"}],
+            tools=[{"type": "function", "function": {"name": "lookup", "parameters": {}}}],
+            max_retries=0,
+        )
+        assert result.content is None
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "lookup"
+        assert result.tool_calls[0].arguments == {"q": "x"}

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -1,7 +1,11 @@
 """
-Tests for the LiteLLM Router LLM provider — chain config parsing, factory
-dispatch, and the Router-backed call paths (plain text, structured output,
-tool calls, retry on transient failure).
+Tests for the LiteLLM Router LLM provider — config parsing, factory dispatch,
+and the Router-backed call paths (plain text, structured output, tool calls,
+retry on transient failure).
+
+The provider is a thin pass-through to ``litellm.Router``. The chain config
+shape mirrors LiteLLM's API; we don't translate model names or impose
+fallbacks. See https://docs.litellm.ai/docs/routing.
 """
 
 import json
@@ -12,34 +16,39 @@ import pytest
 from pydantic import BaseModel
 
 from hindsight_api.config import (
-    ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN,
-    ENV_LLM_LITELLMROUTER_CHAIN,
+    ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG,
+    ENV_LLM_LITELLMROUTER_CONFIG,
     ENV_LLM_PROVIDER,
-    ENV_REFLECT_LLM_LITELLMROUTER_CHAIN,
-    ENV_RETAIN_LLM_LITELLMROUTER_CHAIN,
+    ENV_REFLECT_LLM_LITELLMROUTER_CONFIG,
+    ENV_RETAIN_LLM_LITELLMROUTER_CONFIG,
     HindsightConfig,
-    _parse_llm_router_chain,
+    _parse_llm_router_config,
 )
 from hindsight_api.engine.llm_wrapper import create_llm_provider
-from hindsight_api.engine.providers.litellm_router_llm import (
-    LiteLLMRouterLLM,
-    _build_fallbacks,
-    _build_litellm_model,
-    _build_model_list,
-)
+from hindsight_api.engine.providers.litellm_router_llm import LiteLLMRouterLLM
 
 
 @pytest.fixture
-def two_step_chain() -> list[dict[str, Any]]:
-    return [
-        {
-            "provider": "openai",
-            "model": "MiniMax-M2.7",
-            "api_key": "sk-primary",
-            "base_url": "https://api.minimax.io/v1",
-        },
-        {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-fallback", "base_url": None},
-    ]
+def two_step_config() -> dict[str, Any]:
+    """Raw LiteLLM Router config: two deployments wired for ordered fallback."""
+    return {
+        "model_list": [
+            {
+                "model_name": "primary",
+                "litellm_params": {
+                    "model": "openai/MiniMax-M2.7",
+                    "api_key": "sk-primary",
+                    "api_base": "https://api.minimax.io/v1",
+                },
+            },
+            {
+                "model_name": "fallback",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-fallback"},
+            },
+        ],
+        "fallbacks": [{"primary": ["fallback"]}],
+        "num_retries": 0,
+    }
 
 
 @pytest.fixture
@@ -56,209 +65,108 @@ def mock_router_response() -> MagicMock:
     return response
 
 
-# --- chain parsing -----------------------------------------------------------
+# --- config parsing ----------------------------------------------------------
 
 
-class TestParseLLMRouterChain:
+class TestParseRouterConfig:
     def test_unset_returns_none(self, monkeypatch):
-        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CHAIN, raising=False)
-        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) is None
+        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CONFIG, raising=False)
+        assert _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) is None
 
     def test_empty_string_returns_none(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "  ")
-        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) is None
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, "  ")
+        assert _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) is None
 
-    def test_valid_chain(self, monkeypatch):
-        chain = [
-            {"provider": "openai", "model": "gpt-4o-mini", "api_key": "k1"},
-            {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "k2"},
-        ]
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps(chain))
-        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) == chain
+    def test_valid_config_passes_through(self, monkeypatch, two_step_config):
+        """Whatever the user provides round-trips verbatim — no translation."""
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps(two_step_config))
+        assert _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) == two_step_config
 
     def test_invalid_json(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "{not json")
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, "{not json")
         with pytest.raises(ValueError, match="invalid JSON"):
-            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
 
-    def test_not_a_list(self, monkeypatch):
+    def test_must_be_object(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps([{"model_name": "x"}]))
+        with pytest.raises(ValueError, match="JSON object"):
+            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
+
+    def test_model_list_required(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps({"fallbacks": []}))
+        with pytest.raises(ValueError, match="'model_list' must be a non-empty list"):
+            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
+
+    def test_model_list_empty(self, monkeypatch):
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps({"model_list": []}))
+        with pytest.raises(ValueError, match="'model_list' must be a non-empty list"):
+            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
+
+    def test_entry_must_have_model_name(self, monkeypatch):
         monkeypatch.setenv(
-            ENV_LLM_LITELLMROUTER_CHAIN,
-            json.dumps({"provider": "openai", "model": "x"}),
+            ENV_LLM_LITELLMROUTER_CONFIG,
+            json.dumps({"model_list": [{"litellm_params": {"model": "openai/gpt-4o"}}]}),
         )
-        with pytest.raises(ValueError, match="non-empty JSON list"):
-            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
-
-    def test_empty_list(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, "[]")
-        with pytest.raises(ValueError, match="non-empty JSON list"):
-            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
-
-    def test_missing_required_keys(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps([{"provider": "openai"}]))
-        with pytest.raises(ValueError, match="'provider' and 'model' are required"):
-            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
-
-    def test_extra_keys_pass_through(self, monkeypatch):
-        """Unknown keys are forwarded to LiteLLM verbatim — the parser only requires provider+model."""
-        chain = [
-            {
-                "provider": "openai",
-                "model": "gpt-4o",
-                "api_key": "k",
-                "rpm": 1000,
-                "tpm": 100000,
-                "weight": 5,
-                "litellm_params": {"temperature": 0.7},
-            }
-        ]
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps(chain))
-        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) == chain
+        with pytest.raises(ValueError, match="'model_name' is required"):
+            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
 
 
-class TestFromEnvLoadsChains:
-    def test_chain_loaded_when_provider_is_litellmrouter(self, monkeypatch):
+class TestFromEnvLoadsConfig:
+    def test_loaded_when_provider_is_litellmrouter(self, monkeypatch, two_step_config):
         monkeypatch.setenv(ENV_LLM_PROVIDER, "litellmrouter")
-        monkeypatch.setenv(
-            ENV_LLM_LITELLMROUTER_CHAIN,
-            json.dumps(
-                [
-                    {"provider": "openai", "model": "gpt-4o-mini", "api_key": "k1"},
-                    {"provider": "openai", "model": "gpt-4o", "api_key": "k2"},
-                ]
-            ),
-        )
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps(two_step_config))
         cfg = HindsightConfig.from_env()
-        # Provider name is whatever the user set — no auto-promotion.
         assert cfg.llm_provider == "litellmrouter"
-        assert cfg.llm_litellmrouter_chain is not None
-        assert len(cfg.llm_litellmrouter_chain) == 2
+        assert cfg.llm_litellmrouter_config == two_step_config
 
-    def test_chain_unset_keeps_default_provider(self, monkeypatch):
+    def test_unset_keeps_default_provider(self, monkeypatch):
         monkeypatch.setenv(ENV_LLM_PROVIDER, "openai")
         monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-primary")
-        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CHAIN, raising=False)
+        monkeypatch.delenv(ENV_LLM_LITELLMROUTER_CONFIG, raising=False)
         cfg = HindsightConfig.from_env()
         assert cfg.llm_provider == "openai"
-        assert cfg.llm_litellmrouter_chain is None
+        assert cfg.llm_litellmrouter_config is None
 
-    def test_per_op_chains_independent(self, monkeypatch):
-        """Per-op chain env vars populate per-op fields without affecting the default."""
+    def test_per_op_configs_independent(self, monkeypatch):
+        """Per-op env vars populate per-op fields without touching the default."""
+        retain_config = {
+            "model_list": [{"model_name": "r", "litellm_params": {"model": "openai/retain", "api_key": "rk"}}]
+        }
+        reflect_config = {
+            "model_list": [{"model_name": "f", "litellm_params": {"model": "anthropic/claude", "api_key": "ak"}}]
+        }
+        consol_config = {
+            "model_list": [{"model_name": "c", "litellm_params": {"model": "openai/consol", "api_key": "ck"}}]
+        }
         monkeypatch.setenv(ENV_LLM_PROVIDER, "openai")
         monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-primary")
-        monkeypatch.setenv(
-            ENV_RETAIN_LLM_LITELLMROUTER_CHAIN,
-            json.dumps([{"provider": "openai", "model": "retain-1", "api_key": "rk"}]),
-        )
-        monkeypatch.setenv(
-            ENV_REFLECT_LLM_LITELLMROUTER_CHAIN,
-            json.dumps([{"provider": "anthropic", "model": "claude", "api_key": "ak"}]),
-        )
-        monkeypatch.setenv(
-            ENV_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN,
-            json.dumps([{"provider": "openai", "model": "consol-1", "api_key": "ck"}]),
-        )
+        monkeypatch.setenv(ENV_RETAIN_LLM_LITELLMROUTER_CONFIG, json.dumps(retain_config))
+        monkeypatch.setenv(ENV_REFLECT_LLM_LITELLMROUTER_CONFIG, json.dumps(reflect_config))
+        monkeypatch.setenv(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG, json.dumps(consol_config))
         cfg = HindsightConfig.from_env()
-        assert cfg.llm_litellmrouter_chain is None
-        assert cfg.retain_llm_litellmrouter_chain == [{"provider": "openai", "model": "retain-1", "api_key": "rk"}]
-        assert cfg.reflect_llm_litellmrouter_chain == [{"provider": "anthropic", "model": "claude", "api_key": "ak"}]
-        assert cfg.consolidation_llm_litellmrouter_chain == [
-            {"provider": "openai", "model": "consol-1", "api_key": "ck"}
-        ]
-
-
-# --- helper translation ------------------------------------------------------
-
-
-class TestModelTranslation:
-    def test_known_provider_prefixes(self):
-        assert _build_litellm_model("openai", "gpt-4o-mini") == "openai/gpt-4o-mini"
-        assert _build_litellm_model("anthropic", "claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
-        assert _build_litellm_model("gemini", "gemini-2.5-flash") == "gemini/gemini-2.5-flash"
-        assert _build_litellm_model("vertexai", "gemini-2.5-flash") == "vertex_ai/gemini-2.5-flash"
-
-    def test_unknown_provider_falls_back_to_openai(self):
-        # OpenAI-compatible providers (lmstudio, custom, etc.) route via openai/ + base_url
-        assert _build_litellm_model("lmstudio", "qwen3") == "openai/qwen3"
-        assert _build_litellm_model("minimax", "MiniMax-M2.7") == "openai/MiniMax-M2.7"
-
-    def test_pre_qualified_model_passes_through(self):
-        assert _build_litellm_model("openai", "anthropic/claude-sonnet-4-5") == "anthropic/claude-sonnet-4-5"
-
-    def test_litellm_provider_uses_raw_model(self):
-        assert _build_litellm_model("litellm", "bedrock/anthropic.claude-3-5-sonnet") == (
-            "bedrock/anthropic.claude-3-5-sonnet"
-        )
-
-
-class TestModelListBuilder:
-    def test_builds_one_group_per_chain_entry(self, two_step_chain):
-        ml = _build_model_list(two_step_chain, timeout=30.0)
-        assert [d["model_name"] for d in ml] == ["hindsight-chain-0", "hindsight-chain-1"]
-        assert ml[0]["litellm_params"]["model"] == "openai/MiniMax-M2.7"
-        assert ml[0]["litellm_params"]["api_key"] == "sk-primary"
-        assert ml[0]["litellm_params"]["api_base"] == "https://api.minimax.io/v1"
-        assert ml[1]["litellm_params"]["model"] == "openai/gpt-4o-mini"
-        assert "api_base" not in ml[1]["litellm_params"]  # base_url=None should be omitted
-
-    def test_fallbacks_wired_in_order(self):
-        assert _build_fallbacks(1) == []
-        assert _build_fallbacks(2) == [{"hindsight-chain-0": ["hindsight-chain-1"]}]
-        assert _build_fallbacks(3) == [{"hindsight-chain-0": ["hindsight-chain-1", "hindsight-chain-2"]}]
-
-    def test_extra_keys_flow_through(self):
-        """Top-level extra keys go to deployment top-level; ``litellm_params`` nests merge into litellm_params."""
-        chain = [
-            {
-                "provider": "openai",
-                "model": "gpt-4o",
-                "api_key": "k",
-                "rpm": 1000,
-                "tpm": 50000,
-                "weight": 7,
-                "model_info": {"id": "abc"},
-                "litellm_params": {"temperature": 0.5, "extra_headers": {"X-Trace": "1"}},
-            }
-        ]
-        ml = _build_model_list(chain, timeout=10.0)
-        deployment = ml[0]
-        # Top-level Router fields
-        assert deployment["rpm"] == 1000
-        assert deployment["tpm"] == 50000
-        assert deployment["weight"] == 7
-        assert deployment["model_info"] == {"id": "abc"}
-        # Nested litellm_params merged on top of our defaults
-        params = deployment["litellm_params"]
-        assert params["model"] == "openai/gpt-4o"
-        assert params["api_key"] == "k"
-        assert params["temperature"] == 0.5
-        assert params["extra_headers"] == {"X-Trace": "1"}
-
-    def test_caller_data_not_mutated(self):
-        """The builder must not mutate the user-supplied chain."""
-        chain = [{"provider": "openai", "model": "gpt-4o", "rpm": 100}]
-        snapshot = json.dumps(chain)
-        _build_model_list(chain, timeout=10.0)
-        assert json.dumps(chain) == snapshot
+        assert cfg.llm_litellmrouter_config is None
+        assert cfg.retain_llm_litellmrouter_config == retain_config
+        assert cfg.reflect_llm_litellmrouter_config == reflect_config
+        assert cfg.consolidation_llm_litellmrouter_config == consol_config
 
 
 # --- factory dispatch --------------------------------------------------------
 
 
 class TestFactoryDispatch:
-    def test_router_provider_requires_chain(self):
-        with pytest.raises(ValueError, match="non-empty chain"):
+    def test_router_provider_requires_config(self):
+        with pytest.raises(ValueError, match="config object"):
             create_llm_provider(
                 provider="litellmrouter",
                 api_key="",
                 base_url="",
                 model="unused",
                 reasoning_effort="low",
-                chain=None,
+                litellmrouter_config=None,
             )
 
-    def test_router_provider_returns_router_impl(self, two_step_chain):
-        with patch.dict("sys.modules", {"litellm": MagicMock(), "litellm.Router": MagicMock()}):
+    def test_router_provider_returns_router_impl(self, two_step_config):
+        with patch.dict("sys.modules", {"litellm": MagicMock()}):
             with patch(
                 "hindsight_api.engine.providers.litellm_router_llm.LiteLLMRouterLLM.__init__",
                 return_value=None,
@@ -269,49 +177,42 @@ class TestFactoryDispatch:
                     base_url="",
                     model="unused",
                     reasoning_effort="low",
-                    chain=two_step_chain,
+                    litellmrouter_config=two_step_config,
                 )
                 assert isinstance(impl, LiteLLMRouterLLM)
-                mock_init.assert_called_once()
                 _, kwargs = mock_init.call_args
-                assert kwargs["chain"] == two_step_chain
+                assert kwargs["config"] == two_step_config
 
 
 # --- Router-backed call paths ------------------------------------------------
 
 
-def _make_router_provider(chain: list[dict[str, Any]], mock_router: Any) -> LiteLLMRouterLLM:
+def _make_router_provider(config: dict[str, Any], mock_router: Any) -> LiteLLMRouterLLM:
     """Construct a LiteLLMRouterLLM with the inner Router replaced by a mock."""
     fake_litellm = MagicMock()
-    fake_router_cls = MagicMock(return_value=mock_router)
-    fake_litellm.Router = fake_router_cls
+    fake_litellm.Router = MagicMock(return_value=mock_router)
     with patch.dict("sys.modules", {"litellm": fake_litellm}):
-        with patch(
-            "hindsight_api.engine.providers.litellm_router_llm.Router",
-            fake_router_cls,
-            create=True,
-        ):
-            # Bypass the import inside __init__ by injecting directly via attribute swap.
-            provider = LiteLLMRouterLLM.__new__(LiteLLMRouterLLM)
-            # Initialise the LLMInterface base attrs without invoking the heavy ctor.
-            provider.provider = "litellmrouter"
-            provider.api_key = ""
-            provider.base_url = ""
-            provider.model = "unused"
-            provider.reasoning_effort = "low"
-            provider.timeout = 300.0
-            provider.chain = chain
-            provider._litellm = fake_litellm
-            provider._router = mock_router
-            return provider
+        # Bypass the heavy ctor chain by injecting state directly.
+        provider = LiteLLMRouterLLM.__new__(LiteLLMRouterLLM)
+        provider.provider = "litellmrouter"
+        provider.api_key = ""
+        provider.base_url = ""
+        provider.model = "unused"
+        provider.reasoning_effort = "low"
+        provider.timeout = 300.0
+        provider.config = config
+        provider._litellm = fake_litellm
+        provider._router = mock_router
+        provider._primary_model_name = config["model_list"][0]["model_name"]
+        return provider
 
 
 class TestRouterCall:
     @pytest.mark.asyncio
-    async def test_plain_text_call(self, two_step_chain, mock_router_response):
+    async def test_plain_text_call_targets_first_model_name(self, two_step_config, mock_router_response):
         mock_router = MagicMock()
         mock_router.acompletion = AsyncMock(return_value=mock_router_response)
-        provider = _make_router_provider(two_step_chain, mock_router)
+        provider = _make_router_provider(two_step_config, mock_router)
 
         result = await provider.call(
             messages=[{"role": "user", "content": "hi"}],
@@ -319,12 +220,12 @@ class TestRouterCall:
             max_retries=0,
         )
         assert result == "ok"
-        # Always invoked against the primary group; Router handles fallback internally.
+        # First entry's model_name is what we route against; Router handles fallback.
         kwargs = mock_router.acompletion.await_args.kwargs
-        assert kwargs["model"] == "hindsight-chain-0"
+        assert kwargs["model"] == "primary"
 
     @pytest.mark.asyncio
-    async def test_structured_output(self, two_step_chain):
+    async def test_structured_output(self, two_step_config):
         class MySchema(BaseModel):
             answer: str
 
@@ -340,7 +241,7 @@ class TestRouterCall:
 
         mock_router = MagicMock()
         mock_router.acompletion = AsyncMock(return_value=response)
-        provider = _make_router_provider(two_step_chain, mock_router)
+        provider = _make_router_provider(two_step_config, mock_router)
 
         result = await provider.call(
             messages=[{"role": "user", "content": "q"}],
@@ -351,26 +252,26 @@ class TestRouterCall:
         assert result.answer == "42"
 
     @pytest.mark.asyncio
-    async def test_retry_on_transient_then_success(self, two_step_chain, mock_router_response):
+    async def test_retry_on_transient_then_success(self, two_step_config, mock_router_response):
         mock_router = MagicMock()
         # First call raises a 503-style error, second call returns ok.
         mock_router.acompletion = AsyncMock(side_effect=[Exception("503 Service Unavailable"), mock_router_response])
-        provider = _make_router_provider(two_step_chain, mock_router)
+        provider = _make_router_provider(two_step_config, mock_router)
 
         result = await provider.call(
             messages=[{"role": "user", "content": "hi"}],
             max_retries=2,
-            initial_backoff=0.0,  # no real sleep in tests
+            initial_backoff=0.0,
             max_backoff=0.0,
         )
         assert result == "ok"
         assert mock_router.acompletion.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_auth_error_does_not_retry(self, two_step_chain):
+    async def test_auth_error_does_not_retry(self, two_step_config):
         mock_router = MagicMock()
         mock_router.acompletion = AsyncMock(side_effect=Exception("401 Unauthorized: bad key"))
-        provider = _make_router_provider(two_step_chain, mock_router)
+        provider = _make_router_provider(two_step_config, mock_router)
 
         with pytest.raises(Exception, match="401"):
             await provider.call(
@@ -381,7 +282,7 @@ class TestRouterCall:
         assert mock_router.acompletion.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_call_with_tools(self, two_step_chain):
+    async def test_call_with_tools(self, two_step_config):
         response = MagicMock()
         choice = MagicMock()
         choice.message.content = None
@@ -398,7 +299,7 @@ class TestRouterCall:
 
         mock_router = MagicMock()
         mock_router.acompletion = AsyncMock(return_value=response)
-        provider = _make_router_provider(two_step_chain, mock_router)
+        provider = _make_router_provider(two_step_config, mock_router)
 
         result = await provider.call_with_tools(
             messages=[{"role": "user", "content": "use tool"}],

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -197,6 +197,7 @@ def _make_router_provider(config: dict[str, Any], mock_router: Any) -> LiteLLMRo
         provider.config = config
         provider._litellm = fake_litellm
         provider._router = mock_router
+        provider._router_output_cap = None  # tests that exercise the cap override this directly
         return provider
 
 
@@ -274,6 +275,44 @@ class TestRouterCall:
                 initial_backoff=0.0,
             )
         assert mock_router.acompletion.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_caps_max_completion_tokens_to_litellm_registry(self, two_step_config, mock_router_response):
+        """Cap max_completion_tokens to the most conservative deployment limit.
+
+        Hindsight's defaults (e.g. retain_max_completion_tokens=64000) target
+        high-capacity models. When a configured deployment has a smaller cap
+        (gpt-4.1-nano = 32768), the call would otherwise be rejected — apply
+        the cap silently using LiteLLM's per-model registry.
+        """
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(return_value=mock_router_response)
+        provider = _make_router_provider(two_step_config, mock_router)
+        provider._router_output_cap = 32768  # what _compute_router_output_cap would yield
+
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_completion_tokens=64000,  # over the cap
+            max_retries=0,
+        )
+        kwargs = mock_router.acompletion.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 32768
+
+    @pytest.mark.asyncio
+    async def test_no_cap_when_litellm_registry_has_no_data(self, two_step_config, mock_router_response):
+        """If LiteLLM doesn't know any of the deployment models, pass the requested value through."""
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock(return_value=mock_router_response)
+        provider = _make_router_provider(two_step_config, mock_router)
+        provider._router_output_cap = None
+
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_completion_tokens=64000,
+            max_retries=0,
+        )
+        kwargs = mock_router.acompletion.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 64000
 
     @pytest.mark.asyncio
     async def test_call_with_tools(self, two_step_config):

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -30,11 +30,16 @@ from hindsight_api.engine.providers.litellm_router_llm import LiteLLMRouterLLM
 
 @pytest.fixture
 def two_step_config() -> dict[str, Any]:
-    """Raw LiteLLM Router config: two deployments wired for ordered fallback."""
+    """Raw LiteLLM Router config: two deployments wired for ordered fallback.
+
+    Hindsight always issues completions against ``model_name="default"``;
+    additional groups become fallback / load-balance pool members per the
+    user's ``fallbacks`` / ``routing_strategy`` settings.
+    """
     return {
         "model_list": [
             {
-                "model_name": "primary",
+                "model_name": "default",
                 "litellm_params": {
                     "model": "openai/MiniMax-M2.7",
                     "api_key": "sk-primary",
@@ -46,7 +51,7 @@ def two_step_config() -> dict[str, Any]:
                 "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-fallback"},
             },
         ],
-        "fallbacks": [{"primary": ["fallback"]}],
+        "fallbacks": [{"default": ["fallback"]}],
         "num_retries": 0,
     }
 
@@ -87,28 +92,17 @@ class TestParseRouterConfig:
         with pytest.raises(ValueError, match="invalid JSON"):
             _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
 
-    def test_must_be_object(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps([{"model_name": "x"}]))
-        with pytest.raises(ValueError, match="JSON object"):
-            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
+    def test_no_shape_validation(self, monkeypatch):
+        """We don't validate the shape — anything that parses as JSON gets passed through.
 
-    def test_model_list_required(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps({"fallbacks": []}))
-        with pytest.raises(ValueError, match="'model_list' must be a non-empty list"):
-            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
-
-    def test_model_list_empty(self, monkeypatch):
-        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps({"model_list": []}))
-        with pytest.raises(ValueError, match="'model_list' must be a non-empty list"):
-            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
-
-    def test_entry_must_have_model_name(self, monkeypatch):
-        monkeypatch.setenv(
-            ENV_LLM_LITELLMROUTER_CONFIG,
-            json.dumps({"model_list": [{"litellm_params": {"model": "openai/gpt-4o"}}]}),
-        )
-        with pytest.raises(ValueError, match="'model_name' is required"):
-            _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG)
+        LiteLLM Router is authoritative for shape errors; we let them surface at
+        Router construction time rather than pre-validating.
+        """
+        # A list, a string, an object with junk keys — all accepted by the parser.
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps([{"hello": "world"}]))
+        assert _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) == [{"hello": "world"}]
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CONFIG, json.dumps({"only": "garbage"}))
+        assert _parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG) == {"only": "garbage"}
 
 
 class TestFromEnvLoadsConfig:
@@ -203,13 +197,12 @@ def _make_router_provider(config: dict[str, Any], mock_router: Any) -> LiteLLMRo
         provider.config = config
         provider._litellm = fake_litellm
         provider._router = mock_router
-        provider._primary_model_name = config["model_list"][0]["model_name"]
         return provider
 
 
 class TestRouterCall:
     @pytest.mark.asyncio
-    async def test_plain_text_call_targets_first_model_name(self, two_step_config, mock_router_response):
+    async def test_plain_text_call_targets_default_entrypoint(self, two_step_config, mock_router_response):
         mock_router = MagicMock()
         mock_router.acompletion = AsyncMock(return_value=mock_router_response)
         provider = _make_router_provider(two_step_config, mock_router)
@@ -220,9 +213,10 @@ class TestRouterCall:
             max_retries=0,
         )
         assert result == "ok"
-        # First entry's model_name is what we route against; Router handles fallback.
+        # Hindsight always issues against model_name="default"; Router handles fallback,
+        # load-balancing, and routing strategy from there.
         kwargs = mock_router.acompletion.await_args.kwargs
-        assert kwargs["model"] == "primary"
+        assert kwargs["model"] == "default"
 
     @pytest.mark.asyncio
     async def test_structured_output(self, two_step_config):

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -99,13 +99,21 @@ class TestParseLLMRouterChain:
         with pytest.raises(ValueError, match="'provider' and 'model' are required"):
             _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
 
-    def test_unknown_keys_rejected(self, monkeypatch):
-        monkeypatch.setenv(
-            ENV_LLM_LITELLMROUTER_CHAIN,
-            json.dumps([{"provider": "openai", "model": "gpt-4o", "weight": 5}]),
-        )
-        with pytest.raises(ValueError, match="unknown keys"):
-            _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN)
+    def test_extra_keys_pass_through(self, monkeypatch):
+        """Unknown keys are forwarded to LiteLLM verbatim — the parser only requires provider+model."""
+        chain = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "k",
+                "rpm": 1000,
+                "tpm": 100000,
+                "weight": 5,
+                "litellm_params": {"temperature": 0.7},
+            }
+        ]
+        monkeypatch.setenv(ENV_LLM_LITELLMROUTER_CHAIN, json.dumps(chain))
+        assert _parse_llm_router_chain(ENV_LLM_LITELLMROUTER_CHAIN) == chain
 
 
 class TestFromEnvLoadsChains:
@@ -197,6 +205,41 @@ class TestModelListBuilder:
         assert _build_fallbacks(1) == []
         assert _build_fallbacks(2) == [{"hindsight-chain-0": ["hindsight-chain-1"]}]
         assert _build_fallbacks(3) == [{"hindsight-chain-0": ["hindsight-chain-1", "hindsight-chain-2"]}]
+
+    def test_extra_keys_flow_through(self):
+        """Top-level extra keys go to deployment top-level; ``litellm_params`` nests merge into litellm_params."""
+        chain = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "k",
+                "rpm": 1000,
+                "tpm": 50000,
+                "weight": 7,
+                "model_info": {"id": "abc"},
+                "litellm_params": {"temperature": 0.5, "extra_headers": {"X-Trace": "1"}},
+            }
+        ]
+        ml = _build_model_list(chain, timeout=10.0)
+        deployment = ml[0]
+        # Top-level Router fields
+        assert deployment["rpm"] == 1000
+        assert deployment["tpm"] == 50000
+        assert deployment["weight"] == 7
+        assert deployment["model_info"] == {"id": "abc"}
+        # Nested litellm_params merged on top of our defaults
+        params = deployment["litellm_params"]
+        assert params["model"] == "openai/gpt-4o"
+        assert params["api_key"] == "k"
+        assert params["temperature"] == 0.5
+        assert params["extra_headers"] == {"X-Trace": "1"}
+
+    def test_caller_data_not_mutated(self):
+        """The builder must not mutate the user-supplied chain."""
+        chain = [{"provider": "openai", "model": "gpt-4o", "rpm": 100}]
+        snapshot = json.dumps(chain)
+        _build_model_list(chain, timeout=10.0)
+        assert json.dumps(chain) == snapshot
 
 
 # --- factory dispatch --------------------------------------------------------

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -319,70 +319,25 @@ For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claud
 
 ### LLM Router (LiteLLM Router)
 
-The `litellmrouter` provider is a thin pass-through to [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The configuration JSON is forwarded verbatim to `litellm.Router(**config)` — Hindsight does not translate model names, infer fallback ordering, or impose defaults. Whatever `Router` supports (ordered fallback chains, load-balanced model groups, rate-limit-aware routing, weighted shuffle, latency-based routing, cooldowns, retries, model-info metadata) is available by writing the corresponding key in your config.
+`HINDSIGHT_API_LLM_PROVIDER=litellmrouter` runs the default LLM through [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The config JSON is forwarded verbatim — for fallback chains, load-balancing, rate limits, routing strategies, and the rest of the supported keys, see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing). Hindsight always issues completions against `model_name: "default"`, so include at least one entry with that name.
 
-Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and point the provider-specific config env var at a JSON object.
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed verbatim to `litellm.Router(**config)`. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
-| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default config. | unset |
-| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CONFIG` | Per-operation override for reflect. | unset |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG` | Per-operation override for consolidation. | unset |
-
-#### Config shape
-
-Hindsight forwards your config verbatim to `litellm.Router(**config)` and does not validate the shape. The single Hindsight-imposed convention: **at least one entry in `model_list` must have `model_name: "default"`** — that's the entrypoint Hindsight issues completions against. Any additional entries become fallback / load-balance / weighted-pool members per your `fallbacks`, `routing_strategy`, `rpm`, `tpm`, `weight`, etc.
-
-If your config is malformed, LiteLLM Router will raise its own error at startup. Refer to the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the complete surface (model_list, fallbacks, context_window_fallbacks, num_retries, cooldown_time, routing_strategy, allowed_fails, model_info, …).
-
-#### Examples
-
-Ordered fallback (entrypoint first, fallbacks only on failure):
+| Variable | Description |
+|----------|-------------|
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed to `litellm.Router(**config)`. Required when provider is `litellmrouter`. |
+| `HINDSIGHT_API_{RETAIN,REFLECT,CONSOLIDATION}_LLM_LITELLMROUTER_CONFIG` | Per-operation overrides. Fall back to the default config when unset. |
 
 ```bash
 export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "default",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
-    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
-    {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
-  ],
-  "fallbacks": [{"default": ["fallback", "local"]}],
-  "num_retries": 0,
-  "cooldown_time": 60
-}'
-```
-
-Load-balanced with rate limits (multiple keys under the same entrypoint):
-
-```bash
-export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
-  "model_list": [
-    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-1"}, "rpm": 1000, "tpm": 100000},
-    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-2"}, "rpm": 1000, "tpm": 100000}
-  ],
-  "routing_strategy": "usage-based-routing-v2"
-}'
-```
-
-Per-operation override (retain uses a stronger entrypoint):
-
-```bash
-export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
-  "model_list": [
-    {"model_name": "default",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
-    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
+    {"model_name": "default",  "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}}
   ],
   "fallbacks": [{"default": ["fallback"]}]
 }'
 ```
 
-Notes:
-- The config is a credential field — its contents are never returned by the bank-config API.
-- Hindsight wraps every call in its own retry loop (`HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF`). If you also set `num_retries` on Router, retries multiply — set `num_retries: 0` to delegate retry policy entirely to Hindsight.
-- Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
+The config is a credential field — never returned by the bank-config API. Hindsight already retries calls; set `"num_retries": 0` in the Router config to avoid double-retries. Batch APIs aren't supported in router mode.
 
 ### Built-in llama.cpp
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -316,6 +316,63 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 :::tip OpenAI Codex, Claude Code & Vertex AI Setup
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
+
+### LLM Router (Fallback Chain)
+
+The `litellmrouter` provider runs the default LLM through LiteLLM's [Router](https://docs.litellm.ai/docs/routing) with ordered fallback (see the [fallbacks reference](https://docs.litellm.ai/docs/routing#fallbacks) for the underlying mechanism). Requests go to the first deployment; on transient errors (rate limit, timeout, 5xx) the Router falls back to the next deployment in declared order. Auth errors (401/403) are not retried — a misconfigured key won't silently cascade through your chain.
+
+Activate it the same way as any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and supply the chain via the provider-specific env var.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN` | JSON list of `{provider, model, api_key?, base_url?}` deployments. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
+| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default chain. | unset |
+| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN` | Per-operation override for reflect. | unset |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN` | Per-operation override for consolidation. | unset |
+
+#### Chain format
+
+A chain is a non-empty JSON array of deployment objects. Each deployment accepts:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `provider` | yes | Hindsight provider name: `openai`, `anthropic`, `gemini`, `groq`, `deepseek`, `bedrock`, `ollama`, `openrouter`, `vertexai`, or any OpenAI-compatible endpoint (use `openai` + `base_url`). |
+| `model` | yes | Model name. If you pass a fully-qualified LiteLLM model string (e.g. `bedrock/anthropic.claude-3-5-sonnet`), it's used verbatim. |
+| `api_key` | no | Credential for that deployment. |
+| `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
+
+Minimal 2-step chain:
+
+```json
+[
+  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
+  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
+]
+```
+
+#### Examples
+
+```bash
+# Default LLM uses a 3-deployment chain.
+export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN='[
+  {"provider": "openai", "model": "MiniMax-M2.7-highspeed", "base_url": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."},
+  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-openai-..."},
+  {"provider": "ollama", "model": "llama3.1:8b", "base_url": "http://localhost:11434"}
+]'
+
+# Optional: give retain its own chain (a stronger model + cheap fallback).
+export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN='[
+  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."},
+  {"provider": "openai", "model": "gpt-4o", "api_key": "sk-openai-..."}
+]'
+```
+
+Notes:
+- The chain is a credential field — its contents are never returned by the bank-config API.
+- `HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF` control retries against the primary group. Cross-deployment fallback is delegated to the Router and triggered by transient errors.
+- Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
 
 ### Built-in llama.cpp
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -332,32 +332,29 @@ Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmr
 
 #### Config shape
 
-Hindsight's only requirements are:
-- The value is a JSON object.
-- It contains a non-empty `model_list`.
-- Each entry in `model_list` has a `model_name`.
+Hindsight forwards your config verbatim to `litellm.Router(**config)` and does not validate the shape. The single Hindsight-imposed convention: **at least one entry in `model_list` must have `model_name: "default"`** — that's the entrypoint Hindsight issues completions against. Any additional entries become fallback / load-balance / weighted-pool members per your `fallbacks`, `routing_strategy`, `rpm`, `tpm`, `weight`, etc.
 
-Requests are routed against the **first entry's `model_name`**. If you want ordered fallback, distinct `model_name` values + a `fallbacks` map. If you want load-balanced same-tier routing, repeat the same `model_name` and pick a `routing_strategy`. Everything else (`num_retries`, `cooldown_time`, `allowed_fails`, `routing_strategy`, per-deployment `rpm`/`tpm`/`weight`/`model_info`, `context_window_fallbacks`, …) is up to you — see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the full surface.
+If your config is malformed, LiteLLM Router will raise its own error at startup. Refer to the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the complete surface (model_list, fallbacks, context_window_fallbacks, num_retries, cooldown_time, routing_strategy, allowed_fails, model_info, …).
 
 #### Examples
 
-Ordered fallback (primary first, fallback only on failure):
+Ordered fallback (entrypoint first, fallbacks only on failure):
 
 ```bash
 export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "primary",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
+    {"model_name": "default",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
     {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
     {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
   ],
-  "fallbacks": [{"primary": ["fallback", "local"]}],
+  "fallbacks": [{"default": ["fallback", "local"]}],
   "num_retries": 0,
   "cooldown_time": 60
 }'
 ```
 
-Load-balanced with rate limits:
+Load-balanced with rate limits (multiple keys under the same entrypoint):
 
 ```bash
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
@@ -369,16 +366,16 @@ export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
 }'
 ```
 
-Per-operation override (retain uses a stronger primary):
+Per-operation override (retain uses a stronger entrypoint):
 
 ```bash
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "primary",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
+    {"model_name": "default",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
     {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
   ],
-  "fallbacks": [{"primary": ["fallback"]}]
+  "fallbacks": [{"default": ["fallback"]}]
 }'
 ```
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -341,6 +341,8 @@ A chain is a non-empty JSON array of deployment objects. Each deployment accepts
 | `api_key` | no | Credential for that deployment. |
 | `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
 
+Any other top-level key is forwarded verbatim to the LiteLLM Router deployment record (`rpm`, `tpm`, `weight`, `model_info`, …). Anything inside an optional `litellm_params` sub-object is merged into the inner `litellm_params` dict (per-deployment `temperature`, `extra_headers`, etc.). We don't validate the extras — typos go straight to LiteLLM. See the [LiteLLM Router deployment reference](https://docs.litellm.ai/docs/routing) for the full set.
+
 Minimal 2-step chain:
 
 ```json

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -317,63 +317,74 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
 
-### LLM Router (Fallback Chain)
+### LLM Router (LiteLLM Router)
 
-The `litellmrouter` provider runs the default LLM through LiteLLM's [Router](https://docs.litellm.ai/docs/routing) with ordered fallback (see the [fallbacks reference](https://docs.litellm.ai/docs/routing#fallbacks) for the underlying mechanism). Requests go to the first deployment; on transient errors (rate limit, timeout, 5xx) the Router falls back to the next deployment in declared order. Auth errors (401/403) are not retried — a misconfigured key won't silently cascade through your chain.
+The `litellmrouter` provider is a thin pass-through to [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The configuration JSON is forwarded verbatim to `litellm.Router(**config)` — Hindsight does not translate model names, infer fallback ordering, or impose defaults. Whatever `Router` supports (ordered fallback chains, load-balanced model groups, rate-limit-aware routing, weighted shuffle, latency-based routing, cooldowns, retries, model-info metadata) is available by writing the corresponding key in your config.
 
-Activate it the same way as any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and supply the chain via the provider-specific env var.
+Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and point the provider-specific config env var at a JSON object.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN` | JSON list of `{provider, model, api_key?, base_url?}` deployments. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
-| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default chain. | unset |
-| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN` | Per-operation override for reflect. | unset |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN` | Per-operation override for consolidation. | unset |
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed verbatim to `litellm.Router(**config)`. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
+| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default config. | unset |
+| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CONFIG` | Per-operation override for reflect. | unset |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG` | Per-operation override for consolidation. | unset |
 
-#### Chain format
+#### Config shape
 
-A chain is a non-empty JSON array of deployment objects. Each deployment accepts:
+Hindsight's only requirements are:
+- The value is a JSON object.
+- It contains a non-empty `model_list`.
+- Each entry in `model_list` has a `model_name`.
 
-| Key | Required | Description |
-|-----|----------|-------------|
-| `provider` | yes | Hindsight provider name: `openai`, `anthropic`, `gemini`, `groq`, `deepseek`, `bedrock`, `ollama`, `openrouter`, `vertexai`, or any OpenAI-compatible endpoint (use `openai` + `base_url`). |
-| `model` | yes | Model name. If you pass a fully-qualified LiteLLM model string (e.g. `bedrock/anthropic.claude-3-5-sonnet`), it's used verbatim. |
-| `api_key` | no | Credential for that deployment. |
-| `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
-
-Any other top-level key is forwarded verbatim to the LiteLLM Router deployment record (`rpm`, `tpm`, `weight`, `model_info`, …). Anything inside an optional `litellm_params` sub-object is merged into the inner `litellm_params` dict (per-deployment `temperature`, `extra_headers`, etc.). We don't validate the extras — typos go straight to LiteLLM. See the [LiteLLM Router deployment reference](https://docs.litellm.ai/docs/routing) for the full set.
-
-Minimal 2-step chain:
-
-```json
-[
-  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
-  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
-]
-```
+Requests are routed against the **first entry's `model_name`**. If you want ordered fallback, distinct `model_name` values + a `fallbacks` map. If you want load-balanced same-tier routing, repeat the same `model_name` and pick a `routing_strategy`. Everything else (`num_retries`, `cooldown_time`, `allowed_fails`, `routing_strategy`, per-deployment `rpm`/`tpm`/`weight`/`model_info`, `context_window_fallbacks`, …) is up to you — see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the full surface.
 
 #### Examples
 
-```bash
-# Default LLM uses a 3-deployment chain.
-export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN='[
-  {"provider": "openai", "model": "MiniMax-M2.7-highspeed", "base_url": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."},
-  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-openai-..."},
-  {"provider": "ollama", "model": "llama3.1:8b", "base_url": "http://localhost:11434"}
-]'
+Ordered fallback (primary first, fallback only on failure):
 
-# Optional: give retain its own chain (a stronger model + cheap fallback).
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "primary",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
+    {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
+  ],
+  "fallbacks": [{"primary": ["fallback", "local"]}],
+  "num_retries": 0,
+  "cooldown_time": 60
+}'
+```
+
+Load-balanced with rate limits:
+
+```bash
+export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-1"}, "rpm": 1000, "tpm": 100000},
+    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-2"}, "rpm": 1000, "tpm": 100000}
+  ],
+  "routing_strategy": "usage-based-routing-v2"
+}'
+```
+
+Per-operation override (retain uses a stronger primary):
+
+```bash
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN='[
-  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."},
-  {"provider": "openai", "model": "gpt-4o", "api_key": "sk-openai-..."}
-]'
+export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "primary",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
+  ],
+  "fallbacks": [{"primary": ["fallback"]}]
+}'
 ```
 
 Notes:
-- The chain is a credential field — its contents are never returned by the bank-config API.
-- `HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF` control retries against the primary group. Cross-deployment fallback is delegated to the Router and triggered by transient errors.
+- The config is a credential field — its contents are never returned by the bank-config API.
+- Hindsight wraps every call in its own retry loop (`HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF`). If you also set `num_retries` on Router, retries multiply — set `num_retries: 0` to delegate retry policy entirely to Hindsight.
 - Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
 
 ### Built-in llama.cpp

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -49,6 +49,12 @@ Set `HINDSIGHT_API_LLM_PROVIDER=litellm` to use any model supported by [LiteLLM]
 See [Configuration](./configuration#llm-provider) for setup examples.
 :::
 
+:::tip LiteLLM Router (fallback chains, load-balancing, per-deployment limits)
+Set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` to run the default LLM through [LiteLLM's Router](https://docs.litellm.ai/docs/routing) — ordered fallback across deployments, load-balanced same-tier routing, weighted picks, per-deployment `rpm`/`tpm` limits, and cooldowns are all available via the [`Router` config](https://docs.litellm.ai/docs/routing#fallbacks). Hindsight passes the JSON config through verbatim.
+
+See [Configuration](./configuration#llm-router-litellm-router) for setup.
+:::
+
 ### Benchmarks
 
 Not sure which model to use? The **[Model Leaderboard](https://benchmarks.hindsight.vectorize.io/)** benchmarks models across accuracy, speed, cost, and reliability for retain, reflect, and observation consolidation so you can pick the right trade-off for your use case.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -319,70 +319,25 @@ For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claud
 
 ### LLM Router (LiteLLM Router)
 
-The `litellmrouter` provider is a thin pass-through to [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The configuration JSON is forwarded verbatim to `litellm.Router(**config)` — Hindsight does not translate model names, infer fallback ordering, or impose defaults. Whatever `Router` supports (ordered fallback chains, load-balanced model groups, rate-limit-aware routing, weighted shuffle, latency-based routing, cooldowns, retries, model-info metadata) is available by writing the corresponding key in your config.
+`HINDSIGHT_API_LLM_PROVIDER=litellmrouter` runs the default LLM through [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The config JSON is forwarded verbatim — for fallback chains, load-balancing, rate limits, routing strategies, and the rest of the supported keys, see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing). Hindsight always issues completions against `model_name: "default"`, so include at least one entry with that name.
 
-Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and point the provider-specific config env var at a JSON object.
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed verbatim to `litellm.Router(**config)`. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
-| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default config. | unset |
-| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CONFIG` | Per-operation override for reflect. | unset |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG` | Per-operation override for consolidation. | unset |
-
-#### Config shape
-
-Hindsight forwards your config verbatim to `litellm.Router(**config)` and does not validate the shape. The single Hindsight-imposed convention: **at least one entry in `model_list` must have `model_name: "default"`** — that's the entrypoint Hindsight issues completions against. Any additional entries become fallback / load-balance / weighted-pool members per your `fallbacks`, `routing_strategy`, `rpm`, `tpm`, `weight`, etc.
-
-If your config is malformed, LiteLLM Router will raise its own error at startup. Refer to the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the complete surface (model_list, fallbacks, context_window_fallbacks, num_retries, cooldown_time, routing_strategy, allowed_fails, model_info, …).
-
-#### Examples
-
-Ordered fallback (entrypoint first, fallbacks only on failure):
+| Variable | Description |
+|----------|-------------|
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed to `litellm.Router(**config)`. Required when provider is `litellmrouter`. |
+| `HINDSIGHT_API_{RETAIN,REFLECT,CONSOLIDATION}_LLM_LITELLMROUTER_CONFIG` | Per-operation overrides. Fall back to the default config when unset. |
 
 ```bash
 export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "default",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
-    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
-    {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
-  ],
-  "fallbacks": [{"default": ["fallback", "local"]}],
-  "num_retries": 0,
-  "cooldown_time": 60
-}'
-```
-
-Load-balanced with rate limits (multiple keys under the same entrypoint):
-
-```bash
-export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
-  "model_list": [
-    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-1"}, "rpm": 1000, "tpm": 100000},
-    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-2"}, "rpm": 1000, "tpm": 100000}
-  ],
-  "routing_strategy": "usage-based-routing-v2"
-}'
-```
-
-Per-operation override (retain uses a stronger entrypoint):
-
-```bash
-export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
-  "model_list": [
-    {"model_name": "default",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
-    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
+    {"model_name": "default",  "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}}
   ],
   "fallbacks": [{"default": ["fallback"]}]
 }'
 ```
 
-Notes:
-- The config is a credential field — its contents are never returned by the bank-config API.
-- Hindsight wraps every call in its own retry loop (`HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF`). If you also set `num_retries` on Router, retries multiply — set `num_retries: 0` to delegate retry policy entirely to Hindsight.
-- Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
+The config is a credential field — never returned by the bank-config API. Hindsight already retries calls; set `"num_retries": 0` in the Router config to avoid double-retries. Batch APIs aren't supported in router mode.
 
 ### Built-in llama.cpp
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -316,6 +316,63 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 :::tip OpenAI Codex, Claude Code & Vertex AI Setup
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
+
+### LLM Router (Fallback Chain)
+
+The `litellmrouter` provider runs the default LLM through LiteLLM's [Router](https://docs.litellm.ai/docs/routing) with ordered fallback (see the [fallbacks reference](https://docs.litellm.ai/docs/routing#fallbacks) for the underlying mechanism). Requests go to the first deployment; on transient errors (rate limit, timeout, 5xx) the Router falls back to the next deployment in declared order. Auth errors (401/403) are not retried — a misconfigured key won't silently cascade through your chain.
+
+Activate it the same way as any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and supply the chain via the provider-specific env var.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN` | JSON list of `{provider, model, api_key?, base_url?}` deployments. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
+| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default chain. | unset |
+| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN` | Per-operation override for reflect. | unset |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN` | Per-operation override for consolidation. | unset |
+
+#### Chain format
+
+A chain is a non-empty JSON array of deployment objects. Each deployment accepts:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `provider` | yes | Hindsight provider name: `openai`, `anthropic`, `gemini`, `groq`, `deepseek`, `bedrock`, `ollama`, `openrouter`, `vertexai`, or any OpenAI-compatible endpoint (use `openai` + `base_url`). |
+| `model` | yes | Model name. If you pass a fully-qualified LiteLLM model string (e.g. `bedrock/anthropic.claude-3-5-sonnet`), it's used verbatim. |
+| `api_key` | no | Credential for that deployment. |
+| `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
+
+Minimal 2-step chain:
+
+```json
+[
+  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
+  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
+]
+```
+
+#### Examples
+
+```bash
+# Default LLM uses a 3-deployment chain.
+export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN='[
+  {"provider": "openai", "model": "MiniMax-M2.7-highspeed", "base_url": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."},
+  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-openai-..."},
+  {"provider": "ollama", "model": "llama3.1:8b", "base_url": "http://localhost:11434"}
+]'
+
+# Optional: give retain its own chain (a stronger model + cheap fallback).
+export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN='[
+  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."},
+  {"provider": "openai", "model": "gpt-4o", "api_key": "sk-openai-..."}
+]'
+```
+
+Notes:
+- The chain is a credential field — its contents are never returned by the bank-config API.
+- `HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF` control retries against the primary group. Cross-deployment fallback is delegated to the Router and triggered by transient errors.
+- Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
 
 ### Built-in llama.cpp
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -332,32 +332,29 @@ Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmr
 
 #### Config shape
 
-Hindsight's only requirements are:
-- The value is a JSON object.
-- It contains a non-empty `model_list`.
-- Each entry in `model_list` has a `model_name`.
+Hindsight forwards your config verbatim to `litellm.Router(**config)` and does not validate the shape. The single Hindsight-imposed convention: **at least one entry in `model_list` must have `model_name: "default"`** — that's the entrypoint Hindsight issues completions against. Any additional entries become fallback / load-balance / weighted-pool members per your `fallbacks`, `routing_strategy`, `rpm`, `tpm`, `weight`, etc.
 
-Requests are routed against the **first entry's `model_name`**. If you want ordered fallback, distinct `model_name` values + a `fallbacks` map. If you want load-balanced same-tier routing, repeat the same `model_name` and pick a `routing_strategy`. Everything else (`num_retries`, `cooldown_time`, `allowed_fails`, `routing_strategy`, per-deployment `rpm`/`tpm`/`weight`/`model_info`, `context_window_fallbacks`, …) is up to you — see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the full surface.
+If your config is malformed, LiteLLM Router will raise its own error at startup. Refer to the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the complete surface (model_list, fallbacks, context_window_fallbacks, num_retries, cooldown_time, routing_strategy, allowed_fails, model_info, …).
 
 #### Examples
 
-Ordered fallback (primary first, fallback only on failure):
+Ordered fallback (entrypoint first, fallbacks only on failure):
 
 ```bash
 export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "primary",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
+    {"model_name": "default",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
     {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
     {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
   ],
-  "fallbacks": [{"primary": ["fallback", "local"]}],
+  "fallbacks": [{"default": ["fallback", "local"]}],
   "num_retries": 0,
   "cooldown_time": 60
 }'
 ```
 
-Load-balanced with rate limits:
+Load-balanced with rate limits (multiple keys under the same entrypoint):
 
 ```bash
 export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
@@ -369,16 +366,16 @@ export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
 }'
 ```
 
-Per-operation override (retain uses a stronger primary):
+Per-operation override (retain uses a stronger entrypoint):
 
 ```bash
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
 export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
   "model_list": [
-    {"model_name": "primary",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
+    {"model_name": "default",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
     {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
   ],
-  "fallbacks": [{"primary": ["fallback"]}]
+  "fallbacks": [{"default": ["fallback"]}]
 }'
 ```
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -341,6 +341,8 @@ A chain is a non-empty JSON array of deployment objects. Each deployment accepts
 | `api_key` | no | Credential for that deployment. |
 | `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
 
+Any other top-level key is forwarded verbatim to the LiteLLM Router deployment record (`rpm`, `tpm`, `weight`, `model_info`, …). Anything inside an optional `litellm_params` sub-object is merged into the inner `litellm_params` dict (per-deployment `temperature`, `extra_headers`, etc.). We don't validate the extras — typos go straight to LiteLLM. See the [LiteLLM Router deployment reference](https://docs.litellm.ai/docs/routing) for the full set.
+
 Minimal 2-step chain:
 
 ```json

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -317,63 +317,74 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
 
-### LLM Router (Fallback Chain)
+### LLM Router (LiteLLM Router)
 
-The `litellmrouter` provider runs the default LLM through LiteLLM's [Router](https://docs.litellm.ai/docs/routing) with ordered fallback (see the [fallbacks reference](https://docs.litellm.ai/docs/routing#fallbacks) for the underlying mechanism). Requests go to the first deployment; on transient errors (rate limit, timeout, 5xx) the Router falls back to the next deployment in declared order. Auth errors (401/403) are not retried — a misconfigured key won't silently cascade through your chain.
+The `litellmrouter` provider is a thin pass-through to [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The configuration JSON is forwarded verbatim to `litellm.Router(**config)` — Hindsight does not translate model names, infer fallback ordering, or impose defaults. Whatever `Router` supports (ordered fallback chains, load-balanced model groups, rate-limit-aware routing, weighted shuffle, latency-based routing, cooldowns, retries, model-info metadata) is available by writing the corresponding key in your config.
 
-Activate it the same way as any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and supply the chain via the provider-specific env var.
+Activate it like any other provider — set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` and point the provider-specific config env var at a JSON object.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN` | JSON list of `{provider, model, api_key?, base_url?}` deployments. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
-| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default chain. | unset |
-| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CHAIN` | Per-operation override for reflect. | unset |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CHAIN` | Per-operation override for consolidation. | unset |
+| `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` | JSON object passed verbatim to `litellm.Router(**config)`. Required when `HINDSIGHT_API_LLM_PROVIDER=litellmrouter`. | unset |
+| `HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG` | Per-operation override for retain. Used when `HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter`; falls back to the default config. | unset |
+| `HINDSIGHT_API_REFLECT_LLM_LITELLMROUTER_CONFIG` | Per-operation override for reflect. | unset |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG` | Per-operation override for consolidation. | unset |
 
-#### Chain format
+#### Config shape
 
-A chain is a non-empty JSON array of deployment objects. Each deployment accepts:
+Hindsight's only requirements are:
+- The value is a JSON object.
+- It contains a non-empty `model_list`.
+- Each entry in `model_list` has a `model_name`.
 
-| Key | Required | Description |
-|-----|----------|-------------|
-| `provider` | yes | Hindsight provider name: `openai`, `anthropic`, `gemini`, `groq`, `deepseek`, `bedrock`, `ollama`, `openrouter`, `vertexai`, or any OpenAI-compatible endpoint (use `openai` + `base_url`). |
-| `model` | yes | Model name. If you pass a fully-qualified LiteLLM model string (e.g. `bedrock/anthropic.claude-3-5-sonnet`), it's used verbatim. |
-| `api_key` | no | Credential for that deployment. |
-| `base_url` | no | Endpoint override (for OpenAI-compatible providers like LM Studio, Ollama, MiniMax, custom proxies). |
-
-Any other top-level key is forwarded verbatim to the LiteLLM Router deployment record (`rpm`, `tpm`, `weight`, `model_info`, …). Anything inside an optional `litellm_params` sub-object is merged into the inner `litellm_params` dict (per-deployment `temperature`, `extra_headers`, etc.). We don't validate the extras — typos go straight to LiteLLM. See the [LiteLLM Router deployment reference](https://docs.litellm.ai/docs/routing) for the full set.
-
-Minimal 2-step chain:
-
-```json
-[
-  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
-  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."}
-]
-```
+Requests are routed against the **first entry's `model_name`**. If you want ordered fallback, distinct `model_name` values + a `fallbacks` map. If you want load-balanced same-tier routing, repeat the same `model_name` and pick a `routing_strategy`. Everything else (`num_retries`, `cooldown_time`, `allowed_fails`, `routing_strategy`, per-deployment `rpm`/`tpm`/`weight`/`model_info`, `context_window_fallbacks`, …) is up to you — see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing) for the full surface.
 
 #### Examples
 
-```bash
-# Default LLM uses a 3-deployment chain.
-export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN='[
-  {"provider": "openai", "model": "MiniMax-M2.7-highspeed", "base_url": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."},
-  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-openai-..."},
-  {"provider": "ollama", "model": "llama3.1:8b", "base_url": "http://localhost:11434"}
-]'
+Ordered fallback (primary first, fallback only on failure):
 
-# Optional: give retain its own chain (a stronger model + cheap fallback).
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
+export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "primary",  "litellm_params": {"model": "openai/MiniMax-M2.7-highspeed", "api_base": "https://api.minimax.io/v1", "api_key": "sk-minimax-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-openai-..."}},
+    {"model_name": "local",    "litellm_params": {"model": "ollama_chat/llama3.1:8b", "api_base": "http://localhost:11434"}}
+  ],
+  "fallbacks": [{"primary": ["fallback", "local"]}],
+  "num_retries": 0,
+  "cooldown_time": 60
+}'
+```
+
+Load-balanced with rate limits:
+
+```bash
+export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-1"}, "rpm": 1000, "tpm": 100000},
+    {"model_name": "default", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-key-2"}, "rpm": 1000, "tpm": 100000}
+  ],
+  "routing_strategy": "usage-based-routing-v2"
+}'
+```
+
+Per-operation override (retain uses a stronger primary):
+
+```bash
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=litellmrouter
-export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN='[
-  {"provider": "anthropic", "model": "claude-sonnet-4-5", "api_key": "sk-ant-..."},
-  {"provider": "openai", "model": "gpt-4o", "api_key": "sk-openai-..."}
-]'
+export HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG='{
+  "model_list": [
+    {"model_name": "primary",  "litellm_params": {"model": "anthropic/claude-sonnet-4-5", "api_key": "sk-ant-..."}},
+    {"model_name": "fallback", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-openai-..."}}
+  ],
+  "fallbacks": [{"primary": ["fallback"]}]
+}'
 ```
 
 Notes:
-- The chain is a credential field — its contents are never returned by the bank-config API.
-- `HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF` control retries against the primary group. Cross-deployment fallback is delegated to the Router and triggered by transient errors.
+- The config is a credential field — its contents are never returned by the bank-config API.
+- Hindsight wraps every call in its own retry loop (`HINDSIGHT_API_LLM_MAX_RETRIES` / `..._INITIAL_BACKOFF` / `..._MAX_BACKOFF`). If you also set `num_retries` on Router, retries multiply — set `num_retries: 0` to delegate retry policy entirely to Hindsight.
 - Batch APIs are not supported in `litellmrouter` mode — fall back to a single-provider config for batch retain.
 
 ### Built-in llama.cpp

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -60,6 +60,11 @@ See [Configuration](./configuration#built-in-llamacpp) for all options.
 Set `HINDSIGHT_API_LLM_PROVIDER=litellm` to use any model supported by [LiteLLM](https://docs.litellm.ai/docs/providers), including **Azure OpenAI**, **Together AI**, **Fireworks AI**, and many more. Model names use LiteLLM's provider prefix format (e.g., `azure/gpt-4o`).
 
 See [Configuration](./configuration#llm-provider) for setup examples.
+> **💡 LiteLLM Router (fallback chains, load-balancing, per-deployment limits)**
+> 
+Set `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` to run the default LLM through [LiteLLM's Router](https://docs.litellm.ai/docs/routing) — ordered fallback across deployments, load-balanced same-tier routing, weighted picks, per-deployment `rpm`/`tpm` limits, and cooldowns are all available via the [`Router` config](https://docs.litellm.ai/docs/routing#fallbacks). Hindsight passes the JSON config through verbatim.
+
+See [Configuration](./configuration#llm-router-litellm-router) for setup.
 ### Benchmarks
 
 Not sure which model to use? The **[Model Leaderboard](https://benchmarks.hindsight.vectorize.io/)** benchmarks models across accuracy, speed, cost, and reliability for retain, reflect, and observation consolidation so you can pick the right trade-off for your use case.


### PR DESCRIPTION
## Summary

Closes #1464.

Adds a new `litellmrouter` LLM provider that wraps [LiteLLM Router](https://docs.litellm.ai/docs/routing) ([fallbacks reference](https://docs.litellm.ai/docs/routing#fallbacks)) with **ordered fallback** across a configurable chain of deployments. On transient errors (rate-limit, timeout, 5xx) the Router tries the next deployment; auth errors (401/403) are not retried so a misconfigured key cannot silently cascade through the chain.

Chain config is provider-scoped — `LITELLMROUTER` is intentionally a single token to avoid clashing with the existing `LITELLM_*` namespace used by embeddings/reranker. Each chain entry is `{provider, model, api_key?, base_url?}`. Entries are credential fields, never exposed via the bank-config API.

## Configuration

```bash
export HINDSIGHT_API_LLM_PROVIDER=litellmrouter
export HINDSIGHT_API_LLM_LITELLMROUTER_CHAIN='[
  {"provider": "openai", "model": "MiniMax-M2.7-highspeed", "base_url": "https://api.minimax.io/v1", "api_key": "sk-..."},
  {"provider": "openai", "model": "gpt-4o-mini", "api_key": "sk-..."},
  {"provider": "ollama", "model": "llama3.1:8b", "base_url": "http://localhost:11434"}
]'
```

Per-operation chains follow the existing per-op pattern (`HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CHAIN`, `..._REFLECT_...`, `..._CONSOLIDATION_...`) and fall back to the default chain when unset.

## Implementation

- `LiteLLMRouterLLM` — new `LLMInterface` impl in `hindsight_api/engine/providers/litellm_router_llm.py`. Each chain entry becomes a distinct LiteLLM `model_name` group; the primary group's `fallbacks` list orders the rest, giving deterministic ordered fallback (vs the load-balancing you get from same-group deployments).
- `create_llm_provider()` and `LLMProvider` accept an explicit `chain` kwarg. `MemoryEngine` threads the right chain into each per-op `LLMConfig`.
- `HindsightConfig` gains `llm_litellmrouter_chain` + per-op variants. All four are tagged as credential fields. `_parse_llm_router_chain(env_var)` validates required keys and rejects unknown keys.

## Notable non-goals

- **Per-bank chains** — chain definitions live server-side, not in bank config. Per-bank routing (e.g. picking a chain by name) is intentionally deferred.
- **Batch APIs** — `submit_batch`/`get_batch_status` aren't supported in router mode; configure a single provider for batch retain.
- **LiteLLM Proxy** — this PR is in-process Router only. Proxy mode is a separate follow-up if/when cloud deploys need shared cooldown state across replicas.

## Test plan

- [x] New tests in `tests/test_llm_router_provider.py` (24 tests): chain parsing, helper translation, factory dispatch, plain/structured/tool calls through the Router, transient retry, auth no-retry, per-op chain isolation.
- [x] Regression suite for LLM-touching tests stays green: `test_config_validation`, `test_llm_tools`, `test_per_operation_llm_config`, `test_bank_template_configurable_fields`, `test_litellm_sdk_*`, `test_extensions`, `test_none_llm_provider` (146 passing).
- [x] Ruff + ty clean on changed files.
- [ ] Manual smoke test: deliberately misconfigure the primary deployment, verify retain/reflect/recall continue using the fallback.