### PR TITLE
fix(control-plane): verify signed session cookie instead of presence

### DIFF
--- a/hindsight-control-plane/src/app/api/auth/login/route.ts
+++ b/hindsight-control-plane/src/app/api/auth/login/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const ACCESS_KEY_COOKIE = "hindsight_cp_access";
+import {
+  ACCESS_KEY_COOKIE,
+  SESSION_MAX_AGE_SECONDS,
+  createSessionToken,
+  sessionCookieOptions,
+} from "@/lib/auth/session";
 
 export async function POST(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
@@ -28,15 +33,11 @@ export async function POST(request: NextRequest) {
 
   const response = NextResponse.json({ success: true });
 
-  // Set HttpOnly, Secure, SameSite cookie
   response.cookies.set({
     name: ACCESS_KEY_COOKIE,
-    value: "authenticated",
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24, // 24 hours
+    value: await createSessionToken(accessKey),
+    ...sessionCookieOptions(request),
+    maxAge: SESSION_MAX_AGE_SECONDS,
   });
 
   return response;

--- a/hindsight-control-plane/src/app/api/auth/logout/route.ts
+++ b/hindsight-control-plane/src/app/api/auth/logout/route.ts
@@ -1,17 +1,14 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-const ACCESS_KEY_COOKIE = "hindsight_cp_access";
+import { ACCESS_KEY_COOKIE, sessionCookieOptions } from "@/lib/auth/session";
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   const response = NextResponse.json({ success: true });
 
   response.cookies.set({
     name: ACCESS_KEY_COOKIE,
     value: "",
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    path: "/",
+    ...sessionCookieOptions(request),
     maxAge: 0,
   });
 

--- a/hindsight-control-plane/src/lib/auth/session.test.ts
+++ b/hindsight-control-plane/src/lib/auth/session.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+import {
+  SESSION_MAX_AGE_SECONDS,
+  createSessionToken,
+  isSecureRequest,
+  verifySessionToken,
+} from "./session";
+
+const ACCESS_KEY = "super-secret-access-key";
+
+function fakeRequest({
+  protocol = "http:",
+  forwardedProto,
+}: {
+  protocol?: "http:" | "https:";
+  forwardedProto?: string;
+} = {}): NextRequest {
+  const headers = new Headers();
+  if (forwardedProto !== undefined) {
+    headers.set("x-forwarded-proto", forwardedProto);
+  }
+  return {
+    headers,
+    nextUrl: { protocol },
+  } as unknown as NextRequest;
+}
+
+describe("createSessionToken / verifySessionToken", () => {
+  it("round-trips: a freshly issued token verifies", async () => {
+    const token = await createSessionToken(ACCESS_KEY);
+    expect(await verifySessionToken(token, ACCESS_KEY)).toBe(true);
+  });
+
+  it("emits the documented `<issuedAt>.<sig>` shape", async () => {
+    const token = await createSessionToken(ACCESS_KEY);
+    const [issuedAt, sig, ...rest] = token.split(".");
+    expect(rest).toHaveLength(0);
+    expect(Number.isInteger(Number(issuedAt))).toBe(true);
+    expect(sig.length).toBeGreaterThan(0);
+  });
+
+  it("rejects when the signature is tampered", async () => {
+    const token = await createSessionToken(ACCESS_KEY);
+    const [issuedAt] = token.split(".");
+    const forged = `${issuedAt}.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+    expect(await verifySessionToken(forged, ACCESS_KEY)).toBe(false);
+  });
+
+  it("rejects when the payload is swapped (signature no longer matches)", async () => {
+    const token = await createSessionToken(ACCESS_KEY);
+    const [, sig] = token.split(".");
+    const futureTime = (Math.floor(Date.now() / 1000) - 10).toString();
+    const forged = `${futureTime}.${sig}`;
+    expect(await verifySessionToken(forged, ACCESS_KEY)).toBe(false);
+  });
+
+  it("rejects the bare-string cookie value that the old impl accepted", async () => {
+    expect(await verifySessionToken("authenticated", ACCESS_KEY)).toBe(false);
+  });
+
+  it.each(["", undefined, ".", "abc", "abc.", ".abc", "notanumber.sig"])(
+    "rejects malformed token: %j",
+    async (bad) => {
+      expect(await verifySessionToken(bad, ACCESS_KEY)).toBe(false);
+    }
+  );
+
+  it("rejects when the access key has rotated since the token was issued", async () => {
+    const token = await createSessionToken(ACCESS_KEY);
+    expect(await verifySessionToken(token, "different-access-key")).toBe(false);
+  });
+
+  describe("expiry", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("accepts a token issued just inside the max-age window", async () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const token = await createSessionToken(ACCESS_KEY);
+      vi.setSystemTime(new Date(Date.now() + (SESSION_MAX_AGE_SECONDS - 5) * 1000));
+      expect(await verifySessionToken(token, ACCESS_KEY)).toBe(true);
+    });
+
+    it("rejects a token issued past the max-age window", async () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const token = await createSessionToken(ACCESS_KEY);
+      vi.setSystemTime(new Date(Date.now() + (SESSION_MAX_AGE_SECONDS + 5) * 1000));
+      expect(await verifySessionToken(token, ACCESS_KEY)).toBe(false);
+    });
+
+    it("rejects a token whose issuedAt is implausibly in the future", async () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const farFuture = Math.floor(Date.now() / 1000) + 3600;
+      // Forge a properly-signed token with a future iat to isolate the iat
+      // check (a tampered iat alone would also fail the signature check).
+      const { hmacSha256 } = await loadHmacHelper();
+      const futureSig = await hmacSha256(ACCESS_KEY, farFuture.toString());
+      expect(await verifySessionToken(`${farFuture}.${futureSig}`, ACCESS_KEY)).toBe(false);
+    });
+  });
+});
+
+describe("isSecureRequest", () => {
+  it("returns true when X-Forwarded-Proto is https", () => {
+    expect(isSecureRequest(fakeRequest({ forwardedProto: "https" }))).toBe(true);
+  });
+
+  it("returns false when X-Forwarded-Proto is http (even on a production build)", () => {
+    expect(isSecureRequest(fakeRequest({ forwardedProto: "http" }))).toBe(false);
+  });
+
+  it("uses the first value when X-Forwarded-Proto is a comma list", () => {
+    expect(isSecureRequest(fakeRequest({ forwardedProto: "https, http" }))).toBe(true);
+    expect(isSecureRequest(fakeRequest({ forwardedProto: "http, https" }))).toBe(false);
+  });
+
+  it("falls back to the request URL protocol when no forwarded header is set", () => {
+    expect(isSecureRequest(fakeRequest({ protocol: "https:" }))).toBe(true);
+    expect(isSecureRequest(fakeRequest({ protocol: "http:" }))).toBe(false);
+  });
+
+  it("is case-insensitive on the forwarded value", () => {
+    expect(isSecureRequest(fakeRequest({ forwardedProto: "HTTPS" }))).toBe(true);
+  });
+});
+
+// Inlined HMAC helper for the future-iat test — re-derives a signature without
+// reaching into private module internals.
+async function loadHmacHelper() {
+  async function hmacSha256(secret: string, message: string): Promise<string> {
+    const enc = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      enc.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, enc.encode(message)));
+    let binary = "";
+    for (const byte of sig) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+  }
+  return { hmacSha256 };
+}

--- a/hindsight-control-plane/src/lib/auth/session.ts
+++ b/hindsight-control-plane/src/lib/auth/session.ts
@@ -1,0 +1,93 @@
+import type { NextRequest } from "next/server";
+
+export const ACCESS_KEY_COOKIE = "hindsight_cp_access";
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24;
+
+const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
+
+/**
+ * Session token format: `<issuedAtSeconds>.<base64urlHmacSha256>`.
+ *
+ * The HMAC is computed over `issuedAtSeconds` using the access key as the
+ * secret, so the token cannot be forged without knowing the key, and rotating
+ * the key invalidates every outstanding session. No server-side state needed.
+ */
+export async function createSessionToken(accessKey: string): Promise<string> {
+  const issuedAt = Math.floor(Date.now() / 1000).toString();
+  const signature = await hmacSha256Base64Url(accessKey, issuedAt);
+  return `${issuedAt}.${signature}`;
+}
+
+export async function verifySessionToken(
+  token: string | undefined,
+  accessKey: string
+): Promise<boolean> {
+  if (!token) return false;
+  const separator = token.indexOf(".");
+  if (separator <= 0 || separator === token.length - 1) return false;
+
+  const payload = token.slice(0, separator);
+  const providedSignature = token.slice(separator + 1);
+
+  const issuedAt = Number(payload);
+  if (!Number.isInteger(issuedAt) || issuedAt <= 0) return false;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (issuedAt > nowSeconds + CLOCK_SKEW_TOLERANCE_SECONDS) return false;
+  if (nowSeconds - issuedAt > SESSION_MAX_AGE_SECONDS) return false;
+
+  const expectedSignature = await hmacSha256Base64Url(accessKey, payload);
+  return constantTimeEqual(expectedSignature, providedSignature);
+}
+
+/**
+ * True when the original client connection used HTTPS. Honors
+ * `X-Forwarded-Proto` from a TLS-terminating proxy first; falls back to the
+ * request URL's protocol. We deliberately do NOT key off `NODE_ENV` — a
+ * production build served over plain HTTP (common in self-hosted setups) must
+ * still set a usable cookie.
+ */
+export function isSecureRequest(request: NextRequest): boolean {
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  if (forwardedProto) {
+    return forwardedProto.split(",")[0]?.trim().toLowerCase() === "https";
+  }
+  return request.nextUrl.protocol === "https:";
+}
+
+export function sessionCookieOptions(request: NextRequest) {
+  return {
+    httpOnly: true,
+    secure: isSecureRequest(request),
+    sameSite: "lax" as const,
+    path: "/",
+  };
+}
+
+async function hmacSha256Base64Url(secret: string, message: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return base64UrlEncode(new Uint8Array(signature));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-const ACCESS_KEY_COOKIE = "hindsight_cp_access";
+import { ACCESS_KEY_COOKIE, verifySessionToken } from "@/lib/auth/session";
 
 // Routes that don't require authentication
 const PUBLIC_PATTERNS = [
@@ -16,7 +16,7 @@ const PUBLIC_PATTERNS = [
   "/static",
 ];
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
 
   // If no access key is configured, skip auth entirely
@@ -33,8 +33,8 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Check for the session cookie
-  const isAuthenticated = request.cookies.has(ACCESS_KEY_COOKIE);
+  const sessionCookie = request.cookies.get(ACCESS_KEY_COOKIE)?.value;
+  const isAuthenticated = await verifySessionToken(sessionCookie, accessKey);
 
   if (!isAuthenticated) {
     // For API routes, return 401 JSON instead of redirecting to HTML login page


### PR DESCRIPTION
## Summary

Fixes #1723.

The access-key middleware from #1148 had two security/UX bugs:

1. **Auth bypass.** Login set the cookie value to the literal string `"authenticated"` and `middleware.ts` checked only `request.cookies.has(ACCESS_KEY_COOKIE)`. Anyone could open DevTools → Application → Cookies, paste `hindsight_cp_access=anything`, reload, and get full access. The reporter showed this with a screenshot.
2. **`Secure` flag breaks plain-HTTP self-hosting.** `secure` was keyed off `NODE_ENV === "production"`, so a production build served over HTTP (or a `NODE_ENV=production` shell behind a non-TLS proxy) sets `Secure: true` and the browser silently drops the cookie on subsequent requests.

## Fix

- **Signed session token.** Cookie value is now `<issuedAt>.<base64url(HMAC-SHA256(accessKey, issuedAt))>`. Middleware recomputes the HMAC in constant time and enforces the 24h max-age from the timestamp *inside* the token. A forged cookie can't satisfy either check, and rotating `HINDSIGHT_CP_ACCESS_KEY` invalidates every outstanding session — no server-side state required. Uses Web Crypto (`crypto.subtle`) so it runs in the Next.js Edge middleware runtime.
- **`Secure` flag from request protocol.** Reads `X-Forwarded-Proto` first (standard for TLS-terminating proxies), falls back to the request URL protocol. `NODE_ENV` no longer involved.
- Centralizes the cookie name and cookie-options into `src/lib/auth/session.ts` (was duplicated across three files).

Migration note: existing sessions issued before this change won't verify and users will be redirected to `/login` once — the cookie format itself is incompatible.

## Out of scope

- No rate limit on `/api/auth/login` — brute-force protection is a separate concern.
- Pre-existing TypeScript error in `src/app/api/operations/[agentId]/route.ts:20` (SDK type mismatch on `exclude_parents`) — unrelated to this PR.

## Test plan

- [x] `npm test` in `hindsight-control-plane/` — all 33 vitest tests pass, including 19 new ones in `session.test.ts` covering round-trip, tampered signatures, expired tokens, key rotation, malformed input, the bare-string `"authenticated"` regression, and `isSecureRequest` cases (https/http forwarded-proto, comma lists, URL fallback, case-insensitivity).
- [x] `npx eslint --fix` and `npx prettier --write` on changed files — clean.
- [x] Pre-commit `./scripts/hooks/lint.sh` — passes.
- [ ] Manual smoke: with `HINDSIGHT_CP_ACCESS_KEY` set, log in via the form, confirm cookie is opaque (not `"authenticated"`), confirm pasting a fake cookie no longer grants access, confirm logout clears the cookie on HTTP.