### PR TITLE
feat: support Codex OAuth embeddings

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -200,6 +200,7 @@ ENV_EMBEDDINGS_OPENAI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"
 ENV_EMBEDDINGS_OPENAI_MODEL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"
 ENV_EMBEDDINGS_OPENAI_BASE_URL = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"
 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"
+ENV_EMBEDDINGS_OPENAI_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"
 
 # Gemini/Vertex AI embeddings configuration
 ENV_EMBEDDINGS_GEMINI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY"
@@ -792,6 +793,13 @@ def _parse_positive_int(name: str, raw: str | None, default: int) -> int:
     return parsed
 
 
+def _parse_optional_positive_int(name: str, raw: str | None) -> int | None:
+    """Parse an optional env var that must be a positive integer when set."""
+    if raw is None or raw == "":
+        return None
+    return _parse_positive_int(name, raw, 1)
+
+
 def _validate_extraction_mode(mode: str) -> str:
     """Validate and normalize extraction mode."""
     mode_lower = mode.lower()
@@ -1179,6 +1187,7 @@ class HindsightConfig:
     # Defaulted fields (source-compatible additions — existing direct constructor callers keep working).
     # Keep at the end of the dataclass; Python forbids non-default fields after default fields.
     embeddings_openai_batch_size: int = DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE
+    embeddings_openai_dimensions: int | None = None
 
     # Class-level sets for configuration categorization
 
@@ -1537,6 +1546,10 @@ class HindsightConfig:
                 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE,
                 os.getenv(ENV_EMBEDDINGS_OPENAI_BATCH_SIZE),
                 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE,
+            ),
+            embeddings_openai_dimensions=_parse_optional_positive_int(
+                ENV_EMBEDDINGS_OPENAI_DIMENSIONS,
+                os.getenv(ENV_EMBEDDINGS_OPENAI_DIMENSIONS),
             ),
             # Cohere embeddings (with backward-compatible fallback to shared API key)
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -9,10 +9,12 @@ The database schema is automatically adjusted to match the model's dimension.
 Configuration via environment variables - see hindsight_api.config for all env var names.
 """
 
+import json
 import logging
 import os
 import warnings
 from abc import ABC, abstractmethod
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import httpx
@@ -385,6 +387,7 @@ class OpenAIEmbeddings(Embeddings):
         model: str = DEFAULT_EMBEDDINGS_OPENAI_MODEL,
         base_url: str | None = None,
         batch_size: int = 100,
+        dimensions: int | None = None,
         max_retries: int = 3,
     ):
         """
@@ -395,12 +398,14 @@ class OpenAIEmbeddings(Embeddings):
             model: OpenAI embedding model name (default: text-embedding-3-small)
             base_url: Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI endpoint)
             batch_size: Maximum batch size for embedding requests (default: 100)
+            dimensions: Optional requested output dimensions for OpenAI text-embedding-3 models
             max_retries: Maximum number of retries for failed requests (default: 3)
         """
         self.api_key = api_key
         self.model = model
         self.base_url = base_url
         self.batch_size = batch_size
+        self.dimensions = dimensions
         self.max_retries = max_retries
         self._client = None
         self._dimension: int | None = None
@@ -445,7 +450,9 @@ class OpenAIEmbeddings(Embeddings):
         self._client = OpenAI(**client_kwargs)
 
         # Try to get dimension from known models, otherwise do a test embedding
-        if self.model in self.MODEL_DIMENSIONS:
+        if self.dimensions is not None:
+            self._dimension = self.dimensions
+        elif self.model in self.MODEL_DIMENSIONS:
             self._dimension = self.MODEL_DIMENSIONS[self.model]
         else:
             # Do a test embedding to detect dimension
@@ -480,16 +487,72 @@ class OpenAIEmbeddings(Embeddings):
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
 
-            response = self._client.embeddings.create(
-                model=self.model,
-                input=batch,
-            )
+            request = {
+                "model": self.model,
+                "input": batch,
+            }
+            if self.dimensions is not None:
+                request["dimensions"] = self.dimensions
+
+            response = self._client.embeddings.create(**request)
 
             # Sort by index to ensure correct order
             batch_embeddings = sorted(response.data, key=lambda x: x.index)
             all_embeddings.extend([e.embedding for e in batch_embeddings])
 
         return all_embeddings
+
+
+class CodexOAuthEmbeddings(OpenAIEmbeddings):
+    """
+    OpenAI embeddings using the Codex/ChatGPT OAuth token from ``~/.codex/auth.json``.
+
+    Codex OAuth is an LLM-provider auth path in Hindsight, but the same bearer token
+    can also authenticate against the standard OpenAI embeddings endpoint. This keeps
+    embeddings on the user's existing Codex subscription/OAuth path without requiring
+    a separate OpenAI/OpenRouter/Gemini/Cohere API key.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_EMBEDDINGS_OPENAI_MODEL,
+        batch_size: int = 100,
+        dimensions: int | None = None,
+        max_retries: int = 3,
+    ):
+        access_token = self._load_codex_access_token()
+        super().__init__(
+            api_key=access_token,
+            model=model,
+            base_url="https://api.openai.com/v1",
+            batch_size=batch_size,
+            dimensions=dimensions,
+            max_retries=max_retries,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "openai-codex"
+
+    @staticmethod
+    def _load_codex_access_token() -> str:
+        """Load the Codex OAuth access token without logging or exposing it."""
+        auth_file = Path.home() / ".codex" / "auth.json"
+        if not auth_file.exists():
+            raise FileNotFoundError(f"Codex auth file not found: {auth_file}. Run 'codex auth login' to authenticate.")
+
+        with open(auth_file) as f:
+            data = json.load(f)
+
+        auth_mode = data.get("auth_mode")
+        if auth_mode != "chatgpt":
+            raise ValueError(f"Expected Codex auth_mode='chatgpt', got: {auth_mode}")
+
+        access_token = (data.get("tokens") or {}).get("access_token")
+        if not access_token:
+            raise ValueError("No access_token found in Codex auth file. Run 'codex auth login' again.")
+
+        return access_token
 
 
 class CohereEmbeddings(Embeddings):
@@ -1140,6 +1203,14 @@ def create_embeddings_from_env() -> Embeddings:
             model=model,
             base_url=base_url,
             batch_size=config.embeddings_openai_batch_size,
+            dimensions=config.embeddings_openai_dimensions,
+        )
+    elif provider == "openai-codex":
+        model = os.environ.get(ENV_EMBEDDINGS_OPENAI_MODEL, DEFAULT_EMBEDDINGS_OPENAI_MODEL)
+        return CodexOAuthEmbeddings(
+            model=model,
+            batch_size=config.embeddings_openai_batch_size,
+            dimensions=config.embeddings_openai_dimensions,
         )
     elif provider == "openrouter":
         api_key = config.embeddings_openrouter_api_key
@@ -1206,5 +1277,6 @@ def create_embeddings_from_env() -> Embeddings:
     else:
         raise ValueError(
             f"Unknown embeddings provider: {provider}. "
-            f"Supported: 'local', 'tei', 'openai', 'cohere', 'google', 'litellm', 'litellm-sdk'"
+            f"Supported: 'local', 'tei', 'openai', 'openai-codex', 'openrouter', 'cohere', 'google', "
+            f"'litellm', 'litellm-sdk'"
         )

--- a/hindsight-api-slim/tests/test_embeddings_openai_batch_size.py
+++ b/hindsight-api-slim/tests/test_embeddings_openai_batch_size.py
@@ -7,6 +7,7 @@ limits (e.g. DashScope / Aliyun Tongyi cap at 10). Users must be able to overrid
 the batch size via env var so `encode()` splits into smaller chunks.
 """
 
+import json
 import os
 
 import pytest
@@ -22,6 +23,7 @@ def setup_test_env():
         "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY",
         "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL",
         "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE",
+        "HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS",
         "HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY",
         "HINDSIGHT_API_LLM_API_KEY",
         "HINDSIGHT_API_LLM_PROVIDER",
@@ -64,6 +66,17 @@ def test_openai_batch_size_env_var_is_read():
     assert config.embeddings_openai_batch_size == 10
 
 
+def test_openai_dimensions_env_var_is_read():
+    """HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS requests reduced OpenAI output dims."""
+    from hindsight_api.config import HindsightConfig
+
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"] = "384"
+
+    config = HindsightConfig.from_env()
+    assert config.embeddings_openai_dimensions == 384
+
+
 def test_openai_embeddings_provider_uses_configured_batch_size():
     """create_embeddings_from_env() propagates config to OpenAIEmbeddings for 'openai' provider."""
     from hindsight_api.engine.embeddings import OpenAIEmbeddings, create_embeddings_from_env
@@ -90,6 +103,41 @@ def test_openrouter_provider_uses_configured_batch_size():
     embeddings = create_embeddings_from_env()
     assert isinstance(embeddings, OpenAIEmbeddings)
     assert embeddings.batch_size == 8
+
+
+def test_openai_codex_provider_uses_codex_oauth_token_and_configured_batch_size(tmp_path, monkeypatch):
+    """'openai-codex' embeddings reuse Codex OAuth auth without a separate API key."""
+    from hindsight_api.engine.embeddings import CodexOAuthEmbeddings, create_embeddings_from_env
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "codex-oauth-token-test",
+                    "account_id": "acct-test",
+                },
+            }
+        )
+    )
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    os.environ["HINDSIGHT_API_LLM_PROVIDER"] = "mock"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] = "openai-codex"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] = "text-embedding-3-small"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"] = "7"
+    os.environ["HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS"] = "384"
+
+    embeddings = create_embeddings_from_env()
+    assert isinstance(embeddings, CodexOAuthEmbeddings)
+    assert embeddings.provider_name == "openai-codex"
+    assert embeddings.model == "text-embedding-3-small"
+    assert embeddings.base_url == "https://api.openai.com/v1"
+    assert embeddings.api_key == "codex-oauth-token-test"
+    assert embeddings.batch_size == 7
+    assert embeddings.dimensions == 384
 
 
 def test_zero_batch_size_is_rejected():
@@ -144,7 +192,34 @@ def test_openai_encode_splits_on_configured_batch_size(monkeypatch):
 
     vectors = emb.encode(["x"] * 25)
 
+    assert calls == [10, 10, 5]
     assert len(vectors) == 25
-    assert calls == [10, 10, 5], (
-        f"Expected upstream calls of size 10, 10, 5 when batch_size=10 and 25 inputs, got {calls}"
+
+
+def test_openai_encode_passes_configured_dimensions():
+    """OpenAI embeddings requests include the optional dimensions parameter when configured."""
+    from types import SimpleNamespace
+
+    from hindsight_api.engine.embeddings import OpenAIEmbeddings
+
+    emb = OpenAIEmbeddings(
+        api_key="sk-test",
+        model="text-embedding-3-small",
+        batch_size=10,
+        dimensions=384,
     )
+
+    calls: list[int | None] = []
+
+    def fake_create(*, model, input, dimensions=None):
+        calls.append(dimensions)
+        return SimpleNamespace(data=[SimpleNamespace(index=i, embedding=[0.0] * 384) for i in range(len(input))])
+
+    emb._client = SimpleNamespace(embeddings=SimpleNamespace(create=fake_create))
+    emb._dimension = 384
+
+    vectors = emb.encode(["x"] * 2)
+
+    assert calls == [384]
+    assert len(vectors) == 2
+    assert len(vectors[0]) == 384

--- a/hindsight-docs/blog/2026-03-23-claude-code-telegram.md
+++ b/hindsight-docs/blog/2026-03-23-claude-code-telegram.md
@@ -46,7 +46,7 @@ Open Telegram and start a chat with [@BotFather][3].
 Send `/newbot` and follow the prompts — pick a name and a username (must end in `bot`). BotFather will give you a token like:
 
 ```
-1234567890:ABCDefghIJKlmnOPQrstUVwxyz
+[REDACTED_TELEGRAM_BOT_TOKEN]
 ```
 
 Keep this token for Step 3.

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -455,7 +455,7 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1m
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
+| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openai-codex`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
@@ -464,6 +464,7 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1m
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
+| `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_MODEL` | OpenRouter embedding model | `perplexity/pplx-embed-v1-0.6b` |
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY` | Cohere API key for embeddings | - |
@@ -522,8 +523,14 @@ export HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
 
 # OpenAI - cloud-based embeddings
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxxxxxxxxxx  # or reuses HINDSIGHT_API_LLM_API_KEY
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=***  # or reuses HINDSIGHT_API_LLM_API_KEY
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
+
+# OpenAI Codex OAuth - uses existing ChatGPT/Codex login, no API key needed
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai-codex
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
 
 # Azure OpenAI - embeddings via Azure endpoint
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai


### PR DESCRIPTION
## Summary
- Add `openai-codex` embeddings provider support backed by Codex OAuth credentials.
- Preserve/refresh Codex OAuth tokens without logging token values.
- Document Codex OAuth embedding configuration and 384-dimensional override use cases.

## Tests
- `uv run --directory hindsight-api-slim --extra test pytest tests/test_embeddings_openai_batch_size.py tests/test_codex_oauth_refresh.py -q` → 34 passed

## Notes
- UO25D local service smoke verified health, retain, recall, and reflect with `openai-codex`, `text-embedding-3-small`, 384 dimensions, and RRF reranker.
