### PR TITLE
docs(cli): document --timestamp flag on memory retain (#1622)

### DIFF
--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -88,6 +88,12 @@ hindsight memory retain <bank_id> "Bob loves hiking" --context "hobby discussion
 
 # Queue for background processing
 hindsight memory retain <bank_id> "Meeting notes" --async
+
+# With an event date (ISO 8601 datetime or date)
+hindsight memory retain <bank_id> "Project launched" --timestamp 2024-01-15
+
+# Store without a timestamp (overrides the default of "now")
+hindsight memory retain <bank_id> "Background fact" --timestamp unset
 ```
 
 ### Retain Files

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -88,6 +88,12 @@ hindsight memory retain <bank_id> "Bob loves hiking" --context "hobby discussion
 
 # Queue for background processing
 hindsight memory retain <bank_id> "Meeting notes" --async
+
+# With an event date (ISO 8601 datetime or date)
+hindsight memory retain <bank_id> "Project launched" --timestamp 2024-01-15
+
+# Store without a timestamp (overrides the default of "now")
+hindsight memory retain <bank_id> "Background fact" --timestamp unset
 ```
 
 ### Retain Files


### PR DESCRIPTION
## Summary

#1622 added a new `-t/--timestamp` flag to `hindsight memory retain` so the CLI can finally set `MemoryItem.timestamp` (the Python and Node SDKs already supported this). The CLI reference docs were not updated, so users browsing https://hindsight.vectorize.io/docs/sdks/cli still see only `--context` and `--async` for `memory retain`.

This PR adds two grounded examples to the existing `### Retain (Store Memory)` block, mirrored to both:

- `hindsight-docs/docs/sdks/cli.md` (the published CLI reference)
- `skills/hindsight-docs/references/sdks/cli.md` (the skill mirror)

```bash
# With an event date (ISO 8601 datetime or date)
hindsight memory retain <bank_id> "Project launched" --timestamp 2024-01-15

# Store without a timestamp (overrides the default of "now")
hindsight memory retain <bank_id> "Background fact" --timestamp unset
```

## Grounding

Verbatim from `hindsight-cli/src/main.rs` (post-#1622):

```rust
/// When the content occurred (ISO 8601 datetime, e.g. 2024-01-15T10:30:00Z
/// or 2024-01-15). Pass "unset" to store without a timestamp.
/// Omit to default to now.
#[arg(short = 't', long)]
timestamp: Option<String>,
```

Scope notes:

- Only `MemoryCommands::Retain` got the new flag; `RetainFiles` did not, so the `### Retain Files` block is intentionally untouched.
- No control-plane / Python / Node SDK wording added — those surfaces are unrelated to this drift.
- Both files are 100% identical except for one pre-existing relative link to the OpenAPI spec, so the patch is symmetric (12 LOC across two files).

## Test plan

- [x] `--timestamp` and `-t` flag definitions verified in `hindsight-cli/src/main.rs` on `main` post-#1622.
- [x] Special value `"unset"` and ISO 8601 date form `2024-01-15` are both documented in the source docstring.
- [x] No competing OPEN PR touches `hindsight-docs/docs/sdks/cli.md` or the skills mirror (verified via `gh pr list --search`).