### PR TITLE
docs(retrieval): note pg_search configurable tokenizer in BM25 backends table

### DIFF
--- a/hindsight-docs/docs/developer/retrieval.md
+++ b/hindsight-docs/docs/developer/retrieval.md
@@ -72,7 +72,7 @@ No single search method handles all these well. Hindsight solves this with **TEM
 | `vchord` | `vchord_bm25` extension | No |
 | `pg_textsearch` | Timescale `pg_textsearch` extension | No |
 | `pgroonga` | PGroonga (Groonga) full-text extension, `TokenBigram` polyglot tokenizer | No |
-| `pg_search` | ParadeDB `pg_search` extension | Yes |
+| `pg_search` | ParadeDB `pg_search` extension, configurable tokenizer (e.g. `jieba`, `chinese_compatible`, `ngram`) via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` | Yes |
 
 If you need true BM25 ranking on a horizontally scaled Postgres (Citus) cluster,
 `pg_search` is the only option. See the [`pg_search` docker-compose example](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/pg_search).

--- a/skills/hindsight-docs/references/developer/retrieval.md
+++ b/skills/hindsight-docs/references/developer/retrieval.md
@@ -72,7 +72,7 @@ No single search method handles all these well. Hindsight solves this with **TEM
 | `vchord` | `vchord_bm25` extension | No |
 | `pg_textsearch` | Timescale `pg_textsearch` extension | No |
 | `pgroonga` | PGroonga (Groonga) full-text extension, `TokenBigram` polyglot tokenizer | No |
-| `pg_search` | ParadeDB `pg_search` extension | Yes |
+| `pg_search` | ParadeDB `pg_search` extension, configurable tokenizer (e.g. `jieba`, `chinese_compatible`, `ngram`) via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER` | Yes |
 
 If you need true BM25 ranking on a horizontally scaled Postgres (Citus) cluster,
 `pg_search` is the only option. See the [`pg_search` docker-compose example](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/pg_search).


### PR DESCRIPTION
The BM25 backends comparison table in `developer/retrieval.md` documents pgroonga's `TokenBigram` tokenizer but the `pg_search` row carries no tokenizer note, even though #1776 (feat(api): add pg_search tokenizer configuration) made the `pg_search` tokenizer configurable via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`.

#1776 documented the env var in `developer/configuration.md` but the backend-comparison table — the surface users consult when *choosing* a backend — still shows `pg_search` with no tokenizer capability. CJK/multilingual users comparing backends can't tell that `pg_search` now supports `jieba`/`chinese_compatible`/`lindera` tokenizers, parity with the already-noted pgroonga tokenizer.

This adds a short tokenizer note to the `pg_search` row, mirroring the pgroonga row's style. Tokenizer example values are taken verbatim from the `configuration.md` canonical list added by #1776. Dual-doc: docs + skills mirror.