### PR TITLE
Regenerate hindsight-docs skill references

### DIFF
--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
Auto-generated by the `generate-docs-skill.sh` pre-commit hook — updates `skills/hindsight-docs/references/` to reflect recent changes in the docs source files (opencode-go integration drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)