### PR TITLE
fix: handle transient OID errors in embedding dimension migration

### DIFF
--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -478,6 +478,9 @@ def _migrate_table_embedding_dimension(
     logger.info(f"Altering {table_name}.embedding column dimension from {current_dim} to {required_dimension}")
 
     # Drop existing vector index (works for HNSW, DiskANN, vchordrq, and ScaNN)
+    # The EXCEPTION block handles 'could not open relation with OID' errors that
+    # occur when concurrent sessions drop schemas (e.g. pytest-xdist workers),
+    # invalidating pg_indexes OID references mid-cursor-iteration.
     conn.execute(
         text(f"""
             DO $$
@@ -492,6 +495,9 @@ def _migrate_table_embedding_dimension(
                 LOOP
                     EXECUTE 'DROP INDEX IF EXISTS {schema_name}.' || idx_name;
                 END LOOP;
+            EXCEPTION WHEN internal_error THEN
+                -- Stale OID from concurrent schema drop; nothing to drop anyway
+                NULL;
             END $$;
         """)
     )

--- a/hindsight-api-slim/tests/test_custom_embedding_dimension.py
+++ b/hindsight-api-slim/tests/test_custom_embedding_dimension.py
@@ -112,6 +112,35 @@ def _ensure_embedding_dimension_with_retry(db_url: str, dimension: int, schema: 
             raise
 
 
+def _assert_raises_runtime_error_with_retry(
+    db_url: str,
+    dimension: int,
+    schema: str,
+    expected_messages: list[str],
+):
+    """Assert ensure_embedding_dimension raises RuntimeError, retrying on transient OID errors.
+
+    Concurrent xdist workers can cause 'could not open relation with OID' errors
+    that mask the expected RuntimeError. This retries to give the system a chance to
+    reach the actual dimension-mismatch check.
+    """
+    import time
+
+    for attempt in range(3):
+        try:
+            ensure_embedding_dimension(db_url, dimension, schema=schema)
+            raise AssertionError("Expected RuntimeError but ensure_embedding_dimension succeeded")
+        except RuntimeError as e:
+            for msg in expected_messages:
+                assert msg in str(e), f"Expected '{msg}' in error message, got: {e}"
+            return
+        except Exception as e:
+            if "could not open relation with OID" in str(e) and attempt < 2:
+                time.sleep(0.5)
+                continue
+            raise
+
+
 def get_column_dimension(db_url: str, schema: str = "public", table: str = "memory_units") -> int | None:
     """Get the current embedding column dimension from the database."""
     engine = create_engine(db_url)
@@ -255,12 +284,12 @@ class TestEmbeddingDimension:
         insert_test_embedding(db_url, schema, 384)
         assert get_row_count(db_url, schema) == 1
 
-        # Try to change dimension - should raise error
-        with pytest.raises(RuntimeError) as exc_info:
-            ensure_embedding_dimension(db_url, 768, schema=schema)
-
-        assert "Cannot change embedding dimension" in str(exc_info.value)
-        assert "1 rows with embeddings" in str(exc_info.value)
+        # Try to change dimension - should raise RuntimeError.
+        # Retry on transient OID errors from concurrent xdist schema drops.
+        _assert_raises_runtime_error_with_retry(
+            db_url, 768, schema,
+            expected_messages=["Cannot change embedding dimension", "1 rows with embeddings"],
+        )
 
         # Dimension should be unchanged
         assert get_column_dimension(db_url, schema) == 384
@@ -300,11 +329,12 @@ class TestEmbeddingDimension:
         clear_mental_model_embeddings(db_url, schema)
         insert_test_mental_model_embedding(db_url, schema, 384)
 
-        with pytest.raises(RuntimeError) as exc_info:
-            ensure_embedding_dimension(db_url, 768, schema=schema)
-
-        assert "Cannot change embedding dimension" in str(exc_info.value)
-        assert "mental_models" in str(exc_info.value)
+        # Try to change dimension - should raise RuntimeError.
+        # Retry on transient OID errors from concurrent xdist schema drops.
+        _assert_raises_runtime_error_with_retry(
+            db_url, 768, schema,
+            expected_messages=["Cannot change embedding dimension", "mental_models"],
+        )
 
         assert get_column_dimension(db_url, schema, table="mental_models") == 384
 


### PR DESCRIPTION
## Summary
- Adds `EXCEPTION WHEN internal_error` handling to the PL/pgSQL DO block in `migrations.py` that drops vector indexes during embedding dimension changes
- Adds retry wrapper to two test cases (`test_dimension_change_blocked_with_data`, `test_mental_models_dimension_change_blocked_with_data`) that previously called `ensure_embedding_dimension()` directly without OID-race protection

## Root cause
The DO block iterates `pg_indexes` via a PL/pgSQL cursor. When concurrent pytest-xdist workers execute `DROP SCHEMA ... CASCADE`, the OID references held by the open cursor become stale, causing `could not open relation with OID` errors. This is a transient failure that only manifests under parallel test execution (CI with `-n auto`).

The fix addresses the issue at two levels:
1. **SQL layer** (primary fix): The DO block now catches `internal_error` exceptions, since a concurrent schema drop means there's nothing left to drop anyway
2. **Test layer** (defense-in-depth): The two "blocked with data" tests now use `_assert_raises_runtime_error_with_retry()` which retries on transient OID errors before asserting the expected `RuntimeError`

## Test plan
- [ ] `test-api` CI job passes (specifically `test_custom_embedding_dimension.py`)
- [ ] No regressions in other test jobs

🔗 Related: this was the flaky failure in #1610