### PR TITLE
chore: improve hindsight maintenance path

### DIFF
--- a/hindsight-all/tests/test_embedded.py
+++ b/hindsight-all/tests/test_embedded.py
@@ -386,7 +386,7 @@ def test_embedded_ui_flag(llm_config):
 
         # Verify UI is reachable and reports connected dataplane
         ui_url = client.ui_url
-        assert ui_url, "ui_url should be set"
+        assert isinstance(ui_url, str) and ui_url, "ui_url should be a non-empty string"
 
         health_url = f"{ui_url}/api/health"
         with urllib.request.urlopen(health_url, timeout=10) as resp:


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in hindsight-all/tests/test_embedded.py, hindsight-api-slim/tests/conftest.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.