### PR TITLE
docs(strands): prioritize Hindsight Cloud in quickstart

### DIFF
--- a/hindsight-docs/docs-integrations/strands.md
+++ b/hindsight-docs/docs-integrations/strands.md
@@ -23,13 +23,18 @@ pip install hindsight-strands
 
 ## Quick Start
 
+:::tip Recommended: Hindsight Cloud
+[Sign up free](https://ui.hindsight.vectorize.io/signup) and grab an API key — no self-hosting required.
+:::
+
 ```python
 from strands import Agent
 from hindsight_strands import create_hindsight_tools
 
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
 )
 
 agent = Agent(tools=tools)
@@ -43,6 +48,19 @@ The agent now has three tools it can call:
 - **`hindsight_recall`** — Search long-term memory for relevant facts
 - **`hindsight_reflect`** — Synthesize a reasoned answer from memories
 
+### Self-hosting (local development)
+
+If you're running Hindsight locally with `./scripts/dev/start-api.sh`, swap the URL:
+
+```python
+tools = create_hindsight_tools(
+    bank_id="user-123",
+    hindsight_api_url="http://localhost:8888",
+)
+```
+
+See the [installation guide](/developer/installation) for self-hosting setup.
+
 ## With Memory Instructions
 
 Pre-recall relevant memories and inject them into the system prompt:
@@ -52,12 +70,14 @@ from hindsight_strands import create_hindsight_tools, memory_instructions
 
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 memories = memory_instructions(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 agent = Agent(
@@ -81,7 +101,7 @@ from hindsight_strands import create_hindsight_tools, memory_instructions
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    client = Hindsight(base_url="http://localhost:8888", api_key="test-key")
+    client = Hindsight(base_url="https://api.hindsight.vectorize.io", api_key="hsk_...")
     app.state.hindsight_client = client
     try:
         yield
@@ -111,7 +131,8 @@ Include only the tools you need:
 ```python
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
     enable_retain=True,
     enable_recall=True,
     enable_reflect=False,  # Omit reflect
@@ -178,7 +199,7 @@ tools = create_hindsight_tools(bank_id="user-123")
 
 | Parameter | Default | Description |
 |---|---|---|
-| `hindsight_api_url` | Production API | Hindsight API URL |
+| `hindsight_api_url` | Hindsight Cloud (`https://api.hindsight.vectorize.io`) | Hindsight API URL |
 | `api_key` | `HINDSIGHT_API_KEY` env | API key for authentication |
 | `budget` | `"mid"` | Default recall budget level |
 | `max_tokens` | `4096` | Default max tokens for recall |

--- a/hindsight-docs/guides/2026-05-04-guide-strands-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-05-04-guide-strands-memory-with-hindsight.md
@@ -44,15 +44,20 @@ pip install hindsight-strands
 
 ## Step 2: Connect Strands to Hindsight
 
+> ✨ **Recommended:** [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — free tier, no self-hosting required.
+
 ```python
 from hindsight_strands import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
     budget="mid",
     max_tokens=4096,
 )
 ```
+
+If you're self-hosting Hindsight locally instead, swap the API URL for `http://localhost:8888` and drop the `api_key`.
 
 ## Step 3: Wire memory into your runtime
 
@@ -62,12 +67,14 @@ from hindsight_strands import create_hindsight_tools, memory_instructions
 
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 memories = memory_instructions(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 agent = Agent(

--- a/hindsight-integrations/strands/README.md
+++ b/hindsight-integrations/strands/README.md
@@ -17,13 +17,16 @@ pip install hindsight-strands
 
 ## Quick Start
 
+> ✨ **Recommended: [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** — free tier, no self-hosting required. Sign up and grab an API key in under a minute.
+
 ```python
 from strands import Agent
 from hindsight_strands import create_hindsight_tools
 
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
 )
 
 agent = Agent(tools=tools)
@@ -38,6 +41,19 @@ The agent now has three tools it can call:
 - **`hindsight_recall`** — Search long-term memory for relevant facts
 - **`hindsight_reflect`** — Synthesize a reasoned answer from memories
 
+### Self-hosting (local development)
+
+If you're running Hindsight locally with `./scripts/dev/start-api.sh`, point at your local server instead:
+
+```python
+tools = create_hindsight_tools(
+    bank_id="user-123",
+    hindsight_api_url="http://localhost:8888",
+)
+```
+
+See the [Hindsight installation guide](https://hindsight.vectorize.io/developer/installation) for self-hosting setup.
+
 ## With Memory Instructions
 
 Pre-recall relevant memories and inject them into the system prompt:
@@ -47,12 +63,14 @@ from hindsight_strands import create_hindsight_tools, memory_instructions
 
 tools = create_hindsight_tools(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 memories = memory_instructions(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
 )
 
 agent = Agent(

--- a/hindsight-integrations/strands/hindsight_strands/__init__.py
+++ b/hindsight-integrations/strands/hindsight_strands/__init__.py
@@ -10,7 +10,8 @@ Basic usage::
 
     tools = create_hindsight_tools(
         bank_id="user-123",
-        hindsight_api_url="http://localhost:8888",
+        hindsight_api_url="https://api.hindsight.vectorize.io",
+        api_key="hsk_...",
     )
 
     agent = Agent(tools=tools)

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
Part 2 of the Cloud-first rollout (after #1689 for crewai).

Updates README, docs page, and framework guide for hindsight-strands to lead with Hindsight Cloud sign-up + Cloud API URL example. Self-hosting (`localhost:8888`) moved to a 'Self-hosting (local development)' section below.

Also updates the docstring example in `__init__.py` to show Cloud-first usage.

Tests: 82/82 pass.

Includes 2-line incidental `skills/hindsight-docs/` regen drift (will appear in every PR until the upstream drift lands on main).