### PR TITLE
feat(claude-code): expose configurable MCP request timeout (#1575)

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -8,6 +8,13 @@
   from the `HINDSIGHT_USER_ID` env var (empty string if unset). Enables
   machine-independent per-user memory scoping without hardcoding user ids in
   `settings.json`.
+- `requestTimeoutSeconds` config (env: `HINDSIGHT_REQUEST_TIMEOUT_SECONDS`) to
+  override the per-call HTTP timeout used by recall (10s), retain (15s) and the
+  knowledge MCP tools. Defaults to `null`, which preserves current per-call
+  behavior. Set this when self-hosted Hindsight legitimately takes longer than
+  10s under contention (e.g. parallel recalls) so the client doesn't surface
+  `read operation timed out` on requests the server completes successfully.
+  Does not affect the health check, which stays at 5s. Fixes #1575.
 
 ### Changed
 

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -182,6 +182,7 @@ These settings control how the plugin connects to the Hindsight API.
 | `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `0` | Seconds of inactivity before the local daemon shuts itself down. `0` means the daemon stays running until the session ends. |
 | `embedVersion` | `HINDSIGHT_EMBED_VERSION` | `"latest"` | Which version of `hindsight-embed` to install via `uvx`. Pin to a specific version (e.g. `"0.5.2"`) for reproducibility. |
 | `embedPackagePath` | `HINDSIGHT_EMBED_PACKAGE_PATH` | `null` | Local filesystem path to a `hindsight-embed` checkout. When set, the plugin runs from this path instead of installing via `uvx`. Useful for development. |
+| `requestTimeoutSeconds` | `HINDSIGHT_REQUEST_TIMEOUT_SECONDS` | `null` | Overrides the per-call request timeout for recall (default `10s`), retain (default `15s`) and knowledge tool calls (`10–15s`). When unset, the per-call defaults are preserved. Bump this when self-hosted Hindsight legitimately takes longer than 10s under contention (e.g. parallel recalls), to avoid client-side `read operation timed out` errors on requests the server completes successfully. Does not affect the health check, which intentionally stays fast (5s). |
 
 ---
 

--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -44,9 +44,19 @@ def _validate_api_url(url: str) -> str:
 class HindsightClient:
     """HTTP client for the Hindsight API."""
 
-    def __init__(self, api_url: str, api_token: Optional[str] = None):
+    def __init__(
+        self,
+        api_url: str,
+        api_token: Optional[str] = None,
+        request_timeout_override: Optional[int] = None,
+    ):
         self.api_url = _validate_api_url(api_url)
         self.api_token = api_token
+        self.request_timeout_override = request_timeout_override
+
+    def _resolve_timeout(self, timeout: int) -> int:
+        """Return the override if configured, otherwise the caller's timeout."""
+        return self.request_timeout_override if self.request_timeout_override is not None else timeout
 
     def _headers(self) -> dict:
         headers = {
@@ -58,6 +68,7 @@ class HindsightClient:
         return headers
 
     def request(self, method: str, path: str, body: Optional[dict] = None, timeout: int = DEFAULT_TIMEOUT) -> dict:
+        timeout = self._resolve_timeout(timeout)
         url = f"{self.api_url}{path}"
         data = json.dumps(body).encode() if body else None
         req = urllib.request.Request(url, data=data, headers=self._headers(), method=method)

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -40,6 +40,7 @@ DEFAULTS = {
     "daemonIdleTimeout": 0,
     "embedVersion": "latest",
     "embedPackagePath": None,
+    "requestTimeoutSeconds": None,
     # Bank
     "bankId": None,
     "bankIdPrefix": "",
@@ -73,6 +74,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),
     "HINDSIGHT_DAEMON_IDLE_TIMEOUT": ("daemonIdleTimeout", int),
+    "HINDSIGHT_REQUEST_TIMEOUT_SECONDS": ("requestTimeoutSeconds", int),
     "HINDSIGHT_EMBED_VERSION": ("embedVersion", str),
     "HINDSIGHT_EMBED_PACKAGE_PATH": ("embedPackagePath", str),
     "HINDSIGHT_DYNAMIC_BANK_ID": ("dynamicBankId", bool),

--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -46,7 +46,11 @@ except Exception as e:
 
 _hook_input = {"cwd": os.getcwd(), "session_id": ""}
 _default_bank_id = derive_bank_id(_hook_input, _config)
-_client = HindsightClient(_api_url, _config.get("hindsightApiToken"))
+_client = HindsightClient(
+    _api_url,
+    _config.get("hindsightApiToken"),
+    request_timeout_override=_config.get("requestTimeoutSeconds"),
+)
 
 _dbg(f"MCP server starting — API: {_api_url}, bank: {_default_bank_id}")
 

--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -110,7 +110,11 @@ def main():
 
     api_token = config.get("hindsightApiToken")
     try:
-        client = HindsightClient(api_url, api_token)
+        client = HindsightClient(
+            api_url,
+            api_token,
+            request_timeout_override=config.get("requestTimeoutSeconds"),
+        )
     except ValueError as e:
         print(f"[Hindsight] Invalid API URL: {e}", file=sys.stderr)
         return

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -141,7 +141,11 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
 
     api_token = config.get("hindsightApiToken")
     try:
-        client = HindsightClient(api_url, api_token)
+        client = HindsightClient(
+            api_url,
+            api_token,
+            request_timeout_override=config.get("requestTimeoutSeconds"),
+        )
     except ValueError as e:
         print(f"[Hindsight] Invalid API URL: {e}", file=sys.stderr)
         return

--- a/hindsight-integrations/claude-code/tests/test_client.py
+++ b/hindsight-integrations/claude-code/tests/test_client.py
@@ -212,6 +212,91 @@ class TestHindsightClientHealthCheck:
         assert call_count == 3
 
 
+class TestRequestTimeoutOverride:
+    """The override (passed via constructor) replaces the per-call timeout
+    argument that recall/retain/request would otherwise use. When unset,
+    the original per-call default is preserved (issue #1575)."""
+
+    def test_override_replaces_recall_default(self):
+        c = HindsightClient("http://localhost:9077", request_timeout_override=60)
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert captured["timeout"] == 60
+
+    def test_override_replaces_retain_default(self):
+        c = HindsightClient("http://localhost:9077", request_timeout_override=60)
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.retain("bank", "content")
+
+        assert captured["timeout"] == 60
+
+    def test_override_replaces_explicit_request_timeout(self):
+        c = HindsightClient("http://localhost:9077", request_timeout_override=60)
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.request("GET", "/v1/anything", timeout=10)
+
+        assert captured["timeout"] == 60
+
+    def test_no_override_preserves_recall_default(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert captured["timeout"] == 10
+
+    def test_no_override_preserves_retain_default(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.retain("bank", "content")
+
+        assert captured["timeout"] == 15
+
+    def test_override_does_not_affect_health_check(self):
+        c = HindsightClient("http://localhost:9077", request_timeout_override=60)
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return FakeResp({}, status=200)
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            with patch("time.sleep"):
+                c.health_check()
+
+        assert captured["timeout"] == 5
+
+
 class TestHindsightClientSetBankMission:
     def test_patches_config_endpoint(self):
         c = HindsightClient("http://localhost:9077")

--- a/hindsight-integrations/claude-code/tests/test_config.py
+++ b/hindsight-integrations/claude-code/tests/test_config.py
@@ -71,6 +71,17 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg["apiPort"] == 9999
 
+    def test_request_timeout_default_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        cfg = load_config()
+        assert cfg["requestTimeoutSeconds"] is None
+
+    def test_request_timeout_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_REQUEST_TIMEOUT_SECONDS", "60")
+        cfg = load_config()
+        assert cfg["requestTimeoutSeconds"] == 60
+
     def test_invalid_settings_json_falls_back_to_defaults(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
         (tmp_path / "settings.json").write_text("not valid json{{")


### PR DESCRIPTION
Closes #1575.

## What

Exposes `requestTimeoutSeconds` in the claude-code plugin config (env: `HINDSIGHT_REQUEST_TIMEOUT_SECONDS`). When set, overrides the hardcoded per-call HTTP timeouts (10s recall, 15s retain, 10–15s in the knowledge MCP tools). When unset, per-call defaults are preserved — **fully backward compatible**.

## Why

Self-hosted Hindsight users hit `read operation timed out` on legitimate >10s recalls under contention (e.g. parallel batches), even though the server completes them successfully. The issue thread has full repro + handler timings.

## How

- `HindsightClient` gains an optional `request_timeout_override` constructor arg.
- A small `_resolve_timeout()` helper returns the override when set, else the caller's `timeout` arg — so the existing 10s/15s per-call defaults stay as the no-config behavior.
- Resolution happens in `request()`, which is the single funnel for all HTTP calls (`recall`, `retain`, knowledge tools). Per-call `timeout=...` arguments at call sites are left untouched — they're the defaults when nothing is configured.
- Three call sites that construct `HindsightClient` (`mcp_server.py`, `recall.py`, `retain.py`) now pass `config.get("requestTimeoutSeconds")`. `session_start.py` was skipped — it only instantiates a client to validate the URL and never makes a request.
- `health_check()` does **not** go through `request()` and is intentionally **not** affected by the override — it stays at 5s so an unreachable server is detected fast.

## Tests

- 6 new tests in `tests/test_client.py` covering: override replaces recall/retain/explicit-request timeouts; absence preserves the 10s/15s defaults; health check is unaffected.
- 2 new tests in `tests/test_config.py` covering: default is `None`; env var override (`HINDSIGHT_REQUEST_TIMEOUT_SECONDS`) is read and typed correctly.
- Full plugin suite: **178/178 passing**.
- Ruff: 0 new lint errors introduced (pre-existing ones in `mcp_server.py` and test files are untouched).

## Docs

- `README.md` — added a row in the Connection settings table.
- `CHANGELOG.md` — entry under `[Unreleased]`.

Happy to adjust the design (e.g. split into `recallTimeoutSeconds` / `retainTimeoutSeconds`) if you'd prefer finer-grained control — I went with the single global override per your comment on the issue.