### PR TITLE
chore: update gemini embedding model from preview to GA

### DIFF
--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -454,7 +454,7 @@ class TestLiteLLMSDKEmbeddings:
         ):
             emb = LiteLLMSDKEmbeddings(
                 api_key="test_key",
-                model="gemini/gemini-embedding-2-preview",
+                model="gemini/gemini-embedding-2",
                 encoding_format="",
             )
             await emb.initialize()
@@ -542,7 +542,7 @@ class TestLiteLLMSDKEmbeddingsFactory:
         mock_config = MagicMock()
         mock_config.embeddings_provider = "litellm-sdk"
         mock_config.embeddings_litellm_sdk_api_key = "test_key"
-        mock_config.embeddings_litellm_sdk_model = "gemini/gemini-embedding-2-preview"
+        mock_config.embeddings_litellm_sdk_model = "gemini/gemini-embedding-2"
         mock_config.embeddings_litellm_sdk_api_base = None
         mock_config.embeddings_litellm_sdk_output_dimensions = 768
 


### PR DESCRIPTION
Replace gemini-embedding-2-preview with gemini-embedding-2 in LiteLLM SDK embedding tests now that the GA model is available.