### PR TITLE
paperclip: add sharedBankName config for cross-agent memory sharing

### DIFF
--- a/hindsight-integrations/paperclip/README.md
+++ b/hindsight-integrations/paperclip/README.md
@@ -33,13 +33,14 @@ Or [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — no self-hosti
 
 ## Configuration
 
-| Field                | Default                 | Description                                                    |
-| -------------------- | ----------------------- | -------------------------------------------------------------- |
-| `hindsightApiUrl`    | `http://localhost:8888` | Hindsight server URL                                           |
-| `hindsightApiKeyRef` | —                       | Paperclip secret name holding Hindsight Cloud API key          |
-| `bankGranularity`    | `["company", "agent"]`  | Memory isolation: per company+agent, per company, or per agent |
-| `recallBudget`       | `mid`                   | `low` = fastest, `mid` = balanced, `high` = most thorough      |
-| `autoRetain`         | `true`                  | Automatically retain run output after every run                |
+| Field                | Default                 | Description                                                            |
+| -------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| `hindsightApiUrl`    | `http://localhost:8888` | Hindsight server URL                                                   |
+| `hindsightApiKeyRef` | —                       | Paperclip secret name holding Hindsight Cloud API key                  |
+| `sharedBankName`     | —                       | Fixed bank name override — all agents share this single bank when set  |
+| `bankGranularity`    | `["company", "agent"]`  | Memory isolation when `sharedBankName` is unset                        |
+| `recallBudget`       | `mid`                   | `low` = fastest, `mid` = balanced, `high` = most thorough              |
+| `autoRetain`         | `true`                  | Automatically retain run output after every run                        |
 
 ## Bank ID Format
 
@@ -47,7 +48,15 @@ Or [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — no self-hosti
 paperclip::{companyId}::{agentId}    ← default (company + agent granularity)
 paperclip::{companyId}               ← company granularity (shared across agents)
 paperclip::{agentId}                 ← agent granularity (agent memory across companies)
+{sharedBankName}                     ← fixed name override (all agents read/write the same bank)
 ```
+
+### Shared bank for cross-agent collaboration
+
+Set `sharedBankName` to a fixed string (e.g. `"spool-farm"`) when you want every agent in
+the company to read and write the same bank — useful when a multi-agent cohort (CEO/CTO/
+Staff/QA/Researcher etc.) needs to collaborate on a single pool of project context,
+decisions, and lessons. Overrides `bankGranularity` and the `paperclip::…` prefix.
 
 ## Agent Tools
 

--- a/hindsight-integrations/paperclip/src/bank.ts
+++ b/hindsight-integrations/paperclip/src/bank.ts
@@ -6,6 +6,11 @@
  * bankGranularity: ['company']        → "paperclip::{companyId}"
  * bankGranularity: ['agent']          → "paperclip::{agentId}"
  * bankGranularity: ['company','agent'] → "paperclip::{companyId}::{agentId}"
+ *
+ * sharedBankName overrides both granularity-based derivation and the
+ * "paperclip" prefix entirely — every agent in the company points at the
+ * named bank. Useful when multiple agents must collaborate on a single
+ * pool of memories (e.g. a CEO/CTO/Staff cohort sharing project context).
  */
 
 export interface BankContext {
@@ -14,10 +19,19 @@ export interface BankContext {
 }
 
 export interface BankConfig {
+  /**
+   * Fixed bank name override. When set (non-empty after trim), `deriveBankId`
+   * returns this value verbatim and ignores `bankGranularity` + identity.
+   */
+  sharedBankName?: string;
   bankGranularity?: Array<"company" | "agent">;
 }
 
 export function deriveBankId(context: BankContext, config: BankConfig): string {
+  if (typeof config.sharedBankName === "string" && config.sharedBankName.trim()) {
+    return config.sharedBankName.trim();
+  }
+
   const granularity = config.bankGranularity ?? ["company", "agent"];
   const parts: string[] = ["paperclip"];
 

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -38,11 +38,17 @@ const manifest: PaperclipPluginManifestV1 = {
         description:
           "Name of the Paperclip secret holding your Hindsight Cloud API key. Leave empty for self-hosted.",
       },
+      sharedBankName: {
+        type: "string",
+        title: "Shared Bank Name",
+        description:
+          "Optional. When set, all agents read/write this single bank, overriding bankGranularity. Use for cross-agent collaboration on a shared memory pool (e.g. 'spool-farm').",
+      },
       bankGranularity: {
         type: "array",
         title: "Bank Granularity",
         description:
-          "Controls memory isolation. Default ['company', 'agent'] gives each agent its own bank per company.",
+          "Controls memory isolation when sharedBankName is unset. Default ['company', 'agent'] gives each agent its own bank per company.",
         items: { type: "string", enum: ["company", "agent"] },
         default: ["company", "agent"],
       },

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -20,6 +20,7 @@ import { deriveBankId } from "./bank.js";
 interface PluginConfig {
   hindsightApiUrl: string;
   hindsightApiKeyRef?: string;
+  sharedBankName?: string;
   bankGranularity?: Array<"company" | "agent">;
   recallBudget?: "low" | "mid" | "high";
   autoRetain?: boolean;

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -77,6 +77,39 @@ describe("bank ID derivation", () => {
       deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankGranularity: ["agent"] })
     ).toBe("paperclip::ag-1");
   });
+
+  it("sharedBankName overrides granularity and identity", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { sharedBankName: "spool-farm", bankGranularity: ["company", "agent"] }
+      )
+    ).toBe("spool-farm");
+  });
+
+  it("sharedBankName is trimmed", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { sharedBankName: "  spool-farm  " })
+    ).toBe("spool-farm");
+  });
+
+  it("empty/whitespace sharedBankName falls through to granularity", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { sharedBankName: "   ", bankGranularity: ["company"] }
+      )
+    ).toBe("paperclip::co-1");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { sharedBankName: "", bankGranularity: ["agent"] }
+      )
+    ).toBe("paperclip::ag-1");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -152,6 +185,24 @@ describe("agent.run.started", () => {
         { companyId: "co-1" }
       )
     ).resolves.not.toThrow();
+  });
+
+  it("routes recall to sharedBankName when configured (cross-agent shared pool)", async () => {
+    const harness = buildHarness({ ...DEFAULT_CONFIG, sharedBankName: "spool-farm" });
+    await setupPlugin(harness);
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-shared-1", issueTitle: "Plan sprint" },
+      { companyId: "co-1" }
+    );
+
+    const recallCall = fetchMock.mock.calls.find(([url]: [string]) => url.includes("recall"));
+    expect(recallCall).toBeDefined();
+    // Bank ID should be "spool-farm" — URL-encoded as "spool-farm" (hyphen is safe).
+    expect(recallCall?.[0]).toContain("/banks/spool-farm/");
+    // And explicitly NOT the granularity-derived ID for this agent/company.
+    expect(recallCall?.[0]).not.toContain("paperclip%3A%3Aco-1");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an optional `sharedBankName` string to the **`hindsight-integrations/paperclip`** plugin's instance config. When set, every agent in the company reads/writes the same Hindsight bank — overriding `bankGranularity` and the default `paperclip::{companyId}::{agentId}` derivation.

This is a small, additive, backwards-compatible change. No behavior changes for any existing install that doesn't set the new field.

## Motivation

The current `bankGranularity: [\"company\", \"agent\"]` default isolates each agent's memory. That's the right default — memory shouldn't leak across unrelated agents.

But for **multi-agent cohorts that need to collaborate on a shared pool of project context** (e.g. a CEO/CTO/Staff/QA/Researcher team working a single backlog), there's no first-class way to point them at one bank.

Concrete use case: I run a 5-agent Paperclip company where each agent must see decisions, lessons, and project state created by the others. With current granularity, each agent talks to its own bank — `hindsight_recall` returns nothing the agent didn't write itself, and cross-agent compound knowledge never accrues.

Workarounds I considered:
- `bankGranularity: [\"company\"]` collapses to a per-company bank — but the bank ID is still `paperclip::{companyId}`, which is fine for a single deployment but not when you want a human-readable bank name shared across companies or instances.
- A wrapper plugin re-implementing the same logic against a fixed bank — significant maintenance cost for what's essentially a one-line override.

The cleanest fix is a tiny optional config override. That's this PR.

## What changed

- **`src/bank.ts`**: extend `BankConfig` with optional `sharedBankName`; `deriveBankId` returns the trimmed value verbatim when set, otherwise falls through to the existing granularity logic unchanged.
- **`src/manifest.ts`**: add `sharedBankName` to `instanceConfigSchema` so it's configurable from Settings → Plugins → Hindsight Memory.
- **`src/worker.ts`**: add the field to the internal `PluginConfig` type.
- **`tests/plugin.spec.ts`**: 4 new tests — 3 unit tests for the override semantics (trimming, empty/whitespace fallthrough, normal override) + 1 integration test that verifies recall routes to the shared bank URL.
- **`README.md`**: document the field and add a *Shared bank for cross-agent collaboration* section.

## Backwards compatibility

The field is optional. Existing installs without `sharedBankName` keep the existing `paperclip::{companyId}::{agentId}` derivation untouched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 19/19 tests pass (15 existing + 4 new)
- [x] `npm run build` — clean esbuild output
- [x] Verified locally against a 5-agent company: with `sharedBankName: \"spool-farm\"`, recall/retain from all 5 agents now route to the single `spool-farm` bank.

## Notes for review

Happy to adjust naming (`sharedBankName` vs `bankName` vs `bankOverride`), schema placement, or split into smaller commits if preferred. The full change is +89/-8 across 5 files.