### PR TITLE
fix(consolidation): resolve orphaned-task and scheduling bugs

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -883,6 +883,16 @@ async def _process_memory_batch(
     for update in llm_result.updates:
         source_mems = [mem_by_id[fid] for fid in update.source_fact_ids if fid in mem_by_id]
         if not source_mems:
+            # The LLM returned source_fact_ids that don't match any memory UUID in
+            # this batch. Common cause: model hallucinated IDs, changed UUID format
+            # (e.g. no dashes / uppercase), or referenced IDs from previous batches.
+            unknown_ids = [fid for fid in update.source_fact_ids if fid not in mem_by_id]
+            logger.warning(
+                f"[CONSOLIDATION] bank={bank_id} rejected update for observation "
+                f"{update.observation_id}: none of source_fact_ids {update.source_fact_ids!r} "
+                f"matched a memory in this batch (unknown: {unknown_ids!r}, "
+                f"batch_ids={list(mem_by_id)[:5]}...)"
+            )
             continue
         # Security: the observation must have been recalled for at least one of the source facts
         if not any(update.observation_id in per_fact_obs_ids.get(str(m["id"]), set()) for m in source_mems):
@@ -912,6 +922,12 @@ async def _process_memory_batch(
     for create in llm_result.creates:
         source_mems = [mem_by_id[fid] for fid in create.source_fact_ids if fid in mem_by_id]
         if not source_mems:
+            unknown_ids = [fid for fid in create.source_fact_ids if fid not in mem_by_id]
+            logger.warning(
+                f"[CONSOLIDATION] bank={bank_id} rejected create '{create.text[:80]}': "
+                f"none of source_fact_ids {create.source_fact_ids!r} matched a memory in this batch "
+                f"(unknown: {unknown_ids!r}, batch_ids={list(mem_by_id)[:5]}...)"
+            )
             continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
         await _execute_create_action(

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -731,11 +731,15 @@ class OracleOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                # Two-step: find busy banks first, then claim excluding them
+                # Two-step: find busy banks first, then claim excluding them.
+                # claimed_at IS NULL means the row was never actually claimed — treat as
+                # orphaned.  Tasks stuck for > 2 hours are also orphaned.
                 busy_banks = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
                     WHERE operation_type = 'consolidation' AND status = 'processing'
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at > SYSDATE - 2/24
                     """,
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
@@ -837,10 +841,13 @@ class OracleOps(DataAccessOps):
 
             # 2b. Consolidation tasks (with bank-serialization)
             if remaining_shared > 0:
+                # Same guard as Phase 1: only banks with a recent, non-NULL claimed_at are busy.
                 busy_banks_2 = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
                     WHERE operation_type = 'consolidation' AND status = 'processing'
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at > SYSDATE - 2/24
                     """,
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -775,10 +775,18 @@ class PostgreSQLOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
+                # Only exclude banks with a *recent*, actively-claimed processing task.
+                # claimed_at IS NULL means the row was never actually claimed (worker
+                # crashed before setting it, or it pre-dates the column) — treat it as
+                # orphaned.  Tasks stuck for > 2 hours are also treated as orphaned.
+                # recover_own_tasks() handles cleanup at startup; this guard prevents
+                # indefinite blocking between restarts.
                 busy_banks = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
                     WHERE operation_type = 'consolidation' AND status = 'processing'
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at > now() - interval '2 hours'
                     """,
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
@@ -880,10 +888,13 @@ class PostgreSQLOps(DataAccessOps):
 
             # 2b. Consolidation tasks (with bank-serialization)
             if remaining_shared > 0:
+                # Same guard as Phase 1: only banks with a recent, non-NULL claimed_at are busy.
                 busy_banks_2 = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
                     WHERE operation_type = 'consolidation' AND status = 'processing'
+                      AND claimed_at IS NOT NULL
+                      AND claimed_at > now() - interval '2 hours'
                     """,
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1709,14 +1709,28 @@ class MemoryEngine(MemoryEngineInterface):
             backend = await self._get_backend()
             async with acquire_with_retry(backend) as conn:
                 async with conn.transaction():
+                    # Merge consolidation stats into result_metadata so items_count
+                    # and observation counters are visible in the operations list.
+                    items_count = result.get("memories_processed", 0) if result else 0
+                    extra_meta = json.dumps(
+                        {
+                            "items_count": items_count,
+                            "observations_created": result.get("observations_created", 0) if result else 0,
+                            "observations_updated": result.get("observations_updated", 0) if result else 0,
+                            "observations_deleted": result.get("observations_deleted", 0) if result else 0,
+                        },
+                        default=_json_default,
+                    )
                     row = await conn.fetchrow(
                         f"""
                         UPDATE {fq_table("async_operations")}
-                        SET status = 'completed', updated_at = NOW(), completed_at = NOW()
+                        SET status = 'completed', updated_at = NOW(), completed_at = NOW(),
+                            result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb
                         WHERE operation_id = $1
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
+                        extra_meta,
                     )
                     if row is None:
                         logger.info(
@@ -7034,7 +7048,9 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT
                     MAX(consolidated_at) as last_consolidated_at,
-                    COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) as pending,
+                    COUNT(*) FILTER (WHERE consolidated_at IS NULL
+                                      AND consolidation_failed_at IS NULL
+                                      AND fact_type IN ('experience', 'world')) as pending,
                     COUNT(*) FILTER (WHERE consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')) as failed
                 FROM {fq_table("memory_units")}
                 WHERE bank_id = $1
@@ -9040,7 +9056,7 @@ class MemoryEngine(MemoryEngineInterface):
         async with acquire_with_retry(backend) as conn:
             # Check if operation exists, belongs to this bank, and is in a cancellable state
             result = await conn.fetchrow(
-                f"SELECT bank_id, status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+                f"SELECT bank_id, status, claimed_at FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
                 op_uuid,
                 bank_id,
             )
@@ -9048,13 +9064,32 @@ class MemoryEngine(MemoryEngineInterface):
             if not result:
                 raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
 
-            if result["status"] != "pending":
+            status = result["status"]
+            if status not in ("pending", "processing"):
                 from hindsight_api.extensions import OperationValidationError
 
                 raise OperationValidationError(
-                    f"Operation {operation_id} cannot be cancelled: status is '{result['status']}', only 'pending' operations can be cancelled",
+                    f"Operation {operation_id} cannot be cancelled: status is '{status}', "
+                    "only 'pending' or 'processing' (after 5 minutes) operations can be cancelled",
                     409,
                 )
+
+            if status == "processing":
+                from hindsight_api.extensions import OperationValidationError
+
+                # Allow cancellation of processing tasks only if they have been running
+                # for at least 5 minutes — avoids races with tasks that just started.
+                # _check_op_alive() in run_consolidation_job detects the 'cancelled' status
+                # at each batch checkpoint and stops early.
+                claimed_at = result["claimed_at"]
+                if claimed_at is not None:
+                    age_seconds = (datetime.now(UTC) - claimed_at).total_seconds()
+                    if age_seconds < 300:
+                        raise OperationValidationError(
+                            f"Operation {operation_id} has been 'processing' for only {int(age_seconds)}s; "
+                            "wait at least 5 minutes before cancelling a running operation",
+                            409,
+                        )
 
             # Mark the operation as cancelled
             await conn.execute(

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -735,9 +735,18 @@ class WorkerPoller:
         """
         Recover tasks that were assigned to this worker but not completed.
 
-        This handles the case where a worker crashes while processing tasks.
-        On startup, we reset any tasks stuck in 'processing' for this worker_id
-        back to 'pending' so they can be picked up again.
+        Two recovery passes are run on every startup:
+
+        Pass 1 — own tasks: reset any 'processing' row whose worker_id matches
+        this worker.  This handles the common crash/restart case.
+
+        Pass 2 — orphaned tasks: reset 'processing' rows from *any* worker that
+        have been stuck for longer than STALE_TASK_THRESHOLD_S.  This handles
+        the case where the previous worker process exited with a different
+        worker_id (e.g. container replaced, binary updated), leaving rows that
+        Pass 1 would never touch.  Without this pass, the bank-serialisation
+        logic in claim_tasks permanently blocks new consolidation for the same
+        bank because it finds a 'processing' row and skips the bank.
 
         Also recovers batch API operations that were in-flight.
 
@@ -746,6 +755,9 @@ class WorkerPoller:
         Returns:
             Number of tasks recovered
         """
+        # Tasks stuck in processing for longer than this are considered orphaned.
+        STALE_TASK_THRESHOLD_S = 7200  # 2 hours
+
         schemas = await self._get_schemas()
         total_count = 0
 
@@ -757,8 +769,8 @@ class WorkerPoller:
                 batch_count = await self._recover_batch_operations(schema)
                 total_count += batch_count
 
-                # Then reset normal worker tasks
                 async with self._backend.acquire() as conn:
+                    # Pass 1: reset tasks that belong to this worker (crashed/restarted).
                     result = await conn.execute(
                         f"""
                         UPDATE {table}
@@ -767,10 +779,32 @@ class WorkerPoller:
                         """,
                         self._worker_id,
                     )
+                    own_count = int(result.split()[-1]) if result else 0
 
-                # Parse "UPDATE N" to get count
-                count = int(result.split()[-1]) if result else 0
-                total_count += count
+                    # Pass 2: reset orphaned tasks from *any* worker that have been
+                    # stuck in processing beyond the stale threshold.  These were
+                    # abandoned by a dead worker with a different worker_id and can
+                    # never be recovered by Pass 1.
+                    result2 = await conn.execute(
+                        f"""
+                        UPDATE {table}
+                        SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                        WHERE status = 'processing'
+                          AND worker_id != $1
+                          AND result_metadata->>'batch_id' IS NULL
+                          AND (claimed_at IS NULL OR claimed_at < now() - interval '{STALE_TASK_THRESHOLD_S} seconds')
+                        """,
+                        self._worker_id,
+                    )
+                    stale_count = int(result2.split()[-1]) if result2 else 0
+
+                total_count += own_count + stale_count
+                if stale_count > 0:
+                    schema_display = f'"{schema}"' if schema else "default"
+                    logger.warning(
+                        f"Worker {self._worker_id} reset {stale_count} orphaned processing tasks "
+                        f"(stuck >{STALE_TASK_THRESHOLD_S}s from other workers) in schema {schema_display}"
+                    )
             except Exception as e:
                 # Format schema for logging: custom schemas in quotes, None as-is
                 schema_display = f'"{schema}"' if schema else str(schema)

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -264,11 +264,17 @@ async def test_cancel_allows_stale_processing_operations(api_client, memory, tes
 
 
 @pytest.mark.asyncio
-async def test_cancel_rejects_processing_with_null_claimed_at(api_client, memory, test_bank_id):
-    """A processing op with NULL claimed_at is not yet claimed; cancel should be rejected (age=0s)."""
+async def test_cancel_allows_processing_with_null_claimed_at(api_client, memory, test_bank_id):
+    """A processing op with NULL claimed_at was never claimed by a worker; cancel should succeed (200)."""
     pool = memory._pool
     await _ensure_bank(pool, test_bank_id)
 
     op_id = await _insert_operation(pool, test_bank_id, "processing", claimed_at=None)
     response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
-    assert response.status_code == 409
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    # Verify status is now cancelled
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -7,8 +7,9 @@ Regression tests:
 - Cancel used to delete the operation row; now it sets status to 'cancelled'.
 - Retry now accepts both 'failed' and 'cancelled' operations.
 """
+
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -41,17 +42,24 @@ async def _ensure_bank(pool, bank_id: str) -> None:
     )
 
 
-async def _insert_operation(pool, bank_id: str, status: str) -> str:
+async def _insert_operation(
+    pool,
+    bank_id: str,
+    status: str,
+    *,
+    claimed_at: datetime | None = None,
+) -> str:
     """Insert a test operation with the given status and return its ID."""
     op_id = uuid.uuid4()
     await pool.execute(
         """
-        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
-        VALUES ($1, $2, 'retain', $3, '{"test": true}'::jsonb)
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, claimed_at)
+        VALUES ($1, $2, 'retain', $3, '{"test": true}'::jsonb, $4)
         """,
         op_id,
         bank_id,
         status,
+        claimed_at,
     )
     return str(op_id)
 
@@ -124,9 +132,7 @@ async def test_get_operation_returns_processing_status(api_client, memory, test_
 
     processing_id = await _insert_operation(pool, test_bank_id, "processing")
 
-    response = await api_client.get(
-        f"/v1/default/banks/{test_bank_id}/operations/{processing_id}"
-    )
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{processing_id}")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "processing"
@@ -154,9 +160,7 @@ async def test_all_statuses_returned_correctly(api_client, memory, test_bank_id)
 
     # Verify get endpoint for each
     for status, op_id in ids.items():
-        response = await api_client.get(
-            f"/v1/default/banks/{test_bank_id}/operations/{op_id}"
-        )
+        response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
         assert response.status_code == 200
         assert response.json()["status"] == status, f"Get: expected {status} for {op_id}"
 
@@ -170,16 +174,12 @@ async def test_cancel_sets_cancelled_status(api_client, memory, test_bank_id):
     op_id = await _insert_operation(pool, test_bank_id, "pending")
 
     # Cancel the operation
-    response = await api_client.delete(
-        f"/v1/default/banks/{test_bank_id}/operations/{op_id}"
-    )
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
     assert response.status_code == 200
     assert response.json()["success"] is True
 
     # Verify the operation still exists with 'cancelled' status
-    response = await api_client.get(
-        f"/v1/default/banks/{test_bank_id}/operations/{op_id}"
-    )
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
     assert response.status_code == 200
     assert response.json()["status"] == "cancelled"
 
@@ -203,16 +203,12 @@ async def test_retry_cancelled_operation(api_client, memory, test_bank_id):
     op_id = await _insert_operation(pool, test_bank_id, "cancelled")
 
     # Retry the cancelled operation
-    response = await api_client.post(
-        f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry"
-    )
+    response = await api_client.post(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry")
     assert response.status_code == 200
     assert response.json()["success"] is True
 
     # Verify the operation is now pending
-    response = await api_client.get(
-        f"/v1/default/banks/{test_bank_id}/operations/{op_id}"
-    )
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
     assert response.status_code == 200
     assert response.json()["status"] == "pending"
 
@@ -225,21 +221,54 @@ async def test_retry_rejects_non_retriable_statuses(api_client, memory, test_ban
 
     for status in ("pending", "processing", "completed"):
         op_id = await _insert_operation(pool, test_bank_id, status)
-        response = await api_client.post(
-            f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry"
-        )
+        response = await api_client.post(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry")
         assert response.status_code == 409, f"Expected 409 for {status}, got {response.status_code}"
 
 
 @pytest.mark.asyncio
-async def test_cancel_rejects_non_pending_operations(api_client, memory, test_bank_id):
-    """DELETE /operations/{id} should only cancel pending operations."""
+async def test_cancel_rejects_terminal_and_recent_processing_operations(api_client, memory, test_bank_id):
+    """DELETE /operations/{id} should reject completed/failed and recently-claimed processing ops."""
     pool = memory._pool
     await _ensure_bank(pool, test_bank_id)
 
-    for status in ("processing", "completed", "failed"):
+    # Terminal statuses always get 409
+    for status in ("completed", "failed"):
         op_id = await _insert_operation(pool, test_bank_id, status)
-        response = await api_client.delete(
-            f"/v1/default/banks/{test_bank_id}/operations/{op_id}"
-        )
+        response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
         assert response.status_code == 409, f"Expected 409 for {status}, got {response.status_code}"
+
+    # Processing with claimed_at < 5 min ago → 409 (too recent to force-cancel)
+    recent_claimed = datetime.now(UTC) - timedelta(minutes=1)
+    op_id = await _insert_operation(pool, test_bank_id, "processing", claimed_at=recent_claimed)
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 409, "Expected 409 for recently-claimed processing op"
+
+
+@pytest.mark.asyncio
+async def test_cancel_allows_stale_processing_operations(api_client, memory, test_bank_id):
+    """DELETE /operations/{id} should succeed for processing ops claimed more than 5 minutes ago."""
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    stale_claimed = datetime.now(UTC) - timedelta(minutes=10)
+    op_id = await _insert_operation(pool, test_bank_id, "processing", claimed_at=stale_claimed)
+
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    # Verify status is now cancelled
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_rejects_processing_with_null_claimed_at(api_client, memory, test_bank_id):
+    """A processing op with NULL claimed_at is not yet claimed; cancel should be rejected (age=0s)."""
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    op_id = await _insert_operation(pool, test_bank_id, "processing", claimed_at=None)
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 409


### PR DESCRIPTION
## Summary

Fix a cluster of consolidation scheduling, recovery, and observability gaps that made interrupted consolidation hard to recover from. The central issue is a `claimed_at IS NULL` recovery gap: old `processing` rows can have no claim timestamp, stale detection does not recognize them, and the bank serialization guard can keep treating the bank as busy indefinitely.

## Root cause

Hindsight uses `async_operations` to coordinate background memory work such as retain, batch retain, and consolidation. The memories themselves live in `documents` / `memory_units`; this table matters here because a single stuck `processing` queue row can make the consolidation scheduler believe the whole bank is still busy.

```text
-- async_operations, simplified to columns relevant to this bug
┌──────────┬────────────────┬────────────┬───────────┬────────────┬──────────────────────┐
│ bank_id  │ operation_type │ status     │ worker_id │ claimed_at │ effect               │
├──────────┼────────────────┼────────────┼───────────┼────────────┼──────────────────────┤
│ bank-xyz │ retain         │ completed  │ worker-1  │ 14:22      │ normal recent retain │
│ bank-xyz │ retain         │ completed  │ worker-1  │ 14:22      │ normal recent retain │
│ bank-xyz │ batch_retain   │ completed  │           │            │ parent aggregator    │
│ bank-xyz │ consolidation  │ completed  │ worker-1  │ 13:58      │ last successful run  │
│ bank-xyz │ consolidation  │ processing │ worker-1  │ NULL       │ orphaned blocker ✗   │
│ bank-xyz │ consolidation  │ pending    │           │            │ claimable, blocked ✗ │
│ bank-xyz │ consolidation  │ pending    │           │            │ claimable, blocked ✗ │
│ bank-xyz │ consolidation  │ pending    │           │            │ claimable, blocked ✗ │
└──────────┴────────────────┴────────────┴───────────┴────────────┴──────────────────────┘
```

The blocker is bank-level serialization: Hindsight only allows one active consolidation per bank. Before this fix, any `processing` consolidation row made the bank look busy, even if it was orphaned with `claimed_at IS NULL`. That put `bank-xyz` in `busy_bank_ids`, so the pending consolidation rows for the same bank were skipped on every poll cycle.

The flow is:

```text
  Before fix                                      After fix
  ──────────                                      ─────────
  │                                               │
  │  async_operations has one stuck job row       │  Worker startup recovery
  │                                               │
  │    bank_id=bank-xyz                           │    Pass 1: reset this worker's
  │    operation_type=consolidation               │      own processing rows
  │    status=processing                          │
  │    claimed_at=NULL                            │    Pass 2: reset any processing
  │                                               │      row stuck > 2 hours,
  │  ─────────────────────────────                │      including claimed_at=NULL ✓
  │                                               │
  │  New consolidation jobs arrive                │  Bank serialization guard
  │                                               │
  │    bank_id=bank-xyz                           │    only treats recently claimed
  │    status=pending                             │    processing rows as active ✓
  │                                               │
  │  Bank serialization guard                     │
  │                                               │
  │    sees status=processing                     │
  │    assumes bank is busy                       │
  │    skips pending rows forever ✗               │
  │                                               │
  ▼                                               ▼
  claimable=3, assigned=0                         stuck job recovered or ignored;
                                                  pending rows can be claimed
```

**Result:** a single orphaned row in `async_operations` is enough to permanently lock a bank out of consolidation. A `processing` row with `claimed_at IS NULL` is not recognized as stale, so it can survive recovery and keep blocking the bank even when the worker is alive again. The bank serialization guard then treats that orphaned row as an active consolidation, leaving the bank frozen with no warning logged, for hours or indefinitely.

The fix adds two guards: Pass 2 resets orphaned processing tasks at startup, and the bank guard now ignores rows with `claimed_at IS NULL` or `claimed_at` older than 2 hours. This is safe for consolidation because `async_operations` is only the job queue. The durable source of truth is `memory_units`; when the operation is retried, the worker reselects still-unconsolidated units from the bank.

## Real-world impact

These bugs were discovered on a live Hindsight instance with 20k+ memory units. In the incident, consolidation ran overnight until the LLM provider quota was rate-limited; after interruption/restart, the orphaned `processing` row kept the bank locked, so new consolidation requests deduplicated or stayed pending instead of recovering.

| Evidence from the live incident | Operational impact |
|---------------------------------|--------------------|
| **22,103 memory units** in the `hermes` bank; **21,249** were `experience` / `world` units | Large consolidation backlog |
| **1,458** consolidation HTTP 429 log lines; **9,945** `GoUsageLimitError` log lines | Provider quota was exhausted during consolidation |
| `claimable=1 ... assigned=0` repeated **2,051** times | Work looked ready but stayed unassigned |
| Active consolidation reported as `[STUCK?]` **298** times | Processing row needed recovery / cancellation |
| **1,803** failed `experience` / `world` units in DB | Pending counter was inflated by failed work |

## What changed

- **Recover orphaned processing tasks** (`worker/poller.py`): startup now runs a second recovery pass for abandoned `processing` rows, including rows with `claimed_at IS NULL`; batch parent operations stay on their existing recovery path.
- **Fix bank serialization** (`db/ops_postgresql.py`, `db/ops_oracle.py`): a bank is considered busy only when it has a recently claimed consolidation task; orphaned `NULL` or >2h-old claims no longer block pending work.
- **Make operation progress visible** (`memory_engine.py`): completed consolidation jobs now write `items_count` and observation counters into `result_metadata`.
- **Fix pending consolidation counts** (`memory_engine.py`): failed memory units are no longer counted as still pending consolidation.
- **Allow safe cancellation of stuck processing ops** (`memory_engine.py`): stale `processing` operations can be cancelled through the API after the grace period instead of requiring manual SQL.
- **Log rejected LLM source IDs** (`consolidation/consolidator.py`): create/update outputs whose `source_fact_ids` match no memory in the batch now emit a warning with batch context.

### Tests (`tests/test_operation_status.py`)

`_insert_operation()` now accepts an optional `claimed_at` parameter, enabling tests to simulate operations at various claim ages.

```bash
cd hindsight-api-slim
uv sync --extra test --extra local-ml --extra embedded-db
uv run pytest tests/test_operation_status.py -q
# 11 passed
```

<details>
<summary>Unit test scenarios</summary>

| Scenario | Test |
|----------|------|
| `claimed_at` > 10 min ago → cancel succeeds (200), status = `cancelled` | `test_cancel_allows_stale_processing_operations` |
| `claimed_at IS NULL` → cancel succeeds (200), status = `cancelled` (never claimed, safe) | `test_cancel_allows_processing_with_null_claimed_at` |
| `claimed_at` < 1 min ago → cancel rejected (409, within 5-min grace) | `test_cancel_rejects_terminal_and_recent_processing_operations` |
| Terminal statuses (`completed`, `failed`) → cancel rejected (409) | (same test as above, first loop) |
| Cancel pending operation → status becomes `cancelled` (row preserved) | `test_cancel_sets_cancelled_status` |
| Retry cancelled operation → status becomes `pending` | `test_retry_cancelled_operation` |
| Retry pending/processing/completed → rejected (409) | `test_retry_rejects_non_retriable_statuses` |
| List endpoint preserves `processing` status (not collapsed to `pending`) | `test_list_operations_returns_processing_status` |
| Filter `?status=processing` returns only processing ops | `test_list_operations_filter_by_processing` |
| Filter `?status=pending` excludes processing ops | `test_list_operations_filter_by_pending_excludes_processing` |
| Get endpoint returns `processing` status correctly | `test_get_operation_returns_processing_status` |
| All five statuses round-trip through list and get | `test_all_statuses_returned_correctly` |

</details>

## Test plan
- [x] Ruff + `ruff format --check` clean on all touched files
- [x] Type annotations consistent with existing codebase style
- [x] Unit tests:
  ```bash
  cd hindsight-api-slim
  HINDSIGHT_API_LLM_PROVIDER=none uv run pytest tests/test_operation_status.py -q
  # 11 passed
  ```
- [ ] Orphan recovery: insert processing task with `claimed_at=NULL` and dead `worker_id`, restart Hindsight, verify second scan recovers it
- [ ] Cancel stale processing operation: trigger consolidation, wait 6 min for grace period, cancel via API, verify status = `cancelled`
- [ ] items_count in result_metadata: after consolidation completes, verify counters present and non-zero

## Related

- #991 Stale `claimed_at` not reclaimed after worker crash (closed — matched `worker_id` only)
- #1719 Zombie worker tasks permanently block consolidation after container restart (closed — matched `worker_id` only)
- #1671 Async operations need poison quarantine / degraded queue health (open — partially addressed by better recovery, cancellation, and visibility)

## Checklist

- [x] 🐛 Bug fix
- [x] 🔒 No secrets disclosed
- [x] 📝 Conventional Commits
- [x] 🔄 Rebased on upstream/main
- [x] 🗄️ PostgreSQL + Oracle paths updated symmetrically
- [x] Ruff format + lint clean on touched files



























