### PR TITLE
fix(openclaw): flush un-retained turns on session_end

### DIFF
--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -2257,8 +2257,18 @@ ${memoriesFormatted}
       }
     });
 
-    // Hook signature: (event, ctx) where event has {messages, success, error?, durationMs?}
-    api.on("agent_end", async (event: any, ctx?: PluginHookAgentContext) => {
+    // Shared retain path for `agent_end` (per-turn cadence) and `session_end`
+    // (force-flush at session close, bypassing the cadence so short sessions
+    // and the un-retained tail of long sessions still land on disk). See #1726.
+    const runRetain = async (
+      event: any,
+      ctx: PluginHookAgentContext | undefined,
+      retainOptions: { force?: boolean; hookName: "agent_end" | "session_end" } = {
+        hookName: "agent_end",
+      }
+    ): Promise<void> => {
+      const force = retainOptions.force === true;
+      const hookName = retainOptions.hookName;
       // Optional perf instrumentation (#1406). Only emitted when an actual
       // retain RPC fires; the many early-return skip paths are not measured.
       const perfHookStart = pluginConfig.debugPerfTiming ? Date.now() : 0;
@@ -2350,9 +2360,12 @@ ${memoriesFormatted}
         }
 
         const bankId = deriveBankId(resolvedCtxForRetain, pluginConfig);
-        debug(`[Hindsight Hook] agent_end triggered - bank: ${bankId}`);
+        debug(`[Hindsight Hook] ${hookName} triggered - bank: ${bankId}`);
 
-        if (event.success === false) {
+        // `event.success === false` is a per-agent-end signal; session_end
+        // doesn't carry it and a failed last turn shouldn't block the final
+        // flush of preceding successful turns. (#1726)
+        if (!force && event.success === false) {
           debug("[Hindsight Hook] Agent run failed, skipping retention");
           return;
         }
@@ -2378,27 +2391,63 @@ ${memoriesFormatted}
 
         if (retainEveryN > 1) {
           const sessionTrackingKey = `${bankId}:${effectiveCtx?.sessionKey || "session"}`;
-          const turnCount = (turnCountBySession.get(sessionTrackingKey) || 0) + 1;
-          setCappedMapValue(turnCountBySession, sessionTrackingKey, turnCount);
-
-          if (turnCount % retainEveryN !== 0) {
-            const nextRetainAt = Math.ceil(turnCount / retainEveryN) * retainEveryN;
-            debug(
-              `[Hindsight Hook] Turn ${turnCount}/${retainEveryN}, skipping retain (next at turn ${nextRetainAt})`
-            );
-            return;
+          // session_end is a flush, not a turn — don't increment the counter.
+          const turnCount = force
+            ? turnCountBySession.get(sessionTrackingKey) || 0
+            : (turnCountBySession.get(sessionTrackingKey) || 0) + 1;
+          if (!force) {
+            setCappedMapValue(turnCountBySession, sessionTrackingKey, turnCount);
           }
 
-          // Sliding window in turns: N turns + configured overlap turns.
-          // We slice by actual turn boundaries (user-role messages), so this
-          // remains stable even when system/tool messages are present.
-          const overlapTurns = pluginConfig.retainOverlapTurns ?? 0;
-          const windowTurns = retainEveryN + overlapTurns;
-          messagesToRetain = sliceLastTurnsByUserBoundary(allMessages, windowTurns);
-          retainFullWindow = true;
-          debug(
-            `[Hindsight Hook] Turn ${turnCount}: chunked retain firing (window: ${windowTurns} turns, ${messagesToRetain.length} messages)`
-          );
+          const cadenceBoundary = turnCount > 0 && turnCount % retainEveryN === 0;
+          const unretainedTurns = turnCount % retainEveryN;
+
+          if (force) {
+            // session_end: only flush if there are un-retained turns since the
+            // last cadence boundary. The most recent agent_end either already
+            // retained (cadenceBoundary) or accumulated `unretainedTurns` turns
+            // that would otherwise be lost when the session closes. (#1726)
+            if (turnCount === 0 || cadenceBoundary) {
+              debug(
+                `[Hindsight Hook] session_end: nothing un-retained (turnCount=${turnCount}, retainEveryN=${retainEveryN}), skipping flush`
+              );
+              return;
+            }
+            const overlapTurns = pluginConfig.retainOverlapTurns ?? 0;
+            const windowTurns = unretainedTurns + overlapTurns;
+            messagesToRetain = sliceLastTurnsByUserBoundary(allMessages, windowTurns);
+            retainFullWindow = true;
+            // Reset so a subsequent session_end (if the host re-emits) doesn't
+            // re-retain the same window.
+            turnCountBySession.delete(sessionTrackingKey);
+            debug(
+              `[Hindsight Hook] session_end: forced flush of ${unretainedTurns} un-retained turns (window: ${windowTurns} turns, ${messagesToRetain.length} messages)`
+            );
+          } else {
+            if (!cadenceBoundary) {
+              const nextRetainAt = Math.ceil(turnCount / retainEveryN) * retainEveryN;
+              debug(
+                `[Hindsight Hook] Turn ${turnCount}/${retainEveryN}, skipping retain (next at turn ${nextRetainAt})`
+              );
+              return;
+            }
+
+            // Sliding window in turns: N turns + configured overlap turns.
+            // We slice by actual turn boundaries (user-role messages), so this
+            // remains stable even when system/tool messages are present.
+            const overlapTurns = pluginConfig.retainOverlapTurns ?? 0;
+            const windowTurns = retainEveryN + overlapTurns;
+            messagesToRetain = sliceLastTurnsByUserBoundary(allMessages, windowTurns);
+            retainFullWindow = true;
+            debug(
+              `[Hindsight Hook] Turn ${turnCount}: chunked retain firing (window: ${windowTurns} turns, ${messagesToRetain.length} messages)`
+            );
+          }
+        } else if (force) {
+          // retainEveryN === 1 means every agent_end already retained — the
+          // session_end flush would only duplicate work. (#1726)
+          debug("[Hindsight Hook] session_end: retainEveryNTurns=1, nothing to flush");
+          return;
         }
 
         const inlineRetainTags = normalizeRetainTags(
@@ -2515,7 +2564,7 @@ ${memoriesFormatted}
 
         if (pluginConfig.debugPerfTiming) {
           log.info(
-            formatHookPerf("agent_end", Date.now() - perfHookStart, {
+            formatHookPerf(hookName, Date.now() - perfHookStart, {
               retain: `${retainElapsedMs}ms`,
               outcome: retainOutcome,
               bank: bankId,
@@ -2526,6 +2575,18 @@ ${memoriesFormatted}
       } catch (error) {
         log.error("error retaining messages", error);
       }
+    };
+
+    // Hook signature: (event, ctx) where event has {messages, success, error?, durationMs?}
+    api.on("agent_end", async (event: any, ctx?: PluginHookAgentContext) => {
+      await runRetain(event, ctx, { hookName: "agent_end" });
+    });
+
+    // session_end fires once per OpenClaw session close. We force-flush so
+    // short conversations (fewer turns than `retainEveryNTurns`) and the
+    // un-retained tail of long conversations are not silently dropped. (#1726)
+    api.on("session_end", async (event: any, ctx?: PluginHookAgentContext) => {
+      await runRetain(event, ctx, { hookName: "session_end", force: true });
     });
     debug("[Hindsight] Hooks registered");
     log.info("agent hooks registered");

--- a/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
+++ b/hindsight-integrations/openclaw/tests/hooks.integration.test.ts
@@ -703,3 +703,128 @@ describe("agent_end hook", () => {
     expect(options?.metadata?.message_count).toBe("3");
   });
 });
+
+// ---------------------------------------------------------------------------
+// session_end hook (#1726) — force-flush of un-retained turns on session close
+// ---------------------------------------------------------------------------
+
+describe("session_end hook (#1726)", () => {
+  // Separate handle so we can configure retainEveryNTurns > 1; the shared
+  // beforeAll uses retainEveryNTurns: 1 which never skips any turn.
+  let triggerSessionEnd: MockApiHandle["trigger"];
+
+  beforeAll(async () => {
+    if (!apiReachable) return;
+
+    const mod = await import("../src/index.js");
+    const handle = createMockApi({
+      hindsightApiUrl: HINDSIGHT_API_URL,
+      dynamicBankId: true,
+      retainEveryNTurns: 5,
+      retainOverlapTurns: 0,
+    });
+    triggerSessionEnd = handle.trigger;
+    mod.default(handle.api);
+    await handle.startServices();
+  }, 30_000);
+
+  it("flushes un-retained turns when session_end fires before the cadence boundary", async () => {
+    if (!apiReachable) return;
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    // 2 agent_end ticks with retainEveryNTurns=5 — neither hits the cadence
+    // boundary, so retain should not yet have been called.
+    await triggerSessionEnd(
+      "agent_end",
+      {
+        success: true,
+        messages: [{ role: "user", content: "I just adopted a corgi named Pepper." }],
+      },
+      { messageProvider: "telegram", senderId: "U1726A", sessionKey: "sess-1726-short" }
+    );
+    await triggerSessionEnd(
+      "agent_end",
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "I just adopted a corgi named Pepper." },
+          { role: "assistant", content: "Pepper sounds adorable!" },
+          { role: "user", content: "She loves chasing tennis balls." },
+        ],
+      },
+      { messageProvider: "telegram", senderId: "U1726A", sessionKey: "sess-1726-short" }
+    );
+
+    expect(retainSpy).not.toHaveBeenCalled();
+
+    // session_end should force-flush the un-retained turns.
+    await triggerSessionEnd(
+      "session_end",
+      {
+        messages: [
+          { role: "user", content: "I just adopted a corgi named Pepper." },
+          { role: "assistant", content: "Pepper sounds adorable!" },
+          { role: "user", content: "She loves chasing tennis balls." },
+        ],
+      },
+      { messageProvider: "telegram", senderId: "U1726A", sessionKey: "sess-1726-short" }
+    );
+
+    expect(retainSpy).toHaveBeenCalledOnce();
+    const [, content] = retainSpy.mock.calls[0];
+    expect(content).toContain("Pepper");
+  });
+
+  it("is a no-op when session_end fires on a cadence boundary (already retained)", async () => {
+    if (!apiReachable) return;
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    // 5 turns triggers cadence retain at turn 5.
+    for (let i = 1; i <= 5; i++) {
+      await triggerSessionEnd(
+        "agent_end",
+        {
+          success: true,
+          messages: Array.from({ length: i }, (_, j) => ({
+            role: j % 2 === 0 ? "user" : "assistant",
+            content: `turn ${j + 1} message about hiking`,
+          })),
+        },
+        { messageProvider: "telegram", senderId: "U1726B", sessionKey: "sess-1726-aligned" }
+      );
+    }
+
+    expect(retainSpy).toHaveBeenCalledOnce();
+    retainSpy.mockReset();
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    // session_end after the boundary: nothing un-retained, must not duplicate.
+    await triggerSessionEnd(
+      "session_end",
+      {
+        messages: Array.from({ length: 5 }, (_, j) => ({
+          role: j % 2 === 0 ? "user" : "assistant",
+          content: `turn ${j + 1} message about hiking`,
+        })),
+      },
+      { messageProvider: "telegram", senderId: "U1726B", sessionKey: "sess-1726-aligned" }
+    );
+
+    expect(retainSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when session_end fires for a session with no agent_end turns", async () => {
+    if (!apiReachable) return;
+    retainSpy.mockResolvedValue(OK_RETAIN);
+
+    await triggerSessionEnd(
+      "session_end",
+      {
+        messages: [{ role: "user", content: "ephemeral message that never reached agent_end" }],
+      },
+      { messageProvider: "telegram", senderId: "U1726C", sessionKey: "sess-1726-empty" }
+    );
+
+    expect(retainSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Refactors the `agent_end` retain body into a shared `runRetain(event, ctx, { force?, hookName })` helper.
- Registers a `session_end` hook that calls it with `force: true` to flush turns the cadence skipped.
- 3 new integration tests cover the bug repro, the no-op when the cadence already fired, and the no-op when no agent_end ever ran.

## Why

From #1726:

> When `retainEveryNTurns > 1` and a conversation ends before the next cadence boundary, all remaining turns are silently dropped.
>
> 1. Configure an OpenClaw integration with `retainEveryNTurns: 5`.
> 2. Have a conversation of only 2 turns, then end the session.
> 3. Check the bank — no documents were retained for this session.

Mirror of the fix shipped for `hindsight-memory` in #1145 (Python/Claude Code's `SessionEnd` hook). The OpenClaw integration was missed.

## Behavior

`session_end` force path:
- `retainEveryNTurns === 1` → no-op (every turn already retained).
- `turnCount === 0` or `turnCount % retainEveryNTurns === 0` → no-op (nothing pending).
- Otherwise → slice the last `turnCount % retainEveryNTurns` un-retained turns (+ configured overlap), retain them as a window scope, then drop the per-session counter so a re-emitted `session_end` cannot duplicate the flush.

The non-force `agent_end` path is functionally unchanged (same turnCount increment, same cadence-boundary trigger, same sliding-window slice).

## Test plan

- [x] `npx vitest run src/` — 237/237 unit tests pass
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `./scripts/hooks/lint.sh` — green
- [ ] Integration tests (`npm run test:integration`) — run in CI against the live API

Closes #1726