### PR TITLE
docs(models): list openai-codex and openrouter in embeddings Supported Providers table

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -394,6 +394,8 @@ Converts text into dense vector representations for semantic similarity search.
 |----------|-------------|----------|
 | `local` | SentenceTransformers (default) | Development, low latency |
 | `openai` | OpenAI embeddings API | Production, high quality |
+| `openai-codex` | OpenAI embeddings via Codex OAuth (ChatGPT Plus/Pro, no API key) | Existing ChatGPT/Codex subscribers |
+| `openrouter` | OpenRouter embeddings (OpenAI-compatible gateway) | Multi-provider setups |
 | `cohere` | Cohere embeddings API | Production, multilingual |
 | `google` | Google embeddings (Gemini API or Vertex AI) | Production, multilingual, high quality |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -421,6 +421,8 @@ Converts text into dense vector representations for semantic similarity search.
 |----------|-------------|----------|
 | `local` | SentenceTransformers (default) | Development, low latency |
 | `openai` | OpenAI embeddings API | Production, high quality |
+| `openai-codex` | OpenAI embeddings via Codex OAuth (ChatGPT Plus/Pro, no API key) | Existing ChatGPT/Codex subscribers |
+| `openrouter` | OpenRouter embeddings (OpenAI-compatible gateway) | Multi-provider setups |
 | `cohere` | Cohere embeddings API | Production, multilingual |
 | `google` | Google embeddings (Gemini API or Vertex AI) | Production, multilingual, high quality |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |


### PR DESCRIPTION
The embeddings **Supported Providers** table in `models.mdx` lists 8 providers, but `HINDSIGHT_API_EMBEDDINGS_PROVIDER` accepts 10 (`configuration.md`): `openai-codex` and `openrouter` are both valid values that are missing from the reference table, so users picking an embeddings provider can't discover them there.

- `openai-codex` embeddings shipped recently (#1704); it reuses ChatGPT/Codex OAuth login (no API key).
- `openrouter` embeddings has existed since #930 (April) and was never added to this table.

Adds the two missing rows to the main doc + the `skills/` mirror (which had the identical gap; regeneration tooling did not backfill it).