### PR TITLE
fix(ci): paperclip lint formatting + openclaw hook test expectations

### DIFF
--- a/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
+++ b/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
@@ -495,6 +495,7 @@ describe("agent_end hook", () => {
     const [, content] = retainSpy.mock.calls[0];
     const parsed = JSON.parse(content);
     expect(parsed).toEqual([
+      { role: "system", content: "[context]\nsender: U013\nprovider: telegram\n[/context]" },
       { role: "user", content: [{ type: "text", text: "I love TypeScript." }] },
       { role: "assistant", content: [{ type: "text", text: "TypeScript is great!" }] },
     ]);
@@ -542,7 +543,7 @@ describe("agent_end hook", () => {
     expect(options?.metadata?.channel_id).toBe("chat-999");
     expect(options?.metadata?.sender_id).toBe("U015");
     expect(options?.metadata?.retained_at).toBeDefined();
-    expect(options?.metadata?.message_count).toBe("1");
+    expect(options?.metadata?.message_count).toBe("2");
   });
 
   it("uses identity cached in before_dispatch for retain metadata when agent_end ctx is sparse", async () => {
@@ -694,10 +695,11 @@ describe("agent_end hook", () => {
     // Default retainFormat is 'json' with Anthropic-shaped typed blocks.
     const parsed = JSON.parse(content);
     expect(parsed).toEqual([
+      { role: "system", content: "[context]\nsender: U019\nprovider: telegram\n[/context]" },
       { role: "user", content: [{ type: "text", text: "I work as a data scientist." }] },
       { role: "assistant", content: [{ type: "text", text: "That's a fascinating career!" }] },
     ]);
     expect(content).not.toContain("My name is Carol.");
-    expect(options?.metadata?.message_count).toBe("2");
+    expect(options?.metadata?.message_count).toBe("3");
   });
 });

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -173,7 +173,7 @@ const plugin = definePlugin({
           /* ignore */
         }
       }
-      
+
       if (!bankAgentId) {
         ctx.logger.info("Skipping retain — no agent attribution available", {
           commentId,

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -250,11 +250,15 @@ describe("issue.comment.created", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
-  
+
   it("skips retain when autoRetain is false", async () => {
     const harness = buildHarness({ ...DEFAULT_CONFIG, autoRetain: false });
     await setupPlugin(harness);
-    const issue = await seedIssue(harness, { companyId: "co-1", title: "x", assigneeAgentId: "ag-1" });
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "x",
+      assigneeAgentId: "ag-1",
+    });
     const comment = await harness.ctx.issues.createComment(issue.id, "Some output", "co-1", {
       authorAgentId: "ag-1",
     });
@@ -286,7 +290,11 @@ describe("issue.comment.created", () => {
       title: "x",
       assigneeAgentId: "ag-assignee",
     });
-    const comment = await harness.ctx.issues.createComment(issue.id, "User says: please do X", "co-1");
+    const comment = await harness.ctx.issues.createComment(
+      issue.id,
+      "User says: please do X",
+      "co-1"
+    );
 
     await harness.emit(
       "issue.comment.created",

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -480,6 +480,30 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1m
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_REGION` | Vertex AI region for embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_REGION`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_VERTEXAI_SERVICE_ACCOUNT_KEY` | Service account key for Vertex AI embeddings (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`) | - |
 
+#### Common Pitfall: Provider-Specific Embedding Env Var Names
+
+Embedding environment variables include a provider segment in the key name:
+
+`HINDSIGHT_API_EMBEDDINGS_{PROVIDER}_{PARAMETER}`
+
+For example, when `HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai`:
+
+| Wrong | Correct |
+|---|---|
+| `HINDSIGHT_API_EMBEDDINGS_BASE_URL` | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` |
+| `HINDSIGHT_API_EMBEDDINGS_MODEL` | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` |
+| `HINDSIGHT_API_EMBEDDINGS_API_KEY` | `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` |
+
+This differs from LLM variables, which follow `HINDSIGHT_API_LLM_{PARAMETER}` without a provider segment.
+
+:::warning
+If embedding keys are misnamed, Hindsight may fall back to default OpenAI embedding settings (for example, `text-embedding-3-small`) and fail with auth errors against the wrong endpoint.
+:::
+
+#### DeepSeek and Embeddings
+
+DeepSeek is supported as an **LLM** provider, but it does **not** expose an embeddings endpoint. If your LLM is DeepSeek, use a different embedding provider (for example `local`, `openai`, `cohere`, or `google`).
+
 ```bash
 # Local (default) - uses SentenceTransformers
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=local

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -325,6 +325,32 @@ hindsight-api
 You can also use the slim package (`pip install hindsight-api-slim`) if you configure external providers for embeddings and reranking. See [Configuration](./configuration#embeddings) for details.
 :::
 
+### Windows + China Network Notes
+
+If you are running on Windows behind China network restrictions:
+
+1. DeepSeek works well for `HINDSIGHT_API_LLM_PROVIDER`, but DeepSeek does not provide an embeddings endpoint.
+2. Use local embeddings (recommended for privacy and reliability in restricted networks).
+3. Set `HF_ENDPOINT=https://hf-mirror.com` before starting Hindsight so Hugging Face model downloads use a China-accessible mirror.
+
+```powershell
+set HF_ENDPOINT=https://hf-mirror.com
+
+set HINDSIGHT_API_LLM_PROVIDER=deepseek
+set HINDSIGHT_API_LLM_API_KEY=sk-your-deepseek-key
+set HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+set HINDSIGHT_API_LLM_BASE_URL=https://api.deepseek.com
+
+set HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
+set HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
+
+set HINDSIGHT_API_RERANKER_PROVIDER=flashrank
+
+hindsight-api
+```
+
+The `HF_ENDPOINT` variable is used by Hugging Face tooling (`huggingface_hub`), not by Hindsight itself.
+
 ---
 
 ## Embedded in a Python Application


### PR DESCRIPTION
## Summary

- **paperclip**: commit the trailing whitespace and line-length formatting fixes that the lint hook auto-produces. This has been causing `verify-generated-files` to fail on every PR since the paperclip integration landed.
- **openclaw**: update 3 `agent_end` hook tests to expect the system-role context message that `includeSenderContext` (default: `true`) now prepends to the transcript before calling retain. The tests were written before this feature and never updated.

## Test plan

- [ ] `verify-generated-files` passes (no longer detects paperclip drift)
- [ ] `test-openclaw-integration` passes (3 previously failing tests now match actual behavior)