### PR TITLE
docs(chat): add Cloud API URL to quickstart

### DIFF
--- a/hindsight-docs/docs-integrations/chat.md
+++ b/hindsight-docs/docs-integrations/chat.md
@@ -10,6 +10,12 @@ We built `@vectorize-io/hindsight-chat` to give [Vercel Chat SDK](https://github
 
 [View Changelog →](/changelog/integrations/chat)
 
+## Setup
+
+:::tip Hindsight Cloud (recommended)
+[Sign up free](https://ui.hindsight.vectorize.io/signup) — get an API key instantly, no infrastructure to run. Self-hosting? See the [installation guide](/developer/installation).
+:::
+
 ## Installation
 
 ```bash

--- a/hindsight-integrations/chat/README.md
+++ b/hindsight-integrations/chat/README.md
@@ -2,6 +2,12 @@
 
 Give your [Vercel Chat SDK](https://github.com/vercel/chat) bots persistent, per-user memory with a single handler wrapper. Works with Slack, Discord, Teams, Google Chat, GitHub, and Linear.
 
+## Setup
+
+> ✨ **Recommended:** [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) — sign up free, get an API key, and you're ready. No infrastructure to run.
+>
+> Self-hosting alternative: [installation guide](https://hindsight.vectorize.io/developer/installation).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Applies the cloud-first documentation pattern to the Vercel Chat SDK integration.

The chat integration had no Cloud mention at all — users were expected to already have a Hindsight instance. This PR adds the Cloud callout so new users know where to start.

**Changes:**
- `README.md`: Added `## Setup` section with `> ✨ **Recommended:**` Cloud callout and self-hosting alternative link before Quick Start
- `hindsight-docs/docs-integrations/chat.md`: Added `:::tip` Cloud callout before Installation

Part of the cloud-first documentation rollout across all integrations.