### PR TITLE
docs: attribute 0.6.2 release post to benfrank241

### DIFF
--- a/hindsight-docs/blog/2026-05-14-version-0-6-2.md
+++ b/hindsight-docs/blog/2026-05-14-version-0-6-2.md
@@ -1,7 +1,7 @@
 ---
 title: "What's new in Hindsight 0.6.2"
 description: Security and reliability patches for Hindsight 0.6.2
-authors: [nicoloboschi]
+authors: [benfrank241]
 date: 2026-05-14
 hide_table_of_contents: true
 tags: [release]


### PR DESCRIPTION
## Summary

Updates the 0.6.2 release blog post author from `nicoloboschi` to `benfrank241`, since Ben drove the 0.6.2 release.

Re-targets the change at `main` — the prior PR #1634 was merged into the (now stale) `docs-changelog-0.6.2` branch and never reached `main`.

## Test plan

- [x] Trivial frontmatter change; build-docs will re-verify