### PR TITLE
fix(graph): cap /banks/{bank_id}/graph response size to keep Control Plane parseable on dense banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2981,6 +2981,13 @@ def _register_routes(app: FastAPI):
         request_context: RequestContext = Depends(get_request_context),
     ):
         """Get graph data from database, filtered by bank_id and optionally by type."""
+        # Edge count scales quadratically with node count for densely-linked banks.
+        # Empirical measurement on a 14k-memory bank: limit=200 → 23 MiB,
+        # limit=500 → 147 MiB, limit=1000 → 596 MiB. The Control Plane fetches
+        # via Next.js which deserializes the response as a single JS string,
+        # and V8 caps string length at ~512 MiB. Cap server-side so giant banks
+        # remain visualizable instead of erroring out the UI entirely.
+        limit = min(max(1, limit), 200)
         try:
             data = await app.state.memory.get_graph_data(
                 bank_id,

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2972,7 +2972,16 @@ def _register_routes(app: FastAPI):
     async def api_graph(
         bank_id: str,
         type: str | None = None,
-        limit: int = 1000,
+        limit: int = Query(
+            200,
+            ge=1,
+            description=(
+                "Max nodes to return. Silently clamped to 200 server-side because "
+                "edge count scales quadratically with node count on dense banks and "
+                "the Control Plane UI cannot parse responses past V8's ~512 MiB "
+                "string limit. Requests above 200 are clamped, not rejected."
+            ),
+        ),
         q: str | None = None,
         tags: list[str] | None = Query(None),
         tags_match: str = "all_strict",
@@ -2981,13 +2990,11 @@ def _register_routes(app: FastAPI):
         request_context: RequestContext = Depends(get_request_context),
     ):
         """Get graph data from database, filtered by bank_id and optionally by type."""
-        # Edge count scales quadratically with node count for densely-linked banks.
-        # Empirical measurement on a 14k-memory bank: limit=200 → 23 MiB,
-        # limit=500 → 147 MiB, limit=1000 → 596 MiB. The Control Plane fetches
-        # via Next.js which deserializes the response as a single JS string,
-        # and V8 caps string length at ~512 MiB. Cap server-side so giant banks
-        # remain visualizable instead of erroring out the UI entirely.
-        limit = min(max(1, limit), 200)
+        # Empirical sizing on a 14k-memory bank: limit=200 → 23 MiB,
+        # limit=500 → 147 MiB, limit=1000 → 596 MiB (past V8's ~512 MiB
+        # string cap). Clamp silently rather than 422 so existing UI/SDK
+        # callers passing limit>200 keep working with a smaller response.
+        limit = min(limit, 200)
         try:
             data = await app.state.memory.get_graph_data(
                 bank_id,

--- a/hindsight-api-slim/tests/test_graph_endpoint_clamp.py
+++ b/hindsight-api-slim/tests/test_graph_endpoint_clamp.py
@@ -1,0 +1,76 @@
+"""Tests for the server-side clamp on /banks/{bank_id}/graph?limit=...
+
+Edge count scales quadratically with node count for dense banks; the Control
+Plane (Next.js) deserializes the response as a single JS string, capped at
+~512 MiB by V8. The endpoint silently clamps ``limit`` at 200 to keep
+responses parseable while preserving backwards-compat for callers passing
+larger values.
+"""
+
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api.http import create_app
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+GRAPH_LIMIT_CAP = 200
+
+
+@pytest_asyncio.fixture
+async def graph_clamp_api_client(memory):
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_graph_limit_above_cap_is_silently_clamped(
+    memory: MemoryEngine, request_context, graph_clamp_api_client: httpx.AsyncClient
+):
+    """Requests above 200 succeed (200 OK) and the response's ``limit`` field
+    reflects the clamped value, not the requested value."""
+    bank_id = f"graph-clamp-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    # A single retain is enough to make the endpoint return a non-empty graph;
+    # the clamp behavior is independent of bank density.
+    await memory.retain_async(
+        bank_id=bank_id,
+        content="Alice met Bob at the conference.",
+        request_context=request_context,
+    )
+
+    response = await graph_clamp_api_client.get(
+        f"/v1/default/banks/{bank_id}/graph",
+        params={"limit": 1000},
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["limit"] == GRAPH_LIMIT_CAP, (
+        f"expected clamped limit={GRAPH_LIMIT_CAP}, got {data['limit']}"
+    )
+    assert len(data["nodes"]) <= GRAPH_LIMIT_CAP
+
+
+@pytest.mark.asyncio
+async def test_graph_limit_below_cap_passes_through(
+    memory: MemoryEngine, request_context, graph_clamp_api_client: httpx.AsyncClient
+):
+    """Requests at or below 200 are not modified."""
+    bank_id = f"graph-clamp-passthrough-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    await memory.retain_async(
+        bank_id=bank_id,
+        content="Carol travels to Boston monthly.",
+        request_context=request_context,
+    )
+
+    response = await graph_clamp_api_client.get(
+        f"/v1/default/banks/{bank_id}/graph",
+        params={"limit": 50},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["limit"] == 50


### PR DESCRIPTION
## Summary

Cap the `limit` parameter on `GET /v1/default/banks/{bank_id}/graph` server-side at 200. Edge count scales quadratically with node count for densely-linked banks, and the Control Plane (Next.js) deserializes the response as a single JS string which V8 caps at 0x1fffffe8 (~512 MiB).

## Repro

On a 14k-memory bank with ~835k memory_links and 17k entities:

| `limit` | response size | Control Plane outcome |
|---|---|---|
| 100 | 6 MiB | ✓ renders |
| 200 | 23 MiB | ✓ renders |
| 500 | 147 MiB | borderline — Next.js parse stalls |
| **1000** (Control Plane default) | **596 MiB** | **✗ V8 string-length error: \"Cannot create a string longer than 0x1fffffe8 characters\" → UI shows \"Server Error: Failed to fetch graph data\"** |

The Control Plane's `useState(1000)` in `data-view.tsx` sets the initial fetchLimit, which falls within the API's old `limit: int = 1000` signature. Smaller banks fit; banks past ~10k highly-linked memories silently break the UI.

## What changes

```python
limit = min(max(1, limit), 200)
```

A single `min(max(...))` clamp inside the `api_graph` handler. Smaller queries pass through unchanged; large ones clamp to 200 with no error response. UI continues to function on dense banks instead of erroring out entirely.

## Why 200

- 200 nodes is past the practical readable density limit for any 2D graph viz (force-directed layouts get unusable past ~150 nodes regardless).
- 23 MiB is well within Next.js / V8 parse capacity.
- Smaller banks where the user requests >200 still get a usable graph; they were never going to hit the V8 limit anyway.

## Why server-side

The UI fix would be a one-line change to `data-view.tsx`'s `useState(1000)` → `useState(200)`. Either works; server-side caps protect SDK and direct API consumers too without depending on the UI staying in sync. Open to swapping for a UI-only fix if maintainers prefer.

## Real fix

This is a guard, not a solution. Long-term the graph endpoint should support pagination or streaming so high-density banks can be explored without truncation. Filing this as a stop-gap so the Control Plane stops 500'ing on production banks at scale.

## Test plan

- Verified clamp behavior at limits 10, 200, 1000 against a 14k-memory bank — clamped responses are well-formed `GraphDataResponse` JSON.
- No behavior change for `limit ≤ 200` requests.
- `pre-commit` hooks (`ruff check --fix`, `ruff format`, `ty check`) all green.