### PR TITLE
fix(api): honor explicit daemon host and port

### DIFF
--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -73,29 +73,42 @@ def _signal_handler(signum, frame):
     sys.exit(0)
 
 
-def resolve_daemon_host_port(*, args_host: str, args_port: int, config_host: str, config_port: int) -> tuple[str, int]:
+@dataclasses.dataclass(frozen=True)
+class ResolvedDaemonHostPort:
+    host: str
+    port: int
+
+
+def resolve_daemon_host_port(
+    *,
+    args_host: str,
+    args_port: int,
+    explicit_host: bool,
+    explicit_port: bool,
+) -> ResolvedDaemonHostPort:
     """Resolve host/port for daemon mode.
 
     Defaults to 127.0.0.1 for security, but honors explicit user overrides
     via --host flag or HINDSIGHT_API_HOST env var. Uses DEFAULT_DAEMON_PORT
     unless the user specified a custom port.
     """
-    port = args_port if args_port != config_port else DEFAULT_DAEMON_PORT
+    port = args_port if explicit_port else DEFAULT_DAEMON_PORT
     # Only force localhost if the user didn't explicitly set a host
-    if args_host != config_host or os.environ.get(ENV_HOST):
+    if explicit_host or os.environ.get(ENV_HOST):
         host = args_host
     else:
         host = "127.0.0.1"
-    return host, port
+    return ResolvedDaemonHostPort(host=host, port=port)
 
 
-def main():
-    """Main entry point for the CLI."""
-    global _memory
+@dataclasses.dataclass(frozen=True)
+class ParsedCliArgs:
+    args: argparse.Namespace
+    explicit_host: bool
+    explicit_port: bool
 
-    # Load configuration from environment (for CLI args defaults)
-    config = _get_raw_config()
 
+def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
     parser = argparse.ArgumentParser(
         prog="hindsight-api",
         description="Hindsight API Server",
@@ -103,12 +116,14 @@ def main():
 
     # Server options
     parser.add_argument(
-        "--host", default=config.host, help=f"Host to bind to (default: {config.host}, env: HINDSIGHT_API_HOST)"
+        "--host",
+        default=argparse.SUPPRESS,
+        help=f"Host to bind to (default: {config.host}, env: HINDSIGHT_API_HOST)",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=config.port,
+        default=argparse.SUPPRESS,
         help=f"Port to bind to (default: {config.port}, env: HINDSIGHT_API_PORT)",
     )
     parser.add_argument(
@@ -166,7 +181,27 @@ def main():
         help=f"Idle timeout in seconds before auto-exit in daemon mode (default: {DEFAULT_IDLE_TIMEOUT})",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    explicit_host = hasattr(args, "host")
+    explicit_port = hasattr(args, "port")
+    if not explicit_host:
+        args.host = config.host
+    if not explicit_port:
+        args.port = config.port
+
+    return ParsedCliArgs(args=args, explicit_host=explicit_host, explicit_port=explicit_port)
+
+
+def main():
+    """Main entry point for the CLI."""
+    global _memory
+
+    # Load configuration from environment (for CLI args defaults)
+    config = _get_raw_config()
+
+    parsed_cli_args = _parse_cli_args(sys.argv[1:], config)
+    args = parsed_cli_args.args
 
     # Daemon mode handling.
     # is_daemon_child is True when we are the re-exec'd child spawned by
@@ -177,12 +212,14 @@ def main():
     is_daemon = args.daemon or is_daemon_child
 
     if is_daemon:
-        args.host, args.port = resolve_daemon_host_port(
+        resolved_daemon_host_port = resolve_daemon_host_port(
             args_host=args.host,
             args_port=args.port,
-            config_host=config.host,
-            config_port=config.port,
+            explicit_host=parsed_cli_args.explicit_host,
+            explicit_port=parsed_cli_args.explicit_port,
         )
+        args.host = resolved_daemon_host_port.host
+        args.port = resolved_daemon_host_port.port
 
         # Detach into background (parent re-execs and exits; child redirects
         # stdio to log file).  No lockfile needed — port binding prevents
@@ -256,8 +293,6 @@ def main():
     # When using workers or reload, we must use import string so each worker can import the app
     use_import_string = args.workers > 1 or args.reload
     # Check for uvloop/winloop availability
-    import sys
-
     loop_impl = "asyncio"
     if sys.platform == "win32":
         try:

--- a/hindsight-api-slim/tests/test_daemon_host_resolution.py
+++ b/hindsight-api-slim/tests/test_daemon_host_resolution.py
@@ -7,11 +7,17 @@ See: https://github.com/vectorize-io/hindsight/issues/1402
 """
 
 from hindsight_api.daemon import DEFAULT_DAEMON_PORT
-from hindsight_api.main import resolve_daemon_host_port
+from hindsight_api.main import _parse_cli_args, resolve_daemon_host_port
 
 # Default config values matching production defaults
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8888
+
+
+class _Config:
+    host = DEFAULT_HOST
+    port = DEFAULT_PORT
+    log_level = "info"
 
 
 class TestResolveDaemonHostPort:
@@ -20,65 +26,145 @@ class TestResolveDaemonHostPort:
     def test_defaults_to_localhost_when_no_override(self, monkeypatch):
         """With no explicit host setting, daemon should bind to 127.0.0.1."""
         monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
-        host, port = resolve_daemon_host_port(
-            args_host=DEFAULT_HOST, args_port=DEFAULT_PORT,
-            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
         )
-        assert host == "127.0.0.1"
-        assert port == DEFAULT_DAEMON_PORT
+        assert resolved.host == "127.0.0.1"
+        assert resolved.port == DEFAULT_DAEMON_PORT
 
     def test_honors_cli_host_flag(self, monkeypatch):
         """--host 0.0.0.0 --daemon should bind to 0.0.0.0, not 127.0.0.1."""
         monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
-        host, port = resolve_daemon_host_port(
-            args_host="0.0.0.0", args_port=DEFAULT_PORT,
-            config_host="127.0.0.1", config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host="0.0.0.0",
+            args_port=DEFAULT_PORT,
+            explicit_host=True,
+            explicit_port=False,
         )
-        assert host == "0.0.0.0"
+        assert resolved.host == "0.0.0.0"
+
+    def test_honors_cli_host_flag_matching_config_default(self, monkeypatch):
+        """An explicit --host should be honored even when it matches config."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=DEFAULT_PORT,
+            explicit_host=True,
+            explicit_port=False,
+        )
+        assert resolved.host == DEFAULT_HOST
 
     def test_honors_env_var_host(self, monkeypatch):
         """HINDSIGHT_API_HOST=0.0.0.0 --daemon should bind to 0.0.0.0."""
         monkeypatch.setenv("HINDSIGHT_API_HOST", "0.0.0.0")
         # When env var is set, config.host already reflects it, so
-        # args_host == config_host — but the env var presence is the signal.
-        host, port = resolve_daemon_host_port(
-            args_host="0.0.0.0", args_port=DEFAULT_PORT,
-            config_host="0.0.0.0", config_port=DEFAULT_PORT,
+        # args_host matches the config default, but the env var presence is the signal.
+        resolved = resolve_daemon_host_port(
+            args_host="0.0.0.0",
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
         )
-        assert host == "0.0.0.0"
+        assert resolved.host == "0.0.0.0"
 
     def test_honors_custom_host_via_env(self, monkeypatch):
         """HINDSIGHT_API_HOST=10.0.0.5 should be respected in daemon mode."""
         monkeypatch.setenv("HINDSIGHT_API_HOST", "10.0.0.5")
-        host, _ = resolve_daemon_host_port(
-            args_host="10.0.0.5", args_port=DEFAULT_PORT,
-            config_host="10.0.0.5", config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host="10.0.0.5",
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
         )
-        assert host == "10.0.0.5"
+        assert resolved.host == "10.0.0.5"
 
     def test_cli_flag_overrides_env_var(self, monkeypatch):
         """--host flag should take precedence over env var."""
         monkeypatch.setenv("HINDSIGHT_API_HOST", "10.0.0.5")
-        host, _ = resolve_daemon_host_port(
-            args_host="192.168.1.1", args_port=DEFAULT_PORT,
-            config_host="10.0.0.5", config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host="192.168.1.1",
+            args_port=DEFAULT_PORT,
+            explicit_host=True,
+            explicit_port=False,
         )
-        assert host == "192.168.1.1"
+        assert resolved.host == "192.168.1.1"
 
     def test_custom_port_preserved(self, monkeypatch):
         """--port 9999 --daemon should keep 9999, not switch to daemon default."""
         monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
-        _, port = resolve_daemon_host_port(
-            args_host=DEFAULT_HOST, args_port=9999,
-            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=9999,
+            explicit_host=False,
+            explicit_port=True,
         )
-        assert port == 9999
+        assert resolved.port == 9999
+
+    def test_explicit_port_matching_config_is_preserved(self, monkeypatch):
+        """--port should be honored even when it matches HINDSIGHT_API_PORT."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=9555,
+            explicit_host=False,
+            explicit_port=True,
+        )
+        assert resolved.port == 9555
 
     def test_default_port_becomes_daemon_port(self, monkeypatch):
         """No --port flag in daemon mode should use DEFAULT_DAEMON_PORT."""
         monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
-        _, port = resolve_daemon_host_port(
-            args_host=DEFAULT_HOST, args_port=DEFAULT_PORT,
-            config_host=DEFAULT_HOST, config_port=DEFAULT_PORT,
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
         )
-        assert port == DEFAULT_DAEMON_PORT
+        assert resolved.port == DEFAULT_DAEMON_PORT
+
+    def test_env_port_without_cli_still_uses_daemon_default(self, monkeypatch):
+        """HINDSIGHT_API_PORT alone does not override daemon mode's default."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=9555,
+            explicit_host=False,
+            explicit_port=False,
+        )
+        assert resolved.port == DEFAULT_DAEMON_PORT
+
+    def test_argparse_marks_abbreviated_port_as_explicit(self, monkeypatch):
+        """Argparse-accepted --po should be treated like explicit --port."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        config = _Config()
+        config.port = 9555
+        parsed = _parse_cli_args(["--daemon", "--po", "9555"], config)
+        assert parsed.args.port == 9555
+        assert parsed.explicit_port is True
+
+        resolved = resolve_daemon_host_port(
+            args_host=parsed.args.host,
+            args_port=parsed.args.port,
+            explicit_host=parsed.explicit_host,
+            explicit_port=parsed.explicit_port,
+        )
+        assert resolved.port == 9555
+
+    def test_argparse_marks_abbreviated_host_as_explicit(self, monkeypatch):
+        """Argparse-accepted --ho should be treated like explicit --host."""
+        monkeypatch.delenv("HINDSIGHT_API_HOST", raising=False)
+        config = _Config()
+        parsed = _parse_cli_args(["--daemon", "--ho", DEFAULT_HOST], config)
+        assert parsed.args.host == DEFAULT_HOST
+        assert parsed.explicit_host is True
+
+        resolved = resolve_daemon_host_port(
+            args_host=parsed.args.host,
+            args_port=parsed.args.port,
+            explicit_host=parsed.explicit_host,
+            explicit_port=parsed.explicit_port,
+        )
+        assert resolved.host == DEFAULT_HOST


### PR DESCRIPTION
## Summary

Fix daemon-mode host/port resolution so explicit CLI values are honored even when they match environment-derived config defaults.

Before this change, daemon mode inferred whether `--host` or `--port` had been explicitly supplied by comparing parsed argparse values with the loaded config. That breaks when the CLI value equals an environment-derived default. For example:

```bash
HINDSIGHT_API_PORT=9555 hindsight-api --daemon --port 9555
```

`argparse` parsed `args.port=9555`, config also had `port=9555`, and daemon mode treated the port as implicit, falling back to `DEFAULT_DAEMON_PORT` (`8888`). This caused `hindsight-embed` named profile startup to wait on the profile port while the API daemon listened on the default daemon port instead.

## Changes

- Track explicit `--host` / `--port` through argparse itself using `argparse.SUPPRESS` defaults.
- Preserve explicit daemon host/port values even when they match config defaults.
- Keep argparse-accepted long-option abbreviations, such as `--po` and `--ho`, on the same explicit-argument path.
- Return a named dataclass from daemon host/port resolution instead of a multi-value tuple.
- Extend daemon host/port tests for:
  - explicit `--port` matching `HINDSIGHT_API_PORT`
  - env-only port still using daemon default behavior
  - explicit `--host` matching config default
  - argparse abbreviations `--po` and `--ho`

## Tests

```bash
uv run ruff check hindsight_api/main.py tests/test_daemon_host_resolution.py
uv run ruff format --check hindsight_api/main.py tests/test_daemon_host_resolution.py
uv run ty check hindsight_api/main.py
uv run pytest tests/test_daemon_host_resolution.py tests/test_daemonize.py
```

`tests/test_daemon_host_resolution.py tests/test_daemonize.py`: 15 passed.

Note: the full local pre-commit hook currently also runs `generate-docs-skill.sh`, which reports existing generated-docs drift unrelated to this daemon fix. This PR intentionally keeps the daemon fix scoped to `hindsight-api-slim/hindsight_api/main.py` and `hindsight-api-slim/tests/test_daemon_host_resolution.py`.

Fixes #1786.