### PR TITLE
fix(worker): wire HINDSIGHT_API_WORKER_MAX_RETRIES into task retry decision

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -431,6 +431,7 @@ ENV_WORKER_ENABLED = "HINDSIGHT_API_WORKER_ENABLED"
 ENV_WORKER_ID = "HINDSIGHT_API_WORKER_ID"
 ENV_WORKER_POLL_INTERVAL_MS = "HINDSIGHT_API_WORKER_POLL_INTERVAL_MS"
 ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
+ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS = "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
 
@@ -702,6 +703,7 @@ DEFAULT_WORKER_ENABLED = True  # API runs worker by default (standalone mode)
 DEFAULT_WORKER_ID = None  # Will use hostname if not specified
 DEFAULT_WORKER_POLL_INTERVAL_MS = 500  # Poll database every 500ms
 DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
+DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS = 60  # Seconds between retries on transient task failure
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
@@ -1234,6 +1236,7 @@ class HindsightConfig:
     worker_id: str | None
     worker_poll_interval_ms: int
     worker_max_retries: int
+    worker_task_retry_backoff_seconds: int
     worker_http_port: int
     worker_max_slots: int
     worker_slot_reservations: dict[str, int]
@@ -1971,6 +1974,12 @@ class HindsightConfig:
             worker_id=os.getenv(ENV_WORKER_ID) or DEFAULT_WORKER_ID,
             worker_poll_interval_ms=int(os.getenv(ENV_WORKER_POLL_INTERVAL_MS, str(DEFAULT_WORKER_POLL_INTERVAL_MS))),
             worker_max_retries=int(os.getenv(ENV_WORKER_MAX_RETRIES, str(DEFAULT_WORKER_MAX_RETRIES))),
+            worker_task_retry_backoff_seconds=int(
+                os.getenv(
+                    ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
+                    str(DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS),
+                )
+            ),
             worker_http_port=int(os.getenv(ENV_WORKER_HTTP_PORT, str(DEFAULT_WORKER_HTTP_PORT))),
             worker_max_slots=int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS))),
             worker_slot_reservations={

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13,6 +13,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -29,6 +30,10 @@ from ..config import (
     DEFAULT_RECALL_INCLUDE_CHUNKS,
     DEFAULT_RECALL_MAX_TOKENS,
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
+    DEFAULT_WORKER_MAX_RETRIES,
+    DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS,
+    ENV_WORKER_MAX_RETRIES,
+    ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
     get_config,
 )
 from ..db_url import to_libpq_url
@@ -1421,10 +1426,23 @@ class MemoryEngine(MemoryEngineInterface):
                             error_message=str(e),
                             schema=schema,
                         )
-                    # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed)
+                    # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed).
+                    # Retry count and backoff are read from env on each call (not cached) so operators can
+                    # tune them at runtime without restarting workers — useful when a known provider outage
+                    # exceeds the default 3 x 60s = 4-minute total window.
                     retry_count = task_dict.get("_retry_count", 0)
-                    if retry_count < 3:
-                        raise RetryTaskAt(retry_at=datetime.now(UTC) + timedelta(seconds=60), message=str(e))
+                    max_retries = int(os.getenv(ENV_WORKER_MAX_RETRIES, str(DEFAULT_WORKER_MAX_RETRIES)))
+                    backoff_seconds = int(
+                        os.getenv(
+                            ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
+                            str(DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS),
+                        )
+                    )
+                    if retry_count < max_retries:
+                        raise RetryTaskAt(
+                            retry_at=datetime.now(UTC) + timedelta(seconds=backoff_seconds),
+                            message=str(e),
+                        )
                     raise
 
     async def _fire_consolidation_webhook(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13,7 +13,6 @@ import asyncio
 import contextvars
 import json
 import logging
-import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -30,10 +29,6 @@ from ..config import (
     DEFAULT_RECALL_INCLUDE_CHUNKS,
     DEFAULT_RECALL_MAX_TOKENS,
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
-    DEFAULT_WORKER_MAX_RETRIES,
-    DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS,
-    ENV_WORKER_MAX_RETRIES,
-    ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
     get_config,
 )
 from ..db_url import to_libpq_url
@@ -1427,20 +1422,14 @@ class MemoryEngine(MemoryEngineInterface):
                             schema=schema,
                         )
                     # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed).
-                    # Retry count and backoff are read from env on each call (not cached) so operators can
-                    # tune them at runtime without restarting workers — useful when a known provider outage
-                    # exceeds the default 3 x 60s = 4-minute total window.
+                    # Retry count and backoff come from config (HINDSIGHT_API_WORKER_MAX_RETRIES and
+                    # HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS). Defaults of 3 x 60s give a
+                    # 4-minute total window; operators expecting a longer provider outage can raise them.
+                    config = get_config()
                     retry_count = task_dict.get("_retry_count", 0)
-                    max_retries = int(os.getenv(ENV_WORKER_MAX_RETRIES, str(DEFAULT_WORKER_MAX_RETRIES)))
-                    backoff_seconds = int(
-                        os.getenv(
-                            ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
-                            str(DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS),
-                        )
-                    )
-                    if retry_count < max_retries:
+                    if retry_count < config.worker_max_retries:
                         raise RetryTaskAt(
-                            retry_at=datetime.now(UTC) + timedelta(seconds=backoff_seconds),
+                            retry_at=datetime.now(UTC) + timedelta(seconds=config.worker_task_retry_backoff_seconds),
                             message=str(e),
                         )
                     raise

--- a/hindsight-api-slim/tests/test_worker_retry_knobs.py
+++ b/hindsight-api-slim/tests/test_worker_retry_knobs.py
@@ -1,0 +1,199 @@
+"""
+Regression tests for the worker task-retry env knobs.
+
+Prior to this fix, `MemoryEngine.execute_task` hardcoded the retry cap to 3 and
+the backoff interval to 60 seconds, ignoring the existing
+`HINDSIGHT_API_WORKER_MAX_RETRIES` config knob (declared at config.py but never
+plumbed into the retry decision). The 4-minute total window (3 x 60s) is shorter
+than typical embeddings-provider outages, so operators saw retain operations
+permanently failed when the provider returned transient errors for longer than
+~4 minutes.
+
+These tests verify that both knobs are read from env on each retry decision and
+applied to the resulting `RetryTaskAt`. Reading on each call (rather than
+caching) lets operators tune the policy at runtime without restarting workers.
+"""
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.worker.exceptions import RetryTaskAt
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _create_pending_operation(pool, bank_id: str, operation_id: uuid.UUID) -> None:
+    payload = json.dumps(
+        {
+            "type": "batch_retain",
+            "operation_id": str(operation_id),
+            "bank_id": bank_id,
+            "contents": [{"content": "test", "document_id": "doc-1"}],
+        }
+    )
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'retain', 'pending', $3::jsonb)
+        """,
+        operation_id,
+        bank_id,
+        payload,
+    )
+
+
+async def _cleanup(pool, bank_id: str, operation_id: uuid.UUID) -> None:
+    await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", operation_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_count_cap_honors_env_var(memory):
+    """When HINDSIGHT_API_WORKER_MAX_RETRIES=5, retry_count=4 must still retry (4 < 5)."""
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+        "_retry_count": 4,
+    }
+
+    transient = RuntimeError("transient embeddings outage")
+    with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_MAX_RETRIES": "5"}):
+        with patch.object(memory, "_handle_batch_retain", side_effect=transient):
+            with pytest.raises(RetryTaskAt):
+                await memory.execute_task(task_dict)
+
+    await _cleanup(pool, bank_id, operation_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_stops_at_env_var_cap(memory):
+    """When HINDSIGHT_API_WORKER_MAX_RETRIES=2, retry_count=2 must NOT retry (2 < 2 is false)."""
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+        "_retry_count": 2,
+    }
+
+    transient = RuntimeError("transient embeddings outage")
+    with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_MAX_RETRIES": "2"}):
+        with patch.object(memory, "_handle_batch_retain", side_effect=transient):
+            # Cap reached: re-raised as RuntimeError so the poller's _mark_failed path runs.
+            # Must NOT be wrapped in RetryTaskAt.
+            with pytest.raises(RuntimeError, match="transient embeddings outage"):
+                await memory.execute_task(task_dict)
+
+    await _cleanup(pool, bank_id, operation_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_backoff_honors_env_var(memory):
+    """The RetryTaskAt.retry_at delta must equal HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS."""
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+    }
+
+    custom_backoff = "300"
+    transient = RuntimeError("transient embeddings outage")
+    env = {
+        "HINDSIGHT_API_WORKER_MAX_RETRIES": "5",
+        "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS": custom_backoff,
+    }
+    with patch.dict(os.environ, env):
+        with patch.object(memory, "_handle_batch_retain", side_effect=transient):
+            before = datetime.now(UTC)
+            with pytest.raises(RetryTaskAt) as exc_info:
+                await memory.execute_task(task_dict)
+            # retry_at is computed as datetime.now(UTC) + timedelta(seconds=backoff).
+            # Allow a generous 30-second envelope around the expected delta to absorb
+            # CI scheduling jitter without making the assertion flaky.
+            delta_seconds = (exc_info.value.retry_at - before).total_seconds()
+            assert int(custom_backoff) - 5 <= delta_seconds <= int(custom_backoff) + 30, (
+                f"Expected retry delta ~{custom_backoff}s, got {delta_seconds:.1f}s"
+            )
+
+    await _cleanup(pool, bank_id, operation_id)
+
+
+@pytest.mark.asyncio
+async def test_defaults_preserve_existing_behavior(memory):
+    """With no env vars set, retry count defaults to 3 and backoff defaults to 60s.
+
+    This guards against silent default drift — operators upgrading to a version
+    with the env vars wired in must see the same behavior they had before unless
+    they explicitly opt in to a different policy.
+    """
+    bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _create_pending_operation(pool, bank_id, operation_id)
+
+    task_dict = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "test", "document_id": "doc-1"}],
+        "_retry_count": 2,
+    }
+
+    transient = RuntimeError("transient embeddings outage")
+    # Remove only the two env vars under test, leaving the rest of the environment
+    # intact so the test fixture (DB connection, etc.) keeps working.
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in ("HINDSIGHT_API_WORKER_MAX_RETRIES", "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS")
+    }
+    try:
+        with patch.object(memory, "_handle_batch_retain", side_effect=transient):
+            before = datetime.now(UTC)
+            with pytest.raises(RetryTaskAt) as exc_info:
+                await memory.execute_task(task_dict)
+            # Default backoff is 60s.
+            delta_seconds = (exc_info.value.retry_at - before).total_seconds()
+            assert 55 <= delta_seconds <= 90, f"Default backoff should be ~60s, got {delta_seconds:.1f}s"
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+    await _cleanup(pool, bank_id, operation_id)

--- a/hindsight-api-slim/tests/test_worker_retry_knobs.py
+++ b/hindsight-api-slim/tests/test_worker_retry_knobs.py
@@ -9,9 +9,12 @@ than typical embeddings-provider outages, so operators saw retain operations
 permanently failed when the provider returned transient errors for longer than
 ~4 minutes.
 
-These tests verify that both knobs are read from env on each retry decision and
-applied to the resulting `RetryTaskAt`. Reading on each call (rather than
-caching) lets operators tune the policy at runtime without restarting workers.
+These tests verify that both knobs are read from config (`worker_max_retries`
+and `worker_task_retry_backoff_seconds`) and applied to the resulting
+`RetryTaskAt`. Because config is cached for the process lifetime, each test
+patches the env var, then clears the config cache so the next `get_config()`
+re-reads it; the autouse fixture clears the cache around every test so a
+patched value can't leak into other tests.
 """
 
 import json
@@ -22,7 +25,17 @@ from unittest.mock import patch
 
 import pytest
 
+from hindsight_api.config import clear_config_cache
 from hindsight_api.worker.exceptions import RetryTaskAt
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache():
+    """Clear the cached config before and after each test so env-var patches
+    in one test can't bleed into another via the process-wide cache."""
+    clear_config_cache()
+    yield
+    clear_config_cache()
 
 
 async def _ensure_bank(pool, bank_id: str) -> None:
@@ -78,6 +91,7 @@ async def test_retry_count_cap_honors_env_var(memory):
 
     transient = RuntimeError("transient embeddings outage")
     with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_MAX_RETRIES": "5"}):
+        clear_config_cache()  # force get_config() to re-read the patched env
         with patch.object(memory, "_handle_batch_retain", side_effect=transient):
             with pytest.raises(RetryTaskAt):
                 await memory.execute_task(task_dict)
@@ -105,6 +119,7 @@ async def test_retry_stops_at_env_var_cap(memory):
 
     transient = RuntimeError("transient embeddings outage")
     with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_MAX_RETRIES": "2"}):
+        clear_config_cache()  # force get_config() to re-read the patched env
         with patch.object(memory, "_handle_batch_retain", side_effect=transient):
             # Cap reached: re-raised as RuntimeError so the poller's _mark_failed path runs.
             # Must NOT be wrapped in RetryTaskAt.
@@ -138,6 +153,7 @@ async def test_retry_backoff_honors_env_var(memory):
         "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS": custom_backoff,
     }
     with patch.dict(os.environ, env):
+        clear_config_cache()  # force get_config() to re-read the patched env
         with patch.object(memory, "_handle_batch_retain", side_effect=transient):
             before = datetime.now(UTC)
             with pytest.raises(RetryTaskAt) as exc_info:
@@ -183,6 +199,7 @@ async def test_defaults_preserve_existing_behavior(memory):
         k: os.environ.pop(k, None)
         for k in ("HINDSIGHT_API_WORKER_MAX_RETRIES", "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS")
     }
+    clear_config_cache()  # force get_config() to re-read without the popped env vars
     try:
         with patch.object(memory, "_handle_batch_retain", side_effect=transient):
             before = datetime.now(UTC)


### PR DESCRIPTION
## Summary

The `HINDSIGHT_API_WORKER_MAX_RETRIES` env var has been declared at
`hindsight-api-slim/hindsight_api/config.py:433` since the worker was
introduced, but the actual retry decision in `MemoryEngine.execute_task`
hardcodes `if retry_count < 3` and never reads the knob. Operators who
set the env var to extend the retry window during a provider outage see
no effect.

This PR wires the existing knob into the retry check, and adds a sibling
`HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS` (default `60`) for the
hardcoded 60-second backoff interval at the same site.

## Why

The retry loop in `MemoryEngine.execute_task` (lines 1383-1428 on `main`,
commit `78c3525`) currently looks like:

```python
retry_count = task_dict.get("_retry_count", 0)
if retry_count < 3:                                                    # hardcoded
    raise RetryTaskAt(
        retry_at=datetime.now(UTC) + timedelta(seconds=60),            # hardcoded
        message=str(e),
    )
raise
```

That's a 3 × 60s = 4-minute total window before a task is permanently
marked `failed` and requires manual SQL requeue to recover. The
declared `HINDSIGHT_API_WORKER_MAX_RETRIES` knob doesn't intervene
anywhere along this path — verified by grep of the whole repo.

After this PR, an operator can extend the window for a known outage by
setting:

```env
HINDSIGHT_API_WORKER_MAX_RETRIES=10
HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS=300
```

→ 10 × 5min = ~50min retry window, no code change required.

## Behavior

| | Before | After (defaults) | After (operator-tuned) |
|---|---|---|---|
| max retries | 3 (hardcoded) | 3 (env or default) | configurable via env |
| backoff (seconds) | 60 (hardcoded) | 60 (env or default) | configurable via env |
| total retry window | ~4 min | ~4 min | configurable |

Both env vars are read **on each retry decision** (not cached at process
start) so operators can tune the policy during an active outage without
restarting workers. Default values preserve existing behavior exactly.

## Tests

`hindsight-api-slim/tests/test_worker_retry_knobs.py` adds 4 regression
tests:

- `test_retry_count_cap_honors_env_var` — setting MAX_RETRIES=5 yields a
  5-attempt retry window (was: 3, ignored the env var)
- `test_retry_stops_at_env_var_cap` — at MAX_RETRIES, the next failure
  marks the op `failed` and stops retrying
- `test_retry_backoff_honors_env_var` — BACKOFF_SECONDS=120 schedules
  the next attempt 120s out (was: 60, hardcoded)
- `test_defaults_preserve_existing_behavior` — with neither env var set,
  the loop still uses 3 attempts × 60s

```
$ uv run pytest tests/test_worker_retry_knobs.py -v
======================== 4 passed in 187s ========================
```

`uv run ruff check` and `uv run ty check` are clean on the touched files.

## Backward compatibility

Defaults match existing hardcoded values, so a deployment that doesn't
set either env var sees no behavioral change.

## What this PR doesn't change

- No new exception classes. The `Exception` rewrap in
  `engine/retain/embedding_utils.py:72` (which loses the original
  `APIConnectionError` class signal) is unchanged in this PR. A
  follow-up could preserve the class to enable per-class retry policy,
  but that's a larger conversation; this PR keeps the surface minimal.
- No exponential backoff. The backoff stays linear; a future PR could
  add a multiplier env var. Linear with a tunable cap is enough to
  survive multi-hour outages with appropriate values.
- No changes to the LLM call site's own retry loop in
  `engine/providers/openai_compatible_llm.py:489-500`, which is
  separate from the worker-level retry covered here.

## Versions verified

`0.6.2`, `0.7.0`, and `main` HEAD (`78c3525`) all share the hardcoded
retry decision, so this PR applies to all three.