### PR TITLE
fix(control-plane): add graph_maintenance to operations type filter

### DIFF
--- a/hindsight-control-plane/src/components/bank-operations-view.tsx
+++ b/hindsight-control-plane/src/components/bank-operations-view.tsx
@@ -98,6 +98,7 @@ const OPERATION_TYPE_OPTIONS = [
   { value: "refresh_mental_model", label: "Mental Model Refresh" },
   { value: "file_convert_retain", label: "File Convert & Retain" },
   { value: "webhook_delivery", label: "Webhook Delivery" },
+  { value: "graph_maintenance", label: "Graph Maintenance" },
 ];
 
 export function BankOperationsView() {


### PR DESCRIPTION
## Summary
- Add `graph_maintenance` operation type to the operations view dropdown filter in the control plane UI
- This was missing after `graph_maintenance` was introduced in cc3ba4a3

## Test plan
- [ ] Open bank operations view, verify "Graph Maintenance" appears in the type filter dropdown