### PR TITLE
feat(api): add pg_search tokenizer configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,19 @@ HINDSIGHT_API_LOG_LEVEL=info
 # For Azure PostgreSQL with DiskANN:
 # HINDSIGHT_API_VECTOR_EXTENSION=pgvectorscale  # Auto-detects pg_diskann on Azure
 
+# Text Search Extension (Optional - uses native PostgreSQL full-text search by default)
+# Backend options: "native" (default), "vchord", "pg_textsearch", "pgroonga", "pg_search"
+# HINDSIGHT_API_TEXT_SEARCH_EXTENSION=native
+# Native backend dictionary (only used by HINDSIGHT_API_TEXT_SEARCH_EXTENSION=native)
+# HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE=english
+# ParadeDB pg_search tokenizer (only used when creating pg_search BM25 indexes).
+# Empty uses ParadeDB's default tokenizer: unicode_words.
+# Supported values: unicode_words, simple, whitespace, literal, literal_normalized,
+# chinese_compatible, icu, jieba, source_code,
+# chinese_lindera/lindera(chinese), japanese_lindera/lindera(japanese),
+# korean_lindera/lindera(korean), ngram(min,max), edge_ngram(min,max)
+# HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER=
+
 # Embeddings Configuration (Optional - uses local by default)
 # Provider: "local" (default), "tei", "openai", "cohere", "google", "openrouter", "zeroentropy", "litellm", or "litellm-sdk"
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=local

--- a/docker/docker-compose/pg_search/docker-compose.yaml
+++ b/docker/docker-compose/pg_search/docker-compose.yaml
@@ -15,6 +15,8 @@ name: hindsight
 # - HINDSIGHT_VERSION: Hindsight application version (default: latest)
 # - HINDSIGHT_DB_USER: PostgreSQL user (default: hindsight_user)
 # - HINDSIGHT_DB_NAME: PostgreSQL database name (default: hindsight_db)
+# - HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER: ParadeDB pg_search
+#   tokenizer for new BM25 indexes (default: empty, uses ParadeDB default)
 
 services:
   db:
@@ -78,6 +80,7 @@ services:
       # Vector and Text Search Extensions
       HINDSIGHT_API_VECTOR_EXTENSION: pgvector
       HINDSIGHT_API_TEXT_SEARCH_EXTENSION: pg_search
+      HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER: ${HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER:-}
 
     depends_on:
       - db

--- a/hindsight-api-slim/hindsight_api/_pg_search.py
+++ b/hindsight-api-slim/hindsight_api/_pg_search.py
@@ -1,0 +1,85 @@
+"""Helpers for ParadeDB pg_search index configuration."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+PG_SEARCH_TOKENIZER_ENV = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER"
+
+_SIMPLE_TOKENIZERS = {
+    "unicode_words",
+    "simple",
+    "whitespace",
+    "literal",
+    "literal_normalized",
+    "chinese_compatible",
+    "icu",
+    "jieba",
+    "source_code",
+}
+
+_TOKENIZER_ALIASES = {
+    "chinese_lindera": "lindera(chinese)",
+    "japanese_lindera": "lindera(japanese)",
+    "korean_lindera": "lindera(korean)",
+    "lindera_chinese": "lindera(chinese)",
+    "lindera_japanese": "lindera(japanese)",
+    "lindera_korean": "lindera(korean)",
+}
+
+
+def normalize_pg_search_tokenizer(value: str | None) -> str:
+    """Validate and normalize a ParadeDB pg_search tokenizer setting.
+
+    Returns an empty string when unset. The returned value is safe to embed after
+    ``pdb.`` in a CREATE INDEX expression.
+    """
+
+    tokenizer = (value or "").strip().lower()
+    if not tokenizer:
+        return ""
+
+    if tokenizer in _TOKENIZER_ALIASES:
+        return _TOKENIZER_ALIASES[tokenizer]
+
+    if tokenizer in _SIMPLE_TOKENIZERS:
+        return tokenizer
+
+    lindera_match = re.fullmatch(r"lindera\((chinese|japanese|korean)\)", tokenizer)
+    if lindera_match:
+        return tokenizer
+
+    ngram_match = re.fullmatch(r"(ngram|edge_ngram)\((\d{1,3}),\s*(\d{1,3})\)", tokenizer)
+    if ngram_match:
+        kind, min_gram, max_gram = ngram_match.groups()
+        min_value = int(min_gram)
+        max_value = int(max_gram)
+        if min_value <= 0 or min_value > max_value:
+            raise ValueError(
+                f"Invalid {PG_SEARCH_TOKENIZER_ENV}: {value!r}. "
+                "ngram and edge_ngram require positive min/max gram sizes with min <= max."
+            )
+        return f"{kind}({min_value},{max_value})"
+
+    raise ValueError(
+        f"Invalid {PG_SEARCH_TOKENIZER_ENV}: {value!r}. "
+        "Supported values are: unicode_words, simple, whitespace, literal, "
+        "literal_normalized, chinese_compatible, icu, jieba, source_code, "
+        "chinese_lindera, japanese_lindera, korean_lindera, or "
+        "lindera(chinese|japanese|korean), ngram(min,max), or edge_ngram(min,max)."
+    )
+
+
+def pg_search_bm25_columns(
+    key_field: str,
+    text_fields: Sequence[str],
+    tokenizer: str | None,
+) -> str:
+    """Build a ParadeDB BM25 column list for CREATE INDEX."""
+
+    normalized = normalize_pg_search_tokenizer(tokenizer)
+    if not normalized:
+        return ", ".join([key_field, *text_fields])
+
+    return ", ".join([key_field, *(f"({field}::pdb.{normalized})" for field in text_fields)])

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -268,6 +268,7 @@ async def _run_migration(
         ensure_text_search_extension(
             resolved_url,
             text_search_extension=config.text_search_extension,
+            pg_search_tokenizer=config.text_search_extension_pg_search_tokenizer,
             schema=schema,
         )
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
@@ -15,6 +15,11 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 
+from hindsight_api._pg_search import (
+    PG_SEARCH_TOKENIZER_ENV,
+    normalize_pg_search_tokenizer,
+    pg_search_bm25_columns,
+)
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -149,6 +154,10 @@ def _detect_text_search_extension() -> str:
             f"Invalid HINDSIGHT_API_TEXT_SEARCH_EXTENSION: {text_search_extension}. "
             "Must be 'native', 'vchord', 'pg_textsearch', 'pgroonga', or 'pg_search'"
         )
+
+
+def _pg_search_tokenizer() -> str:
+    return normalize_pg_search_tokenizer(os.getenv(PG_SEARCH_TOKENIZER_ENV))
 
 
 def _pg_upgrade() -> None:
@@ -376,11 +385,14 @@ def _pg_upgrade() -> None:
     elif text_search_ext == "pg_search":
         # ParadeDB pg_search BM25 index on (id, text, context). The key_field
         # reloption is required and must match the table's primary key column.
-        op.execute("""
+        bm25_cols = pg_search_bm25_columns("id", ("text", "context"), _pg_search_tokenizer())
+        op.execute(
+            """
             CREATE INDEX idx_memory_units_text_search ON memory_units
-            USING bm25 (id, text, context)
+            USING bm25 ({bm25_cols})
             WITH (key_field='id')
-        """)
+        """.format(bm25_cols=bm25_cols)
+        )
     else:  # native
         # Native PostgreSQL GIN index
         op.execute("""

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a2b3c4d5e6f7_add_text_signals_column.py
@@ -19,6 +19,11 @@ from collections.abc import Sequence
 
 from alembic import context, op
 
+from hindsight_api._pg_search import (
+    PG_SEARCH_TOKENIZER_ENV,
+    normalize_pg_search_tokenizer,
+    pg_search_bm25_columns,
+)
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "a2b3c4d5e6f7"
@@ -34,6 +39,10 @@ def _get_schema_prefix() -> str:
 
 def _detect_text_search_extension() -> str:
     return os.getenv("HINDSIGHT_API_TEXT_SEARCH_EXTENSION", "native").lower()
+
+
+def _pg_search_tokenizer() -> str:
+    return normalize_pg_search_tokenizer(os.getenv(PG_SEARCH_TOKENIZER_ENV))
 
 
 def _pg_upgrade() -> None:
@@ -66,10 +75,11 @@ def _pg_upgrade() -> None:
     elif text_search_ext == "pg_search":
         # ParadeDB pg_search: drop the existing BM25 index and recreate it
         # to include text_signals alongside text and context.
+        bm25_cols = pg_search_bm25_columns("id", ("text", "context", "text_signals"), _pg_search_tokenizer())
         op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
         op.execute(f"""
             CREATE INDEX idx_memory_units_text_search ON {table}
-            USING bm25 (id, text, context, text_signals)
+            USING bm25 ({bm25_cols})
             WITH (key_field='id')
         """)
 
@@ -98,10 +108,11 @@ def _pg_downgrade() -> None:
         """)
     elif text_search_ext == "pg_search":
         # Restore the original (id, text, context) BM25 index without text_signals.
+        bm25_cols = pg_search_bm25_columns("id", ("text", "context"), _pg_search_tokenizer())
         op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_text_search")
         op.execute(f"""
             CREATE INDEX idx_memory_units_text_search ON {table}
-            USING bm25 (id, text, context)
+            USING bm25 ({bm25_cols})
             WITH (key_field='id')
         """)
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
@@ -16,6 +16,11 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
+from hindsight_api._pg_search import (
+    PG_SEARCH_TOKENIZER_ENV,
+    normalize_pg_search_tokenizer,
+    pg_search_bm25_columns,
+)
 from hindsight_api.alembic._dialect import run_for_dialect
 
 # revision identifiers, used by Alembic.
@@ -154,6 +159,10 @@ def _detect_text_search_extension() -> str:
         )
 
 
+def _pg_search_tokenizer() -> str:
+    return normalize_pg_search_tokenizer(os.getenv(PG_SEARCH_TOKENIZER_ENV))
+
+
 def _pg_upgrade() -> None:
     """Create learnings and pinned_reflections tables."""
     schema = _get_schema_prefix()
@@ -224,12 +233,13 @@ def _pg_upgrade() -> None:
     elif text_search_ext == "pg_search":
         # ParadeDB pg_search: dummy TEXT column; BM25 index is built directly over (id, text)
         # with key_field='id' (matches the table's primary key).
+        bm25_cols = pg_search_bm25_columns("id", ("text",), _pg_search_tokenizer())
         op.execute(f"""
             ALTER TABLE {schema}learnings ADD COLUMN search_vector TEXT
         """)
         op.execute(f"""
             CREATE INDEX idx_learnings_text_search ON {schema}learnings
-            USING bm25 (id, text)
+            USING bm25 ({bm25_cols})
             WITH (key_field='id')
         """)
     else:  # native
@@ -299,12 +309,13 @@ def _pg_upgrade() -> None:
     elif text_search_ext == "pg_search":
         # ParadeDB pg_search: dummy TEXT column; BM25 index over (id, name, content)
         # with key_field='id'.
+        bm25_cols = pg_search_bm25_columns("id", ("name", "content"), _pg_search_tokenizer())
         op.execute(f"""
             ALTER TABLE {schema}pinned_reflections ADD COLUMN search_vector TEXT
         """)
         op.execute(f"""
             CREATE INDEX idx_pinned_reflections_text_search ON {schema}pinned_reflections
-            USING bm25 (id, name, content)
+            USING bm25 ({bm25_cols})
             WITH (key_field='id')
         """)
     else:  # native

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from dotenv import find_dotenv, load_dotenv
 
+from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
 from .utils import mask_network_location
 
@@ -302,6 +303,7 @@ ENV_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY = "HINDSIGHT_API_RERANKER_GOOGLE_SERVICE
 ENV_VECTOR_EXTENSION = "HINDSIGHT_API_VECTOR_EXTENSION"
 ENV_TEXT_SEARCH_EXTENSION = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION"
 ENV_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE"
+ENV_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER = "HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER"
 ENV_LLM_OUTPUT_LANGUAGE = "HINDSIGHT_API_LLM_OUTPUT_LANGUAGE"
 
 ENV_HOST = "HINDSIGHT_API_HOST"
@@ -595,6 +597,7 @@ DEFAULT_TEXT_SEARCH_EXTENSION = "native"  # Options: "native", "vchord", "pg_tex
 # tokenizers (vchord: llmlingua2, pg_textsearch: hardcoded english,
 # pgroonga: TokenBigram polyglot, pg_search: per-field Tantivy tokenizer).
 DEFAULT_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE = "english"
+DEFAULT_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER = ""
 
 # LiteLLM defaults
 DEFAULT_LITELLM_API_BASE = "http://localhost:4000"
@@ -946,6 +949,9 @@ class HindsightConfig:
     # uses TokenBigram, vchord uses llmlingua2, pg_textsearch hardcodes english,
     # pg_search uses Tantivy per-field tokenizers.
     text_search_extension_native_language: str
+    # ParadeDB pg_search tokenizer used when building BM25 indexes. Empty keeps
+    # ParadeDB's default tokenizer.
+    text_search_extension_pg_search_tokenizer: str
     # When set, every LLM-generated artifact (retain facts, consolidation
     # observations, reflect responses) is forced into this language regardless
     # of the source content. Unset preserves source language.
@@ -1444,6 +1450,10 @@ class HindsightConfig:
                 f"'french', 'simple', 'zhparser'."
             )
 
+        self.text_search_extension_pg_search_tokenizer = normalize_pg_search_tokenizer(
+            self.text_search_extension_pg_search_tokenizer
+        )
+
         # When LLM provider is "none", force chunks-only mode and disable LLM-dependent features
         if self.llm_provider == "none":
             self.retain_extraction_mode = "chunks"
@@ -1529,6 +1539,10 @@ class HindsightConfig:
                 ENV_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE,
                 DEFAULT_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE,
             ).lower(),
+            text_search_extension_pg_search_tokenizer=os.getenv(
+                ENV_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER,
+                DEFAULT_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER,
+            ),
             llm_output_language=(os.getenv(ENV_LLM_OUTPUT_LANGUAGE) or None),
             # LLM
             llm_provider=llm_provider,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2074,7 +2074,10 @@ class MemoryEngine(MemoryEngineInterface):
                         schema = tenant.schema
                         if schema:
                             ensure_text_search_extension(
-                                self.db_url, text_search_extension=config.text_search_extension, schema=schema
+                                self.db_url,
+                                text_search_extension=config.text_search_extension,
+                                pg_search_tokenizer=config.text_search_extension_pg_search_tokenizer,
+                                schema=schema,
                             )
 
         logger.info(f"Connecting to database at {mask_network_location(self.db_url)}")

--- a/hindsight-api-slim/hindsight_api/extensions/context.py
+++ b/hindsight-api-slim/hindsight_api/extensions/context.py
@@ -146,7 +146,11 @@ class DefaultExtensionContext(ExtensionContext):
 
         # Ensure text search columns/indexes match the configured extension
         await asyncio.to_thread(
-            ensure_text_search_extension, db_url, text_search_extension=config.text_search_extension, schema=schema
+            ensure_text_search_extension,
+            db_url,
+            text_search_extension=config.text_search_extension,
+            pg_search_tokenizer=config.text_search_extension_pg_search_tokenizer,
+            schema=schema,
         )
 
     def get_memory_engine(self) -> "MemoryEngineInterface":

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -27,6 +27,7 @@ from alembic.config import Config
 from alembic.script.revision import ResolutionError
 from sqlalchemy import Connection, create_engine, text
 
+from ._pg_search import normalize_pg_search_tokenizer, pg_search_bm25_columns
 from ._vector_index import (
     bootstrap_extension,
     detect_vector_extension,
@@ -803,6 +804,7 @@ def ensure_text_search_extension(
     database_url: str,
     text_search_extension: str = "native",
     schema: str | None = None,
+    pg_search_tokenizer: str | None = None,
 ) -> None:
     """
     Ensure the text search columns and indexes match the configured extension.
@@ -816,13 +818,17 @@ def ensure_text_search_extension(
     Args:
         database_url: SQLAlchemy database URL
         text_search_extension: Configured text search extension — one of
-            "native", "vchord", "pg_textsearch", or "pgroonga"
+            "native", "vchord", "pg_textsearch", "pgroonga", or "pg_search"
         schema: Target PostgreSQL schema name (None for public)
+        pg_search_tokenizer: Optional ParadeDB tokenizer to apply to pg_search
+            BM25 text fields when indexes are created. Empty keeps the
+            ParadeDB default.
 
     Raises:
         RuntimeError: If extension mismatch with existing data
     """
     schema_name = schema or "public"
+    pg_search_tokenizer = normalize_pg_search_tokenizer(pg_search_tokenizer)
 
     engine = create_engine(to_libpq_url(database_url))
     with engine.connect() as conn:
@@ -1076,9 +1082,17 @@ def ensure_text_search_extension(
                 # ParadeDB BM25 index over the table's primary key and text columns.
                 # Column list mirrors what the initial / text_signals migrations create.
                 if table_name == "memory_units":
-                    bm25_cols = "id, text, context, text_signals"
+                    bm25_cols = pg_search_bm25_columns(
+                        "id",
+                        ("text", "context", "text_signals"),
+                        pg_search_tokenizer,
+                    )
                 else:  # reflections
-                    bm25_cols = "id, name, content"
+                    bm25_cols = pg_search_bm25_columns(
+                        "id",
+                        ("name", "content"),
+                        pg_search_tokenizer,
+                    )
 
                 logger.info(f"Creating ParadeDB BM25 index on {table_name}")
                 conn.execute(

--- a/hindsight-api-slim/tests/test_admin_backup_restore.py
+++ b/hindsight-api-slim/tests/test_admin_backup_restore.py
@@ -328,8 +328,11 @@ async def test_run_migration_without_schema_discovers_and_deduplicates_schemas(m
         database_url: str,
         text_search_extension: str = "native",
         schema: str | None = None,
+        pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append((database_url, text_search_extension, schema))
+        calls["ensure_text_search_extension"].append(
+            (database_url, text_search_extension, pg_search_tokenizer, schema)
+        )
 
     monkeypatch.setenv("HINDSIGHT_API_DATABASE_URL", "postgresql://test")
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
@@ -353,8 +356,8 @@ async def test_run_migration_without_schema_discovers_and_deduplicates_schemas(m
         ("resolved::postgresql://test", "pgvector", "tenant_demo"),
     ]
     assert calls["ensure_text_search_extension"] == [
-        ("resolved::postgresql://test", "native", "public"),
-        ("resolved::postgresql://test", "native", "tenant_demo"),
+        ("resolved::postgresql://test", "native", "", "public"),
+        ("resolved::postgresql://test", "native", "", "tenant_demo"),
     ]
 
 
@@ -398,8 +401,11 @@ async def test_run_migration_without_schema_runs_optional_post_migration_hooks(m
         database_url: str,
         text_search_extension: str = "native",
         schema: str | None = None,
+        pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append((database_url, text_search_extension, schema))
+        calls["ensure_text_search_extension"].append(
+            (database_url, text_search_extension, pg_search_tokenizer, schema)
+        )
 
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
     monkeypatch.setattr(admin_cli, "resolve_database_url", fake_resolve_database_url)
@@ -431,8 +437,8 @@ async def test_run_migration_without_schema_runs_optional_post_migration_hooks(m
         ("resolved::postgresql://test", "pgvector", "tenant_demo"),
     ]
     assert calls["ensure_text_search_extension"] == [
-        ("resolved::postgresql://test", "native", "public"),
-        ("resolved::postgresql://test", "native", "tenant_demo"),
+        ("resolved::postgresql://test", "native", "", "public"),
+        ("resolved::postgresql://test", "native", "", "tenant_demo"),
     ]
 
 
@@ -467,8 +473,11 @@ async def test_run_migration_with_schema_only_runs_requested_schema(monkeypatch)
         database_url: str,
         text_search_extension: str = "native",
         schema: str | None = None,
+        pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append((database_url, text_search_extension, schema))
+        calls["ensure_text_search_extension"].append(
+            (database_url, text_search_extension, pg_search_tokenizer, schema)
+        )
 
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
     monkeypatch.setattr(admin_cli, "resolve_database_url", fake_resolve_database_url)
@@ -484,4 +493,4 @@ async def test_run_migration_with_schema_only_runs_requested_schema(monkeypatch)
     assert schemas == ["tenant_demo"]
     assert calls["run_migrations"] == [("resolved::postgresql://test", "tenant_demo")]
     assert calls["ensure_vector_extension"] == [("resolved::postgresql://test", "pgvector", "tenant_demo")]
-    assert calls["ensure_text_search_extension"] == [("resolved::postgresql://test", "native", "tenant_demo")]
+    assert calls["ensure_text_search_extension"] == [("resolved::postgresql://test", "native", "", "tenant_demo")]

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -276,6 +276,56 @@ def test_text_search_extension_rejects_unknown(monkeypatch):
         HindsightConfig.from_env()
 
 
+def test_pg_search_tokenizer_defaults_to_empty(monkeypatch):
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.delenv("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.text_search_extension_pg_search_tokenizer == ""
+
+
+def test_pg_search_tokenizer_loaded_from_env(monkeypatch):
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER", "Jieba")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.text_search_extension_pg_search_tokenizer == "jieba"
+
+
+def test_pg_search_tokenizer_accepts_lindera_alias(monkeypatch):
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER", "chinese_lindera")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.text_search_extension_pg_search_tokenizer == "lindera(chinese)"
+
+
+@pytest.mark.parametrize("bad_value", ["jieba;DROP TABLE", "ngram(3,2)", "unknown", "pdb.jieba"])
+def test_pg_search_tokenizer_rejects_invalid_values(monkeypatch, bad_value):
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER", bad_value)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    with pytest.raises(ValueError, match="Invalid HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER"):
+        HindsightConfig.from_env()
+
+
+def test_pg_search_bm25_columns_apply_tokenizer():
+    from hindsight_api._pg_search import pg_search_bm25_columns
+
+    assert pg_search_bm25_columns("id", ("text", "context"), "") == "id, text, context"
+    assert pg_search_bm25_columns("id", ("text", "context"), "jieba") == "id, (text::pdb.jieba), (context::pdb.jieba)"
+    assert pg_search_bm25_columns("id", ("text",), "ngram(2, 3)") == "id, (text::pdb.ngram(2,3))"
+    assert pg_search_bm25_columns("id", ("text",), "edge_ngram(2, 5)") == "id, (text::pdb.edge_ngram(2,5))"
+
+
 def test_llm_output_language_defaults_to_none(monkeypatch):
     from hindsight_api.config import HindsightConfig
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -142,6 +142,7 @@ If you need to switch from one extension to another:
 |----------|-------------|---------|
 | `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` | Text search backend: `native`, `vchord`, `pg_textsearch`, `pgroonga`, or `pg_search` | `native` |
 | `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE` | PostgreSQL text search dictionary used by the `native` backend (e.g. `english`, `french`, `simple`, `zhparser`) | `english` |
+| `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` | ParadeDB `pg_search` tokenizer used when creating BM25 indexes. Empty uses ParadeDB's default tokenizer (`unicode_words`). | unset |
 | `HINDSIGHT_API_LLM_OUTPUT_LANGUAGE` | When set, forces every LLM-generated artifact (retain facts, consolidation observations, reflect responses) into this language. Free-form (e.g. `Spanish`, `Japanese`). | unset |
 
 Hindsight supports five backends for BM25 keyword retrieval:
@@ -152,6 +153,8 @@ Hindsight supports five backends for BM25 keyword retrieval:
 - **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible.
 
 To switch backends: set `HINDSIGHT_API_TEXT_SEARCH_EXTENSION`. With existing data, you'll get an error and migration instructions; with an empty database the columns/indexes are recreated automatically on startup.
+
+`HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` only applies when `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, and only when BM25 indexes are created. Changing it for an existing database requires rebuilding the `pg_search` indexes or recreating the database. Supported values are empty/unset, `unicode_words`, `simple`, `whitespace`, `literal`, `literal_normalized`, `chinese_compatible`, `icu`, `jieba`, `source_code`, `chinese_lindera`/`lindera(chinese)`, `japanese_lindera`/`lindera(japanese)`, `korean_lindera`/`lindera(korean)`, `ngram(min,max)`, and `edge_ngram(min,max)`.
 
 For non-English banks (especially CJK) and the language/extraction-language tradeoffs, see the [Multilingual Support](./multilingual) page.
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -142,6 +142,7 @@ If you need to switch from one extension to another:
 |----------|-------------|---------|
 | `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` | Text search backend: `native`, `vchord`, `pg_textsearch`, `pgroonga`, or `pg_search` | `native` |
 | `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE` | PostgreSQL text search dictionary used by the `native` backend (e.g. `english`, `french`, `simple`, `zhparser`) | `english` |
+| `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` | ParadeDB `pg_search` tokenizer used when creating BM25 indexes. Empty uses ParadeDB's default tokenizer (`unicode_words`). | unset |
 | `HINDSIGHT_API_LLM_OUTPUT_LANGUAGE` | When set, forces every LLM-generated artifact (retain facts, consolidation observations, reflect responses) into this language. Free-form (e.g. `Spanish`, `Japanese`). | unset |
 
 Hindsight supports five backends for BM25 keyword retrieval:
@@ -152,6 +153,8 @@ Hindsight supports five backends for BM25 keyword retrieval:
 - **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible.
 
 To switch backends: set `HINDSIGHT_API_TEXT_SEARCH_EXTENSION`. With existing data, you'll get an error and migration instructions; with an empty database the columns/indexes are recreated automatically on startup.
+
+`HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` only applies when `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, and only when BM25 indexes are created. Changing it for an existing database requires rebuilding the `pg_search` indexes or recreating the database. Supported values are empty/unset, `unicode_words`, `simple`, `whitespace`, `literal`, `literal_normalized`, `chinese_compatible`, `icu`, `jieba`, `source_code`, `chinese_lindera`/`lindera(chinese)`, `japanese_lindera`/`lindera(japanese)`, `korean_lindera`/`lindera(korean)`, `ngram(min,max)`, and `edge_ngram(min,max)`.
 
 For non-English banks (especially CJK) and the language/extraction-language tradeoffs, see the [Multilingual Support](./multilingual) page.
 


### PR DESCRIPTION
## Summary

Add an optional ParadeDB `pg_search` tokenizer configuration for Hindsight BM25 indexes.

This introduces `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`, allowing deployments using `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search` to choose a tokenizer such as `jieba`, `chinese_compatible`, `lindera(chinese)`, `ngram(min,max)`, or `edge_ngram(min,max)` when BM25 indexes are created.

The default remains empty/unset, which preserves the existing behavior and uses ParadeDB's default tokenizer (`unicode_words`).

## Changes

- Add tokenizer validation and BM25 index column generation helpers for `pg_search`
- Wire the new config through migrations, runtime index reconciliation, admin migrations, and extension context migrations
- Document the new env var in `.env.example` and developer configuration docs
- Add the env var to the `docker/docker-compose/pg_search` example
- Add tests for default behavior, accepted values, invalid values, and index column generation

## Notes

This setting only affects `pg_search` BM25 indexes when they are created. Changing it for an existing database requires rebuilding the `pg_search` indexes or recreating the database.

## Testing

- `uv run --extra embedded-db --extra local-ml pytest tests/test_config_validation.py tests/test_admin_backup_restore.py -q`
- `uv run --extra embedded-db --extra local-ml ty check`
- `docker compose -f docker/docker-compose/pg_search/docker-compose.yaml config --quiet`
