### PR TITLE
fix(mcp): keep FastMCP transport options off constructor

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -90,7 +90,7 @@ def create_mcp_server(memory: MemoryEngine, multi_bank: bool = True) -> FastMCP:
     Returns:
         Configured FastMCP server instance
     """
-    mcp = FastMCP("hindsight-mcp-server", version=HINDSIGHT_VERSION)
+    mcp = _create_fastmcp_server()
 
     global_config = _get_raw_config()
 
@@ -155,6 +155,16 @@ def create_mcp_server(memory: MemoryEngine, multi_bank: bool = True) -> FastMCP:
     _make_tools_tolerant(mcp)
 
     return mcp
+
+
+def _create_fastmcp_server() -> FastMCP:
+    """Create a FastMCP server without HTTP transport options.
+
+    FastMCP 3.x rejects transport kwargs such as stateless_http on the constructor.
+    Keep those options on http_app() so importing or creating the MCP server works
+    across FastMCP 3.x releases.
+    """
+    return FastMCP("hindsight-mcp-server", version=HINDSIGHT_VERSION)
 
 
 def _get_mcp_tools(mcp: FastMCP) -> dict:

--- a/hindsight-api-slim/tests/test_mcp_server_version.py
+++ b/hindsight-api-slim/tests/test_mcp_server_version.py
@@ -1,6 +1,6 @@
 """Tests for MCP server identity reported via serverInfo."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from hindsight_api import __version__ as HINDSIGHT_VERSION
 from hindsight_api.api.mcp import create_mcp_server
@@ -11,3 +11,24 @@ def test_mcp_server_reports_hindsight_version():
     memory = MagicMock()
     server = create_mcp_server(memory, multi_bank=True)
     assert server.version == HINDSIGHT_VERSION
+
+
+def test_mcp_server_constructor_does_not_receive_http_transport_options():
+    """FastMCP 3.x rejects stateless_http on the constructor; pass it only to http_app()."""
+    from hindsight_api.api import mcp as mcp_module
+
+    server = MagicMock()
+
+    with (
+        patch.object(mcp_module, "FastMCP", return_value=server) as fastmcp_cls,
+        patch.object(mcp_module, "_get_raw_config") as raw_config,
+        patch.object(mcp_module, "register_mcp_tools"),
+        patch.object(mcp_module, "load_extension", return_value=None),
+        patch.object(mcp_module, "_make_tools_tolerant"),
+    ):
+        raw_config.return_value.mcp_enabled_tools = None
+
+        assert create_mcp_server(MagicMock(), multi_bank=True) is server
+
+    fastmcp_cls.assert_called_once_with("hindsight-mcp-server", version=HINDSIGHT_VERSION)
+    assert "stateless_http" not in fastmcp_cls.call_args.kwargs


### PR DESCRIPTION
fix #1641