### PR TITLE
test: stabilize pre-existing CI flakes

### DIFF
--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -4,7 +4,7 @@ Test OpenAI Batch API integration for retain fact extraction.
 Tests cover:
 - Normal batch API flow (submit, poll, complete)
 - Crash recovery (resume from existing batch_id)
-- Provider fallback (when batch API not supported)
+- Hard error when provider doesn't support the batch API (no silent fallback)
 - Worker recovery on restart
 """
 import pytest
@@ -332,20 +332,19 @@ async def test_batch_api_crash_recovery(mock_llm_config, test_contents, hindsigh
 
 
 @pytest.mark.asyncio
-async def test_batch_api_fallback_unsupported_provider(mock_llm_config, test_contents, hindsight_config):
-    """Test fallback to sync mode when provider doesn't support batch API."""
+async def test_batch_api_raises_for_unsupported_provider(mock_llm_config, test_contents, hindsight_config):
+    """Batch extraction must surface a hard error (not silently fall back) when
+    the configured provider doesn't support the batch API.
 
-    # Mock provider that doesn't support batch API
+    The silent-fallback behavior was removed in #1463 because it created a
+    mutual-recursion path between sync and batch extraction. Misconfiguration
+    should fail loudly and be caught at startup; this test guards that
+    contract.
+    """
     mock_llm_config._provider_impl.supports_batch_api = AsyncMock(return_value=False)
-    mock_llm_config.provider = "groq"  # Example of provider
+    mock_llm_config.provider = "groq"
 
-    # Patch the sync mode function to verify it's called
-    with patch(
-        "hindsight_api.engine.retain.fact_extraction.extract_facts_from_contents"
-    ) as mock_sync_extract:
-        mock_sync_extract.return_value = ([], [], MagicMock())
-
-        # Call batch API extraction (should fallback to sync)
+    with pytest.raises(RuntimeError, match="does not.*support the batch API"):
         await extract_facts_from_contents_batch_api(
             contents=test_contents,
             llm_config=mock_llm_config,
@@ -356,13 +355,7 @@ async def test_batch_api_fallback_unsupported_provider(mock_llm_config, test_con
             schema=None,
         )
 
-        # Verify fallback occurred
-        mock_sync_extract.assert_called_once()
-
-        # Verify batch API methods were NOT called
-        mock_llm_config._provider_impl.submit_batch.assert_not_called()
-
-        logger.info("✅ Fallback to sync mode test passed")
+    mock_llm_config._provider_impl.submit_batch.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -1658,6 +1658,14 @@ class TestHierarchicalRetrieval:
 class TestMentalModelRefreshAfterConsolidation:
     """Test that mental models with refresh_after_consolidation trigger are refreshed after consolidation."""
 
+    # The full chain (retain → consolidation → refresh) makes several real LLM
+    # calls. Under parallel test load these can hit provider rate limits;
+    # `retain_batch_async` swallows consolidation errors (non-critical for
+    # retain) so a rate-limited consolidation leaves last_refreshed_at
+    # unchanged and the assertion fails. Rerun on transient flakes — the
+    # contract under test is the steady-state refresh trigger, not LLM
+    # availability.
+    @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.asyncio
     async def test_mental_model_with_trigger_is_refreshed_after_consolidation(
         self, memory: MemoryEngine, request_context

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -401,6 +401,12 @@ class TestRecallWithObservationsAndMentalModels:
 class TestReflectUsesMentalModels:
     """Test that reflect searches and uses mental models when available."""
 
+    # Reflect doesn't pin a tool-call temperature, so weaker models in the
+    # acceptance matrix (e.g. gemini-2.5-flash-lite) occasionally pick `recall`
+    # or `search_observations` instead of `search_mental_models`. Rerun a
+    # couple of times before declaring a regression — the contract we care
+    # about (MM-aware tool gets invoked) holds in the steady state.
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
     @pytest.mark.hs_llm_mat
     @pytest.mark.asyncio
     async def test_reflect_searches_mental_models_when_available(self, memory: MemoryEngine, request_context):

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -96,17 +96,37 @@ def test_register_profile_calls_create_when_api_keys_present():
     )
 
 
-def test_find_ui_command_uses_npx_yes_flag_for_published_control_plane(monkeypatch):
-    """First-run UI installs must auto-confirm the published control-plane package."""
+def test_find_ui_command_uses_npx_yes_flag_when_npx_not_on_path(monkeypatch):
+    """When npx is not on PATH, fall back to a bare `npx -y` command so the
+    surrounding FileNotFoundError handler can report a clean install hint."""
     manager = DaemonEmbedManager()
     monkeypatch.setenv("HINDSIGHT_EMBED_CP_VERSION", "9.9.9")
 
-    with patch("pathlib.Path.exists", return_value=False):
+    with patch("pathlib.Path.exists", return_value=False), \
+         patch("shutil.which", return_value=None):
         assert manager._find_ui_command() == [
             "npx",
             "-y",
             "@vectorize-io/hindsight-control-plane@9.9.9",
         ]
+
+
+def test_find_ui_command_resolves_npx_absolute_path_with_yes_flag(monkeypatch):
+    """When npx is on PATH, use the resolved absolute path (Windows detached
+    processes don't always inherit PATH — see embed_manager._find_ui_command).
+    Either way, `-y` must be set so first-run installs don't block on a prompt."""
+    manager = DaemonEmbedManager()
+    monkeypatch.setenv("HINDSIGHT_EMBED_CP_VERSION", "9.9.9")
+
+    with patch("pathlib.Path.exists", return_value=False), \
+         patch("shutil.which", return_value="/usr/local/bin/npx"):
+        cmd = manager._find_ui_command()
+
+    assert cmd == [
+        "/usr/local/bin/npx",
+        "-y",
+        "@vectorize-io/hindsight-control-plane@9.9.9",
+    ]
 
 
 def test_find_api_command_prefers_installed_binary_over_uvx(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Three independent test fixes for failures pre-existing on `main` (none of these are caused by recent code changes — verified by running the broken tests against a clean `origin/main` checkout).

### test_batch_api: assert hard error on unsupported provider
PR #1463 replaced the silent sync-mode fallback in `extract_facts_from_contents_batch_api` with a hard `RuntimeError` (to break a mutual-recursion path between the sync and batch extractors), but `test_batch_api_fallback_unsupported_provider` still asserted the old fallback behavior and has broken CI ever since. Updated the test to assert the raise and renamed it to `test_batch_api_raises_for_unsupported_provider`.

### test_embed_manager: npx path handling
`test_find_ui_command_uses_npx_yes_flag_for_published_control_plane` only mocked `Path.exists`, not `shutil.which`. On any CI runner with npx installed the production code returns the resolved absolute path (`/usr/local/bin/npx` on Linux, `C:\Program Files\...\npx` on Windows), so the literal `"npx"` assertion fails on both `test-embed` and `test-embed-windows`. Split into two tests covering both branches (npx absent vs. resolved).

### test_reflect_searches_mental_models_when_available (LLM acceptance flake)
Reflect doesn't pin a tool-call temperature, so weaker models in the LLM acceptance matrix (notably `vertexai/gemini-2.5-flash-lite`) occasionally route to `recall`/`search_observations` on a single run. Marked `@pytest.mark.flaky(reruns=2)` to absorb the transient nondeterminism — the steady-state contract holds across the matrix and via the direct Gemini provider with the same model.

### test_mental_model_with_trigger_is_refreshed_after_consolidation (consolidation flake)
The test exercises the full `retain → consolidation → refresh` chain over real LLM calls. Under parallel xdist load these can hit provider rate limits; `retain_batch_async` swallows consolidation errors as non-critical, so a rate-limited consolidation leaves `last_refreshed_at` unchanged and the assertion fails. Marked `@pytest.mark.flaky(reruns=2)` on the same rationale.

## Test plan

- [x] All four tests pass locally
- [x] Lint and type check pass
- [ ] CI confirms the failures are gone (verify-generated-files already passing on main after #1738)

## Not addressed in this PR

- `test-python-client-oracle` "Setup Oracle test user" — appears to be a transient infra flake that self-resolved on the latest re-run of #1738. If it recurs, will investigate separately.