### PR TITLE
fix(openclaw): update Hindsight dependency ranges

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -86,7 +86,7 @@ The plugin will automatically capture conversations after each turn and inject r
 
 **Auto-Recall:** Before each agent response, relevant memories are automatically injected into the context (up to 1024 tokens by default). The agent uses past context without needing to call tools.
 
-**Manual Recall Tools:** When `enableKnowledgeTools` is enabled, the plugin also exposes `agent_knowledge_recall` for explicit lookups. Its `max_tokens` parameter controls the recall response token budget; automatic injection uses `recallMaxTokens` and optionally `recallTopK` for a post-response count cap.
+**Manual Knowledge Tools:** When `enableKnowledgeTools` is enabled, the plugin exposes `agent_knowledge_*` tools for explicit memory lookup, deliberate reflection, document ingest, and knowledge-page management. Use `agent_knowledge_recall` for ordinary lookup and `agent_knowledge_reflect` only when you want Hindsight to synthesize an answer from memories. Automatic injection still uses `recallMaxTokens` and optionally `recallTopK` for a post-response count cap.
 
 **Feedback Loop Prevention:** The plugin automatically strips injected memory tags (`<hindsight_memories>`) before storing conversations. This prevents recalled memories from being re-extracted as new facts, which would cause exponential memory growth and duplicate entries.
 
@@ -143,10 +143,12 @@ Optional settings in `~/.openclaw/openclaw.json`:
 - `recallRoles` - Which message roles to include when composing the contextual recall query (default: `["user", "assistant"]`).
 - `retainEveryNTurns` - Retain every Nth turn (default: `1` = every turn). Values > 1 enable chunked retention.
 - `retainOverlapTurns` - Extra prior turns included when chunked retention fires (default: `0`).
-- `enableKnowledgeTools` - Register `agent_knowledge_*` tools for explicit agent-driven lookup and knowledge-page management (default: `false`).
+- `enableKnowledgeTools` - Register `agent_knowledge_*` tools for explicit agent-driven lookup, reflection, ingest, and knowledge-page management (default: `false`).
 - `debug` - Enable debug logging (default: `false`).
 
 When using `agent_knowledge_recall` manually, pass `max_tokens` to control how much memory text the recall response may contain. Do not use `max_results` for this tool; OpenClaw auto-recall uses `recallTopK` when you need a count cap for automatically injected memories.
+
+When using `agent_knowledge_reflect`, keep the default conservative settings unless you intentionally need a deeper synthesis: `budget` defaults to `low`, `max_tokens` defaults to `1024`, and `fact_types` defaults to `world`, `experience`, and `observation`. Reflect calls can be more expensive than recall because they retrieve memories and then call the configured Reflect LLM to generate an answer. For production banks, set a finite bank-level `reflect_source_facts_max_tokens` value (for example `4096` or `8192`) instead of leaving it unlimited, so ad-hoc reflection cannot pull an unbounded amount of source facts into the LLM context.
 
 ### Memory Isolation
 

--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -84,7 +84,9 @@ The plugin will automatically capture conversations after each turn and inject r
 
 **Auto-Capture:** Every conversation is automatically stored after each turn. Facts, entities, and relationships are extracted in the background.
 
-**Auto-Recall:** Before each agent response, relevant memories are automatically injected into the context (up to 1024 tokens). The agent uses past context without needing to call tools.
+**Auto-Recall:** Before each agent response, relevant memories are automatically injected into the context (up to 1024 tokens by default). The agent uses past context without needing to call tools.
+
+**Manual Recall Tools:** When `enableKnowledgeTools` is enabled, the plugin also exposes `agent_knowledge_recall` for explicit lookups. Its `max_tokens` parameter controls the recall response token budget; automatic injection uses `recallMaxTokens` and optionally `recallTopK` for a post-response count cap.
 
 **Feedback Loop Prevention:** The plugin automatically strips injected memory tags (`<hindsight_memories>`) before storing conversations. This prevents recalled memories from being re-extracted as new facts, which would cause exponential memory growth and duplicate entries.
 
@@ -141,7 +143,10 @@ Optional settings in `~/.openclaw/openclaw.json`:
 - `recallRoles` - Which message roles to include when composing the contextual recall query (default: `["user", "assistant"]`).
 - `retainEveryNTurns` - Retain every Nth turn (default: `1` = every turn). Values > 1 enable chunked retention.
 - `retainOverlapTurns` - Extra prior turns included when chunked retention fires (default: `0`).
+- `enableKnowledgeTools` - Register `agent_knowledge_*` tools for explicit agent-driven lookup and knowledge-page management (default: `false`).
 - `debug` - Enable debug logging (default: `false`).
+
+When using `agent_knowledge_recall` manually, pass `max_tokens` to control how much memory text the recall response may contain. Do not use `max_results` for this tool; OpenClaw auto-recall uses `recallTopK` when you need a count cap for automatically injected memories.
 
 ### Memory Isolation
 

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -118,6 +118,13 @@ Optional settings in `~/.openclaw/openclaw.json` under `plugins.entries.hindsigh
 | `statelessSessionPatterns` | `[]`                           | Session key glob patterns for read-only sessions — retain is always skipped; recall is skipped when `skipStatelessSessions` is `true` (e.g. `["agent:*:subagent:**", "agent:*:heartbeat:**"]`)                                                                                                              |
 | `skipStatelessSessions`    | `true`                         | When `true`, sessions matching `statelessSessionPatterns` also skip recall. Set to `false` to allow recall but still skip retain.                                                                                                                                                                           |
 | `debugPerfTiming`          | `false`                        | Emit one info-level perf line per `before_prompt_build` (recall path) and `agent_end` (retain path) so you can spot whether latency is in the plugin or upstream. Off by default. Format: `perf: <hook> hook_total=Xms <hook-specific fields>`. Safe in production — uses the existing logger.              |
+| `enableKnowledgeTools`     | `false`                        | Register `agent_knowledge_*` tools for explicit agent-driven lookup, reflection, ingest, and knowledge-page management. Set automatically by the self-driving-agents CLI.                                                                                                                                   |
+
+### Manual Knowledge Tools
+
+When `enableKnowledgeTools` is enabled, the plugin registers explicit `agent_knowledge_*` tools in addition to automatic recall. Use `agent_knowledge_recall` for ordinary memory lookup. Use `agent_knowledge_reflect` only for deliberate synthesis, retrospectives, or long-term preference/pattern questions; it retrieves memories and then calls the configured Reflect LLM to generate an answer.
+
+`agent_knowledge_reflect` uses conservative defaults: `budget: "low"`, `max_tokens: 1024`, and `fact_types: ["world", "experience", "observation"]`. Production deployments should also set a finite bank-level `reflect_source_facts_max_tokens` value, such as `4096` or `8192`, rather than leaving reflection source facts unlimited.
 
 ### Session pattern filtering
 

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -18,6 +18,7 @@
       "agent_knowledge_update_page",
       "agent_knowledge_delete_page",
       "agent_knowledge_recall",
+      "agent_knowledge_reflect",
       "agent_knowledge_ingest"
     ]
   },
@@ -297,7 +298,7 @@
       },
       "enableKnowledgeTools": {
         "type": "boolean",
-        "description": "Register agent_knowledge_* tools for self-driving agents. Set automatically by the self-driving-agents CLI.",
+        "description": "Register agent_knowledge_* tools for explicit lookup, reflection, ingest, and knowledge-page management. Set automatically by the self-driving-agents CLI.",
         "default": false
       }
     },
@@ -482,7 +483,7 @@
     },
     "enableKnowledgeTools": {
       "label": "Enable Knowledge Tools",
-      "placeholder": "false (default) — enable agent_knowledge_* tools"
+      "placeholder": "false (default) — enable agent_knowledge_* tools, including reflect"
     },
     "retainQueuePath": {
       "label": "Retain Queue File Path",

--- a/hindsight-integrations/openclaw/package-lock.json
+++ b/hindsight-integrations/openclaw/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@vectorize-io/hindsight-openclaw",
-  "version": "0.7.0",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-openclaw",
-      "version": "0.7.0",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.2.0",
         "@vectorize-io/hindsight-agent-sdk": "^0.1.0",
-        "@vectorize-io/hindsight-all": "^0.1.0",
-        "@vectorize-io/hindsight-client": "^0.5.0"
+        "@vectorize-io/hindsight-all": "^0.6.2",
+        "@vectorize-io/hindsight-client": "^0.6.2"
       },
       "bin": {
         "hindsight-openclaw-backfill": "dist/backfill.js",
@@ -453,19 +453,25 @@
         "@vectorize-io/hindsight-client": "^0.5.6"
       }
     },
+    "node_modules/@vectorize-io/hindsight-agent-sdk/node_modules/@vectorize-io/hindsight-client": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
+      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
+      "license": "MIT"
+    },
     "node_modules/@vectorize-io/hindsight-all": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-all/-/hindsight-all-0.1.0.tgz",
-      "integrity": "sha512-7UDlnmerKla1YZm/vVEFO9C98s8APM2QCLxByuM8qBZ97DqxB9WEFxZ8flApwAlvk0kmoBFTAsRxsGlAQAd/gg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-all/-/hindsight-all-0.6.2.tgz",
+      "integrity": "sha512-HZHlwWaAx9wcmJpJRpOUIsfshNhu9mIM9AVfT1r/O1UfE0sXuO3P8zwN9b1gNv8O+NACByFfZhWuzbWAusdpOg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
-      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.6.2.tgz",
+      "integrity": "sha512-bymmlMWI1z0zOjgY+wRMLudNxzqcW20VHMtyV3QLhwJm63NeQN/nEZ4plWPR0p28DffaUM5nk2VSxzQljN+Mow==",
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {

--- a/hindsight-integrations/openclaw/package.json
+++ b/hindsight-integrations/openclaw/package.json
@@ -47,8 +47,8 @@
   "dependencies": {
     "@clack/prompts": "^1.2.0",
     "@vectorize-io/hindsight-agent-sdk": "^0.1.0",
-    "@vectorize-io/hindsight-all": "^0.1.0",
-    "@vectorize-io/hindsight-client": "^0.5.0"
+    "@vectorize-io/hindsight-all": "^0.6.2",
+    "@vectorize-io/hindsight-client": "^0.6.2"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/hindsight-tools/hindsight-agent-sdk/package-lock.json
+++ b/hindsight-tools/hindsight-agent-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.5.6"
+        "@vectorize-io/hindsight-client": "^0.6.2"
       },
       "devDependencies": {
         "typescript": "^5.4",
@@ -391,12 +391,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
-      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {

--- a/hindsight-tools/hindsight-agent-sdk/package.json
+++ b/hindsight-tools/hindsight-agent-sdk/package.json
@@ -27,7 +27,7 @@
     "directory": "hindsight-agent-sdk"
   },
   "dependencies": {
-    "@vectorize-io/hindsight-client": "^0.5.6"
+    "@vectorize-io/hindsight-client": "^0.6.2"
   },
   "devDependencies": {
     "typescript": "^5.4",

--- a/hindsight-tools/hindsight-agent-sdk/src/index.ts
+++ b/hindsight-tools/hindsight-agent-sdk/src/index.ts
@@ -38,6 +38,12 @@ export interface CreateKnowledgeToolsOptions {
 
 // ── Constants ──────────────────────────────────────────
 
+const FACT_TYPES = ["world", "experience", "observation"] as const;
+type FactType = (typeof FACT_TYPES)[number];
+
+const DEFAULT_RECALL_FACT_TYPES = ["world", "experience"] as const satisfies readonly FactType[];
+const DEFAULT_REFLECT_FACT_TYPES = FACT_TYPES;
+
 const PAGE_DEFAULTS = {
   mode: "delta" as const,
   refresh_after_consolidation: true,
@@ -62,6 +68,26 @@ export type KnowledgeToolName = (typeof TOOL_NAMES)[number];
 
 function ok(data: unknown): KnowledgeToolResult {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function normalizeFactTypes(input: unknown, defaultTypes: readonly FactType[]): FactType[] {
+  if (input === undefined || input === null) return [...defaultTypes];
+
+  const raw = Array.isArray(input)
+    ? input
+    : typeof input === "string"
+      ? input.split(/[\s,]+/).filter(Boolean)
+      : [];
+
+  const normalized = raw.filter(
+    (t): t is FactType => typeof t === "string" && (FACT_TYPES as readonly string[]).includes(t)
+  );
+
+  if (normalized.length !== raw.length || normalized.length === 0) {
+    throw new Error(`Invalid fact_types/types. Expected one or more of: ${FACT_TYPES.join(", ")}`);
+  }
+
+  return [...new Set(normalized)];
 }
 
 // ── Factory ────────────────────────────────────────────
@@ -212,6 +238,17 @@ export function createKnowledgeTools(opts: CreateKnowledgeToolsOptions): Knowled
         properties: {
           query: { type: "string", description: "What to search for" },
           max_tokens: { type: "number", description: "Token budget for results (default 1024)" },
+          fact_types: {
+            type: "array",
+            items: { type: "string", enum: ["world", "experience", "observation"] },
+            description:
+              "Memory types to recall. Defaults to world and experience. Include observation for consolidated knowledge pages/rules/preferences.",
+          },
+          types: {
+            type: "array",
+            items: { type: "string", enum: ["world", "experience", "observation"] },
+            description: "Alias for fact_types.",
+          },
         },
         required: ["query"],
       },
@@ -220,8 +257,13 @@ export function createKnowledgeTools(opts: CreateKnowledgeToolsOptions): Knowled
           (params.max_tokens as number | undefined) ??
           (params.max_results as number | undefined) ??
           1024;
+        const types = normalizeFactTypes(
+          params.fact_types ?? params.types,
+          DEFAULT_RECALL_FACT_TYPES
+        );
         const result = await client.recall(bankId, params.query as string, {
           maxTokens,
+          types,
         });
         return ok(result);
       },
@@ -262,13 +304,7 @@ export function createKnowledgeTools(opts: CreateKnowledgeToolsOptions): Knowled
         required: ["query"],
       },
       async execute(params: Record<string, unknown>) {
-        const factTypesParam = params.fact_types;
-        const factTypes = Array.isArray(factTypesParam)
-          ? factTypesParam.filter(
-              (t): t is "world" | "experience" | "observation" =>
-                t === "world" || t === "experience" || t === "observation"
-            )
-          : (["world", "experience", "observation"] as const);
+        const factTypes = normalizeFactTypes(params.fact_types, DEFAULT_REFLECT_FACT_TYPES);
         const maxTokens = Math.max(1, Math.floor(Number(params.max_tokens ?? 1024)));
         const budget =
           params.budget === "mid" || params.budget === "high" || params.budget === "low"

--- a/hindsight-tools/hindsight-agent-sdk/src/index.ts
+++ b/hindsight-tools/hindsight-agent-sdk/src/index.ts
@@ -52,6 +52,7 @@ export const TOOL_NAMES = [
   "agent_knowledge_update_page",
   "agent_knowledge_delete_page",
   "agent_knowledge_recall",
+  "agent_knowledge_reflect",
   "agent_knowledge_ingest",
 ] as const;
 
@@ -223,6 +224,75 @@ export function createKnowledgeTools(opts: CreateKnowledgeToolsOptions): Knowled
           maxTokens,
         });
         return ok(result);
+      },
+    },
+    {
+      name: "agent_knowledge_reflect",
+      label: "Reflect on memories",
+      description:
+        "Generate a concise answer using the memory bank. Use for deliberate synthesis, retrospectives, or long-term preference/pattern questions; use agent_knowledge_recall for ordinary lookup.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Question or synthesis prompt" },
+          budget: {
+            type: "string",
+            enum: ["low", "mid", "high"],
+            description: "Retrieval/reasoning budget (default low)",
+          },
+          max_tokens: {
+            type: "number",
+            description: "Maximum output tokens for the generated answer (default 1024)",
+          },
+          fact_types: {
+            type: "array",
+            items: { type: "string", enum: ["world", "experience", "observation"] },
+            description: "Memory types to use. Defaults to world, experience, and observation.",
+          },
+          include_facts: {
+            type: "boolean",
+            description: "Include supporting facts/evidence in the tool result (default false)",
+          },
+          exclude_mental_models: {
+            type: "boolean",
+            description:
+              "Exclude stored knowledge pages/mental models from reflection (default false)",
+          },
+        },
+        required: ["query"],
+      },
+      async execute(params: Record<string, unknown>) {
+        const factTypesParam = params.fact_types;
+        const factTypes = Array.isArray(factTypesParam)
+          ? factTypesParam.filter(
+              (t): t is "world" | "experience" | "observation" =>
+                t === "world" || t === "experience" || t === "observation"
+            )
+          : (["world", "experience", "observation"] as const);
+        const maxTokens = Math.max(1, Math.floor(Number(params.max_tokens ?? 1024)));
+        const budget =
+          params.budget === "mid" || params.budget === "high" || params.budget === "low"
+            ? (params.budget as "low" | "mid" | "high")
+            : "low";
+        const resp = await sdk.reflect({
+          client: lowLevel,
+          path: { bank_id: bankId },
+          body: {
+            query: params.query as string,
+            budget,
+            max_tokens: maxTokens,
+            fact_types: [...factTypes],
+            include: params.include_facts === true ? { facts: {} } : undefined,
+            exclude_mental_models:
+              typeof params.exclude_mental_models === "boolean"
+                ? params.exclude_mental_models
+                : undefined,
+          },
+        });
+        if (resp.error) {
+          throw new Error(`agent_knowledge_reflect failed: ${JSON.stringify(resp.error)}`);
+        }
+        return ok(resp.data);
       },
     },
     {

--- a/hindsight-tools/hindsight-agent-sdk/tests/index.test.ts
+++ b/hindsight-tools/hindsight-agent-sdk/tests/index.test.ts
@@ -142,7 +142,7 @@ describe("createKnowledgeTools", () => {
     expect(JSON.parse(result.content[0].text)).toEqual({ success: true });
   });
 
-  it("recall sends POST with query", async () => {
+  it("recall sends POST with query and default fact types", async () => {
     mockFetch.mockReturnValueOnce(mockResponse({ results: [{ text: "found" }] }));
 
     const tool = tools.find((t) => t.name === "agent_knowledge_recall")!;
@@ -152,6 +152,32 @@ describe("createKnowledgeTools", () => {
     const opts = getOpts(mockFetch.mock.calls[0]);
     expect(url).toContain("/v1/default/banks/test-bank/memories/recall");
     expect(opts.method).toBe("POST");
+    const body = await getBody(mockFetch.mock.calls[0]);
+    expect(body.query).toBe("what happened?");
+    expect(body.types).toEqual(["world", "experience"]);
+  });
+
+  it("recall can explicitly include observation fact types", async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ results: [{ text: "rule" }] }));
+
+    const tool = tools.find((t) => t.name === "agent_knowledge_recall")!;
+    await tool.execute({
+      query: "stable rules",
+      fact_types: ["world", "experience", "observation"],
+    });
+
+    const body = await getBody(mockFetch.mock.calls[0]);
+    expect(body.types).toEqual(["world", "experience", "observation"]);
+  });
+
+  it("recall accepts types as an alias for fact_types", async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ results: [{ text: "rule" }] }));
+
+    const tool = tools.find((t) => t.name === "agent_knowledge_recall")!;
+    await tool.execute({ query: "stable rules", types: ["observation"] });
+
+    const body = await getBody(mockFetch.mock.calls[0]);
+    expect(body.types).toEqual(["observation"]);
   });
 
   it("reflect sends POST with conservative defaults", async () => {

--- a/hindsight-tools/hindsight-agent-sdk/tests/index.test.ts
+++ b/hindsight-tools/hindsight-agent-sdk/tests/index.test.ts
@@ -55,8 +55,8 @@ describe("createKnowledgeTools", () => {
     });
   });
 
-  it("returns all 7 tools", () => {
-    expect(tools).toHaveLength(7);
+  it("returns all 8 tools", () => {
+    expect(tools).toHaveLength(8);
     const names = tools.map((t) => t.name);
     expect(names).toEqual([...TOOL_NAMES]);
   });
@@ -154,6 +154,44 @@ describe("createKnowledgeTools", () => {
     expect(opts.method).toBe("POST");
   });
 
+  it("reflect sends POST with conservative defaults", async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ text: "answer" }));
+
+    const tool = tools.find((t) => t.name === "agent_knowledge_reflect")!;
+    await tool.execute({ query: "what patterns matter?" });
+
+    const url = getUrl(mockFetch.mock.calls[0]);
+    const opts = getOpts(mockFetch.mock.calls[0]);
+    expect(url).toContain("/v1/default/banks/test-bank/reflect");
+    expect(opts.method).toBe("POST");
+    const body = await getBody(mockFetch.mock.calls[0]);
+    expect(body.query).toBe("what patterns matter?");
+    expect(body.budget).toBe("low");
+    expect(body.max_tokens).toBe(1024);
+    expect(body.fact_types).toEqual(["world", "experience", "observation"]);
+  });
+
+  it("reflect can include facts and override options", async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ text: "answer", based_on: { memories: [] } }));
+
+    const tool = tools.find((t) => t.name === "agent_knowledge_reflect")!;
+    await tool.execute({
+      query: "summarize",
+      budget: "mid",
+      max_tokens: 512,
+      fact_types: ["observation"],
+      include_facts: true,
+      exclude_mental_models: true,
+    });
+
+    const body = await getBody(mockFetch.mock.calls[0]);
+    expect(body.budget).toBe("mid");
+    expect(body.max_tokens).toBe(512);
+    expect(body.fact_types).toEqual(["observation"]);
+    expect(body.include).toEqual({ facts: {} });
+    expect(body.exclude_mental_models).toBe(true);
+  });
+
   it("ingest sends POST with content and document_id", async () => {
     mockFetch.mockReturnValueOnce(mockResponse({ status: "queued" }));
 
@@ -173,14 +211,15 @@ describe("createKnowledgeTools", () => {
       apiUrl: "http://localhost:9077",
       bankId: "test-bank",
     });
-    expect(noAuthTools).toHaveLength(7);
+    expect(noAuthTools).toHaveLength(8);
   });
 });
 
 describe("TOOL_NAMES", () => {
-  it("exports all 7 tool names", () => {
-    expect(TOOL_NAMES).toHaveLength(7);
+  it("exports all 8 tool names", () => {
+    expect(TOOL_NAMES).toHaveLength(8);
     expect(TOOL_NAMES).toContain("agent_knowledge_list_pages");
+    expect(TOOL_NAMES).toContain("agent_knowledge_reflect");
     expect(TOOL_NAMES).toContain("agent_knowledge_ingest");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,18 +513,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.5.6"
+        "@vectorize-io/hindsight-client": "^0.6.2"
       },
       "devDependencies": {
         "typescript": "^5.4",
         "vitest": "^4.1.2"
       }
-    },
-    "hindsight-tools/hindsight-agent-sdk/node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
-      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
-      "license": "MIT"
     },
     "hindsight-tools/self-driving-agents": {
       "name": "@vectorize-io/self-driving-agents",


### PR DESCRIPTION
## Summary

- update the OpenClaw integration to depend on `@vectorize-io/hindsight-all` and `@vectorize-io/hindsight-client` `^0.6.2`
- update the Agent SDK dependency on `@vectorize-io/hindsight-client` to `^0.6.2`
- document the OpenClaw distinction between automatic recall injection and manual `agent_knowledge_recall`, including `max_tokens` vs `recallTopK`

## Why

`@vectorize-io/hindsight-openclaw@0.7.7` currently still installs `@vectorize-io/hindsight-all@0.1.0` because `^0.1.0` resolves to `<0.2.0`. That leaves the embedded OpenClaw path on an old Hindsight server package even though the current Hindsight packages are at `0.6.2`.

The Agent SDK also still pins the client range to `^0.5.6`, so consumers can end up with a mixed dependency tree even after the `agent_knowledge_recall` `max_results` -> `max_tokens` fix.

## Verification

- `cd hindsight-tools/hindsight-agent-sdk && npm test`
- `cd hindsight-tools/hindsight-agent-sdk && npm run build`
- `cd hindsight-integrations/openclaw && npm run build`
- `cd hindsight-integrations/openclaw && npx vitest run src/manifest.test.ts src/index.test.ts src/setup-lib.test.ts src/session-patterns.test.ts`

Note: full `cd hindsight-integrations/openclaw && npm test` still has an unrelated existing failure in `src/backfill.test.ts` (`treats a symlinked bin path as direct execution`). The targeted OpenClaw suites above pass.


Update: this PR now also exposes `agent_knowledge_reflect` through the OpenClaw knowledge tools. The new tool uses conservative defaults (`budget: low`, `max_tokens: 1024`, `fact_types: ["world", "experience", "observation"]`) and the docs call out that production banks should set a finite `reflect_source_facts_max_tokens` (for example 4096 or 8192) to avoid unbounded source-fact context during ad-hoc reflection.
