### PR TITLE
blog: add category filter to blog landing page

### DIFF
--- a/hindsight-docs/blog/2026-01-28-learning-capabilities.md
+++ b/hindsight-docs/blog/2026-01-28-learning-capabilities.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 image: /img/reflect-operation.webp
 date: 2026-01-28T12:00
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Today we're releasing Hindsight 0.4.0, which introduces two powerful learning capabilities for AI agents: **Observations** for automatic knowledge consolidation, and **Mental Models** for user-curated summaries.

--- a/hindsight-docs/blog/2026-02-09-resolving-memory-conflicts.md
+++ b/hindsight-docs/blog/2026-02-09-resolving-memory-conflicts.md
@@ -6,6 +6,7 @@ authors: [chrislatimer]
 image: /img/blog/2026-02-09/consolidation-pipeline.png
 date: 2026-02-09T12:00
 hide_table_of_contents: true
+tags: [deep-dive]
 ---
 
 # How We Solved Memory Conflicts in Hindsight

--- a/hindsight-docs/blog/2026-02-13-version-0-4-11.md
+++ b/hindsight-docs/blog/2026-02-13-version-0-4-11.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.4.11
 authors: [nicoloboschi]
 date: 2026-02-13T12:00
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.4.11 focuses on production-ready deployments with improved flexibility and observability.

--- a/hindsight-docs/blog/2026-02-18-version-0-4-12.md
+++ b/hindsight-docs/blog/2026-02-18-version-0-4-12.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.4.12
 authors: [nicoloboschi]
 date: 2026-02-18T12:00
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.4.12 expands what you can ingest, cuts ingestion costs, and broadens where you can run it.

--- a/hindsight-docs/blog/2026-02-26-chat.md
+++ b/hindsight-docs/blog/2026-02-26-chat.md
@@ -2,7 +2,7 @@
 title: "Your Vercel Chat SDK bot forgets everything. Hindsight fixes that."
 authors: [nicoloboschi]
 date: 2026-02-26T12:00
-tags: [chat-sdk, slack, discord, typescript, memory]
+tags: [chat-sdk, slack, discord, typescript, memory, tutorial]
 image: /img/blog/vercel-chat.png
 ---
 

--- a/hindsight-docs/blog/2026-02-27-version-0-4-13-0-4-14.md
+++ b/hindsight-docs/blog/2026-02-27-version-0-4-13-0-4-14.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.4.13 and 0.4.14
 authors: [nicoloboschi]
 date: 2026-02-27T12:00
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.4.13 and 0.4.14 add Chat SDK support, CrewAI integration, configurable MCP tools, graph retrieval tag filtering, and a new reranker provider—plus a set of reliability and performance improvements across the board.

--- a/hindsight-docs/blog/2026-03-03-version-0-4-15.md
+++ b/hindsight-docs/blog/2026-03-03-version-0-4-15.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-03T12:00
 hide_table_of_contents: true
 image: /img/blog/release0415.png
+tags: [release]
 ---
 
 Hindsight 0.4.15 adds PydanticAI integration, observation scopes, richer entity labels, and several performance improvements—alongside a set of reliability and stability fixes.

--- a/hindsight-docs/blog/2026-03-05-add-memory-to-openai-application.md
+++ b/hindsight-docs/blog/2026-03-05-add-memory-to-openai-application.md
@@ -2,7 +2,7 @@
 title: "Give Your OpenAI App a Memory in 5 Minutes"
 authors: [benfrank241]
 date: 2026-03-05T12:00
-tags: [memory, openai, python, docker, rag, llm, vector, embedding]
+tags: [memory, openai, python, docker, rag, llm, vector, embedding, tutorial]
 image: /img/blog/add-memory-to-openai-application.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-05-version-0-4-16.md
+++ b/hindsight-docs/blog/2026-03-05-version-0-4-16.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-05T12:00
 hide_table_of_contents: true
 image: /img/blog/release0416.png
+tags: [release]
 ---
 
 Hindsight 0.4.16 introduces a webhook system for event-driven memory pipelines, improved search quality, and several reliability fixes.

--- a/hindsight-docs/blog/2026-03-06-adding-memory-to-openclaw-with-hindsight.md
+++ b/hindsight-docs/blog/2026-03-06-adding-memory-to-openclaw-with-hindsight.md
@@ -2,7 +2,7 @@
 title: "How to Add Persistent Memory to OpenClaw with Hindsight"
 authors: [benfrank241]
 date: 2026-03-06T12:00
-tags: [openclaw, memory, agents, persistent-memory, knowledge-graph]
+tags: [openclaw, memory, agents, persistent-memory, knowledge-graph, tutorial]
 image: /img/blog/adding-memory-to-openclaw-with-hindsight.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-09-pydantic-ai-persistent-memory.md
+++ b/hindsight-docs/blog/2026-03-09-pydantic-ai-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Pydantic AI Persistent Memory: Add It in 5 Lines of Code"
 authors: [benfrank241]
 date: 2026-03-09T12:00
-tags: [memory, openai, anthropic, gemini, python, rust, agents, rag, vector, pydantic-ai, knowledge-graph]
+tags: [memory, openai, anthropic, gemini, python, rust, agents, rag, vector, pydantic-ai, knowledge-graph, tutorial]
 image: /img/blog/pydantic-ai-persistent-memory.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-10-version-0-4-17.md
+++ b/hindsight-docs/blog/2026-03-10-version-0-4-17.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-10T12:00
 hide_table_of_contents: true
 image: /img/blog/release0417.png
+tags: [release]
 ---
 
 Hindsight 0.4.17 adds history tracking with diff views for mental models and observations, flexible per-request file parsing, manual retry for failed async operations, and tag management for existing documents—plus several reliability fixes.

--- a/hindsight-docs/blog/2026-03-12-spreading-activation-memory-graphs.md
+++ b/hindsight-docs/blog/2026-03-12-spreading-activation-memory-graphs.md
@@ -2,7 +2,7 @@
 title: "How We Built Time-Aware Spreading Activation for Memory Graphs"
 authors: [chrislatimer]
 date: 2026-03-12T12:00
-tags: [retrieval, graph, temporal, spreading-activation, memory]
+tags: [retrieval, graph, temporal, spreading-activation, memory, deep-dive]
 image: /img/blog/spreading-activation-memory-graphs.png
 ---
 

--- a/hindsight-docs/blog/2026-03-13-disposition-aware-agents.md
+++ b/hindsight-docs/blog/2026-03-13-disposition-aware-agents.md
@@ -2,7 +2,7 @@
 title: "How We Built Disposition-Aware Agents That Actually Think Differently"
 authors: [chrislatimer]
 date: 2026-03-13T12:00
-tags: [disposition, personality, skepticism, empathy, reflect, agents]
+tags: [disposition, personality, skepticism, empathy, reflect, agents, deep-dive]
 image: /img/blog/disposition-aware-agents.png
 ---
 

--- a/hindsight-docs/blog/2026-03-13-version-0-4-18.md
+++ b/hindsight-docs/blog/2026-03-13-version-0-4-18.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-13T12:00
 hide_table_of_contents: true
 image: /img/blog/release0418.png
+tags: [release]
 ---
 
 Hindsight 0.4.18 adds compound tag filtering with boolean logic, slimmer Python packages, MiniMax and Jina MLX (Apple Silicon) provider support, per-bank HNSW vector indexes, and a configurable recall query token limit.

--- a/hindsight-docs/blog/2026-03-18-version-0-4-19.md
+++ b/hindsight-docs/blog/2026-03-18-version-0-4-19.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-18T12:00
 hide_table_of_contents: true
 image: /img/blog/release0419.jpg
+tags: [release]
 ---
 
 Hindsight 0.4.19 adds Agno and Hermes Agent integrations, three new retain extraction modes with named per-call strategies, Deno support for the TypeScript client, and a recovery mechanism for consolidation failures.

--- a/hindsight-docs/blog/2026-03-19-nemoclaw-memory.md
+++ b/hindsight-docs/blog/2026-03-19-nemoclaw-memory.md
@@ -6,6 +6,7 @@ authors: [hindsight]
 date: 2026-03-19T12:00
 image: /img/blog/2026-03-19/nemoclaw-memory.png
 hide_table_of_contents: true
+tags: [tutorial]
 ---
 
 ![Give NemoClaw the Best Agent Memory Available In One Command](/img/blog/2026-03-19/nemoclaw-memory.png)

--- a/hindsight-docs/blog/2026-03-23-agent-memory-benchmark.mdx
+++ b/hindsight-docs/blog/2026-03-23-agent-memory-benchmark.mdx
@@ -2,7 +2,7 @@
 title: "Agent Memory Benchmark: A Manifesto"
 authors: [nicoloboschi]
 date: 2026-03-23T12:00
-tags: [benchmark, memory, agents, evaluation, longmemeval, locomo, open-source]
+tags: [benchmark, memory, agents, evaluation, longmemeval, locomo, open-source, deep-dive]
 image: /img/blog/amb/explorer-0.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-24-langgraph-longterm-memory.md
+++ b/hindsight-docs/blog/2026-03-24-langgraph-longterm-memory.md
@@ -3,7 +3,7 @@ title: "Adding Long-Term Memory to LangGraph and LangChain Agents"
 description: Learn how to add long-term memory to LangGraph and LangChain agents using three integration patterns — tools, nodes, and BaseStore — with per-user memory banks and semantic recall.
 authors: [DK09876]
 date: 2026-03-24T12:00
-tags: [langgraph, langchain, integrations, agents, memory]
+tags: [langgraph, langchain, integrations, agents, memory, tutorial]
 image: /img/blog/langgraph-longterm-memory.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-24-version-0-4-20.md
+++ b/hindsight-docs/blog/2026-03-24-version-0-4-20.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-24
 hide_table_of_contents: true
 image: /img/blog/release0420.png
+tags: [release]
 ---
 
 Hindsight 0.4.20 adds Claude Code and LangGraph integrations, a NemoClaw setup CLI, independent versioning for integration packages, and reflect improvements including fact type filters, mental model exclusion, and a wall-clock timeout—plus a batch of reliability fixes.

--- a/hindsight-docs/blog/2026-03-27-parallel-hybrid-search.md
+++ b/hindsight-docs/blog/2026-03-27-parallel-hybrid-search.md
@@ -3,7 +3,7 @@ title: "How We Built a 4-Way Hybrid Search System That Actually Runs in Parallel
 description: Sequential async queries were killing our retrieval latency. Here's how we built a true 4-way parallel hybrid search system with asyncio and RRF fusion — then evolved it further with connection sharing, cross-encoder reranking, and multiplicative boost scoring.
 authors: [chrislatimer, nicoloboschi, benfrank241]
 date: 2026-03-27T12:00
-tags: [engineering, retrieval, search, python, asyncio, performance]
+tags: [engineering, retrieval, search, python, asyncio, performance, deep-dive]
 image: /img/blog/parallel-hybrid-search.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-30-llamaindex-agent-memory.md
+++ b/hindsight-docs/blog/2026-03-30-llamaindex-agent-memory.md
@@ -3,7 +3,7 @@ title: "Teaching the Llama to Remember"
 description: LlamaIndex agents reset memory every session. Learn how to add persistent cross-session memory using hindsight-llamaindex in 3 steps. Full code examples included.
 authors: [DK09876]
 date: 2026-03-30T12:00
-tags: [llamaindex, integrations, agents, memory, python]
+tags: [llamaindex, integrations, agents, memory, python, tutorial]
 image: /img/blog/llamaindex-agent-memory.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-03-30-version-0-4-21.md
+++ b/hindsight-docs/blog/2026-03-30-version-0-4-21.md
@@ -5,6 +5,7 @@ authors: [nicoloboschi]
 date: 2026-03-30
 hide_table_of_contents: true
 image: /img/blog/release0421.png
+tags: [release]
 ---
 
 Hindsight 0.4.21 adds three new framework integrations (LlamaIndex, AG2, Strands), a Codex CLI integration, delta retain to skip unchanged content, a LiteLLM provider for 100+ LLM backends, native Windows support, audit logging, and a batch of reliability fixes across the board.

--- a/hindsight-docs/blog/2026-03-31-version-0-4-22.md
+++ b/hindsight-docs/blog/2026-03-31-version-0-4-22.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.4.22
 authors: [nicoloboschi]
 date: 2026-03-31
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.4.22 is primarily a bugfix release, with fixes across providers, integrations, and the recall pipeline. It also adds mental model trigger tag filtering and exposes document metadata through the API and Control Plane.

--- a/hindsight-docs/blog/2026-04-02-beam-sota.md
+++ b/hindsight-docs/blog/2026-04-02-beam-sota.md
@@ -2,7 +2,7 @@
 title: "Hindsight Is #1 on BEAM — the Benchmark That Tests Memory at 10 Million Tokens"
 authors: [benfrank241]
 date: 2026-04-02
-tags: [benchmark, memory, beam, evaluation, open-source]
+tags: [benchmark, memory, beam, evaluation, open-source, release]
 image: /img/blog/beam-benchmark-chart.png
 description: "Hindsight is #1 on BEAM — the memory benchmark that tests at 10M tokens where context stuffing is impossible. See every published result and what drives the 58% margin."
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-06-autogen-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-06-autogen-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Persistent Memory for AutoGen Agents with Hindsight"
 authors: [DK09876]
 date: 2026-04-06
-tags: [autogen, integrations, agents, memory, python, microsoft]
+tags: [autogen, integrations, agents, memory, python, microsoft, tutorial]
 description: "AutoGen agents lose all state when a session ends. hindsight-autogen adds three tools — retain, recall, reflect — that give your agents persistent memory across sessions."
 image: /img/blog/autogen-persistent-memory.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-06-hermes-native-memory-provider.md
+++ b/hindsight-docs/blog/2026-04-06-hermes-native-memory-provider.md
@@ -2,7 +2,7 @@
 title: "Hindsight Is Now a Native Memory Provider in Hermes Agent"
 authors: [benfrank241]
 date: 2026-04-06
-tags: [hermes, memory, hindsight, integration]
+tags: [hermes, memory, hindsight, integration, release]
 description: "Hermes Agent now supports pluggable memory providers. Here's why Hindsight is the backend to use, and how to set it up in two minutes."
 image: /img/blog/hermes-native-memory-provider.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-07-one-memory-for-every-ai-tool.md
+++ b/hindsight-docs/blog/2026-04-07-one-memory-for-every-ai-tool.md
@@ -2,7 +2,7 @@
 title: "One Memory for Every AI Tool I Use"
 authors: [404sand808s]
 date: 2026-04-07
-tags: [mcp, memory, claude, claude-code, openai, hindsight, integration, self-hosting]
+tags: [mcp, memory, claude, claude-code, openai, hindsight, integration, self-hosting, tutorial]
 description: "How to wire Claude, ChatGPT, Claude Code, Codex, and OpenClaw to a single shared Hindsight memory bank using Cloudflare Workers as an OAuth 2.1 proxy."
 image: /img/blog/one-memory-for-every-ai-tool.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-07-version-0-5-0.md
+++ b/hindsight-docs/blog/2026-04-07-version-0-5-0.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.0
 authors: [nicoloboschi]
 date: 2026-04-07T12:00
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.5.0 introduces the Bank Template Hub for portable configuration, a Constellation graph view in the Control Plane, major retain and recall performance improvements, new LLM providers (llama.cpp, OpenRouter, Google), retain append mode, new framework integrations (AutoGen, OpenCode), and a breaking removal of legacy graph retrieval strategies and the Hermes integration.

--- a/hindsight-docs/blog/2026-04-09-agno-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-09-agno-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Agno Persistent Memory: Long-Term Memory for Agno Agents"
 authors: [benfrank241]
 date: 2026-04-09T09:00
-tags: [agno, integrations, agents, memory, persistent-memory, python]
+tags: [agno, integrations, agents, memory, persistent-memory, python, tutorial]
 description: "Agno agents start each run fresh. hindsight-agno adds HindsightTools and memory_instructions so they can retain, recall, and reflect across sessions."
 image: /img/blog/agno-persistent-memory.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-13-version-0-5-1.md
+++ b/hindsight-docs/blog/2026-04-13-version-0-5-1.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.1
 authors: [nicoloboschi]
 date: 2026-04-13
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.5.1 is a polish release focused on the CLI and reliability fixes across retain, recall, and the embedded daemon. It also introduces a Cloudflare OAuth proxy for self-hosted deployments, SiliconFlow as a reranker provider, a default bank template applied at bank creation, and a new `@vectorize-io/hindsight-all` daemon lifecycle package.

--- a/hindsight-docs/blog/2026-04-15-version-0-5-2.md
+++ b/hindsight-docs/blog/2026-04-15-version-0-5-2.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.2
 authors: [nicoloboschi]
 date: 2026-04-15
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.5.2 lands a new entity co-occurrence graph in the control plane, gives operators more control over mental model refresh, exposes richer metadata on async operations, and delivers a handful of reliability fixes across retain, consolidation, and the embedded daemon.

--- a/hindsight-docs/blog/2026-04-16-constellation-view.md
+++ b/hindsight-docs/blog/2026-04-16-constellation-view.md
@@ -2,7 +2,7 @@
 title: "Your AI's Memory Is a Black Box. Constellation View Makes It Visible."
 authors: [benfrank241]
 date: 2026-04-16
-tags: [hindsight, control-plane, memory, visualization]
+tags: [hindsight, control-plane, memory, visualization, release]
 description: "Constellation View and the Entity Co-occurrence Graph let you inspect the structure of a Hindsight bank as an interactive graph — debug memory quality, spot noisy hubs, and explain agent recall visually."
 image: /img/blog/constellation-view.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-17-openai-agents-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-17-openai-agents-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "OpenAI Agents Forget Everything Between Runs. Here's the Fix."
 authors: [DK09876]
 date: 2026-04-17
-tags: [openai, integrations, agents, memory, python]
+tags: [openai, integrations, agents, memory, python, tutorial]
 description: "OpenAI Agents SDK agents lose all state when a run ends. hindsight-openai-agents adds three tools and auto-injected memory instructions that give your agents persistent memory across sessions."
 image: /img/blog/openai-agents-persistent-memory.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-17-version-0-5-3.md
+++ b/hindsight-docs/blog/2026-04-17-version-0-5-3.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.3
 authors: [nicoloboschi]
 date: 2026-04-17
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.5.3 focuses on multi-tenant fairness and operational resilience. A new consolidation round limit prevents a single bank from monopolizing worker slots, mental models get smarter delta-based refreshes, the OpenAI Agents SDK gains first-class support, and a batch of fixes hardens file retain, migration paths, and GPU reranking.

--- a/hindsight-docs/blog/2026-04-20-opencode-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-20-opencode-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Your OpenCode Agent Forgets Everything Between Sessions. Here's the Fix."
 authors: [DK09876]
 date: 2026-04-20
-tags: [opencode, memory, integrations, typescript]
+tags: [opencode, memory, integrations, typescript, tutorial]
 description: "OpenCode sessions are stateless by default. The @vectorize-io/opencode-hindsight plugin adds persistent memory via automatic hooks and three explicit tools."
 image: /img/blog/opencode-persistent-memory.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
+++ b/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
@@ -4,6 +4,7 @@ description: "How Hindsight became the community's choice for agent memory in 4.
 slug: "2026/04/22/hindsight-10k-stars"
 date: 2026-04-22T12:00
 image: "/img/blog/hindsight-10k-stars.png"
+tags: [release]
 ---
 
 ![Hindsight Reaches 10,000 Stars](/img/blog/hindsight-10k-stars.png)

--- a/hindsight-docs/blog/2026-04-22-version-0-5-4.md
+++ b/hindsight-docs/blog/2026-04-22-version-0-5-4.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.4
 authors: [nicoloboschi]
 date: 2026-04-22
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.5.4 makes delta mental model refreshes dramatically faster and more accurate, hardens embedded mode with daemon crash recovery, and includes a wave of reflect and retain reliability fixes from the community.

--- a/hindsight-docs/blog/2026-04-23-your-agent-is-not-forgetful.md
+++ b/hindsight-docs/blog/2026-04-23-your-agent-is-not-forgetful.md
@@ -3,7 +3,7 @@ title: "Your Agent Is Not Forgetful. It Was Never Given a Memory."
 description: "Why agents seem forgetful, and why memory is different from context windows and retrieval. How Hindsight adds long-term memory to agents."
 authors: [benfrank241]
 date: 2026-04-23
-tags: [memory, agents, hindsight, learning]
+tags: [memory, agents, hindsight, learning, deep-dive]
 image: /img/blog/your-agent-is-not-forgetful.png
 ---
 

--- a/hindsight-docs/blog/2026-04-28-pipecat-voice-ai-persistent-memory.md
+++ b/hindsight-docs/blog/2026-04-28-pipecat-voice-ai-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Pipecat Voice AI Persistent Memory: Add Memory to Your Voice Pipeline"
 authors: [benfrank241]
 date: 2026-04-28
-tags: [memory, voice, ai, pipecat, python, agent, real-time, streaming, context, knowledge-graph]
+tags: [memory, voice, ai, pipecat, python, agent, real-time, streaming, context, knowledge-graph, tutorial]
 description: "Add persistent long-term memory to Pipecat voice AI pipelines. Recall relevant past conversations and retain new exchanges with a single FrameProcessor between your user aggregator and LLM service."
 image: /img/blog/pipecat-voice-ai-persistent-memory.png
 ---

--- a/hindsight-docs/blog/2026-04-28-version-0-5-5.md
+++ b/hindsight-docs/blog/2026-04-28-version-0-5-5.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.5.5
 authors: [nicoloboschi]
 date: 2026-04-28
 hide_table_of_contents: true
+tags: [release]
 ---
 
 :::warning

--- a/hindsight-docs/blog/2026-04-29-smolagents-memory-tools.md
+++ b/hindsight-docs/blog/2026-04-29-smolagents-memory-tools.md
@@ -2,7 +2,7 @@
 title: "Agent Memory in SmolAgents: Retain, Recall, and Reflect"
 authors: [benfrank241]
 date: 2026-04-29T15:00:00Z
-tags: [integrations, agents, smolagents, memory, guide]
+tags: [integrations, agents, smolagents, memory, guide, tutorial]
 description: "Add persistent memory to SmolAgents with Hindsight. Retain facts, recall context, and reflect on agent decisions across sessions."
 image: /img/blog/smolagents-memory-tools.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-05-01-agentcore-persistent-memory.md
+++ b/hindsight-docs/blog/2026-05-01-agentcore-persistent-memory.md
@@ -2,7 +2,7 @@
 title: "Multi-Turn Agent Memory with AWS AgentCore: Remember Across Sessions"
 authors: [benfrank241]
 date: 2026-05-01T16:00:00Z
-tags: [integrations, aws, agentcore, bedrock, agents, memory, guide]
+tags: [integrations, aws, agentcore, bedrock, agents, memory, guide, tutorial]
 description: "Add persistent memory to AWS AgentCore agents with Hindsight. Agents remember context, decisions, and learnings across multi-turn conversations and sessions."
 image: /img/blog/agentcore-persistent-memory.png
 hide_table_of_contents: true

--- a/hindsight-docs/blog/2026-05-04-agent-harness-needs-memory.md
+++ b/hindsight-docs/blog/2026-05-04-agent-harness-needs-memory.md
@@ -3,7 +3,7 @@ title: "The Missing Layer in Every Agent Harness"
 description: "Modern agent harnesses ship with tools, MCP, and IDE integrations — but no memory. Why that's the missing layer, and how harnesses are starting to fix it."
 authors: [benfrank241]
 date: 2026-05-04
-tags: [memory, agents, hindsight, harness, claude-code, openclaw, hermes]
+tags: [memory, agents, hindsight, harness, claude-code, openclaw, hermes, deep-dive]
 image: /img/blog/agent-harness-needs-memory.png
 ---
 

--- a/hindsight-docs/blog/2026-05-05-version-0-6-0.md
+++ b/hindsight-docs/blog/2026-05-05-version-0-6-0.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.6.0
 authors: [nicoloboschi]
 date: 2026-05-05
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.6.0 is a major release that adds an **Oracle 23ai database backend**, new integrations for **Dify**, **n8n**, **SmolAgents**, and **AWS Bedrock AgentCore**, and significant reliability improvements. On the reliability side, retain gets transactional atomicity fixes, BM25 search ranking is corrected, and entity timeline accuracy is improved.

--- a/hindsight-docs/blog/2026-05-06-claude-code-subagents-shared-memory.md
+++ b/hindsight-docs/blog/2026-05-06-claude-code-subagents-shared-memory.md
@@ -3,7 +3,7 @@ title: "Your Claude Code Subagents Don't Share What They Learn"
 description: "Claude Code subagents (Plan, Explore, general-purpose, custom) each spawn fresh and discard everything they discover. Here's how to give them shared memory."
 authors: [benfrank241]
 date: 2026-05-06
-tags: [memory, agents, hindsight, claude-code, subagents]
+tags: [memory, agents, hindsight, claude-code, subagents, tutorial]
 image: /img/blog/claude-code-subagents-memory.png
 ---
 

--- a/hindsight-docs/blog/2026-05-07-n8n-persistent-memory.md
+++ b/hindsight-docs/blog/2026-05-07-n8n-persistent-memory.md
@@ -3,7 +3,7 @@ title: "The Memory Layer Every n8n Workflow Was Missing"
 description: "Hindsight's new community node adds persistent memory to any n8n workflow — Retain, Recall, Reflect. Workflows compound across runs instead of resetting."
 authors: [benfrank241]
 date: 2026-05-07
-tags: [hindsight, n8n, integration, memory, agents, workflows, no-code]
+tags: [hindsight, n8n, integration, memory, agents, workflows, no-code, tutorial]
 image: /img/blog/n8n-persistent-memory.png
 ---
 

--- a/hindsight-docs/blog/2026-05-08-how-hindsight-scales.md
+++ b/hindsight-docs/blog/2026-05-08-how-hindsight-scales.md
@@ -3,7 +3,7 @@ title: "How Hindsight Scales"
 description: "A design analysis of how Hindsight's memory operations scale with data volume — what costs grow, what stays bounded, and why."
 authors: [nicoloboschi]
 date: 2026-05-08T12:00
-tags: [scaling, performance, architecture, engineering]
+tags: [scaling, performance, architecture, engineering, deep-dive]
 image: /img/blog/how-hindsight-scales.png
 hide_table_of_contents: true
 ---

--- a/hindsight-docs/blog/2026-05-08-version-0-6-1.md
+++ b/hindsight-docs/blog/2026-05-08-version-0-6-1.md
@@ -4,6 +4,7 @@ description: New features and improvements in Hindsight 0.6.1
 authors: [nicoloboschi]
 date: 2026-05-08
 hide_table_of_contents: true
+tags: [release]
 ---
 
 Hindsight 0.6.1 is a follow-up to 0.6.0 with two new LLM provider integrations (**z.ai** and a **LiteLLM router** with fallback chains), an **AlloyDB ScaNN** vector index for high-performance recall, **map-type entity labels** for structured entity extraction, an **optional read-only backend** for splitting recall traffic from writes, and **access-key login** for the Control Plane. Several reliability fixes also land — most notably retry-storm prevention in fact extraction and macOS daemon-mode compatibility with PyTorch MPS.

--- a/hindsight-docs/src/theme/BlogListPage/index.tsx
+++ b/hindsight-docs/src/theme/BlogListPage/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import {useLocation, useHistory} from '@docusaurus/router';
@@ -7,9 +8,17 @@ import type {PropBlogPostContent} from '@docusaurus/plugin-content-blog';
 import PageHero from '@site/src/components/PageHero';
 import styles from './styles.module.css';
 
-const CLOUD_TAG = 'hindsight-cloud';
-const CLOUD_PREVIEW_COUNT = 3;
-const HINDSIGHT_PAGE_SIZE = 9;
+type Category = {slug: string; label: string; tag: string | null};
+
+const CATEGORIES: Category[] = [
+  {slug: 'all', label: 'All', tag: null},
+  {slug: 'cloud', label: 'Hindsight Cloud', tag: 'hindsight-cloud'},
+  {slug: 'deep-dives', label: 'Deep Dives', tag: 'deep-dive'},
+  {slug: 'releases', label: 'Announcements & Releases', tag: 'release'},
+  {slug: 'tutorials', label: 'Tutorials & Integrations', tag: 'tutorial'},
+];
+
+const PAGE_SIZE = 9;
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
@@ -44,20 +53,8 @@ function BlogCard({content}: {content: PropBlogPostContent}) {
   );
 }
 
-function SectionHeader({title, subtitle, viewAllHref}: {title: string; subtitle?: string; viewAllHref?: string}) {
-  return (
-    <div className={styles.sectionHeader}>
-      <div className={styles.sectionHeaderRow}>
-        <h2 className={styles.sectionTitle}>{title}</h2>
-        {viewAllHref && (
-          <Link to={viewAllHref} className={styles.sectionViewAll}>
-            View all →
-          </Link>
-        )}
-      </div>
-      {subtitle && <p className={styles.sectionSubtitle}>{subtitle}</p>}
-    </div>
-  );
+function postHasTag(content: PropBlogPostContent, tag: string): boolean {
+  return (content.metadata.tags ?? []).some((t) => t.label === tag);
 }
 
 export default function BlogListPage({items, metadata}: Props): React.ReactElement {
@@ -65,20 +62,27 @@ export default function BlogListPage({items, metadata}: Props): React.ReactEleme
   const location = useLocation();
   const history = useHistory();
 
-  const currentPage = Math.max(1, parseInt(new URLSearchParams(location.search).get('page') ?? '1', 10));
+  const searchParams = new URLSearchParams(location.search);
+  const requestedCat = searchParams.get('cat') ?? 'all';
+  const activeCategory = CATEGORIES.find((c) => c.slug === requestedCat) ?? CATEGORIES[0];
+  const currentPage = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
 
-  const cloudPosts = items.filter(({content}) =>
-    (content.metadata.tags ?? []).some((t) => t.label === CLOUD_TAG),
-  );
-  const hindsightPosts = items.filter(({content}) =>
-    !(content.metadata.tags ?? []).some((t) => t.label === CLOUD_TAG),
-  );
+  const filteredItems = activeCategory.tag
+    ? items.filter(({content}) => postHasTag(content, activeCategory.tag!))
+    : items;
 
-  const totalHindsightPages = Math.max(1, Math.ceil(hindsightPosts.length / HINDSIGHT_PAGE_SIZE));
-  const hindsightPagePosts = hindsightPosts.slice(
-    (currentPage - 1) * HINDSIGHT_PAGE_SIZE,
-    currentPage * HINDSIGHT_PAGE_SIZE,
-  );
+  const totalPages = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const pagePosts = filteredItems.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  const selectCategory = (slug: string) => {
+    const params = new URLSearchParams();
+    if (slug !== 'all') {
+      params.set('cat', slug);
+    }
+    const search = params.toString();
+    history.push({pathname: location.pathname, search: search ? `?${search}` : ''});
+  };
 
   const goToPage = (page: number) => {
     const params = new URLSearchParams(location.search);
@@ -96,47 +100,47 @@ export default function BlogListPage({items, metadata}: Props): React.ReactEleme
       <main className={styles.blogPage}>
         <PageHero title={blogTitle} subtitle={blogDescription} />
 
-        {currentPage === 1 && cloudPosts.length > 0 && (
+        <nav className={styles.categoryStrip} aria-label="Blog categories">
+          {CATEGORIES.map((cat) => (
+            <button
+              key={cat.slug}
+              type="button"
+              onClick={() => selectCategory(cat.slug)}
+              className={clsx(
+                styles.categoryPill,
+                cat.slug === activeCategory.slug && styles.categoryPillActive,
+              )}
+              aria-pressed={cat.slug === activeCategory.slug}
+            >
+              {cat.label}
+            </button>
+          ))}
+        </nav>
+
+        {pagePosts.length > 0 ? (
           <section className={styles.section}>
-            <SectionHeader
-              title="Hindsight Cloud"
-              subtitle="News and updates from Hindsight Cloud"
-              viewAllHref={cloudPosts.length > CLOUD_PREVIEW_COUNT ? `/blog/tags/${CLOUD_TAG}` : undefined}
-            />
             <div className={styles.grid}>
-              {cloudPosts.slice(0, CLOUD_PREVIEW_COUNT).map(({content: BlogPostContent}) => (
+              {pagePosts.map(({content: BlogPostContent}) => (
                 <BlogCard key={BlogPostContent.metadata.permalink} content={BlogPostContent} />
               ))}
             </div>
           </section>
+        ) : (
+          <p className={styles.emptyState}>No posts in this category yet.</p>
         )}
 
-        {hindsightPagePosts.length > 0 && (
-          <section className={styles.section}>
-            <SectionHeader
-              title="Hindsight"
-              subtitle="Releases, guides, and deep dives into agent memory"
-            />
-            <div className={styles.grid}>
-              {hindsightPagePosts.map(({content: BlogPostContent}) => (
-                <BlogCard key={BlogPostContent.metadata.permalink} content={BlogPostContent} />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {totalHindsightPages > 1 && (
+        {totalPages > 1 && (
           <nav className={styles.pagination}>
-            {currentPage > 1 && (
-              <button onClick={() => goToPage(currentPage - 1)} className={styles.paginationButton}>
+            {safePage > 1 && (
+              <button onClick={() => goToPage(safePage - 1)} className={styles.paginationButton}>
                 ← Previous
               </button>
             )}
             <span className={styles.paginationInfo}>
-              Page {currentPage} of {totalHindsightPages}
+              Page {safePage} of {totalPages}
             </span>
-            {currentPage < totalHindsightPages && (
-              <button onClick={() => goToPage(currentPage + 1)} className={styles.paginationButton}>
+            {safePage < totalPages && (
+              <button onClick={() => goToPage(safePage + 1)} className={styles.paginationButton}>
                 Next →
               </button>
             )}

--- a/hindsight-docs/src/theme/BlogListPage/styles.module.css
+++ b/hindsight-docs/src/theme/BlogListPage/styles.module.css
@@ -4,6 +4,79 @@
   padding: 2rem 2rem 6rem;
 }
 
+/* ── Category strip ──────────────────────────────── */
+.categoryStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2.5rem;
+  padding-bottom: 0.25rem;
+}
+
+@media (max-width: 640px) {
+  .categoryStrip {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    margin-left: -2rem;
+    margin-right: -2rem;
+    padding: 0 2rem 0.5rem;
+    scrollbar-width: thin;
+  }
+}
+
+.categoryPill {
+  padding: 0.4rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  background: transparent;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+}
+
+.categoryPill:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.categoryPillActive,
+.categoryPillActive:hover {
+  background: #0074d9;
+  border-color: #0074d9;
+  color: #ffffff;
+}
+
+.emptyState {
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  padding: 3rem 0;
+  font-size: 0.95rem;
+}
+
+/* ── Tag archive header ──────────────────────────── */
+.header {
+  margin-bottom: 2.5rem;
+}
+
+.headerTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+  color: var(--ifm-heading-color);
+}
+
+.headerSubtitle {
+  font-size: 1rem;
+  color: var(--ifm-color-emphasis-600);
+  margin: 0;
+  line-height: 1.6;
+}
+
 /* ── Section ─────────────────────────────────────── */
 .section {
   margin-bottom: 4rem;

--- a/hindsight-docs/src/theme/BlogTagsPostsPage/index.tsx
+++ b/hindsight-docs/src/theme/BlogTagsPostsPage/index.tsx
@@ -43,6 +43,18 @@ const TAG_LABELS: Record<string, {title: string; subtitle: string}> = {
     title: 'Hindsight Cloud',
     subtitle: 'News and updates from Hindsight Cloud',
   },
+  'deep-dive': {
+    title: 'Deep Dives',
+    subtitle: 'Architecture, engineering, and benchmarks',
+  },
+  'release': {
+    title: 'Announcements & Releases',
+    subtitle: 'New versions, milestones, and product news',
+  },
+  'tutorial': {
+    title: 'Tutorials & Integrations',
+    subtitle: 'How to use Hindsight with your stack',
+  },
 };
 
 export default function BlogTagsPostsPage({tag, items, listMetadata}: Props): React.ReactElement {


### PR DESCRIPTION
## Summary

- Adds a 5-pill category filter to `/blog` (All / Hindsight Cloud / Deep Dives / Announcements & Releases / Tutorials & Integrations). Selection is reflected in URL as `?cat=<slug>` so filtered views are shareable and refresh-stable.
- Backfills the canonical category tag (`release` / `tutorial` / `deep-dive`) onto the 49 existing posts that needed one. `hindsight-cloud` was already in use and is unchanged.
- Extends `BlogTagsPostsPage` with friendly titles for the new tags so `/blog/tags/{release,tutorial,deep-dive}` render with the same look as the existing `/blog/tags/hindsight-cloud` page.

Motivation: from a recent team discussion — technical deep dives like *How Hindsight Scales* were hard to discover among announcements and release notes. A small, curated taxonomy on top of the existing tag system fixes that without a new content model.

## What does not change

- No post permalinks change. No tag-archive URLs change. No redirects needed; SEO preserved.
- Existing tags on posts are untouched apart from appending the canonical category tag.

## Final tag counts (verified from Docusaurus route output)

| Category | Tag | Posts |
|---|---|---|
| Hindsight Cloud | `hindsight-cloud` | 5 |
| Deep Dives | `deep-dive` | 8 |
| Announcements & Releases | `release` | 30 |
| Tutorials & Integrations | `tutorial` | 27 |

## Test plan

- [ ] `npx docusaurus start` compiles cleanly
- [ ] `/blog` renders pill strip with "All" active by default
- [ ] Clicking each pill updates the URL to `?cat=<slug>` and filters the grid
- [ ] Switching category resets pagination to page 1
- [ ] Refreshing on `/blog?cat=cloud` shows the Cloud pill active on load
- [ ] `/blog/tags/{deep-dive,release,tutorial,hindsight-cloud}` render with friendly titles
- [ ] Spot-check existing permalinks (`/blog/2026/05/08/how-hindsight-scales`, `/blog/2026/04/22/hindsight-10k-stars`) still load
- [ ] Mobile (~375px): pills wrap or scroll cleanly