### PR TITLE
fix(docs): correct DATABASE_URL env var name and fix invisible code in tip titles

### DIFF
--- a/hindsight-docs/docs/developer/storage.md
+++ b/hindsight-docs/docs/developer/storage.md
@@ -55,7 +55,7 @@ pg0 is a single binary containing:
 
 ### Behavior
 
-When no `DATABASE_URL` is configured, Hindsight:
+When no `HINDSIGHT_API_DATABASE_URL` is configured, Hindsight:
 1. Starts an embedded PostgreSQL instance on port 5555
 2. Initializes the schema
 3. Stores data in `~/.hindsight/pg0/`
@@ -65,7 +65,7 @@ When no `DATABASE_URL` is configured, Hindsight:
 | Environment | Database | Configuration |
 |-------------|----------|---------------|
 | Development | pg0 (embedded) | Automatic |
-| Production | PostgreSQL 15+ | `DATABASE_URL` environment variable |
+| Production | PostgreSQL 15+ | `HINDSIGHT_API_DATABASE_URL` environment variable |
 
 ## Requirements
 

--- a/hindsight-docs/src/css/custom.css
+++ b/hindsight-docs/src/css/custom.css
@@ -542,6 +542,14 @@ article a:not(.button):not([class*="hash-link"]):hover {
   align-items: center !important;
 }
 
+/* Inline code inside admonition headings: don't inherit the transparent
+   text fill from the gradient title, or backticks render invisible. */
+[class*="admonitionHeading_"] code {
+  -webkit-text-fill-color: initial !important;
+  color: var(--ifm-color-content) !important;
+  background-image: none !important;
+}
+
 /* Admonition icon - gradient start color */
 [class*="admonitionIcon_"] svg,
 [class*="admonitionIcon_"] svg path {

--- a/skills/hindsight-docs/references/developer/storage.md
+++ b/skills/hindsight-docs/references/developer/storage.md
@@ -55,7 +55,7 @@ pg0 is a single binary containing:
 
 ### Behavior
 
-When no `DATABASE_URL` is configured, Hindsight:
+When no `HINDSIGHT_API_DATABASE_URL` is configured, Hindsight:
 1. Starts an embedded PostgreSQL instance on port 5555
 2. Initializes the schema
 3. Stores data in `~/.hindsight/pg0/`
@@ -65,7 +65,7 @@ When no `DATABASE_URL` is configured, Hindsight:
 | Environment | Database | Configuration |
 |-------------|----------|---------------|
 | Development | pg0 (embedded) | Automatic |
-| Production | PostgreSQL 15+ | `DATABASE_URL` environment variable |
+| Production | PostgreSQL 15+ | `HINDSIGHT_API_DATABASE_URL` environment variable |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Storage page referenced `DATABASE_URL` but the actual env var is `HINDSIGHT_API_DATABASE_URL` (matches `configuration.md` and `admin-cli.md`). Closes #1722.
- Admonition heading uses `-webkit-text-fill-color: transparent` for the gradient title effect, which inline `<code>` children were inheriting — making backtick content in titles like `:::tip Set a stable HINDSIGHT_API_WORKER_ID in production` render invisible. Added a CSS rule that resets the fill color (and uses `--ifm-color-content`) for code inside admonition headings.

## Test plan
- [ ] `npm run start` in `hindsight-docs/`; visit `/developer/storage` — the variable name reads `HINDSIGHT_API_DATABASE_URL` in both the Behavior paragraph and the Environments table.
- [ ] Visit `/developer/installation#docker` and `/developer/api/quickstart` — the `HINDSIGHT_API_WORKER_ID` backtick text in the tip title is visible in both light and dark mode.