### PR TITLE
fix(claude-code-mcp): rename recall max_results→max_tokens

### DIFF
--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -133,9 +133,9 @@ def agent_knowledge_delete_page(page_id: str) -> str:
 
 
 @mcp.tool()
-def agent_knowledge_recall(query: str, max_results: int = 10) -> str:
-    """Search across all retained conversations and documents for specific facts, numbers, or details not covered by your knowledge pages."""
-    resp = _client.recall(bank_id=_default_bank_id, query=query, max_tokens=max_results, budget="mid", timeout=10)
+def agent_knowledge_recall(query: str, max_tokens: int = 1024) -> str:
+    """Search across all retained conversations and documents for specific facts, numbers, or details not covered by your knowledge pages. max_tokens is the result token budget (server returns whatever fits)."""
+    resp = _client.recall(bank_id=_default_bank_id, query=query, max_tokens=max_tokens, budget="mid", timeout=10)
     return json.dumps(resp, indent=2)
 
 


### PR DESCRIPTION
## Summary

`agent_knowledge_recall` in `hindsight-integrations/claude-code/scripts/mcp_server.py` exposes a parameter named `max_results: int = 10`, but pipes that value directly into the server's `max_tokens` budget on `/v1/default/banks/{bank_id}/memories/recall`. The server has no `max_results` concept — recall returns whatever fits in the token budget, then truncates — so a default of 10 tokens collapses every result set to `[]`.

This makes the MCP recall tool look like a connection or auth failure to callers, even when the bank holds thousands of memories. Direct API recall and the `recall.py` UserPromptSubmit hook both work correctly because they pass a sane `max_tokens` value.

The fix renames the MCP parameter to match server semantics and bumps the default to `1024` (the same default `client.recall` already uses on line 100 of `lib/client.py`).

## Repro

1. Configure the plugin against any bank with retained memories.
2. From a Claude Code session, call `agent_knowledge_recall("known phrase")`.
3. Observe `{"results": []}` regardless of bank contents.
4. Hit `POST /v1/default/banks/<bank>/memories/recall` directly with the same query — returns rich results.

## Test plan

- [ ] Manually call the MCP tool against a populated bank — expect non-empty `results`.
- [ ] Call with `max_tokens=4096` — expect deeper result set (more entries fit).
- [ ] Confirm no other call sites reference the old `max_results` parameter (none in repo per grep).