### PR TITLE
fix(ci): set UV_FROZEN=1 on verify-generated-files job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3463,6 +3463,8 @@ jobs:
 
   verify-generated-files:
     runs-on: ubuntu-latest
+    env:
+      UV_FROZEN: "1"
     steps:
     - uses: actions/checkout@v6
       with:

--- a/scripts/hooks/lint.sh
+++ b/scripts/hooks/lint.sh
@@ -34,13 +34,9 @@ run_task() {
 echo "  Syncing Python dependencies..."
 # Run uv sync first to avoid race conditions when multiple uv run commands
 # try to reinstall local packages in parallel (e.g., after version bump).
-# In CI, use --frozen to avoid re-resolving the lockfile (which would cause
-# verify-generated-files to report spurious diffs on Dependabot PRs).
-if [ -n "$CI" ]; then
-    uv sync --frozen --quiet
-else
-    uv sync --quiet
-fi
+# In CI, UV_FROZEN=1 is set at the job level so this becomes a no-op for
+# lockfile resolution (see verify-generated-files in test.yml).
+uv sync --quiet
 
 echo "  Running lints in parallel..."
 


### PR DESCRIPTION
## Summary
- Sets `UV_FROZEN=1` as a job-level env var on the `verify-generated-files` CI job
- This is the [idiomatic uv approach](https://docs.astral.sh/uv/reference/environment/) for CI — all `uv sync`, `uv run`, and `uv lock` calls respect the committed lockfile without re-resolving
- Reverts the lint.sh CI-specific `--frozen` logic from #1618 since the env var covers it globally

## Why
Generation scripts (`generate-openapi.sh`, `generate-bank-template-schema.sh`) and `lint.sh` all call `uv run` which implicitly triggers `uv sync`, re-resolving the lockfile. This caused spurious `uv.lock` diffs that failed `verify-generated-files` on every Dependabot PR. The #1618 fix only addressed `lint.sh` but not the generation scripts.

## Test plan
- [ ] `verify-generated-files` passes on this PR
- [ ] After merge, `@dependabot recreate` on #1620 should produce green CI