### PR TITLE
fix(api): wire up per-operation LLM concurrency caps

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1697,9 +1697,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
     elif provider == "alibaba":
         api_key = config.reranker_alibaba_api_key
         if not api_key:
-            raise ValueError(
-                f"{ENV_RERANKER_ALIBABA_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'alibaba'"
-            )
+            raise ValueError(f"{ENV_RERANKER_ALIBABA_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'alibaba'")
         return AlibabaCloudCrossEncoder(
             api_key=api_key,
             model=config.reranker_alibaba_model,

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -9,6 +9,7 @@ import os
 import re
 import time
 import uuid
+from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import Any
 
@@ -27,9 +28,12 @@ except ImportError:
 from ..config import (
     DEFAULT_LLM_MAX_CONCURRENT,
     DEFAULT_LLM_TIMEOUT,
+    ENV_CONSOLIDATION_LLM_MAX_CONCURRENT,
     ENV_LLM_GROQ_SERVICE_TIER,
     ENV_LLM_MAX_CONCURRENT,
     ENV_LLM_TIMEOUT,
+    ENV_REFLECT_LLM_MAX_CONCURRENT,
+    ENV_RETAIN_LLM_MAX_CONCURRENT,
 )
 from ..metrics import get_metrics_collector
 from .response_models import TokenUsage
@@ -42,10 +46,72 @@ logger = logging.getLogger(__name__)
 # Disable httpx logging
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
-# Global semaphore to limit concurrent LLM requests across all instances
-# Set HINDSIGHT_API_LLM_MAX_CONCURRENT=1 for local LLMs (LM Studio, Ollama)
+# Global semaphore to limit concurrent LLM requests across all instances.
+# Set HINDSIGHT_API_LLM_MAX_CONCURRENT=1 for local LLMs (LM Studio, Ollama).
 _llm_max_concurrent = int(os.getenv(ENV_LLM_MAX_CONCURRENT, str(DEFAULT_LLM_MAX_CONCURRENT)))
 _global_llm_semaphore = asyncio.Semaphore(_llm_max_concurrent)
+
+
+def _build_per_op_semaphores() -> dict[str, asyncio.Semaphore]:
+    """Build the per-operation semaphore registry from env vars.
+
+    Each per-op cap is composed with — not a substitute for — the global cap:
+    a call that matches a configured operation must acquire both its per-op
+    semaphore and the global semaphore. This lets operators reserve headroom
+    in the global pool by capping individual operations (e.g. cap retain at 2
+    of 4 global slots so the live chat path always has 2 slots available).
+
+    Operations without a configured env var are absent from the registry and
+    therefore only constrained by the global cap.
+    """
+    semaphores: dict[str, asyncio.Semaphore] = {}
+    for op, env_var in (
+        ("retain", ENV_RETAIN_LLM_MAX_CONCURRENT),
+        ("reflect", ENV_REFLECT_LLM_MAX_CONCURRENT),
+        ("consolidation", ENV_CONSOLIDATION_LLM_MAX_CONCURRENT),
+    ):
+        raw = os.getenv(env_var)
+        if raw is None or raw == "":
+            continue
+        value = int(raw)
+        if value <= 0:
+            raise ValueError(f"{env_var} must be a positive integer, got {raw!r}")
+        semaphores[op] = asyncio.Semaphore(value)
+    return semaphores
+
+
+_per_op_llm_semaphores: dict[str, asyncio.Semaphore] = _build_per_op_semaphores()
+
+
+def _scope_to_operation(scope: str) -> str | None:
+    """Map a call scope to its per-operation concurrency bucket.
+
+    Returns None for scopes that don't belong to a tracked operation
+    (verification probes, bank_mission, memory_think, mental_model_delta_ops),
+    which then run under the global cap only.
+    """
+    if scope.startswith("retain"):
+        return "retain"
+    if scope.startswith("reflect"):
+        return "reflect"
+    if scope.startswith("consolidation"):
+        return "consolidation"
+    return None
+
+
+def _semaphores_for_scope(scope: str) -> list[asyncio.Semaphore]:
+    """Return the semaphores a call with the given scope must acquire.
+
+    Always includes the global semaphore; includes the per-op semaphore when
+    one is configured for the scope's operation bucket.
+    """
+    op = _scope_to_operation(scope)
+    per_op = _per_op_llm_semaphores.get(op) if op is not None else None
+    if per_op is None:
+        return [_global_llm_semaphore]
+    # Per-op acquired first so contention queues on the narrower cap before
+    # holding a global slot.
+    return [per_op, _global_llm_semaphore]
 
 
 def sanitize_llm_output(text: str | None) -> str | None:
@@ -629,7 +695,10 @@ class LLMProvider:
         structured = "+structured" if response_format is not None else ""
         set_stage(f"llm.{self.provider}.{scope}{structured}")
 
-        async with _global_llm_semaphore:
+        async with AsyncExitStack() as stack:
+            for sem in _semaphores_for_scope(scope):
+                await stack.enter_async_context(sem)
+
             # Delegate to provider implementation
             result = await self._provider_impl.call(
                 messages=messages,
@@ -654,7 +723,7 @@ class LLMProvider:
                     # Sync the mock calls from provider implementation to wrapper
                     self._mock_calls = self._provider_impl.get_mock_calls()
 
-            return result
+        return result
 
     async def call_with_tools(
         self,
@@ -689,7 +758,10 @@ class LLMProvider:
 
         set_stage(f"llm.{self.provider}.{scope}+tools")
 
-        async with _global_llm_semaphore:
+        async with AsyncExitStack() as stack:
+            for sem in _semaphores_for_scope(scope):
+                await stack.enter_async_context(sem)
+
             # Delegate to provider implementation
             result = await self._provider_impl.call_with_tools(
                 messages=messages,
@@ -712,7 +784,7 @@ class LLMProvider:
                     # Sync the mock calls from provider implementation to wrapper
                     self._mock_calls = self._provider_impl.get_mock_calls()
 
-            return result
+        return result
 
     def set_response_callback(self, fn: Any) -> None:
         """Set a callback invoked on each call() instead of the fixed mock response."""

--- a/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
+++ b/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
@@ -1,0 +1,245 @@
+"""Tests for per-operation LLM concurrency caps.
+
+These tests exercise the dispatch logic in `llm_wrapper` that gates calls on
+per-operation semaphores when `HINDSIGHT_API_{RETAIN,REFLECT,CONSOLIDATION}_LLM_MAX_CONCURRENT`
+is set. They patch the module-level semaphore registry so they can run without
+needing to re-import the module with custom env vars.
+"""
+import asyncio
+from contextlib import AsyncExitStack
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.engine import llm_wrapper
+from hindsight_api.engine.llm_wrapper import (
+    LLMProvider,
+    _scope_to_operation,
+    _semaphores_for_scope,
+)
+
+
+class TestScopeToOperation:
+    """Map call-site scope strings to per-operation buckets."""
+
+    @pytest.mark.parametrize(
+        "scope, expected",
+        [
+            ("retain", "retain"),
+            ("retain_extract_facts", "retain"),
+            ("reflect", "reflect"),
+            ("reflect_structured", "reflect"),
+            ("reflect_tool_call", "reflect"),
+            ("consolidation", "consolidation"),
+            # Out-of-bucket scopes — only the global cap applies.
+            ("memory_think", None),
+            ("bank_mission", None),
+            ("mental_model_delta_ops", None),
+            ("verification", None),
+            ("", None),
+        ],
+    )
+    def test_scope_dispatch(self, scope, expected):
+        assert _scope_to_operation(scope) == expected
+
+
+class TestSemaphoresForScope:
+    """`_semaphores_for_scope` always returns the global semaphore, plus the
+    per-op one when configured."""
+
+    def test_no_per_op_configured(self):
+        with patch.object(llm_wrapper, "_per_op_llm_semaphores", {}):
+            sems = _semaphores_for_scope("retain_extract_facts")
+            assert sems == [llm_wrapper._global_llm_semaphore]
+
+    def test_per_op_configured_for_matching_scope(self):
+        retain_sem = asyncio.Semaphore(2)
+        with patch.object(llm_wrapper, "_per_op_llm_semaphores", {"retain": retain_sem}):
+            sems = _semaphores_for_scope("retain_extract_facts")
+            # Per-op acquired first so contention queues on the narrower cap.
+            assert sems == [retain_sem, llm_wrapper._global_llm_semaphore]
+
+    def test_per_op_configured_for_other_scope(self):
+        retain_sem = asyncio.Semaphore(2)
+        with patch.object(llm_wrapper, "_per_op_llm_semaphores", {"retain": retain_sem}):
+            sems = _semaphores_for_scope("reflect")
+            # Reflect call does not see retain's per-op semaphore.
+            assert sems == [llm_wrapper._global_llm_semaphore]
+
+    def test_unbucketed_scope_only_global(self):
+        retain_sem = asyncio.Semaphore(2)
+        reflect_sem = asyncio.Semaphore(2)
+        consolidation_sem = asyncio.Semaphore(2)
+        with patch.object(
+            llm_wrapper,
+            "_per_op_llm_semaphores",
+            {
+                "retain": retain_sem,
+                "reflect": reflect_sem,
+                "consolidation": consolidation_sem,
+            },
+        ):
+            assert _semaphores_for_scope("mental_model_delta_ops") == [
+                llm_wrapper._global_llm_semaphore
+            ]
+            assert _semaphores_for_scope("memory_think") == [llm_wrapper._global_llm_semaphore]
+            assert _semaphores_for_scope("verification") == [llm_wrapper._global_llm_semaphore]
+
+
+class TestBuildPerOpSemaphores:
+    """`_build_per_op_semaphores()` reads env vars and validates them."""
+
+    def test_empty_when_no_env_vars(self, monkeypatch):
+        monkeypatch.delenv("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT", raising=False)
+        assert llm_wrapper._build_per_op_semaphores() == {}
+
+    def test_populated_when_env_vars_set(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", "2")
+        monkeypatch.setenv("HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT", "3")
+        monkeypatch.delenv("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT", raising=False)
+        result = llm_wrapper._build_per_op_semaphores()
+        assert set(result.keys()) == {"retain", "reflect"}
+        # asyncio.Semaphore's internal counter is _value; assert it matches.
+        assert result["retain"]._value == 2
+        assert result["reflect"]._value == 3
+
+    def test_empty_string_treated_as_unset(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", "")
+        monkeypatch.delenv("HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT", raising=False)
+        assert llm_wrapper._build_per_op_semaphores() == {}
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1"])
+    def test_rejects_non_positive(self, monkeypatch, bad_value):
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", bad_value)
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            llm_wrapper._build_per_op_semaphores()
+
+
+class TestSemaphoreEnforcement:
+    """End-to-end: a fake provider call gated through `_semaphores_for_scope`
+    actually respects the per-op and global caps under concurrent load."""
+
+    @pytest.mark.asyncio
+    async def test_per_op_cap_limits_concurrency(self):
+        retain_sem = asyncio.Semaphore(2)
+        # Global is wide-open so we isolate the per-op cap.
+        global_sem = asyncio.Semaphore(100)
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_call():
+            nonlocal in_flight, peak
+            sems = [retain_sem, global_sem]
+            async with AsyncExitStack() as stack:
+                for s in sems:
+                    await stack.enter_async_context(s)
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.01)
+                in_flight -= 1
+
+        await asyncio.gather(*[fake_call() for _ in range(10)])
+
+        assert peak == 2, f"per-op cap should limit to 2, observed peak={peak}"
+
+    @pytest.mark.asyncio
+    async def test_global_cap_still_applies_when_per_op_unset(self):
+        global_sem = asyncio.Semaphore(2)
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_call():
+            nonlocal in_flight, peak
+            async with global_sem:
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.01)
+                in_flight -= 1
+
+        await asyncio.gather(*[fake_call() for _ in range(10)])
+
+        assert peak == 2, f"global cap should limit to 2, observed peak={peak}"
+
+    @pytest.mark.asyncio
+    async def test_llm_provider_call_respects_per_op_cap(self):
+        """End-to-end: `LLMProvider.call()` actually goes through
+        `_semaphores_for_scope`, so patching the per-op registry caps real
+        provider calls."""
+        provider = LLMProvider(provider="mock", api_key="", base_url="", model="test-model")
+
+        in_flight = 0
+        peak = 0
+
+        # Replace the mock provider's call with one that holds the semaphore long
+        # enough to observe concurrency. We can't sleep inside the real MockLLM
+        # path without rewriting its internals.
+        async def slow_mock_call(**kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return "ok"
+
+        provider._provider_impl.call = slow_mock_call  # type: ignore[assignment]
+
+        retain_sem = asyncio.Semaphore(2)
+        with patch.object(llm_wrapper, "_per_op_llm_semaphores", {"retain": retain_sem}):
+            await asyncio.gather(
+                *[
+                    provider.call(
+                        messages=[{"role": "user", "content": "x"}],
+                        scope="retain_extract_facts",
+                    )
+                    for _ in range(8)
+                ]
+            )
+
+        assert peak == 2, f"retain cap should hold even for end-to-end calls, peak={peak}"
+
+    @pytest.mark.asyncio
+    async def test_per_op_composes_with_global(self):
+        """When both caps are set, the tighter one wins on its operation but
+        the global cap still constrains the sum across operations."""
+        retain_sem = asyncio.Semaphore(2)
+        reflect_sem = asyncio.Semaphore(10)
+        global_sem = asyncio.Semaphore(3)
+
+        retain_in_flight = 0
+        retain_peak = 0
+        total_in_flight = 0
+        total_peak = 0
+
+        async def retain_call():
+            nonlocal retain_in_flight, retain_peak, total_in_flight, total_peak
+            async with AsyncExitStack() as stack:
+                await stack.enter_async_context(retain_sem)
+                await stack.enter_async_context(global_sem)
+                retain_in_flight += 1
+                total_in_flight += 1
+                retain_peak = max(retain_peak, retain_in_flight)
+                total_peak = max(total_peak, total_in_flight)
+                await asyncio.sleep(0.01)
+                retain_in_flight -= 1
+                total_in_flight -= 1
+
+        async def reflect_call():
+            nonlocal total_in_flight, total_peak
+            async with AsyncExitStack() as stack:
+                await stack.enter_async_context(reflect_sem)
+                await stack.enter_async_context(global_sem)
+                total_in_flight += 1
+                total_peak = max(total_peak, total_in_flight)
+                await asyncio.sleep(0.01)
+                total_in_flight -= 1
+
+        tasks = [retain_call() for _ in range(6)] + [reflect_call() for _ in range(6)]
+        await asyncio.gather(*tasks)
+
+        assert retain_peak <= 2, f"retain cap exceeded: peak={retain_peak}"
+        assert total_peak <= 3, f"global cap exceeded: peak={total_peak}"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -385,7 +385,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_RETAIN_LLM_API_KEY` | API key for retain LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_RETAIN_LLM_MODEL` | Model for retain operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_RETAIN_LLM_BASE_URL` | Base URL for retain LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT` | Max concurrent requests for retain | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT` | Extra cap on concurrent retain LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES` | Max retries for retain | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF` | Initial backoff for retain retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF` | Max backoff cap for retain retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -394,7 +394,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_REFLECT_LLM_API_KEY` | API key for reflect LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_REFLECT_LLM_MODEL` | Model for reflect operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_REFLECT_LLM_BASE_URL` | Base URL for reflect LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT` | Max concurrent requests for reflect | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT` | Extra cap on concurrent reflect LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES` | Max retries for reflect | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_REFLECT_LLM_INITIAL_BACKOFF` | Initial backoff for reflect retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_REFLECT_LLM_MAX_BACKOFF` | Max backoff cap for reflect retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -403,7 +403,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY` | API key for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MODEL` | Model for consolidation operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL` | Base URL for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` | Max concurrent requests for consolidation | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` | Extra cap on concurrent consolidation LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES` | Max retries for consolidation | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF` | Initial backoff for consolidation retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF` | Max backoff cap for consolidation retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -450,6 +450,17 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES=3
 export HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF=2.0  # Start at 2s instead of 1s
 export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1min
 ```
+
+:::note Per-operation concurrency composes with the global cap
+`HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT`, `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT`, and
+`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` add an extra cap that applies *on top of*
+`HINDSIGHT_API_LLM_MAX_CONCURRENT`. A retain call counts against both the retain cap and the
+global cap; a reflect call without a per-op cap is bounded only by the global cap.
+
+To reserve headroom for live chat/reflect on a rate-limited provider, cap retain and
+consolidation below the global value — e.g. global=4, retain=1, consolidation=1 leaves
+two slots that retain/consolidation cannot consume.
+:::
 
 ### Embeddings
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -385,7 +385,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_RETAIN_LLM_API_KEY` | API key for retain LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_RETAIN_LLM_MODEL` | Model for retain operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_RETAIN_LLM_BASE_URL` | Base URL for retain LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT` | Max concurrent requests for retain | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT` | Extra cap on concurrent retain LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES` | Max retries for retain | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF` | Initial backoff for retain retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF` | Max backoff cap for retain retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -394,7 +394,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_REFLECT_LLM_API_KEY` | API key for reflect LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_REFLECT_LLM_MODEL` | Model for reflect operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_REFLECT_LLM_BASE_URL` | Base URL for reflect LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT` | Max concurrent requests for reflect | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT` | Extra cap on concurrent reflect LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES` | Max retries for reflect | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_REFLECT_LLM_INITIAL_BACKOFF` | Initial backoff for reflect retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_REFLECT_LLM_MAX_BACKOFF` | Max backoff cap for reflect retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -403,7 +403,7 @@ Different memory operations have different requirements. **Retain** (fact extrac
 | `HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY` | API key for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_API_KEY` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MODEL` | Model for consolidation operations | Falls back to `HINDSIGHT_API_LLM_MODEL` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL` | Base URL for consolidation LLM | Falls back to `HINDSIGHT_API_LLM_BASE_URL` |
-| `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` | Max concurrent requests for consolidation | Falls back to `HINDSIGHT_API_LLM_MAX_CONCURRENT` |
+| `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` | Extra cap on concurrent consolidation LLM requests, composed with the global cap. Unset → only the global cap applies. | Unset |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES` | Max retries for consolidation | Falls back to `HINDSIGHT_API_LLM_MAX_RETRIES` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF` | Initial backoff for consolidation retries (seconds) | Falls back to `HINDSIGHT_API_LLM_INITIAL_BACKOFF` |
 | `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF` | Max backoff cap for consolidation retries (seconds) | Falls back to `HINDSIGHT_API_LLM_MAX_BACKOFF` |
@@ -450,6 +450,17 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES=3
 export HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF=2.0  # Start at 2s instead of 1s
 export HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF=120.0    # Cap at 2min instead of 1min
 ```
+
+:::note Per-operation concurrency composes with the global cap
+`HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT`, `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT`, and
+`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` add an extra cap that applies *on top of*
+`HINDSIGHT_API_LLM_MAX_CONCURRENT`. A retain call counts against both the retain cap and the
+global cap; a reflect call without a per-op cap is bounded only by the global cap.
+
+To reserve headroom for live chat/reflect on a rate-limited provider, cap retain and
+consolidation below the global value — e.g. global=4, retain=1, consolidation=1 leaves
+two slots that retain/consolidation cannot consume.
+:::
 
 ### Embeddings
 


### PR DESCRIPTION
## Summary

`HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT`, `HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT`, and `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT` were parsed into `HindsightConfig` but never read — every LLM call shared the single global `_global_llm_semaphore`. Users on rate-limited providers (Ollama Cloud, Groq free tier, etc.) who set these to reserve per-operation LLM capacity were silently getting the global cap instead.

This PR wires them up. Per-operation semaphores live in `llm_wrapper`, dispatched by call-scope prefix (`retain*` → retain, `reflect*` → reflect, `consolidation*` → consolidation). Each per-op cap **composes with** rather than replaces the global cap: a retain call must acquire both the retain semaphore and the global semaphore. To reserve headroom for live chat, an operator can now set `global=4, retain=1, consolidation=1` and trust that two slots stay available for non-retain/consolidation work.

Scopes without a tracked operation (`bank_mission`, `memory_think`, `mental_model_delta_ops`, `verification`) continue to use only the global cap.

Fixes #1574.

## Changes

- `hindsight-api-slim/hindsight_api/engine/llm_wrapper.py` — added `_build_per_op_semaphores`, `_scope_to_operation`, `_semaphores_for_scope`; replaced the single `async with _global_llm_semaphore` in `call()` / `call_with_tools()` with an `AsyncExitStack` over the resolved semaphore list.
- `hindsight-api-slim/tests/test_llm_per_op_concurrency.py` (new) — 24 tests covering scope dispatch, env-var parsing/validation (rejects `0`/`-1`, treats empty string as unset), semaphore enforcement under concurrent load, composition with the global cap, and an end-to-end test through `LLMProvider.call()`.
- `hindsight-docs/docs/developer/configuration.md` — updated the three env-var rows and added a note explaining the composition semantics.

## Test plan

- [x] New tests pass: `uv run pytest tests/test_llm_per_op_concurrency.py` — 24 passed
- [x] Existing per-operation LLM config tests still pass: `uv run pytest tests/test_per_operation_llm_config.py tests/test_llm_wrapper.py tests/test_llm_tools.py` — 58 passed
- [x] Lint passes: `./scripts/hooks/lint.sh`
- [x] Type check passes: `uv run ty check hindsight_api/`