### PR TITLE
docs(faq): explain Hindsight's event-centric graph vs. traditional KGs

### DIFF
--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -369,7 +369,9 @@ No. In Hindsight, entities (people, places, concepts, or classification labels) 
 
 #### How does Hindsight find connections if entities aren't directly linked?
 
-Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+Through shared stickers. Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands along shared-sticker connections from those seeds to surface related memories. The semantic layer picks the starting points; the graph fills in the connections.
+
+If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
 
 ```
 Memory A → [pedagogy:scaffolding] → Memory B

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -333,7 +333,7 @@ Re-retaining with the same `id` replaces the old document and its facts, so you 
 
 ### How is Hindsight's graph different from a traditional knowledge graph?
 
-Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+Hindsight uses an **event-centric graph** that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. Memories are the anchor: entities attach to the memories they appear in, and memories themselves can also be linked directly to each other (more on that below). The closest analogy is a map versus a scrapbook.
 
 **A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
 
@@ -369,22 +369,20 @@ No. In Hindsight, entities (people, places, concepts, or classification labels) 
 
 #### How does Hindsight find connections if entities aren't directly linked?
 
-Through shared stickers. Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands along shared-sticker connections from those seeds to surface related memories. The semantic layer picks the starting points; the graph fills in the connections.
+Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands from those seeds through three parallel signals:
 
-If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+- **Shared entities.** If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight traverses `Memory A → [pedagogy:scaffolding] → Memory B`. This is the scrapbook-pages-with-the-same-stickers case.
+- **Semantic links between memories.** When a new memory is retained, Hindsight precomputes links to its nearest neighbors in embedding space, so semantically related pages connect directly without needing a shared sticker.
+- **Causal links between memories.** Hindsight also extracts explicit causal relationships (`causes`, `caused_by`, `enables`, `prevents`) between memories, so cause-and-effect chains are first-class edges rather than something the model has to infer.
 
-```
-Memory A → [pedagogy:scaffolding] → Memory B
-```
-
-It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
+The semantic layer picks the starting points; the graph fills in the connections through whichever of those three signals is strongest for each candidate.
 
 #### Does this graph structure help reduce hallucinations in my agent?
 
 Yes — by giving the consuming LLM better-grounded context to reason from. Three properties of the scrapbook model contribute directly:
 
 - **History is preserved, not collapsed.** The model sees time-bounded facts (Alice worked at Acme last year, Stark Industries now) rather than a contradictory present-tense edge that forces it to reconcile or guess.
-- **Connections come from real shared entities, not inference.** When recall surfaces two related memories, it's because they genuinely share an entity sticker — the link appears in the retrieved context, so the model doesn't have to invent one.
+- **Connections come from recorded links, not inference.** When recall surfaces two related memories, it's because they share an entity, a precomputed semantic neighbor, or an explicit causal edge — the link appears in the retrieved context, so the model doesn't have to invent one.
 - **Convergent evidence accumulates.** Multiple memories anchoring to the same entity reinforce each other instead of competing, giving the model corroborated claims rather than singular unsupported ones.
 
 ---

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -360,8 +360,8 @@ This is where traditional graphs run into major limitations when used for AI mem
 
 The creation of stickers happens through a mix of AI automation and developer control:
 
-- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers. If you want to lock the bank to a strict controlled vocabulary, this default can be disabled by setting `entities_allow_free_form: false` on the bank config — the LLM then only emits entries that match your configured `entity_labels` and skips free-form named entities entirely.
-- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](/developer/retain#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](/developer/retain#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`. To lock the bank to *only* your configured labels and turn off the open-world automation above, also set `entities_allow_free_form: false` on the bank config — the LLM then skips free-form named entities entirely and emits only entries that match your schema.
 
 #### Can I build direct entity-to-entity pipelines?
 

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -11,6 +11,7 @@ import PageHero from '@site/src/components/PageHero';
 
 **Contents**
 - [What is Hindsight and how does it differ from RAG?](#what-is-hindsight-and-how-does-it-differ-from-rag)
+- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 - [Why use Hindsight instead of other solutions?](#why-use-hindsight-instead-of-other-solutions)
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
@@ -38,6 +39,54 @@ Hindsight is an agent memory system that provides long-term memory for AI agents
 - **Enables disposition-aware reflection** for nuanced reasoning
 
 For a detailed comparison, see [RAG vs Memory](/developer/rag-vs-hindsight).
+
+---
+
+### How is Hindsight's graph different from a traditional knowledge graph?
+
+Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+
+**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
+
+```
+[Toronto] ──IS_IN──> [Canada]
+```
+
+**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
+
+```
+Scrapbook page: "Math Class"
+  [Alice]   [Acme]   [pedagogy:scaffolding]
+```
+
+#### How do the two handle change over time?
+
+This is where traditional graphs run into major limitations when used for AI memory.
+
+**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
+
+**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
+
+#### Where do the stickers come from? How do I control them?
+
+The creation of stickers happens through a mix of AI automation and developer control:
+
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](/developer/retain#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+
+#### Can I build direct entity-to-entity pipelines?
+
+No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
+
+#### How does Hindsight find connections if entities aren't directly linked?
+
+Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+
+```
+Memory A → [pedagogy:scaffolding] → Memory B
+```
+
+It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -379,6 +379,14 @@ Memory A → [pedagogy:scaffolding] → Memory B
 
 It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
+#### Does this graph structure help reduce hallucinations in my agent?
+
+Yes — by giving the consuming LLM better-grounded context to reason from. Three properties of the scrapbook model contribute directly:
+
+- **History is preserved, not collapsed.** The model sees time-bounded facts (Alice worked at Acme last year, Stark Industries now) rather than a contradictory present-tense edge that forces it to reconcile or guess.
+- **Connections come from real shared entities, not inference.** When recall surfaces two related memories, it's because they genuinely share an entity sticker — the link appears in the retrieved context, so the model doesn't have to invent one.
+- **Convergent evidence accumulates.** Multiple memories anchoring to the same entity reinforce each other instead of competing, giving the model corroborated claims rather than singular unsupported ones.
+
 ---
 
 ## Still have questions?

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -11,7 +11,6 @@ import PageHero from '@site/src/components/PageHero';
 
 **Contents**
 - [What is Hindsight and how does it differ from RAG?](#what-is-hindsight-and-how-does-it-differ-from-rag)
-- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 - [Why use Hindsight instead of other solutions?](#why-use-hindsight-instead-of-other-solutions)
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
@@ -25,6 +24,7 @@ import PageHero from '@site/src/components/PageHero';
 - [Tags, metadata, and entity labels](#does-hindsight-support-metadata-filtering)
 - [Controlling which memory types are recalled](#how-do-i-control-which-types-of-memories-are-recalled)
 - [Recommended format for conversations](#what-is-the-recommended-format-for-retaining-conversations)
+- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 
 ---
 
@@ -39,54 +39,6 @@ Hindsight is an agent memory system that provides long-term memory for AI agents
 - **Enables disposition-aware reflection** for nuanced reasoning
 
 For a detailed comparison, see [RAG vs Memory](/developer/rag-vs-hindsight).
-
----
-
-### How is Hindsight's graph different from a traditional knowledge graph?
-
-Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
-
-**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
-
-```
-[Toronto] ──IS_IN──> [Canada]
-```
-
-**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
-
-```
-Scrapbook page: "Math Class"
-  [Alice]   [Acme]   [pedagogy:scaffolding]
-```
-
-#### How do the two handle change over time?
-
-This is where traditional graphs run into major limitations when used for AI memory.
-
-**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
-
-**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
-
-#### Where do the stickers come from? How do I control them?
-
-The creation of stickers happens through a mix of AI automation and developer control:
-
-- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
-- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](/developer/retain#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
-
-#### Can I build direct entity-to-entity pipelines?
-
-No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
-
-#### How does Hindsight find connections if entities aren't directly linked?
-
-Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
-
-```
-Memory A → [pedagogy:scaffolding] → Memory B
-```
-
-It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 
@@ -376,6 +328,54 @@ await client.retain(
 Re-retaining with the same `id` replaces the old document and its facts, so you won't accumulate duplicates as the conversation grows.
 
 **Don't pre-summarize or pre-extract facts.** Hindsight does this automatically and needs the full conversation for context — a message like "yes, exactly" or "I'll go with option 2" is meaningless without the surrounding exchange.
+
+---
+
+### How is Hindsight's graph different from a traditional knowledge graph?
+
+Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+
+**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
+
+```
+[Toronto] ──IS_IN──> [Canada]
+```
+
+**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
+
+```
+Scrapbook page: "Math Class"
+  [Alice]   [Acme]   [pedagogy:scaffolding]
+```
+
+#### How do the two handle change over time?
+
+This is where traditional graphs run into major limitations when used for AI memory.
+
+**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
+
+**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
+
+#### Where do the stickers come from? How do I control them?
+
+The creation of stickers happens through a mix of AI automation and developer control:
+
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers. If you want to lock the bank to a strict controlled vocabulary, this default can be disabled by setting `entities_allow_free_form: false` on the bank config — the LLM then only emits entries that match your configured `entity_labels` and skips free-form named entities entirely.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](/developer/retain#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+
+#### Can I build direct entity-to-entity pipelines?
+
+No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
+
+#### How does Hindsight find connections if entities aren't directly linked?
+
+Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+
+```
+Memory A → [pedagogy:scaffolding] → Memory B
+```
+
+It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -343,7 +343,7 @@ Re-retaining with the same `id` replaces the old document and its facts, so you 
 
 ### How is Hindsight's graph different from a traditional knowledge graph?
 
-Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+Hindsight uses an **event-centric graph** that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. Memories are the anchor: entities attach to the memories they appear in, and memories themselves can also be linked directly to each other (more on that below). The closest analogy is a map versus a scrapbook.
 
 **A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
 
@@ -379,22 +379,20 @@ No. In Hindsight, entities (people, places, concepts, or classification labels) 
 
 #### How does Hindsight find connections if entities aren't directly linked?
 
-Through shared stickers. Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands along shared-sticker connections from those seeds to surface related memories. The semantic layer picks the starting points; the graph fills in the connections.
+Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands from those seeds through three parallel signals:
 
-If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+- **Shared entities.** If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight traverses `Memory A → [pedagogy:scaffolding] → Memory B`. This is the scrapbook-pages-with-the-same-stickers case.
+- **Semantic links between memories.** When a new memory is retained, Hindsight precomputes links to its nearest neighbors in embedding space, so semantically related pages connect directly without needing a shared sticker.
+- **Causal links between memories.** Hindsight also extracts explicit causal relationships (`causes`, `caused_by`, `enables`, `prevents`) between memories, so cause-and-effect chains are first-class edges rather than something the model has to infer.
 
-```
-Memory A → [pedagogy:scaffolding] → Memory B
-```
-
-It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
+The semantic layer picks the starting points; the graph fills in the connections through whichever of those three signals is strongest for each candidate.
 
 #### Does this graph structure help reduce hallucinations in my agent?
 
 Yes — by giving the consuming LLM better-grounded context to reason from. Three properties of the scrapbook model contribute directly:
 
 - **History is preserved, not collapsed.** The model sees time-bounded facts (Alice worked at Acme last year, Stark Industries now) rather than a contradictory present-tense edge that forces it to reconcile or guess.
-- **Connections come from real shared entities, not inference.** When recall surfaces two related memories, it's because they genuinely share an entity sticker — the link appears in the retrieved context, so the model doesn't have to invent one.
+- **Connections come from recorded links, not inference.** When recall surfaces two related memories, it's because they share an entity, a precomputed semantic neighbor, or an explicit causal edge — the link appears in the retrieved context, so the model doesn't have to invent one.
 - **Convergent evidence accumulates.** Multiple memories anchoring to the same entity reinforce each other instead of competing, giving the model corroborated claims rather than singular unsupported ones.
 
 ---

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -4,7 +4,6 @@
 
 **Contents**
 - [What is Hindsight and how does it differ from RAG?](#what-is-hindsight-and-how-does-it-differ-from-rag)
-- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 - [Why use Hindsight instead of other solutions?](#why-use-hindsight-instead-of-other-solutions)
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
@@ -18,6 +17,7 @@
 - [Tags, metadata, and entity labels](#does-hindsight-support-metadata-filtering)
 - [Controlling which memory types are recalled](#how-do-i-control-which-types-of-memories-are-recalled)
 - [Recommended format for conversations](#what-is-the-recommended-format-for-retaining-conversations)
+- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 
 ---
 
@@ -32,54 +32,6 @@ Hindsight is an agent memory system that provides long-term memory for AI agents
 - **Enables disposition-aware reflection** for nuanced reasoning
 
 For a detailed comparison, see [RAG vs Memory](developer/rag-vs-hindsight.md).
-
----
-
-### How is Hindsight's graph different from a traditional knowledge graph?
-
-Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
-
-**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
-
-```
-[Toronto] ──IS_IN──> [Canada]
-```
-
-**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
-
-```
-Scrapbook page: "Math Class"
-  [Alice]   [Acme]   [pedagogy:scaffolding]
-```
-
-#### How do the two handle change over time?
-
-This is where traditional graphs run into major limitations when used for AI memory.
-
-**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
-
-**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
-
-#### Where do the stickers come from? How do I control them?
-
-The creation of stickers happens through a mix of AI automation and developer control:
-
-- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
-- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](developer/retain.md#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
-
-#### Can I build direct entity-to-entity pipelines?
-
-No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
-
-#### How does Hindsight find connections if entities aren't directly linked?
-
-Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
-
-```
-Memory A → [pedagogy:scaffolding] → Memory B
-```
-
-It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 
@@ -386,6 +338,54 @@ await client.retain(
 Re-retaining with the same `id` replaces the old document and its facts, so you won't accumulate duplicates as the conversation grows.
 
 **Don't pre-summarize or pre-extract facts.** Hindsight does this automatically and needs the full conversation for context — a message like "yes, exactly" or "I'll go with option 2" is meaningless without the surrounding exchange.
+
+---
+
+### How is Hindsight's graph different from a traditional knowledge graph?
+
+Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+
+**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
+
+```
+[Toronto] ──IS_IN──> [Canada]
+```
+
+**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
+
+```
+Scrapbook page: "Math Class"
+  [Alice]   [Acme]   [pedagogy:scaffolding]
+```
+
+#### How do the two handle change over time?
+
+This is where traditional graphs run into major limitations when used for AI memory.
+
+**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
+
+**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
+
+#### Where do the stickers come from? How do I control them?
+
+The creation of stickers happens through a mix of AI automation and developer control:
+
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers. If you want to lock the bank to a strict controlled vocabulary, this default can be disabled by setting `entities_allow_free_form: false` on the bank config — the LLM then only emits entries that match your configured `entity_labels` and skips free-form named entities entirely.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](developer/retain.md#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+
+#### Can I build direct entity-to-entity pipelines?
+
+No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
+
+#### How does Hindsight find connections if entities aren't directly linked?
+
+Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+
+```
+Memory A → [pedagogy:scaffolding] → Memory B
+```
+
+It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -4,6 +4,7 @@
 
 **Contents**
 - [What is Hindsight and how does it differ from RAG?](#what-is-hindsight-and-how-does-it-differ-from-rag)
+- [How is Hindsight's graph different from a traditional knowledge graph?](#how-is-hindsights-graph-different-from-a-traditional-knowledge-graph)
 - [Why use Hindsight instead of other solutions?](#why-use-hindsight-instead-of-other-solutions)
 - [Supported clients, integrations, and LLM providers](#which-clients-and-languages-are-supported)
 - [Which model should I use?](#which-model-should-i-use-with-hindsight)
@@ -31,6 +32,54 @@ Hindsight is an agent memory system that provides long-term memory for AI agents
 - **Enables disposition-aware reflection** for nuanced reasoning
 
 For a detailed comparison, see [RAG vs Memory](developer/rag-vs-hindsight.md).
+
+---
+
+### How is Hindsight's graph different from a traditional knowledge graph?
+
+Hindsight uses an **event-centric graph** — technically a temporal bipartite hypergraph — that organizes data around moments (conversations, observations, memories) rather than static, isolated facts. The closest analogy is a map versus a scrapbook.
+
+**A traditional graph (like Neo4j) is a map.** It shows how places connect directly to each other via roads, mapping rigid structural facts about the world:
+
+```
+[Toronto] ──IS_IN──> [Canada]
+```
+
+**A Hindsight graph is a scrapbook.** Each page is a single memory. On that page, you slap stickers of all the people, concepts, and labels present in that specific moment. The stickers don't touch each other — they just live on the same page together:
+
+```
+Scrapbook page: "Math Class"
+  [Alice]   [Acme]   [pedagogy:scaffolding]
+```
+
+#### How do the two handle change over time?
+
+This is where traditional graphs run into major limitations when used for AI memory.
+
+**Traditional graphs struggle with change.** If Alice leaves Acme Corp to work at Stark Industries, you have to manually delete or rewrite the old `[WORKS_AT]` arrow. If you don't, the graph contradicts reality by stating she works at both places simultaneously. Traditional graphs are built for the absolute present; they lose history when data changes.
+
+**Hindsight handles change effortlessly because history is preserved.** If Alice changes jobs, you don't rewrite the past. You simply create a new scrapbook page — `Memory: Tuesday's Call` with a sticker for `[Stark Industries]`. The old page from last year still accurately links her to `[Acme Corp]`. The graph naturally tracks how the world evolves without complex database maintenance.
+
+#### Where do the stickers come from? How do I control them?
+
+The creation of stickers happens through a mix of AI automation and developer control:
+
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](developer/retain.md#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+
+#### Can I build direct entity-to-entity pipelines?
+
+No. In Hindsight, entities (people, places, concepts, or classification labels) do not have direct arrows connecting them to one another. Instead, they interact by anchoring to the same parent memory unit — the same scrapbook page.
+
+#### How does Hindsight find connections if entities aren't directly linked?
+
+Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+
+```
+Memory A → [pedagogy:scaffolding] → Memory B
+```
+
+It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
 ---
 

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -379,7 +379,9 @@ No. In Hindsight, entities (people, places, concepts, or classification labels) 
 
 #### How does Hindsight find connections if entities aren't directly linked?
 
-Through shared stickers. If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
+Through shared stickers. Recall starts with semantic search — finding the memories most relevant to your query as seed pages — and then expands along shared-sticker connections from those seeds to surface related memories. The semantic layer picks the starting points; the graph fills in the connections.
+
+If Memory A and Memory B both anchor to the same entity node — like `[pedagogy:scaffolding]` — Hindsight instantly traverses the path:
 
 ```
 Memory A → [pedagogy:scaffolding] → Memory B

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -370,8 +370,8 @@ This is where traditional graphs run into major limitations when used for AI mem
 
 The creation of stickers happens through a mix of AI automation and developer control:
 
-- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers. If you want to lock the bank to a strict controlled vocabulary, this default can be disabled by setting `entities_allow_free_form: false` on the bank config — the LLM then only emits entries that match your configured `entity_labels` and skips free-form named entities entirely.
-- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](developer/retain.md#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`.
+- **Open-world automation (default):** Hindsight's LLM pipeline automatically detects and extracts standard entities — people, places, dates — from raw text and turns them into stickers.
+- **Developer control via `entity_labels`:** You can define a custom schema using [entity labels](developer/retain.md#entity-labels). This forces the LLM to categorize memories using a strict, predefined vocabulary. Instead of letting the AI invent random descriptors, you choose the exact names and parameters for the stickers — for example, forcing a `pedagogy` key to only choose from `scaffolding`, `direct_instruction`, or `socratic_questioning`. To lock the bank to *only* your configured labels and turn off the open-world automation above, also set `entities_allow_free_form: false` on the bank config — the LLM then skips free-form named entities entirely and emits only entries that match your schema.
 
 #### Can I build direct entity-to-entity pipelines?
 

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -389,6 +389,14 @@ Memory A → [pedagogy:scaffolding] → Memory B
 
 It links your experiences by finding different scrapbook pages that happen to share the exact same stickers.
 
+#### Does this graph structure help reduce hallucinations in my agent?
+
+Yes — by giving the consuming LLM better-grounded context to reason from. Three properties of the scrapbook model contribute directly:
+
+- **History is preserved, not collapsed.** The model sees time-bounded facts (Alice worked at Acme last year, Stark Industries now) rather than a contradictory present-tense edge that forces it to reconcile or guess.
+- **Connections come from real shared entities, not inference.** When recall surfaces two related memories, it's because they genuinely share an entity sticker — the link appears in the retrieved context, so the model doesn't have to invent one.
+- **Convergent evidence accumulates.** Multiple memories anchoring to the same entity reinforce each other instead of competing, giving the model corroborated claims rather than singular unsupported ones.
+
 ---
 
 ## Still have questions?


### PR DESCRIPTION
## Summary

Adds a new FAQ entry — **"How is Hindsight's graph different from a traditional knowledge graph?"** — answering one of the most common conceptual questions from customers evaluating Hindsight when they already have a property-graph stack (Neo4j, RDF, etc.).

Uses the **map-vs-scrapbook analogy** to make the event-centric, temporal bipartite hypergraph model intuitive without requiring graph-theory jargon. Placed at the bottom of the FAQ since it's the most technical entry — basic onboarding questions should reach the reader first.

Subsections cover the questions that come up next on sales calls:

- How history is preserved when facts change (the "Alice changes jobs" case) without rewriting edges
- Where entity stickers come from, including both open-world automation and developer control via `entity_labels` (with the `entities_allow_free_form: false` knob to lock the bank to *only* the configured schema)
- Why entities don't link directly to each other
- How shared entity-anchoring drives connection discovery — including the high-level note that recall starts with semantic search to pick seed memories before the graph traversal expands from there

## Why

This is genuinely the most common follow-up question after "what's the difference from RAG?" — customers who already have a KG want to know where Hindsight fits relative to what they're running. Having a canonical FAQ entry reduces sales-call back-and-forth and gives Solutions a single link to share.

## Test plan

- [x] `npm run build` in `hindsight-docs/` succeeds (no new broken anchors; pre-existing warnings in unrelated blog posts are untouched)
- [x] Rendered HTML verified locally — content appears in `build/faq.html` with `entities_allow_free_form` correctly rendered
- [x] Pre-commit lint passes
- [x] `skills/hindsight-docs/references/faq.md` regenerated by pre-commit and included so the docs skill stays in sync with source

## Commit history

Left as four small commits showing the review iteration (initial entry → reorder + disable note → disable note moved to correct bullet → semantic-seeding note). Squash or leave as-is, your call.