### PR TITLE
feat(worker): add opt-in periodic scanner for pending consolidations

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -431,6 +431,9 @@ ENV_WORKER_ENABLED = "HINDSIGHT_API_WORKER_ENABLED"
 ENV_WORKER_ID = "HINDSIGHT_API_WORKER_ID"
 ENV_WORKER_POLL_INTERVAL_MS = "HINDSIGHT_API_WORKER_POLL_INTERVAL_MS"
 ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
+ENV_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS = (
+    "HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS"
+)
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
 
@@ -702,6 +705,10 @@ DEFAULT_WORKER_ENABLED = True  # API runs worker by default (standalone mode)
 DEFAULT_WORKER_ID = None  # Will use hostname if not specified
 DEFAULT_WORKER_POLL_INTERVAL_MS = 500  # Poll database every 500ms
 DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
+# Periodic scan that re-queues consolidation for banks with unconsolidated
+# memory_units (a backstop for cases where the retain-side trigger chain breaks).
+# 0 = disabled (preserves existing behavior); typical opt-in value 300 (5 min).
+DEFAULT_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS = 0
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
@@ -1234,6 +1241,7 @@ class HindsightConfig:
     worker_id: str | None
     worker_poll_interval_ms: int
     worker_max_retries: int
+    worker_pending_consolidation_scan_interval_seconds: int
     worker_http_port: int
     worker_max_slots: int
     worker_slot_reservations: dict[str, int]
@@ -1971,6 +1979,12 @@ class HindsightConfig:
             worker_id=os.getenv(ENV_WORKER_ID) or DEFAULT_WORKER_ID,
             worker_poll_interval_ms=int(os.getenv(ENV_WORKER_POLL_INTERVAL_MS, str(DEFAULT_WORKER_POLL_INTERVAL_MS))),
             worker_max_retries=int(os.getenv(ENV_WORKER_MAX_RETRIES, str(DEFAULT_WORKER_MAX_RETRIES))),
+            worker_pending_consolidation_scan_interval_seconds=int(
+                os.getenv(
+                    ENV_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS,
+                    str(DEFAULT_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS),
+                )
+            ),
             worker_http_port=int(os.getenv(ENV_WORKER_HTTP_PORT, str(DEFAULT_WORKER_HTTP_PORT))),
             worker_max_slots=int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS))),
             worker_slot_reservations={

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 
 from ..config import get_config
 from ..engine.task_backend import WorkerTaskBackend
+from .pending_consolidation_scanner import PendingConsolidationScanner
 from .poller import WorkerPoller
 
 # Filter deprecation warnings from third-party libraries
@@ -247,6 +248,16 @@ def main():
         from hindsight_api.config import DEFAULT_DATABASE_SCHEMA
 
         schema = None if config.database_schema == DEFAULT_DATABASE_SCHEMA else config.database_schema
+        # When no tenant extension is loaded, construct a DefaultTenantExtension
+        # once here so the poller and the scanner share the same instance and
+        # see the same schema set. Previously the poller did this internally,
+        # which left the scanner with no clean way to obtain it.
+        if tenant_extension is None:
+            from ..extensions.builtin.tenant import DefaultTenantExtension
+
+            te_config = {"schema": schema} if schema else {}
+            tenant_extension = DefaultTenantExtension(config=te_config)
+
         poller = WorkerPoller(
             backend=memory._backend,
             worker_id=args.worker_id,
@@ -256,6 +267,16 @@ def main():
             tenant_extension=tenant_extension,
             max_slots=config.worker_max_slots,
             slot_reservations=config.worker_slot_reservations,
+        )
+
+        # Optional periodic backstop that re-queues consolidation for banks with
+        # unconsolidated memory_units that the event-driven trigger chain missed.
+        # Default interval is 0 (disabled); set HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS
+        # to a positive number to enable.
+        pending_consolidation_scanner = PendingConsolidationScanner(
+            memory=memory,
+            tenant_extension=tenant_extension,
+            interval_seconds=config.worker_pending_consolidation_scan_interval_seconds,
         )
 
         # Create the HTTP app for metrics/health
@@ -306,11 +327,17 @@ def main():
         )
         server = uvicorn.Server(uvicorn_config)
 
-        # Run the poller and HTTP server concurrently
+        # Run the poller, HTTP server, and optional pending-consolidation scanner concurrently
         poller_task = asyncio.create_task(poller.run())
         http_task = asyncio.create_task(server.serve())
+        scanner_task = asyncio.create_task(pending_consolidation_scanner.run())
 
         print(f"Worker started. Metrics available at http://{args.http_host}:{args.http_port}/metrics")
+        if pending_consolidation_scanner.enabled:
+            print(
+                f"Pending-consolidation scanner enabled "
+                f"(interval={config.worker_pending_consolidation_scan_interval_seconds}s)"
+            )
 
         # Wait for shutdown signal
         try:
@@ -321,6 +348,17 @@ def main():
         # Graceful shutdown
         print("Shutting down HTTP server...")
         server.should_exit = True
+
+        print("Stopping pending-consolidation scanner...")
+        pending_consolidation_scanner.shutdown()
+        try:
+            await asyncio.wait_for(scanner_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            scanner_task.cancel()
+            try:
+                await scanner_task
+            except asyncio.CancelledError:
+                pass
 
         print("Waiting for poller to finish...")
         await poller.shutdown_graceful(timeout=30.0)

--- a/hindsight-api-slim/hindsight_api/worker/pending_consolidation_scanner.py
+++ b/hindsight-api-slim/hindsight_api/worker/pending_consolidation_scanner.py
@@ -1,0 +1,159 @@
+"""
+Periodic backstop that re-queues consolidation for banks with unconsolidated
+``memory_units``.
+
+The retain pipeline already submits consolidation on every successful retain
+(see ``MemoryEngine`` callers of ``submit_async_consolidation``). This scanner
+is a backstop for the case where that trigger chain breaks — embeddings
+provider outage that fails retains for hours, manual data import that bypasses
+retain, etc. Without it, ``memory_units.consolidated_at IS NULL`` rows
+accumulate silently because nothing observes the state on its own.
+
+Opt-in via ``HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS``.
+Default ``0`` (disabled) preserves existing behavior; set to a positive number
+of seconds (e.g. ``300``) to enable.
+"""
+
+import asyncio
+import logging
+
+from ..engine.memory_engine import MemoryEngine
+from ..engine.schema import fq_table_explicit as fq_table
+from ..extensions.tenant import TenantExtension
+from ..models import RequestContext
+
+logger = logging.getLogger(__name__)
+
+# LIMIT on the per-schema DISTINCT bank_id query. The scanner is a backstop and
+# does not need to be strictly complete on every cycle — banks not picked up on
+# one cycle will be on the next. The cap protects against a pathological case
+# where a tenant has tens of thousands of distinct banks with pending work.
+_MAX_BANKS_PER_SCHEMA_PER_SCAN = 100
+
+
+class PendingConsolidationScanner:
+    """Polls ``memory_units`` for unconsolidated rows and queues consolidation.
+
+    Safe to run alongside the existing event-driven triggers: the underlying
+    ``submit_async_consolidation`` call passes ``dedupe_by_bank=True``, so if
+    a consolidation is already pending for a bank, the scanner's submit is a
+    no-op rather than a duplicate enqueue.
+    """
+
+    def __init__(
+        self,
+        memory: MemoryEngine,
+        tenant_extension: TenantExtension,
+        interval_seconds: int,
+    ) -> None:
+        self._memory = memory
+        self._tenant_extension = tenant_extension
+        self._interval_seconds = interval_seconds
+        self._shutdown = asyncio.Event()
+        # Reuse the same RequestContext shape that other internal/background
+        # operations use (e.g. `internal=True` skips extension auth).
+        self._internal_ctx = RequestContext(internal=True)
+
+    @property
+    def enabled(self) -> bool:
+        return self._interval_seconds > 0
+
+    async def run(self) -> None:
+        """Loop until ``shutdown()`` is set, scanning every ``interval_seconds``.
+
+        If ``interval_seconds <= 0`` the loop returns immediately without doing
+        any work, so it's safe to start unconditionally.
+        """
+        if not self.enabled:
+            logger.info(
+                "PendingConsolidationScanner disabled "
+                "(HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS=0)"
+            )
+            return
+        logger.info(f"PendingConsolidationScanner started (interval={self._interval_seconds}s)")
+        # Run an initial scan immediately so newly-started workers don't wait a
+        # full interval to surface backlog left over from a prior process.
+        await self._scan_safely()
+        while not self._shutdown.is_set():
+            try:
+                await asyncio.wait_for(self._shutdown.wait(), timeout=self._interval_seconds)
+            except TimeoutError:
+                await self._scan_safely()
+        logger.info("PendingConsolidationScanner shutting down")
+
+    def shutdown(self) -> None:
+        """Request a graceful exit from the scan loop on the next iteration."""
+        self._shutdown.set()
+
+    async def _scan_safely(self) -> None:
+        """Wrapper around ``_scan_once`` that absorbs scan-level errors so the
+        loop survives transient DB hiccups."""
+        try:
+            queued = await self._scan_once()
+            if queued > 0:
+                logger.info(f"PendingConsolidationScanner queued {queued} bank(s)")
+        except Exception as e:
+            logger.warning(f"PendingConsolidationScanner scan failed (will retry next interval): {e}")
+
+    async def _scan_once(self) -> int:
+        """Scan every schema once. Returns the number of banks for which a NEW
+        consolidation op was queued (banks that hit dedupe are not counted).
+        """
+        tenants = await self._tenant_extension.list_tenants()
+        queued = 0
+        for tenant in tenants:
+            # Mirror the poller's schema normalization: SQL helpers omit the
+            # default-schema prefix, so use None to signal that.
+            from ..config import DEFAULT_DATABASE_SCHEMA
+
+            schema = None if tenant.schema == DEFAULT_DATABASE_SCHEMA else tenant.schema
+            bank_ids = await self._find_pending_banks(schema)
+            for bank_id in bank_ids:
+                queued += await self._submit_if_not_dedup(bank_id, schema)
+        return queued
+
+    async def _find_pending_banks(self, schema: str | None) -> list[str]:
+        """Return distinct ``bank_id``s in the given schema with at least one
+        ``memory_units`` row where ``consolidated_at IS NULL`` and consolidation
+        hasn't already failed permanently.
+        """
+        backend = await self._memory._get_backend()
+        table = fq_table("memory_units", schema)
+        async with backend.acquire() as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT DISTINCT bank_id
+                FROM {table}
+                WHERE fact_type IN ('experience', 'world')
+                  AND consolidated_at IS NULL
+                  AND consolidation_failed_at IS NULL
+                LIMIT $1
+                """,
+                _MAX_BANKS_PER_SCHEMA_PER_SCAN,
+            )
+        return [r["bank_id"] for r in rows]
+
+    async def _submit_if_not_dedup(self, bank_id: str, schema: str | None) -> int:
+        """Submit consolidation for ``bank_id``. Returns 1 if a NEW op was
+        created, 0 if dedupe collapsed it or the call failed.
+
+        Errors are logged but not raised so one bad bank doesn't stop the scan.
+        """
+        # The scanner runs from the worker process which doesn't have a native
+        # tenant schema context, so set it explicitly via the contextvar.
+        # ALWAYS set (including to None) so a prior tenant's schema doesn't
+        # leak into the next iteration.
+        from ..engine.memory_engine import _current_schema
+
+        token = _current_schema.set(schema)
+        try:
+            result = await self._memory.submit_async_consolidation(bank_id=bank_id, request_context=self._internal_ctx)
+            return 0 if result.get("deduplicated") else 1
+        except Exception as e:
+            logger.warning(
+                f"PendingConsolidationScanner: submit_async_consolidation failed "
+                f"for bank={bank_id} schema={schema}: {e}"
+            )
+            return 0
+        finally:
+            _current_schema.reset(token)

--- a/hindsight-api-slim/tests/test_pending_consolidation_scanner.py
+++ b/hindsight-api-slim/tests/test_pending_consolidation_scanner.py
@@ -1,0 +1,183 @@
+"""
+Regression tests for the pending-consolidation scanner.
+
+The scanner is a periodic backstop that re-queues consolidation for banks with
+``memory_units`` rows where ``consolidated_at IS NULL`` and the event-driven
+trigger chain (retain success / deletion / manual API call) hasn't already
+queued one. It exists so a single failure mode in the trigger chain
+(embeddings-provider outage, manual data import that bypasses retain, etc.)
+doesn't leave memory_units unconsolidated indefinitely.
+
+These tests verify:
+
+1. Scanner enabled + bank has unconsolidated rows → calls submit_async_consolidation for the bank
+2. Scanner reports dedupe correctly when submit returns ``deduplicated=True``
+3. Scanner enabled + bank has only consolidated rows → does not call submit
+4. Scanner disabled (interval=0) → returns immediately without scanning
+
+Tests mock ``MemoryEngine.submit_async_consolidation`` so we exercise the
+scanner's SQL-driven discovery and dispatch logic without entangling them with
+the consolidator pipeline (which runs inline under ``SyncTaskBackend`` and
+would make assertions about pending-op state non-deterministic).
+"""
+
+import asyncio
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api.extensions.builtin.tenant import DefaultTenantExtension
+from hindsight_api.worker.pending_consolidation_scanner import PendingConsolidationScanner
+
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _insert_unconsolidated_memory(pool, bank_id: str, fact_type: str = "experience") -> uuid.UUID:
+    """Insert a memory_unit row with consolidated_at = NULL."""
+    unit_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, NOW(), NOW())
+        """,
+        unit_id,
+        bank_id,
+        f"test fact {unit_id}",
+        fact_type,
+    )
+    return unit_id
+
+
+async def _insert_consolidated_memory(pool, bank_id: str, fact_type: str = "experience") -> uuid.UUID:
+    """Insert a memory_unit row with consolidated_at set (i.e. already done)."""
+    unit_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, consolidated_at, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW())
+        """,
+        unit_id,
+        bank_id,
+        f"test fact {unit_id}",
+        fact_type,
+    )
+    return unit_id
+
+
+async def _cleanup_bank(pool, bank_id: str) -> None:
+    await pool.execute("DELETE FROM async_operations WHERE bank_id = $1", bank_id)
+    await pool.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+class _SubmitRecorder:
+    """Drop-in async replacement for ``MemoryEngine.submit_async_consolidation``
+    that records the calls instead of running the consolidator.
+
+    ``deduplicated`` controls the return value so tests can drive the
+    scanner's branch that distinguishes "new op queued" from "dedupe hit".
+    """
+
+    def __init__(self, *, deduplicated: bool = False) -> None:
+        self.deduplicated = deduplicated
+        self.calls: list[str] = []
+
+    async def __call__(self, *, bank_id: str, request_context) -> dict:
+        self.calls.append(bank_id)
+        return {"operation_id": str(uuid.uuid4()), "deduplicated": self.deduplicated}
+
+
+@pytest_asyncio.fixture
+async def scanner(memory):
+    """Build a scanner bound to the test's memory engine and default tenant."""
+    tenant_extension = DefaultTenantExtension(config={})
+    return PendingConsolidationScanner(
+        memory=memory,
+        tenant_extension=tenant_extension,
+        interval_seconds=300,  # value irrelevant for these unit-style tests; we call _scan_once directly
+    )
+
+
+@pytest.mark.asyncio
+async def test_scanner_queues_when_no_pending_op(memory, scanner, monkeypatch):
+    """A bank with unconsolidated rows triggers exactly one submit call."""
+    bank_id = f"test-scanner-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        await _insert_unconsolidated_memory(pool, bank_id)
+        recorder = _SubmitRecorder(deduplicated=False)
+        monkeypatch.setattr(memory, "submit_async_consolidation", recorder)
+
+        queued = await scanner._scan_once()
+
+        assert bank_id in recorder.calls, (
+            f"scanner did not call submit_async_consolidation for bank {bank_id}; calls={recorder.calls}"
+        )
+        assert queued >= 1, "scanner should report at least one bank queued"
+    finally:
+        await _cleanup_bank(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_scanner_reports_dedupe_when_submit_dedupes(memory, scanner, monkeypatch):
+    """When submit returns ``deduplicated=True``, the scanner must not count it as queued."""
+    bank_id = f"test-scanner-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        await _insert_unconsolidated_memory(pool, bank_id)
+        recorder = _SubmitRecorder(deduplicated=True)
+        monkeypatch.setattr(memory, "submit_async_consolidation", recorder)
+
+        queued = await scanner._scan_once()
+
+        assert bank_id in recorder.calls, "scanner must still attempt submit even when dedupe will hit"
+        assert queued == 0, f"scanner must not count dedupe hits as queued banks; got queued={queued}"
+    finally:
+        await _cleanup_bank(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_scanner_skips_fully_consolidated_bank(memory, scanner, monkeypatch):
+    """A bank with only consolidated rows must not trigger any submit call."""
+    bank_id = f"test-scanner-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        await _insert_consolidated_memory(pool, bank_id)
+        recorder = _SubmitRecorder()
+        monkeypatch.setattr(memory, "submit_async_consolidation", recorder)
+
+        await scanner._scan_once()
+
+        assert bank_id not in recorder.calls, (
+            f"scanner must not submit for banks whose memory_units are all consolidated; calls={recorder.calls}"
+        )
+    finally:
+        await _cleanup_bank(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_scanner_disabled_short_circuits(memory):
+    """When interval_seconds <= 0, ``run()`` must return immediately without scanning."""
+    tenant_extension = DefaultTenantExtension(config={})
+    disabled_scanner = PendingConsolidationScanner(
+        memory=memory,
+        tenant_extension=tenant_extension,
+        interval_seconds=0,
+    )
+    assert disabled_scanner.enabled is False
+
+    # run() should return immediately (well under a second) without doing any work.
+    # Use a tight timeout to guard against the loop accidentally starting.
+    await asyncio.wait_for(disabled_scanner.run(), timeout=2.0)


### PR DESCRIPTION
## Summary

Adds an opt-in background task in the worker that periodically scans
`memory_units WHERE consolidated_at IS NULL AND consolidation_failed_at IS NULL`
for distinct `bank_id` values and calls `submit_async_consolidation` for each.
The underlying submit already passes `dedupe_by_bank=True`, so the scanner is
safe to run alongside the existing event-driven triggers: if a consolidation
is already pending for a bank, the scanner's submit collapses to a no-op.

The scanner is **disabled by default** — set
`HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS` to a
positive number of seconds to enable. Default `0` preserves existing behavior
exactly, so this PR has zero runtime impact unless an operator opts in.

## Why

Consolidation today is purely event-driven. Every existing trigger of
`submit_async_consolidation` runs only after some *other* operation succeeds:

| Trigger | File:line (main HEAD `78c3525`) |
|---|---|
| After successful retain (gated on `enable_observations`) | `memory_engine.py:2711` |
| After document deletion that invalidates observations | `memory_engine.py:4236` |
| After retain/delete-adjacent paths | `memory_engine.py:4402, 4494, 4641` |
| After single-memory deletion orphaning observations | `memory_engine.py:4808` |
| Self-resubmit (only when round limit was hit) | `consolidation/consolidator.py` |
| Manual HTTP API trigger | `api/http.py` (`POST /v1/default/banks/{bank_id}/consolidate`) |

Notably absent: any code that observes `memory_units.consolidated_at IS NULL`
on its own. If the event chain breaks — embeddings-provider outage that
fails retains for hours, a manual import that bypasses retain, fact-extraction
LLM 5xx exceeding `retain_llm_max_retries`, hook misconfiguration that
swallows the trigger call — `memory_units` accumulate unprocessed and no
observer notices until someone runs SQL or hits the manual endpoint.

This PR doesn't replace any of those event-driven triggers. It adds a
backstop that catches the residue.

## How it works

`hindsight-api-slim/hindsight_api/worker/pending_consolidation_scanner.py`
defines a small class:

```python
class PendingConsolidationScanner:
    async def run(self) -> None:
        """Loop until shutdown(); short-circuits if interval <= 0."""

    async def _scan_once(self) -> int:
        """Scan every schema once; returns count of NEW ops queued."""

    async def _find_pending_banks(self, schema) -> list[str]:
        """SELECT DISTINCT bank_id FROM memory_units
           WHERE fact_type IN ('experience','world')
             AND consolidated_at IS NULL
             AND consolidation_failed_at IS NULL
           LIMIT 100"""

    async def _submit_if_not_dedup(self, bank_id, schema) -> int:
        """submit_async_consolidation; returns 1 for new ops, 0 for dedupe hits."""
```

`worker/main.py` constructs the scanner once, alongside the existing
`Poller`, and runs both as `asyncio.create_task(...)`. Graceful shutdown
calls `scanner.shutdown()` before the poller shuts down, so an in-flight
scan can complete without orphaned ops.

## Design notes

- **Why opt-in?** The retain-side trigger chain already covers the common
  path. Keeping the scanner off by default ships a safety net without
  changing default semantics for existing deployments. Operators who hit
  the failure mode can enable it; operators who haven't lose nothing.

- **Why a separate task in `worker/main.py` rather than embedded in the
  poller?** The scanner needs the `MemoryEngine` instance to call
  `submit_async_consolidation` (the poller only has the bound `execute_task`
  method). Putting it alongside the poller in `worker/main.py` keeps the
  engine reference in one place and avoids passing the engine through the
  poller's constructor.

- **Multi-tenant safety.** The scanner iterates the same
  `tenant_extension.list_tenants()` as the poller. The single-instance
  `DefaultTenantExtension` is now constructed once in `worker/main.py`
  and shared between the poller and scanner, replacing the poller's
  internal-only construction.

- **Schema contextvar discipline.** `_current_schema` is `set()` / `reset()`
  around each per-bank submit using the token pattern, so a prior tenant's
  schema can't leak into the next iteration.

- **Per-scan cap.** `LIMIT 100` distinct `bank_id`s per schema per scan.
  The scanner is a backstop, not a complete sweep — banks not picked up
  on one cycle are picked up on the next. This caps DB pressure on
  deployments with very many distinct banks.

- **Error isolation.** Per-bank submit failures are logged and counted
  as `0` queued, not raised. One bad bank can't kill the scan. Scan-level
  failures (DB hiccup) are also absorbed and retried on the next interval.

## Tests

`hindsight-api-slim/tests/test_pending_consolidation_scanner.py` adds
4 regression tests:

- `test_scanner_queues_when_no_pending_op` — bank with unconsolidated
  rows triggers exactly one `submit_async_consolidation` call
- `test_scanner_reports_dedupe_when_submit_dedupes` — when submit returns
  `deduplicated=True`, the scanner does not count it as a queued bank
- `test_scanner_skips_fully_consolidated_bank` — bank with only
  consolidated rows is filtered out by the SQL query; no submit is attempted
- `test_scanner_disabled_short_circuits` — when interval=0, `run()`
  returns inside 2 seconds without touching the database

```
$ uv run pytest tests/test_pending_consolidation_scanner.py -v
======================== 4 passed, 2 warnings in 39.58s ========================
```

Tests mock `MemoryEngine.submit_async_consolidation` so the scanner's
SQL-driven discovery and dispatch logic is exercised without entangling
with the consolidator pipeline (which runs inline under `SyncTaskBackend`
and would make assertions about `async_operations.status` non-deterministic).

`uv run ruff check` and `uv run ty check` are clean on the touched files.

## Backward compatibility

Without setting `HINDSIGHT_API_WORKER_PENDING_CONSOLIDATION_SCAN_INTERVAL_SECONDS`,
the scanner's `run()` short-circuits after a single log line and never
touches the database. `test_scanner_disabled_short_circuits` guards this
with a 2-second timeout.

## What this PR doesn't change

- No changes to existing event-driven triggers. The scanner is purely additive.
- No changes to `dedupe_by_bank` semantics. Existing `submit_async_consolidation`
  deduplication handles the safety.
- No SQL migrations. The query reads from existing `memory_units` columns.

## Open questions for reviewers

1. **Default off vs default on at low frequency.** Currently default 0
   (disabled). The argument for default-on (e.g. `300`) is that the
   scanner is the only mechanism that recovers from event-chain breaks;
   the argument for default-off is that the project shouldn't change
   default semantics in a feature PR. Happy to flip if you'd prefer.

2. **Per-tenant interval.** Not implemented. All tenants share the same
   interval. Could add a per-tenant override later if needed.

3. **Metrics.** Not added. The scanner logs counts of queued banks but
   doesn't emit Prometheus metrics. Easy to add a counter in a follow-up.

4. **Cap on banks per scan (`_MAX_BANKS_PER_SCHEMA_PER_SCAN = 100`).**
   Chosen as a reasonable default. Open to making this configurable.

## Versions verified

`0.6.2`, `0.7.0`, and `main` HEAD (`78c3525`) all share the same gap —
no file under `worker/` periodically scans `memory_units` for
unconsolidated rows. Verified by grep.