### PR TITLE
fix(embed): show actionable message when npx is missing on PATH

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -9,6 +9,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sysconfig
 import time
@@ -580,6 +581,33 @@ class DaemonEmbedManager(EmbedManager):
         except Exception:
             return False
 
+    @staticmethod
+    def _print_ui_unavailable_panel(missing_cmd: str, api_url: str) -> None:
+        """Print an actionable panel when the UI launcher (npx/node) is missing.
+
+        The daemon is already running at this point, so the panel reframes the
+        situation: the API is usable now, the UI is optional, and there's a
+        concrete install link plus a follow-up command.
+        """
+        message = (
+            f"The UI requires [bold]{missing_cmd}[/bold], which was not found on PATH.\n\n"
+            f"Your daemon is running and the API is usable at: [bold]{api_url}[/bold]\n"
+            "Memory operations via the API, MCP, or SDKs work without the UI.\n\n"
+            "To enable the UI:\n"
+            "  1. Install Node.js from https://nodejs.org (the LTS build includes npx)\n"
+            "  2. Re-open your shell so PATH picks up the new install\n"
+            "  3. Run: hindsight-embed ui start"
+        )
+        console.print(
+            Panel(
+                Text.from_markup(message),
+                title="[bold yellow]UI Unavailable (Node.js not found)[/bold yellow]",
+                border_style="yellow",
+                padding=(1, 2),
+            )
+        )
+        console.print()
+
     def start_ui(self, profile: str, ui_port: int | None = None, hostname: str = "0.0.0.0") -> bool:
         """Start the control plane UI in background.
 
@@ -621,6 +649,13 @@ class DaemonEmbedManager(EmbedManager):
             "--api-url",
             api_url,
         ]
+
+        # Pre-flight: the UI runs via npx (or `node` in dev). If neither is on
+        # PATH the spawn would raise FileNotFoundError — catch it up-front and
+        # show an actionable panel that frames the daemon as still usable.
+        if shutil.which(cmd[0]) is None:
+            self._print_ui_unavailable_panel(cmd[0], api_url)
+            return False
 
         try:
             with open(ui_log, "wb") as log_file:
@@ -677,18 +712,10 @@ class DaemonEmbedManager(EmbedManager):
             return False
 
         except FileNotFoundError:
-            error_msg = (
-                f"Command not found: {cmd[0]}\nFull command: {' '.join(cmd)}\n\nInstall Node.js and npx to run the UI."
-            )
-            console.print(
-                Panel(
-                    Text(error_msg, style="red"),
-                    title="[bold red]✗ Command Not Found[/bold red]",
-                    border_style="red",
-                    padding=(1, 2),
-                )
-            )
-            console.print()
+            # `shutil.which` found the binary but the spawn still failed to
+            # locate it — rare, but can happen on Windows when PATH resolution
+            # diverges between Python and the OS loader.
+            self._print_ui_unavailable_panel(cmd[0], api_url)
             return False
         except Exception as e:
             error_msg = f"Failed to start UI: {e}\n\nCommand: {' '.join(cmd)}\nLog file: {ui_log}"

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -109,6 +109,34 @@ def test_find_ui_command_uses_npx_yes_flag_for_published_control_plane(monkeypat
         ]
 
 
+def test_start_ui_skips_spawn_when_npx_missing(tmp_path, monkeypatch):
+    """When npx is absent, start_ui must surface a friendly panel and never
+    invoke subprocess.Popen (which would crash on a non-existent binary)."""
+    manager = DaemonEmbedManager()
+
+    paths = MagicMock()
+    paths.port = 8000
+    paths.ui_log = tmp_path / "ui.log"
+
+    manager._profile_manager = MagicMock()
+    manager._profile_manager.resolve_profile_paths.return_value = paths
+
+    monkeypatch.setattr(manager, "is_ui_running", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(manager, "get_url", lambda _profile: "http://127.0.0.1:8000")
+    monkeypatch.setattr(
+        manager, "_find_ui_command", lambda: ["npx", "-y", "@vectorize-io/hindsight-control-plane@9.9.9"]
+    )
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.shutil.which", return_value=None),
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen") as popen,
+    ):
+        result = manager.start_ui("default")
+
+    assert result is False
+    popen.assert_not_called()
+
+
 def test_find_api_command_prefers_installed_binary_over_uvx(tmp_path, monkeypatch):
     """
     When hindsight-api is installed alongside hindsight-embed (e.g. via

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
## Summary
- When the UI launcher hits a system without `npx` (common on Windows without Node.js), `start_ui` no longer surfaces the generic red "Command Not Found" panel. Daemon stays healthy and usable; the panel now reframes the UI as optional with concrete next steps (Node.js download link + `hindsight-embed ui start` follow-up).
- Pre-flight check with `shutil.which` so we catch the missing binary up-front instead of relying on `FileNotFoundError` from `subprocess.Popen` — that path is brittle on Windows where PATH resolution can diverge between Python and the OS loader.

## Motivation
User report on the community channel: daemon started fine, then this hard-failure panel scared them off — they thought the whole setup was broken. It wasn't; only the UI was unavailable because Node.js wasn't installed.

## Test plan
- [x] `uv run pytest tests/test_embed_manager.py -v` — 12/12 pass, including new `test_start_ui_skips_spawn_when_npx_missing`
- [x] `./scripts/hooks/lint.sh` clean
- [ ] Manual smoke on a host without `npx`: confirm the new panel renders and the daemon URL is shown