### PR TITLE
fix(webhooks): avoid duplicate retain batch deliveries

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -5807,9 +5807,8 @@ def _register_routes(app: FastAPI):
                             strategy=group_strategy,
                             request_context=request_context,
                             return_usage=True,
-                            outbox_callback=app.state.memory._build_retain_outbox_callback(
+                            outbox_callback_factory=app.state.memory._build_retain_outbox_callback_factory(
                                 bank_id=bank_id,
-                                contents=contents,
                                 operation_id=None,
                                 schema=_current_schema.get(),
                             ),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -207,6 +207,9 @@ from .search.reranking import CrossEncoderReranker, apply_combined_scoring
 from .search.tags import TagGroup, TagsMatch, build_tags_where_clause
 from .task_backend import TaskBackend
 
+RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
+RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
+
 
 def _is_oracledb_connection_error(e: Exception) -> bool:
     """Check if an exception is an Oracle connection/interface error."""
@@ -789,9 +792,8 @@ class MemoryEngine(MemoryEngineInterface):
             request_context=context,
             operation_id=operation_id,
             strategy=strategy,
-            outbox_callback=self._build_retain_outbox_callback(
+            outbox_callback_factory=self._build_retain_outbox_callback_factory(
                 bank_id=bank_id,
-                contents=contents,
                 operation_id=operation_id,
                 schema=_current_schema.get(),
             ),
@@ -1314,10 +1316,10 @@ class MemoryEngine(MemoryEngineInterface):
     def _build_retain_outbox_callback(
         self,
         bank_id: str,
-        contents: list[dict],
+        contents: list[RetainContentDict],
         operation_id: str | None,
         schema: str | None = None,
-    ) -> "Callable[[asyncpg.Connection], Awaitable[None]] | None":
+    ) -> RetainOutboxCallback | None:
         """Build a transactional outbox callback for retain.completed webhook events.
 
         Returns a coroutine function that queues one webhook delivery row per content
@@ -1361,6 +1363,31 @@ class MemoryEngine(MemoryEngineInterface):
                 await webhook_manager.fire_event_with_conn(event, conn, schema=resolved_schema)
 
         return _callback
+
+    def _build_retain_outbox_callback_factory(
+        self,
+        bank_id: str,
+        operation_id: str | None,
+        schema: str | None = None,
+    ) -> RetainOutboxCallbackFactory:
+        """Build retain outbox callbacks for grouped retain batches.
+
+        The factory captures one operation_id so per-document webhook events from
+        the same logical retain operation keep a shared event operation_id.
+        """
+        op_id = operation_id or uuid.uuid4().hex
+
+        def _factory(
+            callback_contents: list[RetainContentDict],
+        ) -> RetainOutboxCallback | None:
+            return self._build_retain_outbox_callback(
+                bank_id=bank_id,
+                contents=callback_contents,
+                operation_id=op_id,
+                schema=schema,
+            )
+
+        return _factory
 
     async def _update_webhook_delivery_metadata(
         self, operation_id: str, status_code: int | None, response_body: str | None
@@ -2272,7 +2299,8 @@ class MemoryEngine(MemoryEngineInterface):
         document_tags: list[str] | None = None,
         return_usage: bool = False,
         operation_id: str | None = None,
-        outbox_callback: "Callable[[asyncpg.Connection], Awaitable[None]] | None" = None,
+        outbox_callback: RetainOutboxCallback | None = None,
+        outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
         strategy: str | None = None,
     ):
         """
@@ -2359,6 +2387,9 @@ class MemoryEngine(MemoryEngineInterface):
             for item in contents:
                 if "document_id" not in item:
                     item["document_id"] = document_id
+
+        if outbox_callback is None and outbox_callback_factory is not None:
+            outbox_callback = outbox_callback_factory(contents)
 
         # Validate no duplicate document_ids in the batch
         # Having duplicate document_ids causes race conditions in document upserts during parallel processing
@@ -2450,6 +2481,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # Outbox callback runs inside the last sub-batch's transaction so the
                     # webhook delivery row is committed atomically with the final retain data.
                     outbox_callback=outbox_callback if i == len(sub_batches) else None,
+                    outbox_callback_factory=outbox_callback_factory if i == len(sub_batches) else None,
                 )
                 all_results.extend(sub_results)
                 total_usage = total_usage + sub_usage
@@ -2476,6 +2508,7 @@ class MemoryEngine(MemoryEngineInterface):
                 operation_id=operation_id,
                 strategy=strategy,
                 outbox_callback=outbox_callback,
+                outbox_callback_factory=outbox_callback_factory,
             )
 
         # Call post-operation hook if validator is configured
@@ -2525,7 +2558,8 @@ class MemoryEngine(MemoryEngineInterface):
         fact_type_override: str | None = None,
         document_tags: list[str] | None = None,
         operation_id: str | None = None,
-        outbox_callback: "Callable[[asyncpg.Connection], Awaitable[None]] | None" = None,
+        outbox_callback: RetainOutboxCallback | None = None,
+        outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
         strategy: str | None = None,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
@@ -2588,6 +2622,7 @@ class MemoryEngine(MemoryEngineInterface):
                 operation_id=operation_id,
                 schema=_current_schema.get(),
                 outbox_callback=outbox_callback,
+                outbox_callback_factory=outbox_callback_factory,
                 db_semaphore=self._put_semaphore,
             )
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -108,6 +108,9 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
+RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
+
 
 def _build_retain_params(contents_dicts, document_tags=None, doc_contents=None):
     """Build retain_params and merged_tags from content dicts."""
@@ -340,7 +343,7 @@ async def _insert_facts_and_links(
     # an IndexError (see issue #1037).
     result_unit_ids = _map_results_to_contents(contents, processed_facts, unit_ids if unit_ids else [])
 
-    if outbox_callback:
+    if outbox_callback is not None:
         await outbox_callback(conn)
 
     return result_unit_ids, phase3_context
@@ -449,7 +452,8 @@ async def retain_batch(
     document_tags: list[str] | None = None,
     operation_id: str | None = None,
     schema: str | None = None,
-    outbox_callback: Callable[["asyncpg.Connection"], Awaitable[None]] | None = None,
+    outbox_callback: RetainOutboxCallback | None = None,
+    outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
 ) -> tuple[list[list[str]], TokenUsage, int | None]:
     """
@@ -507,6 +511,10 @@ async def retain_batch(
             total_usage = TokenUsage()
             total_processed_tokens: int | None = 0
             for doc_key, (group_dicts, group_contents) in groups.items():
+                group_outbox_callback = (
+                    outbox_callback_factory(group_dicts) if outbox_callback_factory is not None else outbox_callback
+                )
+
                 group_ids, group_usage, group_processed = await retain_batch(
                     pool=pool,
                     embeddings_model=embeddings_model,
@@ -522,7 +530,8 @@ async def retain_batch(
                     document_tags=document_tags,
                     operation_id=operation_id,
                     schema=schema,
-                    outbox_callback=outbox_callback,
+                    outbox_callback=group_outbox_callback,
+                    outbox_callback_factory=outbox_callback_factory,
                     db_semaphore=db_semaphore,
                 )
                 for group_idx, orig_idx in enumerate(original_indices[doc_key]):
@@ -1844,7 +1853,7 @@ async def _delta_metadata_only(
                 merged_tags,
             )
             await fact_storage.update_memory_units_tags(conn, bank_id, document_id, merged_tags)
-            if outbox_callback:
+            if outbox_callback is not None:
                 await outbox_callback(conn)
 
     total_time = time.time() - start_time

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
+from hindsight_api import LLMConfig
 from hindsight_api.api import create_app
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.webhooks.manager import MAX_ATTEMPTS, RETRY_DELAYS, WebhookManager
@@ -27,7 +28,6 @@ from hindsight_api.webhooks.models import (
     WebhookEventType,
 )
 from hindsight_api.worker.exceptions import RetryTaskAt
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -896,6 +896,87 @@ class TestRetainCompletedWebhook:
             assert "doc-2" in doc_ids_in_payloads
         finally:
             async with memory._pool.acquire() as conn:
+                await conn.execute(
+                    "DELETE FROM async_operations WHERE operation_type = 'webhook_delivery' AND bank_id = $1",
+                    bank_id,
+                )
+                await conn.execute("DELETE FROM webhooks WHERE id = $1", webhook_id)
+
+    @pytest.mark.asyncio
+    async def test_async_batch_retain_queues_one_webhook_per_document(
+        self, memory_no_llm_verify: MemoryEngine, request_context
+    ):
+        """Distinct document_id groups must not replay the full-batch outbox."""
+        bank_id = f"wh-retain-batch-{uuid.uuid4().hex[:8]}"
+        webhook_id = uuid.uuid4()
+        original_llm_config = memory_no_llm_verify._llm_config
+        original_retain_llm_config = memory_no_llm_verify._retain_llm_config
+        original_webhook_manager = memory_no_llm_verify._webhook_manager
+
+        try:
+            none_config = LLMConfig(provider="none", api_key="", base_url="", model="none")
+            memory_no_llm_verify._llm_config = none_config
+            memory_no_llm_verify._retain_llm_config = none_config
+            memory_no_llm_verify._webhook_manager = WebhookManager(
+                backend=memory_no_llm_verify._backend,
+                global_webhooks=[],
+            )
+
+            await _ensure_bank(memory_no_llm_verify._pool, bank_id)
+            async with memory_no_llm_verify._pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO webhooks (id, bank_id, url, secret, event_types, enabled, created_at, updated_at)
+                    VALUES ($1, $2, $3, NULL, $4, true, NOW(), NOW())
+                    """,
+                    webhook_id,
+                    bank_id,
+                    "https://example.com/retain-hook",
+                    ["retain.completed"],
+                )
+
+            await memory_no_llm_verify.submit_async_retain(
+                bank_id=bank_id,
+                contents=[
+                    {"content": "Alice works at Google", "document_id": "doc-1"},
+                    {"content": "Bob loves Python", "document_id": "doc-2"},
+                ],
+                request_context=request_context,
+            )
+
+            async with memory_no_llm_verify._pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT task_payload
+                    FROM async_operations
+                    WHERE operation_type = 'webhook_delivery'
+                      AND bank_id = $1
+                      AND task_payload->>'event_type' = 'retain.completed'
+                    ORDER BY created_at
+                    """,
+                    bank_id,
+                )
+
+            assert len(rows) == 2
+            doc_ids = []
+            event_operation_ids = []
+            for row in rows:
+                payload = row["task_payload"]
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+                event_payload = json.loads(payload["payload"])
+                doc_ids.append(event_payload.get("data", {}).get("document_id"))
+                event_operation_ids.append(event_payload.get("operation_id"))
+
+            assert len(doc_ids) == len(set(doc_ids))
+            assert sorted(doc_ids) == ["doc-1", "doc-2"]
+            assert all(event_operation_ids)
+            assert len(set(event_operation_ids)) == 1
+        finally:
+            memory_no_llm_verify._llm_config = original_llm_config
+            memory_no_llm_verify._retain_llm_config = original_retain_llm_config
+            memory_no_llm_verify._webhook_manager = original_webhook_manager
+            async with memory_no_llm_verify._pool.acquire() as conn:
                 await conn.execute(
                     "DELETE FROM async_operations WHERE operation_type = 'webhook_delivery' AND bank_id = $1",
                     bank_id,


### PR DESCRIPTION
## Summary
- Scope retain.completed outbox callbacks to each per-document retain group.
- Prevent retainBatch with multiple document_ids from replaying the full batch webhook outbox for every group.
- Add a regression test covering async retainBatch with two document_ids and one retain.completed webhook per item.

Closes #1642.

## Tests
- `uv run ruff check hindsight_api/engine/memory_engine.py hindsight_api/engine/retain/orchestrator.py tests/test_webhooks.py`
- `uv run ty check hindsight_api/engine/memory_engine.py hindsight_api/engine/retain/orchestrator.py`
- `HINDSIGHT_API_LLM_PROVIDER=none uv run pytest tests/test_webhooks.py::TestRetainCompletedWebhook -q`
- `./scripts/hooks/lint.sh`