### PR TITLE
fix(api): anchor recall recency to query timestamp

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -152,7 +152,11 @@ class RecallRequest(BaseModel):
     max_tokens: int = 4096
     trace: bool = False
     query_timestamp: str | None = Field(
-        default=None, description="ISO format date string (e.g., '2023-05-30T23:40:00')"
+        default=None,
+        description=(
+            "ISO format date string (e.g., '2023-05-30T23:40:00'). Used as the query-time anchor for "
+            "relative temporal expressions and recency scoring."
+        ),
     )
     include: IncludeOptions = FieldWithDefault(
         IncludeOptions,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -396,6 +396,15 @@ def utcnow():
     return datetime.now(UTC)
 
 
+def _recall_scoring_now(question_date: datetime | None) -> datetime:
+    """Return the reference time for recall scoring boosts."""
+    if question_date is None:
+        return utcnow()
+    if question_date.tzinfo is None or question_date.utcoffset() is None:
+        return question_date.replace(tzinfo=UTC)
+    return question_date.astimezone(UTC)
+
+
 # Logger for memory system
 logger = logging.getLogger(__name__)
 
@@ -2890,7 +2899,7 @@ class MemoryEngine(MemoryEngineInterface):
                        Results are returned until token budget is reached, stopping before
                        including a fact that would exceed the limit
             enable_trace: Whether to return trace for debugging (deprecated)
-            question_date: Optional date when question was asked (for temporal filtering)
+            question_date: Optional date when question was asked (for temporal filtering and recency scoring)
             include_entities: Whether to include entity observations in the response
             max_entity_tokens: Maximum tokens for entity observations (default 500)
             include_chunks: Whether to include raw chunks in the response
@@ -3549,7 +3558,11 @@ class MemoryEngine(MemoryEngineInterface):
             if scored_results:
                 ce = reranker_instance.cross_encoder
                 is_passthrough = ce is not None and ce.provider_name == "rrf"
-                apply_combined_scoring(scored_results, now=utcnow(), is_passthrough_reranker=is_passthrough)
+                apply_combined_scoring(
+                    scored_results,
+                    now=_recall_scoring_now(question_date),
+                    is_passthrough_reranker=is_passthrough,
+                )
                 scored_results.sort(key=lambda x: x.weight, reverse=True)
                 log_buffer.append("  [4.6] Combined scoring: ce * recency_boost(0.2) * temporal_boost(0.2)")
 

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -799,7 +799,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     {"tags": [...], "match": "any_strict"} or compound {"and": [...]}, {"or": [...]}, {"not": {...}}.
                     Example: [{"not": {"tags": ["closeout"], "match": "any_strict"}}] excludes memories tagged closeout.
                     Mutually exclusive with tags.
-                query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z'). Helps retrieve time-relevant memories.
+                query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
+                    Anchors relative temporal expressions and recency scoring.
                 bank_id: Optional bank to search in (defaults to session bank). Use for cross-bank operations.
             """
             try:
@@ -869,7 +870,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     {"tags": [...], "match": "any_strict"} or compound {"and": [...]}, {"or": [...]}, {"not": {...}}.
                     Example: [{"not": {"tags": ["closeout"], "match": "any_strict"}}] excludes memories tagged closeout.
                     Mutually exclusive with tags.
-                query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z'). Helps retrieve time-relevant memories.
+                query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
+                    Anchors relative temporal expressions and recency scoring.
             """
             try:
                 target_bank = config.bank_id_resolver()

--- a/hindsight-api-slim/tests/test_recall_scoring_time.py
+++ b/hindsight-api-slim/tests/test_recall_scoring_time.py
@@ -1,0 +1,130 @@
+import asyncio
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.engine import memory_engine
+from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.engine.search.retrieval import MultiFactTypeRetrievalResult, ParallelRetrievalResult
+from hindsight_api.engine.search.types import RetrievalResult, ScoredResult
+from hindsight_api.models import RequestContext
+
+
+class _ConfigResolver:
+    async def get_bank_config(self, _bank_id: str, _request_context: RequestContext) -> dict[str, object]:
+        return {}
+
+
+class _Reranker:
+    def __init__(self) -> None:
+        self.cross_encoder = None
+
+    async def ensure_initialized(self) -> None:
+        return None
+
+    async def rerank(self, _query: str, candidates: list[Any]) -> list[ScoredResult]:
+        return [
+            ScoredResult(
+                candidate=candidates[0],
+                cross_encoder_score=0.8,
+                cross_encoder_score_normalized=0.8,
+                weight=0.8,
+            )
+        ]
+
+
+def test_recall_scoring_now_uses_question_date():
+    question_date = datetime(2023, 5, 30, 13, 53, tzinfo=UTC)
+
+    assert memory_engine._recall_scoring_now(question_date) == question_date
+
+
+def test_recall_scoring_now_normalizes_naive_question_date_to_utc():
+    question_date = datetime(2023, 5, 30, 13, 53)
+
+    assert memory_engine._recall_scoring_now(question_date) == datetime(2023, 5, 30, 13, 53, tzinfo=UTC)
+
+
+def test_recall_scoring_now_converts_aware_question_date_to_utc():
+    question_date = datetime(2023, 5, 30, 21, 53, tzinfo=timezone(timedelta(hours=8)))
+
+    assert memory_engine._recall_scoring_now(question_date) == datetime(2023, 5, 30, 13, 53, tzinfo=UTC)
+
+
+def test_recall_scoring_now_falls_back_to_current_time(monkeypatch):
+    now = datetime(2026, 5, 27, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(memory_engine, "utcnow", lambda: now)
+
+    assert memory_engine._recall_scoring_now(None) == now
+
+
+@pytest.mark.asyncio
+async def test_recall_async_passes_question_date_to_combined_scoring(monkeypatch):
+    question_date = datetime(2023, 5, 30, 21, 53, tzinfo=timezone(timedelta(hours=8)))
+    captured_now: datetime | None = None
+
+    engine = memory_engine.MemoryEngine.__new__(memory_engine.MemoryEngine)
+    engine._operation_validator = None
+    engine._config_resolver = _ConfigResolver()
+    engine._search_semaphore = asyncio.Semaphore(1)
+    engine._initialized = True
+    engine._read_backend = object()
+    engine.embeddings = object()
+    engine.query_analyzer = object()
+    engine._cross_encoder_reranker = _Reranker()
+    engine._authenticate_tenant = AsyncMock()
+
+    async def generate_embeddings_batch(*_args: object, **_kwargs: object) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3]]
+
+    async def retrieve_all_fact_types_parallel(*_args: object, **_kwargs: object) -> MultiFactTypeRetrievalResult:
+        retrieval = RetrievalResult(
+            id="00000000-0000-0000-0000-000000000001",
+            text="Alice likes machine learning.",
+            fact_type="world",
+            occurred_start=datetime(2023, 5, 29, tzinfo=UTC),
+            similarity=0.9,
+        )
+        return MultiFactTypeRetrievalResult(
+            results_by_fact_type={
+                "world": ParallelRetrievalResult(
+                    semantic=[retrieval],
+                    bm25=[],
+                    graph=[],
+                    temporal=None,
+                    timings={"semantic": 0.0, "bm25": 0.0, "graph": 0.0, "temporal_extraction": 0.0},
+                )
+            }
+        )
+
+    def apply_combined_scoring(
+        scored_results: list[ScoredResult], *, now: datetime, is_passthrough_reranker: bool
+    ) -> None:
+        nonlocal captured_now
+        assert is_passthrough_reranker is False
+        captured_now = now
+        for result in scored_results:
+            result.combined_score = result.cross_encoder_score_normalized
+            result.weight = result.combined_score
+
+    monkeypatch.setattr(memory_engine.embedding_utils, "generate_embeddings_batch", generate_embeddings_batch)
+    monkeypatch.setattr(
+        "hindsight_api.engine.search.retrieval.retrieve_all_fact_types_parallel",
+        retrieve_all_fact_types_parallel,
+    )
+    monkeypatch.setattr(memory_engine, "apply_combined_scoring", apply_combined_scoring)
+
+    result = await engine.recall_async(
+        bank_id="test-bank",
+        query="What does Alice like?",
+        budget=Budget.LOW,
+        fact_type=["world"],
+        question_date=question_date,
+        request_context=RequestContext(),
+        _quiet=True,
+    )
+
+    assert [fact.text for fact in result.results] == ["Alice likes machine learning."]
+    assert captured_now == datetime(2023, 5, 30, 13, 53, tzinfo=UTC)

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -392,7 +392,8 @@ class Hindsight:
             max_tokens: Maximum tokens in results (default: 4096)
             budget: Budget level for recall - "low", "mid", or "high" (default: "mid")
             trace: Enable trace output (default: False)
-            query_timestamp: Optional ISO format date string (e.g., '2023-05-30T23:40:00')
+            query_timestamp: Optional ISO format date string used as the query-time anchor for relative
+                temporal expressions and recency scoring (e.g., '2023-05-30T23:40:00')
             include_entities: Include entity observations in results (default: False)
             max_entity_tokens: Maximum tokens for entity observations (default: 500)
             include_chunks: Include raw text chunks in results (default: False)
@@ -841,7 +842,8 @@ class Hindsight:
             max_tokens: Maximum tokens in results (default: 4096)
             budget: Budget level for recall - "low", "mid", or "high" (default: "mid")
             trace: Enable trace output (default: False)
-            query_timestamp: Optional ISO format date string (e.g., '2023-05-30T23:40:00')
+            query_timestamp: Optional ISO format date string used as the query-time anchor for relative
+                temporal expressions and recency scoring (e.g., '2023-05-30T23:40:00')
             include_entities: Include entity observations in results (default: False)
             max_entity_tokens: Maximum tokens for entity observations (default: 500)
             include_chunks: Include raw text chunks in results (default: False)

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2329,7 +2329,7 @@ export type RecallRequest = {
   /**
    * Query Timestamp
    *
-   * ISO format date string (e.g., '2023-05-30T23:40:00')
+   * ISO format date string (e.g., '2023-05-30T23:40:00'). Used as the query-time anchor for relative temporal expressions and recency scoring.
    */
   query_timestamp?: string | null;
   /**

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -122,7 +122,7 @@ The maximum number of tokens the returned facts can collectively occupy. Default
 
 ### query_timestamp
 
-An ISO 8601 datetime representing when the query is being asked, from the user's perspective. When provided, it is used as the anchor for resolving relative temporal expressions in the query — for example, if the query says "last month" and `query_timestamp` is `2023-05-30`, the temporal search window becomes approximately April 2023. Without it, the server's current time is used as the anchor. This field matters most for replaying historical conversations or building agents that need time-anchored recall.
+An ISO 8601 datetime representing when the query is being asked, from the user's perspective. When provided, it is used as the anchor for resolving relative temporal expressions in the query and for recency scoring — for example, if the query says "last month" and `query_timestamp` is `2023-05-30`, the temporal search window becomes approximately April 2023, and recency boosts are calculated as of May 30, 2023. Without it, the server's current time is used as the anchor. This field matters most for replaying historical conversations or building agents that need time-anchored recall.
 
 ### include
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -156,7 +156,7 @@ Search memories to provide personalized responses.
 | `types` | list[string] | No | Filter by fact type: `world`, `experience`, `opinion`. Defaults to all |
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
-| `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time |
+| `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
 
 **Example:**
 ```json

--- a/hindsight-docs/docs/developer/retrieval.md
+++ b/hindsight-docs/docs/developer/retrieval.md
@@ -317,7 +317,7 @@ Linear decay over 365 days from the memory's occurrence date:
 recency = clamp(1.0 - days_ago / 365, 0.1, 1.0)
 ```
 
-A memory from today has recency 1.0 (+10% boost). A memory from 6 months ago has recency ~0.5 (neutral). A memory older than a year has recency 0.1 (-8% penalty). Memories without dates get 0.5 (neutral — no boost or penalty).
+A memory from the query timestamp has recency 1.0 (+10% boost). A memory from 6 months before the query timestamp has recency ~0.5 (neutral). A memory more than a year before the query timestamp has recency 0.1 (-8% penalty). If no `query_timestamp` is provided, the server's current time is used. Memories without dates get 0.5 (neutral — no boost or penalty).
 
 #### Temporal proximity signal
 

--- a/hindsight-docs/src/pages/best-practices.mdx
+++ b/hindsight-docs/src/pages/best-practices.mdx
@@ -448,7 +448,7 @@ This is a hard SQL WHERE clause applied across all four retrieval strategies. Th
 
 ### `query_timestamp`
 
-Set for time-sensitive queries. Anchors temporal ranking to a specific point in time.
+Set for time-sensitive queries. Anchors relative temporal expressions and recency scoring to a specific point in time.
 
 ```python
 # "What was the team working on in January?"

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9042,7 +9042,7 @@
               }
             ],
             "title": "Query Timestamp",
-            "description": "ISO format date string (e.g., '2023-05-30T23:40:00')"
+            "description": "ISO format date string (e.g., '2023-05-30T23:40:00'). Used as the query-time anchor for relative temporal expressions and recency scoring."
           },
           "include": {
             "$ref": "#/components/schemas/IncludeOptions",

--- a/skills/hindsight-docs/references/best-practices.md
+++ b/skills/hindsight-docs/references/best-practices.md
@@ -442,7 +442,7 @@ This is a hard SQL WHERE clause applied across all four retrieval strategies. Th
 
 ### `query_timestamp`
 
-Set for time-sensitive queries. Anchors temporal ranking to a specific point in time.
+Set for time-sensitive queries. Anchors relative temporal expressions and recency scoring to a specific point in time.
 
 ```python
 # "What was the team working on in January?"

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -234,7 +234,7 @@ hindsight memory recall my-bank "Alice's email" --max-tokens 500
 
 ### query_timestamp
 
-An ISO 8601 datetime representing when the query is being asked, from the user's perspective. When provided, it is used as the anchor for resolving relative temporal expressions in the query — for example, if the query says "last month" and `query_timestamp` is `2023-05-30`, the temporal search window becomes approximately April 2023. Without it, the server's current time is used as the anchor. This field matters most for replaying historical conversations or building agents that need time-anchored recall.
+An ISO 8601 datetime representing when the query is being asked, from the user's perspective. When provided, it is used as the anchor for resolving relative temporal expressions in the query and for recency scoring — for example, if the query says "last month" and `query_timestamp` is `2023-05-30`, the temporal search window becomes approximately April 2023, and recency boosts are calculated as of May 30, 2023. Without it, the server's current time is used as the anchor. This field matters most for replaying historical conversations or building agents that need time-anchored recall.
 
 ### include
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -156,7 +156,7 @@ Search memories to provide personalized responses.
 | `types` | list[string] | No | Filter by fact type: `world`, `experience`, `opinion`. Defaults to all |
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
-| `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time |
+| `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
 
 **Example:**
 ```json

--- a/skills/hindsight-docs/references/developer/retrieval.md
+++ b/skills/hindsight-docs/references/developer/retrieval.md
@@ -317,7 +317,7 @@ Linear decay over 365 days from the memory's occurrence date:
 recency = clamp(1.0 - days_ago / 365, 0.1, 1.0)
 ```
 
-A memory from today has recency 1.0 (+10% boost). A memory from 6 months ago has recency ~0.5 (neutral). A memory older than a year has recency 0.1 (-8% penalty). Memories without dates get 0.5 (neutral — no boost or penalty).
+A memory from the query timestamp has recency 1.0 (+10% boost). A memory from 6 months before the query timestamp has recency ~0.5 (neutral). A memory more than a year before the query timestamp has recency 0.1 (-8% penalty). If no `query_timestamp` is provided, the server's current time is used. Memories without dates get 0.5 (neutral — no boost or penalty).
 
 #### Temporal proximity signal
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9042,7 +9042,7 @@
               }
             ],
             "title": "Query Timestamp",
-            "description": "ISO format date string (e.g., '2023-05-30T23:40:00')"
+            "description": "ISO format date string (e.g., '2023-05-30T23:40:00'). Used as the query-time anchor for relative temporal expressions and recency scoring."
           },
           "include": {
             "$ref": "#/components/schemas/IncludeOptions",


### PR DESCRIPTION
## Summary

This PR makes recall recency scoring honor `query_timestamp`.

Before this change, `query_timestamp` already anchored temporal retrieval for relative time expressions, but combined scoring still calculated recency against the server's current wall-clock time. That means historical replay, offline evaluation, and imported conversation logs could incorrectly penalize memories that were recent at the time the user asked the question.

With this change, recall uses the public `query_timestamp` parameter, parsed internally as `question_date`, as the reference time for combined scoring. If no `query_timestamp` is provided, behavior remains unchanged and scoring falls back to the server's current UTC time.

## What Changed

- Added a recall scoring time helper that:
  - uses the public `query_timestamp` value, parsed internally as `question_date`, when provided
  - normalizes timezone-aware timestamps to UTC
  - treats naive timestamps as UTC
  - falls back to `utcnow()` when no query timestamp is provided
- Changed recall combined scoring to use that query-time anchor instead of always using `utcnow()`.
- Updated API, Python client, TypeScript generated types, OpenAPI, MCP docs, and developer docs to document that `query_timestamp` anchors both:
  - relative temporal expressions
  - recency scoring
- Added recall-level tests to verify combined scoring receives the query-time anchor.
- Regenerated docs skill references.

## Why

`query_timestamp` is documented as "recall as if asking at this point in time". Since Hindsight already uses it to anchor temporal retrieval, recency scoring should use the same query-time anchor instead of switching back to server wall-clock time.

For example, if a benchmark replays a query from May 30, 2023, a memory from May 22, 2023 should be considered recent. Previously, if the server processed that replay in 2026, the same memory would be treated as more than a year old and receive the minimum recency score.

This is especially important for:

- historical conversation replay
- offline benchmarks
- migrated/imported agent logs
- tests that provide `query_timestamp` to reproduce past recall behavior

## Compatibility

This is backward compatible for live recall requests that do not pass `query_timestamp`: those still use the server's current UTC time for recency scoring.

The only behavior change is for requests that explicitly provide `query_timestamp`; those now consistently use it for both temporal retrieval and recency scoring.

## Tests

Ran:

```bash
uv run pytest \
  hindsight-api-slim/tests/test_recall_scoring_time.py \
  hindsight-api-slim/tests/test_combined_scoring.py
```

Result:

```text
21 passed
```

Also ran:

```bash
uv run pytest \
  hindsight-api-slim/tests/test_mcp_tools.py::TestRecallNewParams::test_recall_with_query_timestamp -q
```

Result:

```text
1 passed
```

Docs/generated checks:

```bash
./scripts/generate-openapi.sh
./scripts/generate-clients.sh
./scripts/generate-docs-skill.sh
./scripts/hooks/generate-docs-skill.sh
./scripts/hooks/lint.sh
npm run build -w hindsight-docs
git diff --check
git diff --cached --check
```

The docs build passed. It still reports existing Docusaurus warnings about a blog truncation marker and two broken anchors in an unrelated version blog page.
