### PR TITLE
fix: derive HINDSIGHT_API_HEALTH_URL default from HINDSIGHT_API_PORT

### DIFF
--- a/docker/standalone/start-all.sh
+++ b/docker/standalone/start-all.sh
@@ -156,7 +156,7 @@ PIDS=()
 # Start API if enabled
 if [ "$ENABLE_API" = "true" ]; then
     cd /app/api
-    API_HEALTH_URL="${HINDSIGHT_API_HEALTH_URL:-http://localhost:8888/health}"
+    API_HEALTH_URL="${HINDSIGHT_API_HEALTH_URL:-http://localhost:${HINDSIGHT_API_PORT:-8888}/health}"
     API_STARTUP_WAIT_SECONDS="${HINDSIGHT_API_STARTUP_WAIT_SECONDS:-300}"
 
     # Run API directly - Python's PYTHONUNBUFFERED=1 handles output buffering


### PR DESCRIPTION
## Problem

`HINDSIGHT_API_HEALTH_URL` default is hardcoded to port 8888 and does not 
respect `HINDSIGHT_API_PORT`. When a custom port is set, the health check 
polls the wrong port and the container fails to start after 300s.

## Fix

One-line change in `docker/standalone/start-all.sh`:

```diff
-    API_HEALTH_URL="${HINDSIGHT_API_HEALTH_URL:-http://localhost:8888/health}"
+    API_HEALTH_URL="${HINDSIGHT_API_HEALTH_URL:-http://localhost:${HINDSIGHT_API_PORT:-8888}/health}"
```

No behavior change when `HINDSIGHT_API_PORT` is not set — defaults to 8888 as before.

Closes #1708