### PR TITLE
fix(api): isolate claude-code provider subprocess from user plugins

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -9,6 +9,7 @@ automatically handles authentication via `claude auth login` credentials.
 import asyncio
 import json
 import logging
+import tempfile
 import time
 from typing import Any
 
@@ -19,6 +20,32 @@ from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult,
 from hindsight_api.metrics import get_metrics_collector
 
 logger = logging.getLogger(__name__)
+
+
+# Isolation env passed to the spawned `claude` CLI. CLAUDE_CONFIG_DIR
+# redirects the subprocess away from the host's ~/.claude/, so any
+# operator-installed plugins (e.g. hindsight-memory) and their Stop hooks do
+# not fire inside our LLM-call subprocesses. Without this, retain/reflect/
+# consolidation LLM calls would trigger a Stop-hook retain of the subprocess
+# transcript back into the same bank — a recursive feedback loop (issue #1751).
+# CLAUDE_SECURESTORAGE_CONFIG_DIR="" forces the CLI's keychain service name
+# back to the canonical un-suffixed entry that `claude auth login` wrote;
+# otherwise it would be namespaced by sha256(CLAUDE_CONFIG_DIR) and OAuth
+# lookup would fail. Requires bundled CLI >= 2.1.150 (claude-agent-sdk 0.2.82).
+_isolated_claude_env: dict[str, str] | None = None
+
+
+def _get_isolated_claude_env() -> dict[str, str]:
+    """Return a process-lifetime env dict that isolates the spawned CLI from user plugins."""
+    global _isolated_claude_env
+    if _isolated_claude_env is None:
+        path = tempfile.mkdtemp(prefix="hindsight-claude-code-")
+        _isolated_claude_env = {
+            "CLAUDE_CONFIG_DIR": path,
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR": "",
+        }
+        logger.debug(f"Claude Code: isolated CLAUDE_CONFIG_DIR={path}")
+    return _isolated_claude_env
 
 
 class ClaudeCodeLLM(LLMInterface):
@@ -183,6 +210,7 @@ class ClaudeCodeLLM(LLMInterface):
             system_prompt=system_prompt if system_prompt else None,
             max_turns=1,  # Single-turn for API-style interactions
             allowed_tools=[],  # Disable tools for standard LLM calls
+            env=_get_isolated_claude_env(),
         )
 
         # Call Claude Agent SDK
@@ -473,6 +501,7 @@ class ClaudeCodeLLM(LLMInterface):
             max_turns=2,  # Allow tool call + tool result round-trip
             mcp_servers=mcp_servers_config,
             allowed_tools=allowed_tool_names,
+            env=_get_isolated_claude_env(),
         )
 
         # Call Claude Agent SDK with retry logic

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "sqlalchemy>=2.0.44",
     "alembic>=1.17.1",
     "pgvector>=0.4.1",
-    "greenlet>=3.2.4,<3.4.0",  # 3.4.0 lacks arm64 wheels for manylinux_2_41
+    "greenlet>=3.2.4,<3.4.0", # 3.4.0 lacks arm64 wheels for manylinux_2_41
     "psycopg2-binary>=2.9.11",
     "tiktoken>=0.12.0",
     "httpx>=0.27.0",
@@ -68,7 +68,7 @@ dependencies = [
     "tornado>=6.5.5", # DoS multipart/incomplete cookie validation fix
     "aiohttp>=3.13.3", # Multiple DoS vulnerabilities
     "pygments>=2.20.0", # ReDoS via inefficient GUID regex fix
-    "claude-agent-sdk>=0.1.27",
+    "claude-agent-sdk>=0.2.82",
     "boto3>=1.42.74",
 ]
 

--- a/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
@@ -1,0 +1,176 @@
+"""Regression test for the Claude Code provider's subprocess isolation.
+
+When an operator runs the API with HINDSIGHT_API_*_LLM_PROVIDER=claude-code,
+the Claude Agent SDK spawns the `claude` CLI as a subprocess for every LLM
+call. If that subprocess inherits the host's CLAUDE_CONFIG_DIR, it loads any
+user-installed plugins (e.g. hindsight-memory). Their Stop hooks then retain
+the subprocess's own transcript back into the same bank, causing a recursive
+feedback loop documented in issue #1751.
+
+The fix redirects the subprocess to an isolated config dir via env. This test
+mocks the SDK to capture the ClaudeAgentOptions passed at call time and asserts
+the isolation env is present on both code paths (`call` and `call_with_tools`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@dataclass
+class _FakeOptions:
+    """Stand-in for ClaudeAgentOptions; captures kwargs without importing SDK."""
+
+    system_prompt: str | None = None
+    max_turns: int | None = None
+    allowed_tools: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    mcp_servers: dict[str, Any] = field(default_factory=dict)
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content: list[Any]) -> None:
+        self.content = content
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def _instantiate_provider():
+    from hindsight_api.engine.providers.claude_code_llm import ClaudeCodeLLM
+
+    return ClaudeCodeLLM(
+        provider="claude-code",
+        api_key="",
+        base_url="",
+        model="claude-haiku-4-5",
+        reasoning_effort="low",
+    )
+
+
+def _assert_isolation_env(env: dict[str, str]) -> None:
+    assert "CLAUDE_CONFIG_DIR" in env, "Subprocess env missing CLAUDE_CONFIG_DIR redirect"
+    assert env["CLAUDE_CONFIG_DIR"], "CLAUDE_CONFIG_DIR must be a non-empty path"
+    assert env["CLAUDE_CONFIG_DIR"].startswith("/"), "CLAUDE_CONFIG_DIR must be an absolute path"
+    assert env.get("CLAUDE_SECURESTORAGE_CONFIG_DIR") == "", (
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR must be set to '' to force the un-suffixed keychain entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_passes_isolation_env_to_sdk_options(monkeypatch):
+    """call() must pass CLAUDE_CONFIG_DIR + SECURESTORAGE_CONFIG_DIR='' to the spawned CLI."""
+    import claude_agent_sdk
+
+    captured: dict[str, _FakeOptions] = {}
+
+    async def fake_query(prompt: str, options: _FakeOptions):
+        captured["options"] = options
+        yield _FakeAssistantMessage(content=[_FakeTextBlock(text="ok")])
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+
+    provider = _instantiate_provider()
+    result = await provider.call(
+        messages=[{"role": "user", "content": "hi"}],
+        max_retries=0,
+        scope="test",
+    )
+
+    assert result == "ok"
+    assert "options" in captured, "fake query was not called"
+    _assert_isolation_env(captured["options"].env)
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_passes_isolation_env_to_sdk_options(monkeypatch):
+    """call_with_tools() must apply the same isolation env."""
+    import claude_agent_sdk
+
+    captured: dict[str, _FakeOptions] = {}
+
+    class _FakeClient:
+        def __init__(self, options: _FakeOptions) -> None:
+            captured["options"] = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str) -> None:
+            return None
+
+        async def receive_response(self):
+            yield _FakeAssistantMessage(content=[_FakeTextBlock(text="ok")])
+
+    @dataclass
+    class _FakeSdkMcpTool:
+        name: str
+        description: str
+        input_schema: dict[str, Any]
+        handler: Any
+
+    def fake_create_sdk_mcp_server(name: str, version: str, tools=None):
+        return {"name": name, "version": version, "tools": tools}
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch.setattr(claude_agent_sdk, "AssistantMessage", _FakeAssistantMessage)
+    monkeypatch.setattr(claude_agent_sdk, "TextBlock", _FakeTextBlock)
+    monkeypatch.setattr(claude_agent_sdk, "ToolUseBlock", type("ToolUseBlock", (), {}))
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", _FakeClient)
+    monkeypatch.setattr(claude_agent_sdk, "SdkMcpTool", _FakeSdkMcpTool)
+    monkeypatch.setattr(claude_agent_sdk, "create_sdk_mcp_server", fake_create_sdk_mcp_server)
+
+    provider = _instantiate_provider()
+    result = await provider.call_with_tools(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "function": {
+                    "name": "noop",
+                    "description": "no-op",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            }
+        ],
+        max_retries=0,
+        scope="test",
+    )
+
+    assert result.content == "ok"
+    assert "options" in captured, "fake client was not constructed"
+    _assert_isolation_env(captured["options"].env)
+
+
+def test_isolation_dir_is_reused_across_calls():
+    """The isolated dir is created once per process; concurrent calls share it."""
+    from hindsight_api.engine.providers.claude_code_llm import _get_isolated_claude_env
+
+    env_a = _get_isolated_claude_env()
+    env_b = _get_isolated_claude_env()
+    assert env_a is env_b, "Isolated env dict must be cached for the process lifetime"
+    assert env_a["CLAUDE_CONFIG_DIR"] == env_b["CLAUDE_CONFIG_DIR"]
+
+
+def test_isolation_dir_is_not_home():
+    """Guard against the isolated dir accidentally pointing at $HOME (would not isolate plugins)."""
+    import os
+
+    from hindsight_api.engine.providers.claude_code_llm import _get_isolated_claude_env
+
+    env = _get_isolated_claude_env()
+    assert env["CLAUDE_CONFIG_DIR"] != os.path.expanduser("~"), (
+        "Isolated dir must not be $HOME, or it would still load installed_plugins.json"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -660,18 +660,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.31"
+version = "0.2.87"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/df/071dce5803c4db8cd53708bcda3b6022c1c4b68fc00e9007593309515286/claude_agent_sdk-0.1.31.tar.gz", hash = "sha256:b68c681083d7cc985dd3e48f73aabf459f056c1a7e1c5b9c47033c6af94da1a1", size = 61191 }
+sdist = { url = "https://files.pythonhosted.org/packages/26/dc/e2afd59a1dd6484b6500245fa2331a0d8c0b68e6c180bc29d8ce9540f38a/claude_agent_sdk-0.2.87.tar.gz", hash = "sha256:56f02a49a97f7be37e0cd7323494d1c09e52fb0db7ab94f53bba8a230bb4bd0e", size = 252063 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/7c/e249a3b4215e28a9722b3d9ab6057bceeeaa2b948530f022065ef2154555/claude_agent_sdk-0.1.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:801bacfe4192782a7cc7b61b0d23a57f061c069993dd3dfa8109aa2e7050a530", size = 54284257 },
-    { url = "https://files.pythonhosted.org/packages/d6/a8/1a8288736aeafcc48e3dcb3326ec7f487dbf89ebba77d526e9464786a299/claude_agent_sdk-0.1.31-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:0b608e0cbfcedcb827427e6d16a73fe573d58e7f93e15f95435066feacbe6511", size = 68462461 },
-    { url = "https://files.pythonhosted.org/packages/26/7a/7dcd0b77263ed55b17554fa3a67a6772b788e7048a524fd06c9baa970564/claude_agent_sdk-0.1.31-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d0cb30e026a22246e84d9237d23bb4df20be5146913a04d2802ddd37d4f8b8c9", size = 70173234 },
-    { url = "https://files.pythonhosted.org/packages/37/a5/4a8de7a9738f454b54aa97557f0fba9c74b0901ea418597008c668243fea/claude_agent_sdk-0.1.31-py3-none-win_amd64.whl", hash = "sha256:8ceca675c2770ad739bd1208362059a830e91c74efcf128045b5a7af14d36f2b", size = 72366975 },
+    { url = "https://files.pythonhosted.org/packages/6c/4e/b83c4c6ec1e0b63e9d4d58ba9a5abfd9936c55b8ee4c06b88f5e93bdfd70/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_arm64.whl", hash = "sha256:52204a9609dec3aa96032afd48c07d72e05d13311faf614978f17b61326e6e31", size = 63037960 },
+    { url = "https://files.pythonhosted.org/packages/13/d7/5fb02260c5b95c66e108c35e046d4d66011921251f7896274b6b21594f14/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:1713e34e50b830ecac54386d39af14e3a2775f833f1ef715eb53566eaa1b6325", size = 65095745 },
+    { url = "https://files.pythonhosted.org/packages/1d/84/1061f6580bbbc78de629467abf051cdbbabe71b982297b401e3fde65c7e0/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e9e23119d2a02ad1ea1a2707214db98f5baf2c8809577186629843ddfcb8ec18", size = 72725120 },
+    { url = "https://files.pythonhosted.org/packages/04/50/449f5044d76d9de18cf6a9f4b1c9386a74f41b4e2da5312df245d9dd23ef/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5ac525d9ae3481296df5639d005e12ce2b6b0427426991f35da64db30be25c6e", size = 72875504 },
+    { url = "https://files.pythonhosted.org/packages/80/dd/3f9d7c491d5a98138d293192b31cc9ed792d3552b3a7e276163d7fe2d43a/claude_agent_sdk-0.2.87-py3-none-win_amd64.whl", hash = "sha256:f34973669a1efaeb1543e7b22d7b22feefd8af2fae3adfd39181635077dae432", size = 73514880 },
 ]
 
 [[package]]
@@ -1660,7 +1662,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "authlib", specifier = ">=1.6.9" },
     { name = "boto3", specifier = ">=1.42.74" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.27" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.82" },
     { name = "cohere", specifier = ">=5.0.0" },
     { name = "cryptography", specifier = ">=46.0.6,<47" },
     { name = "dateparser", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary

Fixes #1751 — when `HINDSIGHT_API_*_LLM_PROVIDER=claude-code`, the spawned `claude` CLI inherits the host's `CLAUDE_CONFIG_DIR` and loads any operator-installed plugins (e.g. `hindsight-memory`). Their Stop hooks then retain the subprocess's own transcript back into the same bank — a recursive feedback loop that produced ~5M tokens/day on a single active bank in the reporter's environment.

- Redirect each spawned CLI to a per-process isolated config dir via `CLAUDE_CONFIG_DIR`.
- Pair it with `CLAUDE_SECURESTORAGE_CONFIG_DIR=""` so the keychain service name stays canonical (the CLI hashes `CLAUDE_CONFIG_DIR` into the service name otherwise, which breaks OAuth lookup).
- Bump `claude-agent-sdk` to `>=0.2.82` — the minimum that ships bundled CLI v2.1.150 with the `CLAUDE_SECURESTORAGE_CONFIG_DIR` escape hatch. Earlier bundled CLIs (e.g. 2.1.33 in SDK 0.1.31) lack it and would have broken auth.
- Adds 4 regression tests mocking the SDK to assert the isolation env is present on both `call()` and `call_with_tools()` paths.

The plugin (`hindsight-integrations/claude-code`) is intentionally **not** modified — the fix works against any third-party Claude Code plugin the operator might have installed, not just `hindsight-memory`.

## Test plan

- [x] `uv run pytest tests/test_claude_code_llm_isolation.py -v` — all 4 tests pass
- [x] `./scripts/hooks/lint.sh` — clean
- [x] `uv run ty check hindsight_api/engine/providers/claude_code_llm.py` — clean
- [x] End-to-end manual verification against a real `claude` install with `hindsight-memory` plugin enabled at user level:
  - Subprocess debug log shows `installed_plugins.json doesn't exist, returning empty` → `Found 0 plugins (0 enabled, 0 disabled)` → `Registered 0 hooks from 0 plugins`.
  - OAuth via `claude auth login` keeps working — real LLM call returns expected response.