### PR TITLE
fix(openclaw): stop silently skipping dispatch on synthetic-main + static-banking setups

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   parseSessionKey,
   extractTelegramDirectSenderId,
   resolveSessionIdentity,
+  resolveAndCacheIdentity,
   getIdentitySkipReason,
   isEphemeralOperationalText,
   deriveBankId,
@@ -1184,6 +1185,90 @@ describe("session identity helpers", () => {
       isEphemeralOperationalText("[role: user]\nA new session was started via /new.\n[user:end]")
     ).toBe(true);
     expect(isEphemeralOperationalText("Tell me what I said about dark mode.")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAndCacheIdentity — dispatch-surface gate (#1541)
+// ---------------------------------------------------------------------------
+
+describe("resolveAndCacheIdentity dispatch-surface gate (#1541)", () => {
+  it("does not skip when session provider is synthetic 'main' (telegram dispatch)", () => {
+    const { resolvedCtx, skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:bug1541-tg:main",
+      ctx: { sessionKey: "agent:bug1541-tg:main" },
+      dispatchChannel: "telegram",
+    });
+
+    expect(skipReason).toBeUndefined();
+    expect(resolvedCtx?.messageProvider).toBe("telegram");
+  });
+
+  it("does not skip when session provider is synthetic 'main' (webchat dispatch)", () => {
+    const { skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:bug1541-wc:main",
+      ctx: { sessionKey: "agent:bug1541-wc:main" },
+      dispatchChannel: "webchat",
+    });
+
+    expect(skipReason).toBeUndefined();
+  });
+
+  it("does not skip when a static bankId is configured (feishu session via webchat)", () => {
+    const { skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:main:feishu:direct:user-1541-static",
+      ctx: {
+        sessionKey: "agent:main:feishu:direct:user-1541-static",
+        senderId: "user-1541-static",
+      },
+      dispatchChannel: "webchat",
+      pluginConfig: { dynamicBankId: false, bankId: "shared-bank" },
+    });
+
+    expect(skipReason).toBeUndefined();
+  });
+
+  it("does not skip when granularity excludes channel and provider (qqbot via webchat)", () => {
+    const { skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:main:qqbot:direct:user-1541-agentonly",
+      ctx: {
+        sessionKey: "agent:main:qqbot:direct:user-1541-agentonly",
+        senderId: "user-1541-agentonly",
+      },
+      dispatchChannel: "webchat",
+      pluginConfig: { dynamicBankGranularity: ["agent", "user"] },
+    });
+
+    expect(skipReason).toBeUndefined();
+  });
+
+  it("still skips real-provider mismatch with default granularity (qqbot via webchat)", () => {
+    const { skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:main:qqbot:direct:user-1541-default",
+      ctx: {
+        sessionKey: "agent:main:qqbot:direct:user-1541-default",
+        senderId: "user-1541-default",
+      },
+      dispatchChannel: "webchat",
+    });
+
+    expect(skipReason).toEqual({
+      kind: "final",
+      detail: "dispatch surface webchat does not match session provider qqbot",
+    });
+  });
+
+  it("does not skip when dispatch surface matches session provider (qqbot via qqbot)", () => {
+    const { skipReason } = resolveAndCacheIdentity({
+      sessionKey: "agent:main:qqbot:direct:user-1541-match",
+      ctx: {
+        sessionKey: "agent:main:qqbot:direct:user-1541-match",
+        senderId: "user-1541-match",
+      },
+      dispatchChannel: "qqbot",
+    });
+
+    expect(skipReason).toBeUndefined();
   });
 });
 

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -915,7 +915,7 @@ function cacheSessionIdentity(
   });
 }
 
-interface ResolveAndCacheIdentityOptions {
+export interface ResolveAndCacheIdentityOptions {
   sessionKey?: string;
   ctx?: PluginHookAgentContext;
   senderIdHint?: string;
@@ -923,7 +923,7 @@ interface ResolveAndCacheIdentityOptions {
   pluginConfig?: PluginConfig;
 }
 
-function resolveAndCacheIdentity(options: ResolveAndCacheIdentityOptions): {
+export function resolveAndCacheIdentity(options: ResolveAndCacheIdentityOptions): {
   effectiveCtx: PluginHookAgentContext | undefined;
   resolvedCtx: PluginHookAgentContext | undefined;
   skipReason?: IdentitySkipReason;
@@ -933,6 +933,15 @@ function resolveAndCacheIdentity(options: ResolveAndCacheIdentityOptions): {
   const cachedIdentity = sessionKey ? sessionIdentityBySession.get(sessionKey) : undefined;
   const baseCtx =
     options.ctx || (sessionKey ? ({ sessionKey } as PluginHookAgentContext) : undefined);
+  // "main" is the synthetic provider produced by parseSessionKey for default
+  // `agent:<id>:main` sessions — the *real* dispatch surface (telegram,
+  // webchat, qqbot, …) is whatever the dispatcher provides. Treat it as if
+  // the session key carried no provider so the dispatchChannel flows through
+  // as the effective surface for downstream identity resolution. (#1541)
+  const sessionProvider =
+    parsedSession.provider && parsedSession.provider !== "main"
+      ? parsedSession.provider
+      : undefined;
   const effectiveCtx =
     baseCtx || cachedIdentity || options.senderIdHint || options.dispatchChannel || sessionKey
       ? {
@@ -949,19 +958,40 @@ function resolveAndCacheIdentity(options: ResolveAndCacheIdentityOptions): {
       ? {
           ...effectiveCtx,
           messageProvider:
-            effectiveCtx.messageProvider ?? parsedSession.provider ?? options.dispatchChannel,
+            effectiveCtx.messageProvider ?? sessionProvider ?? options.dispatchChannel,
           channelId: effectiveCtx.channelId ?? parsedSession.channel,
         }
       : undefined
   );
 
+  // The dispatch-surface gate guards against retaining a turn into a bank
+  // keyed by the *wrong* channel when the user has explicitly opted into
+  // channel-scoped routing. Only fire when:
+  //   - The session key carries a real (non-synthetic) provider.
+  //   - The live dispatch surface actually differs from it.
+  //   - Bank routing depends on the dispatch surface (granularity includes
+  //     "channel" or "provider") AND the user has not pinned a static bank.
+  // Without these guards, default `agent:<id>:main` sessions dispatched via
+  // a real surface (telegram, webchat, …) and statically-banked setups were
+  // silently skipped on every turn. (#1541)
+  const granularity =
+    options.pluginConfig?.dynamicBankGranularity ?? DEFAULT_DYNAMIC_BANK_GRANULARITY;
+  const bankRoutingDependsOnSurface =
+    granularity.includes("channel") || granularity.includes("provider");
+  const staticBanking =
+    options.pluginConfig?.dynamicBankId === false &&
+    typeof options.pluginConfig?.bankId === "string" &&
+    options.pluginConfig.bankId.length > 0;
+
   if (
-    parsedSession.provider &&
+    sessionProvider &&
     options.dispatchChannel &&
-    parsedSession.provider !== options.dispatchChannel
+    sessionProvider !== options.dispatchChannel &&
+    bankRoutingDependsOnSurface &&
+    !staticBanking
   ) {
     const skipReason = finalSkipReason(
-      `dispatch surface ${options.dispatchChannel} does not match session provider ${parsedSession.provider}`
+      `dispatch surface ${options.dispatchChannel} does not match session provider ${sessionProvider}`
     );
     if (sessionKey) {
       setCappedMapValue(skipHindsightTurnBySession, sessionKey, skipReason);

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1175,7 +1175,7 @@ Observations are deduplicated, evidence-grounded knowledge consolidated from mul
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_ENABLE_OBSERVATIONS` | Enable observation consolidation | `true` |
-| `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION` | Automatically trigger consolidation after retain, delete, and update operations. When `false`, consolidation only runs when explicitly triggered via the consolidate endpoint. Configurable per bank. | `true` |
+| `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION` | Automatically trigger consolidation after retain, delete, and update operations. When `false`, consolidation only runs when explicitly triggered via the [consolidate endpoint](api/operations.md#consolidation). Configurable per bank. | `true` |
 | `HINDSIGHT_API_ENABLE_OBSERVATION_HISTORY` | Track history of changes to each observation (previous content + timestamp). Disable to reduce storage if audit trails are not needed. | `true` |
 | `HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS` | Outer retry attempts for the consolidation LLM batch call. Each attempt uses the inner retry budget (`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`). Worst-case API calls per batch = `MAX_ATTEMPTS × (LLM_MAX_RETRIES + 1)`. | `3` |
 | `HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE` | Memories to load per batch (internal optimization) | `50` |

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.6.2"
+    "version": "0.7.0"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
## Summary

- Relaxes the dispatch-surface gate in `resolveAndCacheIdentity` so it no longer silently skips recall + retain for default `agent:<id>:main` sessions, statically-banked setups, and granularities that don't depend on the dispatch surface.
- Real-provider mismatches under default granularity (e.g. a `qqbot` session dispatched via `webchat`) still get the gate.
- Exports `resolveAndCacheIdentity` + its options interface for direct unit testing; adds 6 cases covering the bug's reported shapes.

## Why

`hindsight-openclaw` skipped every turn whenever `parseSessionKey(sessionKey).provider !== options.dispatchChannel`. That string match wrongly treated three legitimate shapes as routing errors:

1. **Synthetic-main sessions on a real surface.** `agent:<id>:main` parses to provider `"main"` — a synthetic default, not a real provider. So `agent:main:main` + telegram/webchat/qqbot dispatch was always rejected ("dispatch surface telegram does not match session provider main"). This is the default OpenClaw single-agent setup.
2. **Static banking.** With `dynamicBankId: false + bankId: "..."` the user pinned a single bank, so cross-surface routing is moot — but the gate fired before the static-banking carve-out in `getIdentitySkipReason` was reached.
3. **Non-surface-scoped granularity.** With `dynamicBankGranularity: ["agent", "user"]` the bank ID doesn't include channel/provider, so a surface mismatch can't pollute routing.

In all three cases the plugin reported `Ready` while silently skipping `before_dispatch`, `recall`, and `retain` — a trust-breaker called out by multiple reporters on the issue.

## Fix

`resolveAndCacheIdentity` now:
- Treats `parsedSession.provider === "main"` as if no session provider were set, so the dispatch surface flows through as the effective provider for downstream identity resolution.
- Only fires the dispatch-surface skip when **all** of: real (non-`main`) session provider, surface differs, bank routing depends on the surface, and no static bank is configured.
- Real cross-surface mismatches under default granularity (real-provider session via a different surface) still skip, preserving the original guard intent for those who opted into channel-scoped routing.

## Test plan

- [x] `npx vitest run` in `hindsight-integrations/openclaw/` — 237/237 pass, including 6 new cases for #1541 shapes (synthetic-main + telegram/webchat, static-bank carve-out, granularity-without-surface carve-out, real-provider gate still fires under default granularity, matching surface passes through)
- [x] `./scripts/hooks/lint.sh` — green

Closes #1541