### PR TITLE
fix(integrations-claude-code): label 'Current time' as UTC in recall context

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -221,10 +221,13 @@ def format_memories(results: list) -> str:
 def format_current_time() -> str:
     """Format current UTC time for recall context.
 
+    The "UTC" suffix is explicit so client LLMs do not misread the
+    value as local time when reasoning about wall-clock context.
+
     Port of: formatCurrentTimeForRecall() in index.js
     """
     now = datetime.now(timezone.utc)
-    return now.strftime("%Y-%m-%d %H:%M")
+    return now.strftime("%Y-%m-%d %H:%M UTC")
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -1,11 +1,14 @@
 """Tests for lib/content.py — pure content-processing functions."""
 
+import re
+
 import pytest
 
 from lib.content import (
     _extract_text_content,
     _is_channel_message_tool,
     compose_recall_query,
+    format_current_time,
     format_memories,
     prepare_retention_transcript,
     slice_last_turns_by_user_boundary,
@@ -469,3 +472,18 @@ class TestPrepareRetentionTranscript:
         transcript, _ = prepare_retention_transcript(msgs, retain_full_window=True, include_tool_calls=False)
         assert "[role: user]" in transcript
         assert "[user:end]" in transcript
+
+
+# ---------------------------------------------------------------------------
+# format_current_time
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCurrentTime:
+    def test_includes_utc_suffix(self):
+        # The "UTC" suffix prevents client LLMs from misreading the
+        # timestamp as local time.
+        assert format_current_time().endswith(" UTC")
+
+    def test_format_shape(self):
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC", format_current_time())


### PR DESCRIPTION
## Problem

The Hindsight recall hook injects `Current time - <ts>` into the `<hindsight_memories>` block on every `UserPromptSubmit`, but the timestamp is rendered as UTC with no timezone label. Client-side LLMs running in non-UTC timezones routinely misread the value as local time.

Concrete repro #1 (Claude Code, JST / UTC+9):

- Local wall clock: `2026-05-11 08:55` (morning)
- Injected line: `Current time - 2026-05-10 23:55`
- Result: the model reasons that it is late evening and replies things like *"sounds like a good place to wrap up for the day"* even though it is morning in the user's actual timezone.

Concrete repro #2 — much worse, observed since the original report:

- A long-running Claude Code session had an earlier `Current time - <ts>` line still sitting in its scrolled-back context (UTC value).
- Later in the same session (local time now ~9 hours ahead in JST), the model re-read that scrolled-back stamp while reasoning about command history, parsed the UTC value as local time, and concluded that **a different user had executed the same command roughly 9 hours earlier** — i.e. it invented a second actor to explain the apparent time gap.
- It then opened a security investigation into the "unauthorized duplicate execution." Sounds like a joke but it actually happened.
- The 9-hour delta is exactly JST→UTC, which is the smoking gun: same root cause as repro #1, but the failure mode is paranoia / false security incident rather than just a wrong greeting.

## Fix

`format_current_time()` now returns `2026-05-10 23:55 UTC`. The `UTC` suffix matches the convention already used by the `opencode` integration:

https://github.com/vectorize-io/hindsight/blob/main/hindsight-integrations/opencode/src/hooks.ts#L117

so this is parity rather than novelty.

## Scope

- `hindsight-integrations/claude-code/scripts/lib/content.py` — the actual change (4 lines)
- `hindsight-integrations/claude-code/tests/test_content.py` — regression tests (suffix + format-shape)

The same `format_current_time()` shape exists in the `codex` and `openclaw` integrations and is theoretically affected by the same issue. This PR intentionally leaves them out:

- The misreading behaviour has only been **observed and confirmed against Claude Code** by the reporter.
- `hindsight-integrations/codex/scripts/lib/content.py` carries pre-existing ruff-format drift in unrelated regions, so editing the same file would either (a) fail `verify-generated-files` CI or (b) require reformatting ~120 unrelated lines — out of scope for this fix.

Happy to open follow-up PRs for `codex` / `openclaw` if you want the parity extended.

## Test plan

- [x] `pytest hindsight-integrations/claude-code/tests/test_content.py` — 57 passed, including the two new tests.
- [x] `ruff check --config ./ruff.toml hindsight-integrations/claude-code/scripts/lib/content.py` — clean.
- [x] `ruff format --config ./ruff.toml --check hindsight-integrations/claude-code/scripts/lib/content.py` — already formatted.

## Rebase note

Rebased onto `8b10231b Release v0.6.2` to stay current with the v0.6.2 release line.
