### PR TITLE
docs(claude-code): document requestTimeoutSeconds option from #1591

### DIFF
--- a/hindsight-docs/docs-integrations/claude-code.md
+++ b/hindsight-docs/docs-integrations/claude-code.md
@@ -118,6 +118,7 @@ These settings control how the plugin connects to the Hindsight API.
 | `daemonIdleTimeout` | `HINDSIGHT_DAEMON_IDLE_TIMEOUT` | `0` | Seconds of inactivity before the local daemon shuts itself down. `0` means the daemon stays running until the session ends. |
 | `embedVersion` | `HINDSIGHT_EMBED_VERSION` | `"latest"` | Which version of `hindsight-embed` to install via `uvx`. Pin to a specific version (e.g. `"0.5.2"`) for reproducibility. |
 | `embedPackagePath` | `HINDSIGHT_EMBED_PACKAGE_PATH` | `null` | Local filesystem path to a `hindsight-embed` checkout. When set, the plugin runs from this path instead of installing via `uvx`. Useful for development. |
+| `requestTimeoutSeconds` | `HINDSIGHT_REQUEST_TIMEOUT_SECONDS` | `null` | Overrides the per-call request timeout for recall (default `10s`), retain (default `15s`) and knowledge tool calls (`10–15s`). When unset, the per-call defaults are preserved. Bump this when self-hosted Hindsight legitimately takes longer than 10s under contention (e.g. parallel recalls), to avoid client-side `read operation timed out` errors on requests the server completes successfully. Does not affect the health check, which intentionally stays fast (5s). |
 
 ---
 


### PR DESCRIPTION
## What

Adds a row to the **Connection & Daemon** settings table in `hindsight-docs/docs-integrations/claude-code.md` documenting the `requestTimeoutSeconds` / `HINDSIGHT_REQUEST_TIMEOUT_SECONDS` option introduced in #1591.

## Why

#1591 ([feat(claude-code): expose configurable MCP request timeout](https://github.com/vectorize-io/hindsight/pull/1591), merged 2026-05-13) exposed the new option in the plugin README (`hindsight-integrations/claude-code/README.md`) and CHANGELOG, but the public Docusaurus docs at `hindsight-docs/docs-integrations/claude-code.md` were not updated. Users browsing the docs site under [Integrations → Claude Code](https://hindsight-docs.vectorize.io/sdks/integrations/claude-code) cannot discover the option from the public surface.

The Connection & Daemon table on the docs site is the canonical reference for env-var-driven settings (already lists `daemonIdleTimeout`, `embedVersion`, `embedPackagePath`, etc.). Adding the new row preserves parity with the plugin README so the docs site, README, and `~/.hindsight/claude-code.json` schema all match.

## How

1-line additive row in the Connection & Daemon table, byte-for-byte mirror of the row in the integration README's Connection settings table (same wording for default, behavior, and the recall-timeout caveat — verbatim from #1591's README diff).

## Scope

- File: `hindsight-docs/docs-integrations/claude-code.md` (1 line added after `embedPackagePath` row).
- Net diff: +1 / -0.
- No semantic changes elsewhere — does not touch troubleshooting section's hardcoded "12-second timeout" note (that refers specifically to the recall hook outside the override path).

## Source-of-truth references

- #1591 PR body: "`README.md` — added a row in the Connection settings table."
- `hindsight-integrations/claude-code/README.md` — `requestTimeoutSeconds` row in Connection & Daemon table (current main).
- #1575 issue: original repro of `read operation timed out` under parallel recall contention.