### PR TITLE
docs(hermes): add Cloud API URL to quickstart

### DIFF
--- a/hindsight-docs/docs-integrations/hermes.md
+++ b/hindsight-docs/docs-integrations/hermes.md
@@ -10,6 +10,10 @@ Persistent long-term memory for [Hermes Agent](https://github.com/NousResearch/h
 
 ## Quick Start
 
+:::tip Hindsight Cloud (recommended)
+[Sign up free](https://ui.hindsight.vectorize.io/signup) — get an API key instantly, no infrastructure to run.
+:::
+
 **1. Get an API key** at [ui.hindsight.vectorize.io/connect](https://ui.hindsight.vectorize.io/connect). The API endpoint is `https://api.hindsight.vectorize.io`.
 
 **2. Run the setup wizard:**


### PR DESCRIPTION
Applies the cloud-first documentation pattern to the Hermes integration docs.

The Hermes docs page already led with Cloud URLs in Quick Start and listed Cloud as the recommended Connection Mode. This PR adds the `:::tip` callout banner to make the Cloud recommendation explicit and consistent with all other integrations.

**Changes:**
- `hindsight-docs/docs-integrations/hermes.md`: `:::tip` Cloud callout before Quick Start

Note: The `hindsight-hermes` Python package was dropped (PR #931), so there is no README to update — this PR touches only the docs page.

Part of the cloud-first documentation rollout across all integrations.