### PR TITLE
fix(embed): resolve npx absolute path on Windows before spawning UI

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -546,6 +546,8 @@ class DaemonEmbedManager(EmbedManager):
 
     def _find_ui_command(self) -> list[str]:
         """Find the command to run the control plane UI."""
+        import shutil
+
         # Check if we're in development mode (monorepo)
         dev_cp_path = Path(__file__).parent.parent.parent / "hindsight-control-plane"
         cli_js = dev_cp_path / "bin" / "cli.js"
@@ -559,7 +561,13 @@ class DaemonEmbedManager(EmbedManager):
         # `npx` prompts before installing missing packages on first run unless `-y` is set.
         # The UI starts in the background with stdout/stderr redirected to a log file, so an
         # interactive prompt would be invisible to users and the health-check loop would time out.
-        return ["npx", "-y", f"@vectorize-io/hindsight-control-plane@{cp_version}"]
+        # On Windows, detached processes may not inherit the parent's PATH, so resolve the
+        # absolute path to npx to avoid "Command not found" errors.
+        npx_path = shutil.which("npx")
+        if npx_path is None:
+            # Fallback to bare command so the FileNotFoundError handler can report it cleanly
+            return ["npx", "-y", f"@vectorize-io/hindsight-control-plane@{cp_version}"]
+        return [npx_path, "-y", f"@vectorize-io/hindsight-control-plane@{cp_version}"]
 
     def get_ui_url(self, profile: str, ui_port: int | None = None, hostname: str | None = None) -> str:
         """Get the URL for the UI serving this profile."""


### PR DESCRIPTION
## Problem

On Windows 11, running `hindsight-embed -p <profile> ui start` in **local/embedded mode** fails with:

```
Command not found: npx
```

even when `npx` is installed and available in the user's PATH.

## Root Cause

`subprocess.Popen()` with `creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows spawns a process that does **not** inherit the parent's PATH environment. The bare string `npx` cannot be resolved in the detached process context.

## Fix

Use `shutil.which("npx")` to resolve the absolute path to `npx` before spawning the subprocess. Falls back to the bare `npx` command so that existing `FileNotFoundError` error handlers can still report the missing command cleanly.

### Changes

- `hindsight-embed/hindsight_embed/daemon_embed_manager.py`: `_find_ui_command()` method

## Testing

- [x] Verified on Windows 11 with PowerShell / Git Bash
- [x] `npx` resolves to `C:\Program Files\nodejs\npx.cmd`
- [x] UI starts successfully after the fix
- [x] Fallback still produces clean error when `npx` is truly missing
- [x] Original behavior preserved: daemon starts in popup terminal, UI runs in foreground with Ctrl+C support

Fixes #1681