### PR TITLE
docs: document observation-only recall limits

### DIFF
--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -82,6 +82,12 @@ Each type runs the full four-strategy retrieval pipeline independently, so narro
 Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes) and carries a computed freshness trend, and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
 :::
 
+#### Observation-only recall in long-running agents
+
+Using `types=["observation"]` (or an integration setting such as `recall_types=["observation"]`) is a good way to avoid injecting every raw fact into an agent prompt. It is not a retention or output-deduplication policy. If an agent retains every turn for days, broad queries can still match many overlapping observations because the observation layer continues to accumulate durable patterns.
+
+For long-running conversational agents, use stable [`document_id`](./retain#document_id) values, retain less aggressively when your integration allows it, keep `max_tokens` tight, and scope recall with tags. If a bank has already accumulated noisy or obsolete observations, delete the noisy source documents or memories first, then [reset observations](../observations#resetting-all-observations) so consolidation rebuilds from the remaining evidence. To bound future growth, consider `max_observations_per_scope` in the bank's observations configuration.
+
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.

--- a/hindsight-docs/src/pages/best-practices.mdx
+++ b/hindsight-docs/src/pages/best-practices.mdx
@@ -400,6 +400,8 @@ recall(
 | `["observation"]` | Consolidated patterns only — faster for high-level questions |
 | `["world", "experience"]` | Raw facts only — for ground-truth or citation-sensitive queries |
 
+**Long-running agents:** Observation-only recall is useful for reducing prompt noise, but it does not stop observations from accumulating. Agents that retain every conversation turn can still build overlapping observations over days of normal use, especially for broad user-profile or project-status queries. Keep a stable [`document_id`](/developer/api/retain#document_id), lower retain frequency when the integration allows it, use tags and `max_tokens` to narrow recall, and periodically delete obsolete source documents before [resetting observations](/developer/observations#resetting-all-observations) if the bank has become noisy. Use `max_observations_per_scope` when you need a hard cap per observation scope.
+
 ---
 
 ### Filtering by Memory Shape with Entity Labels

--- a/hindsight-docs/versioned_docs/version-0.6/developer/api/recall.mdx
+++ b/hindsight-docs/versioned_docs/version-0.6/developer/api/recall.mdx
@@ -82,6 +82,12 @@ Each type runs the full four-strategy retrieval pipeline independently, so narro
 Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes) and carries a computed freshness trend, and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
 :::
 
+#### Observation-only recall in long-running agents
+
+Using `types=["observation"]` (or an integration setting such as `recall_types=["observation"]`) is a good way to avoid injecting every raw fact into an agent prompt. It is not a retention or output-deduplication policy. If an agent retains every turn for days, broad queries can still match many overlapping observations because the observation layer continues to accumulate durable patterns.
+
+For long-running conversational agents, use stable [`document_id`](./retain#document_id) values, retain less aggressively when your integration allows it, keep `max_tokens` tight, and scope recall with tags. If a bank has already accumulated noisy or obsolete observations, delete the noisy source documents or memories first, then [reset observations](../observations#resetting-all-observations) so consolidation rebuilds from the remaining evidence. To bound future growth, consider `max_observations_per_scope` in the bank's observations configuration.
+
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.

--- a/skills/hindsight-docs/references/best-practices.md
+++ b/skills/hindsight-docs/references/best-practices.md
@@ -394,6 +394,8 @@ recall(
 | `["observation"]` | Consolidated patterns only — faster for high-level questions |
 | `["world", "experience"]` | Raw facts only — for ground-truth or citation-sensitive queries |
 
+**Long-running agents:** Observation-only recall is useful for reducing prompt noise, but it does not stop observations from accumulating. Agents that retain every conversation turn can still build overlapping observations over days of normal use, especially for broad user-profile or project-status queries. Keep a stable [`document_id`](developer/api/retain.md#document_id), lower retain frequency when the integration allows it, use tags and `max_tokens` to narrow recall, and periodically delete obsolete source documents before [resetting observations](developer/observations.md#resetting-all-observations) if the bank has become noisy. Use `max_observations_per_scope` when you need a hard cap per observation scope.
+
 ---
 
 ### Filtering by Memory Shape with Entity Labels

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -152,6 +152,12 @@ hindsight memory recall my-bank "query" --fact-type world,observation
 > **💡 About Observations**
 > 
 Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes) and carries a computed freshness trend, and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
+#### Observation-only recall in long-running agents
+
+Using `types=["observation"]` (or an integration setting such as `recall_types=["observation"]`) is a good way to avoid injecting every raw fact into an agent prompt. It is not a retention or output-deduplication policy. If an agent retains every turn for days, broad queries can still match many overlapping observations because the observation layer continues to accumulate durable patterns.
+
+For long-running conversational agents, use stable [`document_id`](./retain#document_id) values, retain less aggressively when your integration allows it, keep `max_tokens` tight, and scope recall with tags. If a bank has already accumulated noisy or obsolete observations, delete the noisy source documents or memories first, then [reset observations](../observations#resetting-all-observations) so consolidation rebuilds from the remaining evidence. To bound future growth, consider `max_observations_per_scope` in the bank's observations configuration.
+
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.


### PR DESCRIPTION
fix #1531 