### PR TITLE
fix(openclaw): label "Current time" as UTC in injected memory context

### DIFF
--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   stripMemoryTags,
   extractRecallQuery,
+  formatCurrentTimeForRecall,
   formatMemories,
   prepareRetentionTranscript,
   countUserTurns,
@@ -246,6 +247,22 @@ describe("formatMemories", () => {
 
   it("returns empty string for empty memories", () => {
     expect(formatMemories([])).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCurrentTimeForRecall — UTC label (#1789, mirrors #1568)
+// ---------------------------------------------------------------------------
+
+describe("formatCurrentTimeForRecall", () => {
+  it("renders the UTC suffix so the LLM doesn't misread it as local time", () => {
+    const fixed = new Date(Date.UTC(2026, 4, 27, 16, 25, 0)); // 2026-05-27 16:25 UTC
+    expect(formatCurrentTimeForRecall(fixed)).toBe("2026-05-27 16:25 UTC");
+  });
+
+  it("zero-pads month / day / hours / minutes", () => {
+    const fixed = new Date(Date.UTC(2026, 0, 3, 4, 5, 0));
+    expect(formatCurrentTimeForRecall(fixed)).toBe("2026-01-03 04:05 UTC");
   });
 });
 

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -316,13 +316,16 @@ async function flushRetainQueue(): Promise<void> {
 const DEFAULT_RECALL_PROMPT_PREAMBLE =
   "Relevant memories from past conversations (prioritize recent when conflicting). Only use memories that are directly useful to continue this conversation; ignore the rest:";
 
-function formatCurrentTimeForRecall(date = new Date()): string {
+export function formatCurrentTimeForRecall(date = new Date()): string {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   const day = String(date.getUTCDate()).padStart(2, "0");
   const hours = String(date.getUTCHours()).padStart(2, "0");
   const minutes = String(date.getUTCMinutes()).padStart(2, "0");
-  return `${year}-${month}-${day} ${hours}:${minutes}`;
+  // Suffix with " UTC" so the LLM doesn't misread the timestamp as local
+  // time and make wrong recency judgments. Mirrors the fix landed for the
+  // Claude Code integration in #1568. (#1789)
+  return `${year}-${month}-${day} ${hours}:${minutes} UTC`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Append ` UTC` to the `Current time -` header injected above recalled memories so the LLM doesn't misread it as local time. This is the same fix that landed for the Claude Code integration in #1568 — the OpenClaw integration was overlooked.

## Why

From #1789:

> The `Current time - 2026-05-27 16:25` line is read as local time and the LLM makes wrong temporal judgments.

The issue also requested an opt-out for the per-memory `(YYYY-MM-DDTHH:MM:SS+00:00)` suffix; that's been intentionally dropped from this PR to keep the scope minimal.

## What changed

- `formatCurrentTimeForRecall` now appends ` UTC` and is exported for direct unit testing.
- 2 new tests cover the UTC-label rendering and zero-padding edge case.

## Test plan

- [x] `npx vitest run` in `hindsight-integrations/openclaw/` — 233/233 pass, including new cases
- [x] `./scripts/hooks/lint.sh` — green

Closes #1789
