### PR TITLE
docs(models): list openrouter, google, and jina-mlx in Cross-Encoder Supported Providers table

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -511,13 +511,16 @@ Reranks initial search results to improve precision.
 |----------|-------------|----------|
 | `local` | SentenceTransformers CrossEncoder (default) | Development, low latency |
 | `cohere` | Cohere rerank API | Production, high quality |
+| `openrouter` | OpenRouter rerank API (Cohere-compatible gateway) | Multi-provider setups |
 | `zeroentropy` | ZeroEntropy rerank API (zerank-2) | Production, state-of-the-art accuracy |
 | `siliconflow` | SiliconFlow rerank API (Cohere-compatible `/rerank` endpoint) | Users in China or anyone on SiliconFlow's platform |
 | `alibaba` | Alibaba Cloud DashScope rerank API (qwen3-rerank) | Users on Alibaba Cloud / DashScope |
+| `google` | Google Discovery Engine ranking API (REST + Google auth) | Production, GCP integration |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
 | `flashrank` | FlashRank (lightweight, fast) | Resource-constrained environments |
 | `litellm` | LiteLLM proxy (unified gateway) | Multi-provider setups |
 | `litellm-sdk` | LiteLLM SDK (direct API, no proxy) | Multi-provider, simpler setup |
+| `jina-mlx` | Jina rerank v3 via Apple Silicon MLX (local, no API key) | Apple Silicon (M1+) local inference |
 | `rrf` | RRF-only (no neural reranking) | Testing, minimal resources |
 
 ### Local Models

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -537,13 +537,16 @@ Reranks initial search results to improve precision.
 |----------|-------------|----------|
 | `local` | SentenceTransformers CrossEncoder (default) | Development, low latency |
 | `cohere` | Cohere rerank API | Production, high quality |
+| `openrouter` | OpenRouter rerank API (Cohere-compatible gateway) | Multi-provider setups |
 | `zeroentropy` | ZeroEntropy rerank API (zerank-2) | Production, state-of-the-art accuracy |
 | `siliconflow` | SiliconFlow rerank API (Cohere-compatible `/rerank` endpoint) | Users in China or anyone on SiliconFlow's platform |
 | `alibaba` | Alibaba Cloud DashScope rerank API (qwen3-rerank) | Users on Alibaba Cloud / DashScope |
+| `google` | Google Discovery Engine ranking API (REST + Google auth) | Production, GCP integration |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
 | `flashrank` | FlashRank (lightweight, fast) | Resource-constrained environments |
 | `litellm` | LiteLLM proxy (unified gateway) | Multi-provider setups |
 | `litellm-sdk` | LiteLLM SDK (direct API, no proxy) | Multi-provider, simpler setup |
+| `jina-mlx` | Jina rerank v3 via Apple Silicon MLX (local, no API key) | Apple Silicon (M1+) local inference |
 | `rrf` | RRF-only (no neural reranking) | Testing, minimal resources |
 
 ### Local Models


### PR DESCRIPTION
## Summary

`developer/models.mdx` Cross-Encoder **Supported Providers** table only lists 10 of the 13 first-class reranker providers wired up in `cross_encoder.py` and already enumerated in `developer/configuration.md` (`HINDSIGHT_API_RERANKER_PROVIDER` description, L645). Three real providers — `openrouter`, `google`, `jina-mlx` — are silently absent from the discovery surface.

Sister catch to the just-merged #1792 (embeddings Supported Providers extension) on the same `models.mdx` structural surface.

## Details

- canonical `hindsight-docs/docs/developer/models.mdx`: 3 rows added inside the existing Cross-Encoder Supported Providers table (between `cohere` and `zeroentropy` for openrouter; between `alibaba` and `tei` for google; between `litellm-sdk` and `rrf` for jina-mlx).
- skills mirror `skills/hindsight-docs/references/developer/models.md`: identical 3-row mirror.
- 6 LOC total, additive, no row removals.
- Descriptions byte-grounded against `configuration.md` L645 enum + per-provider env-var docs (openrouter L657–659, google L684–687, jina-mlx L691) and existing configuration examples (openrouter L709–711, google L765–767).

## Why this matters

The Cross-Encoder Supported Providers table is the canonical discovery surface for picking a reranker. Currently a user browsing it cannot discover:

- `openrouter` — only Cohere-compatible reranker gateway with multi-provider routing
- `google` — only first-class GCP reranker (Discovery Engine REST API)
- `jina-mlx` — only Apple-Silicon local reranker (no API key needed)

All three are fully documented elsewhere in `configuration.md`, registered in `cross_encoder.py`'s `elif` chain, and listed in the `HINDSIGHT_API_RERANKER_PROVIDER` enum — asymmetric coverage vs the rest of the docs is a real DX gap, especially after #1792 just closed the analogous gap on the embeddings table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)