### PR TITLE
docs(docker): add local llama.cpp sidecar compose example

### DIFF
--- a/docker/docker-compose/local-llm/README.md
+++ b/docker/docker-compose/local-llm/README.md
@@ -1,0 +1,103 @@
+# Hindsight with a local llama.cpp server sidecar
+
+Example Docker Compose setup that runs Hindsight against a **local
+llama.cpp server**, fully offline, with no external API key required.
+
+## Architecture
+
+```
+┌────────────┐  HTTP /v1/chat/completions  ┌──────────────────────────────┐
+│ hindsight  │ ──────────────────────────▶ │ llama.cpp server (sidecar)   │
+│ (API + CP) │                             │ ghcr.io/ggml-org/llama.cpp   │
+└────────────┘                             └──────────────────────────────┘
+```
+
+`llama.cpp` runs as its own container and exposes an OpenAI-compatible
+HTTP API. Hindsight talks to it via the standard `openai` LLM provider
+with `HINDSIGHT_API_LLM_BASE_URL` pointed at the sidecar.
+
+This pattern follows
+[*Hosting llama-server with Docker* (ServiceStack)](https://servicestack.net/posts/hosting-llama-server).
+
+### Why a sidecar and not the in-process `llamacpp` provider?
+
+Hindsight does ship an in-process `llamacpp` provider that spawns
+`llama-cpp-python`, but the **published `ghcr.io/vectorize-io/hindsight`
+image deliberately omits `llama-cpp-python`** to keep the image small and
+avoid bundling native inference libraries that most users don't need.
+Trying to set `HINDSIGHT_API_LLM_PROVIDER=llamacpp` against the published
+image fails with `ModuleNotFoundError: No module named 'llama_cpp'`.
+
+The sidecar approach side-steps that entirely: the official llama.cpp
+image is used as-is for inference, Hindsight is used as-is for memory.
+Clean separation, no derived images.
+
+## Quick start
+
+```bash
+docker compose -f docker/docker-compose/local-llm/docker-compose.yaml up
+```
+
+- API: http://localhost:8888
+- Control Plane: http://localhost:9999
+
+**First boot downloads ~3.5 GB** (Gemma 4 E2B Q4_K_M GGUF) into the
+`llama_models` named volume. Subsequent boots reuse it.
+
+Hindsight only starts after llama.cpp's `/health` endpoint reports
+healthy, so the API will appear "stuck" for a few minutes on the first
+run while the model downloads.
+
+## Using a different model
+
+Override the HuggingFace repo / file in `docker-compose.yaml`:
+
+```yaml
+environment:
+  LLAMA_ARG_HF_REPO: bartowski/Qwen2.5-7B-Instruct-GGUF
+  LLAMA_ARG_HF_FILE: Qwen2.5-7B-Instruct-Q4_K_M.gguf
+```
+
+Also update `HINDSIGHT_API_LLM_MODEL` on the `hindsight` service to a
+matching alias (the value is sent to llama-server as the OpenAI `model`
+field — llama-server is lenient about this but it shows up in logs).
+
+## GPU acceleration
+
+The default compose file targets CPU because not everyone has a GPU. On
+CPU, Gemma 4 E2B runs at ~2-3 tokens/sec — fine for a smoke test, but the
+retain pipeline (which makes several multi-hundred-token LLM calls per
+memory) will time out against Hindsight's default LLM timeout. **For any
+real use, run on a GPU.**
+
+### NVIDIA
+
+1. Switch the `llama` service image from `:server` to `:server-cuda`.
+2. Uncomment the `LLAMA_ARG_N_GPU_LAYERS: "999"` env var (offload all
+   layers to GPU).
+3. Uncomment the `deploy.resources.reservations.devices` block.
+4. Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+   on the host.
+
+The compose file has all four spots marked with inline comments.
+
+### Apple Silicon / ROCm / Vulkan
+
+The official `ghcr.io/ggml-org/llama.cpp` image only ships CPU and CUDA
+variants. For Metal (Apple Silicon), ROCm (AMD), or Vulkan backends,
+build llama.cpp yourself with the appropriate flags and reference the
+image you build instead. Docker Desktop on macOS cannot pass through the
+host GPU to a Linux container in any case — for Apple Silicon, run
+llama-server directly on the host and only put Hindsight in Docker.
+
+## Caveats
+
+- llama.cpp's HTTP API is OpenAI-compatible but not 100% feature-parity.
+  Function/tool calling support depends on the chat template baked into
+  the GGUF; some retain/reflect flows may behave differently than against
+  a hosted OpenAI model.
+- Small GGUFs (~3 B params) are useful for smoke testing but will
+  underperform a hosted frontier model on retain quality. Use a larger
+  GGUF (7-13 B params) for production-quality memory.
+- The `llama_models` named volume persists the GGUF across `docker
+  compose down`/`up` so the model is downloaded once, not every restart.

--- a/docker/docker-compose/local-llm/docker-compose.yaml
+++ b/docker/docker-compose/local-llm/docker-compose.yaml
@@ -1,0 +1,74 @@
+name: hindsight-local-llm
+# Example: run Hindsight against a local llama.cpp server sidecar — fully
+# offline, no external API key needed.
+#
+# Pattern follows https://servicestack.net/posts/hosting-llama-server :
+# llama.cpp runs as its own container exposing an OpenAI-compatible HTTP
+# API, and Hindsight talks to it via the `openai` LLM provider with a
+# custom `base_url`. This means we can use the published Hindsight image
+# unchanged — no derived Dockerfile, no `llama-cpp-python` install on top.
+#
+# Quick start:
+#   docker compose -f docker/docker-compose/local-llm/docker-compose.yaml up
+#
+# First boot downloads the default Gemma 4 E2B GGUF (~3.5 GB) into the
+# `llama_models` volume; subsequent boots reuse it.
+
+services:
+  llama:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    container_name: hindsight-local-llm-llama
+    environment:
+      LLAMA_ARG_HOST: 0.0.0.0
+      LLAMA_ARG_PORT: "8080"
+      # Auto-download a small GGUF from HuggingFace on first start.
+      # Override these to use a different model.
+      LLAMA_ARG_HF_REPO: bartowski/google_gemma-4-E2B-it-GGUF
+      LLAMA_ARG_HF_FILE: google_gemma-4-E2B-it-Q4_K_M.gguf
+      LLAMA_ARG_CTX_SIZE: "8192"
+      # Uncomment for NVIDIA GPU (and switch image to :server-cuda):
+      # LLAMA_ARG_N_GPU_LAYERS: "999"
+    volumes:
+      # llama-server stores HuggingFace downloads under ~/.cache/huggingface
+      # (not ~/.cache/llama.cpp), so mount the named volume there to avoid
+      # re-downloading the GGUF on every recreate.
+      - llama_models:/root/.cache/huggingface
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
+    # For NVIDIA GPU acceleration, swap the image above to
+    # `ghcr.io/ggml-org/llama.cpp:server-cuda` and uncomment:
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  hindsight:
+    image: ghcr.io/vectorize-io/hindsight:latest
+    container_name: hindsight-local-llm
+    depends_on:
+      llama:
+        condition: service_healthy
+    ports:
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      # llama-server is OpenAI-compatible, so use the `openai` provider and
+      # point base_url at the sidecar. The API key is unused by llama-server
+      # but Hindsight requires the env var to be set.
+      HINDSIGHT_API_LLM_PROVIDER: openai
+      HINDSIGHT_API_LLM_BASE_URL: http://llama:8080/v1
+      HINDSIGHT_API_LLM_API_KEY: not-needed
+      HINDSIGHT_API_LLM_MODEL: gemma-4-e2b-it
+    volumes:
+      - pg_data:/home/hindsight/.pg0
+
+volumes:
+  pg_data:
+  llama_models:

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -40,6 +40,8 @@ See [Configuration](./configuration#llm-provider) for setup examples.
 :::tip Built-in llama.cpp (fully local, no API key)
 Set `HINDSIGHT_API_LLM_PROVIDER=llamacpp` to run a built-in llama.cpp server with no external dependencies. A Gemma 4 E2B GGUF model (~3.5 GB) is auto-downloaded on first run. Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
 
+The published Docker image does not bundle `llama-cpp-python` (to keep the image small). For a runnable Docker setup that adds it on top, see [`docker/docker-compose/local-llm/`](https://github.com/vectorize-io/hindsight/tree/main/docker/docker-compose/local-llm).
+
 See [Configuration](./configuration#built-in-llamacpp) for all options.
 :::
 


### PR DESCRIPTION
## Summary

- Reported bug: setting `HINDSIGHT_API_LLM_PROVIDER=llamacpp` against the published `ghcr.io/vectorize-io/hindsight:latest` image fails with `ModuleNotFoundError: No module named 'llama_cpp'`. The Docker image deliberately omits the `local-llm` extra to keep image size down, and that constraint isn't documented anywhere users would find it.
- Adds `docker/docker-compose/local-llm/` — a runnable compose recipe that runs the official `ghcr.io/ggml-org/llama.cpp:server` container as a sidecar and points Hindsight's `openai` provider at it via `HINDSIGHT_API_LLM_BASE_URL`. No derived image needed, no native deps to install on top of the Hindsight container. Pattern based on [Hosting llama-server with Docker (ServiceStack)](https://servicestack.net/posts/hosting-llama-server).
- Named volume mounted at `/root/.cache/huggingface` (where `llama-server` actually caches downloads — `~/.cache/llama.cpp` is empty in practice) so the GGUF survives `docker compose down`/`up`.
- README documents CPU perf reality (Gemma 4 E2B at ~2-3 tok/s on CPU is too slow for the retain pipeline) and the four spots to flip for NVIDIA GPU. Apple Silicon / ROCm / Vulkan called out as out-of-scope because the official llama.cpp image only ships CPU and CUDA variants.
- Links the recipe from the "Built-in llama.cpp" tip in `hindsight-docs/docs/developer/models.mdx` so users following the docs find it.

## Test plan

- [x] `docker compose -f docker/docker-compose/local-llm/docker-compose.yaml up` brings both containers up clean.
- [x] llama-server downloads `bartowski/google_gemma-4-E2B-it-GGUF` on first boot and the `llama` container's healthcheck passes.
- [x] Hindsight waits for llama's healthcheck, then `/health` returns `{"status":"healthy","database":"connected"}` and the Control Plane is reachable on `:9999`.
- [x] A `POST .../memories` retain call reaches llama.cpp end-to-end (verified via llama-server's `slot print_timing` logs — generation runs at ~2.7 tok/s on CPU, confirming the OpenAI-compatible bridge works).
- [ ] **Not verified, follow-up:** confirm that `docker compose down` + `up` reuses the cached GGUF instead of re-downloading. The volume path was set based on the live filesystem (`lsof` of `/proc/1/fd/` on the running llama container) but I didn't run the full down/up cycle to prove it because that would re-pull ~3.5 GB.
- [ ] **Not verified:** NVIDIA GPU mode — host has no NVIDIA hardware. The commented blocks mirror the ServiceStack reference verbatim.