### PR TITLE
docs(mcp): document clear_mental_model tool

### DIFF
--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -295,6 +295,16 @@ Re-generate a mental model's content from the latest memories. Runs asynchronous
 
 ---
 
+### clear_mental_model
+
+Clear a mental model's content while keeping its definition. After clearing, call `refresh_mental_model` to rebuild it from the latest memories.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `mental_model_id` | string | Yes | The ID of the mental model to clear |
+
+---
+
 ### list_banks (multi-bank mode only)
 
 List all available memory banks.

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -295,6 +295,16 @@ Re-generate a mental model's content from the latest memories. Runs asynchronous
 
 ---
 
+### clear_mental_model
+
+Clear a mental model's content while keeping its definition. After clearing, call `refresh_mental_model` to rebuild it from the latest memories.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `mental_model_id` | string | Yes | The ID of the mental model to clear |
+
+---
+
 ### list_banks (multi-bank mode only)
 
 List all available memory banks.


### PR DESCRIPTION
#1743 added the `clear_mental_model` MCP tool (registered in `mcp_tools.py`, exposed at `POST /v1/default/banks/{bank_id}/mental-models/{mental_model_id}/clear`, and added to the OpenAPI spec + SDK clients), but `developer/mcp-server.md` was not updated — its 6 sibling mental-model tools (`create`/`list`/`get`/`update`/`delete`/`refresh`) are all documented, leaving `clear_mental_model` as the only one missing.

The tool-count summary already reads "26 tools" (single-bank) / "All 29 tools", but the doc only enumerates 25 single-bank sections. Adding the `clear_mental_model` section makes the enumeration match the stated counts (26 single-bank / 29 total).

Adds the section after `refresh_mental_model`, mirroring the existing parameter-table format, in both the docs source and the `skills/hindsight-docs` reference mirror.