### PR TITLE
docs(multilingual): add pg_search backend to BM25 selector and comparison table

### DIFF
--- a/hindsight-docs/docs/developer/multilingual.md
+++ b/hindsight-docs/docs/developer/multilingual.md
@@ -193,7 +193,7 @@ The semantic (embedding) arm covers cross-lingual matches by meaning. Hindsight 
 
 There are two knobs that interact:
 
-- `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` — selects the backend (`native`, `vchord`, `pg_textsearch`, or `pgroonga`).
+- `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` — selects the backend (`native`, `vchord`, `pg_textsearch`, `pgroonga`, or `pg_search`).
 - `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE` — selects the PostgreSQL dictionary used by the `native` backend (default: `english`).
 
 Pick the backend based on the languages your bank stores:
@@ -204,6 +204,7 @@ Pick the backend based on the languages your bank stores:
 | `vchord` | Multilingual via `llmlingua2` tokenizer. | Best when you're already using vchord for vector search. |
 | `pg_textsearch` | English only (hardcoded). | Industry-standard BM25 ranking + Block-Max WAND. |
 | `pgroonga` | **Yes — out of the box.** Single index handles English, CJK, and mixed-script content via the `TokenBigram` polyglot tokenizer + `NormalizerNFKC150` Unicode normalization. | Recommended for non-English / mixed-language banks. Requires the `pgroonga` extension. See `docker/docker-compose/pgroonga/`. |
+| `pg_search` | Multilingual via configurable tokenizer (e.g. `chinese_compatible`, `jieba`, `chinese_lindera`, `japanese_lindera`, `korean_lindera`, `ngram`). | ParadeDB `pg_search` extension; the only Citus-compatible BM25 backend. Tokenizer set via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`. See `docker/docker-compose/pg_search/`. |
 
 **Choosing for a single-language bank** (e.g. all Spanish content):
 ```bash

--- a/skills/hindsight-docs/references/developer/multilingual.md
+++ b/skills/hindsight-docs/references/developer/multilingual.md
@@ -193,7 +193,7 @@ The semantic (embedding) arm covers cross-lingual matches by meaning. Hindsight 
 
 There are two knobs that interact:
 
-- `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` — selects the backend (`native`, `vchord`, `pg_textsearch`, or `pgroonga`).
+- `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` — selects the backend (`native`, `vchord`, `pg_textsearch`, `pgroonga`, or `pg_search`).
 - `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_NATIVE_LANGUAGE` — selects the PostgreSQL dictionary used by the `native` backend (default: `english`).
 
 Pick the backend based on the languages your bank stores:
@@ -204,6 +204,7 @@ Pick the backend based on the languages your bank stores:
 | `vchord` | Multilingual via `llmlingua2` tokenizer. | Best when you're already using vchord for vector search. |
 | `pg_textsearch` | English only (hardcoded). | Industry-standard BM25 ranking + Block-Max WAND. |
 | `pgroonga` | **Yes — out of the box.** Single index handles English, CJK, and mixed-script content via the `TokenBigram` polyglot tokenizer + `NormalizerNFKC150` Unicode normalization. | Recommended for non-English / mixed-language banks. Requires the `pgroonga` extension. See `docker/docker-compose/pgroonga/`. |
+| `pg_search` | Multilingual via configurable tokenizer (e.g. `chinese_compatible`, `jieba`, `chinese_lindera`, `japanese_lindera`, `korean_lindera`, `ngram`). | ParadeDB `pg_search` extension; the only Citus-compatible BM25 backend. Tokenizer set via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION_PG_SEARCH_TOKENIZER`. See `docker/docker-compose/pg_search/`. |
 
 **Choosing for a single-language bank** (e.g. all Spanish content):
 ```bash


### PR DESCRIPTION
**Drift catch from #1755**: `pg_search` shipped as the 5th BM25 backend in v0.7.0 and was already added to `retrieval.md` (the "Five pluggable BM25 backends" table) and `configuration.md` (env-var description + tokenizer enum). `developer/multilingual.md` was not updated and still enumerates only 4 backends, so a user reading the multilingual page to pick a BM25 backend for their bank's language doesn't see `pg_search` at all — which is the only Citus-compatible option and the one with the richest tokenizer set for CJK / mixed scripts.

This adds:

1. **Backend selector bullet** (L196): extends `(native, vchord, pg_textsearch, or pgroonga)` → `(native, vchord, pg_textsearch, pgroonga, or pg_search)`.
2. **Comparison table row** (after pgroonga): the `pg_search` row, mirroring `retrieval.md` framing (Citus-compatible, configurable tokenizer) and `configuration.md` tokenizer enum (`chinese_compatible`, `jieba`, `chinese_lindera`, etc.).

Both surfaces (`hindsight-docs/docs/developer/multilingual.md` + `skills/hindsight-docs/references/developer/multilingual.md`) have the identical drift; both files are last touched on 2026-05-26 by #1538 (commit cb04cb79) ~13 min before #1755 landed `pg_search` (commit 4cd260b6). The v0.7.1 release sync commit picked up `versioned_docs/version-0.7/` automatically per the release process, so versioned snapshots are intentionally out of scope here.

If this is already covered by a separate patch, feel free to close and mark accordingly.
