### PR TITLE
fix(claude-code-mcp): make run_mcp.sh bootstrap idempotent on Windows

### DIFF
--- a/hindsight-integrations/claude-code/scripts/run_mcp.sh
+++ b/hindsight-integrations/claude-code/scripts/run_mcp.sh
@@ -7,13 +7,43 @@ VENV="${CLAUDE_PLUGIN_DATA}/venv"
 REQ_SRC="${CLAUDE_PLUGIN_ROOT}/requirements.txt"
 REQ_CACHED="${CLAUDE_PLUGIN_DATA}/requirements.txt"
 
-if [ ! -x "${VENV}/bin/python" ] || ! diff -q "${REQ_SRC}" "${REQ_CACHED}" >/dev/null 2>&1; then
+# Resolve the venv interpreter. On Windows-built venvs `bin/python` is
+# `python.exe`; bash's `[ -x ]` does not honor PATHEXT, so probe both forms.
+resolve_py() {
+  if [ -x "${VENV}/bin/python" ]; then
+    PY="${VENV}/bin/python"
+    PIP="${VENV}/bin/pip"
+  elif [ -x "${VENV}/bin/python.exe" ]; then
+    PY="${VENV}/bin/python.exe"
+    PIP="${VENV}/bin/pip.exe"
+  else
+    PY=""
+    PIP=""
+  fi
+}
+
+resolve_py
+if [ -z "${PY}" ]; then
   mkdir -p "${CLAUDE_PLUGIN_DATA}"
   if ! python3 -m venv "${VENV}" 2>/dev/null; then
     python -m venv "${VENV}"
   fi
-  "${VENV}/bin/pip" install --quiet -r "${REQ_SRC}"
+  resolve_py
+  if [ -z "${PY}" ]; then
+    echo "[Hindsight MCP] venv create failed: no python interpreter at ${VENV}/bin/" >&2
+    exit 1
+  fi
+fi
+
+# Re-pip only when the requirements cache is missing, requirements drifted, or
+# `mcp` is not importable from the venv. Splitting this from venv creation
+# keeps warm starts cheap and avoids re-running pip over a venv that's already
+# in use (which fails with ERROR_SHARING_VIOLATION on Windows).
+if [ ! -f "${REQ_CACHED}" ] \
+   || ! diff -q "${REQ_SRC}" "${REQ_CACHED}" >/dev/null 2>&1 \
+   || ! "${PY}" -c "import mcp" >/dev/null 2>&1; then
+  "${PIP}" install --quiet -r "${REQ_SRC}"
   cp "${REQ_SRC}" "${REQ_CACHED}"
 fi
 
-exec "${VENV}/bin/python" "${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"
+exec "${PY}" "${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"


### PR DESCRIPTION
## Summary

- Resolves the venv interpreter via both `bin/python` and `bin/python.exe`. On Windows-built venvs the file is `python.exe`, and bash's `[ -x ]` test does not honor PATHEXT — so the previous probe never matched and the bootstrap branch fired on every session start.
- Splits venv creation from pip-sync. Pip now reruns only when the requirements cache is missing, requirements drifted, or `mcp` is not importable from the venv. Warm starts now skip both venv recreation and pip install, which also stops the cascade where re-running pip over the in-use venv hit `ERROR_SHARING_VIOLATION` on Windows and left orphan `pip.exe`/`python3.exe` processes locking the venv files.
- Aborts with a clear stderr message if venv creation still produces no usable interpreter, rather than failing later inside `exec`.

Fixes #1564.

## Why

On Windows (msys2 bash + `C:\msys64\mingw64\bin\python.exe`), Claude Code logged `Failed to reconnect to plugin:hindsight-memory:hindsight.` at every session start. `bash -x scripts/run_mcp.sh` showed the bootstrap branch firing every time, falling back to `python -m venv` over an in-use venv, and erroring `[Errno 13] Permission denied: '.../venv/bin/python3.exe'`. Full reproduction in #1564.

## Test plan

- [x] `bash -n hindsight-integrations/claude-code/scripts/run_mcp.sh` — clean.
- [x] Cold start (no venv): bootstrap creates the venv, pip installs, `exec` reaches `mcp_server.py`.
- [x] Warm start (venv + cache present, `mcp` importable): both bootstrap probes short-circuit; script reaches `exec` without touching pip or recreating the venv. Verified on Windows 11 / msys2 5.2.37 / Python 3.12.11.
- [ ] Linux/macOS warm + cold smoke (would appreciate a CI check — I only have Windows handy).

## Notes

- Behavior on systems where `bin/python` exists as an extensionless symlink (Linux/macOS) is unchanged: the first branch of `resolve_py` still hits.
- The script remains a single-file shell change; no Python/Node touched, so I skipped `./scripts/hooks/lint.sh`.
- I'm not adding a tests/ entry — the existing pytest suite under `hindsight-integrations/claude-code/tests/` covers Python modules, not the bootstrap shell. Happy to wire up a tiny shell-test harness if you want it.