### PR TITLE
fix(paperclip): align with Paperclip's actual event payloads

### DIFF
--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -17,6 +17,8 @@ const manifest: PaperclipPluginManifestV1 = {
     "http.outbound",
     "secrets.read-ref",
     "agents.read",
+    "issues.read",
+    "issue.comments.read",
   ],
   entrypoints: {
     worker: "./dist/worker.js",

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -173,6 +173,14 @@ const plugin = definePlugin({
           /* ignore */
         }
       }
+      
+      if (!bankAgentId) {
+        ctx.logger.info("Skipping retain — no agent attribution available", {
+          commentId,
+          issueId,
+        });
+        return;
+      }
 
       try {
         const apiKey = await resolveApiKey(ctx, config);

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -4,8 +4,13 @@
  * Gives Paperclip agents persistent long-term memory via Hindsight.
  *
  * Lifecycle:
- *   agent.run.started  → recall relevant memories, store in plugin state for the run
- *   agent.run.finished → retain agent output to Hindsight (if autoRetain is enabled)
+ *   agent.run.started      → fetch the run's issue, recall relevant memories,
+ *                            cache them in plugin state for the run.
+ *   issue.comment.created  → retain the full comment body to Hindsight (this is
+ *                            the durable signal — it covers both user comments
+ *                            and agent-authored comments).
+ *   agent.run.finished     → no-op (Paperclip's lifecycle payload does not
+ *                            carry run output; subscription kept for future use).
  *
  * Agent tools (callable mid-run):
  *   hindsight_recall(query)   → search memory, returns relevant context
@@ -28,15 +33,19 @@ interface PluginConfig {
 interface RunStartedPayload {
   agentId: string;
   runId: string;
-  issueTitle?: string;
-  issueDescription?: string;
+  issueId?: string | null;
 }
 
 interface RunFinishedPayload {
   agentId: string;
   runId: string;
-  output?: string;
-  result?: string;
+}
+
+interface CommentCreatedPayload {
+  commentId?: string;
+  bodySnippet?: string;
+  agentId?: string | null;
+  runId?: string | null;
 }
 
 async function getConfig(ctx: {
@@ -59,15 +68,33 @@ const plugin = definePlugin({
     ctx.logger.info("Hindsight memory plugin starting");
 
     // ---------------------------------------------------------------------------
-    // agent.run.started — recall memories and cache them for this run
+    // agent.run.started — recall memories using the issue's title + description
+    //
+    // Paperclip's lifecycle payload only includes runId/agentId/issueId/etc.,
+    // so we fetch the issue via ctx.issues.get to obtain the title/description
+    // we need for a meaningful recall query.
     // ---------------------------------------------------------------------------
     ctx.events.on("agent.run.started", async (event) => {
       const payload = event.payload as RunStartedPayload;
       const config = await getConfig(ctx);
-      const { agentId, runId, issueTitle, issueDescription } = payload;
+      const { agentId, runId, issueId } = payload;
       const companyId = event.companyId;
+      if (!issueId || !companyId) return;
 
-      const query = [issueTitle, issueDescription].filter(Boolean).join("\n");
+      let issue;
+      try {
+        issue = await ctx.issues.get(issueId, companyId);
+      } catch (err) {
+        ctx.logger.warn("Failed to fetch issue for recall", {
+          runId,
+          issueId,
+          error: String(err),
+        });
+        return;
+      }
+      if (!issue) return;
+
+      const query = [issue.title, issue.description].filter(Boolean).join("\n");
       if (!query.trim()) return;
 
       try {
@@ -99,33 +126,88 @@ const plugin = definePlugin({
     });
 
     // ---------------------------------------------------------------------------
-    // agent.run.finished — retain run output to Hindsight
+    // issue.comment.created — retain the full comment body
+    //
+    // Paperclip's comment-created event payload only carries a 120-char snippet,
+    // so we fetch the full comment via ctx.issues.listComments. Comments are the
+    // primary durable record of agent + user output, so this captures both.
     // ---------------------------------------------------------------------------
-    ctx.events.on("agent.run.finished", async (event) => {
-      const payload = event.payload as RunFinishedPayload;
+    ctx.events.on("issue.comment.created", async (event) => {
       const config = await getConfig(ctx);
-
       if (config.autoRetain === false) return;
 
-      const { agentId, runId, output, result } = payload;
       const companyId = event.companyId;
-      const content = output ?? result;
+      const issueId = event.entityId;
+      const payload = (event.payload ?? {}) as CommentCreatedPayload;
+      const commentId = payload.commentId;
+      const payloadAgentId = payload.agentId ?? null;
+      if (!issueId || !companyId || !commentId) return;
 
-      if (!content?.trim()) return;
+      let body = "";
+      try {
+        const comments = await ctx.issues.listComments(issueId, companyId);
+        const match = comments.find((c) => c.id === commentId);
+        if (match && typeof match.body === "string") body = match.body;
+      } catch (err) {
+        // Fall back to the truncated snippet if listComments isn't available.
+        if (typeof payload.bodySnippet === "string") {
+          body = payload.bodySnippet;
+        } else {
+          ctx.logger.warn("Failed to fetch comment body", {
+            commentId,
+            error: String(err),
+          });
+          return;
+        }
+      }
+      if (!body.trim()) return;
+
+      // Bank attribution: comments authored by an agent belong in that agent's
+      // bank; user/system comments fall back to the issue's assignee.
+      let bankAgentId: string | null = payloadAgentId;
+      if (!bankAgentId) {
+        try {
+          const issue = await ctx.issues.get(issueId, companyId);
+          bankAgentId = issue?.assigneeAgentId ?? null;
+        } catch {
+          /* ignore */
+        }
+      }
 
       try {
         const apiKey = await resolveApiKey(ctx, config);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
-        const bankId = deriveBankId({ companyId, agentId }, config);
-
-        await client.retain(bankId, content, runId, { agentId, companyId, runId });
-        ctx.logger.info("Retained run output to memory", { runId, bankId });
+        const bankId = deriveBankId({ companyId, agentId: bankAgentId }, config);
+        await client.retain(bankId, body, commentId, {
+          agentId: bankAgentId,
+          companyId,
+          issueId,
+          commentId,
+        });
+        ctx.logger.info("Retained comment to memory", { commentId, bankId });
       } catch (err) {
-        ctx.logger.warn("Failed to retain run output", {
-          runId,
+        ctx.logger.warn("Failed to retain comment", {
+          commentId,
           error: String(err),
         });
       }
+    });
+
+    // ---------------------------------------------------------------------------
+    // agent.run.finished — no-op
+    //
+    // Paperclip's run-lifecycle payload only includes status/timing fields and
+    // does not carry the agent's output. Retention now flows through the
+    // issue.comment.created handler above. The subscription is kept so the
+    // plugin remains visible in the event subscription list and so future
+    // payload additions (e.g. an output reference) can be picked up here.
+    // ---------------------------------------------------------------------------
+    ctx.events.on("agent.run.finished", async (event) => {
+      const payload = event.payload as RunFinishedPayload;
+      ctx.logger.debug(
+        "agent.run.finished received (no-op; retention handled by issue.comment.created)",
+        { runId: payload?.runId }
+      );
     });
 
     // ---------------------------------------------------------------------------

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -42,11 +42,27 @@ const DEFAULT_CONFIG = {
 };
 
 function buildHarness(config: Record<string, unknown> = DEFAULT_CONFIG) {
-  return createTestHarness({ manifest, config, capabilities: manifest.capabilities });
+  return createTestHarness({
+    manifest,
+    config,
+    capabilities: [...manifest.capabilities, "issues.create", "issue.comments.create"],
+  });
 }
 
 async function setupPlugin(harness: ReturnType<typeof buildHarness>) {
   await plugin.definition.setup(harness.ctx);
+}
+
+async function seedIssue(
+  harness: ReturnType<typeof buildHarness>,
+  opts: { companyId: string; title: string; description?: string; assigneeAgentId?: string }
+) {
+  return harness.ctx.issues.create({
+    companyId: opts.companyId,
+    title: opts.title,
+    description: opts.description,
+    assigneeAgentId: opts.assigneeAgentId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -97,24 +113,28 @@ describe("agent.run.started", () => {
     vi.unstubAllGlobals();
   });
 
-  it("calls recall and caches memories in plugin state", async () => {
+  it("fetches the issue, calls recall, and caches memories in plugin state", async () => {
     const harness = buildHarness();
     await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Refactor auth module",
+      description: "Migrate to JWT",
+    });
 
     await harness.emit(
       "agent.run.started",
-      {
-        agentId: "ag-1",
-        runId: "run-1",
-        issueTitle: "Refactor auth module",
-        issueDescription: "Migrate to JWT",
-      },
+      { agentId: "ag-1", runId: "run-1", issueId: issue.id },
       { companyId: "co-1" }
     );
 
     const recallCall = fetchMock.mock.calls.find(([url]: [string]) => url.includes("recall"));
     expect(recallCall).toBeDefined();
     expect(recallCall?.[0]).toContain("paperclip%3A%3Aco-1%3A%3Aag-1");
+
+    const recallBody = JSON.parse(recallCall?.[1]?.body as string) as { query: string };
+    expect(recallBody.query).toContain("Refactor auth module");
+    expect(recallBody.query).toContain("Migrate to JWT");
 
     const state = harness.getState({
       scopeKind: "run",
@@ -124,13 +144,27 @@ describe("agent.run.started", () => {
     expect(state).toContain("TypeScript");
   });
 
-  it("skips recall when no issue context provided", async () => {
+  it("skips recall when no issueId is provided", async () => {
     const harness = buildHarness();
     await setupPlugin(harness);
 
     await harness.emit(
       "agent.run.started",
       { agentId: "ag-1", runId: "run-2" },
+      { companyId: "co-1" }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips recall when the issue has no title or description", async () => {
+    const harness = buildHarness();
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-2b", issueId: issue.id },
       { companyId: "co-1" }
     );
 
@@ -144,11 +178,12 @@ describe("agent.run.started", () => {
     );
     const harness = buildHarness();
     await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Fix bug" });
 
     await expect(
       harness.emit(
         "agent.run.started",
-        { agentId: "ag-1", runId: "run-3", issueTitle: "Fix bug" },
+        { agentId: "ag-1", runId: "run-3", issueId: issue.id },
         { companyId: "co-1" }
       )
     ).resolves.not.toThrow();
@@ -156,10 +191,10 @@ describe("agent.run.started", () => {
 });
 
 // ---------------------------------------------------------------------------
-// agent.run.finished — auto-retain
+// issue.comment.created — auto-retain
 // ---------------------------------------------------------------------------
 
-describe("agent.run.finished", () => {
+describe("issue.comment.created", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -171,54 +206,82 @@ describe("agent.run.finished", () => {
     vi.unstubAllGlobals();
   });
 
-  it("retains run output with runId as document ID", async () => {
+  it("retains the full comment body with the commentId as document ID", async () => {
     const harness = buildHarness();
     await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Refactor auth",
+      assigneeAgentId: "ag-1",
+    });
+    const comment = await harness.ctx.issues.createComment(
+      issue.id,
+      "Refactored auth. Migrated to JWT with 24h expiry.",
+      "co-1",
+      { authorAgentId: "ag-1" }
+    );
 
     await harness.emit(
-      "agent.run.finished",
-      {
-        agentId: "ag-1",
-        runId: "run-1",
-        output: "Refactored auth. Migrated to JWT with 24h expiry.",
-      },
-      { companyId: "co-1" }
+      "issue.comment.created",
+      { commentId: comment.id, agentId: "ag-1", runId: "run-1" },
+      { companyId: "co-1", entityId: issue.id }
     );
 
     const retainCall = fetchMock.mock.calls.find(([url]: [string]) => /memories$/.test(url));
     expect(retainCall).toBeDefined();
-
     const body = JSON.parse(retainCall?.[1]?.body as string) as {
       items: Array<{ content: string; document_id?: string }>;
     };
     expect(body.items[0]?.content).toContain("JWT");
-    expect(body.items[0]?.document_id).toBe("run-1");
-  });
-
-  it("skips retain when output is empty", async () => {
-    const harness = buildHarness();
-    await setupPlugin(harness);
-
-    await harness.emit(
-      "agent.run.finished",
-      { agentId: "ag-1", runId: "run-2", output: "" },
-      { companyId: "co-1" }
-    );
-
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(body.items[0]?.document_id).toBe(comment.id);
   });
 
   it("skips retain when autoRetain is false", async () => {
     const harness = buildHarness({ ...DEFAULT_CONFIG, autoRetain: false });
     await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "x", assigneeAgentId: "ag-1" });
+    const comment = await harness.ctx.issues.createComment(issue.id, "Some output", "co-1", {
+      authorAgentId: "ag-1",
+    });
 
     await harness.emit(
-      "agent.run.finished",
-      { agentId: "ag-1", runId: "run-3", output: "Some output" },
-      { companyId: "co-1" }
+      "issue.comment.created",
+      { commentId: comment.id, agentId: "ag-1" },
+      { companyId: "co-1", entityId: issue.id }
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips retain when commentId is missing", async () => {
+    const harness = buildHarness();
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "x" });
+
+    await harness.emit("issue.comment.created", {}, { companyId: "co-1", entityId: issue.id });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the issue assignee for bank attribution when comment has no agent author", async () => {
+    const harness = buildHarness();
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "x",
+      assigneeAgentId: "ag-assignee",
+    });
+    const comment = await harness.ctx.issues.createComment(issue.id, "User says: please do X", "co-1");
+
+    await harness.emit(
+      "issue.comment.created",
+      { commentId: comment.id, agentId: null },
+      { companyId: "co-1", entityId: issue.id }
+    );
+
+    const retainCall = fetchMock.mock.calls.find(([url]: [string]) => /memories$/.test(url));
+    expect(retainCall).toBeDefined();
+    expect(retainCall?.[0]).toContain("paperclip%3A%3Aco-1%3A%3Aag-assignee");
   });
 });
 
@@ -232,25 +295,23 @@ describe("hindsight_recall tool", () => {
   });
 
   it("returns cached memories from run start without additional API call", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("{}", { status: 200 }))
-    );
     const harness = buildHarness();
     await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Update UI",
+    });
 
-    // Emit agent.run.started so recall fires and caches state
     vi.stubGlobal(
       "fetch",
       mockFetch([{ url: /recall/, body: { results: [{ text: "User prefers dark mode" }] } }])
     );
     await harness.emit(
       "agent.run.started",
-      { agentId: "ag-1", runId: "run-1", issueTitle: "Update UI" },
+      { agentId: "ag-1", runId: "run-1", issueId: issue.id },
       { companyId: "co-1" }
     );
 
-    // Now recall tool should return cached state, not hit the API again
     const callsBefore = (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock.calls.length;
     const result = await harness.executeTool(
       "hindsight_recall",

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -236,6 +236,21 @@ describe("issue.comment.created", () => {
     expect(body.items[0]?.document_id).toBe(comment.id);
   });
 
+  it("skips retain when comment has no agent author and issue has no assignee", async () => {
+    const harness = buildHarness();
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "x" });
+    const comment = await harness.ctx.issues.createComment(issue.id, "User message", "co-1");
+
+    await harness.emit(
+      "issue.comment.created",
+      { commentId: comment.id, agentId: null },
+      { companyId: "co-1", entityId: issue.id }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  
   it("skips retain when autoRetain is false", async () => {
     const harness = buildHarness({ ...DEFAULT_CONFIG, autoRetain: false });
     await setupPlugin(harness);


### PR DESCRIPTION
The plugin's `agent.run.started` and `agent.run.finished` handlers destructured fields (`issueTitle`, `issueDescription`, `output`, `result`) that Paperclip's host does not publish. Paperclip emits a thin lifecycle payload — `{runId, agentId, status, invocationSource, triggerDetail, error, errorCode, issueId, startedAt, finishedAt}` — so both handlers silently early-returned and the plugin never recalled or retained anything despite registering successfully.

Changes:

- `agent.run.started` now uses `payload.issueId` to look up the issue via `ctx.issues.get` and builds the recall query from the issue's title + description.

- New `issue.comment.created` subscription replaces the `agent.run.finished` retain path. Comments are the durable record of agent + user output and the existing payload only carries a 120-char snippet, so we fetch the full body via `ctx.issues.listComments`. Bank attribution falls back to the issue's assignee when a comment has no agent author (e.g. user comments).

- `agent.run.finished` is kept as a debug no-op so the subscription stays visible and can be reused if Paperclip ever embeds output in the lifecycle payload.

- Manifest gains `issues.read` and `issue.comments.read` capabilities, required by the new SDK calls.

- Tests updated to seed issues/comments via the harness, exercise the new comment-created path, and cover the assignee-fallback for unauthored comments.

Verified end-to-end against a local Paperclip + self-hosted Hindsight: the patched plugin retains real comment bodies to the correct bank and Hindsight's recall API returns them on subsequent queries.