### PR TITLE
fix: avoid retrying invalid embedding dimensions

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -226,6 +226,30 @@ def _is_oracledb_integrity_error(e: Exception) -> bool:
     return isinstance(e, oracledb.IntegrityError)
 
 
+def _is_invalid_embedding_dimension_error(e: Exception) -> bool:
+    """Return True for deterministic embedding-dimension failures.
+
+    These errors come from either PR #1670's preflight validation
+    ("embedding 0 has dimension 0; expected 384") or from pgvector itself
+    ("different vector dimensions 384 and 0"). Retrying the same poisoned
+    embedding response only burns worker slots; a fresh retain request or a
+    fixed embedding backend is required.
+    """
+    message = str(e).lower()
+    return "different vector dimensions" in message or (
+        "embedding" in message and "dimension" in message and "expected" in message
+    )
+
+
+def _is_non_retryable_task_error(e: Exception) -> bool:
+    """Classify deterministic task failures that should skip worker retry."""
+    return (
+        isinstance(e, asyncpg.exceptions.IntegrityConstraintViolationError)
+        or _is_oracledb_integrity_error(e)
+        or _is_invalid_embedding_dimension_error(e)
+    )
+
+
 class Budget(str, Enum):
     """Budget levels for recall/reflect operations."""
 
@@ -1236,17 +1260,11 @@ class MemoryEngine(MemoryEngineInterface):
                     logger.error(f"Not retrying task {task_type} (non-retryable), marking as failed")
                     if operation_id:
                         await self._mark_operation_failed(operation_id, str(e), error_traceback)
-                elif isinstance(e, asyncpg.exceptions.IntegrityConstraintViolationError) or (
-                    _is_oracledb_integrity_error(e)
-                ):
-                    # Non-retryable: deterministic integrity violations (PG or Oracle)
-                    # (UniqueViolationError, ForeignKeyViolationError, CheckViolationError,
-                    # NotNullViolationError, ExclusionViolationError / ORA-00001, ORA-02291, etc.)
-                    # will never succeed on retry — the offending row state is already committed.
-                    # Retrying just burns worker capacity. See vectorize-io/hindsight#980.
-                    logger.error(
-                        f"Not retrying task {task_type} (integrity violation, deterministic): {type(e).__name__}"
-                    )
+                elif _is_non_retryable_task_error(e):
+                    # Non-retryable: deterministic task failures (integrity violations,
+                    # invalid embedding dimensions, etc.) will not succeed by rerunning
+                    # the same payload. Retrying just burns worker capacity.
+                    logger.error(f"Not retrying task {task_type} (deterministic failure): {type(e).__name__}")
                     if task_type == "consolidation" and operation_id:
                         await self._fire_consolidation_webhook(
                             bank_id=task_dict.get("bank_id", ""),

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -306,15 +306,19 @@ class OpenAICompatibleLLM(LLMInterface):
             self.api_key = "local"
 
         # Validate API key for cloud providers
-        if self.provider in (
-            "openai",
-            "groq",
-            "minimax",
-            "deepseek",
-            "openrouter",
-            "zai",
-            "opencode-go",
-        ) and not self.api_key:
+        if (
+            self.provider
+            in (
+                "openai",
+                "groq",
+                "minimax",
+                "deepseek",
+                "openrouter",
+                "zai",
+                "opencode-go",
+            )
+            and not self.api_key
+        ):
             raise ValueError(f"API key is required for {self.provider}")
 
         # Service tier configuration (from config, not env vars)

--- a/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
+++ b/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
@@ -151,13 +151,33 @@ async def test_foreign_key_violation_also_not_retried(memory):
     await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "embedding 0 has dimension 0; expected 384",
+        "different vector dimensions 384 and 0",
+    ],
+)
+def test_invalid_embedding_dimension_error_is_non_retryable(message):
+    """Embedding dimension mismatches are deterministic and must not be retried.
+
+    PR #1670 validates empty/mismatched embedding vectors before pgvector writes.
+    pgvector may also raise its own dimension-mismatch error if an invalid vector
+    reaches the database layer. In both cases, rerunning the same poisoned
+    embedding response only burns worker slots; a fresh retain request or fixed
+    embedding backend is required.
+    """
+    from hindsight_api.engine.memory_engine import _is_non_retryable_task_error
+
+    assert _is_non_retryable_task_error(RuntimeError(message)) is True
+
+
 @pytest.mark.asyncio
 async def test_non_integrity_error_still_retried(memory):
     """
     Sanity check: non-integrity errors (network errors, timeouts, value errors)
     should STILL use the existing retry path — i.e., raise RetryTaskAt when
-    ``_retry_count < 3``. Only integrity violations are the new non-retryable
-    class.
+    ``_retry_count < 3``. Only deterministic task errors are non-retryable.
     """
     bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
     operation_id = uuid.uuid4()

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
## Summary

Classify deterministic embedding-dimension failures as non-retryable worker errors, so poisoned embedding responses fail immediately instead of burning worker slots through the generic retry path.

## Context

This complements #1670, but no longer depends on it: this PR now applies cleanly on current `main` and catches both the preflight validation error shape and pgvector's native dimension-mismatch error shape.

## Changes

- Extract `_is_non_retryable_task_error()` for deterministic worker failure classification.
- Preserve existing asyncpg/Oracle integrity-violation non-retry behavior.
- Add invalid embedding-dimension classification for:
  - `embedding 0 has dimension 0; expected 384`
  - `different vector dimensions 384 and 0`
- Keep transient non-integrity errors on the retry path.

## Verification

- Rebased onto current `origin/main` (`113d7da9`) and cherry-picked only `fix: avoid retrying invalid embedding dimensions`.
- `env HINDSIGHT_API_LLM_PROVIDER=mock HINDSIGHT_API_LLM_MODEL=mock HINDSIGHT_API_LLM_API_KEY=mock uv run --extra embedded-db --extra local-ml pytest -n0 tests/test_integrity_violation_not_retried.py -q` → 5 passed, 2 warnings
- `uv run ruff check hindsight_api/engine/memory_engine.py tests/test_integrity_violation_not_retried.py` → passed
- `uv run python -m py_compile hindsight_api/engine/memory_engine.py tests/test_integrity_violation_not_retried.py` → passed
- Added-line hygiene scan → 0 secret/shell/eval/pickle hits

## AI usage disclosure

Prepared with AI assistance (TARS/Codex) using TDD, targeted local tests, and manual diff review.