### PR TITLE
feat(control-plane): surface clear_mental_model in UI

### DIFF
--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -141,6 +141,7 @@ const MCP_TOOL_GROUPS: { label: string; tools: string[] }[] = [
       "update_mental_model",
       "delete_mental_model",
       "refresh_mental_model",
+      "clear_mental_model",
     ],
   },
   { label: "Directives", tools: ["list_directives", "create_directive", "delete_directive"] },

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -22,6 +22,7 @@ import {
   ChevronLeft,
   ChevronRight,
   MoreVertical,
+  Eraser,
   Pencil,
   RefreshCw,
   Trash2,
@@ -570,6 +571,7 @@ interface MentalModelDetailModalProps {
   onClose: () => void;
   onEdit?: (m: MentalModel) => void;
   onDelete?: (m: MentalModel) => void;
+  onClear?: (m: MentalModel) => void;
   onRefreshed?: (m: MentalModel) => void;
   initialTab?: "content" | "configuration" | "history";
 }
@@ -579,6 +581,7 @@ export function MentalModelDetailModal({
   onClose,
   onEdit,
   onDelete,
+  onClear,
   onRefreshed,
   initialTab = "content",
 }: MentalModelDetailModalProps) {
@@ -786,6 +789,12 @@ export function MentalModelDetailModal({
                       <RefreshCw className="h-4 w-4 mr-2" />
                       Refresh Manually
                     </DropdownMenuItem>
+                    {onClear && (
+                      <DropdownMenuItem onClick={() => onClear(mentalModel)}>
+                        <Eraser className="h-4 w-4 mr-2" />
+                        Clear Content
+                      </DropdownMenuItem>
+                    )}
                     {onDelete && (
                       <>
                         <DropdownMenuSeparator />

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -43,6 +43,7 @@ import {
   Sparkles,
   Loader2,
   Trash2,
+  Eraser,
   RefreshCw,
   ChevronLeft,
   ChevronRight,
@@ -124,6 +125,11 @@ export function MentalModelsView() {
     name: string;
   } | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [clearTarget, setClearTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [clearing, setClearing] = useState(false);
 
   // Tag filtering happens server-side; only the search text is applied locally.
   const filteredMentalModels = mentalModels.filter((m) => {
@@ -199,6 +205,23 @@ export function MentalModelsView() {
       // Error toast is shown automatically by the API client interceptor
     } finally {
       setDeleting(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (!currentBank || !clearTarget) return;
+
+    setClearing(true);
+    try {
+      const updated = await client.clearMentalModel(currentBank, clearTarget.id);
+      setMentalModels((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+      if (selectedMentalModel?.id === updated.id) setSelectedMentalModel(updated);
+      toast.success("Mental model content cleared");
+      setClearTarget(null);
+    } catch {
+      // Error toast handled by API client interceptor
+    } finally {
+      setClearing(false);
     }
   };
 
@@ -355,6 +378,9 @@ export function MentalModelsView() {
                                 setShowUpdateDialog(true);
                               }}
                               onRefresh={handleRowRefresh}
+                              onClear={(target) =>
+                                setClearTarget({ id: target.id, name: target.name })
+                              }
                               onDelete={(target) =>
                                 setDeleteTarget({ id: target.id, name: target.name })
                               }
@@ -415,6 +441,7 @@ export function MentalModelsView() {
                     setShowUpdateDialog(true);
                   }}
                   onRefresh={handleRowRefresh}
+                  onClear={(target) => setClearTarget({ id: target.id, name: target.name })}
                   onDelete={(target) => setDeleteTarget({ id: target.id, name: target.name })}
                 />
               )}
@@ -519,10 +546,33 @@ export function MentalModelsView() {
         </AlertDialogContent>
       </AlertDialog>
 
+      <AlertDialog open={!!clearTarget} onOpenChange={(open) => !open && setClearTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear Mental Model Content</AlertDialogTitle>
+            <AlertDialogDescription>
+              Clear the content of{" "}
+              <span className="font-semibold">&quot;{clearTarget?.name}&quot;</span>?
+              <br />
+              <br />
+              The next refresh will re-synthesize content from scratch.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-row justify-end space-x-2">
+            <AlertDialogCancel className="mt-0">Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleClear} disabled={clearing}>
+              {clearing ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+              Clear
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <MentalModelDetailModal
         mentalModelId={selectedMentalModel?.id ?? null}
         onClose={() => setSelectedMentalModel(null)}
         onDelete={(m) => setDeleteTarget({ id: m.id, name: m.name })}
+        onClear={(m) => setClearTarget({ id: m.id, name: m.name })}
         onEdit={(m) => {
           setMentalModelToUpdate(m);
           setShowUpdateDialog(true);
@@ -558,6 +608,7 @@ function RowActionsMenu({
   refreshing,
   onEdit,
   onRefresh,
+  onClear,
   onDelete,
   triggerClassName,
 }: {
@@ -565,6 +616,7 @@ function RowActionsMenu({
   refreshing: boolean;
   onEdit: (m: MentalModel) => void;
   onRefresh: (m: MentalModel) => void;
+  onClear: (m: MentalModel) => void;
   onDelete: (m: MentalModel) => void;
   triggerClassName?: string;
 }) {
@@ -589,6 +641,10 @@ function RowActionsMenu({
         <DropdownMenuItem onClick={() => onRefresh(m)} disabled={refreshing}>
           <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? "animate-spin" : ""}`} />
           Refresh Manually
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onClear(m)}>
+          <Eraser className="h-4 w-4 mr-2" />
+          Clear Content
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
@@ -1425,6 +1481,7 @@ function FilesView({
   refreshingIds,
   onEdit,
   onRefresh,
+  onClear,
   onDelete,
 }: {
   mentalModels: MentalModel[];
@@ -1434,6 +1491,7 @@ function FilesView({
   refreshingIds: Set<string>;
   onEdit: (m: MentalModel) => void;
   onRefresh: (m: MentalModel) => void;
+  onClear: (m: MentalModel) => void;
   onDelete: (m: MentalModel) => void;
 }) {
   const effectiveId =
@@ -1526,6 +1584,7 @@ function FilesView({
                     refreshing={refreshingIds.has(selected.id)}
                     onEdit={onEdit}
                     onRefresh={onRefresh}
+                    onClear={onClear}
                     onDelete={onDelete}
                   />
                 </div>

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1187,6 +1187,16 @@ export class ControlPlaneClient {
   }
 
   /**
+   * Clear a mental model's content. The next refresh re-synthesizes from scratch.
+   */
+  async clearMentalModel(bankId: string, mentalModelId: string) {
+    return this.fetchApi<MentalModel>(
+      bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/clear`),
+      { method: "POST" }
+    );
+  }
+
+  /**
    * Get the refresh history of a mental model
    */
   async getMentalModelHistory(bankId: string, mentalModelId: string) {

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -453,7 +453,7 @@ two slots that retain/consolidation cannot consume.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
+| `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `tei`, `openai`, `openai-codex`, `openrouter`, `cohere`, `google`, `litellm`, or `litellm-sdk` | `local` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider | `BAAI/bge-small-en-v1.5` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` | Force CPU mode for local embeddings (avoids MPS/XPC issues on macOS) | `false` |
@@ -462,6 +462,7 @@ two slots that retain/consolidation cannot consume.
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL` | OpenAI embedding model | `text-embedding-3-small` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible API (e.g., Azure OpenAI) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE` | Max inputs per `embeddings.create` call for `openai`/`openrouter` providers — lower this when the upstream endpoint enforces stricter limits (e.g. DashScope caps at 10) | `100` |
+| `HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS` | Optional requested output dimensions for OpenAI `text-embedding-3` models (e.g., `384` to match an existing pgvector schema) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY` | OpenRouter API key for embeddings (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_EMBEDDINGS_OPENROUTER_MODEL` | OpenRouter embedding model | `perplexity/pplx-embed-v1-0.6b` |
 | `HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY` | Cohere API key for embeddings | - |
@@ -520,8 +521,14 @@ export HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
 
 # OpenAI - cloud-based embeddings
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-xxxxxxxxxxxx  # or reuses HINDSIGHT_API_LLM_API_KEY
-export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=***  # or reuses HINDSIGHT_API_LLM_API_KEY
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
+
+# OpenAI Codex OAuth - uses existing ChatGPT/Codex login, no API key needed
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai-codex
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small  # 1536 dimensions by default
+# export HINDSIGHT_API_EMBEDDINGS_OPENAI_DIMENSIONS=384  # optional reduced output size
 
 # Azure OpenAI - embeddings via Azure endpoint
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai


### PR DESCRIPTION
## Summary

- Add `clear_mental_model` to `MCP_TOOL_GROUPS` in the bank-config view so it can be toggled per-bank in the MCP tool selector.
- Add a "Clear Content" action to the mental model row dropdown (`RowActionsMenu`) and the detail-modal dropdown, with a confirmation `AlertDialog`. Wires up `clearMentalModel()` in the control-plane API client.

The backend MCP tool + HTTP endpoint + SDK changes landed in #1706, but the control-plane UI wasn't updated. This PR closes that gap.

## Test plan

- [ ] Open Bank → Config → toggle "Restrict MCP tools" → confirm `clear_mental_model` appears under the "Mental models" group.
- [ ] Mental Models page → row "⋮" → click "Clear Content" → confirm dialog → confirm → content empties, toast shown.
- [ ] Open a mental model detail modal → "⋮" → "Clear Content" works the same way.
- [ ] CI green (lint + typecheck).