### PR TITLE
docs(crewai): prioritize Hindsight Cloud in quickstart

### DIFF
--- a/hindsight-docs/docs-integrations/crewai.md
+++ b/hindsight-docs/docs-integrations/crewai.md
@@ -26,12 +26,19 @@ pip install hindsight-crewai
 
 ## Quick Start
 
+:::tip Recommended: Hindsight Cloud
+[Sign up free](https://ui.hindsight.vectorize.io/signup) and grab an API key — no self-hosting required.
+:::
+
 ```python
 from hindsight_crewai import configure, HindsightStorage
 from crewai.memory.external.external_memory import ExternalMemory
 from crewai import Agent, Crew, Task
 
-configure(hindsight_api_url="http://localhost:8888")
+configure(
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
+)
 
 crew = Crew(
     agents=[Agent(role="Researcher", goal="Find information", backstory="...")],
@@ -49,6 +56,16 @@ That's it. CrewAI will automatically:
 - **Store task outputs** to Hindsight after each task completes
 
 Memories persist across crew runs, so your crew learns over time.
+
+### Self-hosting (local development)
+
+If you're running Hindsight locally with `./scripts/dev/start-api.sh`, swap the URL:
+
+```python
+configure(hindsight_api_url="http://localhost:8888")
+```
+
+See the [installation guide](/developer/installation) for self-hosting setup.
 
 ## How It Works
 
@@ -68,7 +85,7 @@ CrewAI calls `search()` automatically at the start of each task and `save()` aft
 from hindsight_crewai import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",  # Hindsight API URL
+    hindsight_api_url="https://api.hindsight.vectorize.io",  # Hindsight Cloud (default)
     api_key="your-api-key",                     # Or set HINDSIGHT_API_KEY env var
     budget="mid",                               # Recall budget: "low", "mid", "high"
     max_tokens=4096,                            # Max tokens for recall results
@@ -161,7 +178,10 @@ from hindsight_crewai import configure, HindsightStorage, HindsightReflectTool
 from crewai.memory.external.external_memory import ExternalMemory
 from crewai import Agent, Crew, Task
 
-configure(hindsight_api_url="http://localhost:8888")
+configure(
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
+)
 
 storage = HindsightStorage(
     bank_id="research-crew",

--- a/hindsight-docs/guides/2026-05-04-guide-crewai-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-05-04-guide-crewai-memory-with-hindsight.md
@@ -44,17 +44,20 @@ pip install hindsight-crewai
 
 ## Step 2: Connect CrewAI to Hindsight
 
+> ✨ **Recommended:** [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — free tier, no self-hosting required.
+
 ```python
 from hindsight_crewai import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
     budget="mid",
     max_tokens=4096,
 )
 ```
 
-If you use [Hindsight Cloud](https://hindsight.vectorize.io), swap the API URL for `https://api.hindsight.vectorize.io` and include your API key.
+If you're self-hosting Hindsight locally instead, swap the API URL for `http://localhost:8888` and drop the `api_key`.
 
 ## Step 3: Wire memory into your runtime
 

--- a/hindsight-integrations/crewai/README.md
+++ b/hindsight-integrations/crewai/README.md
@@ -18,13 +18,18 @@ pip install hindsight-crewai
 
 ## Quick Start
 
+> ✨ **Recommended: [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** — free tier, no self-hosting required. Sign up and grab an API key in under a minute.
+
 ```python
 from hindsight_crewai import configure, HindsightStorage
 from crewai.memory.external.external_memory import ExternalMemory
 from crewai import Agent, Crew, Task
 
-# Step 1: Configure connection
-configure(hindsight_api_url="http://localhost:8888")
+# Step 1: Point CrewAI at Hindsight Cloud
+configure(
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
+)
 
 # Step 2: Create crew with Hindsight-backed memory
 crew = Crew(
@@ -48,6 +53,16 @@ That's it. CrewAI will automatically:
 - **Store task outputs** to Hindsight after each task completes
 
 Memories persist across crew runs, so your crew learns over time.
+
+### Self-hosting (local development)
+
+If you're running Hindsight locally with `./scripts/dev/start-api.sh`, point at your local server instead:
+
+```python
+configure(hindsight_api_url="http://localhost:8888")
+```
+
+See the [Hindsight installation guide](https://hindsight.vectorize.io/developer/installation) for self-hosting setup.
 
 ## Per-Agent Memory Banks
 
@@ -111,7 +126,7 @@ storage = HindsightStorage(
 from hindsight_crewai import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",  # Default: production API
+    hindsight_api_url="https://api.hindsight.vectorize.io",  # Hindsight Cloud (default)
     api_key="your-api-key",                     # Or set HINDSIGHT_API_KEY env var
     budget="mid",                               # Recall budget: low/mid/high
     max_tokens=4096,                            # Max tokens for recall results
@@ -143,7 +158,7 @@ See the [CrewAI memory example](https://github.com/vectorize-io/hindsight-cookbo
 
 | Parameter | Default | Description |
 |---|---|---|
-| `hindsight_api_url` | Production API | Hindsight API URL |
+| `hindsight_api_url` | Hindsight Cloud (`https://api.hindsight.vectorize.io`) | Hindsight API URL |
 | `api_key` | `HINDSIGHT_API_KEY` env | API key for authentication |
 | `budget` | `"mid"` | Recall budget level (low/mid/high) |
 | `max_tokens` | `4096` | Maximum tokens for recall results |

--- a/hindsight-integrations/crewai/hindsight_crewai/__init__.py
+++ b/hindsight-integrations/crewai/hindsight_crewai/__init__.py
@@ -9,7 +9,10 @@ Basic usage::
     from crewai.memory.external.external_memory import ExternalMemory
     from crewai import Crew
 
-    configure(hindsight_api_url="http://localhost:8888")
+    configure(
+        hindsight_api_url="https://api.hindsight.vectorize.io",
+        api_key="hsk_...",
+    )
 
     crew = Crew(
         agents=[...],

--- a/hindsight-integrations/crewai/hindsight_crewai/storage.py
+++ b/hindsight-integrations/crewai/hindsight_crewai/storage.py
@@ -14,7 +14,7 @@ from typing import Any, Callable
 from crewai.memory.storage.interface import Storage
 
 from ._compat import call_sync
-from .config import get_config
+from .config import DEFAULT_HINDSIGHT_API_URL, get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,10 @@ class HindsightStorage(Storage):
         from hindsight_crewai import configure, HindsightStorage
         from crewai.memory.external.external_memory import ExternalMemory
 
-        configure(hindsight_api_url="http://localhost:8888")
+        configure(
+            hindsight_api_url="https://api.hindsight.vectorize.io",
+            api_key="hsk_...",
+        )
         storage = HindsightStorage(bank_id="my-crew")
         external_memory = ExternalMemory(storage=storage)
     """
@@ -84,7 +87,7 @@ class HindsightStorage(Storage):
 
         # Resolve settings: constructor args override global config
         config = get_config()
-        self._api_url = hindsight_api_url or (config.hindsight_api_url if config else "http://localhost:8888")
+        self._api_url = hindsight_api_url or (config.hindsight_api_url if config else DEFAULT_HINDSIGHT_API_URL)
         self._api_key = api_key or (config.api_key if config else None)
         self._budget = budget or (config.budget if config else "mid")
         self._max_tokens = max_tokens or (config.max_tokens if config else 4096)

--- a/hindsight-integrations/crewai/hindsight_crewai/tools.py
+++ b/hindsight-integrations/crewai/hindsight_crewai/tools.py
@@ -15,7 +15,7 @@ from crewai.tools import BaseTool
 from pydantic import Field, PrivateAttr
 
 from ._compat import call_sync
-from .config import get_config
+from .config import DEFAULT_HINDSIGHT_API_URL, get_config
 from .errors import HindsightError
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class HindsightReflectTool(BaseTool):
             from hindsight_client import Hindsight
 
             config = get_config()
-            api_url = self.hindsight_api_url or (config.hindsight_api_url if config else "http://localhost:8888")
+            api_url = self.hindsight_api_url or (config.hindsight_api_url if config else DEFAULT_HINDSIGHT_API_URL)
             api_key = self.api_key or (config.api_key if config else None)
 
             client = Hindsight(

--- a/hindsight-integrations/crewai/tests/test_storage.py
+++ b/hindsight-integrations/crewai/tests/test_storage.py
@@ -254,6 +254,6 @@ class TestHindsightStorage:
     def test_falls_back_to_defaults_without_config(self):
         reset_config()
         storage = HindsightStorage(bank_id="test")
-        assert storage._api_url == "http://localhost:8888"
+        assert storage._api_url == "https://api.hindsight.vectorize.io"
         assert storage._budget == "mid"
         assert storage._max_tokens == 4096

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
## Summary

First in a series prioritizing Hindsight Cloud over local Hindsight across the integrations I authored. **This PR is a prototype to validate the pattern before rolling it out to the other 16.**

For `hindsight-crewai`:

- **README + docs page + framework guide:** Quick Start now leads with Hindsight Cloud (sign-up link + Cloud API URL example + `api_key` field). The localhost `http://localhost:8888` example is moved to a "Self-hosting (local development)" section below.
- **Recommended callout:** Each Quick Start gets a one-line `✨ Recommended: Hindsight Cloud` callout (admonition on the docs page, blockquote in README/guide).
- **Code fix (genuine bug):** Both `HindsightStorage` and `HindsightReflectTool` previously fell back to `http://localhost:8888` when no `configure()` call had been made — even though `DEFAULT_HINDSIGHT_API_URL` in `config.py` is already the Cloud URL. The fallbacks now use `DEFAULT_HINDSIGHT_API_URL` so behavior matches what the docs claim.
- **Docstring examples:** `__init__.py` and `storage.py` examples updated to show Cloud-first usage.
- **Tests:** `test_falls_back_to_defaults_without_config` updated to assert the Cloud URL.

Also includes 2 lines of incidental `skills/hindsight-docs/` regeneration drift (`opencode-go` was added upstream but the skill snapshot hadn't been regenerated). The pre-commit hook required the regen to be staged.

## Test plan

- [x] `uv run pytest tests/` in `hindsight-integrations/crewai/` — **35/35 pass**
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] Pre-commit hooks pass
- [ ] Review the callout wording / section structure — if the shape is wrong here, it will be wrong on the other 16 integrations too

## Next

If this pattern looks right, I'll replicate it across the other 16 integrations I authored (strands, pydantic-ai, smolagents, codex, agentcore, pipecat, agno, n8n, dify, paperclip, nemoclaw, flowise, chat, vapi, roo-code, hermes) as separate PRs.