### PR TITLE
fix(agent-sdk): agent_knowledge_recall — rename max_results to max_tokens, default 1024

### DIFF
--- a/hindsight-tools/hindsight-agent-sdk/src/index.ts
+++ b/hindsight-tools/hindsight-agent-sdk/src/index.ts
@@ -203,13 +203,17 @@ export function createKnowledgeTools(opts: CreateKnowledgeToolsOptions): Knowled
         type: "object",
         properties: {
           query: { type: "string", description: "What to search for" },
-          max_results: { type: "number", description: "Max results (default 10)" },
+          max_tokens: { type: "number", description: "Token budget for results (default 1024)" },
         },
         required: ["query"],
       },
       async execute(params: Record<string, unknown>) {
+        const maxTokens =
+          (params.max_tokens as number | undefined) ??
+          (params.max_results as number | undefined) ??
+          1024;
         const result = await client.recall(bankId, params.query as string, {
-          maxTokens: (params.max_results as number | undefined) ?? 10,
+          maxTokens,
         });
         return ok(result);
       },


### PR DESCRIPTION
## Summary

`agent_knowledge_recall` in `hindsight-tools/hindsight-agent-sdk/src/index.ts` has the same parameter-vs-budget mismatch that #1544 just fixed in `hindsight-integrations/claude-code/scripts/mcp_server.py`.

The schema exposes `max_results` (default `10`) but the executor pipes that value straight into `client.recall(..., { maxTokens })`. The server has no `max_results` concept — `/v1/default/banks/{bank}/memories/recall` returns whatever fits in the token budget — so a default of 10 tokens collapses every result set to `[]` for callers who never override the param. Same bug, different file.

## Change

- Rename the schema parameter to `max_tokens` and update the description ("Token budget for results (default 1024)").
- Bump the default to `1024`, matching #1544 and the Python `client.recall` default.
- Backward-compat: the executor still honors a legacy `max_results` if the caller passes it, so existing consumers of `@vectorize-io/hindsight-agent-sdk` v0.1.0 don't silently fall through to the new default. `max_tokens` wins when both are set.

```ts
const maxTokens =
  (params.max_tokens as number | undefined) ??
  (params.max_results as number | undefined) ??
  1024;
```

## Test plan

- [ ] `cd hindsight-tools/hindsight-agent-sdk && npm test` — existing recall test still passes (it doesn't bind to the parameter name).
- [ ] Manually call the tool against a populated bank with no params — expect non-empty `results` (was `[]` before because of `max_tokens=10`).
- [ ] Pass `max_results: 4096` (legacy) — expect 4096 in body.
- [ ] Pass `max_tokens: 4096` (new) — expect 4096 in body; takes precedence over any `max_results`.

## Notes

- Sister fix to #1544 (offendingcommit, merged ~1 h before this PR opened).
- I kept the legacy alias deliberately because this SDK is published as `@vectorize-io/hindsight-agent-sdk` v0.1.0; happy to drop the alias if you'd rather have a clean rename like #1544 — let me know.
- 0 LOC change to tests/index.test.ts. Tell me if you want a regression assertion on `body.max_tokens` and I'll add it.
