### PR TITLE
fix(directives): honor tag_groups in list_directives and reflect

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -236,7 +236,7 @@ from .retain import bank_utils, embedding_utils
 from .retain.types import RetainContentDict
 from .search import think_utils
 from .search.reranking import CrossEncoderReranker, apply_combined_scoring
-from .search.tags import TagGroup, TagsMatch, build_tags_where_clause
+from .search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
 from .task_backend import TaskBackend
 
 RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
@@ -6593,6 +6593,7 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id=bank_id,
             tags=tags,
             tags_match=tags_match,
+            tag_groups=tag_groups,
             active_only=True,
             request_context=request_context,
             isolation_mode=True,
@@ -8759,7 +8760,8 @@ class MemoryEngine(MemoryEngineInterface):
         bank_id: str,
         *,
         tags: list[str] | None = None,
-        tags_match: str = "any",
+        tags_match: TagsMatch = "any",
+        tag_groups: list[TagGroup] | None = None,
         active_only: bool = True,
         limit: int = 100,
         offset: int = 0,
@@ -8770,15 +8772,19 @@ class MemoryEngine(MemoryEngineInterface):
 
         Args:
             bank_id: Bank identifier
-            tags: Optional tags to filter by
-            tags_match: How to match tags - 'any', 'all', or 'exact'
+            tags: Optional flat tags to filter by
+            tags_match: How to match tags - 'any', 'all', 'any_strict', or 'all_strict'
+            tag_groups: Optional compound tag filter (mutually independent of tags;
+                if both are provided each applies its own OR-with-untagged wrapping
+                and the two are AND-ed together)
             active_only: Only return active directives (default True)
             limit: Maximum number of results
             offset: Offset for pagination
             request_context: Request context for authentication
-            isolation_mode: When True and tags=None, only return directives with no tags.
-                This prevents tag-scoped directives from leaking into untagged operations.
-                Default False (normal API behavior - returns all directives when tags=None)
+            isolation_mode: When True and both tags and tag_groups are None, only
+                return directives with no tags. This prevents tag-scoped directives
+                from leaking into untagged operations. Default False (normal API
+                behavior - returns all directives when no tag filter is supplied).
 
         Returns:
             List of directive dicts
@@ -8800,12 +8806,17 @@ class MemoryEngine(MemoryEngineInterface):
             if active_only:
                 filters.append("is_active = TRUE")
 
-            # Apply tags filter for directives:
+            # Apply tag filters for directives:
             # Directives have special scoping rules:
             #   - Untagged directives (tags=[] or null) always apply regardless of reflect tags
             #   - Tagged directives only apply when the reflect operation includes matching tags
-            #   - If tags=None and isolation_mode=True: only untagged directives (no leakage)
-            #   - If tags=None and isolation_mode=False: all directives (normal API behavior)
+            #   - If no tag filter is supplied and isolation_mode=True: only untagged directives
+            #   - If no tag filter is supplied and isolation_mode=False: all directives (normal API behavior)
+            #
+            # When `tags` and `tag_groups` are both supplied (engine-level callers only;
+            # the public reflect/recall API rejects the combo at the request validator),
+            # both filters apply independently — each wrapped in the untagged-OR rule —
+            # so the directive set is the intersection of what either filter would admit.
             if tags:
                 tags_clause, tags_params, param_idx = build_tags_where_clause(
                     tags=tags, param_offset=param_idx, table_alias="", match=tags_match
@@ -8815,7 +8826,16 @@ class MemoryEngine(MemoryEngineInterface):
                     scoped_clause = tags_clause.replace("AND ", "", 1)
                     filters.append(f"((tags IS NULL OR tags = '{{}}') OR ({scoped_clause}))")
                     params.extend(tags_params)
-            elif isolation_mode:
+            if tag_groups:
+                groups_clause, groups_params, param_idx = build_tag_groups_where_clause(
+                    tag_groups, param_offset=param_idx
+                )
+                if groups_clause:
+                    # Same untagged-OR rule as the flat-tags branch above.
+                    scoped_clause = groups_clause.replace("AND ", "", 1)
+                    filters.append(f"((tags IS NULL OR tags = '{{}}') OR ({scoped_clause}))")
+                    params.extend(groups_params)
+            if not tags and not tag_groups and isolation_mode:
                 # Isolation mode: only include directives with empty/null tags
                 # This ensures tag-scoped directives don't apply to untagged operations
                 filters.append("(tags IS NULL OR tags = '{}')")

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -314,6 +314,76 @@ class TestDirectiveTags:
         # Cleanup
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_list_directives_by_tag_groups(self, memory: MemoryEngine, request_context):
+        """Regression for #1829: list_directives must respect tag_groups.
+
+        Mirrors the OR-with-untagged scoping that tagged directives already
+        get with flat `tags`: untagged directives always apply, tagged
+        directives only when their tags satisfy the tag_groups expression.
+        """
+        from hindsight_api.engine.search.tags import TagGroupLeaf, TagGroupOr
+
+        bank_id = f"test-directive-tag-groups-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        await memory.create_directive(
+            bank_id=bank_id,
+            name="Untagged Rule",
+            content="Applies everywhere",
+            request_context=request_context,
+        )
+        await memory.create_directive(
+            bank_id=bank_id,
+            name="Hardware Rule",
+            content="Hardware-scoped rule",
+            tags=["hardware"],
+            request_context=request_context,
+        )
+        await memory.create_directive(
+            bank_id=bank_id,
+            name="Compliance Rule",
+            content="Compliance-scoped rule",
+            tags=["compliance"],
+            request_context=request_context,
+        )
+
+        # tag_groups = [hardware OR infrastructure] should admit untagged and Hardware,
+        # exclude Compliance.
+        scoped = await memory.list_directives(
+            bank_id=bank_id,
+            tag_groups=[
+                TagGroupOr(
+                    filters=[
+                        TagGroupLeaf(tags=["hardware"]),
+                        TagGroupLeaf(tags=["infrastructure"]),
+                    ]
+                )
+            ],
+            request_context=request_context,
+        )
+        names = {d["name"] for d in scoped}
+        assert names == {"Untagged Rule", "Hardware Rule"}, names
+
+        # Isolation mode with tag_groups still applies (only untagged + tag-matching).
+        isolated = await memory.list_directives(
+            bank_id=bank_id,
+            tag_groups=[TagGroupLeaf(tags=["hardware"])],
+            request_context=request_context,
+            isolation_mode=True,
+        )
+        assert {d["name"] for d in isolated} == {"Untagged Rule", "Hardware Rule"}
+
+        # Without any tag filter and isolation_mode=True, only untagged should come back —
+        # confirming this code path isn't accidentally short-circuited when tag_groups is empty.
+        untagged_only = await memory.list_directives(
+            bank_id=bank_id,
+            request_context=request_context,
+            isolation_mode=True,
+        )
+        assert {d["name"] for d in untagged_only} == {"Untagged Rule"}
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     async def test_list_all_directives_without_filter(self, memory: MemoryEngine, request_context):
         """Test that listing directives without tags returns ALL directives (both tagged and untagged)."""
         bank_id = f"test-directive-list-all-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary

- `list_directives()` accepted flat `tags` + `tags_match` but not `tag_groups`, so when `reflect_async` is called with `tag_groups` only it loaded directives with `tags=None`, isolation_mode=True — i.e. only untagged directives. Tagged directives meant for the same tag scope were silently dropped.
- This PR adds `tag_groups` to `list_directives()` and threads it through `reflect_async`, applying the same OR-with-untagged scoping rule already used for `tags`. When both `tags` and `tag_groups` are supplied (engine-level callers only — the public reflect/recall API rejects the combo at the request validator), each filter is applied independently and AND-ed together.

Fixes #1829. Independent of #1820's filed symptom (which my earlier PR #1828 already pinned down as a non-bug at the kwargs/SQL layer).

## Test plan

- [x] New regression test `test_list_directives_by_tag_groups` covering tag_groups scoping (untagged + matching), isolation_mode with tag_groups, and the no-filter + isolation case (untagged-only).
- [x] All existing `TestDirectiveTags` and `TestDirectives*` tests still pass.
- [x] `./scripts/hooks/lint.sh` clean.