### PR TITLE
feat(gemini-spark): add Hindsight integration for Gemini Spark via MCP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
       integrations-agentcore: ${{ steps.filter.outputs.integrations-agentcore }}
       integrations-smolagents: ${{ steps.filter.outputs.integrations-smolagents }}
       integrations-dify: ${{ steps.filter.outputs.integrations-dify }}
+      integrations-gemini-spark: ${{ steps.filter.outputs.integrations-gemini-spark }}
       tools-agent-sdk: ${{ steps.filter.outputs.tools-agent-sdk }}
       dev: ${{ steps.filter.outputs.dev }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -143,6 +144,8 @@ jobs:
             - 'hindsight-integrations/smolagents/**'
           integrations-dify:
             - 'hindsight-integrations/dify/**'
+          integrations-gemini-spark:
+            - 'hindsight-integrations/gemini-spark/**'
           tools-agent-sdk:
             - 'hindsight-tools/hindsight-agent-sdk/**'
           dev:
@@ -696,6 +699,38 @@ jobs:
 
     - name: Run tests
       working-directory: ./hindsight-integrations/pipecat
+      run: uv run pytest tests -v
+
+  test-gemini-spark-integration:
+    needs: [detect-changes]
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.integrations-gemini-spark == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        prune-cache: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: ".python-version"
+
+    - name: Install dependencies
+      working-directory: ./hindsight-integrations/gemini-spark
+      run: uv sync --frozen
+
+    - name: Run tests
+      working-directory: ./hindsight-integrations/gemini-spark
       run: uv run pytest tests -v
 
 
@@ -3738,6 +3773,7 @@ jobs:
       - build-chat-integration
       - test-paperclip-integration
       - test-pipecat-integration
+      - test-gemini-spark-integration
       - build-control-plane
       - build-docs
       - test-rust-cli

--- a/hindsight-integrations/gemini-spark/README.md
+++ b/hindsight-integrations/gemini-spark/README.md
@@ -1,0 +1,93 @@
+# Hindsight × Gemini Spark
+
+Long-term memory for [Gemini Spark](https://blog.google/products/gemini/gemini-spark/),
+Google's always-on agentic assistant, via MCP.
+
+> **Recommended:** Use [Hindsight Cloud](https://vectorize.io/hindsight/) for the
+> fastest setup — no infrastructure to manage. The setup below works with both
+> Cloud and self-hosted Hindsight.
+
+## How it works
+
+Spark runs on Google's cloud infrastructure. Unlike OpenClaw or Claude Code,
+there is **no plugin host** where Hindsight code runs alongside Spark's agent
+loop. The only third-party extension surface is MCP:
+
+| Capability | Spark support |
+|---|---|
+| Hook-based auto-recall (prepend context to prompt) | Not available — Spark's prompt assembly is private. The agent calls `hindsight_recall` when its planner judges it useful. |
+| Hook-based auto-retain (save transcripts on turn end) | Not available — third parties don't see Spark's transcripts. The agent calls `hindsight_retain` when it learns something worth keeping. |
+| MCP tools (`hindsight_recall`, `hindsight_retain`, etc.) | Yes — Spark calls Hindsight's MCP tools via its built-in MCP client. |
+
+## Architecture
+
+### With Hindsight Cloud (recommended)
+
+```
+Gemini Spark (Google Cloud)
+        |
+        | HTTPS + MCP (Streamable HTTP)
+        v
+Hindsight Cloud (api.hindsight.vectorize.io)
+```
+
+### With self-hosted Hindsight
+
+```
+Gemini Spark (Google Cloud)
+        |
+        | HTTPS + OAuth 2.1 (Spark's MCP client)
+        v
+Cloudflare Worker — hindsight-integrations/cloudflare-oauth-proxy
+   - OAuth authorization server
+   - Auth bridging to Hindsight API token
+        |
+        | HTTPS + Cloudflare Tunnel
+        v
+Self-hosted Hindsight + hindsight-embed (MCP server)
+```
+
+## Setup
+
+### Option 1: Hindsight Cloud (recommended)
+
+1. Sign up at [vectorize.io/hindsight](https://vectorize.io/hindsight/) and
+   create a memory bank
+2. Copy your API key from the dashboard
+3. Register Hindsight in Spark's MCP config (see below)
+
+### Option 2: Self-hosted
+
+1. Deploy a Hindsight instance — see the
+   [self-hosting quickstart](https://vectorize.io/hindsight/docs/quickstart/self-hosting)
+2. Run the `hindsight-embed` MCP server pointed at your instance, exposed on
+   a public HTTPS endpoint
+3. Deploy the [`cloudflare-oauth-proxy`](../cloudflare-oauth-proxy/) (Spark
+   only speaks OAuth 2.1 to MCP servers)
+
+### Register Hindsight in Spark
+
+Spark (via Antigravity 2.0) reads MCP servers from one of two places:
+
+- **Hosted agent / Spark cloud:** an `antigravity.yaml` manifest — see
+  [`manifest.example.yaml`](./manifest.example.yaml)
+- **Antigravity desktop / IDE:** `~/.gemini/antigravity/mcp_config.json` —
+  see [`mcp_config.example.json`](./mcp_config.example.json)
+
+Replace the placeholder URL with your Hindsight Cloud endpoint or OAuth proxy
+URL.
+
+### Verify it works
+
+Prompt Spark with something that should trigger memory tools:
+
+- "What were my open API decisions from last week?" → `hindsight_recall`
+- "Remember that I prefer TypeScript strict mode for new projects." →
+  `hindsight_retain`
+
+## Example configs
+
+- [`manifest.example.yaml`](./manifest.example.yaml) — Antigravity 2.0 agent
+  manifest snippet
+- [`mcp_config.example.json`](./mcp_config.example.json) — Desktop/IDE MCP
+  config for local development

--- a/hindsight-integrations/gemini-spark/README.md
+++ b/hindsight-integrations/gemini-spark/README.md
@@ -15,9 +15,9 @@ loop. The only third-party extension surface is MCP:
 
 | Capability | Spark support |
 |---|---|
-| Hook-based auto-recall (prepend context to prompt) | Not available — Spark's prompt assembly is private. The agent calls `hindsight_recall` when its planner judges it useful. |
-| Hook-based auto-retain (save transcripts on turn end) | Not available — third parties don't see Spark's transcripts. The agent calls `hindsight_retain` when it learns something worth keeping. |
-| MCP tools (`hindsight_recall`, `hindsight_retain`, etc.) | Yes — Spark calls Hindsight's MCP tools via its built-in MCP client. |
+| Hook-based auto-recall (prepend context to prompt) | Not available — Spark's prompt assembly is private. The agent calls `recall` when its planner judges it useful. |
+| Hook-based auto-retain (save transcripts on turn end) | Not available — third parties don't see Spark's transcripts. The agent calls `retain` when it learns something worth keeping. |
+| MCP tools (`recall`, `retain`, etc.) | Yes — Spark calls Hindsight's MCP tools via its built-in MCP client. |
 
 ## Architecture
 
@@ -81,9 +81,9 @@ URL.
 
 Prompt Spark with something that should trigger memory tools:
 
-- "What were my open API decisions from last week?" → `hindsight_recall`
+- "What were my open API decisions from last week?" → `recall`
 - "Remember that I prefer TypeScript strict mode for new projects." →
-  `hindsight_retain`
+  `retain`
 
 ## Example configs
 

--- a/hindsight-integrations/gemini-spark/hindsight_gemini_spark/__init__.py
+++ b/hindsight-integrations/gemini-spark/hindsight_gemini_spark/__init__.py
@@ -1,0 +1,1 @@
+"""Hindsight × Gemini Spark — config examples and documentation only."""

--- a/hindsight-integrations/gemini-spark/manifest.example.yaml
+++ b/hindsight-integrations/gemini-spark/manifest.example.yaml
@@ -1,0 +1,19 @@
+# Example Antigravity 2.0 / Gemini Spark agent manifest snippet.
+#
+# Drop the `tools.mcp_servers` block into your existing antigravity.yaml.
+# This format follows the shape shown in the I/O 2026 developer guide; once
+# Google publishes the formal schema it may need adjusting.
+#
+# For Hindsight Cloud: use https://api.hindsight.vectorize.io/v1/default/mcp
+# For self-hosted:     use your cloudflare-oauth-proxy URL
+
+tools:
+  mcp_servers:
+    - name: hindsight
+      endpoint: https://api.hindsight.vectorize.io/v1/default/mcp
+      auth: bearer
+      description: >
+        Long-term memory across sessions. Call hindsight_recall whenever
+        the user references past work, decisions, or preferences from
+        earlier conversations. Call hindsight_retain whenever the user
+        shares a fact, preference, or decision worth remembering.

--- a/hindsight-integrations/gemini-spark/manifest.example.yaml
+++ b/hindsight-integrations/gemini-spark/manifest.example.yaml
@@ -4,16 +4,16 @@
 # This format follows the shape shown in the I/O 2026 developer guide; once
 # Google publishes the formal schema it may need adjusting.
 #
-# For Hindsight Cloud: use https://api.hindsight.vectorize.io/v1/default/mcp
+# For Hindsight Cloud: use https://api.hindsight.vectorize.io/mcp
 # For self-hosted:     use your cloudflare-oauth-proxy URL
 
 tools:
   mcp_servers:
     - name: hindsight
-      endpoint: https://api.hindsight.vectorize.io/v1/default/mcp
+      endpoint: https://api.hindsight.vectorize.io/mcp
       auth: bearer
       description: >
-        Long-term memory across sessions. Call hindsight_recall whenever
-        the user references past work, decisions, or preferences from
-        earlier conversations. Call hindsight_retain whenever the user
-        shares a fact, preference, or decision worth remembering.
+        Long-term memory across sessions. Call recall whenever the user
+        references past work, decisions, or preferences from earlier
+        conversations. Call retain whenever the user shares a fact,
+        preference, or decision worth remembering.

--- a/hindsight-integrations/gemini-spark/mcp_config.example.json
+++ b/hindsight-integrations/gemini-spark/mcp_config.example.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Drop this entry into ~/.gemini/antigravity/mcp_config.json. For Hindsight Cloud, use the Cloud URL with a Bearer token. For self-hosted with the OAuth proxy, use your proxy URL.",
+  "mcpServers": {
+    "hindsight": {
+      "serverUrl": "https://api.hindsight.vectorize.io/v1/default/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_HINDSIGHT_API_KEY"
+      }
+    }
+  }
+}

--- a/hindsight-integrations/gemini-spark/mcp_config.example.json
+++ b/hindsight-integrations/gemini-spark/mcp_config.example.json
@@ -2,7 +2,7 @@
   "_comment": "Drop this entry into ~/.gemini/antigravity/mcp_config.json. For Hindsight Cloud, use the Cloud URL with a Bearer token. For self-hosted with the OAuth proxy, use your proxy URL.",
   "mcpServers": {
     "hindsight": {
-      "serverUrl": "https://api.hindsight.vectorize.io/v1/default/mcp",
+      "serverUrl": "https://api.hindsight.vectorize.io/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_HINDSIGHT_API_KEY"
       }

--- a/hindsight-integrations/gemini-spark/pyproject.toml
+++ b/hindsight-integrations/gemini-spark/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "hindsight-gemini-spark"
+version = "0.1.0"
+description = "Hindsight integration for Gemini Spark — config examples and documentation"
+requires-python = ">=3.11"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["hindsight_gemini_spark"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pyyaml>=6.0",
+]

--- a/hindsight-integrations/gemini-spark/tests/test_config_examples.py
+++ b/hindsight-integrations/gemini-spark/tests/test_config_examples.py
@@ -1,0 +1,92 @@
+"""Validate that the example config files parse correctly and have the expected structure."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+INTEGRATION_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def manifest() -> dict:
+    path = INTEGRATION_DIR / "manifest.example.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.fixture
+def mcp_config() -> dict:
+    path = INTEGRATION_DIR / "mcp_config.example.json"
+    return json.loads(path.read_text())
+
+
+class TestManifestYAML:
+    def test_parses_without_error(self, manifest: dict) -> None:
+        assert isinstance(manifest, dict)
+
+    def test_has_tools_section(self, manifest: dict) -> None:
+        assert "tools" in manifest
+        assert "mcp_servers" in manifest["tools"]
+
+    def test_mcp_server_entry_structure(self, manifest: dict) -> None:
+        servers = manifest["tools"]["mcp_servers"]
+        assert len(servers) >= 1
+
+        hindsight = servers[0]
+        assert hindsight["name"] == "hindsight"
+        assert "endpoint" in hindsight
+        assert "description" in hindsight
+
+    def test_endpoint_is_https(self, manifest: dict) -> None:
+        endpoint = manifest["tools"]["mcp_servers"][0]["endpoint"]
+        assert endpoint.startswith("https://")
+
+    def test_description_mentions_recall_and_retain(self, manifest: dict) -> None:
+        desc = manifest["tools"]["mcp_servers"][0]["description"]
+        assert "hindsight_recall" in desc
+        assert "hindsight_retain" in desc
+
+
+class TestMCPConfigJSON:
+    def test_parses_without_error(self, mcp_config: dict) -> None:
+        assert isinstance(mcp_config, dict)
+
+    def test_has_mcp_servers_section(self, mcp_config: dict) -> None:
+        assert "mcpServers" in mcp_config
+
+    def test_hindsight_server_entry(self, mcp_config: dict) -> None:
+        hindsight = mcp_config["mcpServers"]["hindsight"]
+        assert "serverUrl" in hindsight
+        assert "headers" in hindsight
+
+    def test_server_url_is_https(self, mcp_config: dict) -> None:
+        url = mcp_config["mcpServers"]["hindsight"]["serverUrl"]
+        assert url.startswith("https://")
+
+    def test_auth_header_present(self, mcp_config: dict) -> None:
+        headers = mcp_config["mcpServers"]["hindsight"]["headers"]
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+
+    def test_no_real_credentials(self, mcp_config: dict) -> None:
+        token = mcp_config["mcpServers"]["hindsight"]["headers"]["Authorization"]
+        assert "YOUR_HINDSIGHT_API_KEY" in token
+
+
+class TestReadme:
+    def test_readme_exists(self) -> None:
+        readme = INTEGRATION_DIR / "README.md"
+        assert readme.exists()
+
+    def test_readme_mentions_cloud(self) -> None:
+        content = (INTEGRATION_DIR / "README.md").read_text()
+        assert "Hindsight Cloud" in content
+        assert "vectorize.io/hindsight" in content
+
+    def test_readme_mentions_both_config_files(self) -> None:
+        content = (INTEGRATION_DIR / "README.md").read_text()
+        assert "manifest.example.yaml" in content
+        assert "mcp_config.example.json" in content

--- a/hindsight-integrations/gemini-spark/tests/test_config_examples.py
+++ b/hindsight-integrations/gemini-spark/tests/test_config_examples.py
@@ -46,8 +46,12 @@ class TestManifestYAML:
 
     def test_description_mentions_recall_and_retain(self, manifest: dict) -> None:
         desc = manifest["tools"]["mcp_servers"][0]["description"]
-        assert "hindsight_recall" in desc
-        assert "hindsight_retain" in desc
+        assert "recall" in desc
+        assert "retain" in desc
+
+    def test_endpoint_path_is_mcp(self, manifest: dict) -> None:
+        endpoint = manifest["tools"]["mcp_servers"][0]["endpoint"]
+        assert endpoint.endswith("/mcp")
 
 
 class TestMCPConfigJSON:

--- a/hindsight-integrations/gemini-spark/uv.lock
+++ b/hindsight-integrations/gemini-spark/uv.lock
@@ -1,0 +1,138 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "hindsight-gemini-spark"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]

--- a/scripts/release-integration.sh
+++ b/scripts/release-integration.sh
@@ -13,7 +13,7 @@ print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-VALID_INTEGRATIONS=("litellm" "pydantic-ai" "crewai" "ag2" "ai-sdk" "chat" "openclaw" "langgraph" "llamaindex" "nemoclaw" "strands" "claude-code" "codex" "hermes" "autogen" "paperclip" "opencode" "cloudflare-oauth-proxy" "openai-agents" "pipecat" "agentcore" "smolagents" "n8n" "dify")
+VALID_INTEGRATIONS=("litellm" "pydantic-ai" "crewai" "ag2" "ai-sdk" "chat" "openclaw" "langgraph" "llamaindex" "nemoclaw" "strands" "claude-code" "codex" "hermes" "autogen" "paperclip" "opencode" "cloudflare-oauth-proxy" "openai-agents" "pipecat" "agentcore" "smolagents" "n8n" "dify" "gemini-spark")
 
 usage() {
     print_error "Usage: $0 <integration> <version>"


### PR DESCRIPTION
## Summary
- Config-only integration connecting Gemini Spark to Hindsight via MCP (Antigravity 2.0 manifest + desktop MCP config)
- Prioritizes Hindsight Cloud, with self-hosted path via cloudflare-oauth-proxy
- 15 pytest tests validating config structure, HTTPS endpoints, correct tool names, and no leaked credentials
- CI job + release script entry

## Notes
- Spark is in limited beta (AI Ultra subscribers, US only) as of May 2026. MCP support is confirmed at launch.
- The Antigravity manifest format is based on the I/O 2026 developer guide and may need adjusting once Google publishes the formal schema.
- MCP endpoint path (`/mcp`) and tool names (`recall`/`retain`) verified via manual round-trip against Hindsight Cloud dev.

## Test plan
- [x] 15/15 pytest tests pass locally
- [x] Manual MCP round-trip: initialize → tools/list → sync_retain → recall (all succeeded against dev)
- [ ] CI `test-gemini-spark-integration` job passes
- [ ] Verify with real Spark client when beta access is available