### PR TITLE
fix(ci): align config field count and CLI consolidation call with #1746

### DIFF
--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -124,9 +124,10 @@ async def test_hierarchical_fields_categorization():
     assert "llm_gemini_safety_settings" in configurable
     assert "mcp_enabled_tools" in configurable
     assert "retain_chunk_batch_size" in configurable
+    assert "enable_auto_consolidation" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 35
+    assert len(configurable) == 36
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -953,7 +953,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::ConsolidationResponse> {
         self.runtime.block_on(async {
-            let response = self.client.trigger_consolidation(bank_id, None).await?;
+            let body = types::ConsolidationRequest::default();
+            let response = self
+                .client
+                .trigger_consolidation(bank_id, None, &body)
+                .await?;
             Ok(response.into_inner())
         })
     }


### PR DESCRIPTION
## Summary
- PR #1746 (`feat(api): add targeted consolidation by observation scopes`) added `enable_auto_consolidation` to `_CONFIGURABLE_FIELDS` but didn't update `test_hierarchical_fields_categorization` (still asserted 35 — now passes with 36 + an explicit assertion for the new field).
- Same PR also added a `ConsolidationRequest` body to `POST /v1/default/banks/{bank_id}/consolidate` but didn't update the CLI wrapper at `hindsight-cli/src/api.rs:956`, which still called the generated client with two args. The third positional arg is now `&ConsolidationRequest::default()`, which has `observation_scopes: None` and keeps the no-scope CLI invocation processing all unconsolidated memories (the documented behavior when the body is omitted).
- These breakages are visible on any post-#1746 PR — e.g. https://github.com/vectorize-io/hindsight/actions/runs/26446337993 fails `test-api`, `test-rust-cli`, `test-embed-windows`, and `test-doc-examples (cli)` for exactly these two reasons.

## Test plan
- [x] `uv run pytest tests/test_hierarchical_config.py::test_hierarchical_fields_categorization` — passes locally
- [x] `cargo build` in `hindsight-cli/` — clean
- [x] `./scripts/hooks/lint.sh` — clean
- [ ] CI on this PR turns green for `test-api`, `test-rust-cli`, `test-embed-windows`, `test-doc-examples (cli)` (waiting for the active GitHub Actions incident at https://stspg.io/6gzfzr1dx684 to clear)