### PR TITLE
ci: pin astral-sh/setup-uv to immutable v8.1.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: npm ci --workspace=hindsight-docs
       - run: uv run generate-llms-full
       - run: npm run build --workspace=hindsight-docs

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -51,7 +51,7 @@ jobs:
         ref: ${{ inputs.ref || github.ref }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -136,7 +136,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install uv
       if: steps.type.outputs.type == 'python'
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 
@@ -676,7 +676,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -843,7 +843,7 @@ jobs:
         retention-days: 1
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1081,7 +1081,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1179,7 +1179,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1304,7 +1304,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1377,7 +1377,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1488,7 +1488,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1658,7 +1658,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1817,7 +1817,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -1934,7 +1934,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2088,7 +2088,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2203,7 +2203,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2317,7 +2317,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2447,7 +2447,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2539,7 +2539,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2575,7 +2575,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2612,7 +2612,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2645,7 +2645,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2681,7 +2681,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2717,7 +2717,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2753,7 +2753,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2789,7 +2789,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2825,7 +2825,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2875,7 +2875,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -2942,7 +2942,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -3018,7 +3018,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> "$GITHUB_ENV"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -3190,7 +3190,7 @@ jobs:
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -3304,7 +3304,7 @@ jobs:
         cp target/release/hindsight /usr/local/bin/hindsight
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -3429,7 +3429,7 @@ jobs:
       run: git fetch --tags
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         prune-cache: false
@@ -3493,7 +3493,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 
@@ -3578,7 +3578,7 @@ jobs:
         fetch-depth: 0  # Fetch full git history to access base branch
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 
@@ -3630,7 +3630,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || '' }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 


### PR DESCRIPTION
## Summary
- Deploy Docs CI on main is failing repeatedly with `An action could not be found at the URI 'https://codeload.github.com/astral-sh/setup-uv/tar.gz/37802adc...'`. The codeload mirror can't serve the v7.6.0 SHA that `@v7` currently resolves to — four consecutive reruns of [run 26447835312](https://github.com/vectorize-io/hindsight/actions/runs/26447835312) failed across regions while curling the same URL returns 200, so it's a sticky cache issue on GitHub's side.
- Per the [v8.0.0 release notes](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) setup-uv dropped floating major/minor tags in favor of immutable releases for supply-chain safety, so pinning to a concrete version is the recommended path forward.
- Bumps all 38 `astral-sh/setup-uv@v7` references to `@v8.1.0`. We only pass `enable-cache` / `prune-cache`, which v8 still supports — the only v8 breaking change was the `manifest-file` format, which we don't use.

## Test plan
- [ ] Deploy Docs workflow on this branch (triggered manually via workflow_dispatch after merge, since `deploy-docs.yml` only runs on push to main)
- [ ] PR-triggered test workflows run successfully on this branch