### PR TITLE
docs(strands): document FastAPI lifecycle pattern from #1547

### DIFF
--- a/hindsight-docs/docs-integrations/strands.md
+++ b/hindsight-docs/docs-integrations/strands.md
@@ -66,6 +66,44 @@ agent = Agent(
 )
 ```
 
+## FastAPI Lifecycle (Recommended)
+
+Prefer creating one shared Hindsight client in app lifespan and passing `client=...`.
+This gives explicit ownership and clean shutdown via `await client.aclose()`.
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from hindsight_client import Hindsight
+from hindsight_strands import create_hindsight_tools, memory_instructions
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    client = Hindsight(base_url="http://localhost:8888", api_key="test-key")
+    app.state.hindsight_client = client
+    try:
+        yield
+    finally:
+        await client.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/chat")
+async def chat():
+    client = app.state.hindsight_client
+    tools = create_hindsight_tools(bank_id="user-123", client=client)
+    memories = memory_instructions(bank_id="user-123", client=client)
+    ...
+```
+
+If you pass `hindsight_api_url`/`api_key` directly to `create_hindsight_tools()`,
+`hindsight-strands` creates the client internally. In that case call
+`await tools.aclose()` (or `tools.close()`) during shutdown.
+
 ## Selecting Tools
 
 Include only the tools you need:


### PR DESCRIPTION
## Summary

Adds the **FastAPI Lifecycle (Recommended)** section to the Strands integration docs page, mirroring the lifecycle guidance added to `hindsight-integrations/strands/README.md` in #1547 ("Fix strands client lifecycle leak for internally-owned clients", merged 2026-05-11).

`hindsight-docs/docs-integrations/strands.md` previously had zero mentions of `lifecycle`, `close`, `aclose`, `FastAPI`, `cleanup`, or `shutdown` — users reading the docs site would miss the recommended shared-client lifespan pattern that `hindsight-integrations/strands/README.md` now documents.

## Source

The added section is a verbatim mirror of the "FastAPI Lifecycle (Recommended)" block in [`hindsight-integrations/strands/README.md`](https://github.com/vectorize-io/hindsight/blob/main/hindsight-integrations/strands/README.md#fastapi-lifecycle-recommended) (added in #1547).

## Risk

Pure docs add (+38 lines, 0 deletions). No code or tests affected.