### PR TITLE
docs(paperclip): document dynamicBankId / bankId / user granularity (#1761)

### DIFF
--- a/hindsight-docs/docs-integrations/paperclip.md
+++ b/hindsight-docs/docs-integrations/paperclip.md
@@ -61,16 +61,20 @@ Memory is keyed to `companyId` + `agentId` — never to the run ID — so it acc
 |-------|---------|-------------|
 | `hindsightApiUrl` | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted) |
 | `hindsightApiKeyRef` | — | Paperclip secret name holding Hindsight Cloud API key |
-| `bankGranularity` | `["company", "agent"]` | Memory isolation: per company+agent, per company, or per agent |
+| `dynamicBankId` | `true` | When `true`, bank ID is derived from `bankGranularity`. Set `false` and provide `bankId` to share one static memory bank across agents |
+| `bankId` | — | Static bank ID used when `dynamicBankId` is `false`. All agents sharing this value read/write the same memory bank |
+| `bankGranularity` | `["company", "agent"]` | Memory isolation when `dynamicBankId` is `true`: per company+agent, per company, or per agent. Add `"user"` for per-user memory isolation (useful for GDPR compliance) |
 | `recallBudget` | `mid` | `low` = fastest, `mid` = balanced, `high` = most thorough |
 | `autoRetain` | `true` | Automatically retain run output after every run |
 
 ## Bank ID Format
 
 ```
-paperclip::{companyId}::{agentId}    ← default (company + agent granularity)
-paperclip::{companyId}               ← company granularity (shared across agents)
-paperclip::{agentId}                 ← agent granularity (agent memory across companies)
+paperclip::{companyId}::{agentId}                  ← default (company + agent granularity)
+paperclip::{companyId}                             ← company granularity (shared across agents)
+paperclip::{agentId}                               ← agent granularity (agent memory across companies)
+paperclip::{companyId}::{agentId}::user::{userId}  ← user granularity (per-user isolation, GDPR-friendly)
+{bankId}                                           ← static shared bank (dynamicBankId = false)
 ```
 
 ## Agent Tools

--- a/hindsight-integrations/paperclip/README.md
+++ b/hindsight-integrations/paperclip/README.md
@@ -34,18 +34,22 @@ hindsight-api
 
 | Field                | Default                              | Description                                                                       |
 | -------------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
-| `hindsightApiUrl`    | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted) |
-| `hindsightApiKeyRef` | —                                    | Paperclip secret name holding Hindsight Cloud API key                             |
-| `bankGranularity`    | `["company", "agent"]`               | Memory isolation: per company+agent, per company, or per agent                    |
-| `recallBudget`       | `mid`                                | `low` = fastest, `mid` = balanced, `high` = most thorough                         |
-| `autoRetain`         | `true`                               | Automatically retain run output after every run                                   |
+| `hindsightApiUrl`    | `https://api.hindsight.vectorize.io` | Hindsight server URL (Cloud default; use `http://localhost:8888` for self-hosted)                                                                                              |
+| `hindsightApiKeyRef` | —                                    | Paperclip secret name holding Hindsight Cloud API key                                                                                                                          |
+| `dynamicBankId`      | `true`                               | When `true`, bank ID is derived from `bankGranularity`. Set `false` and provide `bankId` to share one static memory bank across agents                                         |
+| `bankId`             | —                                    | Static bank ID used when `dynamicBankId` is `false`. All agents sharing this value read/write the same memory bank                                                             |
+| `bankGranularity`    | `["company", "agent"]`               | Memory isolation when `dynamicBankId` is `true`: per company+agent, per company, or per agent. Add `"user"` for per-user memory isolation (useful for GDPR compliance)         |
+| `recallBudget`       | `mid`                                | `low` = fastest, `mid` = balanced, `high` = most thorough                                                                                                                      |
+| `autoRetain`         | `true`                               | Automatically retain run output after every run                                                                                                                                |
 
 ## Bank ID Format
 
 ```
-paperclip::{companyId}::{agentId}    ← default (company + agent granularity)
-paperclip::{companyId}               ← company granularity (shared across agents)
-paperclip::{agentId}                 ← agent granularity (agent memory across companies)
+paperclip::{companyId}::{agentId}                  ← default (company + agent granularity)
+paperclip::{companyId}                             ← company granularity (shared across agents)
+paperclip::{agentId}                               ← agent granularity (agent memory across companies)
+paperclip::{companyId}::{agentId}::user::{userId}  ← user granularity (per-user isolation, GDPR-friendly)
+{bankId}                                           ← static shared bank (dynamicBankId = false)
 ```
 
 ## Agent Tools


### PR DESCRIPTION
## Summary

#1761 (`feat(paperclip): per-user bank granularity + dynamic-bank toggle`, merged 2026-05-26 by benfrank241) added three new user-facing config knobs to the Paperclip integration — `bankGranularity: 'user'`, static `bankId`, and `dynamicBankId` — plus the matching bank-ID format variants. The Configuration table and Bank ID Format block in both the canonical user docs and the integration README still describe the pre-#1761 surface, so end-users configuring per-user memory isolation (GDPR-compliance scenario) or shared multi-agent banks can't discover any of it from the docs.

This PR mirrors the schema additions into both docs surfaces (byte-for-byte parity), with values grounded directly in the integration source:

- Configuration table: new `dynamicBankId` + `bankId` rows; existing `bankGranularity` row expanded to mention the `'user'` granularity value
- Bank ID Format block: new `paperclip::{companyId}::{agentId}::user::{userId}` variant + the static-bank case (`dynamicBankId = false` → bankId verbatim)

All field names, defaults, descriptions, and bank-ID derivation strings are taken from `hindsight-integrations/paperclip/src/manifest.ts` L43-63 (`instanceConfigSchema.properties.{dynamicBankId,bankId,bankGranularity}`) and `hindsight-integrations/paperclip/src/bank.ts` L1-15 + `deriveBankId()` L26-46.

## Files

- `hindsight-docs/docs-integrations/paperclip.md` (+5)
- `hindsight-integrations/paperclip/README.md` (+5)

Pure docs, byte-mirror across canonical user guide + integration README. No code change.