### PR TITLE
docs(paperclip): add Cloud API URL to quickstart and config default

### DIFF
--- a/hindsight-docs/docs-integrations/paperclip.md
+++ b/hindsight-docs/docs-integrations/paperclip.md
@@ -20,16 +20,17 @@ Then configure in **Settings → Plugins → Hindsight Memory**.
 
 ## Prerequisites
 
-Either:
+:::tip Hindsight Cloud (recommended)
+[Sign up free](https://ui.hindsight.vectorize.io/signup) — no infrastructure to run. Skip straight to Configuration below.
+:::
+
+**Self-hosting alternative** — run Hindsight locally:
 
 ```bash
-# Self-hosted
 pip install hindsight-all
 export HINDSIGHT_API_LLM_API_KEY=your-openai-key
 hindsight-api
 ```
-
-Or [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — no self-hosting required.
 
 ## How It Works
 
@@ -58,7 +59,7 @@ Memory is keyed to `companyId` + `agentId` — never to the run ID — so it acc
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `hindsightApiUrl` | `http://localhost:8888` | Hindsight server URL |
+| `hindsightApiUrl` | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted) |
 | `hindsightApiKeyRef` | — | Paperclip secret name holding Hindsight Cloud API key |
 | `bankGranularity` | `["company", "agent"]` | Memory isolation: per company+agent, per company, or per agent |
 | `recallBudget` | `mid` | `low` = fastest, `mid` = balanced, `high` = most thorough |

--- a/hindsight-docs/guides/2026-04-16-guide-paperclip-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-04-16-guide-paperclip-memory-with-hindsight.md
@@ -31,7 +31,7 @@ This guide covers the quick-start path, the HTTP and process adapter patterns, b
 Before you start, make sure you have:
 
 - A Paperclip agent already running through the heartbeat model
-- A reachable Hindsight backend, either self-hosted or [Hindsight Cloud](https://hindsight.vectorize.io)
+- A Hindsight backend: [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) (recommended — free tier, no infrastructure to run) or [self-hosted](https://hindsight.vectorize.io/developer/installation)
 - Stable identifiers for `companyId` and `agentId`
 
 The identifier design matters. Paperclip's default isolation pattern works well because it maps cleanly to a multi-tenant setup.

--- a/hindsight-integrations/paperclip/README.md
+++ b/hindsight-integrations/paperclip/README.md
@@ -32,13 +32,13 @@ hindsight-api
 
 ## Configuration
 
-| Field                | Default                 | Description                                                    |
-| -------------------- | ----------------------- | -------------------------------------------------------------- |
+| Field                | Default                              | Description                                                                       |
+| -------------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
 | `hindsightApiUrl`    | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted) |
-| `hindsightApiKeyRef` | —                       | Paperclip secret name holding Hindsight Cloud API key          |
-| `bankGranularity`    | `["company", "agent"]`  | Memory isolation: per company+agent, per company, or per agent |
-| `recallBudget`       | `mid`                   | `low` = fastest, `mid` = balanced, `high` = most thorough      |
-| `autoRetain`         | `true`                  | Automatically retain run output after every run                |
+| `hindsightApiKeyRef` | —                                    | Paperclip secret name holding Hindsight Cloud API key                             |
+| `bankGranularity`    | `["company", "agent"]`               | Memory isolation: per company+agent, per company, or per agent                    |
+| `recallBudget`       | `mid`                                | `low` = fastest, `mid` = balanced, `high` = most thorough                         |
+| `autoRetain`         | `true`                               | Automatically retain run output after every run                                   |
 
 ## Bank ID Format
 

--- a/hindsight-integrations/paperclip/README.md
+++ b/hindsight-integrations/paperclip/README.md
@@ -20,22 +20,21 @@ Then configure in **Settings → Plugins → Hindsight Memory**.
 
 ## Prerequisites
 
-Either:
+> ✨ **Recommended:** [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — sign up free, get an API key, and skip the self-hosting setup entirely.
+
+**Self-hosting alternative** — run Hindsight locally:
 
 ```bash
-# Self-hosted (runs locally)
 pip install hindsight-all
 export HINDSIGHT_API_LLM_API_KEY=your-openai-key
 hindsight-api
 ```
 
-Or [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — no self-hosting required.
-
 ## Configuration
 
 | Field                | Default                 | Description                                                    |
 | -------------------- | ----------------------- | -------------------------------------------------------------- |
-| `hindsightApiUrl`    | `http://localhost:8888` | Hindsight server URL                                           |
+| `hindsightApiUrl`    | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted) |
 | `hindsightApiKeyRef` | —                       | Paperclip secret name holding Hindsight Cloud API key          |
 | `bankGranularity`    | `["company", "agent"]`  | Memory isolation: per company+agent, per company, or per agent |
 | `recallBudget`       | `mid`                   | `low` = fastest, `mid` = balanced, `high` = most thorough      |

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -31,8 +31,8 @@ const manifest: PaperclipPluginManifestV1 = {
         type: "string",
         title: "Hindsight API URL",
         description:
-          "Base URL of your Hindsight instance. Use http://localhost:8888 for self-hosted.",
-        default: "http://localhost:8888",
+          "Base URL of your Hindsight instance. Defaults to Hindsight Cloud. Use http://localhost:8888 for self-hosted.",
+        default: "https://api.hindsight.vectorize.io",
       },
       hindsightApiKeyRef: {
         type: "string",


### PR DESCRIPTION
Applies the cloud-first documentation pattern to the paperclip integration.

**Changes:**
- `README.md`: Cloud callout in Prerequisites (Cloud first, self-hosted below)
- `src/manifest.ts`: Default `hindsightApiUrl` changed from `http://localhost:8888` to `https://api.hindsight.vectorize.io`
- `hindsight-docs/docs-integrations/paperclip.md`: `:::tip` Cloud callout in Prerequisites
- `hindsight-docs/guides/…-guide-paperclip-memory-with-hindsight.md`: Prerequisites updated to recommend Cloud
- Configuration tables updated to reflect new default URL in both README and docs page

Part of the cloud-first documentation rollout across all integrations.