### PR TITLE
fix(claude-code): enable knowledge tools by default and force LF line endings

### DIFF
--- a/hindsight-integrations/claude-code/.gitattributes
+++ b/hindsight-integrations/claude-code/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.sh text eol=lf

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -55,6 +55,8 @@ DEFAULTS = {
     "llmProvider": None,
     "llmModel": None,
     "llmApiKeyEnv": None,
+    # Tools
+    "enableKnowledgeTools": True,
     # Misc
     "debug": False,
 }

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -33,6 +33,6 @@
   "llmProvider": null,
   "llmModel": null,
   "llmApiKeyEnv": null,
-  "enableKnowledgeTools": false,
+  "enableKnowledgeTools": true,
   "debug": false
 }


### PR DESCRIPTION
## Summary

- **CRLF fix**: The Claude Code marketplace distribution converts all files to CRLF on download. Python tolerates `\r`, so hooks (recall, retain, session_start) work fine — but `run_mcp.sh` is a bash script and fails to parse with `\r` characters, preventing the MCP server from ever starting. Added `.gitattributes` to force LF on checkout.
- **`enableKnowledgeTools` default**: Flipped from `false` to `true` in both `settings.json` and the `DEFAULTS` dict in `config.py`. The previous default meant the MCP server exited immediately even when `~/.hindsight/claude-code.json` had the override set to `true`.

## Test plan

- [ ] Install the plugin fresh via marketplace and verify `run_mcp.sh` has LF endings
- [ ] Start Claude Code and confirm knowledge tools (`agent_knowledge_*`) appear in tool list
- [ ] Verify recall/retain hooks still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)