### PR TITLE
feat(paperclip): add per-user memory isolation via bankGranularity

### DIFF
--- a/hindsight-integrations/paperclip/src/bank.ts
+++ b/hindsight-integrations/paperclip/src/bank.ts
@@ -1,12 +1,18 @@
 /**
  * Bank ID derivation — maps Paperclip company/agent identity onto Hindsight bank IDs.
  *
- * Default format: "paperclip::{companyId}::{agentId}"
+ * Two modes:
  *
- * bankGranularity: ['company']               → "paperclip::{companyId}"
- * bankGranularity: ['agent']                 → "paperclip::{agentId}"
- * bankGranularity: ['company','agent']       → "paperclip::{companyId}::{agentId}"
- * bankGranularity: ['company','agent','user'] → "paperclip::{companyId}::{agentId}::user::{userId}"
+ *   1. Static:  dynamicBankId = false (default: true) + bankId set
+ *               → returns bankId verbatim, bypassing all derivation.
+ *
+ *   2. Dynamic: dynamicBankId = true (default) or bankId unset
+ *               → derives from bankGranularity:
+ *
+ *      bankGranularity: ['company']               → "paperclip::{companyId}"
+ *      bankGranularity: ['agent']                 → "paperclip::{agentId}"
+ *      bankGranularity: ['company','agent']       → "paperclip::{companyId}::{agentId}"
+ *      bankGranularity: ['company','agent','user'] → "paperclip::{companyId}::{agentId}::user::{userId}"
  */
 
 export interface BankContext {
@@ -16,10 +22,19 @@ export interface BankContext {
 }
 
 export interface BankConfig {
+  bankId?: string;
+  dynamicBankId?: boolean;
   bankGranularity?: Array<"company" | "agent" | "user">;
 }
 
 export function deriveBankId(context: BankContext, config: BankConfig): string {
+  // Static override: when bankId is set and dynamicBankId is not explicitly true
+  const staticId = config.bankId?.trim();
+  if (staticId && config.dynamicBankId !== true) {
+    return staticId;
+  }
+
+  // Dynamic derivation via bankGranularity
   const granularity = config.bankGranularity ?? ["company", "agent"];
   const parts: string[] = ["paperclip"];
 

--- a/hindsight-integrations/paperclip/src/bank.ts
+++ b/hindsight-integrations/paperclip/src/bank.ts
@@ -3,18 +3,20 @@
  *
  * Default format: "paperclip::{companyId}::{agentId}"
  *
- * bankGranularity: ['company']        → "paperclip::{companyId}"
- * bankGranularity: ['agent']          → "paperclip::{agentId}"
- * bankGranularity: ['company','agent'] → "paperclip::{companyId}::{agentId}"
+ * bankGranularity: ['company']               → "paperclip::{companyId}"
+ * bankGranularity: ['agent']                 → "paperclip::{agentId}"
+ * bankGranularity: ['company','agent']       → "paperclip::{companyId}::{agentId}"
+ * bankGranularity: ['company','agent','user'] → "paperclip::{companyId}::{agentId}::user::{userId}"
  */
 
 export interface BankContext {
   companyId: string;
   agentId: string;
+  userId?: string;
 }
 
 export interface BankConfig {
-  bankGranularity?: Array<"company" | "agent">;
+  bankGranularity?: Array<"company" | "agent" | "user">;
 }
 
 export function deriveBankId(context: BankContext, config: BankConfig): string {
@@ -24,7 +26,40 @@ export function deriveBankId(context: BankContext, config: BankConfig): string {
   for (const field of granularity) {
     if (field === "company") parts.push(context.companyId);
     if (field === "agent") parts.push(context.agentId);
+    if (field === "user" && context.userId) {
+      parts.push("user");
+      parts.push(context.userId);
+    }
   }
 
   return parts.join("::");
+}
+
+/**
+ * Extract a user identifier from a Paperclip issue.
+ *
+ * Paperclip issues carry an `originId` field with the format
+ * "channel-key::user-email" (e.g. "slack::alice@acme.com"). We scan the
+ * segments backwards for one that looks like an email. Falls back to
+ * `creatorEmail` if the issue object carries it.
+ *
+ * Returns undefined when no user can be identified — callers treat this as
+ * "user granularity not applicable for this event" (the bank ID just omits
+ * the user segment).
+ */
+export function extractUserFromIssue(issue: {
+  originId?: string | null;
+  creatorEmail?: string | null;
+}): string | undefined {
+  // Prefer explicit creatorEmail when available
+  if (issue.creatorEmail) return issue.creatorEmail;
+
+  if (!issue.originId) return undefined;
+
+  // originId format: "channel-key::user-email" — scan backwards for an email
+  const parts = issue.originId.split("::");
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i].includes("@")) return parts[i];
+  }
+  return undefined;
 }

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -40,11 +40,24 @@ const manifest: PaperclipPluginManifestV1 = {
         description:
           "Name of the Paperclip secret holding your Hindsight Cloud API key. Leave empty for self-hosted.",
       },
+      dynamicBankId: {
+        type: "boolean",
+        title: "Dynamic Bank ID",
+        description:
+          "When true (default), bank ID is derived from bankGranularity. Set false and provide bankId to use a static shared bank.",
+        default: true,
+      },
+      bankId: {
+        type: "string",
+        title: "Static Bank ID",
+        description:
+          "Static bank ID used when dynamicBankId is false. All agents sharing this value read/write the same memory bank.",
+      },
       bankGranularity: {
         type: "array",
         title: "Bank Granularity",
         description:
-          "Controls memory isolation. Default ['company', 'agent'] gives each agent its own bank per company. Add 'user' for per-user memory isolation (useful for GDPR compliance).",
+          "Controls memory isolation when dynamicBankId is true. Default ['company', 'agent'] gives each agent its own bank per company. Add 'user' for per-user memory isolation (useful for GDPR compliance).",
         items: { type: "string", enum: ["company", "agent", "user"] },
         default: ["company", "agent"],
       },

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -44,8 +44,8 @@ const manifest: PaperclipPluginManifestV1 = {
         type: "array",
         title: "Bank Granularity",
         description:
-          "Controls memory isolation. Default ['company', 'agent'] gives each agent its own bank per company.",
-        items: { type: "string", enum: ["company", "agent"] },
+          "Controls memory isolation. Default ['company', 'agent'] gives each agent its own bank per company. Add 'user' for per-user memory isolation (useful for GDPR compliance).",
+        items: { type: "string", enum: ["company", "agent", "user"] },
         default: ["company", "agent"],
       },
       recallBudget: {

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -25,6 +25,8 @@ import { deriveBankId, extractUserFromIssue } from "./bank.js";
 interface PluginConfig {
   hindsightApiUrl: string;
   hindsightApiKeyRef?: string;
+  bankId?: string;
+  dynamicBankId?: boolean;
   bankGranularity?: Array<"company" | "agent" | "user">;
   recallBudget?: "low" | "mid" | "high";
   autoRetain?: boolean;

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -108,10 +108,7 @@ const plugin = definePlugin({
 
       // Cache userId so tool calls within this run can derive the same bank ID
       if (userId) {
-        await ctx.state.set(
-          { scopeKind: "run", scopeId: runId, stateKey: "user-id" },
-          userId
-        );
+        await ctx.state.set({ scopeKind: "run", scopeId: runId, stateKey: "user-id" }, userId);
       }
 
       try {

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -20,12 +20,12 @@
 import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { HindsightClient, formatMemories } from "./client.js";
-import { deriveBankId } from "./bank.js";
+import { deriveBankId, extractUserFromIssue } from "./bank.js";
 
 interface PluginConfig {
   hindsightApiUrl: string;
   hindsightApiKeyRef?: string;
-  bankGranularity?: Array<"company" | "agent">;
+  bankGranularity?: Array<"company" | "agent" | "user">;
   recallBudget?: "low" | "mid" | "high";
   autoRetain?: boolean;
 }
@@ -97,10 +97,25 @@ const plugin = definePlugin({
       const query = [issue.title, issue.description].filter(Boolean).join("\n");
       if (!query.trim()) return;
 
+      // Extract userId from the specific issue being worked on (not an
+      // arbitrary one from list). This is only used when bankGranularity
+      // includes "user".
+      const userId = config.bankGranularity?.includes("user")
+        ? extractUserFromIssue(issue)
+        : undefined;
+
+      // Cache userId so tool calls within this run can derive the same bank ID
+      if (userId) {
+        await ctx.state.set(
+          { scopeKind: "run", scopeId: runId, stateKey: "user-id" },
+          userId
+        );
+      }
+
       try {
         const apiKey = await resolveApiKey(ctx, config);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
-        const bankId = deriveBankId({ companyId, agentId }, config);
+        const bankId = deriveBankId({ companyId, agentId, userId }, config);
 
         const response = await client.recall(bankId, query, config.recallBudget ?? "mid");
 
@@ -165,12 +180,19 @@ const plugin = definePlugin({
       // Bank attribution: comments authored by an agent belong in that agent's
       // bank; user/system comments fall back to the issue's assignee.
       let bankAgentId: string | null = payloadAgentId;
-      if (!bankAgentId) {
+      let userId: string | undefined;
+      let issueForAttribution;
+      if (!bankAgentId || config.bankGranularity?.includes("user")) {
         try {
-          const issue = await ctx.issues.get(issueId, companyId);
-          bankAgentId = issue?.assigneeAgentId ?? null;
+          issueForAttribution = await ctx.issues.get(issueId, companyId);
+          if (!bankAgentId) {
+            bankAgentId = issueForAttribution?.assigneeAgentId ?? null;
+          }
+          if (config.bankGranularity?.includes("user") && issueForAttribution) {
+            userId = extractUserFromIssue(issueForAttribution);
+          }
         } catch {
-          /* ignore */
+          /* ignore — userId stays undefined, bankAgentId fallback already handled */
         }
       }
 
@@ -185,7 +207,7 @@ const plugin = definePlugin({
       try {
         const apiKey = await resolveApiKey(ctx, config);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
-        const bankId = deriveBankId({ companyId, agentId: bankAgentId }, config);
+        const bankId = deriveBankId({ companyId, agentId: bankAgentId, userId }, config);
         await client.retain(bankId, body, commentId, {
           agentId: bankAgentId,
           companyId,
@@ -237,8 +259,20 @@ const plugin = definePlugin({
       async (params: unknown, runCtx: ToolRunContext) => {
         const { query } = params as { query: string };
         const config = await getConfig(ctx);
+
+        // Read userId cached by agent.run.started for consistent bank derivation
+        let userId: string | undefined;
+        if (config.bankGranularity?.includes("user")) {
+          const cachedUserId = await ctx.state.get({
+            scopeKind: "run",
+            scopeId: runCtx.runId,
+            stateKey: "user-id",
+          });
+          if (cachedUserId && typeof cachedUserId === "string") userId = cachedUserId;
+        }
+
         const bankId = deriveBankId(
-          { companyId: runCtx.companyId, agentId: runCtx.agentId },
+          { companyId: runCtx.companyId, agentId: runCtx.agentId, userId },
           config
         );
 
@@ -288,8 +322,20 @@ const plugin = definePlugin({
       async (params: unknown, runCtx: ToolRunContext) => {
         const { content } = params as { content: string };
         const config = await getConfig(ctx);
+
+        // Read userId cached by agent.run.started for consistent bank derivation
+        let userId: string | undefined;
+        if (config.bankGranularity?.includes("user")) {
+          const cached = await ctx.state.get({
+            scopeKind: "run",
+            scopeId: runCtx.runId,
+            stateKey: "user-id",
+          });
+          if (cached && typeof cached === "string") userId = cached;
+        }
+
         const bankId = deriveBankId(
-          { companyId: runCtx.companyId, agentId: runCtx.agentId },
+          { companyId: runCtx.companyId, agentId: runCtx.agentId, userId },
           config
         );
 

--- a/hindsight-integrations/paperclip/tests/bank-edge-cases.spec.ts
+++ b/hindsight-integrations/paperclip/tests/bank-edge-cases.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * Edge-case and interaction tests for bank ID derivation.
+ *
+ * These tests cover scenarios where the two new features (per-user isolation
+ * and static shared banks) interact, plus boundary conditions not covered by
+ * the main test suite.
+ */
+
+import { describe, expect, it } from "vitest";
+import { deriveBankId, extractUserFromIssue } from "../src/bank.js";
+
+// ---------------------------------------------------------------------------
+// Feature interaction: bankId + user granularity
+// ---------------------------------------------------------------------------
+
+describe("feature interaction: static bankId vs user granularity", () => {
+  it("static bankId wins over user granularity when dynamicBankId is not true", () => {
+    // If someone sets both bankId AND user granularity, static wins.
+    // This is intentional — bankId is an explicit override.
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1", userId: "alice@acme.com" },
+        {
+          bankId: "shared-team-bank",
+          bankGranularity: ["company", "agent", "user"],
+        }
+      )
+    ).toBe("shared-team-bank");
+  });
+
+  it("dynamicBankId=true restores user granularity even when bankId is set", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1", userId: "alice@acme.com" },
+        {
+          bankId: "shared-team-bank",
+          dynamicBankId: true,
+          bankGranularity: ["company", "agent", "user"],
+        }
+      )
+    ).toBe("paperclip::co-1::ag-1::user::alice@acme.com");
+  });
+
+  it("dynamicBankId=true with user granularity but no userId omits user segment", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        {
+          bankId: "shared-team-bank",
+          dynamicBankId: true,
+          bankGranularity: ["company", "agent", "user"],
+        }
+      )
+    ).toBe("paperclip::co-1::ag-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Static bankId edge cases
+// ---------------------------------------------------------------------------
+
+describe("static bankId edge cases", () => {
+  it("bankId with special characters is returned verbatim (no encoding)", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "team::project::shared" }
+      )
+    ).toBe("team::project::shared");
+  });
+
+  it("dynamicBankId=false explicitly is same as omitting it", () => {
+    const withFalse = deriveBankId(
+      { companyId: "co-1", agentId: "ag-1" },
+      { bankId: "my-bank", dynamicBankId: false }
+    );
+    const withOmit = deriveBankId(
+      { companyId: "co-1", agentId: "ag-1" },
+      { bankId: "my-bank" }
+    );
+    expect(withFalse).toBe(withOmit);
+    expect(withFalse).toBe("my-bank");
+  });
+
+  it("bankId without dynamicBankId set defaults to static", () => {
+    // Critical backwards-compat check: if someone sets only bankId,
+    // they expect it to be used. dynamicBankId defaults to undefined,
+    // which is !== true, so static path should activate.
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "spool-farm" }
+      )
+    ).toBe("spool-farm");
+  });
+
+  it("empty string bankId falls through to dynamic", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "", bankGranularity: ["company"] }
+      )
+    ).toBe("paperclip::co-1");
+  });
+
+  it("bankId of only tabs/newlines falls through to dynamic", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "\t\n  \t", bankGranularity: ["agent"] }
+      )
+    ).toBe("paperclip::ag-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic derivation edge cases
+// ---------------------------------------------------------------------------
+
+describe("dynamic derivation edge cases", () => {
+  it("empty granularity array produces only the prefix", () => {
+    expect(deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankGranularity: [] })).toBe(
+      "paperclip"
+    );
+  });
+
+  it("user-only granularity with userId", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1", userId: "alice@acme.com" },
+        { bankGranularity: ["user"] }
+      )
+    ).toBe("paperclip::user::alice@acme.com");
+  });
+
+  it("user-only granularity without userId produces only prefix", () => {
+    expect(
+      deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankGranularity: ["user"] })
+    ).toBe("paperclip");
+  });
+
+  it("duplicate granularity fields are handled (company twice)", () => {
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankGranularity: ["company", "company"] }
+      )
+    ).toBe("paperclip::co-1::co-1");
+  });
+
+  it("no config at all uses default granularity", () => {
+    expect(deriveBankId({ companyId: "co-1", agentId: "ag-1" }, {})).toBe(
+      "paperclip::co-1::ag-1"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUserFromIssue edge cases
+// ---------------------------------------------------------------------------
+
+describe("extractUserFromIssue edge cases", () => {
+  it("null originId returns undefined", () => {
+    expect(extractUserFromIssue({ originId: null })).toBeUndefined();
+  });
+
+  it("null creatorEmail falls through to originId", () => {
+    expect(
+      extractUserFromIssue({ creatorEmail: null, originId: "slack::alice@acme.com" })
+    ).toBe("alice@acme.com");
+  });
+
+  it("empty string creatorEmail falls through to originId", () => {
+    // creatorEmail is truthy check, empty string is falsy
+    expect(
+      extractUserFromIssue({ creatorEmail: "", originId: "slack::bob@co.io" })
+    ).toBe("bob@co.io");
+  });
+
+  it("originId with no separators but containing @ is returned", () => {
+    expect(extractUserFromIssue({ originId: "user@example.com" })).toBe("user@example.com");
+  });
+
+  it("originId with multiple emails picks the last one", () => {
+    // Scans backwards — last segment with @ wins
+    expect(
+      extractUserFromIssue({ originId: "admin@corp.io::slack::alice@acme.com" })
+    ).toBe("alice@acme.com");
+  });
+
+  it("both null returns undefined", () => {
+    expect(extractUserFromIssue({ originId: null, creatorEmail: null })).toBeUndefined();
+  });
+});

--- a/hindsight-integrations/paperclip/tests/bank-edge-cases.spec.ts
+++ b/hindsight-integrations/paperclip/tests/bank-edge-cases.spec.ts
@@ -62,10 +62,7 @@ describe("feature interaction: static bankId vs user granularity", () => {
 describe("static bankId edge cases", () => {
   it("bankId with special characters is returned verbatim (no encoding)", () => {
     expect(
-      deriveBankId(
-        { companyId: "co-1", agentId: "ag-1" },
-        { bankId: "team::project::shared" }
-      )
+      deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankId: "team::project::shared" })
     ).toBe("team::project::shared");
   });
 
@@ -74,10 +71,7 @@ describe("static bankId edge cases", () => {
       { companyId: "co-1", agentId: "ag-1" },
       { bankId: "my-bank", dynamicBankId: false }
     );
-    const withOmit = deriveBankId(
-      { companyId: "co-1", agentId: "ag-1" },
-      { bankId: "my-bank" }
-    );
+    const withOmit = deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankId: "my-bank" });
     expect(withFalse).toBe(withOmit);
     expect(withFalse).toBe("my-bank");
   });
@@ -86,12 +80,9 @@ describe("static bankId edge cases", () => {
     // Critical backwards-compat check: if someone sets only bankId,
     // they expect it to be used. dynamicBankId defaults to undefined,
     // which is !== true, so static path should activate.
-    expect(
-      deriveBankId(
-        { companyId: "co-1", agentId: "ag-1" },
-        { bankId: "spool-farm" }
-      )
-    ).toBe("spool-farm");
+    expect(deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankId: "spool-farm" })).toBe(
+      "spool-farm"
+    );
   });
 
   it("empty string bankId falls through to dynamic", () => {
@@ -149,9 +140,7 @@ describe("dynamic derivation edge cases", () => {
   });
 
   it("no config at all uses default granularity", () => {
-    expect(deriveBankId({ companyId: "co-1", agentId: "ag-1" }, {})).toBe(
-      "paperclip::co-1::ag-1"
-    );
+    expect(deriveBankId({ companyId: "co-1", agentId: "ag-1" }, {})).toBe("paperclip::co-1::ag-1");
   });
 });
 
@@ -165,16 +154,16 @@ describe("extractUserFromIssue edge cases", () => {
   });
 
   it("null creatorEmail falls through to originId", () => {
-    expect(
-      extractUserFromIssue({ creatorEmail: null, originId: "slack::alice@acme.com" })
-    ).toBe("alice@acme.com");
+    expect(extractUserFromIssue({ creatorEmail: null, originId: "slack::alice@acme.com" })).toBe(
+      "alice@acme.com"
+    );
   });
 
   it("empty string creatorEmail falls through to originId", () => {
     // creatorEmail is truthy check, empty string is falsy
-    expect(
-      extractUserFromIssue({ creatorEmail: "", originId: "slack::bob@co.io" })
-    ).toBe("bob@co.io");
+    expect(extractUserFromIssue({ creatorEmail: "", originId: "slack::bob@co.io" })).toBe(
+      "bob@co.io"
+    );
   });
 
   it("originId with no separators but containing @ is returned", () => {
@@ -183,9 +172,9 @@ describe("extractUserFromIssue edge cases", () => {
 
   it("originId with multiple emails picks the last one", () => {
     // Scans backwards — last segment with @ wins
-    expect(
-      extractUserFromIssue({ originId: "admin@corp.io::slack::alice@acme.com" })
-    ).toBe("alice@acme.com");
+    expect(extractUserFromIssue({ originId: "admin@corp.io::slack::alice@acme.com" })).toBe(
+      "alice@acme.com"
+    );
   });
 
   it("both null returns undefined", () => {

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -113,6 +113,43 @@ describe("bank ID derivation", () => {
       )
     ).toBe("paperclip::co-1::ag-1");
   });
+
+  it("static bankId overrides derivation when dynamicBankId is not true", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "spool-farm", bankGranularity: ["company", "agent"] }
+      )
+    ).toBe("spool-farm");
+  });
+
+  it("static bankId is trimmed", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankId: "  shared-bank  " })
+    ).toBe("shared-bank");
+  });
+
+  it("empty/whitespace bankId falls through to dynamic derivation", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "   ", bankGranularity: ["company", "agent"] }
+      )
+    ).toBe("paperclip::co-1::ag-1");
+  });
+
+  it("dynamicBankId=true ignores static bankId", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankId: "spool-farm", dynamicBankId: true, bankGranularity: ["company", "agent"] }
+      )
+    ).toBe("paperclip::co-1::ag-1");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -236,6 +273,31 @@ describe("agent.run.started", () => {
       stateKey: "user-id",
     });
     expect(cachedUserId).toBe("alice@acme.com");
+  });
+
+  it("routes recall to static bankId when dynamicBankId is not true", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      bankId: "spool-farm",
+      dynamicBankId: false,
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Shared project context",
+    });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-static-1", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    const recallCall = fetchMock.mock.calls.find(([url]: [string]) => url.includes("recall"));
+    expect(recallCall).toBeDefined();
+    expect(recallCall?.[0]).toContain(encodeURIComponent("spool-farm"));
+    // Should NOT contain the dynamic derivation prefix
+    expect(recallCall?.[0]).not.toContain(encodeURIComponent("paperclip::"));
   });
 
   it("skips recall when no issueId is provided", async () => {

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -93,6 +93,64 @@ describe("bank ID derivation", () => {
       deriveBankId({ companyId: "co-1", agentId: "ag-1" }, { bankGranularity: ["agent"] })
     ).toBe("paperclip::ag-1");
   });
+
+  it("company + agent + user", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1", userId: "alice@acme.com" },
+        { bankGranularity: ["company", "agent", "user"] }
+      )
+    ).toBe("paperclip::co-1::ag-1::user::alice@acme.com");
+  });
+
+  it("user granularity without userId falls back to company+agent", async () => {
+    const { deriveBankId } = await import("../src/bank.js");
+    expect(
+      deriveBankId(
+        { companyId: "co-1", agentId: "ag-1" },
+        { bankGranularity: ["company", "agent", "user"] }
+      )
+    ).toBe("paperclip::co-1::ag-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUserFromIssue
+// ---------------------------------------------------------------------------
+
+describe("extractUserFromIssue", () => {
+  it("extracts email from originId", async () => {
+    const { extractUserFromIssue } = await import("../src/bank.js");
+    expect(extractUserFromIssue({ originId: "slack::alice@acme.com" })).toBe("alice@acme.com");
+  });
+
+  it("prefers creatorEmail over originId", async () => {
+    const { extractUserFromIssue } = await import("../src/bank.js");
+    expect(
+      extractUserFromIssue({
+        creatorEmail: "bob@acme.com",
+        originId: "slack::alice@acme.com",
+      })
+    ).toBe("bob@acme.com");
+  });
+
+  it("returns undefined when no email found", async () => {
+    const { extractUserFromIssue } = await import("../src/bank.js");
+    expect(extractUserFromIssue({ originId: "slack::channel-123" })).toBeUndefined();
+  });
+
+  it("returns undefined when issue has no originId or creatorEmail", async () => {
+    const { extractUserFromIssue } = await import("../src/bank.js");
+    expect(extractUserFromIssue({})).toBeUndefined();
+  });
+
+  it("handles multi-segment originId", async () => {
+    const { extractUserFromIssue } = await import("../src/bank.js");
+    expect(
+      extractUserFromIssue({ originId: "zendesk::org-42::ticket-7::user@corp.io" })
+    ).toBe("user@corp.io");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -142,6 +200,42 @@ describe("agent.run.started", () => {
       stateKey: "recalled-memories",
     });
     expect(state).toContain("TypeScript");
+  });
+
+  it("uses user-scoped bank ID when bankGranularity includes 'user'", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      bankGranularity: ["company", "agent", "user"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Fix user-specific bug",
+      description: "Details here",
+    });
+    // Simulate originId with user email (set via harness internals)
+    (issue as Record<string, unknown>).originId = "slack::alice@acme.com";
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-user-1", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    const recallCall = fetchMock.mock.calls.find(([url]: [string]) => url.includes("recall"));
+    expect(recallCall).toBeDefined();
+    // Bank ID should include user segment
+    expect(recallCall?.[0]).toContain(
+      encodeURIComponent("paperclip::co-1::ag-1::user::alice@acme.com")
+    );
+
+    // Verify userId was cached in state for tool calls
+    const cachedUserId = harness.getState({
+      scopeKind: "run",
+      scopeId: "run-user-1",
+      stateKey: "user-id",
+    });
+    expect(cachedUserId).toBe("alice@acme.com");
   });
 
   it("skips recall when no issueId is provided", async () => {

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -184,9 +184,9 @@ describe("extractUserFromIssue", () => {
 
   it("handles multi-segment originId", async () => {
     const { extractUserFromIssue } = await import("../src/bank.js");
-    expect(
-      extractUserFromIssue({ originId: "zendesk::org-42::ticket-7::user@corp.io" })
-    ).toBe("user@corp.io");
+    expect(extractUserFromIssue({ originId: "zendesk::org-42::ticket-7::user@corp.io" })).toBe(
+      "user@corp.io"
+    );
   });
 });
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -453,7 +453,7 @@ two slots that retain/consolidation cannot consume.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
+| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openai-codex`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
@@ -462,6 +462,7 @@ two slots that retain/consolidation cannot consume.
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
+| `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_MODEL` | OpenRouter embedding model | `perplexity/pplx-embed-v1-0.6b` |
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY` | Cohere API key for embeddings | - |
@@ -520,8 +521,14 @@ export HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
 
 # OpenAI - cloud-based embeddings
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxxxxxxxxxx  # or reuses HINDSIGHT_API_LLM_API_KEY
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=***  # or reuses HINDSIGHT_API_LLM_API_KEY
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
+
+# OpenAI Codex OAuth - uses existing ChatGPT/Codex login, no API key needed
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai-codex
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
 
 # Azure OpenAI - embeddings via Azure endpoint
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai


### PR DESCRIPTION
## Summary

Two bank-routing features for the Paperclip integration, both requested by external contributors:

### 1. Per-user memory isolation (#1561 by @amirhmoradi)

- Adds `'user'` as a `bankGranularity` option, enabling per-user memory isolation (e.g. `paperclip::co-1::ag-1::user::alice@acme.com`)
- Extracts user identity from the **specific issue in context** (via `originId` email or `creatorEmail`), fixing the design flaw in #1561 which used `ctx.issues.list()` and picked an arbitrary issue
- Caches `userId` in plugin state during `agent.run.started` so mid-run tool calls derive the same bank ID

### 2. Static shared bank (`bankId` / `dynamicBankId`) (#1589 by @SeBru1)

- Adds `bankId` (string) and `dynamicBankId` (boolean, default `true`) matching the convention used by openclaw, claude-code, and opencode
- When `bankId` is set and `dynamicBankId` is not `true`, all agents share the same bank — useful for multi-agent cohorts that need collaborative memory
- Whitespace-only `bankId` falls through to dynamic derivation

Both features are fully backward compatible — default behavior is unchanged.

### Files changed

| File | Change |
|---|---|
| `src/bank.ts` | `userId?` on `BankContext`, `bankId`/`dynamicBankId` on `BankConfig`, static override in `deriveBankId()`, `extractUserFromIssue()` helper |
| `src/worker.ts` | All 4 bank-derivation sites pass `userId`; tools read cached userId from state; `bankId`/`dynamicBankId` on `PluginConfig` |
| `src/manifest.ts` | `dynamicBankId`, `bankId`, `"user"` granularity option |
| `tests/plugin.spec.ts` | 11 new tests (bank derivation, user extraction, static override, integration routing) |

Closes #1561 — thanks @amirhmoradi for the original per-user isolation concept.
Closes #1589 — thanks @SeBru1 for the shared-bank concept (renamed from `sharedBankName` to `bankId`/`dynamicBankId` per review feedback).

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 31/31 pass (20 existing + 11 new)
- [ ] CI `test-paperclip-integration` job passes