### PR TITLE
Fix strands client lifecycle leak for internally-owned clients

### DIFF
--- a/hindsight-integrations/strands/README.md
+++ b/hindsight-integrations/strands/README.md
@@ -29,6 +29,7 @@ tools = create_hindsight_tools(
 agent = Agent(tools=tools)
 agent("Remember that I prefer dark mode")
 agent("What are my preferences?")
+tools.close()  # Close only if hindsight-strands created the client internally
 ```
 
 The agent now has three tools it can call:
@@ -59,6 +60,44 @@ agent = Agent(
     system_prompt=f"You are a helpful assistant.\n\n{memories}",
 )
 ```
+
+## FastAPI Lifecycle (Recommended)
+
+Prefer creating one shared Hindsight client in app lifespan and passing `client=...`.
+This gives explicit ownership and clean shutdown via `await client.aclose()`.
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from hindsight_client import Hindsight
+from hindsight_strands import create_hindsight_tools, memory_instructions
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    client = Hindsight(base_url="http://localhost:8888", api_key="test-key")
+    app.state.hindsight_client = client
+    try:
+        yield
+    finally:
+        await client.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/chat")
+async def chat():
+    client = app.state.hindsight_client
+    tools = create_hindsight_tools(bank_id="user-123", client=client)
+    memories = memory_instructions(bank_id="user-123", client=client)
+    ...
+```
+
+If you pass `hindsight_api_url`/`api_key` directly to `create_hindsight_tools()`,
+`hindsight-strands` creates the client internally. In that case call
+`await tools.aclose()` (or `tools.close()`) during shutdown.
 
 ## Selecting Tools
 
@@ -102,8 +141,8 @@ tools = create_hindsight_tools(bank_id="user-123")
 | Parameter | Default | Description |
 |---|---|---|
 | `bank_id` | *required* | Hindsight memory bank ID |
-| `client` | `None` | Pre-configured Hindsight client |
-| `hindsight_api_url` | `None` | API URL (used if no client provided) |
+| `client` | `None` | Pre-configured Hindsight client (caller owns lifecycle) |
+| `hindsight_api_url` | `None` | API URL (if used, integration creates/owns client) |
 | `api_key` | `None` | API key (used if no client provided) |
 | `budget` | `"mid"` | Recall/reflect budget level (low/mid/high) |
 | `max_tokens` | `4096` | Maximum tokens for recall results |

--- a/hindsight-integrations/strands/hindsight_strands/tools.py
+++ b/hindsight-integrations/strands/hindsight_strands/tools.py
@@ -41,14 +41,50 @@ from .errors import HindsightError
 logger = logging.getLogger(__name__)
 
 
+class HindsightTools(list):
+    """List-compatible container for Strands tools with optional client cleanup."""
+
+    def __init__(self, tools: list[Any], client: Hindsight, owns_client: bool):
+        super().__init__(tools)
+        self._client = client
+        self._owns_client = owns_client
+        self._closed = False
+
+    def close(self) -> None:
+        """Close internally-owned client resources."""
+        if not self._owns_client or self._closed:
+            return
+        _run_in_thread(self._client.close)
+        self._closed = True
+
+    async def aclose(self) -> None:
+        """Async close for internally-owned client resources."""
+        if not self._owns_client or self._closed:
+            return
+        await self._client.aclose()
+        self._closed = True
+
+    def __enter__(self) -> HindsightTools:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> HindsightTools:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.aclose()
+
+
 def _resolve_client(
     client: Hindsight | None,
     hindsight_api_url: str | None,
     api_key: str | None,
-) -> Hindsight:
+) -> tuple[Hindsight, bool]:
     """Resolve a Hindsight client from explicit args or global config."""
     if client is not None:
-        return client
+        return client, False
 
     config = get_config()
     url = hindsight_api_url or (config.hindsight_api_url if config else None)
@@ -62,7 +98,7 @@ def _resolve_client(
     kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:
         kwargs["api_key"] = key
-    return Hindsight(**kwargs)
+    return Hindsight(**kwargs), True
 
 
 def create_hindsight_tools(
@@ -79,7 +115,7 @@ def create_hindsight_tools(
     enable_retain: bool = True,
     enable_recall: bool = True,
     enable_reflect: bool = True,
-) -> list:
+) -> HindsightTools:
     """Create Hindsight memory tools for a Strands agent.
 
     Returns a list of ``@tool``-decorated functions that can be passed
@@ -106,7 +142,7 @@ def create_hindsight_tools(
     Raises:
         HindsightError: If no client or API URL can be resolved.
     """
-    resolved_client = _resolve_client(client, hindsight_api_url, api_key)
+    resolved_client, owns_client = _resolve_client(client, hindsight_api_url, api_key)
 
     # Resolve defaults from global config
     config = get_config()
@@ -212,7 +248,7 @@ def create_hindsight_tools(
 
         tools.append(hindsight_reflect)
 
-    return tools
+    return HindsightTools(tools, resolved_client, owns_client)
 
 
 def memory_instructions(
@@ -254,7 +290,7 @@ def memory_instructions(
     Raises:
         HindsightError: If no client or API URL can be resolved.
     """
-    resolved_client = _resolve_client(client, hindsight_api_url, api_key)
+    resolved_client, owns_client = _resolve_client(client, hindsight_api_url, api_key)
 
     try:
         recall_kwargs: dict[str, Any] = {
@@ -277,3 +313,9 @@ def memory_instructions(
     except Exception:
         # Silently return empty — instructions failures shouldn't block the agent
         return ""
+    finally:
+        if owns_client:
+            try:
+                _run_in_thread(resolved_client.close)
+            except Exception:
+                logger.debug("Failed to close internally-created Hindsight client", exc_info=True)

--- a/hindsight-integrations/strands/tests/test_tools.py
+++ b/hindsight-integrations/strands/tests/test_tools.py
@@ -1,7 +1,7 @@
 """Unit tests for Hindsight Strands tools."""
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from hindsight_strands import (
     reset_config,
 )
 from hindsight_strands.errors import HindsightError
-from hindsight_strands.tools import _resolve_client
+from hindsight_strands.tools import _USER_AGENT, _resolve_client
 
 
 # ---------------------------------------------------------------------------
@@ -27,6 +27,8 @@ def _mock_client():
     client.recall = MagicMock()
     client.reflect = MagicMock()
     client.create_bank = MagicMock()
+    client.close = MagicMock()
+    client.aclose = AsyncMock()
     return client
 
 
@@ -70,64 +72,88 @@ class TestResolveClient:
 
     def test_returns_explicit_client(self):
         client = _mock_client()
-        assert _resolve_client(client, None, None) is client
+        resolved, owns_client = _resolve_client(client, None, None)
+        assert resolved is client
+        assert owns_client is False
 
     def test_explicit_client_ignores_url_and_key(self):
         client = _mock_client()
-        result = _resolve_client(client, "http://ignored", "ignored-key")
-        assert result is client
+        resolved, owns_client = _resolve_client(client, "http://ignored", "ignored-key")
+        assert resolved is client
+        assert owns_client is False
 
     def test_creates_client_from_url(self):
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, "http://localhost:8888", None)
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0
-            )
+            _, owns_client = _resolve_client(None, "http://localhost:8888", None)
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://localhost:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_creates_client_with_api_key(self):
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, "http://localhost:8888", "my-key")
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0, api_key="my-key"
-            )
+            _, owns_client = _resolve_client(None, "http://localhost:8888", "my-key")
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://localhost:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["api_key"] == "my-key"
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_falls_back_to_global_config_url(self):
         configure(hindsight_api_url="http://config:8888")
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, None, None)
-            mock_cls.assert_called_once_with(
-                base_url="http://config:8888", timeout=30.0
-            )
+            _, owns_client = _resolve_client(None, None, None)
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://config:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_falls_back_to_global_config_api_key(self):
         configure(hindsight_api_url="http://config:8888", api_key="config-key")
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, None, None)
-            mock_cls.assert_called_once_with(
-                base_url="http://config:8888", timeout=30.0, api_key="config-key"
-            )
+            _, owns_client = _resolve_client(None, None, None)
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://config:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["api_key"] == "config-key"
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_explicit_url_overrides_config(self):
         configure(hindsight_api_url="http://config:8888")
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, "http://explicit:9999", None)
-            mock_cls.assert_called_once_with(
-                base_url="http://explicit:9999", timeout=30.0
-            )
+            _, owns_client = _resolve_client(None, "http://explicit:9999", None)
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://explicit:9999"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_explicit_api_key_overrides_config(self):
         configure(hindsight_api_url="http://config:8888", api_key="config-key")
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
-            _resolve_client(None, None, "explicit-key")
-            mock_cls.assert_called_once_with(
-                base_url="http://config:8888", timeout=30.0, api_key="explicit-key"
-            )
+            _, owns_client = _resolve_client(None, None, "explicit-key")
+            assert owns_client is True
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://config:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["api_key"] == "explicit-key"
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_raises_without_url_or_config(self):
         with pytest.raises(HindsightError, match="No Hindsight API URL"):
@@ -222,9 +248,11 @@ class TestCreateHindsightTools:
             mock_cls.return_value = _mock_client()
             tools = create_hindsight_tools(bank_id="test")
             assert len(tools) == 3
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0
-            )
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://localhost:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["user_agent"] == _USER_AGENT
 
     def test_api_key_passed_to_client(self):
         with patch("hindsight_strands.tools.Hindsight") as mock_cls:
@@ -234,9 +262,49 @@ class TestCreateHindsightTools:
                 hindsight_api_url="http://localhost:8888",
                 api_key="secret",
             )
-            mock_cls.assert_called_once_with(
-                base_url="http://localhost:8888", timeout=30.0, api_key="secret"
+            mock_cls.assert_called_once()
+            kwargs = mock_cls.call_args.kwargs
+            assert kwargs["base_url"] == "http://localhost:8888"
+            assert kwargs["timeout"] == 30.0
+            assert kwargs["api_key"] == "secret"
+            assert kwargs["user_agent"] == _USER_AGENT
+
+    def test_returns_list_compatible_tools_container(self):
+        client = _mock_client()
+        tools = create_hindsight_tools(bank_id="test", client=client)
+        assert isinstance(tools, list)
+        assert hasattr(tools, "close")
+        assert hasattr(tools, "aclose")
+
+    def test_close_closes_internally_owned_client(self):
+        with patch("hindsight_strands.tools.Hindsight") as mock_cls:
+            internal_client = _mock_client()
+            mock_cls.return_value = internal_client
+            tools = create_hindsight_tools(
+                bank_id="test",
+                hindsight_api_url="http://localhost:8888",
             )
+            tools.close()
+            internal_client.close.assert_called_once()
+
+    def test_close_does_not_close_externally_owned_client(self):
+        external_client = _mock_client()
+        tools = create_hindsight_tools(bank_id="test", client=external_client)
+        tools.close()
+        external_client.close.assert_not_called()
+
+    def test_aclose_closes_internally_owned_client(self):
+        with patch("hindsight_strands.tools.Hindsight") as mock_cls:
+            internal_client = _mock_client()
+            mock_cls.return_value = internal_client
+            tools = create_hindsight_tools(
+                bank_id="test",
+                hindsight_api_url="http://localhost:8888",
+            )
+            import asyncio
+
+            asyncio.run(tools.aclose())
+            internal_client.aclose.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -614,3 +682,33 @@ class TestMemoryInstructions:
             mock_cls.return_value = mock_instance
             result = memory_instructions(bank_id="test")
             assert "fact" in result
+
+    def test_closes_internally_created_client_on_success(self):
+        with patch("hindsight_strands.tools.Hindsight") as mock_cls:
+            mock_instance = _mock_client()
+            mock_instance.recall.return_value = _mock_recall_response(["fact"])
+            mock_cls.return_value = mock_instance
+            result = memory_instructions(
+                bank_id="test",
+                hindsight_api_url="http://localhost:8888",
+            )
+            assert "fact" in result
+            mock_instance.close.assert_called_once()
+
+    def test_closes_internally_created_client_on_exception(self):
+        with patch("hindsight_strands.tools.Hindsight") as mock_cls:
+            mock_instance = _mock_client()
+            mock_instance.recall.side_effect = RuntimeError("network error")
+            mock_cls.return_value = mock_instance
+            result = memory_instructions(
+                bank_id="test",
+                hindsight_api_url="http://localhost:8888",
+            )
+            assert result == ""
+            mock_instance.close.assert_called_once()
+
+    def test_does_not_close_externally_owned_client(self):
+        client = _mock_client()
+        client.recall.return_value = _mock_recall_response(["fact"])
+        memory_instructions(bank_id="test", client=client)
+        client.close.assert_not_called()


### PR DESCRIPTION
## Summary
- track client ownership in `hindsight_strands.tools._resolve_client()`
- return a list-compatible `HindsightTools` container with `close()`/`aclose()` for internally-owned clients
- ensure `memory_instructions()` closes internally-created clients in a `finally` block
- add lifecycle tests for internal vs external ownership and cleanup behavior
- update README lifecycle guidance for FastAPI and shutdown cleanup

## Validation
- `cd hindsight-integrations/strands && PYTHONPATH=. python3 -m pytest -q` (82 passed)
- `uv run --directory hindsight-integrations/strands ruff check .` (passed)

Closes #1387