### PR TITLE
fix(ollama): add ollama-cloud provider and fix native API auth

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -478,6 +478,7 @@ PROVIDER_DEFAULT_MODELS = {
     "zai": "glm-4.5-flash",
     "opencode-go": "deepseek-v4-flash",
     "ollama": "gemma3:12b",
+    "ollama-cloud": "gemma3:12b",
     "llamacpp": "gemma-4-e2b-it",
     "lmstudio": "local-model",
     "vertexai": "google/gemini-2.5-flash-lite",
@@ -1922,6 +1923,8 @@ class HindsightConfig:
             return "https://api.groq.com/openai/v1"
         elif provider == "ollama":
             return "http://localhost:11434/v1"
+        elif provider == "ollama-cloud":
+            return "https://ollama.com/v1"
         elif provider == "lmstudio":
             return "http://localhost:1234/v1"
         else:

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -312,6 +312,7 @@ def create_llm_provider(
         "openai",
         "groq",
         "ollama",
+        "ollama-cloud",
         "lmstudio",
         "minimax",
         "deepseek",
@@ -409,6 +410,7 @@ class LLMProvider:
             "openai",
             "groq",
             "ollama",
+            "ollama-cloud",
             "gemini",
             "anthropic",
             "lmstudio",
@@ -437,6 +439,8 @@ class LLMProvider:
                 self.base_url = "https://api.groq.com/openai/v1"
             elif self.provider == "ollama":
                 self.base_url = "http://localhost:11434/v1"
+            elif self.provider == "ollama-cloud":
+                self.base_url = "https://ollama.com/v1"
             elif self.provider == "lmstudio":
                 self.base_url = "http://localhost:1234/v1"
             elif self.provider == "minimax":

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -518,6 +518,8 @@ class MemoryEngine(MemoryEngineInterface):
                 memory_llm_base_url = "https://api.groq.com/openai/v1"
             elif memory_llm_provider.lower() == "ollama":
                 memory_llm_base_url = "http://localhost:11434/v1"
+            elif memory_llm_provider.lower() == "ollama-cloud":
+                memory_llm_base_url = "https://ollama.com/v1"
             else:
                 memory_llm_base_url = ""
 
@@ -590,6 +592,8 @@ class MemoryEngine(MemoryEngineInterface):
                 retain_base_url = "https://api.groq.com/openai/v1"
             elif retain_provider.lower() == "ollama":
                 retain_base_url = "http://localhost:11434/v1"
+            elif retain_provider.lower() == "ollama-cloud":
+                retain_base_url = "https://ollama.com/v1"
             else:
                 retain_base_url = ""
 
@@ -614,6 +618,8 @@ class MemoryEngine(MemoryEngineInterface):
                 reflect_base_url = "https://api.groq.com/openai/v1"
             elif reflect_provider.lower() == "ollama":
                 reflect_base_url = "http://localhost:11434/v1"
+            elif reflect_provider.lower() == "ollama-cloud":
+                reflect_base_url = "https://ollama.com/v1"
             else:
                 reflect_base_url = ""
 
@@ -638,6 +644,8 @@ class MemoryEngine(MemoryEngineInterface):
                 consolidation_base_url = "https://api.groq.com/openai/v1"
             elif consolidation_provider.lower() == "ollama":
                 consolidation_base_url = "http://localhost:11434/v1"
+            elif consolidation_provider.lower() == "ollama-cloud":
+                consolidation_base_url = "https://ollama.com/v1"
             else:
                 consolidation_base_url = ""
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -270,6 +270,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "openai",
             "groq",
             "ollama",
+            "ollama-cloud",
             "lmstudio",
             "llamacpp",
             "minimax",
@@ -288,6 +289,8 @@ class OpenAICompatibleLLM(LLMInterface):
                 self.base_url = "https://api.groq.com/openai/v1"
             elif self.provider == "ollama":
                 self.base_url = "http://localhost:11434/v1"
+            elif self.provider == "ollama-cloud":
+                self.base_url = "https://ollama.com/v1"
             elif self.provider == "lmstudio":
                 self.base_url = "http://localhost:1234/v1"
             elif self.provider == "minimax":
@@ -316,6 +319,7 @@ class OpenAICompatibleLLM(LLMInterface):
                 "openrouter",
                 "zai",
                 "opencode-go",
+                "ollama-cloud",
             )
             and not self.api_key
         ):
@@ -1073,12 +1077,17 @@ class OpenAICompatibleLLM(LLMInterface):
 
         last_exception = None
 
+        # Pass API key as Bearer token for cloud Ollama endpoints
+        headers: dict[str, str] = {}
+        if self.api_key and self.api_key != "local":
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
         async with httpx.AsyncClient(timeout=300.0) as client:
             for attempt in range(max_retries + 1):
                 if attempt > 0:
                     set_stage(f"llm.ollama_native.{scope}.attempt={attempt + 1}/{max_retries + 1}")
                 try:
-                    response = await client.post(native_url, json=payload)
+                    response = await client.post(native_url, json=payload, headers=headers)
                     response.raise_for_status()
 
                     result = response.json()

--- a/hindsight-api-slim/hindsight_api/tracing.py
+++ b/hindsight-api-slim/hindsight_api/tracing.py
@@ -129,6 +129,7 @@ PROVIDER_NAME_MAPPING = {
     "vertexai": "google",
     "groq": "groq",
     "ollama": "ollama",
+    "ollama-cloud": "ollama",
     "lmstudio": "lmstudio",
     "openai-codex": "openai",
     "claude-code": "anthropic",

--- a/hindsight-docs/docs-integrations/claude-code.md
+++ b/hindsight-docs/docs-integrations/claude-code.md
@@ -128,7 +128,7 @@ These settings configure which LLM the local daemon uses for fact extraction. Th
 
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
-| `llmProvider` | `HINDSIGHT_LLM_PROVIDER` | auto-detect | Which LLM provider to use. Supported values: `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `openai-codex`, `claude-code`. When omitted, the plugin auto-detects by checking for API key env vars in order: `OPENAI_API_KEY` → `ANTHROPIC_API_KEY` → `GEMINI_API_KEY` → `GROQ_API_KEY`. |
+| `llmProvider` | `HINDSIGHT_LLM_PROVIDER` | auto-detect | Which LLM provider to use. Supported values: `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `ollama-cloud`, `openai-codex`, `claude-code`. When omitted, the plugin auto-detects by checking for API key env vars in order: `OPENAI_API_KEY` → `ANTHROPIC_API_KEY` → `GEMINI_API_KEY` → `GROQ_API_KEY`. |
 | `llmModel` | `HINDSIGHT_LLM_MODEL` | provider default | Override the default model for the chosen provider (e.g. `"gpt-4o"`, `"claude-sonnet-4-20250514"`). When omitted, the Hindsight API picks a sensible default for each provider. |
 | `llmApiKeyEnv` | — | provider standard | Name of the environment variable that holds the API key. Normally auto-detected (e.g. `OPENAI_API_KEY` for the `openai` provider). Set this only if your key is in a non-standard env var. |
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -230,6 +230,11 @@ export HINDSIGHT_API_LLM_VERTEXAI_REGION=us-central1
 export HINDSIGHT_API_LLM_PROVIDER=ollama
 export HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
 export HINDSIGHT_API_LLM_MODEL=llama3
+
+# Ollama Cloud (hosted Ollama endpoint, requires API key)
+export HINDSIGHT_API_LLM_PROVIDER=ollama-cloud
+export HINDSIGHT_API_LLM_API_KEY=your-ollama-cloud-api-key
+export HINDSIGHT_API_LLM_MODEL=gemma3:12b
 
 # LM Studio (local, no API key)
 export HINDSIGHT_API_LLM_PROVIDER=lmstudio

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -158,6 +158,11 @@ export HINDSIGHT_API_LLM_PROVIDER=ollama
 export HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
 export HINDSIGHT_API_LLM_MODEL=llama3
 
+# Ollama Cloud (hosted Ollama endpoint, requires API key)
+export HINDSIGHT_API_LLM_PROVIDER=ollama-cloud
+export HINDSIGHT_API_LLM_API_KEY=your-ollama-cloud-api-key
+export HINDSIGHT_API_LLM_MODEL=gemma3:12b
+
 # LM Studio (local)
 export HINDSIGHT_API_LLM_PROVIDER=lmstudio
 export HINDSIGHT_API_LLM_BASE_URL=http://localhost:1234/v1

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -5,6 +5,7 @@
   {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "gemini-2.0-flash-001"},
   {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b"},
   {"id": "ollama",        "label": "Ollama",            "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
+  {"id": "ollama-cloud",  "label": "Ollama Cloud",      "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
   {"id": "lmstudio",      "label": "LM Studio",         "iconKey": "brain",              "defaultModel": "local-model"},
   {"id": "llamacpp",      "label": "llama.cpp",         "iconKey": "terminal",           "defaultModel": "gemma-4-e2b-it", "defaultModelNote": "auto-downloaded GGUF"},
   {"id": "minimax",       "label": "MiniMax",           "iconKey": "sparkles",           "defaultModel": "MiniMax-M2.7"},

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -176,7 +176,7 @@ To switch between backends:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -230,6 +230,11 @@ export HINDSIGHT_API_LLM_VERTEXAI_REGION=us-central1
 export HINDSIGHT_API_LLM_PROVIDER=ollama
 export HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
 export HINDSIGHT_API_LLM_MODEL=llama3
+
+# Ollama Cloud (hosted Ollama endpoint, requires API key)
+export HINDSIGHT_API_LLM_PROVIDER=ollama-cloud
+export HINDSIGHT_API_LLM_API_KEY=your-ollama-cloud-api-key
+export HINDSIGHT_API_LLM_MODEL=gemma3:12b
 
 # LM Studio (local, no API key)
 export HINDSIGHT_API_LLM_PROVIDER=lmstudio

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -25,6 +25,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - Vertex AI
 - Groq
 - Ollama
+- Ollama Cloud
 - LM Studio
 - llama.cpp
 - MiniMax
@@ -105,6 +106,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `vertexai` | `gemini-2.0-flash-001` |
 | `groq` | `openai/gpt-oss-120b` |
 | `ollama` | `gemma3:12b` |
+| `ollama-cloud` | `gemma3:12b` |
 | `lmstudio` | `local-model` |
 | `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
 | `minimax` | `MiniMax-M2.7` |
@@ -186,6 +188,11 @@ export HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-20250514
 export HINDSIGHT_API_LLM_PROVIDER=ollama
 export HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
 export HINDSIGHT_API_LLM_MODEL=llama3
+
+# Ollama Cloud (hosted Ollama endpoint, requires API key)
+export HINDSIGHT_API_LLM_PROVIDER=ollama-cloud
+export HINDSIGHT_API_LLM_API_KEY=your-ollama-cloud-api-key
+export HINDSIGHT_API_LLM_MODEL=gemma3:12b
 
 # LM Studio (local)
 export HINDSIGHT_API_LLM_PROVIDER=lmstudio

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -71,6 +71,7 @@ Browse all supported integrations in the Integrations Hub.
 - Vertex AI
 - Groq
 - Ollama
+- Ollama Cloud
 - LM Studio
 - llama.cpp
 - MiniMax


### PR DESCRIPTION
## Summary

- **Fix native Ollama API auth**: `_call_ollama_native()` used raw httpx without auth headers, causing 401 errors on Ollama Cloud. Now passes `Authorization: Bearer` when a real API key is provided.
- **Add `ollama-cloud` provider**: First-class cloud provider that uses the OpenAI-compatible path exclusively (no native `/api/chat` fallback), requires an API key, and defaults to `https://ollama.com/v1`.
- **Docs**: Added `ollama-cloud` to provider lists, configuration examples, and the provider grid.

Closes #1559

## Test plan

- [x] Verified `ollama-cloud` provider initializes with correct base URL and API key
- [x] Verified simple LLM call succeeds against Ollama Cloud endpoint
- [x] Verified structured output call succeeds via OpenAI-compatible path (the previously failing path)
- [x] Verified original `ollama` provider native API auth fix works (no more 401)
- [x] Linter passes