### PR TITLE
fix: validate embedding dimensions before pgvector writes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -15,9 +15,21 @@ class EmbeddingsBackend(Protocol):
     """Minimal duck-typed surface used by retain/recall — the concrete `Embeddings`
     ABC supplies default implementations that delegate to `encode()`."""
 
+    @property
+    def dimension(self) -> int: ...
+
     def encode_query(self, texts: list[str]) -> list[list[float]]: ...
 
     def encode_documents(self, texts: list[str]) -> list[list[float]]: ...
+
+
+def _validate_embedding_vector(vector: list[float], *, index: int, expected_dimension: int) -> list[float]:
+    actual_dimension = len(vector)
+    if actual_dimension == 0:
+        raise RuntimeError(f"embedding {index} has dimension 0; expected {expected_dimension}")
+    if actual_dimension != expected_dimension:
+        raise RuntimeError(f"embedding {index} has dimension {actual_dimension}; expected {expected_dimension}")
+    return vector
 
 
 def generate_embedding(
@@ -36,9 +48,19 @@ def generate_embedding(
     """
     try:
         embeddings = _encode_with_input_type(embeddings_backend, [text], input_type)
-        return embeddings[0]
     except Exception as e:
         raise Exception(f"Failed to generate embedding: {str(e)}")
+
+    if len(embeddings) != 1:
+        raise RuntimeError(
+            f"Embeddings backend returned {len(embeddings)} vectors for 1 input text; "
+            "expected exact 1:1 alignment"
+        )
+    return _validate_embedding_vector(
+        embeddings[0],
+        index=0,
+        expected_dimension=embeddings_backend.dimension,
+    )
 
 
 def _encode_with_input_type(
@@ -81,4 +103,7 @@ async def generate_embeddings_batch(
             "expected exact 1:1 alignment"
         )
 
-    return embeddings
+    return [
+        _validate_embedding_vector(embedding, index=index, expected_dimension=embeddings_backend.dimension)
+        for index, embedding in enumerate(embeddings)
+    ]

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -53,8 +53,7 @@ def generate_embedding(
 
     if len(embeddings) != 1:
         raise RuntimeError(
-            f"Embeddings backend returned {len(embeddings)} vectors for 1 input text; "
-            "expected exact 1:1 alignment"
+            f"Embeddings backend returned {len(embeddings)} vectors for 1 input text; expected exact 1:1 alignment"
         )
     return _validate_embedding_vector(
         embeddings[0],

--- a/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
+++ b/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
@@ -1,0 +1,41 @@
+import uuid
+
+import pytest
+
+from hindsight_api.engine.consolidation import consolidator
+
+
+class _ZeroLengthEmbeddings:
+    dimension = 384
+
+    def encode(self, texts):
+        assert texts == ["Consolidated observation text."]
+        return [[]]
+
+
+class _FakeMemoryEngine:
+    embeddings = _ZeroLengthEmbeddings()
+
+
+class _FailingConn:
+    async def fetchrow(self, *args, **kwargs):
+        raise AssertionError("zero-length embedding should be rejected before database insert")
+
+
+@pytest.mark.asyncio
+async def test_create_observation_rejects_zero_length_embedding_before_insert(monkeypatch):
+    source_id = uuid.uuid4()
+
+    async def fake_filter_live_source_memories(conn, bank_id, source_memory_ids):
+        return source_memory_ids
+
+    monkeypatch.setattr(consolidator, "_filter_live_source_memories", fake_filter_live_source_memories)
+
+    with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 384"):
+        await consolidator._create_observation_directly(
+            conn=_FailingConn(),
+            memory_engine=_FakeMemoryEngine(),
+            bank_id="test-bank",
+            source_memory_ids=[source_id],
+            observation_text="Consolidated observation text.",
+        )

--- a/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
+++ b/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
@@ -8,7 +8,7 @@ from hindsight_api.engine.consolidation import consolidator
 class _ZeroLengthEmbeddings:
     dimension = 384
 
-    def encode(self, texts):
+    def encode_documents(self, texts):
         assert texts == ["Consolidated observation text."]
         return [[]]
 

--- a/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
+++ b/hindsight-api-slim/tests/test_retain_orchestrator_mapping.py
@@ -90,6 +90,35 @@ class TestMapResultsToContents:
         assert result == [["u-a1"], ["u-b1", "u-b2"]]
 
 
+class TestEmbeddingSingleValidation:
+    def test_generate_embedding_preserves_validation_runtime_error(self):
+        backend = MagicMock()
+        backend.dimension = 3
+        backend.encode_documents.return_value = [[]]
+
+        with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 3"):
+            embedding_utils.generate_embedding(backend, "a")
+
+    def test_generate_embedding_raises_when_backend_returns_wrong_count(self):
+        backend = MagicMock()
+        backend.dimension = 3
+        backend.encode_documents.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+        with pytest.raises(RuntimeError, match="returned 2 vectors for 1 input text"):
+            embedding_utils.generate_embedding(backend, "a")
+
+    def test_generate_embedding_uses_query_encoder_when_requested(self):
+        backend = MagicMock()
+        backend.dimension = 2
+        backend.encode_query.return_value = [[0.1, 0.2]]
+
+        result = embedding_utils.generate_embedding(backend, "a", input_type="query")
+
+        assert result == [0.1, 0.2]
+        backend.encode_query.assert_called_once_with(["a"])
+        backend.encode_documents.assert_not_called()
+
+
 class TestEmbeddingsBatchLengthGuarantee:
     def test_raises_when_backend_returns_fewer_embeddings(self):
         # Regression for #1037: backends that silently truncate must not pass
@@ -110,8 +139,25 @@ class TestEmbeddingsBatchLengthGuarantee:
 
     def test_passes_through_aligned_embeddings(self):
         backend = MagicMock()
+        backend.dimension = 1
         backend.encode_documents.return_value = [[0.1], [0.2]]
 
         result = asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))
 
         assert result == [[0.1], [0.2]]
+
+    def test_raises_when_backend_returns_empty_embedding_vector(self):
+        backend = MagicMock()
+        backend.dimension = 3
+        backend.encode_documents.return_value = [[0.1, 0.2, 0.3], []]
+
+        with pytest.raises(RuntimeError, match="embedding 1 has dimension 0; expected 3"):
+            asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))
+
+    def test_raises_when_backend_returns_wrong_embedding_dimension(self):
+        backend = MagicMock()
+        backend.dimension = 3
+        backend.encode_documents.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5]]
+
+        with pytest.raises(RuntimeError, match="embedding 1 has dimension 2; expected 3"):
+            asyncio.run(embedding_utils.generate_embeddings_batch(backend, ["a", "b"]))


### PR DESCRIPTION
## Summary
- validate embedding vectors before they can reach pgvector writes
- reject empty vectors and vectors whose length does not match the backend's declared dimension
- cover both retain and consolidation observation creation paths with regression tests

## Root cause
Retain embedding generation already guaranteed that the number of returned vectors matched the number of input texts, but it did not validate per-vector dimensions. If an embedding backend returned `[]` or another wrong-sized vector, the invalid value could flow downstream until PostgreSQL/pgvector raised `different vector dimensions 384 and 0`.

The same shared embedding utility is also used by consolidation when creating observations, so the validation boundary protects both retain writes and consolidation-created observations.

## Related reconnaissance
- Fixes #1669.
- Related to #1671: without quarantine/degraded health, poisoned async operations can keep retrying even while `/health` is green.
- Related but separate from #1571, which tracks oversized single retain items not being split before retain processing.
- Existing tests already covered vector count mismatches from #1037; this PR extends the same boundary to validate each vector's shape.

## Test plan
- RED on current `origin/main`: `uv run pytest tests/test_consolidation_embedding_validation.py::test_create_observation_rejects_zero_length_embedding_before_insert -q -o addopts=` failed because the zero-length vector reached the DB insert path.
- `uv run pytest tests/test_consolidation_embedding_validation.py::test_create_observation_rejects_zero_length_embedding_before_insert tests/test_retain_orchestrator_mapping.py -q -o addopts=` → 11 passed
- `uv run ruff check tests/test_consolidation_embedding_validation.py hindsight_api/engine/retain/embedding_utils.py tests/test_retain_orchestrator_mapping.py` → passed
- Added-line secret/private marker scan → 0 findings
