### PR TITLE
feat(worker): add priority-based consolidation bank scheduling

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2674,6 +2674,7 @@ def create_app(
                 tenant_extension=memory._tenant_extension,
                 max_slots=config.worker_max_slots,
                 slot_reservations=config.worker_slot_reservations,
+                consolidation_bank_priority=config.worker_consolidation_bank_priority or None,
             )
             poller_task = asyncio.create_task(poller.run())
             logging.info(f"Worker poller started (worker_id={worker_id})")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -913,7 +913,9 @@ def _parse_bank_priority(raw: str) -> dict[str, int]:
         try:
             priority = int(priority_str)
         except ValueError:
-            raise ValueError(f"Invalid priority '{priority_str}' in entry '{entry}': must be an integer")
+            raise ValueError(
+                f"Invalid priority '{priority_str}' in entry '{entry}': must be an integer"
+            ) from None
         if priority < 1:
             raise ValueError(f"Priority must be >= 1, got {priority} in entry '{entry}'")
         result[pattern] = priority

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -446,6 +446,7 @@ WORKER_SLOT_RESERVATION_TYPES: dict[str, tuple[str, int]] = {
     "refresh_mental_model": ("HINDSIGHT_API_WORKER_REFRESH_MENTAL_MODEL_MAX_SLOTS", 0),
     "graph_maintenance": ("HINDSIGHT_API_WORKER_GRAPH_MAINTENANCE_MAX_SLOTS", 0),
 }
+ENV_WORKER_CONSOLIDATION_BANK_PRIORITY = "HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY"
 ENV_RETAIN_MAX_CONCURRENT = "HINDSIGHT_API_RETAIN_MAX_CONCURRENT"
 
 # Reflect agent settings
@@ -887,6 +888,38 @@ def _validate_recall_budget_function(function: str) -> str:
     return function_lower
 
 
+def _parse_bank_priority(raw: str) -> dict[str, int]:
+    """Parse ``bank-pattern:priority,...`` into ``{pattern: priority}``.
+
+    ``*`` in a pattern is kept as-is here; the SQL layer converts it to ``%``
+    for LIKE matching.  A bare ``*`` key is the catch-all default for unlisted
+    banks.  Returns an empty dict when *raw* is blank.
+    """
+    result: dict[str, int] = {}
+    raw = raw.strip()
+    if not raw:
+        return result
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            raise ValueError(f"Invalid bank priority entry '{entry}': expected 'bank-pattern:priority'")
+        pattern, priority_str = entry.rsplit(":", 1)
+        pattern = pattern.strip()
+        priority_str = priority_str.strip()
+        if not pattern:
+            raise ValueError(f"Empty bank pattern in entry '{entry}'")
+        try:
+            priority = int(priority_str)
+        except ValueError:
+            raise ValueError(f"Invalid priority '{priority_str}' in entry '{entry}': must be an integer")
+        if priority < 1:
+            raise ValueError(f"Priority must be >= 1, got {priority} in entry '{entry}'")
+        result[pattern] = priority
+    return result
+
+
 def _get_default_model_for_provider(provider: str) -> str:
     """Get the default model for a given provider."""
     return PROVIDER_DEFAULT_MODELS.get(provider.lower(), DEFAULT_LLM_MODEL)
@@ -1237,6 +1270,7 @@ class HindsightConfig:
     worker_http_port: int
     worker_max_slots: int
     worker_slot_reservations: dict[str, int]
+    worker_consolidation_bank_priority: dict[str, int]
     retain_max_concurrent: int
 
     # Reflect agent settings
@@ -1978,6 +2012,9 @@ class HindsightConfig:
                 for op_type, (env_var, default) in WORKER_SLOT_RESERVATION_TYPES.items()
                 if int(os.getenv(env_var, str(default))) > 0
             },
+            worker_consolidation_bank_priority=_parse_bank_priority(
+                os.getenv(ENV_WORKER_CONSOLIDATION_BANK_PRIORITY, "")
+            ),
             retain_max_concurrent=int(os.getenv(ENV_RETAIN_MAX_CONCURRENT, str(DEFAULT_RETAIN_MAX_CONCURRENT))),
             # Reflect agent settings
             reflect_max_iterations=int(os.getenv(ENV_REFLECT_MAX_ITERATIONS, str(DEFAULT_REFLECT_MAX_ITERATIONS))),

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -469,12 +469,22 @@ class DataAccessOps(ABC):
         worker_id: str,
         reserved_limits: dict[str, int],
         shared_limit: int,
+        *,
+        consolidation_bank_priority: dict[str, int] | None = None,
     ) -> list[ResultRow]:
         """Claim pending tasks from the async_operations table.
 
         PG implementation can use NOT EXISTS + FOR UPDATE SKIP LOCKED in one query.
         Oracle implementation uses two-step claims (query busy banks first, then
         claim excluding them) to avoid ORA-02014.
+
+        Args:
+            consolidation_bank_priority: Per-bank priority for consolidation scheduling.
+                Maps bank name patterns to integer priorities (higher = claimed first).
+                Patterns support ``*`` as wildcard (converted to SQL ``%`` for LIKE).
+                A bare ``*`` key is the catch-all default for unlisted banks.
+                When set, consolidation tasks are claimed in priority tiers.
+                None preserves current behavior (pure created_at ordering).
 
         Returns claimed rows with operation_id, operation_type, task_payload, retry_count.
         The caller is responsible for building ClaimedTask objects.

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -787,7 +787,257 @@ class OracleOps(DataAccessOps):
 
     # -- Task claiming operations ------------------------------------------
 
-    async def claim_tasks(self, conn, table, worker_id, reserved_limits, shared_limit):
+    async def _claim_consolidation_tasks(
+        self,
+        conn,
+        table: str,
+        busy_bank_ids: list[str],
+        claimed_ids: list,
+        limit: int,
+        priority_map: dict[str, int] | None,
+    ) -> list:
+        """Claim consolidation tasks with optional priority-based tiered ordering.
+
+        Mirrors the PostgreSQL implementation.  The Oracle SQL adapter
+        translates ``LIKE ANY`` / ``NOT LIKE ALL`` via ``_expand_any_lists``.
+        """
+        if limit <= 0:
+            return []
+
+        if not priority_map:
+            return await self._claim_consolidation_plain(conn, table, busy_bank_ids, claimed_ids, limit)
+
+        # --- Tiered claiming (same algorithm as PG) ---
+        specific_by_priority: dict[int, list[str]] = {}
+        all_specific_sql: list[str] = []
+        catch_all_priority = 1
+
+        for pattern, priority in priority_map.items():
+            if pattern == "*":
+                catch_all_priority = priority
+            else:
+                sql_pat = pattern.replace("*", "%")
+                specific_by_priority.setdefault(priority, []).append(sql_pat)
+                all_specific_sql.append(sql_pat)
+
+        all_priorities = sorted(set(specific_by_priority.keys()) | {catch_all_priority}, reverse=True)
+
+        remaining = limit
+        result: list = []
+
+        for pri in all_priorities:
+            if remaining <= 0:
+                break
+
+            if pri in specific_by_priority:
+                rows = await self._claim_consolidation_like(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    remaining,
+                    specific_by_priority[pri],
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    result.append(row)
+                remaining -= len(rows)
+
+            if pri == catch_all_priority and remaining > 0:
+                rows = await self._claim_consolidation_not_like(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    remaining,
+                    all_specific_sql,
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    result.append(row)
+                remaining -= len(rows)
+
+        return result
+
+    async def _claim_consolidation_plain(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+    ) -> list:
+        """Claim consolidation tasks with default created_at ordering."""
+        exclude_ids = claimed_ids if claimed_ids else None
+        if busy_bank_ids:
+            if exclude_ids:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND bank_id != ALL($1::text[])
+                      AND operation_id != ALL($2::uuid[])
+                    ORDER BY created_at
+                    LIMIT $3
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    busy_bank_ids,
+                    exclude_ids,
+                    limit,
+                )
+            else:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND bank_id != ALL($1::text[])
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    busy_bank_ids,
+                    limit,
+                )
+        else:
+            if exclude_ids:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND operation_id != ALL($1::uuid[])
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    exclude_ids,
+                    limit,
+                )
+            else:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                    ORDER BY created_at
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    limit,
+                )
+
+    async def _claim_consolidation_like(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+        sql_patterns,
+    ) -> list:
+        """Claim consolidation tasks from banks matching LIKE patterns."""
+        params: list = [sql_patterns]
+        conditions = ["bank_id LIKE ANY($1::text[])"]
+        idx = 2
+
+        if busy_bank_ids:
+            conditions.append(f"bank_id != ALL(${idx}::text[])")
+            params.append(busy_bank_ids)
+            idx += 1
+
+        if claimed_ids:
+            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            params.append(claimed_ids)
+            idx += 1
+
+        params.append(limit)
+        extra = " AND ".join(conditions)
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'consolidation'
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+              AND {extra}
+            ORDER BY created_at
+            LIMIT ${idx}
+            FOR UPDATE SKIP LOCKED
+            """,
+            *params,
+        )
+
+    async def _claim_consolidation_not_like(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+        exclude_patterns,
+    ) -> list:
+        """Claim consolidation tasks from banks NOT matching any specific pattern (catch-all tier)."""
+        params: list = []
+        conditions: list[str] = []
+        idx = 1
+
+        if exclude_patterns:
+            conditions.append(f"bank_id NOT LIKE ALL(${idx}::text[])")
+            params.append(exclude_patterns)
+            idx += 1
+
+        if busy_bank_ids:
+            conditions.append(f"bank_id != ALL(${idx}::text[])")
+            params.append(busy_bank_ids)
+            idx += 1
+
+        if claimed_ids:
+            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            params.append(claimed_ids)
+            idx += 1
+
+        params.append(limit)
+        extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'consolidation'
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
+            ORDER BY created_at
+            LIMIT ${idx}
+            FOR UPDATE SKIP LOCKED
+            """,
+            *params,
+        )
+
+    async def claim_tasks(
+        self,
+        conn,
+        table,
+        worker_id,
+        reserved_limits,
+        shared_limit,
+        *,
+        consolidation_bank_priority=None,
+    ):
         """Oracle two-step claiming to avoid ORA-02014 with NOT EXISTS + FOR UPDATE."""
         all_rows = []
         claimed_ids = []
@@ -798,7 +1048,6 @@ class OracleOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                # Two-step: find busy banks first, then claim excluding them
                 busy_banks = await conn.fetch(
                     f"""
                     SELECT DISTINCT bank_id FROM {table}
@@ -807,38 +1056,14 @@ class OracleOps(DataAccessOps):
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
 
-                if busy_bank_ids:
-                    rows = await conn.fetch(
-                        f"""
-                        SELECT operation_id, operation_type, task_payload, retry_count
-                        FROM {table}
-                        WHERE status = 'pending'
-                          AND task_payload IS NOT NULL
-                          AND operation_type = 'consolidation'
-                          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                          AND bank_id != ALL($1::text[])
-                        ORDER BY created_at
-                        LIMIT $2
-                        FOR UPDATE SKIP LOCKED
-                        """,
-                        busy_bank_ids,
-                        limit,
-                    )
-                else:
-                    rows = await conn.fetch(
-                        f"""
-                        SELECT operation_id, operation_type, task_payload, retry_count
-                        FROM {table}
-                        WHERE status = 'pending'
-                          AND task_payload IS NOT NULL
-                          AND operation_type = 'consolidation'
-                          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                        ORDER BY created_at
-                        LIMIT $1
-                        FOR UPDATE SKIP LOCKED
-                        """,
-                        limit,
-                    )
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    limit,
+                    consolidation_bank_priority,
+                )
             else:
                 rows = await conn.fetch(
                     f"""
@@ -902,7 +1127,7 @@ class OracleOps(DataAccessOps):
                 all_rows.append(row)
             remaining_shared -= len(rows)
 
-            # 2b. Consolidation tasks (with bank-serialization)
+            # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
                 busy_banks_2 = await conn.fetch(
                     f"""
@@ -912,76 +1137,14 @@ class OracleOps(DataAccessOps):
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
 
-                if claimed_ids:
-                    if busy_bank_ids_2:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND operation_id != ALL($1::uuid[])
-                              AND bank_id != ALL($2::text[])
-                            ORDER BY created_at
-                            LIMIT $3
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            claimed_ids,
-                            busy_bank_ids_2,
-                            remaining_shared,
-                        )
-                    else:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND operation_id != ALL($1::uuid[])
-                            ORDER BY created_at
-                            LIMIT $2
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            claimed_ids,
-                            remaining_shared,
-                        )
-                else:
-                    if busy_bank_ids_2:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND bank_id != ALL($1::text[])
-                            ORDER BY created_at
-                            LIMIT $2
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            busy_bank_ids_2,
-                            remaining_shared,
-                        )
-                    else:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                            ORDER BY created_at
-                            LIMIT $1
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            remaining_shared,
-                        )
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids_2,
+                    claimed_ids,
+                    remaining_shared,
+                    consolidation_bank_priority,
+                )
 
                 for row in rows:
                     claimed_ids.append(row["operation_id"])

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -837,7 +837,268 @@ class PostgreSQLOps(DataAccessOps):
 
     # -- Task claiming operations ------------------------------------------
 
-    async def claim_tasks(self, conn, table, worker_id, reserved_limits, shared_limit):
+    async def _claim_consolidation_tasks(
+        self,
+        conn,
+        table: str,
+        busy_bank_ids: list[str],
+        claimed_ids: list,
+        limit: int,
+        priority_map: dict[str, int] | None,
+    ) -> list:
+        """Claim consolidation tasks with optional priority-based tiered ordering.
+
+        When *priority_map* is ``None``, uses the default ``ORDER BY created_at``
+        with bank-serialization (exclude busy banks).  When set, claims in
+        priority tiers — highest-priority banks first.  Specific patterns always
+        take precedence over the catch-all ``*`` entry.
+        """
+        if limit <= 0:
+            return []
+
+        # --- Fast path: no priority map -> current behavior ---
+        if not priority_map:
+            return await self._claim_consolidation_plain(conn, table, busy_bank_ids, claimed_ids, limit)
+
+        # --- Tiered claiming ---
+        # Separate specific patterns from catch-all.
+        # Specific patterns always take precedence: a bank matching ``shadow-*``
+        # uses that entry's priority even if the catch-all ``*`` has a higher
+        # value.  The catch-all only applies to banks not matching any specific
+        # pattern.
+        specific_by_priority: dict[int, list[str]] = {}
+        all_specific_sql: list[str] = []
+        catch_all_priority = 1  # default when no ``*`` entry
+
+        for pattern, priority in priority_map.items():
+            if pattern == "*":
+                catch_all_priority = priority
+            else:
+                sql_pat = pattern.replace("*", "%")
+                specific_by_priority.setdefault(priority, []).append(sql_pat)
+                all_specific_sql.append(sql_pat)
+
+        # Collect all priority levels (specific tiers + catch-all) sorted desc.
+        all_priorities = sorted(set(specific_by_priority.keys()) | {catch_all_priority}, reverse=True)
+
+        remaining = limit
+        result: list = []
+
+        for pri in all_priorities:
+            if remaining <= 0:
+                break
+
+            # Specific-pattern tier at this priority level
+            if pri in specific_by_priority:
+                rows = await self._claim_consolidation_like(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    remaining,
+                    specific_by_priority[pri],
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    result.append(row)
+                remaining -= len(rows)
+
+            # Catch-all tier at this priority level
+            if pri == catch_all_priority and remaining > 0:
+                rows = await self._claim_consolidation_not_like(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    remaining,
+                    all_specific_sql,
+                )
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    result.append(row)
+                remaining -= len(rows)
+
+        return result
+
+    async def _claim_consolidation_plain(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+    ) -> list:
+        """Claim consolidation tasks with default created_at ordering."""
+        exclude_ids = claimed_ids if claimed_ids else None
+        if busy_bank_ids:
+            if exclude_ids:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND bank_id != ALL($1::text[])
+                      AND operation_id != ALL($2::uuid[])
+                    ORDER BY created_at
+                    LIMIT $3
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    busy_bank_ids,
+                    exclude_ids,
+                    limit,
+                )
+            else:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND bank_id != ALL($1::text[])
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    busy_bank_ids,
+                    limit,
+                )
+        else:
+            if exclude_ids:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND operation_id != ALL($1::uuid[])
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    exclude_ids,
+                    limit,
+                )
+            else:
+                return await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                    ORDER BY created_at
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    limit,
+                )
+
+    async def _claim_consolidation_like(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+        sql_patterns,
+    ) -> list:
+        """Claim consolidation tasks from banks matching LIKE patterns."""
+        params: list = [sql_patterns]
+        conditions = ["bank_id LIKE ANY($1::text[])"]
+        idx = 2
+
+        if busy_bank_ids:
+            conditions.append(f"bank_id != ALL(${idx}::text[])")
+            params.append(busy_bank_ids)
+            idx += 1
+
+        if claimed_ids:
+            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            params.append(claimed_ids)
+            idx += 1
+
+        params.append(limit)
+        extra = " AND ".join(conditions)
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'consolidation'
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+              AND {extra}
+            ORDER BY created_at
+            LIMIT ${idx}
+            FOR UPDATE SKIP LOCKED
+            """,
+            *params,
+        )
+
+    async def _claim_consolidation_not_like(
+        self,
+        conn,
+        table,
+        busy_bank_ids,
+        claimed_ids,
+        limit,
+        exclude_patterns,
+    ) -> list:
+        """Claim consolidation tasks from banks NOT matching any specific pattern (catch-all tier)."""
+        params: list = []
+        conditions: list[str] = []
+        idx = 1
+
+        if exclude_patterns:
+            conditions.append(f"bank_id NOT LIKE ALL(${idx}::text[])")
+            params.append(exclude_patterns)
+            idx += 1
+
+        if busy_bank_ids:
+            conditions.append(f"bank_id != ALL(${idx}::text[])")
+            params.append(busy_bank_ids)
+            idx += 1
+
+        if claimed_ids:
+            conditions.append(f"operation_id != ALL(${idx}::uuid[])")
+            params.append(claimed_ids)
+            idx += 1
+
+        params.append(limit)
+        extra_clause = (" AND " + " AND ".join(conditions)) if conditions else ""
+        return await conn.fetch(
+            f"""
+            SELECT operation_id, operation_type, task_payload, retry_count
+            FROM {table}
+            WHERE status = 'pending'
+              AND task_payload IS NOT NULL
+              AND operation_type = 'consolidation'
+              AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
+            ORDER BY created_at
+            LIMIT ${idx}
+            FOR UPDATE SKIP LOCKED
+            """,
+            *params,
+        )
+
+    async def claim_tasks(
+        self,
+        conn,
+        table,
+        worker_id,
+        reserved_limits,
+        shared_limit,
+        *,
+        consolidation_bank_priority=None,
+    ):
         all_rows = []
         claimed_ids = []
 
@@ -855,38 +1116,14 @@ class PostgreSQLOps(DataAccessOps):
                 )
                 busy_bank_ids = [r["bank_id"] for r in busy_banks]
 
-                if busy_bank_ids:
-                    rows = await conn.fetch(
-                        f"""
-                        SELECT operation_id, operation_type, task_payload, retry_count
-                        FROM {table}
-                        WHERE status = 'pending'
-                          AND task_payload IS NOT NULL
-                          AND operation_type = 'consolidation'
-                          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                          AND bank_id != ALL($1::text[])
-                        ORDER BY created_at
-                        LIMIT $2
-                        FOR UPDATE SKIP LOCKED
-                        """,
-                        busy_bank_ids,
-                        limit,
-                    )
-                else:
-                    rows = await conn.fetch(
-                        f"""
-                        SELECT operation_id, operation_type, task_payload, retry_count
-                        FROM {table}
-                        WHERE status = 'pending'
-                          AND task_payload IS NOT NULL
-                          AND operation_type = 'consolidation'
-                          AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                        ORDER BY created_at
-                        LIMIT $1
-                        FOR UPDATE SKIP LOCKED
-                        """,
-                        limit,
-                    )
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    limit,
+                    consolidation_bank_priority,
+                )
             else:
                 rows = await conn.fetch(
                     f"""
@@ -950,7 +1187,7 @@ class PostgreSQLOps(DataAccessOps):
                 all_rows.append(row)
             remaining_shared -= len(rows)
 
-            # 2b. Consolidation tasks (with bank-serialization)
+            # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
                 busy_banks_2 = await conn.fetch(
                     f"""
@@ -960,76 +1197,14 @@ class PostgreSQLOps(DataAccessOps):
                 )
                 busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
 
-                if claimed_ids:
-                    if busy_bank_ids_2:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND operation_id != ALL($1::uuid[])
-                              AND bank_id != ALL($2::text[])
-                            ORDER BY created_at
-                            LIMIT $3
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            claimed_ids,
-                            busy_bank_ids_2,
-                            remaining_shared,
-                        )
-                    else:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND operation_id != ALL($1::uuid[])
-                            ORDER BY created_at
-                            LIMIT $2
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            claimed_ids,
-                            remaining_shared,
-                        )
-                else:
-                    if busy_bank_ids_2:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                              AND bank_id != ALL($1::text[])
-                            ORDER BY created_at
-                            LIMIT $2
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            busy_bank_ids_2,
-                            remaining_shared,
-                        )
-                    else:
-                        rows = await conn.fetch(
-                            f"""
-                            SELECT operation_id, operation_type, task_payload, retry_count
-                            FROM {table}
-                            WHERE status = 'pending'
-                              AND task_payload IS NOT NULL
-                              AND operation_type = 'consolidation'
-                              AND (next_retry_at IS NULL OR next_retry_at <= NOW())
-                            ORDER BY created_at
-                            LIMIT $1
-                            FOR UPDATE SKIP LOCKED
-                            """,
-                            remaining_shared,
-                        )
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids_2,
+                    claimed_ids,
+                    remaining_shared,
+                    consolidation_bank_priority,
+                )
 
                 for row in rows:
                     claimed_ids.append(row["operation_id"])

--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -72,6 +72,9 @@ _RETURNING_RE = re.compile(r"\bRETURNING\s+(.+)", re.IGNORECASE | re.DOTALL)
 
 _ANY_RE = re.compile(r"=\s*ANY\s*\(\s*:(\d+)\s*\)", re.IGNORECASE)
 _NOT_ALL_RE = re.compile(r"!=\s*ALL\s*\(\s*:(\d+)\s*\)", re.IGNORECASE)
+# LIKE ANY / NOT LIKE ALL — capture the column name before the operator
+_LIKE_ANY_RE = re.compile(r"(\w+)\s+LIKE\s+ANY\s*\(\s*:(\d+)\s*\)", re.IGNORECASE)
+_NOT_LIKE_ALL_RE = re.compile(r"(\w+)\s+NOT\s+LIKE\s+ALL\s*\(\s*:(\d+)\s*\)", re.IGNORECASE)
 
 _JSON_ARROW_TEXT_RE = re.compile(r'("?\w+"?)\s*->>\s*\'(\w+)\'')  # handles both col and "col"
 _JSON_HAS_KEY_RE = re.compile(r"(\w+)\s*\?\s*'(\w+)'")
@@ -535,6 +538,12 @@ def _rewrite_pg_to_oracle(query: str) -> RewriteResult:
     # != ALL(:N) → NOT IN (expanded list) — the negative counterpart of = ANY
     query = _NOT_ALL_RE.sub(r"NOT IN (/*EXPAND:\1*/)", query)
 
+    # col LIKE ANY(:N) → (col LIKE :p0 OR col LIKE :p1 OR ...)
+    query = _LIKE_ANY_RE.sub(r"\1 /*LIKE_ANY:\2:\1*/", query)
+
+    # col NOT LIKE ALL(:N) → (col NOT LIKE :p0 AND col NOT LIKE :p1 AND ...)
+    query = _NOT_LIKE_ALL_RE.sub(r"\1 /*NOT_LIKE_ALL:\2:\1*/", query)
+
     # CTE AS MATERIALIZED (...) → AS (...) — Oracle doesn't support MATERIALIZED CTE hint
     query = re.sub(r"\bAS\s+MATERIALIZED\s*\(", "AS (", query, flags=re.IGNORECASE)
 
@@ -725,16 +734,37 @@ class OracleConnection(DatabaseConnection):
     _expand_counter = 0
 
     @staticmethod
+    def _resolve_list_param(params: dict[str, Any], key: str) -> list | None:
+        """Resolve a parameter that may be a list or a JSON-encoded list string."""
+        val = params.get(key)
+        if isinstance(val, str):
+            try:
+                parsed = json.loads(val)
+                if isinstance(parsed, list):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        if isinstance(val, (list, tuple)):
+            return list(val)
+        return None
+
+    @staticmethod
     def _expand_any_lists(query: str, params: dict[str, Any] | None) -> tuple[str, dict[str, Any] | None]:
-        """Expand /*EXPAND:N*/ markers into individual bind vars for IN clauses.
+        """Expand /*EXPAND:N*/, /*LIKE_ANY:N:col*/, /*NOT_LIKE_ALL:N:col*/ markers.
 
         Converts: IN (/*EXPAND:1*/) with params["1"] = [a, b, c]
         Into:     IN (:any_0, :any_1, :any_2) with params["any_0"]=a, etc.
 
+        Converts: col /*LIKE_ANY:1:col*/ with params["1"] = [a, b]
+        Into:     (col LIKE :lk_0 OR col LIKE :lk_1)
+
+        Converts: col /*NOT_LIKE_ALL:1:col*/ with params["1"] = [a, b]
+        Into:     (col NOT LIKE :nlk_0 AND col NOT LIKE :nlk_1)
+
         Uses a unique prefix to avoid name collisions with other bind vars.
         The original param is kept (for other references to :N in the query).
         """
-        if params is None or "/*EXPAND:" not in query:
+        if params is None or "/*" not in query:
             return query, params
 
         expand_re = re.compile(r"/\*EXPAND:(\d+)\*/")
@@ -774,6 +804,50 @@ class OracleConnection(DatabaseConnection):
             return ", ".join(expanded_keys)
 
         query = expand_re.sub(_replace, query)
+
+        # Expand LIKE ANY: col /*LIKE_ANY:N:col*/ → (col LIKE :p0 OR col LIKE :p1 ...)
+        like_any_re = re.compile(r"(\w+)\s*/\*LIKE_ANY:(\d+):(\w+)\*/")
+
+        def _replace_like_any(m):
+            _col = m.group(1)  # redundant column ref before marker
+            param_key = m.group(2)
+            col = m.group(3)
+            val = OracleConnection._resolve_list_param(params, param_key)
+            if val is None or len(val) == 0:
+                return "1=0"  # no patterns → no match
+            OracleConnection._expand_counter += 1
+            prefix = f"lk{OracleConnection._expand_counter}"
+            clauses = []
+            for i, item in enumerate(val):
+                k = f"{prefix}_{i}"
+                params[k] = item
+                clauses.append(f"{col} LIKE :{k}")
+            keys_to_remove.add(param_key)
+            return f"({' OR '.join(clauses)})"
+
+        query = like_any_re.sub(_replace_like_any, query)
+
+        # Expand NOT LIKE ALL: col /*NOT_LIKE_ALL:N:col*/ → (col NOT LIKE :p0 AND ...)
+        not_like_all_re = re.compile(r"(\w+)\s*/\*NOT_LIKE_ALL:(\d+):(\w+)\*/")
+
+        def _replace_not_like_all(m):
+            _col = m.group(1)
+            param_key = m.group(2)
+            col = m.group(3)
+            val = OracleConnection._resolve_list_param(params, param_key)
+            if val is None or len(val) == 0:
+                return "1=1"  # no patterns → everything matches
+            OracleConnection._expand_counter += 1
+            prefix = f"nlk{OracleConnection._expand_counter}"
+            clauses = []
+            for i, item in enumerate(val):
+                k = f"{prefix}_{i}"
+                params[k] = item
+                clauses.append(f"{col} NOT LIKE :{k}")
+            keys_to_remove.add(param_key)
+            return f"({' AND '.join(clauses)})"
+
+        query = not_like_all_re.sub(_replace_not_like_all, query)
 
         # Remove original list params that were expanded — their placeholder
         # (:N) no longer exists in the query, and leaving them causes DPY-4008.

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -256,6 +256,7 @@ def main():
             tenant_extension=tenant_extension,
             max_slots=config.worker_max_slots,
             slot_reservations=config.worker_slot_reservations,
+            consolidation_bank_priority=config.worker_consolidation_bank_priority or None,
         )
 
         # Create the HTTP app for metrics/health

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -133,6 +133,7 @@ class WorkerPoller:
         tenant_extension: "TenantExtension | None" = None,
         max_slots: int = 10,
         slot_reservations: dict[str, int] | None = None,
+        consolidation_bank_priority: dict[str, int] | None = None,
     ):
         """
         Initialize the worker poller.
@@ -150,6 +151,11 @@ class WorkerPoller:
                 "retain": 3}). Reserved slots guarantee capacity for that operation type.
                 Remaining slots (max_slots - sum of reservations) form a shared pool usable
                 by any operation type. Defaults to {"consolidation": 2} if None.
+            consolidation_bank_priority: Per-bank priority for consolidation scheduling.
+                Maps bank name patterns to integer priorities (higher = claimed first).
+                Patterns support ``*`` as wildcard. A bare ``*`` key is the catch-all default.
+                When set, consolidation tasks are claimed in priority tiers rather than
+                pure created_at order. None or empty dict preserves current behavior.
         """
         self._backend = backend
         self._worker_id = worker_id
@@ -167,6 +173,9 @@ class WorkerPoller:
         self._max_slots = max_slots
         self._slot_reservations: dict[str, int] = (
             slot_reservations if slot_reservations is not None else {"consolidation": 2}
+        )
+        self._consolidation_bank_priority: dict[str, int] | None = (
+            consolidation_bank_priority if consolidation_bank_priority else None
         )
         # Cache of which optional PG routines are installed on the server
         # (probed once, memoised for the life of the poller).
@@ -468,6 +477,7 @@ class WorkerPoller:
                     self._worker_id,
                     reserved_limits,
                     shared_limit,
+                    consolidation_bank_priority=self._consolidation_bank_priority,
                 )
 
                 if not all_rows:

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3315,3 +3315,341 @@ class TestWorkerStatus:
         )
 
         assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# Config parsing tests for _parse_bank_priority
+# ---------------------------------------------------------------------------
+
+
+class TestParseBankPriority:
+    """Tests for the bank priority config parser."""
+
+    def test_empty_string_returns_empty_dict(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        assert _parse_bank_priority("") == {}
+        assert _parse_bank_priority("  ") == {}
+
+    def test_single_entry(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        assert _parse_bank_priority("shadow-meetings:10") == {"shadow-meetings": 10}
+
+    def test_multiple_entries_with_catch_all(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        result = _parse_bank_priority("shadow-*:10,staging-*:5,*:1")
+        assert result == {"shadow-*": 10, "staging-*": 5, "*": 1}
+
+    def test_spaces_are_stripped(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        result = _parse_bank_priority(" shadow-meetings : 10 , * : 1 ")
+        assert result == {"shadow-meetings": 10, "*": 1}
+
+    def test_invalid_no_colon_raises(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        with pytest.raises(ValueError, match="expected 'bank-pattern:priority'"):
+            _parse_bank_priority("shadow-meetings")
+
+    def test_invalid_priority_not_int_raises(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_bank_priority("shadow-meetings:abc")
+
+    def test_invalid_priority_zero_raises(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _parse_bank_priority("shadow-meetings:0")
+
+    def test_invalid_empty_pattern_raises(self):
+        from hindsight_api.config import _parse_bank_priority
+
+        with pytest.raises(ValueError, match="Empty bank pattern"):
+            _parse_bank_priority(":10")
+
+
+# ---------------------------------------------------------------------------
+# Consolidation bank priority tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidationBankPriority:
+    """Tests for priority-based consolidation task claiming."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
+    async def test_high_priority_bank_claimed_first(self, pool, backend, clean_operations):
+        """With priority set, higher-priority bank's task is claimed before lower-priority."""
+        from hindsight_api.worker import WorkerPoller
+
+        high_bank = f"test-worker-shadow-{uuid.uuid4().hex[:8]}"
+        low_bank = f"test-worker-other-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, high_bank)
+        await _ensure_bank(pool, low_bank)
+
+        # Insert low-priority task FIRST (older created_at)
+        low_op_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW() - interval '10 seconds')
+            """,
+            low_op_id,
+            low_bank,
+            json.dumps({"type": "consolidation", "bank_id": low_bank}),
+        )
+
+        # Insert high-priority task SECOND (newer created_at)
+        high_op_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW())
+            """,
+            high_op_id,
+            high_bank,
+            json.dumps({"type": "consolidation", "bank_id": high_bank}),
+        )
+
+        # Priority: shadow-* banks get priority 10, everything else gets 1
+        # Only claim 1 slot to prove ordering
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="test-worker-priority-1",
+            executor=lambda x: None,
+            max_slots=1,
+            slot_reservations={"consolidation": 1},
+            consolidation_bank_priority={"test-worker-shadow-*": 10, "*": 1},
+        )
+
+        claimed = await poller.claim_batch()
+
+        test_banks = {high_bank, low_bank}
+        my_claims = [c for c in claimed if c.task_dict.get("bank_id") in test_banks]
+
+        # High-priority bank should be claimed despite being newer
+        assert len(my_claims) == 1
+        assert my_claims[0].operation_id == str(high_op_id)
+        assert my_claims[0].task_dict["bank_id"] == high_bank
+
+    @pytest.mark.asyncio
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
+    async def test_wildcard_pattern_matching(self, pool, backend, clean_operations):
+        """Wildcard patterns like shadow-* match banks with that prefix."""
+        from hindsight_api.worker import WorkerPoller
+
+        shadow_meetings = f"test-worker-shadow-meetings-{uuid.uuid4().hex[:8]}"
+        shadow_people = f"test-worker-shadow-people-{uuid.uuid4().hex[:8]}"
+        normal_bank = f"test-worker-normal-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, shadow_meetings)
+        await _ensure_bank(pool, shadow_people)
+        await _ensure_bank(pool, normal_bank)
+
+        # Insert normal bank first (oldest)
+        normal_op = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW() - interval '20 seconds')
+            """,
+            normal_op,
+            normal_bank,
+            json.dumps({"type": "consolidation", "bank_id": normal_bank}),
+        )
+
+        # Insert shadow banks (newer)
+        shadow_ops = []
+        for i, bank in enumerate([shadow_meetings, shadow_people]):
+            op_id = uuid.uuid4()
+            shadow_ops.append(op_id)
+            await pool.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+                VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW() - interval '1 seconds' * $4)
+                """,
+                op_id,
+                bank,
+                json.dumps({"type": "consolidation", "bank_id": bank}),
+                10 - i,  # shadow_meetings=9s ago, shadow_people=8s ago
+            )
+
+        # shadow-* gets priority 10, all 3 slots available
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="test-worker-priority-2",
+            executor=lambda x: None,
+            max_slots=3,
+            slot_reservations={"consolidation": 3},
+            consolidation_bank_priority={"test-worker-shadow-*": 10, "*": 1},
+        )
+
+        claimed = await poller.claim_batch()
+        test_banks = {shadow_meetings, shadow_people, normal_bank}
+        my_claims = [c for c in claimed if c.task_dict.get("bank_id") in test_banks]
+
+        # All 3 should be claimed, but shadow banks first
+        assert len(my_claims) == 3
+        claimed_bank_ids = [c.task_dict["bank_id"] for c in my_claims]
+        # First two should be shadow banks (order between them is by created_at)
+        assert set(claimed_bank_ids[:2]) == {shadow_meetings, shadow_people}
+        # Last should be normal bank
+        assert claimed_bank_ids[2] == normal_bank
+
+    @pytest.mark.asyncio
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
+    async def test_catch_all_default_priority(self, pool, backend, clean_operations):
+        """When no wildcard *, unlisted banks still get claimed at default priority 1."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank = f"test-worker-unlisted-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank)
+
+        op_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            op_id,
+            bank,
+            json.dumps({"type": "consolidation", "bank_id": bank}),
+        )
+
+        # Priority map has specific patterns but no catch-all *
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="test-worker-priority-3",
+            executor=lambda x: None,
+            consolidation_bank_priority={"some-other-bank": 10},
+        )
+
+        claimed = await poller.claim_batch()
+        my_claims = [c for c in claimed if c.task_dict.get("bank_id") == bank]
+
+        # Unlisted bank should still be claimed (catch-all tier at priority 1)
+        assert len(my_claims) == 1
+        assert my_claims[0].operation_id == str(op_id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
+    async def test_unset_priority_preserves_created_at_order(self, pool, backend, clean_operations):
+        """When priority is unset (None), tasks are claimed in created_at order (backwards compat)."""
+        from hindsight_api.worker import WorkerPoller
+
+        old_bank = f"test-worker-old-{uuid.uuid4().hex[:8]}"
+        new_bank = f"test-worker-new-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, old_bank)
+        await _ensure_bank(pool, new_bank)
+
+        old_op = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW() - interval '10 seconds')
+            """,
+            old_op,
+            old_bank,
+            json.dumps({"type": "consolidation", "bank_id": old_bank}),
+        )
+
+        new_op = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, created_at)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb, NOW())
+            """,
+            new_op,
+            new_bank,
+            json.dumps({"type": "consolidation", "bank_id": new_bank}),
+        )
+
+        # No priority set — should use created_at order
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="test-worker-priority-4",
+            executor=lambda x: None,
+            max_slots=1,
+            slot_reservations={"consolidation": 1},
+        )
+
+        claimed = await poller.claim_batch()
+        test_banks = {old_bank, new_bank}
+        my_claims = [c for c in claimed if c.task_dict.get("bank_id") in test_banks]
+
+        # Older task should be claimed first
+        assert len(my_claims) == 1
+        assert my_claims[0].operation_id == str(old_op)
+
+    @pytest.mark.asyncio
+    @pytest.mark.flaky(reruns=2, reruns_delay=2)
+    async def test_priority_respects_bank_serialization(self, pool, backend, clean_operations):
+        """High-priority bank with a processing consolidation is still excluded."""
+        from hindsight_api.worker import WorkerPoller
+
+        high_bank = f"test-worker-shadow-ser-{uuid.uuid4().hex[:8]}"
+        low_bank = f"test-worker-other-ser-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, high_bank)
+        await _ensure_bank(pool, low_bank)
+
+        # High-priority bank already has a processing consolidation
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'other-worker')
+            """,
+            uuid.uuid4(),
+            high_bank,
+            json.dumps({"type": "consolidation", "bank_id": high_bank}),
+        )
+
+        # High-priority bank has a pending consolidation (should be skipped)
+        high_pending_op = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            high_pending_op,
+            high_bank,
+            json.dumps({"type": "consolidation", "bank_id": high_bank}),
+        )
+
+        # Low-priority bank has a pending consolidation (should be claimed)
+        low_op = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'pending', $3::jsonb)
+            """,
+            low_op,
+            low_bank,
+            json.dumps({"type": "consolidation", "bank_id": low_bank}),
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="test-worker-priority-5",
+            executor=lambda x: None,
+            consolidation_bank_priority={"test-worker-shadow-*": 10, "*": 1},
+        )
+
+        claimed = await poller.claim_batch()
+        test_banks = {high_bank, low_bank}
+        my_claims = [c for c in claimed if c.task_dict.get("bank_id") in test_banks]
+
+        # Only the low-priority bank should be claimed (high-priority is busy)
+        assert len(my_claims) == 1
+        assert my_claims[0].operation_id == str(low_op)
+        assert my_claims[0].task_dict["bank_id"] == low_bank
+
+        # Verify high-priority pending task is still pending
+        row = await pool.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            high_pending_op,
+        )
+        assert row["status"] == "pending"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1325,6 +1325,7 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Reserved slots for consolidation tasks within `WORKER_MAX_SLOTS` (bank-serialization preserved) | `2` |
+| `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` | Per-bank priority for consolidation scheduling (see note below) | _(unset)_ |
 | `HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS` | Reserved slots for retain tasks within `WORKER_MAX_SLOTS` | `0` |
 | `HINDSIGHT_API_WORKER_FILE_CONVERT_RETAIN_MAX_SLOTS` | Reserved slots for file_convert_retain tasks within `WORKER_MAX_SLOTS` | `0` |
 | `HINDSIGHT_API_WORKER_REFRESH_MENTAL_MODEL_MAX_SLOTS` | Reserved slots for refresh_mental_model tasks within `WORKER_MAX_SLOTS` | `0` |
@@ -1336,6 +1337,17 @@ Per-operation `*_MAX_SLOTS` values are **reservations within** `WORKER_MAX_SLOTS
 Example: `MAX_SLOTS=10, CONSOLIDATION=2, RETAIN=3, REFRESH_MENTAL_MODEL=2` → shared pool = `10 - (2+3+2) = 3`.
 
 With the defaults (`MAX_SLOTS=10`, `CONSOLIDATION_MAX_SLOTS=2`, all other reservations `0`), 2 slots are always reserved for consolidation and the remaining 8 form the shared pool for any operation type. Set `CONSOLIDATION_MAX_SLOTS=0` to release consolidation's reserved capacity into the shared pool.
+:::
+
+:::note Consolidation bank priority
+`HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` controls which banks' consolidation tasks are claimed first when a slot becomes available. Format: comma-separated `bank-pattern:priority` pairs where higher numbers mean higher priority. Patterns support `*` as a wildcard; a bare `*` is the catch-all default for unlisted banks (defaults to `1` if omitted).
+
+Example:
+```
+HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY="shadow-*:10,staging-*:5,*:1"
+```
+
+This ensures `shadow-*` banks are always consolidated before others, even if their tasks were submitted later. Useful for deployments with asymmetric bank sizes where a large bank might be starved by many small banks cycling through limited slots. Bank-serialization (max one concurrent consolidation per bank) is preserved regardless of priority. When unset, consolidation tasks are claimed in `created_at` order (default behavior).
 :::
 
 ### Performance Optimization


### PR DESCRIPTION
## Summary

Closes #1715

- Adds `HINDSIGHT_API_WORKER_CONSOLIDATION_BANK_PRIORITY` env var to control which banks' consolidation tasks are claimed first when a slot opens
- Prevents large banks (e.g., 486K-node `shadow-meetings`) from being starved by many small banks cycling through limited global consolidation slots
- Uses **tiered claiming** — each priority level is a separate index-friendly query (no JOINs or computed ORDER BY). Number of queries = number of distinct priority tiers (typically 2). Zero overhead when unset
- Pattern wildcards supported (e.g., `shadow-*:10,staging-*:5,*:1`), using `LIKE ANY` / `NOT LIKE ALL` in PostgreSQL, expanded to `OR`/`AND` clauses for Oracle
- Bank serialization (max 1 concurrent consolidation per bank) is preserved regardless of priority
- Backwards compatible: when unset, behavior is identical to current `ORDER BY created_at`

### Design decision: priority queues vs per-bank slot reservation

The original issue proposed per-bank slot allocation (`SLOTS_PER_BANK`). We chose priority-based scheduling instead because:
- Consolidation batches are short-lived (capped at 100 memories, then reschedule), so the real problem is scheduling order, not slot reservation
- Priority queues waste no capacity — when a high-priority bank has no pending work, other banks use the slots freely
- This matches standard distributed task system patterns (Celery, SQS, Sidekiq)

## Test plan

- [x] 8 unit tests for config parsing (`TestParseBankPriority`)
- [x] 5 integration tests against real PostgreSQL (`TestConsolidationBankPriority`):
  - High-priority bank claimed before low-priority despite newer `created_at`
  - Wildcard pattern matching (`shadow-*` matches `shadow-meetings`, `shadow-people`)
  - Catch-all default for unlisted banks
  - Backwards compat when priority unset
  - Priority respects bank serialization (busy high-priority bank still excluded)
- [x] All 80 existing worker tests pass with no regressions
- [x] Lint passes