### PR TITLE
fix(api): auto-refresh openai-codex OAuth access_token

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -4,14 +4,26 @@ OpenAI Codex LLM provider using ChatGPT Plus/Pro OAuth authentication.
 This provider enables using ChatGPT Plus/Pro subscriptions for API calls
 without separate OpenAI Platform API credits. It uses OAuth tokens from
 ~/.codex/auth.json and communicates with the ChatGPT backend API.
+
+Tokens are refreshed automatically: the provider decodes the access_token
+JWT's ``exp`` claim and proactively refreshes via
+``POST https://auth.openai.com/oauth/token`` ~60s before expiry. It also
+reactively refreshes once on a 401/403 from the Codex backend before giving
+up. The refresh request shape mirrors the canonical ``@openai/codex`` CLI
+implementation (codex-rs/login/src/auth/manager.rs on github.com/openai/codex)
+so that future server-side changes affect both clients identically.
 """
 
 import asyncio
+import base64
+import binascii
 import json
 import logging
 import os
+import tempfile
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +34,36 @@ from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult,
 from hindsight_api.metrics import get_metrics_collector
 
 logger = logging.getLogger(__name__)
+
+
+# OAuth refresh endpoint and client id, mirrored from the canonical
+# ``@openai/codex`` CLI (codex-rs/login/src/auth/manager.rs on
+# github.com/openai/codex). The endpoint is overridable via env var so that
+# future Codex changes or staging environments can be pointed at without a
+# code change — same env var name the upstream CLI uses.
+_CODEX_REFRESH_TOKEN_URL = os.environ.get("CODEX_REFRESH_TOKEN_URL_OVERRIDE", "https://auth.openai.com/oauth/token")
+_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+# Proactively refresh this many seconds before the JWT ``exp`` claim. The
+# upstream Codex CLI uses no skew (it refreshes at ``exp <= now``); the
+# extra window reduces races where a request leaves the client with a token
+# that the server has already declared expired by the time it arrives.
+_CODEX_TOKEN_REFRESH_SKEW_SECONDS = 60
+
+# OAuth error codes that the refresh endpoint returns when the refresh_token
+# itself is no longer usable. These are terminal — retrying refresh will not
+# succeed; the user must re-run ``codex auth login``.
+_CODEX_TERMINAL_REFRESH_ERROR_CODES = frozenset(
+    {"refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated"}
+)
+
+
+class CodexRefreshExpiredError(RuntimeError):
+    """Raised when the Codex refresh_token itself is no longer valid.
+
+    The user must re-run ``codex auth login`` to obtain new credentials.
+    Callers should surface a clear remediation message and stop retrying.
+    """
 
 
 class CodexLLM(LLMInterface):
@@ -44,9 +86,19 @@ class CodexLLM(LLMInterface):
         """Initialize Codex LLM provider."""
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
+        # Path is fixed at ~/.codex/auth.json — matches the upstream CLI.
+        # Storing it on self lets the refresh path re-read after another
+        # process (e.g. a sidecar) rotates the file out from under us.
+        self._auth_file = Path.home() / ".codex" / "auth.json"
+
+        # Single-flight refresh lock. Multiple concurrent requests racing
+        # toward an expired token should produce one network refresh, not N.
+        self._auth_lock = asyncio.Lock()
+
         # Load Codex OAuth credentials
         try:
             self.access_token, self.account_id = self._load_codex_auth()
+            self.refresh_token = self._load_codex_refresh_token()
             logger.info(f"Loaded Codex OAuth credentials for account: {self.account_id}")
         except Exception as e:
             raise RuntimeError(
@@ -107,6 +159,290 @@ class CodexLLM(LLMInterface):
             raise ValueError("No access_token found in Codex auth file. Run 'codex auth login' again.")
 
         return access_token, account_id
+
+    def _load_codex_refresh_token(self) -> str | None:
+        """Load ``tokens.refresh_token`` from ``~/.codex/auth.json``.
+
+        Returns None when the auth file is unreadable or omits the field —
+        the provider still functions as a one-shot loader in that case, it
+        just can't refresh when the access_token expires. This deliberately
+        does not raise so that ``__init__`` keeps the existing failure mode
+        of raising only on missing ``access_token``.
+        """
+        try:
+            with open(self._auth_file) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(
+                f"Codex auth file unreadable when loading refresh_token: {type(e).__name__}. "
+                "Token refresh will not be available; the access_token in memory will be used until it expires."
+            )
+            return None
+        return data.get("tokens", {}).get("refresh_token")
+
+    @staticmethod
+    def _decode_jwt_exp_unixtime(token: str) -> int | None:
+        """Return the JWT ``exp`` claim as a unix timestamp, or None on parse failure.
+
+        ChatGPT/Codex access_tokens are JWTs whose payload includes ``exp``
+        (RFC 7519). We need the expiry to schedule proactive refresh — the
+        ``auth.json`` file does not persist a separate ``expires_at`` field
+        in the upstream CLI's shape, so decoding the JWT itself is the
+        canonical way to know when the token is stale.
+
+        We do not verify the signature — the server is the source of truth
+        on whether the token is actually accepted, and the only thing this
+        method affects is the *timing* of refresh, not whether to trust the
+        token contents.
+        """
+        try:
+            parts = token.split(".")
+            if len(parts) < 2:
+                return None
+            payload_b64 = parts[1]
+            # JWT uses base64url without padding. Re-pad before decoding.
+            padding = "=" * (-len(payload_b64) % 4)
+            payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
+            payload = json.loads(payload_bytes.decode("utf-8"))
+            exp = payload.get("exp")
+            return int(exp) if exp is not None else None
+        except (ValueError, TypeError, json.JSONDecodeError, binascii.Error):
+            return None
+
+    def _token_is_stale(self, skew_seconds: int = _CODEX_TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+        """True when the cached access_token is past expiry (with skew).
+
+        Returns False when expiry cannot be determined — we'd rather use a
+        possibly-expired token and recover via the reactive 401 path than
+        refresh aggressively on every request when ``exp`` parsing fails.
+        """
+        exp = self._decode_jwt_exp_unixtime(self.access_token)
+        if exp is None:
+            return False
+        return exp <= int(time.time()) + skew_seconds
+
+    def _persist_auth_atomic(self, updated_tokens: dict[str, Any]) -> None:
+        """Write the rotated tokens back to ``~/.codex/auth.json`` atomically.
+
+        Strategy: re-read the on-disk auth.json (so we don't clobber fields
+        another process may have added), patch ``tokens.*`` and
+        ``last_refresh``, write to a tempfile in the same directory with
+        mode 0600, then ``os.replace`` onto the target. ``os.replace`` is
+        atomic within the same filesystem on POSIX and Windows, so a
+        concurrent reader will see either the old file or the fully-written
+        new file — never a partial truncate, which is the upstream CLI's
+        worst-case race.
+
+        On non-Unix platforms the chmod is a best-effort no-op; the parent
+        directory permissions still bound access.
+        """
+        current: dict[str, Any]
+        try:
+            with open(self._auth_file) as f:
+                loaded = json.load(f)
+            # auth.json should always be a JSON object at the top level; if
+            # someone has hand-edited it into a non-object shape, fall back
+            # to the minimal default rather than crashing the refresh path.
+            current = loaded if isinstance(loaded, dict) else {"auth_mode": "chatgpt", "tokens": {}}
+        except (OSError, json.JSONDecodeError):
+            # If the file became unreadable between our last read and now,
+            # construct a minimal shape rather than refusing to persist.
+            current = {"auth_mode": "chatgpt", "tokens": {}}
+
+        existing_tokens = current.get("tokens")
+        tokens: dict[str, Any] = existing_tokens if isinstance(existing_tokens, dict) else {}
+        for key in ("access_token", "refresh_token", "id_token", "account_id"):
+            if key in updated_tokens and updated_tokens[key] is not None:
+                tokens[key] = updated_tokens[key]
+        current["tokens"] = tokens
+        current["last_refresh"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        # Write to a sibling tempfile so the rename is same-filesystem.
+        parent = self._auth_file.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".auth.", suffix=".json.tmp", dir=str(parent))
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(current, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            try:
+                os.chmod(tmp_path, 0o600)
+            except OSError:
+                pass  # best-effort on platforms that don't support chmod
+            os.replace(tmp_path, self._auth_file)
+        except Exception:
+            # Clean up the orphaned tempfile if rename fails.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    async def _refresh_oauth_tokens(self, reason: str = "", *, force: bool = False) -> None:
+        """Refresh the OAuth access_token using the stored refresh_token.
+
+        Single-flight: serialized through ``self._auth_lock`` so concurrent
+        callers produce one network request. The first caller refreshes; the
+        rest wake up and observe that either (a) the in-memory token is no
+        longer stale (proactive case) or (b) the in-memory token has changed
+        since they entered (reactive case), and return without re-refreshing.
+
+        Args:
+            reason: Free-form string included in log lines for diagnostics.
+            force: When True, refresh even if the JWT exp claim looks fresh.
+                Used by the reactive 401 path — the server rejected the
+                token, so we cannot trust the JWT's self-reported expiry.
+
+        Raises:
+            CodexRefreshExpiredError: when the server returns a terminal
+                error code (refresh_token_expired/reused/invalidated) or any
+                401 on the refresh endpoint itself.
+            RuntimeError: for other refresh failures (network, 5xx, etc.).
+        """
+        # Capture the token we'd be refreshing BEFORE acquiring the lock so
+        # that we can detect mid-wait rotation by another coroutine.
+        token_before_lock = self.access_token
+        async with self._auth_lock:
+            if force:
+                # Reactive: skip only if another coroutine already rotated
+                # the token while we were waiting on the lock.
+                if self.access_token != token_before_lock:
+                    return
+            else:
+                # Proactive: skip if the token is no longer stale (the
+                # canonical "another coroutine refreshed first" check).
+                if not self._token_is_stale():
+                    return
+
+            if not self.refresh_token:
+                raise RuntimeError(
+                    "Codex access_token is expired but no refresh_token is available. "
+                    "Run 'codex auth login' to re-authenticate."
+                )
+
+            log_reason = f" ({reason})" if reason else ""
+            logger.info(f"Refreshing Codex OAuth access_token{log_reason}")
+
+            request_body = {
+                "client_id": _CODEX_CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": self.refresh_token,
+            }
+            try:
+                response = await self._client.post(
+                    _CODEX_REFRESH_TOKEN_URL,
+                    json=request_body,
+                    headers={"Content-Type": "application/json"},
+                    timeout=30.0,
+                )
+            except httpx.RequestError as e:
+                raise RuntimeError(f"Codex OAuth refresh network error: {type(e).__name__}") from e
+
+            if response.status_code == 401:
+                # Classify by ``error.code`` (or top-level ``error`` string) — same
+                # mapping as the upstream Rust CLI's request_chatgpt_token_refresh.
+                error_code = self._extract_oauth_error_code(response)
+                if error_code in _CODEX_TERMINAL_REFRESH_ERROR_CODES:
+                    raise CodexRefreshExpiredError(
+                        f"Codex refresh_token is permanently invalid (error.code={error_code}). "
+                        "Run 'codex auth login' to re-authenticate."
+                    )
+                # Unknown 401 — treat as terminal too, matching the upstream classification.
+                raise CodexRefreshExpiredError(
+                    f"Codex OAuth refresh returned 401 with unrecognized error code "
+                    f"({error_code or 'none'}). Run 'codex auth login' to re-authenticate."
+                )
+
+            if response.status_code >= 400:
+                # 5xx and other 4xx are transient/retryable from the caller's
+                # perspective; surface as RuntimeError without leaking the
+                # request body in logs.
+                raise RuntimeError(f"Codex OAuth refresh failed with HTTP {response.status_code}")
+
+            try:
+                body = response.json()
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"Codex OAuth refresh returned non-JSON body: {e}") from e
+
+            new_access = body.get("access_token")
+            if not new_access:
+                raise RuntimeError("Codex OAuth refresh returned no access_token")
+
+            # The refresh_token may rotate on each refresh — adopt the new
+            # one if the server sent it, otherwise keep the existing.
+            new_refresh = body.get("refresh_token") or self.refresh_token
+            new_id_token = body.get("id_token")
+
+            # Update in-memory state first so callers waiting on the lock
+            # see fresh credentials immediately, even if disk write fails.
+            self.access_token = new_access
+            self.refresh_token = new_refresh
+
+            persisted = {
+                "access_token": new_access,
+                "refresh_token": new_refresh,
+            }
+            if new_id_token:
+                persisted["id_token"] = new_id_token
+
+            try:
+                self._persist_auth_atomic(persisted)
+            except OSError as e:
+                # In-memory creds are valid; warn but don't fail the request
+                # path. Future process starts will fall back to the stale
+                # on-disk auth.json and immediately refresh.
+                logger.warning(
+                    f"Codex OAuth refresh succeeded but persisting auth.json failed: {type(e).__name__}. "
+                    "In-memory credentials are up to date; on-disk file is stale."
+                )
+
+            logger.info("Codex OAuth access_token refreshed successfully")
+
+    @staticmethod
+    def _extract_oauth_error_code(response: "httpx.Response") -> str | None:
+        """Pull the OAuth error code out of a 4xx response body, if present.
+
+        The refresh endpoint returns shapes like
+        ``{"error": "...", "error_code": "..."}`` or
+        ``{"error": {"code": "..."}}``. We don't fail the call if the body
+        is unparseable — the caller falls back to a generic "unknown" error.
+        """
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(body, dict):
+            return None
+        # Shape 1: error is a nested object with "code"
+        err = body.get("error")
+        if isinstance(err, dict):
+            code = err.get("code")
+            if isinstance(code, str):
+                return code
+        # Shape 2: top-level error_code string
+        code = body.get("error_code")
+        if isinstance(code, str):
+            return code
+        # Shape 3: error is itself a string code
+        if isinstance(err, str):
+            return err
+        return None
+
+    async def _ensure_fresh_token(self) -> None:
+        """Refresh the access_token proactively if it is near or past expiry.
+
+        Called at the top of every API-bound method. Cheap when the token is
+        fresh (just decodes the JWT exp claim and returns).
+        """
+        if self._token_is_stale():
+            try:
+                await self._refresh_oauth_tokens(reason="proactive (token near expiry)")
+            except CodexRefreshExpiredError:
+                # Surface to the caller as the same RuntimeError shape the
+                # request loop has historically raised, so existing error
+                # handling paths keep working.
+                raise
 
     def _map_reasoning_effort(self, effort: str) -> str:
         """
@@ -189,6 +525,15 @@ class CodexLLM(LLMInterface):
         """Make API call to Codex backend with SSE streaming."""
         start_time = time.time()
 
+        # Proactively refresh the OAuth access_token if it's near expiry.
+        # Cheap when fresh: a JWT exp decode + comparison.
+        await self._ensure_fresh_token()
+
+        # Tracks whether we've already attempted a reactive refresh in
+        # response to a 401 from the backend. Set once on the first auth
+        # failure so we retry exactly once after refresh, not in a loop.
+        attempted_refresh_after_auth_error = False
+
         # Prepare system instructions
         system_instruction = ""
         user_messages = []
@@ -244,7 +589,12 @@ class CodexLLM(LLMInterface):
         url = f"{self.base_url}/codex/responses"
         last_exception = None
 
-        for attempt in range(max_retries + 1):
+        # Manual attempt tracking instead of ``for attempt in range(...)`` so
+        # that the reactive-refresh path can retry once without consuming a
+        # normal-retry budget slot. The refresh-retry is conceptually a
+        # separate auth-recovery attempt that shouldn't compete with backoff.
+        attempt = 0
+        while True:
             try:
                 response = await self._client.post(url, json=payload, headers=headers, timeout=120.0)
                 response.raise_for_status()
@@ -269,6 +619,7 @@ class CodexLLM(LLMInterface):
                             backoff = min(initial_backoff * (2**attempt), max_backoff)
                             await asyncio.sleep(backoff)
                             last_exception = e
+                            attempt += 1
                             continue
                         raise
 
@@ -332,8 +683,38 @@ class CodexLLM(LLMInterface):
                 last_exception = e
                 status_code = e.response.status_code
 
-                # Fast fail on auth errors
+                # Auth error: try one OAuth refresh + retry before giving up.
+                # The proactive refresh at the top of this method catches most
+                # expiries, but a token can also become invalid mid-request if
+                # another process rotates auth.json out from under us, or if
+                # the JWT exp claim is unparseable and we never knew it was
+                # stale. Reactive refresh is the safety net.
                 if status_code in (401, 403):
+                    if not attempted_refresh_after_auth_error:
+                        attempted_refresh_after_auth_error = True
+                        try:
+                            await self._refresh_oauth_tokens(
+                                reason=f"reactive (HTTP {status_code} from codex backend)",
+                                force=True,
+                            )
+                            # Rebuild the Authorization header with the new
+                            # token and retry without consuming a normal-retry
+                            # budget slot — this is a dedicated auth-recovery
+                            # attempt that shouldn't compete with backoff.
+                            headers["Authorization"] = f"Bearer {self.access_token}"
+                            logger.info("Codex auth refreshed after auth error; retrying request once")
+                            continue
+                        except CodexRefreshExpiredError as refresh_err:
+                            logger.error("Codex refresh_token is permanently invalid; cannot recover from auth error")
+                            raise RuntimeError(
+                                "Codex authentication failed and the refresh_token is no longer valid.\n"
+                                "Run 'codex auth login' to re-authenticate."
+                            ) from refresh_err
+                        except Exception as refresh_err:
+                            logger.error(
+                                f"Codex token refresh attempt failed: {type(refresh_err).__name__}: {refresh_err}"
+                            )
+                            # Fall through to the original raise below.
                     logger.error(f"Codex auth error (HTTP {status_code}): {e.response.text[:200]}")
                     raise RuntimeError(
                         "Codex authentication failed. Your OAuth token may have expired.\n"
@@ -349,6 +730,7 @@ class CodexLLM(LLMInterface):
                         f"Codex HTTP error {status_code} (attempt {attempt + 1}/{max_retries + 1}): {error_detail}"
                     )
                     await asyncio.sleep(backoff)
+                    attempt += 1
                     continue
                 else:
                     logger.error(
@@ -362,6 +744,7 @@ class CodexLLM(LLMInterface):
                     backoff = min(initial_backoff * (2**attempt), max_backoff)
                     logger.warning(f"Codex connection error (attempt {attempt + 1}/{max_retries + 1}): {e}")
                     await asyncio.sleep(backoff)
+                    attempt += 1
                     continue
                 else:
                     logger.error(f"Codex connection error after {max_retries + 1} attempts: {e}")
@@ -462,6 +845,11 @@ class CodexLLM(LLMInterface):
         """
         start_time = time.time()
 
+        # Proactively refresh the OAuth access_token if it's near expiry.
+        # Same rationale as in ``call()`` — keeps the request from leaving
+        # the client carrying a token that's already past ``exp``.
+        await self._ensure_fresh_token()
+
         # Prepare system instructions
         system_instruction = ""
         user_messages = []
@@ -534,8 +922,38 @@ class CodexLLM(LLMInterface):
         # Debug logging for troubleshooting
         logger.debug(f"Codex tool call request: url={url}, model={payload['model']}, tools={len(codex_tools)}")
 
+        # One reactive refresh attempt on auth failure, mirroring call().
+        # ``call_with_tools`` doesn't have a retry loop, so we hand-roll a
+        # single retry after refreshing the token. Any non-auth error still
+        # surfaces immediately to keep behavior identical for callers.
+        attempted_refresh_after_auth_error = False
+
         try:
             response = await self._client.post(url, json=payload, headers=headers, timeout=120.0)
+
+            if response.status_code in (401, 403) and not attempted_refresh_after_auth_error:
+                attempted_refresh_after_auth_error = True
+                try:
+                    await self._refresh_oauth_tokens(
+                        reason=f"reactive (HTTP {response.status_code} from codex backend in call_with_tools)",
+                        force=True,
+                    )
+                    headers["Authorization"] = f"Bearer {self.access_token}"
+                    logger.info("Codex auth refreshed after auth error; retrying tool-call request once")
+                    response = await self._client.post(url, json=payload, headers=headers, timeout=120.0)
+                except CodexRefreshExpiredError as refresh_err:
+                    logger.error(
+                        "Codex refresh_token is permanently invalid; cannot recover from auth error in tool-call path"
+                    )
+                    raise RuntimeError(
+                        "Codex authentication failed and the refresh_token is no longer valid.\n"
+                        "Run 'codex auth login' to re-authenticate."
+                    ) from refresh_err
+                except Exception as refresh_err:
+                    logger.error(
+                        f"Codex token refresh attempt failed in tool-call path: {type(refresh_err).__name__}: {refresh_err}"
+                    )
+                    # Fall through to the normal error path below.
 
             # Log response details on error
             if response.status_code != 200:

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -1,0 +1,535 @@
+"""Tests for Codex OAuth token refresh (issue #1637).
+
+The Codex provider was originally a startup-only credential loader: it read
+``~/.codex/auth.json`` once and used the cached access_token forever. These
+tests pin the new automatic-refresh behavior:
+
+- ``refresh_token`` is now actually loaded from auth.json.
+- The provider proactively refreshes ~60s before the JWT ``exp`` claim.
+- It reactively refreshes once on a 401/403 from the Codex backend.
+- The OAuth refresh request shape mirrors the canonical ``@openai/codex``
+  CLI (POST https://auth.openai.com/oauth/token, JSON body with hardcoded
+  client_id, grant_type=refresh_token).
+- Terminal error codes (refresh_token_expired/reused/invalidated) raise a
+  permanent error and do not loop.
+- Concurrent callers serialize through a single-flight lock.
+- ``auth.json`` is persisted atomically via tempfile+rename with mode 0600.
+
+Tests construct ``CodexLLM`` with ``_load_codex_auth`` mocked, then drive
+JWT exp / network / persistence paths through targeted patches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from hindsight_api.engine.providers.codex_llm import (
+    _CODEX_CLIENT_ID,
+    _CODEX_REFRESH_TOKEN_URL,
+    CodexLLM,
+    CodexRefreshExpiredError,
+)
+
+
+def _make_jwt(exp_unixtime: int | None) -> str:
+    """Build a minimal JWT-shaped token with the given ``exp`` claim.
+
+    Signature segment is a placeholder — we don't verify, we only decode
+    the payload to read ``exp``.
+    """
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=").decode()
+    payload_dict: dict[str, object] = {}
+    if exp_unixtime is not None:
+        payload_dict["exp"] = exp_unixtime
+    payload = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).rstrip(b"=").decode()
+    signature = "sig"
+    return f"{header}.{payload}.{signature}"
+
+
+def _build_llm(refresh_token: str | None = "rt-initial", access_token: str | None = None) -> CodexLLM:
+    """Construct a CodexLLM with patched auth-file reads."""
+    if access_token is None:
+        access_token = _make_jwt(int(time.time()) + 3600)  # fresh by default
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=(access_token, "acct-123")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=refresh_token),
+    ):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.4-mini",
+        )
+
+
+# ---------------------------------------------------------------------------
+# JWT exp decode
+# ---------------------------------------------------------------------------
+
+
+def test_jwt_exp_decode_returns_int_for_valid_token():
+    token = _make_jwt(1_800_000_000)
+    assert CodexLLM._decode_jwt_exp_unixtime(token) == 1_800_000_000
+
+
+def test_jwt_exp_decode_returns_none_when_exp_missing():
+    token = _make_jwt(None)
+    assert CodexLLM._decode_jwt_exp_unixtime(token) is None
+
+
+def test_jwt_exp_decode_returns_none_for_malformed_token():
+    assert CodexLLM._decode_jwt_exp_unixtime("not.a.real.jwt") is None
+    assert CodexLLM._decode_jwt_exp_unixtime("only-one-segment") is None
+    assert CodexLLM._decode_jwt_exp_unixtime("a.!!notbase64!!.c") is None
+
+
+# ---------------------------------------------------------------------------
+# Staleness
+# ---------------------------------------------------------------------------
+
+
+def test_token_is_stale_true_when_expired():
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(access_token=expired)
+    assert llm._token_is_stale() is True
+
+
+def test_token_is_stale_true_within_skew_window():
+    # 30s before expiry, default skew is 60s → should be considered stale.
+    soon = _make_jwt(int(time.time()) + 30)
+    llm = _build_llm(access_token=soon)
+    assert llm._token_is_stale() is True
+
+
+def test_token_is_stale_false_when_far_from_expiry():
+    far = _make_jwt(int(time.time()) + 3600)
+    llm = _build_llm(access_token=far)
+    assert llm._token_is_stale() is False
+
+
+def test_token_is_stale_false_when_exp_unparseable():
+    # When we can't decide, we'd rather use a possibly-expired token and
+    # recover via the reactive 401 path than refresh aggressively.
+    llm = _build_llm(access_token="opaque-token-no-jwt-structure")
+    assert llm._token_is_stale() is False
+
+
+# ---------------------------------------------------------------------------
+# refresh_token loading
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_token_loaded_from_auth_file(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "at",
+                    "refresh_token": "rt-from-disk",
+                    "account_id": "acct",
+                },
+            }
+        )
+    )
+    with patch.object(CodexLLM, "_load_codex_auth", return_value=("at", "acct")):
+        llm = CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.4-mini",
+        )
+    # Now point the auth_file at our tmp file and reload.
+    llm._auth_file = auth_file
+    assert llm._load_codex_refresh_token() == "rt-from-disk"
+
+
+def test_refresh_token_returns_none_when_field_absent(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps({"auth_mode": "chatgpt", "tokens": {"access_token": "at"}}))
+    llm = _build_llm()
+    llm._auth_file = auth_file
+    assert llm._load_codex_refresh_token() is None
+
+
+def test_refresh_token_returns_none_when_file_missing(tmp_path: Path):
+    llm = _build_llm()
+    llm._auth_file = tmp_path / "definitely-not-here.json"
+    assert llm._load_codex_refresh_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Atomic persistence
+# ---------------------------------------------------------------------------
+
+
+def test_persist_auth_atomic_writes_mode_0600_and_preserves_fields(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "OPENAI_API_KEY": None,
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "old",
+                    "refresh_token": "rt-old",
+                    "account_id": "acct-keep",
+                    "id_token": {"email": "user@example.com"},
+                },
+                "last_refresh": "2026-01-01T00:00:00Z",
+            }
+        )
+    )
+
+    llm = _build_llm()
+    llm._auth_file = auth_file
+    llm._persist_auth_atomic({"access_token": "new", "refresh_token": "rt-new"})
+
+    written = json.loads(auth_file.read_text())
+    assert written["tokens"]["access_token"] == "new"
+    assert written["tokens"]["refresh_token"] == "rt-new"
+    # Untouched fields are preserved (account_id, id_token, auth_mode).
+    assert written["tokens"]["account_id"] == "acct-keep"
+    assert written["tokens"]["id_token"] == {"email": "user@example.com"}
+    assert written["auth_mode"] == "chatgpt"
+    # last_refresh got bumped to a new ISO-8601 UTC timestamp.
+    assert written["last_refresh"] != "2026-01-01T00:00:00Z"
+    assert written["last_refresh"].endswith("Z")
+
+    if sys.platform != "win32":
+        mode = stat.S_IMODE(auth_file.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
+def test_persist_auth_atomic_does_not_leak_tempfile_on_success(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps({"tokens": {"access_token": "old"}}))
+
+    llm = _build_llm()
+    llm._auth_file = auth_file
+    llm._persist_auth_atomic({"access_token": "new"})
+
+    # No sibling tempfile should remain — atomic rename consumed it.
+    siblings = [p.name for p in tmp_path.iterdir()]
+    assert siblings == ["auth.json"], f"unexpected leftover files: {siblings}"
+
+
+# ---------------------------------------------------------------------------
+# _refresh_oauth_tokens — request shape, in-memory update, rotation
+# ---------------------------------------------------------------------------
+
+
+def _refresh_response(status_code: int, body: dict | str) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    if isinstance(body, dict):
+        response.json.return_value = body
+        response.text = json.dumps(body)
+    else:
+        response.json.side_effect = json.JSONDecodeError("nope", body, 0)
+        response.text = body
+    return response
+
+
+@pytest.mark.asyncio
+async def test_refresh_sends_canonical_request_shape(tmp_path: Path):
+    """POST JSON body with client_id + grant_type=refresh_token + refresh_token."""
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-current", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-current"}}))
+
+    fresh_access = _make_jwt(int(time.time()) + 3600)
+    refresh_resp = _refresh_response(200, {"access_token": fresh_access, "refresh_token": "rt-rotated"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=refresh_resp) as mock_post:
+        await llm._refresh_oauth_tokens()
+
+    call_args = mock_post.call_args
+    assert call_args.args[0] == _CODEX_REFRESH_TOKEN_URL
+    assert call_args.kwargs["headers"]["Content-Type"] == "application/json"
+    assert call_args.kwargs["json"] == {
+        "client_id": _CODEX_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": "rt-current",
+    }
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_in_memory_credentials(tmp_path: Path):
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-old", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-old"}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+    refresh_resp = _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-new"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=refresh_resp):
+        await llm._refresh_oauth_tokens()
+
+    assert llm.access_token == new_access
+    assert llm.refresh_token == "rt-new"
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_existing_refresh_token_when_server_omits_one(tmp_path: Path):
+    """If the OAuth response has no ``refresh_token`` field, keep the one we have."""
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-keep", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-keep"}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+    refresh_resp = _refresh_response(200, {"access_token": new_access})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=refresh_resp):
+        await llm._refresh_oauth_tokens()
+
+    assert llm.refresh_token == "rt-keep"
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_permanent_error_on_terminal_oauth_code(tmp_path: Path):
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-stale", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-stale"}}))
+
+    bad_resp = _refresh_response(401, {"error": {"code": "refresh_token_expired"}})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=bad_resp):
+        with pytest.raises(CodexRefreshExpiredError):
+            await llm._refresh_oauth_tokens()
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_permanent_error_on_unknown_401(tmp_path: Path):
+    """Any 401 from the refresh endpoint is treated as permanent — matches upstream Rust classification."""
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-stale", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-stale"}}))
+
+    bad_resp = _refresh_response(401, {"error": "something_else"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=bad_resp):
+        with pytest.raises(CodexRefreshExpiredError):
+            await llm._refresh_oauth_tokens()
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_runtime_error_on_5xx(tmp_path: Path):
+    """5xx is transient from the caller's perspective — surface as RuntimeError, not CodexRefreshExpiredError."""
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt-current", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt-current"}}))
+
+    bad_resp = _refresh_response(503, "service unavailable")
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=bad_resp):
+        with pytest.raises(RuntimeError) as exc_info:
+            await llm._refresh_oauth_tokens()
+    assert not isinstance(exc_info.value, CodexRefreshExpiredError)
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_log_token_values(tmp_path: Path, caplog):
+    expired = _make_jwt(int(time.time()) - 60)
+    secret_rt = "rt-DO-NOT-LEAK-THIS"
+    llm = _build_llm(refresh_token=secret_rt, access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": secret_rt}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+    refresh_resp = _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-also-secret"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock, return_value=refresh_resp):
+        with caplog.at_level("DEBUG"):
+            await llm._refresh_oauth_tokens()
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert secret_rt not in log_text
+    assert new_access not in log_text
+    assert "rt-also-secret" not in log_text
+
+
+# ---------------------------------------------------------------------------
+# Single-flight under concurrent callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_fresh_token_calls_produce_one_refresh(tmp_path: Path):
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": "x", "refresh_token": "rt"}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+    call_count = 0
+
+    async def fake_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Simulate non-zero refresh latency so concurrent callers actually queue.
+        await asyncio.sleep(0.01)
+        return _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-new"})
+
+    with patch.object(llm._client, "post", new=fake_post):
+        await asyncio.gather(*(llm._ensure_fresh_token() for _ in range(10)))
+
+    assert call_count == 1, f"expected 1 network refresh under contention, got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# Reactive 401 retry on the request path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_reactively_refreshes_on_401_and_retries(tmp_path: Path):
+    """A backend 401 triggers one refresh + retry instead of immediately raising."""
+    fresh = _make_jwt(int(time.time()) + 3600)  # not stale; the 401 is the trigger
+    llm = _build_llm(refresh_token="rt", access_token=fresh)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": fresh, "refresh_token": "rt"}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+
+    # First post → 401 (backend rejects the token). After refresh, second post → 200.
+    success_resp = MagicMock()
+    success_resp.status_code = 200
+    success_resp.raise_for_status.return_value = None
+
+    fail_response = MagicMock()
+    fail_response.status_code = 401
+    fail_response.text = "unauthorized"
+    fail_exc = httpx.HTTPStatusError("401", request=MagicMock(), response=fail_response)
+    success_resp.raise_for_status = MagicMock(return_value=None)
+
+    post_responses = [fail_exc, success_resp]
+
+    async def fake_post(*args, **kwargs):
+        item = post_responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    refresh_resp = _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-new"})
+
+    call_count = {"refresh": 0, "post": 0}
+
+    async def counting_post(url, **kwargs):
+        if url == _CODEX_REFRESH_TOKEN_URL:
+            call_count["refresh"] += 1
+            return refresh_resp
+        call_count["post"] += 1
+        # First backend call fails with 401 wrapped in an HTTPStatusError-style response,
+        # second succeeds.
+        if call_count["post"] == 1:
+            raise httpx.HTTPStatusError("401", request=MagicMock(), response=fail_response)
+        return success_resp
+
+    with (
+        patch.object(llm._client, "post", new=counting_post),
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "ping"}],
+            max_retries=0,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+        )
+
+    assert result == "ok"
+    assert call_count["refresh"] == 1
+    assert call_count["post"] == 2  # one 401, one success after refresh
+    assert llm.access_token == new_access
+
+
+@pytest.mark.asyncio
+async def test_call_proactively_refreshes_when_token_is_stale(tmp_path: Path):
+    """A near-expiry token triggers refresh BEFORE the request is sent."""
+    expired = _make_jwt(int(time.time()) - 60)
+    llm = _build_llm(refresh_token="rt", access_token=expired)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": expired, "refresh_token": "rt"}}))
+
+    new_access = _make_jwt(int(time.time()) + 3600)
+    refresh_resp = _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-new"})
+
+    success_resp = MagicMock()
+    success_resp.status_code = 200
+    success_resp.raise_for_status.return_value = None
+
+    call_order: list[str] = []
+
+    async def fake_post(url, **kwargs):
+        if url == _CODEX_REFRESH_TOKEN_URL:
+            call_order.append("refresh")
+            return refresh_resp
+        call_order.append("backend")
+        # Assert that by the time the backend is called, the new token is in use.
+        assert kwargs["headers"]["Authorization"] == f"Bearer {new_access}"
+        return success_resp
+
+    with (
+        patch.object(llm._client, "post", new=fake_post),
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        await llm.call(
+            messages=[{"role": "user", "content": "ping"}],
+            max_retries=0,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+        )
+
+    assert call_order == ["refresh", "backend"], "expected proactive refresh BEFORE the backend call"
+
+
+@pytest.mark.asyncio
+async def test_call_does_not_refresh_when_token_is_fresh(tmp_path: Path):
+    fresh = _make_jwt(int(time.time()) + 3600)
+    llm = _build_llm(refresh_token="rt", access_token=fresh)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(json.dumps({"tokens": {"access_token": fresh, "refresh_token": "rt"}}))
+
+    success_resp = MagicMock()
+    success_resp.status_code = 200
+    success_resp.raise_for_status.return_value = None
+
+    call_count = {"refresh": 0, "backend": 0}
+
+    async def fake_post(url, **kwargs):
+        if url == _CODEX_REFRESH_TOKEN_URL:
+            call_count["refresh"] += 1
+            raise AssertionError("refresh endpoint should not be hit for a fresh token")
+        call_count["backend"] += 1
+        return success_resp
+
+    with (
+        patch.object(llm._client, "post", new=fake_post),
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        await llm.call(
+            messages=[{"role": "user", "content": "ping"}],
+            max_retries=0,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+        )
+
+    assert call_count == {"refresh": 0, "backend": 1}


### PR DESCRIPTION
## Summary

Closes #1637.

The `openai-codex` provider was a startup-only credential loader: it read `~/.codex/auth.json` once at `__init__` and used the cached `access_token` forever. ChatGPT OAuth tokens are short-lived (hours), so any long-running deployment 401'd on every request once the cached token expired. The only operational recovery was an external cron job to refresh the file plus a container restart — which is what @rsaulo described in the issue body.

This change makes the provider refresh tokens itself, with the request shape grounded in the canonical `@openai/codex` CLI (`codex-rs/login/src/auth/manager.rs` on github.com/openai/codex).

## What's in the change

| Capability | How |
|---|---|
| Loads `tokens.refresh_token` from `auth.json` | New `_load_codex_refresh_token` helper. Previously read but never extracted. |
| Proactive refresh ~60s before JWT `exp` | New `_decode_jwt_exp_unixtime` + `_token_is_stale` + `_ensure_fresh_token`. Called at the top of every `call()` / `call_with_tools()`. Cheap when fresh — just decode + compare. |
| Reactive refresh on 401/403 from the codex backend | The existing fast-fail-on-auth path now tries one refresh + retry before raising. The refresh-retry does **not** consume a normal-retry budget slot (auth recovery is a separate concept from backoff retries). |
| Single-flight | `asyncio.Lock` serializes concurrent refresh attempts. Re-checks under the lock to bail when another coroutine already rotated the token mid-wait. |
| Atomic persistence | `tempfile + os.replace` with mode `0o600` on Unix. The upstream Rust CLI uses truncate-and-overwrite, which a concurrent reader can catch mid-write; tempfile+rename is strictly safer. |
| Terminal error handling | `refresh_token_expired/reused/invalidated` (and any 401 from the refresh endpoint) raise the new `CodexRefreshExpiredError` with a clear "run `codex auth login`" remediation, and do not loop. Matches the upstream Rust CLI's classification. |
| No secrets in logs | Refresh logs the reason + outcome but never token values. Verified by `test_refresh_does_not_log_token_values`. |

## OAuth request shape (verbatim from upstream)

```
POST https://auth.openai.com/oauth/token
Content-Type: application/json

{
  "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
  "grant_type": "refresh_token",
  "refresh_token": "..."
}
```

Endpoint is overridable via `CODEX_REFRESH_TOKEN_URL_OVERRIDE` — same env var name the upstream CLI uses.

## What's covered by `test_codex_oauth_refresh.py` (23 new tests)

- JWT `exp` decode: valid token, missing `exp`, malformed token
- Staleness with skew window: expired / near-expiry / fresh / unparseable
- `refresh_token` loading: present / absent / file missing
- Atomic persistence: writes 0600 + preserves untouched fields + no tempfile leak on success
- Refresh request shape: POSTs to the canonical URL with the canonical JSON body
- In-memory + on-disk credential update
- `refresh_token` rotation (and graceful keep-existing when the server omits one)
- Terminal error code → `CodexRefreshExpiredError`
- 5xx → `RuntimeError` (transient, not terminal)
- No secrets in logs (refresh_token, access_token, rotated refresh_token all redacted)
- Single-flight under 10 concurrent `_ensure_fresh_token` calls → exactly 1 network refresh
- Proactive refresh fires **before** the backend request when token is stale
- Reactive 401 → refresh + retry once → success
- No refresh when token is fresh

Existing `test_codex_tool_choice.py` still passes — no regression.

## Caveats reviewers should know

- **All tests are mocked.** I did not have access to a ChatGPT Plus subscription to validate the OAuth request shape against the real `auth.openai.com` endpoint. The request shape is grounded in the upstream `codex-rs/login/src/auth/manager.rs` source — but a reviewer with actual Codex credentials should validate the end-to-end path before merge.

- **Cross-container coordination is out of scope.** Two `hindsight-api` containers sharing the same mounted `auth.json` will each refresh independently (with an empirical race window of milliseconds). The upstream Rust CLI handles this via mtime-check; we don't, because the typical Hindsight deployment is single-container. For multi-worker deployments this should be documented as a known limitation; can be added in a follow-up if needed.

## Acceptance criteria from #1637

- [x] Long-running `hindsight-api` continues working after the original `access_token` expires (proactive refresh + reactive 401 retry).
- [x] Default, retain, and consolidation LLM clients all use refreshed credentials (they share the `CodexLLM` instance via the provider factory).
- [x] No container restart required after refresh.
- [x] Refresh failures log clearly without exposing secrets.
- [x] Concurrent requests don't race/corrupt `auth.json` (single-flight `asyncio.Lock` + atomic `tempfile+rename`).

## Test plan

- [x] `uv run pytest tests/test_codex_oauth_refresh.py tests/test_codex_tool_choice.py -v` — 25/25 pass
- [x] `uv run pytest tests/ -k "codex or provider or llm_wrapper"` — 100 passed, 1 skipped, 0 failed (no regressions)
- [x] `uv run ruff check hindsight_api/engine/providers/codex_llm.py tests/test_codex_oauth_refresh.py` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check hindsight_api/engine/providers/codex_llm.py` — clean
- [ ] **Reviewer with ChatGPT Plus subscription:** validate end-to-end refresh against `auth.openai.com` before merge