### PR TITLE
fix(consolidation): indefinite retry with backoff + dedup-by-bank guard

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1430,6 +1430,25 @@ class MemoryEngine(MemoryEngineInterface):
                             error_message=str(e),
                             schema=schema,
                         )
+
+                        # When another consolidation is already pending for the same
+                        # bank, skip the retry. The pending op will process the same
+                        # unconsolidated rows when it runs, so retrying ours just
+                        # multiplies retry budgets during a long transient outage
+                        # (every retain enqueues a fresh op, each independently
+                        # consuming `_retry_count` slots — a retry storm).
+                        bank_id_for_dedup = task_dict.get("bank_id", "")
+                        if bank_id_for_dedup and await self._has_other_pending_consolidation(
+                            bank_id=bank_id_for_dedup,
+                            operation_id=operation_id,
+                        ):
+                            logger.info(
+                                f"Consolidation {operation_id} for bank {bank_id_for_dedup} hit "
+                                f"transient error; another consolidation is already pending for "
+                                f"this bank — skipping retry."
+                            )
+                            raise
+
                     # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed)
                     retry_count = task_dict.get("_retry_count", 0)
                     if retry_count < 3:
@@ -9529,6 +9548,42 @@ class MemoryEngine(MemoryEngineInterface):
                 cursor,
             )
         return [dict(row) for row in rows]
+
+    async def _has_other_pending_consolidation(
+        self,
+        *,
+        bank_id: str,
+        operation_id: str,
+    ) -> bool:
+        """Return True if any consolidation op other than ``operation_id`` is
+        ``pending`` for ``bank_id``.
+
+        Used by the task-retry path to skip retrying a transient consolidation
+        failure when another pending op already covers the same bank — the other
+        op will process the same unconsolidated rows when it runs.
+
+        A check failure (DB hiccup) returns ``False`` so the caller proceeds
+        with the normal retry path rather than swallowing a real failure.
+        """
+        backend = await self._get_backend()
+        try:
+            async with acquire_with_retry(backend) as conn:
+                existing = await conn.fetchval(
+                    f"""
+                    SELECT 1 FROM {fq_table("async_operations")}
+                    WHERE bank_id = $1
+                      AND operation_type = 'consolidation'
+                      AND status = 'pending'
+                      AND operation_id != $2
+                    LIMIT 1
+                    """,
+                    bank_id,
+                    uuid.UUID(operation_id),
+                )
+            return existing is not None
+        except Exception as e:
+            logger.warning(f"Failed to check for other pending consolidation ops for bank {bank_id}: {e}")
+            return False
 
     async def _submit_async_operation(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -106,6 +106,25 @@ _PROTECTED_TABLES = frozenset(
 # Enable runtime SQL validation (can be disabled in production for performance)
 _VALIDATE_SQL_SCHEMAS = True
 
+# Consolidation retry: indefinite retry with capped exponential backoff.
+# Transient upstream outages (LLM provider down, DB flapping, tenant-ext
+# blip) must eventually recover; the worker should keep trying rather than
+# silently dead-lettering a bank's consolidation backlog. Deterministic
+# failures (integrity violations, embedding dimension mismatches) are
+# filtered upstream by `_is_non_retryable_task_error` and never reach the
+# retry path. The dedup-by-bank guard prevents per-op retries from
+# multiplying when a peer consolidation is already pending for the bank.
+_CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS = 60
+_CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS = 1800  # 30 min cap
+
+
+def _consolidation_retry_backoff_seconds(retry_count: int) -> int:
+    """Capped exponential backoff: 60, 120, 240, 480, 960, 1800, 1800, …"""
+    return min(
+        _CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS * (2**retry_count),
+        _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS,
+    )
+
 
 class UnqualifiedTableError(Exception):
     """Raised when SQL contains unqualified table references."""
@@ -1448,6 +1467,19 @@ class MemoryEngine(MemoryEngineInterface):
                                 f"this bank — skipping retry."
                             )
                             raise
+
+                        # Indefinite retry with capped exponential backoff.
+                        # Transient outages (LLM provider down, DB flapping) must
+                        # eventually recover; the alternative (cap after 3 retries
+                        # and mark failed) silently dead-letters the bank's backlog.
+                        # The dedup-by-bank guard above prevents this from causing
+                        # a retry storm when multiple ops exist for the same bank.
+                        retry_count = task_dict.get("_retry_count", 0)
+                        backoff = _consolidation_retry_backoff_seconds(retry_count)
+                        raise RetryTaskAt(
+                            retry_at=datetime.now(UTC) + timedelta(seconds=backoff),
+                            message=str(e),
+                        )
 
                     # Retryable: use RetryTaskAt if under the retry limit, else re-raise (poller marks failed)
                     retry_count = task_dict.get("_retry_count", 0)

--- a/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
@@ -1,0 +1,166 @@
+"""
+Regression tests for the consolidation retry-storm guard.
+
+When a consolidation task hits a transient error, the worker's generic retry
+path raises ``RetryTaskAt`` to re-queue the operation (memory_engine.py, see
+``execute_task``'s exception branch). During a long upstream outage, every
+retain on the same bank also enqueues a fresh consolidation op via
+``submit_async_consolidation``. Without dedup, each op then independently
+consumes its own retry budget, multiplying load on the broken dependency.
+
+The guard: if another consolidation op is already ``pending`` for the same
+bank when the retry decision is made, skip the retry and let the other op
+cover the work when it runs.
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.worker.exceptions import RetryTaskAt
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _insert_consolidation_op(pool, bank_id: str, operation_id: uuid.UUID, status: str) -> None:
+    """Insert a consolidation row with the given ``status``."""
+    payload = json.dumps(
+        {
+            "type": "consolidation",
+            "operation_id": str(operation_id),
+            "bank_id": bank_id,
+        }
+    )
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+        VALUES ($1, $2, 'consolidation', $3, $4::jsonb)
+        """,
+        operation_id,
+        bank_id,
+        status,
+        payload,
+    )
+
+
+async def _cleanup(pool, bank_id: str, *operation_ids: uuid.UUID) -> None:
+    if operation_ids:
+        await pool.execute(
+            "DELETE FROM async_operations WHERE operation_id = ANY($1::uuid[])",
+            list(operation_ids),
+        )
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_skipped_when_other_pending_consolidation_exists(memory):
+    """
+    With another pending consolidation op already covering the same bank, a
+    transient failure on the currently-executing op must NOT raise
+    ``RetryTaskAt`` — the pending op will process the same unconsolidated
+    rows when the worker picks it up. Without this guard, a long outage
+    causes a retry storm: every retain enqueues a new op, and each op burns
+    three retry slots against the same broken dependency.
+    """
+    bank_id = f"test-dedup-{uuid.uuid4().hex[:8]}"
+    running_op_id = uuid.uuid4()
+    peer_pending_op_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    # The op currently executing (drives execute_task below).
+    await _insert_consolidation_op(pool, bank_id, running_op_id, status="processing")
+    # A peer consolidation already pending for the same bank — the dedup guard
+    # should fire because of this row.
+    await _insert_consolidation_op(pool, bank_id, peer_pending_op_id, status="pending")
+
+    task_dict = {
+        "type": "consolidation",
+        "operation_id": str(running_op_id),
+        "bank_id": bank_id,
+    }
+
+    transient = RuntimeError("upstream LLM 503")
+    with patch.object(memory, "_handle_consolidation", side_effect=transient):
+        # The original exception must propagate as-is (the poller catches it
+        # and calls _mark_failed). The point of the test is that it is NOT
+        # converted to RetryTaskAt — pytest.raises(RuntimeError) asserts that
+        # implicitly, since RetryTaskAt is not a RuntimeError subclass.
+        with pytest.raises(RuntimeError, match="upstream LLM 503"):
+            await memory.execute_task(task_dict)
+
+    # Peer pending op must be untouched by the dedup guard.
+    peer_row = await pool.fetchrow(
+        "SELECT status FROM async_operations WHERE operation_id = $1",
+        peer_pending_op_id,
+    )
+    assert peer_row["status"] == "pending"
+
+    await _cleanup(pool, bank_id, running_op_id, peer_pending_op_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_happens_when_no_other_pending_consolidation(memory):
+    """
+    Sanity check: with no peer pending op, the normal retry path still fires
+    and ``RetryTaskAt`` is raised — the dedup guard must not regress the
+    common-case behaviour.
+    """
+    bank_id = f"test-dedup-{uuid.uuid4().hex[:8]}"
+    running_op_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _insert_consolidation_op(pool, bank_id, running_op_id, status="processing")
+
+    task_dict = {
+        "type": "consolidation",
+        "operation_id": str(running_op_id),
+        "bank_id": bank_id,
+    }
+
+    transient = RuntimeError("transient blip")
+    with patch.object(memory, "_handle_consolidation", side_effect=transient):
+        with pytest.raises(RetryTaskAt):
+            await memory.execute_task(task_dict)
+
+    await _cleanup(pool, bank_id, running_op_id)
+
+
+@pytest.mark.asyncio
+async def test_peer_only_dedups_when_same_bank(memory):
+    """
+    A pending consolidation for a DIFFERENT bank must not suppress the retry
+    — the dedup guard is per-bank, not global.
+    """
+    bank_id_a = f"test-dedup-a-{uuid.uuid4().hex[:8]}"
+    bank_id_b = f"test-dedup-b-{uuid.uuid4().hex[:8]}"
+    running_op_id = uuid.uuid4()
+    unrelated_pending_op_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id_a)
+    await _ensure_bank(pool, bank_id_b)
+    await _insert_consolidation_op(pool, bank_id_a, running_op_id, status="processing")
+    await _insert_consolidation_op(pool, bank_id_b, unrelated_pending_op_id, status="pending")
+
+    task_dict = {
+        "type": "consolidation",
+        "operation_id": str(running_op_id),
+        "bank_id": bank_id_a,
+    }
+
+    with patch.object(memory, "_handle_consolidation", side_effect=RuntimeError("blip")):
+        with pytest.raises(RetryTaskAt):
+            await memory.execute_task(task_dict)
+
+    await _cleanup(pool, bank_id_a, running_op_id)
+    await _cleanup(pool, bank_id_b, unrelated_pending_op_id)

--- a/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
@@ -1,24 +1,36 @@
 """
-Regression tests for the consolidation retry-storm guard.
+Regression tests for the consolidation retry path.
 
 When a consolidation task hits a transient error, the worker's generic retry
 path raises ``RetryTaskAt`` to re-queue the operation (memory_engine.py, see
-``execute_task``'s exception branch). During a long upstream outage, every
-retain on the same bank also enqueues a fresh consolidation op via
-``submit_async_consolidation``. Without dedup, each op then independently
-consumes its own retry budget, multiplying load on the broken dependency.
+``execute_task``'s exception branch). Two pieces of behaviour live there:
 
-The guard: if another consolidation op is already ``pending`` for the same
-bank when the retry decision is made, skip the retry and let the other op
-cover the work when it runs.
+1. **Dedup guard.** During a long upstream outage, every retain on the same
+   bank enqueues a fresh consolidation op via ``submit_async_consolidation``.
+   Without dedup, each op independently consumes its own retry budget,
+   multiplying load on the broken dependency. The guard: if another
+   consolidation op is already ``pending`` for the same bank when the retry
+   decision is made, skip the retry and let the other op cover the work.
+
+2. **Indefinite retry with capped exponential backoff** (60s, 120, 240, 480,
+   960, 1800-cap). Distinct from the generic 60s × 3 used by other task
+   types. Transient consolidation failures (LLM/DB outage) must eventually
+   recover; capping after a fixed number of attempts silently dead-letters
+   the bank's backlog. The dedup-by-bank guard above prevents a retry
+   storm when multiple ops exist for the same bank.
 """
 
 import json
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
 
+from hindsight_api.engine.memory_engine import (
+    _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS,
+    _consolidation_retry_backoff_seconds,
+)
 from hindsight_api.worker.exceptions import RetryTaskAt
 
 
@@ -164,3 +176,92 @@ async def test_peer_only_dedups_when_same_bank(memory):
 
     await _cleanup(pool, bank_id_a, running_op_id)
     await _cleanup(pool, bank_id_b, unrelated_pending_op_id)
+
+
+def test_backoff_helper_schedule():
+    """
+    The backoff helper produces capped exponential growth:
+    60, 120, 240, 480, 960, then pinned at the 1800s cap.
+    """
+    assert _consolidation_retry_backoff_seconds(0) == 60
+    assert _consolidation_retry_backoff_seconds(1) == 120
+    assert _consolidation_retry_backoff_seconds(2) == 240
+    assert _consolidation_retry_backoff_seconds(3) == 480
+    assert _consolidation_retry_backoff_seconds(4) == 960
+    assert _consolidation_retry_backoff_seconds(5) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
+    # Cap holds at arbitrarily high attempt counts (we never give up).
+    assert _consolidation_retry_backoff_seconds(50) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
+    assert _consolidation_retry_backoff_seconds(1000) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_count", [0, 1, 2, 5])
+async def test_backoff_matches_schedule_by_retry_count(memory, retry_count):
+    """
+    Each retry schedules `retry_at = now + backoff(retry_count)`. The tolerance
+    covers the few seconds between ``now()`` capture in the test and inside
+    the retry handler. Includes retry_count=5 to verify the cap branch.
+    """
+    bank_id = f"test-backoff-{uuid.uuid4().hex[:8]}"
+    op_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _insert_consolidation_op(pool, bank_id, op_id, status="processing")
+
+    task_dict = {
+        "type": "consolidation",
+        "operation_id": str(op_id),
+        "bank_id": bank_id,
+        "_retry_count": retry_count,
+    }
+
+    expected_backoff = _consolidation_retry_backoff_seconds(retry_count)
+    before = datetime.now(UTC)
+    with patch.object(memory, "_handle_consolidation", side_effect=RuntimeError("transient")):
+        with pytest.raises(RetryTaskAt) as excinfo:
+            await memory.execute_task(task_dict)
+
+    delta = (excinfo.value.retry_at - before).total_seconds()
+    assert expected_backoff <= delta <= expected_backoff + 10, (
+        f"retry_count={retry_count}: expected backoff ~{expected_backoff}s, "
+        f"got delta={delta:.2f}s"
+    )
+
+    await _cleanup(pool, bank_id, op_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_is_indefinite(memory):
+    """
+    Consolidation has no attempt cap — even at very high retry_count, a
+    transient failure still raises RetryTaskAt (capped at the max backoff).
+    Without this property, a long outage silently dead-letters the bank's
+    unconsolidated rows once the budget is exhausted.
+    """
+    bank_id = f"test-indefinite-{uuid.uuid4().hex[:8]}"
+    op_id = uuid.uuid4()
+
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    await _insert_consolidation_op(pool, bank_id, op_id, status="processing")
+
+    task_dict = {
+        "type": "consolidation",
+        "operation_id": str(op_id),
+        "bank_id": bank_id,
+        "_retry_count": 100,  # well past any plausible attempt cap
+    }
+
+    before = datetime.now(UTC)
+    with patch.object(memory, "_handle_consolidation", side_effect=RuntimeError("still failing")):
+        with pytest.raises(RetryTaskAt) as excinfo:
+            await memory.execute_task(task_dict)
+
+    delta = (excinfo.value.retry_at - before).total_seconds()
+    cap = _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
+    assert cap <= delta <= cap + 10, (
+        f"At retry_count=100 expected backoff at cap (~{cap}s), got {delta:.2f}s"
+    )
+
+    await _cleanup(pool, bank_id, op_id)


### PR DESCRIPTION
## Summary

Two coupled changes to the consolidation task-retry path in `execute_task`:

1. **Indefinite retry with capped exponential backoff** (60, 120, 240, 480, 960, then pinned at 1800s) — replaces the generic 60s × 3 cap that other task types still use. Transient outages must eventually recover; capping silently dead-letters a bank's unconsolidated rows.
2. **Per-bank dedup guard** — if another consolidation op is already `pending` for the same bank, skip the retry and let the peer cover the work. Without this, indefinite retry would let multiple ops for the same bank retry forever in lockstep during an outage.

Surfaces from the discussion on #1799: the symptom there (event-chain breaks leave `memory_units` unconsolidated) is largely a *retry-budget exhaustion* problem during long outages, not a missing-trigger problem. Fixing the retry layer addresses it without polling `memory_units`.

## Why

Before this PR, `execute_task` retried transient consolidation failures with the generic schedule (60s × 3, then `_mark_failed`). During a sustained upstream outage:

1. Op A runs → LLM 503 → re-pended via `RetryTaskAt`.
2. Retain succeeds and enqueues op B for the same bank (`submit_async_consolidation` dedup only checks `pending`, not `processing`).
3. Both A and B burn 3 retry slots each; every additional retain spawns C, D, … each burning three more.
4. After the budget is exhausted, the ops are marked `failed` and the bank's unconsolidated rows sit untouched until the next retain triggers a fresh op — which then also burns its budget.

This PR breaks the cycle:
- The dedup guard collapses step 3 to a single retrying op per bank.
- The indefinite-with-cap schedule on that single op rides out outages of any length, so step 4 doesn't happen: the next attempt eventually succeeds when the dependency comes back.

Deterministic failures (integrity violations, embedding dimension errors) are still filtered upstream by `_is_non_retryable_task_error` and marked failed immediately. Other task types keep their existing 60s × 3 generic schedule.

## What changed

`hindsight_api/engine/memory_engine.py`
- `_consolidation_retry_backoff_seconds(retry_count)` — capped exponential backoff helper, no attempt cap.
- `_has_other_pending_consolidation(bank_id, operation_id)` — single-row check on `async_operations`, fails open on DB errors.
- Generic exception branch of `execute_task` for `consolidation` tasks: fire failure webhook, run dedup check, then either bare-raise (poller marks failed) or `RetryTaskAt` with the new backoff.

`tests/test_consolidation_retry_dedup_by_bank.py` (new) — 7 regression tests:
- Dedup guard: peer pending → no RetryTaskAt; no peer → RetryTaskAt fires; peer in different bank → no suppression.
- Backoff schedule: unit test of the helper (60/120/240/480/960/cap), parameterised `execute_task` test verifying `retry_at` matches each step, indefinite-retry test at `retry_count=100` confirming the cap holds and we never give up.

## Test plan

- [x] `pytest tests/test_consolidation_retry_dedup_by_bank.py` — 9 passed
- [x] `pytest tests/test_consolidation_retry_budget.py tests/test_consolidation_failure_recovery.py tests/test_integrity_violation_not_retried.py` — no regressions
- [x] `./scripts/hooks/lint.sh` — clean
- [ ] CI green

## What this PR does not change

- No new env vars, no opt-in flag — these are correctness fixes for the current retry semantics.
- No changes to `submit_async_consolidation` dedup semantics — that path still only dedups `pending`.
- No `memory_units` polling — the discussion on #1799 ruled out the scanner approach.
- Other task types (batch_retain, refresh_mental_model, webhook_delivery) keep their existing 60s × 3 retry schedule.
