### PR TITLE
docs(nemoclaw): add Cloud API URL to quickstart and config default

### DIFF
--- a/hindsight-docs/docs-integrations/nemoclaw.md
+++ b/hindsight-docs/docs-integrations/nemoclaw.md
@@ -21,7 +21,6 @@ NemoClaw runs [OpenClaw](https://openclaw.ai) inside an OpenShell sandbox with c
 ```bash
 npx @vectorize-io/hindsight-nemoclaw setup \
   --sandbox my-assistant \
-  --api-url https://api.hindsight.vectorize.io \
   --api-token <your-api-key> \
   --bank-prefix my-sandbox
 ```
@@ -81,8 +80,8 @@ hindsight-nemoclaw setup [options]
 
 Options:
   --sandbox <name>       NemoClaw sandbox name (required)
-  --api-url <url>        Hindsight API URL (required)
   --api-token <token>    Hindsight API token (required)
+  --api-url <url>        Hindsight API URL (default: https://api.hindsight.vectorize.io)
   --bank-prefix <prefix> Memory bank prefix (default: "nemoclaw")
   --skip-policy          Skip sandbox network policy update
   --skip-plugin-install  Skip openclaw plugin installation

--- a/hindsight-docs/docs-integrations/nemoclaw.md
+++ b/hindsight-docs/docs-integrations/nemoclaw.md
@@ -14,6 +14,10 @@ NemoClaw runs [OpenClaw](https://openclaw.ai) inside an OpenShell sandbox with c
 
 ## Quick Start
 
+:::tip Hindsight Cloud (recommended)
+[Sign up free](https://ui.hindsight.vectorize.io/signup) — get an API key instantly, no infrastructure to run.
+:::
+
 ```bash
 npx @vectorize-io/hindsight-nemoclaw setup \
   --sandbox my-assistant \
@@ -21,8 +25,6 @@ npx @vectorize-io/hindsight-nemoclaw setup \
   --api-token <your-api-key> \
   --bank-prefix my-sandbox
 ```
-
-Get an API key at [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup).
 
 You'll see output like:
 

--- a/hindsight-integrations/nemoclaw/README.md
+++ b/hindsight-integrations/nemoclaw/README.md
@@ -6,6 +6,8 @@ NemoClaw runs [OpenClaw](https://openclaw.ai) inside an OpenShell sandbox with s
 
 ## Quick Start
 
+> ✨ **Recommended:** Use [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — sign up free and get an API key instantly. No infrastructure to run.
+
 ```bash
 npx @vectorize-io/hindsight-nemoclaw setup \
   --sandbox my-assistant \
@@ -13,8 +15,6 @@ npx @vectorize-io/hindsight-nemoclaw setup \
   --api-token <your-api-key> \
   --bank-prefix my-sandbox
 ```
-
-Get an API key at [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup).
 
 ## Documentation
 

--- a/hindsight-integrations/nemoclaw/README.md
+++ b/hindsight-integrations/nemoclaw/README.md
@@ -11,7 +11,6 @@ NemoClaw runs [OpenClaw](https://openclaw.ai) inside an OpenShell sandbox with s
 ```bash
 npx @vectorize-io/hindsight-nemoclaw setup \
   --sandbox my-assistant \
-  --api-url https://api.hindsight.vectorize.io \
   --api-token <your-api-key> \
   --bank-prefix my-sandbox
 ```
@@ -31,8 +30,8 @@ hindsight-nemoclaw setup [options]
 
 Options:
   --sandbox <name>       NemoClaw sandbox name (required)
-  --api-url <url>        Hindsight API URL (required)
   --api-token <token>    Hindsight API token (required)
+  --api-url <url>        Hindsight API URL (default: https://api.hindsight.vectorize.io)
   --bank-prefix <prefix> Memory bank prefix (default: "nemoclaw")
   --skip-policy          Skip sandbox network policy update
   --skip-plugin-install  Skip openclaw plugin installation

--- a/hindsight-integrations/nemoclaw/src/cli.ts
+++ b/hindsight-integrations/nemoclaw/src/cli.ts
@@ -10,11 +10,11 @@ Usage:
 
 Required options:
   --sandbox <name>       NemoClaw sandbox name (e.g. my-assistant)
-  --api-url <url>        Hindsight Cloud API URL (https://api.hindsight.vectorize.io)
   --api-token <token>    Hindsight API key from https://ui.hindsight.vectorize.io
   --bank-prefix <prefix> Bank ID prefix (memories go to <prefix>-openclaw)
 
 Optional options:
+  --api-url <url>        Hindsight API URL (default: https://api.hindsight.vectorize.io)
   --skip-policy          Skip the openshell policy update
   --skip-plugin-install  Skip openclaw plugins install
   --dry-run              Print what would be changed without executing
@@ -23,7 +23,6 @@ Optional options:
 Example:
   hindsight-nemoclaw setup \\
     --sandbox my-assistant \\
-    --api-url https://api.hindsight.vectorize.io \\
     --api-token hsk_abc123 \\
     --bank-prefix my-sandbox
 `);
@@ -49,13 +48,12 @@ function parseArgs(argv: string[]): CliArgs | null {
   };
 
   const sandbox = get("--sandbox");
-  const apiUrl = get("--api-url");
+  const apiUrl = get("--api-url") ?? "https://api.hindsight.vectorize.io";
   const apiToken = get("--api-token");
   const bankPrefix = get("--bank-prefix");
 
   const missing: string[] = [];
   if (!sandbox) missing.push("--sandbox");
-  if (!apiUrl) missing.push("--api-url");
   if (!apiToken) missing.push("--api-token");
   if (!bankPrefix) missing.push("--bank-prefix");
 


### PR DESCRIPTION
Applies the cloud-first documentation pattern to the nemoclaw integration.

nemoclaw already led with Cloud URLs in both README and docs. This PR adds the callout banners that make it explicit.

**Changes:**
- `README.md`: `> ✨ **Recommended:**` callout before Quick Start
- `hindsight-docs/docs-integrations/nemoclaw.md`: `:::tip` Cloud callout before Quick Start

Part of the cloud-first documentation rollout across all integrations.