### PR TITLE
fix: reload Codex OAuth credentials on auth failures

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -23,6 +23,7 @@ import os
 import tempfile
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -66,6 +67,21 @@ class CodexRefreshExpiredError(RuntimeError):
     """
 
 
+@dataclass(frozen=True)
+class CodexAuthCredentials:
+    """Credentials parsed from Codex auth.json.
+
+    ``auth.json`` can be either the native Codex CLI shape or a shared auth
+    store that nests Codex credentials under ``providers.openai-codex``. Keep
+    the parsed state named so refresh/reload code does not pass anonymous
+    multi-item tuples around internally.
+    """
+
+    access_token: str
+    account_id: str | None
+    refresh_token: str | None
+
+
 class CodexLLM(LLMInterface):
     """
     LLM provider using OpenAI Codex OAuth authentication.
@@ -99,7 +115,7 @@ class CodexLLM(LLMInterface):
         try:
             self.access_token, self.account_id = self._load_codex_auth()
             self.refresh_token = self._load_codex_refresh_token()
-            logger.info(f"Loaded Codex OAuth credentials for account: {self.account_id}")
+            logger.info("Loaded Codex OAuth credentials")
         except Exception as e:
             raise RuntimeError(
                 f"Failed to load Codex OAuth credentials from ~/.codex/auth.json: {e}\n\n"
@@ -125,7 +141,49 @@ class CodexLLM(LLMInterface):
         # HTTP client for SSE streaming
         self._client = httpx.AsyncClient(timeout=120.0)
 
-    def _load_codex_auth(self) -> tuple[str, str]:
+    def _auth_payload_from_document(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Return the Codex credential object from native or shared auth-store JSON."""
+        providers = data.get("providers")
+        if data.get("auth_mode") is None and isinstance(providers, dict):
+            provider_data = providers.get("openai-codex")
+            if isinstance(provider_data, dict):
+                return provider_data
+        return data
+
+    def _read_codex_auth_credentials(self, require_access_token: bool = True) -> CodexAuthCredentials:
+        """Read Codex OAuth credentials from ``self._auth_file``."""
+        if not self._auth_file.exists():
+            raise FileNotFoundError(
+                f"Codex auth file not found: {self._auth_file}\nRun 'codex auth login' to authenticate with ChatGPT Plus/Pro."
+            )
+
+        with open(self._auth_file) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("Codex auth file must contain a JSON object")
+
+        auth_data = self._auth_payload_from_document(data)
+        auth_mode = auth_data.get("auth_mode")
+        if auth_mode != "chatgpt":
+            raise ValueError(f"Expected auth_mode='chatgpt', got: {auth_mode}")
+
+        tokens = auth_data.get("tokens", {})
+        if not isinstance(tokens, dict):
+            raise ValueError("Expected tokens to be a JSON object")
+        access_token = tokens.get("access_token")
+        account_id = tokens.get("account_id")
+        refresh_token = tokens.get("refresh_token")
+
+        if require_access_token and not access_token:
+            raise ValueError("No access_token found in Codex auth file. Run 'codex auth login' again.")
+
+        return CodexAuthCredentials(
+            access_token=str(access_token or ""),
+            account_id=str(account_id) if account_id else None,
+            refresh_token=str(refresh_token) if refresh_token else None,
+        )
+
+    def _load_codex_auth(self) -> tuple[str, str | None]:
         """
         Load OAuth credentials from ~/.codex/auth.json.
 
@@ -136,29 +194,8 @@ class CodexLLM(LLMInterface):
             FileNotFoundError: If auth file doesn't exist.
             ValueError: If auth file is invalid.
         """
-        auth_file = Path.home() / ".codex" / "auth.json"
-
-        if not auth_file.exists():
-            raise FileNotFoundError(
-                f"Codex auth file not found: {auth_file}\nRun 'codex auth login' to authenticate with ChatGPT Plus/Pro."
-            )
-
-        with open(auth_file) as f:
-            data = json.load(f)
-
-        # Validate auth structure
-        auth_mode = data.get("auth_mode")
-        if auth_mode != "chatgpt":
-            raise ValueError(f"Expected auth_mode='chatgpt', got: {auth_mode}")
-
-        tokens = data.get("tokens", {})
-        access_token = tokens.get("access_token")
-        account_id = tokens.get("account_id")
-
-        if not access_token:
-            raise ValueError("No access_token found in Codex auth file. Run 'codex auth login' again.")
-
-        return access_token, account_id
+        credentials = self._read_codex_auth_credentials(require_access_token=True)
+        return credentials.access_token, credentials.account_id
 
     def _load_codex_refresh_token(self) -> str | None:
         """Load ``tokens.refresh_token`` from ``~/.codex/auth.json``.
@@ -170,15 +207,35 @@ class CodexLLM(LLMInterface):
         of raising only on missing ``access_token``.
         """
         try:
-            with open(self._auth_file) as f:
-                data = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
+            return self._read_codex_auth_credentials(require_access_token=False).refresh_token
+        except (OSError, ValueError, json.JSONDecodeError) as e:
             logger.warning(
                 f"Codex auth file unreadable when loading refresh_token: {type(e).__name__}. "
                 "Token refresh will not be available; the access_token in memory will be used until it expires."
             )
             return None
-        return data.get("tokens", {}).get("refresh_token")
+
+    def _reload_auth_file_if_token_rotated(self, token_before_lock: str) -> bool:
+        """Adopt a token that another process already rotated into auth.json.
+
+        Long-running services may keep an access_token in memory while Codex CLI
+        or another Hindsight process refreshes the shared auth file. On a backend
+        401, reload the file before spending the cached refresh_token; otherwise
+        we can fail with refresh_token_reused even though fresh credentials are
+        already on disk.
+        """
+        try:
+            credentials = self._read_codex_auth_credentials(require_access_token=True)
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            logger.debug(f"Codex auth file reload skipped after auth error: {type(e).__name__}")
+            return False
+        if credentials.access_token == token_before_lock:
+            return False
+        self.access_token = credentials.access_token
+        self.account_id = credentials.account_id
+        self.refresh_token = credentials.refresh_token
+        logger.info("Reloaded Codex OAuth credentials from auth.json")
+        return True
 
     @staticmethod
     def _decode_jwt_exp_unixtime(token: str) -> int | None:
@@ -244,18 +301,20 @@ class CodexLLM(LLMInterface):
             # someone has hand-edited it into a non-object shape, fall back
             # to the minimal default rather than crashing the refresh path.
             current = loaded if isinstance(loaded, dict) else {"auth_mode": "chatgpt", "tokens": {}}
+            auth_data = self._auth_payload_from_document(current)
         except (OSError, json.JSONDecodeError):
             # If the file became unreadable between our last read and now,
             # construct a minimal shape rather than refusing to persist.
             current = {"auth_mode": "chatgpt", "tokens": {}}
+            auth_data = current
 
-        existing_tokens = current.get("tokens")
+        existing_tokens = auth_data.get("tokens")
         tokens: dict[str, Any] = existing_tokens if isinstance(existing_tokens, dict) else {}
         for key in ("access_token", "refresh_token", "id_token", "account_id"):
             if key in updated_tokens and updated_tokens[key] is not None:
                 tokens[key] = updated_tokens[key]
-        current["tokens"] = tokens
-        current["last_refresh"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        auth_data["tokens"] = tokens
+        auth_data["last_refresh"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
         # Write to a sibling tempfile so the rename is same-filesystem.
         parent = self._auth_file.parent
@@ -305,14 +364,20 @@ class CodexLLM(LLMInterface):
         token_before_lock = self.access_token
         async with self._auth_lock:
             if force:
-                # Reactive: skip only if another coroutine already rotated
-                # the token while we were waiting on the lock.
+                # Reactive: skip if another coroutine already rotated the
+                # token while we were waiting. If memory is still stale, re-read
+                # auth.json before spending refresh_token because another
+                # process may have already rotated the shared auth file.
                 if self.access_token != token_before_lock:
+                    return
+                if self._reload_auth_file_if_token_rotated(token_before_lock):
                     return
             else:
                 # Proactive: skip if the token is no longer stale (the
                 # canonical "another coroutine refreshed first" check).
                 if not self._token_is_stale():
+                    return
+                if self._reload_auth_file_if_token_rotated(token_before_lock) and not self._token_is_stale():
                     return
 
             if not self.refresh_token:
@@ -444,6 +509,18 @@ class CodexLLM(LLMInterface):
                 # handling paths keep working.
                 raise
 
+    def _build_codex_headers(self) -> dict[str, str]:
+        """Build request headers from the current in-memory Codex credentials."""
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            "Origin": "https://chatgpt.com",
+        }
+        if self.account_id:
+            headers["OpenAI-Account-ID"] = self.account_id
+        return headers
+
     def _map_reasoning_effort(self, effort: str) -> str:
         """
         Map standard reasoning effort to Codex reasoning summary format.
@@ -491,7 +568,7 @@ class CodexLLM(LLMInterface):
     async def verify_connection(self) -> None:
         """Verify Codex connection by making a simple test call."""
         try:
-            logger.info(f"Verifying Codex LLM: model={self.model}, account={self.account_id}...")
+            logger.info(f"Verifying Codex LLM: model={self.model}...")
             await self.call(
                 messages=[{"role": "user", "content": "Say 'ok'"}],
                 max_completion_tokens=10,
@@ -578,13 +655,7 @@ class CodexLLM(LLMInterface):
             "prompt_cache_key": str(uuid.uuid4()),
         }
 
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-            "OpenAI-Account-ID": self.account_id,
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-            "Origin": "https://chatgpt.com",
-        }
+        headers = self._build_codex_headers()
 
         url = f"{self.base_url}/codex/responses"
         last_exception = None
@@ -701,7 +772,7 @@ class CodexLLM(LLMInterface):
                             # token and retry without consuming a normal-retry
                             # budget slot — this is a dedicated auth-recovery
                             # attempt that shouldn't compete with backoff.
-                            headers["Authorization"] = f"Bearer {self.access_token}"
+                            headers = self._build_codex_headers()
                             logger.info("Codex auth refreshed after auth error; retrying request once")
                             continue
                         except CodexRefreshExpiredError as refresh_err:
@@ -909,13 +980,7 @@ class CodexLLM(LLMInterface):
             "prompt_cache_key": str(uuid.uuid4()),
         }
 
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-            "OpenAI-Account-ID": self.account_id,
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-            "Origin": "https://chatgpt.com",
-        }
+        headers = self._build_codex_headers()
 
         url = f"{self.base_url}/codex/responses"
 
@@ -938,7 +1003,7 @@ class CodexLLM(LLMInterface):
                         reason=f"reactive (HTTP {response.status_code} from codex backend in call_with_tools)",
                         force=True,
                     )
-                    headers["Authorization"] = f"Bearer {self.access_token}"
+                    headers = self._build_codex_headers()
                     logger.info("Codex auth refreshed after auth error; retrying tool-call request once")
                     response = await self._client.post(url, json=payload, headers=headers, timeout=120.0)
                 except CodexRefreshExpiredError as refresh_err:

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -126,8 +126,62 @@ def test_token_is_stale_false_when_exp_unparseable():
 
 
 # ---------------------------------------------------------------------------
-# refresh_token loading
+# auth-file loading
 # ---------------------------------------------------------------------------
+
+
+def test_load_codex_auth_supports_wrapped_openai_codex_provider_shape(tmp_path: Path, monkeypatch):
+    """Hermes-style shared auth stores wrap Codex credentials under providers.openai-codex."""
+    auth_dir = tmp_path / ".codex"
+    auth_dir.mkdir()
+    access = _make_jwt(int(time.time()) + 3600)
+    (auth_dir / "auth.json").write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "openai-codex": {
+                        "auth_mode": "chatgpt",
+                        "tokens": {
+                            "access_token": access,
+                            "refresh_token": "rt-wrapped",
+                            "account_id": "acct-wrapped",
+                        },
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    llm = CodexLLM(
+        provider="openai-codex",
+        api_key="ignored",
+        base_url="https://chatgpt.com/backend-api",
+        model="gpt-5.4-mini",
+    )
+
+    assert llm.access_token == access
+    assert llm.refresh_token == "rt-wrapped"
+    assert llm.account_id == "acct-wrapped"
+
+
+def test_init_does_not_log_codex_account_id(caplog):
+    account_id = "acct-DO-NOT-LEAK"
+    access = _make_jwt(int(time.time()) + 3600)
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=(access, account_id)),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value="rt"),
+    ):
+        with caplog.at_level("INFO"):
+            CodexLLM(
+                provider="openai-codex",
+                api_key="ignored",
+                base_url="https://chatgpt.com/backend-api",
+                model="gpt-5.4-mini",
+            )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert account_id not in log_text
 
 
 def test_refresh_token_loaded_from_auth_file(tmp_path: Path):
@@ -224,6 +278,39 @@ def test_persist_auth_atomic_does_not_leak_tempfile_on_success(tmp_path: Path):
     # No sibling tempfile should remain — atomic rename consumed it.
     siblings = [p.name for p in tmp_path.iterdir()]
     assert siblings == ["auth.json"], f"unexpected leftover files: {siblings}"
+
+
+def test_persist_auth_atomic_updates_wrapped_provider_shape(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "openai-codex": {
+                        "auth_mode": "chatgpt",
+                        "tokens": {
+                            "access_token": "old",
+                            "refresh_token": "rt-old",
+                            "account_id": "acct-keep",
+                        },
+                        "last_refresh": "2026-01-01T00:00:00Z",
+                    }
+                }
+            }
+        )
+    )
+
+    llm = _build_llm()
+    llm._auth_file = auth_file
+    llm._persist_auth_atomic({"access_token": "new", "refresh_token": "rt-new"})
+
+    written = json.loads(auth_file.read_text())
+    provider = written["providers"]["openai-codex"]
+    assert provider["tokens"]["access_token"] == "new"
+    assert provider["tokens"]["refresh_token"] == "rt-new"
+    assert provider["tokens"]["account_id"] == "acct-keep"
+    assert provider["last_refresh"] != "2026-01-01T00:00:00Z"
+    assert "tokens" not in written
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +485,124 @@ async def test_concurrent_ensure_fresh_token_calls_produce_one_refresh(tmp_path:
 # ---------------------------------------------------------------------------
 # Reactive 401 retry on the request path
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_reloads_rotated_auth_file_on_401_without_refresh_request(tmp_path: Path):
+    """If another process already rotated auth.json, adopt it and retry before refreshing."""
+    old_access = _make_jwt(int(time.time()) + 3600)
+    new_access = _make_jwt(int(time.time()) + 7200)
+    llm = _build_llm(refresh_token="rt-old", access_token=old_access)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": new_access,
+                    "refresh_token": "rt-new",
+                    "account_id": "acct-new",
+                },
+            }
+        )
+    )
+
+    fail_response = MagicMock()
+    fail_response.status_code = 401
+    fail_response.text = "unauthorized"
+    success_resp = MagicMock()
+    success_resp.status_code = 200
+    success_resp.raise_for_status.return_value = None
+
+    backend_authorizations: list[str] = []
+    call_count = {"backend": 0, "refresh": 0}
+
+    async def fake_post(url, **kwargs):
+        if url == _CODEX_REFRESH_TOKEN_URL:
+            call_count["refresh"] += 1
+            raise AssertionError("should reload auth.json instead of calling the refresh endpoint")
+        call_count["backend"] += 1
+        backend_authorizations.append(kwargs["headers"]["Authorization"])
+        if call_count["backend"] == 1:
+            raise httpx.HTTPStatusError("401", request=MagicMock(), response=fail_response)
+        return success_resp
+
+    with (
+        patch.object(llm._client, "post", new=fake_post),
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "ping"}],
+            max_retries=0,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+        )
+
+    assert result == "ok"
+    assert call_count == {"backend": 2, "refresh": 0}
+    assert backend_authorizations == [f"Bearer {old_access}", f"Bearer {new_access}"]
+    assert llm.access_token == new_access
+    assert llm.refresh_token == "rt-new"
+    assert llm.account_id == "acct-new"
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_reloads_rotated_auth_file_on_401_without_refresh_request(tmp_path: Path):
+    old_access = _make_jwt(int(time.time()) + 3600)
+    new_access = _make_jwt(int(time.time()) + 7200)
+    llm = _build_llm(refresh_token="rt-old", access_token=old_access)
+    llm._auth_file = tmp_path / "auth.json"
+    llm._auth_file.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": new_access,
+                    "refresh_token": "rt-new",
+                    "account_id": "acct-new",
+                },
+            }
+        )
+    )
+
+    fail_response = MagicMock()
+    fail_response.status_code = 401
+    fail_response.text = "unauthorized"
+    success_resp = MagicMock()
+    success_resp.status_code = 200
+    success_resp.raise_for_status.return_value = None
+
+    backend_authorizations: list[str] = []
+    call_count = {"backend": 0, "refresh": 0}
+
+    async def fake_post(url, **kwargs):
+        if url == _CODEX_REFRESH_TOKEN_URL:
+            call_count["refresh"] += 1
+            raise AssertionError("should reload auth.json instead of calling the refresh endpoint")
+        call_count["backend"] += 1
+        backend_authorizations.append(kwargs["headers"]["Authorization"])
+        if call_count["backend"] == 1:
+            return fail_response
+        return success_resp
+
+    with (
+        patch.object(llm._client, "post", new=fake_post),
+        patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock, return_value=("ok", [])),
+    ):
+        result = await llm.call_with_tools(
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[],
+            max_retries=0,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+        )
+
+    assert result.content == "ok"
+    assert call_count == {"backend": 2, "refresh": 0}
+    assert backend_authorizations == [f"Bearer {old_access}", f"Bearer {new_access}"]
+    assert llm.access_token == new_access
+    assert llm.refresh_token == "rt-new"
+    assert llm.account_id == "acct-new"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reload Codex OAuth credentials from `auth.json` before using a cached refresh token after backend auth failures.
- Support shared auth-store documents that nest Codex credentials under `providers.openai-codex`.
- Avoid logging Codex account IDs during startup/verification.
- Add regression coverage for normal calls, tool-call requests, wrapped auth parsing, and wrapped auth persistence.

## Why
Long-running Hindsight services can keep a stale in-memory Codex access token while another process has already rotated the shared auth file. On a backend 401, spending the cached refresh token can fail or race even though fresh credentials are already available on disk. Reloading the auth file first lets the provider adopt externally rotated credentials before attempting OAuth refresh.

## Test plan
- `uv run pytest tests/test_codex_oauth_refresh.py tests/test_codex_tool_choice.py -q` — 30 passed
- `uv run ruff check hindsight_api/engine/providers/codex_llm.py tests/test_codex_oauth_refresh.py tests/test_codex_tool_choice.py` — passed
- `git diff --check` — passed
- Independent pre-commit review — passed
