### PR TITLE
docs: add HINDSIGHT_API_WORKER_ID tip to API quickstart

### DIFF
--- a/hindsight-docs/docs/developer/api/quickstart.mdx
+++ b/hindsight-docs/docs/developer/api/quickstart.mdx
@@ -52,6 +52,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
+:::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
+The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_ID=hindsight-prod`) so the worker keeps the same identity across restarts. This is recommended even for single-container deployments. For diagnosis and recovery commands, see [Admin CLI - Recovering stuck operations](/developer/admin-cli#recovering-stuck-or-zombie-operations).
+:::
+
 </TabItem>
 </Tabs>
 

--- a/hindsight-docs/versioned_docs/version-0.6/developer/api/quickstart.mdx
+++ b/hindsight-docs/versioned_docs/version-0.6/developer/api/quickstart.mdx
@@ -52,6 +52,12 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
+:::tip Set a stable `HINDSIGHT_API_WORKER_ID` in production
+The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_ID=hindsight-prod`) so the worker keeps the same identity across restarts. This is recommended even for single-container deployments. For diagnosis and recovery commands, see [Admin CLI - Recovering stuck operations](/developer/admin-cli#recovering-stuck-or-zombie-operations).
+:::
+
 </TabItem>
 </Tabs>
 

--- a/skills/hindsight-docs/references/developer/api/quickstart.md
+++ b/skills/hindsight-docs/references/developer/api/quickstart.md
@@ -38,6 +38,11 @@ docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
 - **API**: http://localhost:8888
 - **Control Plane** (Web UI): http://localhost:9999
 
+> **💡 Set a stable `HINDSIGHT_API_WORKER_ID` in production**
+> 
+The worker uses the container hostname as its identity, which Docker sets to the container ID by default. That value changes on every restart, so any task that was being processed when the container went down stays parked under the old ID with no way for the new container to recognize it as its own.
+
+Set `HINDSIGHT_API_WORKER_ID` to a stable value (e.g., `-e HINDSIGHT_API_WORKER_ID=hindsight-prod`) so the worker keeps the same identity across restarts. This is recommended even for single-container deployments. For diagnosis and recovery commands, see [Admin CLI - Recovering stuck operations](../admin-cli.md#recovering-stuck-or-zombie-operations).
 > **💡 LLM Provider**
 > 
 Hindsight requires an LLM with structured output support. Recommended: **Groq** with `gpt-oss-20b` for fast, cost-effective inference.


### PR DESCRIPTION
## Summary
- Mirrors the existing `HINDSIGHT_API_WORKER_ID` tip from `installation.md#docker` into the API quickstart's Docker tab, so new users who land on quickstart first don't miss the guidance.
- Link points to the Admin CLI recovery section using an absolute doc path so it resolves from `/developer/api/quickstart`.

Closes #1616.

## Test plan
- [ ] `cd hindsight-docs && npm run start` and confirm the tip renders in the Docker tab of the API quickstart with a working link to Admin CLI recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)