### PR TITLE
fix(typescript-client): update repository URL to correct repo

### DIFF
--- a/hindsight-clients/typescript/package.json
+++ b/hindsight-clients/typescript/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nicoloboschi/hindsight.git",
+    "url": "https://github.com/vectorize-io/hindsight.git",
     "directory": "hindsight-clients/typescript"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the repository URL for the typescript client to point at the vectorize hindsight repository.