### PR TITLE
Inherit entities from source memories in list_memory_units for observation rows

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5377,17 +5377,18 @@ class MemoryEngine(MemoryEngineInterface):
                 *query_params,
             )
 
-            # Get entity information for these units
+            # Get entity information for these units. _entity_rows_for_units_sql
+            # resolves both direct unit_entities rows and the
+            # observation→source_memory_ids inheritance fallback in a single
+            # query, so observations carry their source memories' entities in
+            # the list response rather than coming back with entities=""
+            # (which made consumers like agent UIs unable to show entity badges
+            # on consolidated observation rows). Mirrors the behavior the
+            # recall path (around line 3856) and get_memory_unit already use.
             if units:
                 unit_ids = [row["id"] for row in units]
                 unit_entities = await conn.fetch(
-                    f"""
-                    SELECT ue.unit_id, e.canonical_name
-                    FROM {fq_table("unit_entities")} ue
-                    JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                    WHERE ue.unit_id = ANY($1::uuid[])
-                    ORDER BY ue.unit_id
-                """,
+                    self._entity_rows_for_units_sql(unit_ids_placeholder=1),
                     unit_ids,
                 )
             else:

--- a/hindsight-api-slim/tests/test_list_memory_units_observation_entities.py
+++ b/hindsight-api-slim/tests/test_list_memory_units_observation_entities.py
@@ -1,0 +1,140 @@
+"""Tests that list_memory_units surfaces entities for observation rows.
+
+Observations don't carry direct unit_entities rows -- their entity associations
+live transitively through source_memory_ids. get_memory_unit and the recall
+path already use _entity_rows_for_units_sql to UNION direct + inherited rows
+in a single query; list_memory_units used to issue a plain JOIN against
+unit_entities, which returned entities="" for every observation row.
+
+This file pins down the desired behavior: list responses for observation
+rows must surface entities inherited from their source memories.
+"""
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    """Observations only get created when the engine config opts in."""
+    from hindsight_api.config import _get_raw_config
+
+    config = _get_raw_config()
+    original_value = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original_value
+
+
+@pytest.mark.asyncio
+async def test_list_memory_units_observation_inherits_entities_from_source(memory, request_context):
+    """Observations returned by list_memory_units carry their source memories' entities.
+
+    Before the fix this assertion failed because list_memory_units issued a
+    direct JOIN against unit_entities -- observations have no rows there, so
+    `entities` came back as an empty string even though the same memory
+    fetched via get_memory_unit had populated entities (because get_memory_unit
+    already used the UNION helper).
+    """
+    bank_id = f"test-list-obs-entities-{uuid.uuid4().hex[:8]}"
+
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        # Retain content with a clearly-named entity. SyncTaskBackend runs
+        # consolidation inline, so an observation row is produced before the
+        # retain call returns in tests.
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="John Smith is the CEO of Acme Corporation.",
+            request_context=request_context,
+        )
+
+        result = await memory.list_memory_units(
+            bank_id=bank_id,
+            fact_type="observation",
+            limit=50,
+            offset=0,
+            request_context=request_context,
+        )
+
+        observation_items = [item for item in result["items"] if item["fact_type"] == "observation"]
+        assert observation_items, "expected at least one observation row after retain"
+
+        # Inherited entities must surface in the list response. At minimum one
+        # of the named entities should land in the comma-joined string -- the
+        # LLM may pick either canonical form (e.g. "John Smith", "Acme
+        # Corporation", or both), so we accept either rather than pinning a
+        # specific name list and making the test brittle.
+        observation_with_entities = next(
+            (item for item in observation_items if item["entities"]),
+            None,
+        )
+        assert observation_with_entities is not None, (
+            "expected list_memory_units to surface inherited entities for at least one "
+            "observation row, got entities='' on every observation. This means the "
+            "observation→source_memory_ids inheritance is missing from the list path."
+        )
+
+        # Cross-check: the same observation fetched via get_memory_unit (which
+        # already used the UNION helper before this change) must produce the
+        # same entity set. If they diverge we've introduced a regression in
+        # one path or the other.
+        single = await memory.get_memory_unit(
+            bank_id=bank_id,
+            memory_id=observation_with_entities["id"],
+            request_context=request_context,
+        )
+        single_entities = set(single["entities"])
+        list_entities = {e.strip() for e in observation_with_entities["entities"].split(",") if e.strip()}
+        assert single_entities == list_entities, (
+            f"list_memory_units entities {list_entities} disagree with "
+            f"get_memory_unit entities {single_entities} for the same observation; "
+            "both paths should use _entity_rows_for_units_sql."
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_list_memory_units_world_facts_still_return_direct_entities(memory, request_context):
+    """Regression guard: world/experience rows continue to receive their own
+    direct unit_entities. The UNION helper only adds inherited rows for
+    observations whose unit has no direct entities; it must not break the
+    common direct-link path that world/experience rely on.
+    """
+    bank_id = f"test-list-world-entities-{uuid.uuid4().hex[:8]}"
+
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Maria works as a software engineer at Microsoft.",
+            request_context=request_context,
+        )
+
+        # Pull world/experience rows specifically -- avoids ordering coupling
+        # with the observation produced by the same retain.
+        for fact_type in ("world", "experience"):
+            result = await memory.list_memory_units(
+                bank_id=bank_id,
+                fact_type=fact_type,
+                limit=50,
+                offset=0,
+                request_context=request_context,
+            )
+            if not result["items"]:
+                # Not every retain produces both fact_types; skip the type
+                # the LLM didn't emit rather than asserting both exist.
+                continue
+
+            item_with_entities = next((item for item in result["items"] if item["entities"]), None)
+            assert item_with_entities is not None, (
+                f"expected at least one {fact_type} row with direct entities; got "
+                f"entities='' on every {fact_type} row. The UNION helper may have "
+                "broken the direct-link path."
+            )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

``list_memory_units`` issues a plain JOIN against ``unit_entities`` to attach entity names to each returned row ([memory_engine.py:5380-5392](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/engine/memory_engine.py#L5380-L5392) on main). Observations don't carry direct ``unit_entities`` rows — their entity links live transitively through ``source_memory_ids`` ([consolidator.py:1134-1145](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py#L1134-L1145)) — so the list response comes back with ``entities=""`` for every observation row.

Meanwhile ``get_memory_unit`` already handles this correctly via the existing ``_entity_rows_for_units_sql`` helper, which UNIONs direct and inherited rows in a single query ([memory_engine.py:3965-4016](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/engine/memory_engine.py#L3965-L4016)). The recall path uses the same helper around [memory_engine.py:3856](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/engine/memory_engine.py#L3856). Only the list path was bypassing it.

This PR switches ``list_memory_units`` to the same helper so consumers building UIs on top of ``/v1/default/banks/{bank_id}/memories/list`` can render entity badges on observation rows without an N+1 fan-out to ``/memories/{id}``.

## Why this matters in practice

I hit this building an agent-memory UI that filters the timeline to ``fact_type=observation`` (cleaner prose summaries than raw world/experience). Observations consistently came back with no entities even though the same memories fetched individually were fully populated. The asymmetry between ``/memories/list`` and ``/memories/{id}`` wasn't obvious — both endpoints look like they should return the same shape — and the docstring in ``_entity_rows_for_units_sql`` reads as if every caller already uses it.

## The change

```diff
-            # Get entity information for these units
-            if units:
-                unit_ids = [row["id"] for row in units]
-                unit_entities = await conn.fetch(
-                    f"""
-                    SELECT ue.unit_id, e.canonical_name
-                    FROM {fq_table("unit_entities")} ue
-                    JOIN {fq_table("entities")} e ON ue.entity_id = e.id
-                    WHERE ue.unit_id = ANY(\$1::uuid[])
-                    ORDER BY ue.unit_id
-                \"\"\",
-                    unit_ids,
-                )
-            else:
-                unit_entities = []
+            # Get entity information for these units. _entity_rows_for_units_sql
+            # resolves both direct unit_entities rows and the
+            # observation→source_memory_ids inheritance fallback in a single
+            # query, so observations carry their source memories' entities in
+            # the list response rather than coming back with entities=""
+            # (...) Mirrors the behavior the recall path (around line 3856)
+            # and get_memory_unit already use.
+            if units:
+                unit_ids = [row[\"id\"] for row in units]
+                unit_entities = await conn.fetch(
+                    self._entity_rows_for_units_sql(unit_ids_placeholder=1),
+                    unit_ids,
+                )
+            else:
+                unit_entities = []
```

The downstream loop reads ``row[\"unit_id\"]`` and ``row[\"canonical_name\"]`` only — both column names the helper preserves on both UNION branches — so no further changes are needed in the result-building code.

## Tests

New file: ``hindsight-api-slim/tests/test_list_memory_units_observation_entities.py``

* ``test_list_memory_units_observation_inherits_entities_from_source`` — retains content with named entities, calls ``list_memory_units(fact_type=\"observation\")``, asserts at least one observation surfaces inherited entities. Also cross-checks that the same observation fetched via ``get_memory_unit`` returns the same entity set (catches divergence between the two paths).
* ``test_list_memory_units_world_facts_still_return_direct_entities`` — regression guard for the common direct-link path. The UNION helper only inherits when a unit has no direct rows; world/experience rows have direct rows, so the helper should still return them. The test pulls ``fact_type=world`` and ``fact_type=experience`` separately and asserts each surfaces direct entities when present (skipping cleanly if a given retain didn't produce that fact_type).

Tests follow the ``test_consolidation.py`` pattern (real ``memory: MemoryEngine`` fixture + ``request_context``, unique bank id per test, ``enable_observations`` autouse fixture, ``delete_bank`` cleanup in ``finally``).

## Verification

- ``uv tool run ruff check`` — clean on both touched files
- ``uv tool run ruff format --check`` — clean
- Did not run the integration test suite locally (requires Postgres + LLM creds). Happy to add details if CI surfaces anything.

## Compat notes

- Public response shape unchanged — ``items[i].entities`` is the same comma-joined string, just no longer empty on observation rows.
- The original query had ``ORDER BY ue.unit_id``. The UNION helper omits an ORDER BY. The downstream loop groups rows into a ``dict[unit_id, list[name]]`` so cross-unit ordering doesn't affect the response; within-unit order was already non-deterministic without an inner ORDER BY. No observable change.