### PR TITLE
feat: add opencode-go LLM provider

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -471,6 +471,7 @@ PROVIDER_DEFAULT_MODELS = {
     "minimax": "MiniMax-M2.7",
     "deepseek": "deepseek-v4-flash",
     "zai": "glm-4.5-flash",
+    "opencode-go": "deepseek-v4-flash",
     "ollama": "gemma3:12b",
     "llamacpp": "gemma-4-e2b-it",
     "lmstudio": "local-model",

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -318,6 +318,7 @@ def create_llm_provider(
         "volcano",
         "openrouter",
         "zai",
+        "opencode-go",
     ):
         return OpenAICompatibleLLM(
             provider=provider,
@@ -425,6 +426,7 @@ class LLMProvider:
             "volcano",
             "openrouter",
             "zai",
+            "opencode-go",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")
@@ -445,6 +447,8 @@ class LLMProvider:
                 self.base_url = "https://openrouter.ai/api/v1"
             elif self.provider == "zai":
                 self.base_url = "https://api.z.ai/api/coding/paas/v4"
+            elif self.provider == "opencode-go":
+                self.base_url = "https://opencode.ai/zen/go/v1"
 
         # Prepare Vertex AI config (if applicable)
         vertexai_project_id = None
@@ -836,7 +840,6 @@ class LLMProvider:
     def from_env(cls) -> "LLMProvider":
         """Create provider from environment variables using config.py constants."""
         from ..config import (
-            DEFAULT_LLM_MODEL,
             DEFAULT_LLM_PROVIDER,
             ENV_LLM_API_KEY,
             ENV_LLM_BASE_URL,
@@ -844,6 +847,7 @@ class LLMProvider:
             ENV_LLM_EXTRA_BODY,
             ENV_LLM_MODEL,
             ENV_LLM_PROVIDER,
+            _get_default_model_for_provider,
         )
 
         provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER)
@@ -857,7 +861,7 @@ class LLMProvider:
             )
 
         base_url = os.getenv(ENV_LLM_BASE_URL, "")
-        model = os.getenv(ENV_LLM_MODEL, DEFAULT_LLM_MODEL)
+        model = os.getenv(ENV_LLM_MODEL) or _get_default_model_for_provider(provider)
         extra_body = json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null"))
         default_headers = json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null"))
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -1,5 +1,6 @@
 """
-OpenAI-compatible LLM provider supporting OpenAI, Groq, Ollama, LMStudio, MiniMax, and DeepSeek.
+OpenAI-compatible LLM provider supporting OpenAI, Groq, Ollama, LMStudio, MiniMax, DeepSeek,
+and Opencode Go.
 
 This provider handles all OpenAI API-compatible models including:
 - OpenAI: GPT-4, GPT-4o, GPT-5, o1, o3 (reasoning models)
@@ -8,6 +9,7 @@ This provider handles all OpenAI API-compatible models including:
 - LMStudio: Local models with OpenAI-compatible API
 - MiniMax: MiniMax-M2.7 models with 1M context window
 - DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via api.deepseek.com
+- Opencode Go: deepseek-v4-flash via https://opencode.ai/zen/go/v1
 
 Features:
 - Reasoning models with extended thinking (o1, o3, GPT-5 families)
@@ -232,6 +234,7 @@ class OpenAICompatibleLLM(LLMInterface):
     - LMStudio: Local models with OpenAI-compatible API
     - MiniMax: MiniMax-M2.7 models via OpenAI-compatible API (https://api.minimax.io/v1)
     - DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via https://api.deepseek.com
+    - opencode-go: deepseek-v4-flash via https://opencode.ai/zen/go/v1
     """
 
     def __init__(
@@ -250,7 +253,7 @@ class OpenAICompatibleLLM(LLMInterface):
         Initialize OpenAI-compatible LLM provider.
 
         Args:
-            provider: Provider name ("openai", "groq", "ollama", "lmstudio").
+            provider: Provider name ("openai", "groq", "ollama", "lmstudio", "opencode-go", etc.).
             api_key: API key (optional for ollama/lmstudio).
             base_url: Base URL for the API (uses defaults for groq/ollama/lmstudio if empty).
             model: Model name.
@@ -274,6 +277,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "volcano",
             "openrouter",
             "zai",
+            "opencode-go",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
@@ -294,13 +298,23 @@ class OpenAICompatibleLLM(LLMInterface):
                 self.base_url = "https://openrouter.ai/api/v1"
             elif self.provider == "zai":
                 self.base_url = "https://api.z.ai/api/coding/paas/v4"
+            elif self.provider == "opencode-go":
+                self.base_url = "https://opencode.ai/zen/go/v1"
 
         # For ollama/lmstudio, use dummy key if not provided
         if self.provider in ("ollama", "lmstudio") and not self.api_key:
             self.api_key = "local"
 
         # Validate API key for cloud providers
-        if self.provider in ("openai", "groq", "minimax", "deepseek", "openrouter", "zai") and not self.api_key:
+        if self.provider in (
+            "openai",
+            "groq",
+            "minimax",
+            "deepseek",
+            "openrouter",
+            "zai",
+            "opencode-go",
+        ) and not self.api_key:
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)

--- a/hindsight-api-slim/tests/test_opencode_go_provider.py
+++ b/hindsight-api-slim/tests/test_opencode_go_provider.py
@@ -1,0 +1,80 @@
+"""Tests for the opencode-go OpenAI-compatible LLM provider."""
+
+import pytest
+
+
+def test_opencode_go_config_has_expected_default_model(monkeypatch):
+    """HindsightConfig should default opencode-go to the DeepSeek v4 flash model."""
+    from hindsight_api.config import PROVIDER_DEFAULT_MODELS, HindsightConfig, clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "opencode-go")
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+    clear_config_cache()
+
+    try:
+        assert PROVIDER_DEFAULT_MODELS["opencode-go"] == "deepseek-v4-flash"
+        config = HindsightConfig.from_env()
+        assert config.llm_provider == "opencode-go"
+        assert config.llm_model == "deepseek-v4-flash"
+    finally:
+        clear_config_cache()
+
+
+def test_opencode_go_llm_provider_from_env_has_expected_default_model(monkeypatch):
+    """LLMProvider.from_env should use the opencode-go provider default model."""
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "opencode-go")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "test-key")
+    monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_LLM_BASE_URL", raising=False)
+    clear_config_cache()
+
+    try:
+        llm = LLMProvider.from_env()
+        assert llm.provider == "opencode-go"
+        assert llm.model == "deepseek-v4-flash"
+        assert llm.base_url == "https://opencode.ai/zen/go/v1"
+    finally:
+        clear_config_cache()
+
+
+def test_opencode_go_requires_api_key_like_zai():
+    """opencode-go is a cloud provider and should require an API key."""
+    from hindsight_api.engine.llm_wrapper import requires_api_key
+
+    assert requires_api_key("opencode-go") is True
+
+
+def test_opencode_go_uses_openai_compatible_provider_with_default_base_url():
+    """The provider factory should route opencode-go to OpenAICompatibleLLM."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+    llm = LLMProvider(
+        provider="opencode-go",
+        api_key="test-key",
+        base_url="",
+        model="deepseek-v4-flash",
+    )
+
+    assert llm.provider == "opencode-go"
+    assert llm.model == "deepseek-v4-flash"
+    assert llm.base_url == "https://opencode.ai/zen/go/v1"
+    assert not llm.base_url.endswith("/")
+    assert isinstance(llm._provider_impl, OpenAICompatibleLLM)
+    assert llm._provider_impl.base_url == "https://opencode.ai/zen/go/v1"
+
+
+def test_opencode_go_rejects_missing_api_key():
+    """opencode-go should fail fast without an API key, matching zai behavior."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    with pytest.raises(ValueError, match="API key is required for opencode-go"):
+        LLMProvider(
+            provider="opencode-go",
+            api_key="",
+            base_url="",
+            model="deepseek-v4-flash",
+        )

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -286,6 +286,12 @@ export HINDSIGHT_API_LLM_PROVIDER=zai
 export HINDSIGHT_API_LLM_API_KEY=your-zai-api-key
 export HINDSIGHT_API_LLM_MODEL=glm-4.5-flash  # or glm-4.5-air for the paid tier
 # Default base_url: https://api.z.ai/api/coding/paas/v4 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+
+# opencode-go (OpenAI-compatible)
+export HINDSIGHT_API_LLM_PROVIDER=opencode-go
+export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+# Default base_url: https://opencode.ai/zen/go/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -178,6 +178,11 @@ export HINDSIGHT_API_LLM_PROVIDER=zai
 export HINDSIGHT_API_LLM_API_KEY=your-zai-api-key
 export HINDSIGHT_API_LLM_MODEL=glm-4.5-flash  # or glm-4.5-air for the paid tier
 
+# opencode-go (OpenAI-compatible)
+export HINDSIGHT_API_LLM_PROVIDER=opencode-go
+export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
 export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
@@ -583,4 +588,3 @@ export HINDSIGHT_API_RERANKER_PROVIDER=rrf
 ```
 
 See [Configuration](./configuration#reranker) for all options including Azure-hosted endpoints and batch settings.
-

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -10,6 +10,7 @@
   {"id": "minimax",       "label": "MiniMax",           "iconKey": "sparkles",           "defaultModel": "MiniMax-M2.7"},
   {"id": "deepseek",      "label": "DeepSeek",          "iconKey": "brain",              "defaultModel": "deepseek-v4-flash"},
   {"id": "zai",           "label": "z.ai",              "iconKey": "sparkles",           "defaultModel": "glm-4.5-flash"},
+  {"id": "opencode-go",   "label": "opencode-go",       "iconKey": "openai-compatible",  "defaultModel": "deepseek-v4-flash"},
   {"id": "volcano",       "label": "Volcano Engine",    "iconKey": "zap",                "defaultModel": "doubao-pro-32k"},
   {"id": "openrouter",    "label": "OpenRouter",        "iconKey": "globe",              "defaultModel": "qwen/qwen3.5-9b"},
   {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4-mini"},

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -286,6 +286,12 @@ export HINDSIGHT_API_LLM_PROVIDER=zai
 export HINDSIGHT_API_LLM_API_KEY=your-zai-api-key
 export HINDSIGHT_API_LLM_MODEL=glm-4.5-flash  # or glm-4.5-air for the paid tier
 # Default base_url: https://api.z.ai/api/coding/paas/v4 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+
+# opencode-go (OpenAI-compatible)
+export HINDSIGHT_API_LLM_PROVIDER=opencode-go
+export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
+# Default base_url: https://opencode.ai/zen/go/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -109,6 +109,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `minimax` | `MiniMax-M2.7` |
 | `deepseek` | `deepseek-v4-flash` |
 | `zai` | `glm-4.5-flash` |
+| `opencode-go` | `deepseek-v4-flash` |
 | `volcano` | `doubao-pro-32k` |
 | `openrouter` | `qwen/qwen3.5-9b` |
 | `openai-codex` | `gpt-5.4-mini` |
@@ -204,6 +205,11 @@ export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash  # or deepseek-v4-pro / deepsee
 export HINDSIGHT_API_LLM_PROVIDER=zai
 export HINDSIGHT_API_LLM_API_KEY=your-zai-api-key
 export HINDSIGHT_API_LLM_MODEL=glm-4.5-flash  # or glm-4.5-air for the paid tier
+
+# opencode-go (OpenAI-compatible)
+export HINDSIGHT_API_LLM_PROVIDER=opencode-go
+export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
+export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
@@ -605,4 +611,3 @@ export HINDSIGHT_API_RERANKER_PROVIDER=rrf
 ```
 
 See [Configuration](./configuration#reranker) for all options including Azure-hosted endpoints and batch settings.
-


### PR DESCRIPTION
## Summary
- add the opencode-go OpenAI-compatible LLM provider
- default opencode-go to deepseek-v4-flash and https://opencode.ai/zen/go/v1
- document the provider and add focused provider tests

## Tests
- uv run pytest tests/test_provider_default_models.py tests/test_opencode_go_provider.py -v
- uv run ruff check hindsight_api tests/test_opencode_go_provider.py

Closes https://github.com/vectorize-io/hindsight/issues/1647