### PR TITLE
docs(pipecat): prioritize Hindsight Cloud in quickstart

### DIFF
--- a/hindsight-docs/docs-integrations/pipecat.md
+++ b/hindsight-docs/docs-integrations/pipecat.md
@@ -10,13 +10,11 @@ Persistent long-term memory for [Pipecat](https://github.com/pipecat-ai/pipecat)
 
 ## Quick Start
 
-```bash
-# 1. Start Hindsight (self-hosted)
-pip install hindsight-all
-export HINDSIGHT_API_LLM_API_KEY=your-openai-key
-hindsight-api
+:::tip Recommended: Hindsight Cloud
+[Sign up free](https://ui.hindsight.vectorize.io/signup) and grab an API key — no self-hosting required.
+:::
 
-# 2. Install the integration
+```bash
 pip install hindsight-pipecat
 ```
 
@@ -26,7 +24,8 @@ from hindsight_pipecat import HindsightMemoryService
 
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
 )
 
 pipeline = Pipeline([
@@ -41,13 +40,22 @@ pipeline = Pipeline([
 ])
 ```
 
-Or with [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup):
+### Self-hosting (local development)
+
+If you'd rather self-host:
+
+```bash
+# 1. Start Hindsight
+pip install hindsight-all
+export HINDSIGHT_API_LLM_API_KEY=your-openai-key
+hindsight-api
+```
 
 ```python
+# 2. Point pipecat at the local server
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="https://api.hindsight.vectorize.io",
-    api_key="hsk_your_token_here",
+    hindsight_api_url="http://localhost:8888",
 )
 ```
 
@@ -91,7 +99,7 @@ HindsightMemoryService(
 from hindsight_pipecat import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",  # Hindsight Cloud (default)
     api_key="hsk_...",
     recall_budget="mid",
 )

--- a/hindsight-docs/guides/2026-05-04-guide-pipecat-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-05-04-guide-pipecat-memory-with-hindsight.md
@@ -44,16 +44,19 @@ pip install hindsight-pipecat
 
 ## Step 2: Connect Pipecat to Hindsight
 
+> ✨ **Recommended:** [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — free tier, no self-hosting required.
+
 ```python
 from hindsight_pipecat import HindsightMemoryService
 
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
 )
 ```
 
-For [Hindsight Cloud](https://hindsight.vectorize.io), set `hindsight_api_url` to `https://api.hindsight.vectorize.io` and pass your API key.
+If you're self-hosting Hindsight locally instead, set `hindsight_api_url` to `http://localhost:8888` and drop the `api_key`.
 
 ## Step 3: Wire memory into your runtime
 
@@ -63,7 +66,8 @@ from hindsight_pipecat import HindsightMemoryService
 
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",
     recall_budget="mid",
     recall_max_tokens=4096,
 )

--- a/hindsight-integrations/pipecat/README.md
+++ b/hindsight-integrations/pipecat/README.md
@@ -8,13 +8,16 @@ Persistent long-term memory for [Pipecat](https://github.com/pipecat-ai/pipecat)
 pip install hindsight-pipecat
 ```
 
+> ✨ **Recommended: [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** — free tier, no self-hosting required. Sign up and grab an API key in under a minute.
+
 ```python
 from pipecat.pipeline.pipeline import Pipeline
 from hindsight_pipecat import HindsightMemoryService
 
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",
+    api_key="hsk_...",  # or set HINDSIGHT_API_KEY env var
 )
 
 pipeline = Pipeline([
@@ -29,15 +32,18 @@ pipeline = Pipeline([
 ])
 ```
 
-Or with [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup):
+### Self-hosting (local development)
+
+If you're running Hindsight locally with `./scripts/dev/start-api.sh`, point at your local server instead:
 
 ```python
 memory = HindsightMemoryService(
     bank_id="user-123",
-    hindsight_api_url="https://api.hindsight.vectorize.io",
-    api_key="hsk_your_token_here",
+    hindsight_api_url="http://localhost:8888",
 )
 ```
+
+See the [Hindsight installation guide](https://hindsight.vectorize.io/developer/installation) for self-hosting setup.
 
 ## How It Works
 
@@ -92,7 +98,7 @@ HindsightMemoryService(
 from hindsight_pipecat import configure
 
 configure(
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="https://api.hindsight.vectorize.io",  # Hindsight Cloud (default)
     api_key="hsk_...",
     recall_budget="mid",
 )

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -30,6 +30,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -76,6 +76,7 @@ Browse all supported integrations in the Integrations Hub.
 - MiniMax
 - DeepSeek
 - z.ai
+- opencode-go
 - Volcano Engine
 - OpenRouter
 - OpenAI Codex


### PR DESCRIPTION
Part 7 of the Cloud-first rollout. README + docs + guide reordered to lead with Cloud, self-hosted moved below. Includes 2-line incidental `skills/hindsight-docs/` regen drift.