### PR TITLE
fix(mental-models): cap history array length to prevent jsonb overflow

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -375,6 +375,7 @@ ENV_OBSERVATIONS_MISSION = "HINDSIGHT_API_OBSERVATIONS_MISSION"
 ENV_MAX_OBSERVATIONS_PER_SCOPE = "HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE"
 ENV_ENABLE_OBSERVATION_HISTORY = "HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY"
 ENV_ENABLE_MENTAL_MODEL_HISTORY = "HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY"
+ENV_MENTAL_MODEL_HISTORY_MAX_ENTRIES = "HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES"
 
 # Webhook configuration (global, static - server-level only)
 ENV_WEBHOOK_URL = "HINDSIGHT_API_WEBHOOK_URL"
@@ -616,6 +617,12 @@ DEFAULT_FILE_DELETE_AFTER_RETAIN = True  # Delete file bytes after retain (saves
 DEFAULT_ENABLE_OBSERVATIONS = True  # Observations enabled by default
 DEFAULT_ENABLE_OBSERVATION_HISTORY = True  # Observation history tracking enabled by default
 DEFAULT_ENABLE_MENTAL_MODEL_HISTORY = True  # Mental model history tracking enabled by default
+# Each history entry snapshots previous_content + previous_reflect_response. Without
+# a cap, sustained mental-model refresh load grows the jsonb array unboundedly until
+# it crosses Postgres's hard 256MB jsonb limit and subsequent UPDATEs fail with
+# SQLSTATE 54000. 50 keeps the array well under 100MB even with large reflect
+# responses, while preserving enough recent history for meaningful audit / rollback.
+DEFAULT_MENTAL_MODEL_HISTORY_MAX_ENTRIES = 50
 DEFAULT_CONSOLIDATION_MAX_ATTEMPTS = 3  # Outer retry attempts for consolidation LLM batch calls
 DEFAULT_CONSOLIDATION_BATCH_SIZE = 50  # Memories to load per batch (internal memory optimization)
 DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = (
@@ -1081,6 +1088,7 @@ class HindsightConfig:
     enable_observations: bool
     enable_observation_history: bool
     enable_mental_model_history: bool
+    mental_model_history_max_entries: int
     consolidation_batch_size: int
     consolidation_max_memories_per_round: int
     consolidation_llm_batch_size: int
@@ -1751,6 +1759,12 @@ class HindsightConfig:
                 ENV_ENABLE_MENTAL_MODEL_HISTORY, str(DEFAULT_ENABLE_MENTAL_MODEL_HISTORY)
             ).lower()
             == "true",
+            mental_model_history_max_entries=int(
+                os.getenv(
+                    ENV_MENTAL_MODEL_HISTORY_MAX_ENTRIES,
+                    str(DEFAULT_MENTAL_MODEL_HISTORY_MAX_ENTRIES),
+                )
+            ),
             consolidation_batch_size=int(
                 os.getenv(ENV_CONSOLIDATION_BATCH_SIZE, str(DEFAULT_CONSOLIDATION_BATCH_SIZE))
             ),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8008,20 +8008,24 @@ class MemoryEngine(MemoryEngineInterface):
                         ]
                     )
                     max_entries = get_config().mental_model_history_max_entries
+                    history_param_idx = param_idx
+                    param_idx += 1
+                    max_entries_param_idx = param_idx
+                    param_idx += 1
                     updates.append(
                         "history = ("
                         "  SELECT COALESCE(jsonb_agg(elem ORDER BY idx), '[]'::jsonb) "
                         "  FROM jsonb_array_elements("
-                        f"    COALESCE(history, '[]'::jsonb) || ${param_idx}::jsonb"
+                        f"    COALESCE(history, '[]'::jsonb) || ${history_param_idx}::jsonb"
                         "  ) WITH ORDINALITY a(elem, idx) "
                         "  WHERE idx > GREATEST("
                         "    jsonb_array_length(COALESCE(history, '[]'::jsonb)) + 1"
-                        f"    - {max_entries}, 0"
+                        f"    - ${max_entries_param_idx}, 0"
                         "  )"
                         ")"
                     )
                     params.append(history_entry)
-                    param_idx += 1
+                    params.append(max_entries)
                 # Also update embedding (convert to string for asyncpg vector type)
                 embedding_text = f"{name or ''} {content}"
                 embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7980,18 +7980,29 @@ class MemoryEngine(MemoryEngineInterface):
                 updates.append("last_refreshed_at = NOW()")
                 # Record history entry with the previous content.
                 #
-                # Cap the array to the most recent N entries at write time. Each
-                # entry snapshots previous_reflect_response, which can be hundreds
-                # of KB; without a cap, sustained refresh load grows the jsonb
-                # array unboundedly until it crosses Postgres's hard 256MB jsonb
-                # limit and the UPDATE fails with SQLSTATE 54000, making the row
-                # permanently un-writable until manually trimmed.
+                # Cap the array to the most recent N entries at write time
+                # (see HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES).
+                #
+                # Each entry stores only the slim slice of previous_reflect_response
+                # that consumers actually read: `based_on` (the fact references that
+                # backed that version). The full reflect_response can be hundreds of
+                # KB once `text`, fact bodies, scoring, and embeddings are included;
+                # storing the full payload made each UPDATE rewrite ~10-20 MB of TOAST
+                # per refresh, which prevented HOT updates and accumulated dead
+                # tuples faster than autovacuum could reclaim them. The slim shape
+                # keeps per-row size in the ~hundreds-of-KB range, which fits in a
+                # single heap page and re-enables HOT updates.
                 if get_config().enable_mental_model_history:
+                    slim_reflect_response: dict[str, Any] | None = None
+                    if previous_reflect_response is not None:
+                        based_on = previous_reflect_response.get("based_on")
+                        if based_on is not None:
+                            slim_reflect_response = {"based_on": based_on}
                     history_entry = json.dumps(
                         [
                             {
                                 "previous_content": previous_content,
-                                "previous_reflect_response": previous_reflect_response,
+                                "previous_reflect_response": slim_reflect_response,
                                 "changed_at": datetime.now(timezone.utc).isoformat(),
                             }
                         ]

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7978,7 +7978,14 @@ class MemoryEngine(MemoryEngineInterface):
                 params.append(content)
                 param_idx += 1
                 updates.append("last_refreshed_at = NOW()")
-                # Record history entry with the previous content
+                # Record history entry with the previous content.
+                #
+                # Cap the array to the most recent N entries at write time. Each
+                # entry snapshots previous_reflect_response, which can be hundreds
+                # of KB; without a cap, sustained refresh load grows the jsonb
+                # array unboundedly until it crosses Postgres's hard 256MB jsonb
+                # limit and the UPDATE fails with SQLSTATE 54000, making the row
+                # permanently un-writable until manually trimmed.
                 if get_config().enable_mental_model_history:
                     history_entry = json.dumps(
                         [
@@ -7989,7 +7996,19 @@ class MemoryEngine(MemoryEngineInterface):
                             }
                         ]
                     )
-                    updates.append(f"history = COALESCE(history, '[]'::jsonb) || ${param_idx}::jsonb")
+                    max_entries = get_config().mental_model_history_max_entries
+                    updates.append(
+                        "history = ("
+                        "  SELECT COALESCE(jsonb_agg(elem ORDER BY idx), '[]'::jsonb) "
+                        "  FROM jsonb_array_elements("
+                        f"    COALESCE(history, '[]'::jsonb) || ${param_idx}::jsonb"
+                        "  ) WITH ORDINALITY a(elem, idx) "
+                        "  WHERE idx > GREATEST("
+                        "    jsonb_array_length(COALESCE(history, '[]'::jsonb)) + 1"
+                        f"    - {max_entries}, 0"
+                        "  )"
+                        ")"
+                    )
                     params.append(history_entry)
                     param_idx += 1
                 # Also update embedding (convert to string for asyncpg vector type)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -696,7 +696,16 @@ class TestMentalModelHistory:
     async def test_history_snapshots_previous_reflect_response(
         self, memory: MemoryEngine, request_context
     ):
-        """Each history entry snapshots the reflect_response that produced previous_content."""
+        """Each history entry stores only the slim {based_on: ...} slice of
+        previous_reflect_response.
+
+        Rationale: the only consumer of `previous_reflect_response` in history
+        is the control-plane UI's "based_on diff" view. Storing the full reflect
+        response (including `text`, fact bodies, scoring) made each UPDATE
+        rewrite ~10-20 MB of TOAST per refresh and prevented HOT updates. The
+        slim shape keeps row size bounded so HOT updates apply and dead tuples
+        self-clean inline.
+        """
         bank_id = f"test-mm-history-reflect-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
 
@@ -728,11 +737,52 @@ class TestMentalModelHistory:
 
         history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
         assert len(history) == 2
-        # Most recent first: replacing v2 snapshotted rr_v1 (the reflect that produced v2).
+        # Most recent first: replacing v2 snapshotted rr_v1's based_on (the only slice
+        # the UI consumes). The bulky `text` and `mental_models` fields are dropped.
         assert history[0]["previous_content"] == "v2"
-        assert history[0]["previous_reflect_response"] == rr_v1
+        assert history[0]["previous_reflect_response"] == {"based_on": rr_v1["based_on"]}
         # The first update replaced v1, which had no reflect_response stored yet.
         assert history[1]["previous_content"] == "v1"
+        assert history[1]["previous_reflect_response"] is None
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_history_snapshots_omit_reflect_response_when_based_on_missing(
+        self, memory: MemoryEngine, request_context
+    ):
+        """If a reflect_response has no `based_on` (older snapshots, malformed
+        payloads), the slim path stores None rather than an empty shell."""
+        bank_id = f"test-mm-history-no-based-on-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Test Model",
+            source_query="What is the test?",
+            content="v1",
+            request_context=request_context,
+        )
+
+        # reflect_response with no based_on field
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="v2",
+            reflect_response={"text": "v1", "mental_models": []},
+            request_context=request_context,
+        )
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="v3",
+            reflect_response={"text": "v2", "based_on": {}},
+            request_context=request_context,
+        )
+
+        history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
+        # First (most recent): had based_on={} → stored as {"based_on": {}}
+        assert history[0]["previous_reflect_response"] == {"based_on": {}}
+        # Second: had no based_on field → stored as None
         assert history[1]["previous_reflect_response"] is None
 
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -808,6 +808,48 @@ class TestMentalModelHistory:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_history_capped_to_max_entries(self, memory: MemoryEngine, request_context, monkeypatch):
+        """History array is trimmed to the most recent N entries on each write.
+
+        Without a cap, sustained updates grow the jsonb array unboundedly and
+        eventually cross Postgres's 256MB jsonb hard limit, after which any
+        further UPDATE fails with SQLSTATE 54000 and the row is stuck.
+        """
+        from hindsight_api.config import clear_config_cache
+
+        monkeypatch.setenv("HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES", "3")
+        clear_config_cache()
+
+        bank_id = f"test-mm-history-cap-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Test Model",
+            source_query="What is the test?",
+            content="v1",
+            request_context=request_context,
+        )
+
+        # 5 content updates → 5 history entries appended → trimmed to last 3
+        for i in range(2, 7):
+            await memory.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                content=f"v{i}",
+                request_context=request_context,
+            )
+
+        history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
+        # Most recent first ordering (per test_history_ordered_most_recent_first):
+        # the trimmed window keeps the newest 3 — v5, v4, v3 — and drops v2, v1.
+        assert len(history) == 3
+        assert history[0]["previous_content"] == "v5"
+        assert history[1]["previous_content"] == "v4"
+        assert history[2]["previous_content"] == "v3"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
 
 class TestMentalModelStaleness:
     """Tests for compute_mental_model_is_stale scope semantics.

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -763,7 +763,8 @@ class TestMentalModelHistory:
             request_context=request_context,
         )
 
-        # reflect_response with no based_on field
+        # reflect_response with no based_on field — will become the "previous"
+        # reflect_response when v3 is written, producing slim None.
         await memory.update_mental_model(
             bank_id=bank_id,
             mental_model_id=mm["id"],
@@ -771,6 +772,8 @@ class TestMentalModelHistory:
             reflect_response={"text": "v1", "mental_models": []},
             request_context=request_context,
         )
+        # reflect_response with based_on={} — will become the "previous"
+        # reflect_response when v4 is written, producing slim {"based_on": {}}.
         await memory.update_mental_model(
             bank_id=bank_id,
             mental_model_id=mm["id"],
@@ -778,12 +781,23 @@ class TestMentalModelHistory:
             reflect_response={"text": "v2", "based_on": {}},
             request_context=request_context,
         )
+        # One more update so that the based_on={} reflect_response becomes
+        # the *previous* state captured in a history entry.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            content="v4",
+            request_context=request_context,
+        )
 
         history = await memory.get_mental_model_history(bank_id, mm["id"], request_context=request_context)
-        # First (most recent): had based_on={} → stored as {"based_on": {}}
+        assert len(history) == 3
+        # Most recent: v3→v4, previous rr had based_on={} → stored as {"based_on": {}}
         assert history[0]["previous_reflect_response"] == {"based_on": {}}
-        # Second: had no based_on field → stored as None
+        # Second: v2→v3, previous rr had no based_on field → stored as None
         assert history[1]["previous_reflect_response"] is None
+        # Third: v1→v2, no reflect_response on the row yet → stored as None
+        assert history[2]["previous_reflect_response"] is None
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -765,7 +765,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp). Disable to reduce storage if audit trails are not needed. | `true` |
-| `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max entries retained in the per-mental-model history jsonb array. Older entries are dropped at write time. Prevents the array from crossing Postgres's hard 256MB jsonb size limit (which would otherwise make further UPDATEs to the row fail with SQLSTATE 54000). | `50` |
+| `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max entries retained in the per-mental-model history jsonb array. Older entries are dropped at write time. Prevents the array from crossing Postgres's hard 256MB jsonb size limit (which would otherwise make further UPDATEs to the row fail with SQLSTATE 54000). Each entry stores only the slim `{based_on}` slice of the prior `reflect_response` (the only field consumed by the control-plane UI's history view) so per-row size stays bounded and HOT updates apply. | `50` |
 
 #### Graph Retrieval Algorithm
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -765,6 +765,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp). Disable to reduce storage if audit trails are not needed. | `true` |
+| `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max entries retained in the per-mental-model history jsonb array. Older entries are dropped at write time. Prevents the array from crossing Postgres's hard 256MB jsonb size limit (which would otherwise make further UPDATEs to the row fail with SQLSTATE 54000). | `50` |
 
 #### Graph Retrieval Algorithm
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -765,6 +765,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` | Max candidates to rerank per recall (RRF pre-filters the rest) | `300` |
 | `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp). Disable to reduce storage if audit trails are not needed. | `true` |
+| `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max entries retained in the per-mental-model history jsonb array. Older entries are dropped at write time. Prevents the array from crossing Postgres's hard 256MB jsonb size limit (which would otherwise make further UPDATEs to the row fail with SQLSTATE 54000). Each entry stores only the slim `{based_on}` slice of the prior `reflect_response` (the only field consumed by the control-plane UI's history view) so per-row size stays bounded and HOT updates apply. | `50` |
 
 #### Graph Retrieval Algorithm
 


### PR DESCRIPTION
## Problem

Each content-changing update to a mental model appends a full snapshot (`previous_content` + `previous_reflect_response` + `changed_at`) to the `mental_models.history` jsonb array. Two compounding issues:

**1. Unbounded growth → jsonb 256 MB overflow.** Without a cap, the array grows forever. PostgreSQL has a hard 256 MB limit on total jsonb array element size; once a row crosses it, every subsequent UPDATE fails:

```
ERROR: total size of jsonb array elements exceeds the maximum of 268435455 bytes
SQLSTATE: 54000
```

The mental model is permanently un-writable until the `history` column is manually trimmed at the DB level. Reachable in normal use: with reflect responses on the order of hundreds of KB and a workload that refreshes a small set of mental models repeatedly, the limit is hit in a few hundred refreshes. Once one tenant's row lands in this state, repeated UPDATE attempts materialize the 256 MB+ array on every retry — significant memory pressure on the primary, degraded availability for unrelated tenants on the same instance.

**2. Per-update bloat → no HOT updates, persistent dead-tuple churn.** Even with a cap in place, storing the full `reflect_response` payload in each snapshot pushes per-row size to ~22 MB at cap=50. That exceeds heap-page fit, so every UPDATE writes a full TOAST row and skips HOT. Every refresh leaves a ~22 MB dead tuple that has to be vacuumed; under sustained refresh load the dead-tuple backlog outruns autovacuum and the table balloons (observed: 570 MB / 43% dead tuples on a single tenant's `mental_models` table).

## Fix

**(a) Cap history length at write time.** Trim to the most recent N entries via a single subquery on `COALESCE(history, '[]'::jsonb) || $new::jsonb`:

```sql
history = (
  SELECT COALESCE(jsonb_agg(elem ORDER BY idx), '[]'::jsonb)
  FROM jsonb_array_elements(
    COALESCE(history, '[]'::jsonb) || $new::jsonb
  ) WITH ORDINALITY a(elem, idx)
  WHERE idx > GREATEST(
    jsonb_array_length(COALESCE(history, '[]'::jsonb)) + 1 - N, 0
  )
)
```

New env var `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` controls N. Default **50** — well under the 256 MB ceiling even with hundreds-of-KB reflect responses, while preserving enough recent history for audit / rollback.

**(b) Slim each history entry to `{based_on: ...}` only.** The control-plane history view (`mental-model-detail-modal.tsx`) only reads `previous_reflect_response.based_on`; every other field in the reflect payload is unused. Store just that slice — per-entry size drops ~100x, rows fit on a heap page, HOT updates re-enable, dead tuples self-clean.

Existing bulky rows rotate out naturally via the cap=50 ring buffer; no migration needed.

## What this PR does NOT do

Rows already over the 256 MB ceiling pre-fix need a **one-shot manual trim** of their `history` column at the DB level. The SQL-side append in this PR cannot heal a row whose existing `history` is already too large to materialize in the jsonb engine — evaluating `history || $new` itself raises 54000. After the manual trim, this fix prevents recurrence.

A standalone migration that trims existing rows is intentionally NOT included here: the right cap depends on per-deployment tolerance and the migration would block on `ACCESS EXCLUSIVE` while trimming potentially-huge rows. Operators should do this as a targeted one-time DML if they've observed the issue.

## Test plan

- [x] `test_history_capped_to_max_entries`: with `max_entries=3`, six content updates produce a 3-element history (most recent first: `v5`, `v4`, `v3` — `v1` and `v2` dropped).
- [x] `test_history_snapshots_previous_reflect_response`: assertions updated to expect the slim `{based_on: ...}` shape.
- [x] `test_history_snapshots_omit_reflect_response_when_based_on_missing`: covers reflect payloads with no `based_on` field (stored as None) and with `based_on: {}` (stored as `{based_on: {}}`).
- [x] Existing history tests cover unchanged ordering, snapshot, and gating behaviors — semantics untouched for short histories.
- [x] Lint clean on modified files.
- [x] Env-var override verified: `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES=7` reads as 7.
- [ ] CI green
