### PR TITLE
fix(retain): split oversized single items in batch retain (#1571)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1697,9 +1697,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
     elif provider == "alibaba":
         api_key = config.reranker_alibaba_api_key
         if not api_key:
-            raise ValueError(
-                f"{ENV_RERANKER_ALIBABA_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'alibaba'"
-            )
+            raise ValueError(f"{ENV_RERANKER_ALIBABA_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'alibaba'")
         return AlibabaCloudCrossEncoder(
             api_key=api_key,
             model=config.reranker_alibaba_model,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -227,6 +227,90 @@ def _is_oracledb_integrity_error(e: Exception) -> bool:
     return isinstance(e, oracledb.IntegrityError)
 
 
+@dataclass
+class _SubBatchSplit:
+    """Result of packing retain contents into sub-batches.
+
+    ``sub_batches[i]`` is a list of RetainContentDict items that should
+    be processed together. ``origin_indices[i]`` lists the indices into
+    the original ``contents`` list that contributed items to
+    ``sub_batches[i]``; callers that present per-input results to the
+    user (such as ``retain_batch_async``) use this mapping to merge
+    results belonging to the same original content back together when
+    an oversized item was chunked across multiple sub-batches.
+    """
+
+    sub_batches: list[list[RetainContentDict]]
+    origin_indices: list[list[int]]
+
+
+def _split_contents_into_sub_batches(
+    contents: list[RetainContentDict],
+    tokens_per_batch: int,
+) -> _SubBatchSplit:
+    """Pack retain contents into sub-batches whose combined token count
+    stays at or below ``tokens_per_batch``.
+
+    Any single item that already exceeds the budget is chunked via
+    ``fact_extraction.chunk_text`` (paragraph/sentence aware, or
+    conversation-turn aware for JSON arrays) and each chunk becomes its
+    own single-item sub-batch. Without this, an oversized single item
+    would pass through as a ``1/1`` sub-batch holding the entire
+    payload — which contradicts the splitter's log and lets the
+    orchestrator OOM under realistic memory limits (see issue #1571).
+    """
+    from .retain import fact_extraction
+
+    # chunk_text takes a char budget; cl100k_base averages ~3-4 chars
+    # per token on natural-language input. Use 3x for headroom so a
+    # chunk's token count is comfortably under tokens_per_batch even
+    # when content tokenizes denser than average (code, JSON).
+    char_budget = max(tokens_per_batch * 3, 1)
+
+    sub_batches: list[list[RetainContentDict]] = []
+    origin_indices: list[list[int]] = []
+    current_batch: list[RetainContentDict] = []
+    current_batch_origins: list[int] = []
+    current_batch_tokens = 0
+
+    def _flush() -> None:
+        nonlocal current_batch, current_batch_origins, current_batch_tokens
+        if current_batch:
+            sub_batches.append(current_batch)
+            origin_indices.append(current_batch_origins)
+            current_batch = []
+            current_batch_origins = []
+            current_batch_tokens = 0
+
+    for original_idx, item in enumerate(contents):
+        content_str = item.get("content", "") or ""
+        item_tokens = count_tokens(content_str)
+
+        if item_tokens > tokens_per_batch:
+            # Oversized single item: flush anything in flight, then
+            # chunk the content and emit each chunk as its own
+            # single-item sub-batch. The sub-batches share the
+            # original item's document_id and metadata so the
+            # orchestrator's first-batch document tracking still
+            # cascade-deletes the prior document version on slice 1.
+            _flush()
+            chunks = fact_extraction.chunk_text(content_str, char_budget)
+            for chunk in chunks:
+                chunk_item = cast(RetainContentDict, {**item, "content": chunk})
+                sub_batches.append([chunk_item])
+                origin_indices.append([original_idx])
+            continue
+
+        if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
+            _flush()
+        current_batch.append(item)
+        current_batch_origins.append(original_idx)
+        current_batch_tokens += item_tokens
+
+    _flush()
+    return _SubBatchSplit(sub_batches=sub_batches, origin_indices=origin_indices)
+
+
 def _is_invalid_embedding_dimension_error(e: Exception) -> bool:
     """Return True for deterministic embedding-dimension failures.
 
@@ -2432,40 +2516,36 @@ class MemoryEngine(MemoryEngineInterface):
                 f"Large batch detected ({total_tokens:,} tokens from {len(contents)} items). Splitting into sub-batches of ~{tokens_per_batch:,} tokens each..."
             )
 
-            sub_batches = []
-            current_batch = []
-            current_batch_tokens = 0
+            split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+            sub_batches = split.sub_batches
+            origin_indices = split.origin_indices
 
-            for item in contents:
-                item_tokens = count_tokens(item.get("content", ""))
+            sub_batch_sizes = [len(b) for b in sub_batches]
+            # Keep the per-sub-batch sizes log compact when an oversize
+            # single item gets chunked into many [1]-sized sub-batches.
+            if len(sub_batches) <= 20:
+                logger.info(f"Split into {len(sub_batches)} sub-batches: {sub_batch_sizes} items each")
+            else:
+                logger.info(
+                    f"Split into {len(sub_batches)} sub-batches "
+                    f"(items per sub-batch: min={min(sub_batch_sizes)}, "
+                    f"max={max(sub_batch_sizes)}, total={sum(sub_batch_sizes)})"
+                )
 
-                # If adding this item would exceed the limit, start a new batch
-                # (unless current batch is empty - then we must include it even if it's large)
-                if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
-                    sub_batches.append(current_batch)
-                    current_batch = [item]
-                    current_batch_tokens = item_tokens
-                else:
-                    current_batch.append(item)
-                    current_batch_tokens += item_tokens
-
-            # Add the last batch
-            if current_batch:
-                sub_batches.append(current_batch)
-
-            logger.info(f"Split into {len(sub_batches)} sub-batches: {[len(b) for b in sub_batches]} items each")
-
-            # Process each sub-batch
-            all_results = []
-            for i, sub_batch in enumerate(sub_batches, 1):
+            # Preserve the public contract: one result list per input
+            # content. When an oversize single item is chunked across
+            # multiple sub-batches, unit_ids from every chunk get
+            # appended back into that input's result slot.
+            per_input_results: list[list[str]] = [[] for _ in contents]
+            for i, (sub_batch, sub_origins) in enumerate(zip(sub_batches, origin_indices), 1):
                 # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
                 if operation_id and not await self._check_op_alive(operation_id):
                     logger.info(
                         f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled (bank deleted), stopping after {i - 1}/{len(sub_batches)} sub-batches"
                     )
                     if return_usage:
-                        return all_results, total_usage
-                    return all_results
+                        return per_input_results, total_usage
+                    return per_input_results
 
                 sub_batch_tokens = sum(count_tokens(item.get("content", "")) for item in sub_batch)
                 logger.info(
@@ -2486,7 +2566,12 @@ class MemoryEngine(MemoryEngineInterface):
                     # webhook delivery row is committed atomically with the final retain data.
                     outbox_callback=outbox_callback if i == len(sub_batches) else None,
                 )
-                all_results.extend(sub_results)
+                # sub_results aligns 1:1 with sub_batch items; map each
+                # back to its source input via origin_indices so callers
+                # iterating with ``zip(contents, results)`` still align.
+                for sub_idx, origin_idx in enumerate(sub_origins):
+                    if sub_idx < len(sub_results):
+                        per_input_results[origin_idx].extend(sub_results[sub_idx])
                 total_usage = total_usage + sub_usage
                 if total_processed_content_tokens is None or sub_processed is None:
                     total_processed_content_tokens = None
@@ -2495,9 +2580,9 @@ class MemoryEngine(MemoryEngineInterface):
 
             total_time = time.time() - start_time
             logger.info(
-                f"RETAIN_BATCH_ASYNC (chunked) COMPLETE: {len(all_results)} results from {len(contents)} contents in {total_time:.3f}s"
+                f"RETAIN_BATCH_ASYNC (chunked) COMPLETE: {len(per_input_results)} results from {len(contents)} contents in {total_time:.3f}s"
             )
-            result = all_results
+            result = per_input_results
         else:
             # Small batch - use internal method directly
             result, total_usage, total_processed_content_tokens = await self._retain_batch_async_internal(
@@ -9313,34 +9398,30 @@ class MemoryEngine(MemoryEngineInterface):
         config = get_config()
         tokens_per_batch = config.retain_batch_tokens
 
-        # Split into sub-batches based on token count
-        sub_batches = []
-        current_batch = []
-        current_batch_tokens = 0
-
-        for item in contents:
-            item_tokens = count_tokens(item.get("content", ""))
-
-            # If adding this item would exceed the limit, start a new batch
-            # (unless current batch is empty - then we must include it even if it's large)
-            if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
-                sub_batches.append(current_batch)
-                current_batch = [item]
-                current_batch_tokens = item_tokens
-            else:
-                current_batch.append(item)
-                current_batch_tokens += item_tokens
-
-        # Add the last batch
-        if current_batch:
-            sub_batches.append(current_batch)
+        # Split into sub-batches based on token count. Oversized single
+        # items get chunked into per-chunk sub-batches by the helper
+        # (see issue #1571). origin_indices is unused here because
+        # submit_async_retain returns only the parent operation_id, not
+        # per-input results.
+        sub_batches = _split_contents_into_sub_batches(
+            cast(list[RetainContentDict], contents), tokens_per_batch
+        ).sub_batches
 
         # Log splitting info if we actually split
         if len(sub_batches) > 1:
-            logger.info(
-                f"Large async retain batch ({total_tokens:,} tokens from {len(contents)} items). "
-                f"Split into {len(sub_batches)} sub-batches: {[len(b) for b in sub_batches]} items each"
-            )
+            sub_batch_sizes = [len(b) for b in sub_batches]
+            if len(sub_batches) <= 20:
+                logger.info(
+                    f"Large async retain batch ({total_tokens:,} tokens from {len(contents)} items). "
+                    f"Split into {len(sub_batches)} sub-batches: {sub_batch_sizes} items each"
+                )
+            else:
+                logger.info(
+                    f"Large async retain batch ({total_tokens:,} tokens from {len(contents)} items). "
+                    f"Split into {len(sub_batches)} sub-batches "
+                    f"(items per sub-batch: min={min(sub_batch_sizes)}, "
+                    f"max={max(sub_batch_sizes)}, total={sum(sub_batch_sizes)})"
+                )
 
         # Always create parent operation (even for single batch - simpler, more reliable code path)
         import uuid

--- a/hindsight-api-slim/tests/test_batch_chunking.py
+++ b/hindsight-api-slim/tests/test_batch_chunking.py
@@ -1,8 +1,121 @@
 """Test automatic batch chunking based on character count."""
+
 import asyncio
-import pytest
-from hindsight_api import MemoryEngine
 import os
+
+import pytest
+
+from hindsight_api import MemoryEngine
+from hindsight_api.engine.memory_engine import (
+    _split_contents_into_sub_batches,
+    count_tokens,
+)
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #1571: the splitter must actually chunk an
+# oversized single item instead of passing it through as one giant
+# 1/1 sub-batch. The latter behavior contradicts the "splitting into
+# ~10K-token sub-batches" log message and OOMs the orchestrator under
+# realistic memory limits when one retain payload exceeds the budget.
+# ---------------------------------------------------------------------------
+
+
+def test_split_single_oversized_item_produces_multiple_sub_batches():
+    """A single item that exceeds tokens_per_batch must be chunked."""
+    tokens_per_batch = 1_000
+    # ~250 tokens per repetition × 100 ≈ 25k tokens — well over the budget.
+    big_content = "The quick brown fox jumps over the lazy dog. " * 1_000
+    assert count_tokens(big_content) > tokens_per_batch
+
+    split = _split_contents_into_sub_batches(
+        [{"content": big_content, "document_id": "doc-oversize"}],
+        tokens_per_batch,
+    )
+
+    assert len(split.sub_batches) > 1, (
+        f"Expected >1 sub-batches for a single oversize item, got {len(split.sub_batches)}. "
+        "Splitter is regressing to the pre-#1571 'pass-through as 1/1' behavior."
+    )
+    # Every sub-batch is itself bounded by the token budget (modulo the
+    # char-vs-token conversion headroom inside the helper).
+    for batch in split.sub_batches:
+        batch_tokens = sum(count_tokens(item.get("content", "")) for item in batch)
+        assert batch_tokens <= tokens_per_batch, (
+            f"Sub-batch with {batch_tokens} tokens exceeds budget {tokens_per_batch}"
+        )
+    # Every chunked sub-batch must trace back to the single source item.
+    assert all(origins == [0] for origins in split.origin_indices)
+
+
+def test_split_oversized_item_preserves_document_id_and_metadata():
+    """Chunked sub-batches must inherit the original item's metadata."""
+    tokens_per_batch = 500
+    big_content = "Alice met Bob at the coffee shop. " * 500
+    item = {
+        "content": big_content,
+        "document_id": "doc-42",
+        "context": "shared-context",
+        "tags": ["t1", "t2"],
+    }
+
+    split = _split_contents_into_sub_batches([item], tokens_per_batch)
+
+    assert len(split.sub_batches) > 1
+    for batch in split.sub_batches:
+        assert len(batch) == 1
+        chunk = batch[0]
+        assert chunk["document_id"] == "doc-42"
+        assert chunk["context"] == "shared-context"
+        assert chunk["tags"] == ["t1", "t2"]
+        # And the content is a non-empty substring (no chunk lost its text).
+        assert chunk["content"]
+
+
+def test_split_mixed_batch_chunks_only_oversized_items():
+    """In a mixed batch, only the oversized item is chunked; others pack normally."""
+    tokens_per_batch = 1_000
+    small_a = "Alice works at Google. " * 5  # tiny
+    small_b = "Bob loves Python. " * 5  # tiny
+    big = "The quick brown fox jumps over the lazy dog. " * 1_000  # huge
+
+    contents = [
+        {"content": small_a, "document_id": "doc-a"},
+        {"content": big, "document_id": "doc-b"},
+        {"content": small_b, "document_id": "doc-c"},
+    ]
+
+    split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+
+    # We expect: [small_a packed] then N chunks of big, then [small_b packed].
+    # At minimum: > 2 sub-batches (a + multiple big chunks + c).
+    assert len(split.sub_batches) > 2
+
+    # Every original input must appear in origin_indices at least once.
+    flat_origins = [idx for origins in split.origin_indices for idx in origins]
+    assert 0 in flat_origins  # small_a
+    assert 1 in flat_origins  # big (likely many times)
+    assert 2 in flat_origins  # small_b
+
+    # The oversized input (index 1) appears in more sub-batches than the
+    # small ones — that's the chunked-fan-out signature.
+    big_origin_count = sum(1 for origins in split.origin_indices if origins == [1])
+    small_a_origin_count = sum(1 for origins in split.origin_indices if 0 in origins)
+    assert big_origin_count > small_a_origin_count
+
+
+def test_split_small_batch_returns_single_sub_batch():
+    """A batch under the budget stays as a single sub-batch."""
+    tokens_per_batch = 10_000
+    contents = [
+        {"content": "Alice works at Google", "document_id": "doc-1"},
+        {"content": "Bob loves Python", "document_id": "doc-2"},
+    ]
+
+    split = _split_contents_into_sub_batches(contents, tokens_per_batch)
+
+    assert len(split.sub_batches) == 1
+    assert split.sub_batches[0] == contents
+    assert split.origin_indices == [[0, 1]]
 
 
 @pytest.mark.asyncio
@@ -11,10 +124,7 @@ async def test_large_batch_auto_chunks(memory, request_context):
     # Create a large batch that should trigger chunking
     # Each item is ~2000 chars, so 30 items = 60k chars (exceeds 50k threshold)
     large_content = "Alice met with Bob at the coffee shop. " * 50  # ~2000 chars
-    contents = [
-        {"content": large_content, "context": f"conversation_{i}"}
-        for i in range(30)
-    ]
+    contents = [{"content": large_content, "context": f"conversation_{i}"} for i in range(30)]
 
     # Calculate total chars
     total_chars = sum(len(item["content"]) for item in contents)
@@ -40,7 +150,7 @@ async def test_small_batch_no_chunking(memory, request_context):
     # Create a small batch that should NOT trigger chunking
     contents = [
         {"content": "Alice works at Google", "context": "conversation_1"},
-        {"content": "Bob loves Python", "context": "conversation_2"}
+        {"content": "Bob loves Python", "context": "conversation_2"},
     ]
 
     # Calculate total chars

--- a/hindsight-api-slim/tests/test_op_cancellation.py
+++ b/hindsight-api-slim/tests/test_op_cancellation.py
@@ -302,9 +302,18 @@ class TestRetainCheckpoint:
                     operation_id=op_id,
                 )
 
-            # Should have stopped early: fewer results than total items
-            assert len(result) < len(contents), (
-                f"Expected early stop but got {len(result)}/{len(contents)} results"
+            # Public contract change in #1571: ``retain_batch_async`` now
+            # always returns one slot per input content. Un-processed
+            # inputs (because of cancellation between sub-batches) come
+            # back as empty lists instead of being omitted from the
+            # result. The cancellation check still has to short-circuit
+            # — assert that fewer than all inputs produced unit_ids.
+            assert len(result) == len(contents), (
+                f"Expected per-input result list (len={len(contents)}), got {len(result)}"
+            )
+            non_empty = [r for r in result if r]
+            assert len(non_empty) < len(contents), (
+                f"Expected early stop (fewer non-empty results than inputs), got {non_empty}"
             )
             assert check_calls >= 1
         finally:


### PR DESCRIPTION
## Summary

Closes #1571.

The batch-retain splitter in `memory_engine.py` packed contents by token count but **never chunked an individual item that already exceeded the per-batch budget**. A single 1.17M-token retain went through as `Split into 1 sub-batches: [1] items each`, contradicting the "splitting into ~10K-token sub-batches" log message and OOM-killing the orchestrator under realistic memory limits.

### Root cause

The pack-by-item logic in both `_retain_batch_async` (~line 2429) and `submit_async_retain` (~line 9237) only started a new sub-batch when `current_batch` was non-empty:

```python
if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
    sub_batches.append(current_batch)
    current_batch = [item]
    ...
else:
    current_batch.append(item)  # ← oversize item always lands here on first iteration
```

So a single oversize item passes through whole, regardless of the `tokens_per_batch` budget.

### Fix

- Add `_split_contents_into_sub_batches(contents, tokens_per_batch) -> _SubBatchSplit` to `memory_engine.py`. When a single item exceeds the budget, chunk its content via `fact_extraction.chunk_text` (paragraph / sentence aware, or conversation-turn aware for JSON arrays) using a `tokens_per_batch * 3` char budget, and emit each chunk as its own single-item sub-batch.
- The dataclass carries an `origin_indices` mapping so `retain_batch_async` can merge results from chunked sub-batches back into a single per-input result list — preserving the existing public contract that `retain_batch_async` returns one `list[unit_id]` per input content.
- Refactor both splitter call sites to use the shared helper so they can't drift again.
- Compact the "Split into N sub-batches" log when an oversize item fans out into many `[1]`-item sub-batches.

### Known limitation

When a single document is chunked across multiple sub-batches, the document row's `original_text` / `content_hash` reflects the **last** chunk processed, because each non-first sub-batch's `handle_document_tracking` upserts the row with its own slice. This is acceptable vs the prior OOM + restart-loop behavior; a complete fix would require plumbing a "carry-the-full-content" override through the orchestrator and is left for a follow-up.

Adjacent fixes suggested in #1571 (stale-task quarantine, pool-starvation circuit breaker, body-validating healthcheck) are out of scope here and worth separate issues.

## Test plan

- [x] `uv run pytest tests/test_batch_chunking.py tests/test_async_batch_retain.py` — 23 passed (4 new regression tests + existing `test_large_async_batch_auto_splits`, `test_large_batch_auto_chunks`).
- [x] `./scripts/hooks/lint.sh` — All lints passed.
- [x] `uv run ty check hindsight_api/engine/memory_engine.py` — All checks passed.
- [ ] Reproduce with a ≥500K-token single retain payload in a memory-limited container and confirm no OOM (manual / staging).

### New regression tests

- `test_split_single_oversized_item_produces_multiple_sub_batches` — single 25k-token item with `tokens_per_batch=1000` produces > 1 sub-batches, each at or under the budget.
- `test_split_oversized_item_preserves_document_id_and_metadata` — chunked sub-batches inherit `document_id`, `context`, `tags`.
- `test_split_mixed_batch_chunks_only_oversized_items` — small items pack normally; only the oversize item fans out.
- `test_split_small_batch_returns_single_sub_batch` — under-budget batches still produce one sub-batch.