### PR TITLE
fix(docs): use real GitHub handle for ContextForge integration author

### DIFF
--- a/hindsight-docs/src/data/integrations.json
+++ b/hindsight-docs/src/data/integrations.json
@@ -285,7 +285,7 @@
       "name": "ContextForge",
       "description": "Register Hindsight as an MCP backend in ContextForge gateway. Gives every connected AI tool access to long-term memory via a unified MCP hub.",
       "type": "community",
-      "by": "omarouldali",
+      "by": "ooa-andera",
       "category": "mcp",
       "link": "/sdks/integrations/context-forge",
       "icon": "/img/icons/mcp.png"


### PR DESCRIPTION
## Summary
- The ContextForge community integration card on the Integrations Hub was rendering a broken-image placeholder next to `@omarouldali` because `github.com/omarouldali` is not a real GitHub user (returns 404), so `github.com/omarouldali.png?size=40` fails to load.
- The contributor who authored both #961 (original ContextForge integration) and #1254 (the rename that introduced `omarouldali`) commits as `ooa-andera`, and that handle resolves to a real avatar.
- One-line JSON change: `by: "omarouldali"` → `by: "ooa-andera"` in `hindsight-docs/src/data/integrations.json`.

## Note
This changes the displayed handle in the card from `@omarouldali` to `@ooa-andera`. If the contributor wanted a different personal handle shown, they'd need to confirm the correct spelling — but as-is no real GitHub account matches `omarouldali`, so the card is broken either way until the handle is corrected.

## Test plan
- [x] Verified `curl -sI https://github.com/omarouldali.png?size=40` returns 404
- [x] Verified `curl -sI https://github.com/ooa-andera.png?size=40` returns 302 (resolves to a real avatar)
- [ ] After deploy: visually confirm the ContextForge card on `/integrations` shows an avatar instead of a broken-image icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)