### PR TITLE
docs(mcp): document sync_retain tool and correct tool counts (26/29 -> 27/30)

### DIFF
--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -100,8 +100,8 @@ The MCP server operates in two modes depending on the URL:
 
 | Mode | URL | Tools | bank_id |
 |------|-----|-------|---------|
-| **Single-bank** | `/mcp/{bank_id}/` | 26 tools (memory, mental models, directives, documents, operations, tags, bank management) | Implicit from URL |
-| **Multi-bank** | `/mcp/` | All 29 tools including `list_banks`, `create_bank`, `get_bank_stats` | Explicit `bank_id` parameter on each tool |
+| **Single-bank** | `/mcp/{bank_id}/` | 27 tools (memory, mental models, directives, documents, operations, tags, bank management) | Implicit from URL |
+| **Multi-bank** | `/mcp/` | All 30 tools including `list_banks`, `create_bank`, `get_bank_stats` | Explicit `bank_id` parameter on each tool |
 
 **Single-bank mode** (recommended) scopes all operations to the bank in the URL. Tools don't expose a `bank_id` parameter.
 
@@ -141,6 +141,38 @@ Store information to long-term memory.
 - Important events or milestones are mentioned
 - Decisions, opinions, or goals are stated
 - Work context or project details are discussed
+
+---
+
+### sync_retain
+
+Store information to long-term memory and wait for completion. Unlike [`retain`](#retain) (which is asynchronous), `sync_retain` blocks until the memory is fully stored and immediately available for recall — useful for read-after-write flows where you query right after storing.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | Yes | The fact or memory to store |
+| `context` | string | No | Category for the memory (default: `general`) |
+| `timestamp` | string | No | ISO 8601 timestamp for when the event occurred |
+| `tags` | list[string] | No | Tags for organizing and filtering this memory |
+| `metadata` | object | No | Key-value metadata to attach (e.g., `{"source": "slack"}`) |
+| `document_id` | string | No | Associate this memory with an existing document |
+
+**Example:**
+```json
+{
+  "name": "sync_retain",
+  "arguments": {
+    "content": "User prefers Python over JavaScript for backend development",
+    "context": "programming_preferences",
+    "tags": ["user:alice", "preferences"]
+  }
+}
+```
+
+**When to use:**
+- You need the memory queryable immediately after storing (read-after-write)
+- A workflow step depends on the stored memory being available before continuing
+- Otherwise prefer `retain` (asynchronous) to avoid blocking on storage
 
 ---
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -100,8 +100,8 @@ The MCP server operates in two modes depending on the URL:
 
 | Mode | URL | Tools | bank_id |
 |------|-----|-------|---------|
-| **Single-bank** | `/mcp/{bank_id}/` | 26 tools (memory, mental models, directives, documents, operations, tags, bank management) | Implicit from URL |
-| **Multi-bank** | `/mcp/` | All 29 tools including `list_banks`, `create_bank`, `get_bank_stats` | Explicit `bank_id` parameter on each tool |
+| **Single-bank** | `/mcp/{bank_id}/` | 27 tools (memory, mental models, directives, documents, operations, tags, bank management) | Implicit from URL |
+| **Multi-bank** | `/mcp/` | All 30 tools including `list_banks`, `create_bank`, `get_bank_stats` | Explicit `bank_id` parameter on each tool |
 
 **Single-bank mode** (recommended) scopes all operations to the bank in the URL. Tools don't expose a `bank_id` parameter.
 
@@ -141,6 +141,38 @@ Store information to long-term memory.
 - Important events or milestones are mentioned
 - Decisions, opinions, or goals are stated
 - Work context or project details are discussed
+
+---
+
+### sync_retain
+
+Store information to long-term memory and wait for completion. Unlike [`retain`](#retain) (which is asynchronous), `sync_retain` blocks until the memory is fully stored and immediately available for recall — useful for read-after-write flows where you query right after storing.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | Yes | The fact or memory to store |
+| `context` | string | No | Category for the memory (default: `general`) |
+| `timestamp` | string | No | ISO 8601 timestamp for when the event occurred |
+| `tags` | list[string] | No | Tags for organizing and filtering this memory |
+| `metadata` | object | No | Key-value metadata to attach (e.g., `{"source": "slack"}`) |
+| `document_id` | string | No | Associate this memory with an existing document |
+
+**Example:**
+```json
+{
+  "name": "sync_retain",
+  "arguments": {
+    "content": "User prefers Python over JavaScript for backend development",
+    "context": "programming_preferences",
+    "tags": ["user:alice", "preferences"]
+  }
+}
+```
+
+**When to use:**
+- You need the memory queryable immediately after storing (read-after-write)
+- A workflow step depends on the stored memory being available before continuing
+- Otherwise prefer `retain` (asynchronous) to avoid blocking on storage
 
 ---
 


### PR DESCRIPTION
## What

The MCP `## Available Tools` reference omits the default-enabled **`sync_retain`** tool, and the **Two Modes** table reports stale tool counts.

`register_mcp_tools` registers **30** tools by default (`hindsight-api-slim/hindsight_api/mcp_tools.py` L212–242), and the set explicitly includes `sync_retain` (L214). But:

- `developer/mcp-server.md` has no `### sync_retain` section — it is registered by default and visible in clients' `list_tools`, yet has zero usage guidance.
- The Two Modes table says single-bank = **26 tools** and multi-bank = **All 29 tools**. With 30 registered and 3 bank-management tools marked multi-bank-only (`list_banks`, `create_bank`, `get_bank_stats`), the correct counts are **27** (single) and **30** (multi) — both off by exactly the undocumented `sync_retain`.

## Change (docs-only)

- Add a `### sync_retain` section after `### retain`, mirroring `retain`'s format. Description grounded verbatim in the tool's docstring (`mcp_tools.py` L670–673): blocks until the memory is fully stored and immediately recallable — useful for read-after-write flows.
- Fix the two counts (26→27, 29→30).
- Regenerate the `skills/hindsight-docs` mirror via the standard generator (committed so `verify-generated-files` stays green).