### PR TITLE
fix(ci): use frozen lockfile in lint.sh during CI

### DIFF
--- a/scripts/hooks/lint.sh
+++ b/scripts/hooks/lint.sh
@@ -33,8 +33,14 @@ run_task() {
 
 echo "  Syncing Python dependencies..."
 # Run uv sync first to avoid race conditions when multiple uv run commands
-# try to reinstall local packages in parallel (e.g., after version bump)
-uv sync --quiet
+# try to reinstall local packages in parallel (e.g., after version bump).
+# In CI, use --frozen to avoid re-resolving the lockfile (which would cause
+# verify-generated-files to report spurious diffs on Dependabot PRs).
+if [ -n "$CI" ]; then
+    uv sync --frozen --quiet
+else
+    uv sync --quiet
+fi
 
 echo "  Running lints in parallel..."
 


### PR DESCRIPTION
## Summary
- `lint.sh` runs `uv sync` without `--frozen` at the repo root, which re-resolves `uv.lock`
- In CI's `verify-generated-files` job, this causes spurious 1-line diffs on every Dependabot PR, blocking them all from merging
- Fix: use `--frozen` when `$CI` is set; local dev keeps non-frozen sync

## Impact
Once merged, Dependabot PRs (like #1613) should pass `verify-generated-files` without manual intervention.

## Test plan
- [ ] `verify-generated-files` passes on this PR
- [ ] After merge, `@dependabot rebase` on #1613 should result in green CI