### PR TITLE
fix(typescript-client): derive CLIENT_VERSION via tsup define

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -53,7 +53,12 @@ import type {
   TagGroupNotInput,
 } from "../generated/types.gen";
 
-export const CLIENT_VERSION = "0.5.1";
+// __CLIENT_VERSION__ is replaced by tsup's `define` with package.json's version
+// at build time. The typeof guard keeps raw-source loads (jest, deno test:deno)
+// from throwing ReferenceError; they get a sentinel that makes drift obvious.
+declare const __CLIENT_VERSION__: string | undefined;
+export const CLIENT_VERSION: string =
+  typeof __CLIENT_VERSION__ !== "undefined" ? __CLIENT_VERSION__ : "0.0.0-dev";
 export const DEFAULT_USER_AGENT = `hindsight-client-typescript/${CLIENT_VERSION}`;
 
 export interface HindsightClientOptions {

--- a/hindsight-clients/typescript/tsup.config.ts
+++ b/hindsight-clients/typescript/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import pkg from "./package.json";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -9,4 +10,9 @@ export default defineConfig({
   sourcemap: true,
   // Bundle all relative imports (src + generated) into the output
   bundle: true,
+  // Substitute __CLIENT_VERSION__ with package.json's version at build time so
+  // the constant in src/index.ts can never drift from what npm publishes.
+  define: {
+    __CLIENT_VERSION__: JSON.stringify(pkg.version),
+  },
 });


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `CLIENT_VERSION = "0.5.1"` (stale through 0.5.6 / 0.5.7 / 0.6.0) with a tsup `define` substitution that bakes `package.json`'s `version` into `dist` at build time.
- Source references the substituted identifier behind a `typeof` guard with a `0.0.0-dev` sentinel, so raw-source loaders (`jest`, `npm run test:deno`) don't throw `ReferenceError`.
- Closes #1535. Same end-state as that PR (constant auto-tracks `package.json`), but avoids the Deno regression I hit verifying that approach.

## Why not `import pkg from "../package.json"`

`import pkg from "../package.json"` works in Node + tsup + jest, but `npm run test:deno` fails:

```
error: Expected a JavaScript or TypeScript module, but identified a Json module.
       Consider importing Json modules with an import attribute with the type of "json".
  Specifier: .../hindsight-clients/typescript/package.json
    at .../src/index.ts:30:17
```

Adding `with { type: "json" }` is not a one-liner here:

1. tsup's `dts` step rejects it with TS2823 because `tsconfig.json` has `"module": "commonjs"`. Needs `module: "preserve"` + `moduleResolution: "bundler"`.
2. Even after that, ts-jest 29 hardcodes `module: "commonjs"` at runtime emit and re-throws TS2823. Fix would require `useESM: true` plus full Jest experimental-ESM mode (`--experimental-vm-modules`, `extensionsToTreatAsEsm`, ...).

A `define` substitution sidesteps all of it: source has no JSON import, every runtime sees a string literal.

## Verified locally

| Path | Result |
|---|---|
| `npm run build` (CJS + ESM + DTS) | ✅ |
| `npx jest tests/prompt_formatting.test.ts` | ✅ 6/6 |
| `node -e 'require("./dist/index.js")'` | `0.6.0` |
| `node --input-type=module -e 'import("./dist/index.mjs")'` | `0.6.0` |
| `deno eval 'import("./dist/index.mjs")'` | `0.6.0` |
| `deno eval --unstable-sloppy-imports 'import("./src/index.ts")'` | `0.0.0-dev` (sentinel) |
| `npx tsc --noEmit` | clean |

`tests/main_operations.test.ts` not exercised — needs a running Hindsight API server.

## Side benefit

dist no longer inlines the entire `package.json` (devDependencies, scripts, `repository.url`) — only the version string is captured. dist size: 56 KB → 55 KB.

## Test plan

- [x] CJS dist resolves substituted version
- [x] ESM dist resolves substituted version
- [x] Deno consuming `dist/index.mjs` resolves substituted version
- [x] Deno loading raw `src/index.ts` falls back to `0.0.0-dev` sentinel without ReferenceError
- [x] jest unit tests pass
- [x] `tsc --noEmit` clean
- [ ] CI green