### PR TITLE
chore: regenerate docs-skill references after v0.7.1

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -933,9 +933,7 @@ def _parse_bank_priority(raw: str) -> dict[str, int]:
         try:
             priority = int(priority_str)
         except ValueError:
-            raise ValueError(
-                f"Invalid priority '{priority_str}' in entry '{entry}': must be an integer"
-            ) from None
+            raise ValueError(f"Invalid priority '{priority_str}' in entry '{entry}': must be an integer") from None
         if priority < 1:
             raise ValueError(f"Priority must be >= 1, got {priority} in entry '{entry}'")
         result[pattern] = priority

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
Output of ./scripts/generate-docs-skill.sh - picks up the API version bump (0.7.0 -> 0.7.1) in openapi.json. CI's verify-generated-files gate flags this as out-of-sync on every new branch off main; this commit clears the gate without affecting API behaviour.

Also folds in the ./scripts/hooks/lint.sh formatter output for the priority parser so the lint hook stays clean.