### PR TITLE
fix(claude-code): get_page detail=content + handle tool-result spillover

### DIFF
--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -94,8 +94,15 @@ def agent_knowledge_list_pages() -> str:
 @mcp.tool()
 def agent_knowledge_get_page(page_id: str) -> str:
     """Read a specific knowledge page by its ID. Returns the full synthesized content."""
+    # detail=content returns the synthesized `content` plus metadata; detail=full
+    # additionally includes `reflect_response`, the internal trace metadata used
+    # to build the page. Empirically reflect_response is 70-95% of the response
+    # bytes and the docstring promises only "synthesized content" — full payloads
+    # at this scale (200+ KB per page) blow past the MCP host's per-tool-result
+    # token cap and force the result to spill to disk, where the agent can't
+    # consume it inline.
     resp = _client.request(
-        "GET", f"/v1/default/banks/{_encode_bank(_default_bank_id)}/mental-models/{page_id}?detail=full", timeout=10
+        "GET", f"/v1/default/banks/{_encode_bank(_default_bank_id)}/mental-models/{page_id}?detail=content", timeout=10
     )
     return json.dumps(resp, indent=2)
 

--- a/hindsight-integrations/claude-code/skills/create-agent/SKILL.md
+++ b/hindsight-integrations/claude-code/skills/create-agent/SKILL.md
@@ -53,6 +53,7 @@ You are the **<agent-name>** agent with long-term memory powered by Hindsight.
 
 1. Call `agent_knowledge_list_pages` to see your knowledge pages.
 2. Call `agent_knowledge_get_page(page_id)` for each page to load your knowledge.
+   - If the call returns an error like `result (N characters) exceeds maximum allowed tokens. Output has been saved to <path>`, the page was too large to inline. Use `Read` on `<path>`; the file is JSON of the form `{"result": "<stringified-page-json>"}` — parse `result` and use the inner `content` field. If parsing or reading is impractical, skip that page and rely on `agent_knowledge_recall` for specific facts later.
 3. Use this knowledge to inform everything you do in this conversation.
 
 ## Creating pages

--- a/hindsight-integrations/claude-code/tests/test_mcp_server.py
+++ b/hindsight-integrations/claude-code/tests/test_mcp_server.py
@@ -42,3 +42,26 @@ class TestListPagesUsesMetadataProjection:
         assert list_pages_def > 0 and next_def > list_pages_def
         list_pages_body = src[list_pages_def:next_def]
         assert "detail=metadata" in list_pages_body
+
+
+class TestGetPageUsesContentProjection:
+    """`agent_knowledge_get_page` must request the API's `content` projection.
+
+    `detail=full` additionally returns `reflect_response`, the internal trace
+    metadata used to build a page. Measured on real banks, reflect_response is
+    70-95% of the response bytes while the synthesized `content` field is
+    typically 1-2%. At realistic page sizes (200-280 KB at full) the response
+    overflows the MCP host's per-tool-result token cap and the result spills to
+    disk, where the agent cannot consume it inline as part of its startup
+    knowledge load. The docstring promises only "the full synthesized content",
+    so the request must pin `detail=content`.
+    """
+
+    def test_get_page_request_uses_detail_content(self):
+        src = _read_mcp_server_source()
+        # Check the URL pattern in the request line; comments may legitimately
+        # mention detail=full when explaining the difference.
+        assert "/mental-models/{page_id}?detail=content" in src, (
+            "get_page must request detail=content; detail=full includes "
+            "reflect_response which dwarfs the actual content"
+        )

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
## Summary

Follow-up to #1528 (which fixed `list_pages`) — same class of issue, but on the `get_page` surface and on the agent prompt.

`agent_knowledge_get_page` was hitting `GET /mental-models/{id}?detail=full`, which returns the synthesized `content` plus the internal `reflect_response` trace metadata. Empirically, `reflect_response` is **70–95%** of the response bytes; the actual `content` is **1–2%**. At realistic page sizes (200–280 KB at full), the response overflows the MCP host's per-tool-result token cap, spills to disk, and the agent cannot consume it inline as part of its startup knowledge load — defeating the whole "list pages then read each one" boot pattern.

## Measurements

Sampled directly from spilled tool-result files of a real subagent that hit the cap:

| page                              | total   | `content` | `reflect_response` |
| --------------------------------- | ------- | --------- | ------------------ |
| Pre-push gate                     | 276 KB  | 2.8 KB    | 201 KB             |
| Local test stack                  | 282 KB  | 4.0 KB    | 205 KB             |
| CI failure triage runbook         | 266 KB  | 2.8 KB    | 194 KB             |
| Don't blame — fix the test        | 215 KB  | 3.2 KB    | 156 KB             |
| CI workflow inventory             | 222 KB  | 3.8 KB    | 161 KB             |
| Common CI failure modes           | 263 KB  | 5.2 KB    | 191 KB             |

`detail=content` (which the API supports natively) drops every one of these to ~5 KB. ~50–70× reduction.

## Why this is safe

- The plugin tool's docstring already promises *"the full synthesized content"* — exactly what the `content` projection returns. `reflect_response` is internal trace metadata an agent does not need at boot time.
- `agent_knowledge_get_page` is the only call site for the per-page `GET /mental-models/{id}` URL in the plugin. No hook or session-start handler depends on `reflect_response`.
- Other plugin integrations (openclaw, codex, opencode, langgraph, dify, crewai, agentcore, llamaindex, pipecat, openai-agents, chat, strands, ag2, agno, ai-sdk, autogen, cloudflare-oauth-proxy, n8n, nemoclaw, paperclip, pydantic-ai, smolagents, litellm) don't call this URL at all, so they're unaffected.

## Prompt change

The `create-agent` SKILL template now tells the agent what to do if `get_page` does spill (rare after this fix, but possible on genuinely large pages): `Read` the spill file, parse the JSON wrapper, or fall back to `agent_knowledge_recall`. This is the contract the agent now needs to know — without it, the boot loop silently degrades when even one large page is encountered.

## Test plan

- [x] New regression test: `tests/test_mcp_server.py::TestGetPageUsesContentProjection` — pins the content projection on the wire URL.
- [x] Full plugin test suite passes locally (170 passed).
- [x] Field sizes verified directly against spilled tool-result files from a real subagent.