### PR TITLE
feat(reranker): per-provider HTTP timeout env vars

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -276,6 +276,14 @@ ENV_RERANKER_TEI_URL = "HINDSIGHT_API_RERANKER_TEI_URL"
 ENV_RERANKER_TEI_BATCH_SIZE = "HINDSIGHT_API_RERANKER_TEI_BATCH_SIZE"
 ENV_RERANKER_TEI_MAX_CONCURRENT = "HINDSIGHT_API_RERANKER_TEI_MAX_CONCURRENT"
 ENV_RERANKER_TEI_HTTP_TIMEOUT = "HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT"
+ENV_RERANKER_COHERE_TIMEOUT = "HINDSIGHT_API_RERANKER_COHERE_TIMEOUT"
+ENV_RERANKER_OPENROUTER_TIMEOUT = "HINDSIGHT_API_RERANKER_OPENROUTER_TIMEOUT"
+ENV_RERANKER_ZEROENTROPY_TIMEOUT = "HINDSIGHT_API_RERANKER_ZEROENTROPY_TIMEOUT"
+ENV_RERANKER_SILICONFLOW_TIMEOUT = "HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT"
+ENV_RERANKER_ALIBABA_TIMEOUT = "HINDSIGHT_API_RERANKER_ALIBABA_TIMEOUT"
+ENV_RERANKER_LITELLM_TIMEOUT = "HINDSIGHT_API_RERANKER_LITELLM_TIMEOUT"
+ENV_RERANKER_LITELLM_SDK_TIMEOUT = "HINDSIGHT_API_RERANKER_LITELLM_SDK_TIMEOUT"
+ENV_RERANKER_GOOGLE_TIMEOUT = "HINDSIGHT_API_RERANKER_GOOGLE_TIMEOUT"
 ENV_RERANKER_MAX_CANDIDATES = "HINDSIGHT_API_RERANKER_MAX_CANDIDATES"
 ENV_RERANKER_FLASHRANK_MODEL = "HINDSIGHT_API_RERANKER_FLASHRANK_MODEL"
 ENV_RERANKER_FLASHRANK_CACHE_DIR = "HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR"
@@ -555,6 +563,16 @@ DEFAULT_RERANKER_LOCAL_BATCH_SIZE = 32  # Batch size for local reranker predict(
 DEFAULT_RERANKER_TEI_BATCH_SIZE = 128
 DEFAULT_RERANKER_TEI_MAX_CONCURRENT = 8
 DEFAULT_RERANKER_TEI_HTTP_TIMEOUT = 30.0  # HTTP timeout for TEI reranker requests (seconds)
+# HTTP timeout (seconds) for remote rerank providers. Defaults match the previous
+# hardcoded constructor defaults so unset envs keep current behavior.
+DEFAULT_RERANKER_COHERE_TIMEOUT = 60.0
+DEFAULT_RERANKER_OPENROUTER_TIMEOUT = 60.0
+DEFAULT_RERANKER_ZEROENTROPY_TIMEOUT = 60.0
+DEFAULT_RERANKER_SILICONFLOW_TIMEOUT = 60.0
+DEFAULT_RERANKER_ALIBABA_TIMEOUT = 60.0
+DEFAULT_RERANKER_LITELLM_TIMEOUT = 60.0
+DEFAULT_RERANKER_LITELLM_SDK_TIMEOUT = 60.0
+DEFAULT_RERANKER_GOOGLE_TIMEOUT = 60.0
 DEFAULT_RERANKER_MAX_CANDIDATES = 300
 DEFAULT_RERANKER_FLASHRANK_MODEL = "ms-marco-MiniLM-L-12-v2"  # Best balance of speed and quality
 DEFAULT_RERANKER_FLASHRANK_CACHE_DIR = None  # Use default cache directory
@@ -1081,26 +1099,34 @@ class HindsightConfig:
     reranker_cohere_api_key: str | None
     reranker_cohere_model: str
     reranker_cohere_base_url: str | None
+    reranker_cohere_timeout: float
     reranker_openrouter_api_key: str | None
     reranker_openrouter_model: str
+    reranker_openrouter_timeout: float
     reranker_litellm_api_base: str
     reranker_litellm_api_key: str | None
     reranker_litellm_model: str
     reranker_litellm_max_tokens_per_doc: int | None
+    reranker_litellm_timeout: float
     reranker_litellm_sdk_api_key: str | None
     reranker_litellm_sdk_model: str
     reranker_litellm_sdk_api_base: str | None
+    reranker_litellm_sdk_timeout: float
     reranker_zeroentropy_api_key: str | None
     reranker_zeroentropy_model: str
     reranker_zeroentropy_base_url: str | None
+    reranker_zeroentropy_timeout: float
     reranker_siliconflow_api_key: str | None
     reranker_siliconflow_model: str
     reranker_siliconflow_base_url: str
+    reranker_siliconflow_timeout: float
     reranker_alibaba_api_key: str | None
     reranker_alibaba_model: str
+    reranker_alibaba_timeout: float
     reranker_google_model: str
     reranker_google_project_id: str | None
     reranker_google_service_account_key: str | None
+    reranker_google_timeout: float
 
     # Server
     host: str
@@ -1781,11 +1807,15 @@ class HindsightConfig:
             reranker_cohere_api_key=os.getenv(ENV_RERANKER_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),
             reranker_cohere_model=os.getenv(ENV_RERANKER_COHERE_MODEL, DEFAULT_RERANKER_COHERE_MODEL),
             reranker_cohere_base_url=os.getenv(ENV_RERANKER_COHERE_BASE_URL) or None,
+            reranker_cohere_timeout=float(os.getenv(ENV_RERANKER_COHERE_TIMEOUT, str(DEFAULT_RERANKER_COHERE_TIMEOUT))),
             # OpenRouter reranker (with fallback to shared OpenRouter key, then LLM key)
             reranker_openrouter_api_key=os.getenv(ENV_RERANKER_OPENROUTER_API_KEY)
             or os.getenv(ENV_OPENROUTER_API_KEY)
             or os.getenv(ENV_LLM_API_KEY),
             reranker_openrouter_model=os.getenv(ENV_RERANKER_OPENROUTER_MODEL, DEFAULT_RERANKER_OPENROUTER_MODEL),
+            reranker_openrouter_timeout=float(
+                os.getenv(ENV_RERANKER_OPENROUTER_TIMEOUT, str(DEFAULT_RERANKER_OPENROUTER_TIMEOUT))
+            ),
             # LiteLLM reranker (with backward-compatible fallback to shared config)
             reranker_litellm_api_base=os.getenv(ENV_RERANKER_LITELLM_API_BASE)
             or os.getenv(ENV_LITELLM_API_BASE, DEFAULT_LITELLM_API_BASE),
@@ -1794,29 +1824,45 @@ class HindsightConfig:
             reranker_litellm_max_tokens_per_doc=int(v)
             if (v := os.getenv(ENV_RERANKER_LITELLM_MAX_TOKENS_PER_DOC))
             else DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC,
+            reranker_litellm_timeout=float(
+                os.getenv(ENV_RERANKER_LITELLM_TIMEOUT, str(DEFAULT_RERANKER_LITELLM_TIMEOUT))
+            ),
             # LiteLLM SDK reranker (direct API access)
             reranker_litellm_sdk_api_key=os.getenv(ENV_RERANKER_LITELLM_SDK_API_KEY),
             reranker_litellm_sdk_model=os.getenv(ENV_RERANKER_LITELLM_SDK_MODEL, DEFAULT_RERANKER_LITELLM_SDK_MODEL),
             reranker_litellm_sdk_api_base=os.getenv(ENV_RERANKER_LITELLM_SDK_API_BASE) or None,
+            reranker_litellm_sdk_timeout=float(
+                os.getenv(ENV_RERANKER_LITELLM_SDK_TIMEOUT, str(DEFAULT_RERANKER_LITELLM_SDK_TIMEOUT))
+            ),
             # ZeroEntropy reranker
             reranker_zeroentropy_api_key=os.getenv(ENV_RERANKER_ZEROENTROPY_API_KEY),
             reranker_zeroentropy_model=os.getenv(ENV_RERANKER_ZEROENTROPY_MODEL, DEFAULT_RERANKER_ZEROENTROPY_MODEL),
             reranker_zeroentropy_base_url=os.getenv(ENV_RERANKER_ZEROENTROPY_BASE_URL) or None,
+            reranker_zeroentropy_timeout=float(
+                os.getenv(ENV_RERANKER_ZEROENTROPY_TIMEOUT, str(DEFAULT_RERANKER_ZEROENTROPY_TIMEOUT))
+            ),
             # SiliconFlow reranker (Cohere-compatible /rerank endpoint)
             reranker_siliconflow_api_key=os.getenv(ENV_RERANKER_SILICONFLOW_API_KEY),
             reranker_siliconflow_model=os.getenv(ENV_RERANKER_SILICONFLOW_MODEL, DEFAULT_RERANKER_SILICONFLOW_MODEL),
             reranker_siliconflow_base_url=os.getenv(
                 ENV_RERANKER_SILICONFLOW_BASE_URL, DEFAULT_RERANKER_SILICONFLOW_BASE_URL
             ),
+            reranker_siliconflow_timeout=float(
+                os.getenv(ENV_RERANKER_SILICONFLOW_TIMEOUT, str(DEFAULT_RERANKER_SILICONFLOW_TIMEOUT))
+            ),
             # Alibaba Cloud DashScope reranker
             reranker_alibaba_api_key=os.getenv(ENV_RERANKER_ALIBABA_API_KEY),
             reranker_alibaba_model=os.getenv(ENV_RERANKER_ALIBABA_MODEL, DEFAULT_RERANKER_ALIBABA_MODEL),
+            reranker_alibaba_timeout=float(
+                os.getenv(ENV_RERANKER_ALIBABA_TIMEOUT, str(DEFAULT_RERANKER_ALIBABA_TIMEOUT))
+            ),
             # Google Discovery Engine reranker (with fallback to LLM Vertex AI keys)
             reranker_google_model=os.getenv(ENV_RERANKER_GOOGLE_MODEL, DEFAULT_RERANKER_GOOGLE_MODEL),
             reranker_google_project_id=os.getenv(ENV_RERANKER_GOOGLE_PROJECT_ID)
             or os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID),
             reranker_google_service_account_key=os.getenv(ENV_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY)
             or os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY),
+            reranker_google_timeout=float(os.getenv(ENV_RERANKER_GOOGLE_TIMEOUT, str(DEFAULT_RERANKER_GOOGLE_TIMEOUT))),
             # Server
             host=os.getenv(ENV_HOST, DEFAULT_HOST),
             port=int(os.getenv(ENV_PORT, DEFAULT_PORT)),

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1666,6 +1666,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             api_key=api_key,
             model=config.reranker_cohere_model,
             base_url=config.reranker_cohere_base_url,
+            timeout=config.reranker_cohere_timeout,
         )
     elif provider == "openrouter":
         api_key = config.reranker_openrouter_api_key
@@ -1678,6 +1679,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             api_key=api_key,
             model=config.reranker_openrouter_model,
             base_url="https://openrouter.ai/api/v1/rerank",
+            timeout=config.reranker_openrouter_timeout,
         )
     elif provider == "flashrank":
         model = os.environ.get(ENV_RERANKER_FLASHRANK_MODEL, DEFAULT_RERANKER_FLASHRANK_MODEL)
@@ -1692,6 +1694,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             api_key=config.reranker_litellm_api_key,
             model=config.reranker_litellm_model,
             max_tokens_per_doc=config.reranker_litellm_max_tokens_per_doc,
+            timeout=config.reranker_litellm_timeout,
         )
     elif provider == "litellm-sdk":
         api_key = config.reranker_litellm_sdk_api_key
@@ -1704,6 +1707,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             model=config.reranker_litellm_sdk_model,
             api_base=config.reranker_litellm_sdk_api_base,
             max_tokens_per_doc=config.reranker_litellm_max_tokens_per_doc,
+            timeout=config.reranker_litellm_sdk_timeout,
         )
     elif provider == "zeroentropy":
         api_key = config.reranker_zeroentropy_api_key
@@ -1715,6 +1719,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             api_key=api_key,
             model=config.reranker_zeroentropy_model,
             base_url=config.reranker_zeroentropy_base_url,
+            timeout=config.reranker_zeroentropy_timeout,
         )
     elif provider == "siliconflow":
         api_key = config.reranker_siliconflow_api_key
@@ -1726,6 +1731,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             api_key=api_key,
             model=config.reranker_siliconflow_model,
             base_url=config.reranker_siliconflow_base_url,
+            timeout=config.reranker_siliconflow_timeout,
         )
     elif provider == "google":
         project_id = config.reranker_google_project_id
@@ -1738,6 +1744,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             project_id=project_id,
             model=config.reranker_google_model,
             service_account_key=config.reranker_google_service_account_key,
+            timeout=config.reranker_google_timeout,
         )
     elif provider == "alibaba":
         api_key = config.reranker_alibaba_api_key
@@ -1746,6 +1753,7 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
         return AlibabaCloudCrossEncoder(
             api_key=api_key,
             model=config.reranker_alibaba_model,
+            timeout=config.reranker_alibaba_timeout,
         )
     elif provider == "rrf":
         return RRFPassthroughCrossEncoder()

--- a/hindsight-api-slim/tests/test_reranker_timeouts.py
+++ b/hindsight-api-slim/tests/test_reranker_timeouts.py
@@ -1,0 +1,125 @@
+"""
+Per-provider HTTP timeout wiring for remote rerankers.
+
+Covers issue #1807: each HTTP-based reranker provider must accept a configurable
+timeout via env var so workloads with large batches don't hit the previously
+hardcoded 60s ceiling.
+"""
+
+from dataclasses import fields
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.cross_encoder import create_cross_encoder_from_env
+
+
+def _make_config(**overrides) -> HindsightConfig:
+    """Build a HindsightConfig with field-type-appropriate zero values plus overrides."""
+    defaults: dict = {}
+    for f in fields(HindsightConfig):
+        if f.type == "str":
+            defaults[f.name] = ""
+        elif f.type == "str | None":
+            defaults[f.name] = None
+        elif f.type == "int":
+            defaults[f.name] = 0
+        elif f.type == "int | None":
+            defaults[f.name] = None
+        elif f.type == "float":
+            defaults[f.name] = 0.0
+        elif f.type == "float | None":
+            defaults[f.name] = None
+        elif f.type == "bool":
+            defaults[f.name] = False
+        else:
+            defaults[f.name] = None
+    defaults.update(overrides)
+    return HindsightConfig(**defaults)
+
+
+@pytest.mark.parametrize(
+    "provider, extra, timeout_field, attr_path",
+    [
+        (
+            "cohere",
+            {"reranker_cohere_api_key": "k", "reranker_cohere_base_url": "https://example/rerank"},
+            "reranker_cohere_timeout",
+            ("_http_client", "timeout"),
+        ),
+        (
+            "openrouter",
+            {"reranker_openrouter_api_key": "k"},
+            "reranker_openrouter_timeout",
+            ("_http_client", "timeout"),
+        ),
+        (
+            "zeroentropy",
+            {"reranker_zeroentropy_api_key": "k"},
+            "reranker_zeroentropy_timeout",
+            ("_client", "timeout"),
+        ),
+        (
+            "siliconflow",
+            {
+                "reranker_siliconflow_api_key": "k",
+                "reranker_siliconflow_base_url": "https://api.siliconflow.cn/v1",
+            },
+            "reranker_siliconflow_timeout",
+            ("_client", "timeout"),
+        ),
+        (
+            "alibaba",
+            {"reranker_alibaba_api_key": "k"},
+            "reranker_alibaba_timeout",
+            ("_client", "timeout"),
+        ),
+        (
+            "litellm",
+            {"reranker_litellm_api_base": "http://localhost:4000"},
+            "reranker_litellm_timeout",
+            ("timeout",),
+        ),
+        (
+            "litellm-sdk",
+            {"reranker_litellm_sdk_api_key": "k"},
+            "reranker_litellm_sdk_timeout",
+            ("timeout",),
+        ),
+        (
+            "google",
+            {"reranker_google_project_id": "test-project"},
+            "reranker_google_timeout",
+            ("timeout",),
+        ),
+    ],
+)
+def test_factory_threads_per_provider_timeout(provider, extra, timeout_field, attr_path):
+    """Env-configured timeout reaches the provider instance (or its inner HTTP client)."""
+    custom_timeout = 300.0
+    config = _make_config(
+        reranker_provider=provider,
+        **{timeout_field: custom_timeout},
+        **extra,
+    )
+    with patch("hindsight_api.config.get_config", return_value=config):
+        encoder = create_cross_encoder_from_env()
+
+    obj = encoder
+    for part in attr_path:
+        obj = getattr(obj, part)
+    assert obj == custom_timeout
+
+
+def test_default_timeouts_preserve_60s_behavior():
+    """Unset env keeps the previously hardcoded 60.0s default for HTTP providers."""
+    config = HindsightConfig.from_env()
+    assert config.reranker_cohere_timeout == 60.0
+    assert config.reranker_openrouter_timeout == 60.0
+    assert config.reranker_zeroentropy_timeout == 60.0
+    assert config.reranker_siliconflow_timeout == 60.0
+    assert config.reranker_alibaba_timeout == 60.0
+    assert config.reranker_litellm_timeout == 60.0
+    assert config.reranker_litellm_sdk_timeout == 60.0
+    assert config.reranker_google_timeout == 60.0

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -655,27 +655,35 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT` | HTTP request timeout for TEI reranker (seconds). Increase when using a slower CPU-based reranker under load. | `30.0` |
 | `HINDSIGHT_API_RERANKER_OPENROUTER_API_KEY` | OpenRouter API key for reranking (falls back to `HINDSIGHT_API_OPENROUTER_API_KEY`, then `HINDSIGHT_API_LLM_API_KEY`) | - |
 | `HINDSIGHT_API_RERANKER_OPENROUTER_MODEL` | OpenRouter rerank model | `cohere/rerank-v3.5` |
+| `HINDSIGHT_API_RERANKER_OPENROUTER_TIMEOUT` | HTTP request timeout for OpenRouter reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_COHERE_API_KEY` | Cohere API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_COHERE_MODEL` | Cohere rerank model | `rerank-english-v3.0` |
 | `HINDSIGHT_API_RERANKER_COHERE_BASE_URL` | Custom base URL for any Cohere-compatible `/rerank` endpoint (Azure AI Foundry, Jina, Voyage, self-hosted BGE, etc.). When set, the `cohere` provider bypasses the Cohere SDK and calls the endpoint directly via HTTP. | - |
+| `HINDSIGHT_API_RERANKER_COHERE_TIMEOUT` | Request timeout for the Cohere reranker (seconds). Applies to both the native Cohere SDK and the Cohere-compatible HTTP path enabled by `HINDSIGHT_API_RERANKER_COHERE_BASE_URL`. | `60.0` |
 | `HINDSIGHT_API_RERANKER_LITELLM_API_BASE` | LiteLLM proxy base URL for reranking | `http://localhost:4000` |
 | `HINDSIGHT_API_RERANKER_LITELLM_API_KEY` | LiteLLM proxy API key for reranking (optional, depends on proxy config) | - |
 | `HINDSIGHT_API_RERANKER_LITELLM_MODEL` | LiteLLM **proxy** rerank model (use provider prefix, e.g., `cohere/rerank-english-v3.0`) | `cohere/rerank-english-v3.0` |
+| `HINDSIGHT_API_RERANKER_LITELLM_TIMEOUT` | HTTP request timeout for the LiteLLM proxy reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_LITELLM_SDK_API_KEY` | LiteLLM **SDK** API key for direct reranking (no proxy needed) | - |
 | `HINDSIGHT_API_RERANKER_LITELLM_SDK_MODEL` | LiteLLM SDK rerank model (e.g., `deepinfra/Qwen3-reranker-8B`) | `cohere/rerank-english-v3.0` |
 | `HINDSIGHT_API_RERANKER_LITELLM_SDK_API_BASE` | Custom API base URL for LiteLLM SDK (optional) | - |
+| `HINDSIGHT_API_RERANKER_LITELLM_SDK_TIMEOUT` | Request timeout for the LiteLLM SDK reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_LITELLM_MAX_TOKENS_PER_DOC` | Truncate documents to this many tokens before sending to the reranker (applies to both `litellm` and `litellm-sdk`). Use for models with small context windows (e.g. set to `900` for a 1024-token limit model). Unset by default (no truncation). | - |
 | `HINDSIGHT_API_RERANKER_ZEROENTROPY_API_KEY` | ZeroEntropy API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_ZEROENTROPY_MODEL` | ZeroEntropy rerank model (`zerank-2`, `zerank-2-small`) | `zerank-2` |
 | `HINDSIGHT_API_RERANKER_ZEROENTROPY_BASE_URL` | Custom base URL for ZeroEntropy-compatible API (e.g., mock server, proxy, or self-hosted deployment) | `https://api.zeroentropy.dev` |
+| `HINDSIGHT_API_RERANKER_ZEROENTROPY_TIMEOUT` | HTTP request timeout for ZeroEntropy reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY` | SiliconFlow API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL` | SiliconFlow rerank model (e.g., `BAAI/bge-reranker-v2-m3`) | `BAAI/bge-reranker-v2-m3` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL` | Base URL for the SiliconFlow `/rerank` endpoint | `https://api.siliconflow.cn/v1` |
+| `HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT` | HTTP request timeout for SiliconFlow reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_ALIBABA_API_KEY` | Alibaba Cloud DashScope API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_ALIBABA_MODEL` | DashScope rerank model | `qwen3-rerank` |
+| `HINDSIGHT_API_RERANKER_ALIBABA_TIMEOUT` | HTTP request timeout for the Alibaba Cloud DashScope reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_GOOGLE_PROJECT_ID` | Google Cloud project ID for Discovery Engine reranking (falls back to `HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID`) | - |
 | `HINDSIGHT_API_RERANKER_GOOGLE_MODEL` | Google Discovery Engine ranking model | `semantic-ranker-default-004` |
 | `HINDSIGHT_API_RERANKER_GOOGLE_SERVICE_ACCOUNT_KEY` | Path to service account JSON key (falls back to `HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY`). If unset, uses ADC. | - |
+| `HINDSIGHT_API_RERANKER_GOOGLE_TIMEOUT` | HTTP request timeout for Google Discovery Engine reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_MODEL` | FlashRank model for fast CPU-based reranking | `ms-marco-MiniLM-L-12-v2` |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CACHE_DIR` | Cache directory for FlashRank models | System default |
 | `HINDSIGHT_API_RERANKER_FLASHRANK_CPU_MEM_ARENA` | Enable ONNX Runtime CPU memory arena for FlashRank. When `true`, ONNX pre-allocates a memory arena that never shrinks, causing RSS to grow monotonically. `false` trades slightly slower per-call allocation for bounded RSS. | `false` |


### PR DESCRIPTION
## Summary

Closes #1807.

Every HTTP-based reranker provider in `cross_encoder.py` (cohere, openrouter, zeroentropy, siliconflow, alibaba, litellm proxy/SDK, google) had a hardcoded 60.0s timeout on its `httpx.AsyncClient` / Cohere SDK / `litellm.arerank` call. The reporter was patching the source via a Docker volume mount to lift it; this PR exposes the knob properly.

- Added one env var per provider: `HINDSIGHT_API_RERANKER_<PROVIDER>_TIMEOUT` (defaults to `60.0` so unset envs keep current behavior).
- Wired each value through `HindsightConfig.from_env()` into `create_cross_encoder_from_env()`.
- TEI was already configurable via `HINDSIGHT_API_RERANKER_TEI_HTTP_TIMEOUT` — unchanged.
- Documented the new vars in `hindsight-docs/docs/developer/configuration.md`.

## Test plan

- [x] `uv run pytest tests/test_reranker_timeouts.py` — new parametrized test asserts each provider's instance (or its inner HTTP client) ends up with the configured timeout; a second test asserts unset envs still yield 60.0.
- [x] `uv run pytest tests/test_cohere_cross_encoder.py tests/test_google_cross_encoder.py tests/test_litellm_sdk_cross_encoder.py tests/test_tei_cross_encoder.py tests/test_reranker_error_handling.py tests/test_reranker_score_normalization.py` — 76 passed, 6 skipped, no regressions.
- [x] `./scripts/hooks/lint.sh` — all lints pass.
- [x] `uv run ty check hindsight_api/` — clean.