### PR TITLE
Bound trigram entity resolution batch size during retain

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -362,6 +362,7 @@ ENV_RETAIN_CUSTOM_INSTRUCTIONS = "HINDSIGHT_API_RETAIN_CUSTOM_INSTRUCTIONS"
 ENV_RETAIN_DEFAULT_STRATEGY = "HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY"
 ENV_RETAIN_BATCH_TOKENS = "HINDSIGHT_API_RETAIN_BATCH_TOKENS"
 ENV_RETAIN_ENTITY_LOOKUP = "HINDSIGHT_API_RETAIN_ENTITY_LOOKUP"
+ENV_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE = "HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE"
 ENV_RETAIN_BATCH_ENABLED = "HINDSIGHT_API_RETAIN_BATCH_ENABLED"
 ENV_RETAIN_BATCH_POLL_INTERVAL_SECONDS = "HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS"
 ENV_RETAIN_CHUNK_BATCH_SIZE = "HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE"
@@ -668,6 +669,7 @@ DEFAULT_RETAIN_CHUNK_BATCH_SIZE = (
 )
 DEFAULT_RETAIN_BATCH_TOKENS = 10_000  # ~40KB of text  # Max chars per sub-batch for async retain auto-splitting
 DEFAULT_RETAIN_ENTITY_LOOKUP = "trigram"  # "full" or "trigram"
+DEFAULT_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE = 100  # Unique entity names per pg_trgm candidate lookup query
 DEFAULT_RETAIN_BATCH_ENABLED = False  # Use LLM Batch API for fact extraction (only when async=True)
 DEFAULT_RETAIN_BATCH_POLL_INTERVAL_SECONDS = 60  # Batch API polling interval in seconds
 
@@ -1201,6 +1203,7 @@ class HindsightConfig:
     retain_batch_enabled: bool
     retain_batch_poll_interval_seconds: int
     retain_entity_lookup: str  # "full" or "trigram"
+    retain_entity_resolution_batch_size: int  # Unique entity names per pg_trgm candidate lookup query
     retain_chunk_batch_size: int  # Max chunks per streaming batch (0 = disabled)
 
     # File storage (static - server-level only)
@@ -1951,6 +1954,11 @@ class HindsightConfig:
             retain_strategies=DEFAULT_RETAIN_STRATEGIES,
             retain_batch_tokens=int(os.getenv(ENV_RETAIN_BATCH_TOKENS, str(DEFAULT_RETAIN_BATCH_TOKENS))),
             retain_entity_lookup=os.getenv(ENV_RETAIN_ENTITY_LOOKUP, DEFAULT_RETAIN_ENTITY_LOOKUP),
+            retain_entity_resolution_batch_size=_parse_positive_int(
+                ENV_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE,
+                os.getenv(ENV_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE),
+                DEFAULT_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE,
+            ),
             retain_batch_enabled=os.getenv(ENV_RETAIN_BATCH_ENABLED, str(DEFAULT_RETAIN_BATCH_ENABLED)).lower()
             == "true",
             retain_batch_poll_interval_seconds=int(

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -97,7 +97,12 @@ class EntityResolver:
     Resolves entities to canonical IDs with disambiguation.
     """
 
-    def __init__(self, pool: Any, entity_lookup: str = "full"):
+    def __init__(
+        self,
+        pool: Any,
+        entity_lookup: str = "full",
+        entity_resolution_batch_size: int = 100,
+    ):
         """
         Initialize entity resolver.
 
@@ -106,9 +111,14 @@ class EntityResolver:
             entity_lookup: Lookup strategy — "full" loads all bank entities then
                 matches in Python; "trigram" uses pg_trgm GIN index to fetch only
                 similar candidates per entity name (much faster for large banks).
+            entity_resolution_batch_size: Number of unique entity names to include
+                in each pg_trgm candidate lookup query.
         """
         self.pool = pool
         self.entity_lookup = entity_lookup
+        if entity_resolution_batch_size < 1:
+            raise ValueError("entity_resolution_batch_size must be >= 1")
+        self.entity_resolution_batch_size = entity_resolution_batch_size
         self._pg_trgm_checked = False
         # Backend-specific operations — accessed via pool.ops (Django pattern).
         self._ops = pool.ops if pool is not None else None
@@ -206,6 +216,11 @@ class EntityResolver:
     def _build_labels_lookup(entity_labels: list | None) -> set[str]:
         """Build a set of valid 'key:value' entity label strings for fast lookup."""
         return _build_labels_lookup_from_config(entity_labels)
+
+    @staticmethod
+    def _chunked(values: list[str], size: int) -> list[list[str]]:
+        """Split values into fixed-size batches."""
+        return [values[i : i + size] for i in range(0, len(values), size)]
 
     async def resolve_entities_batch(
         self,
@@ -390,7 +405,7 @@ class EntityResolver:
         """
         entity_texts = list(set(e["text"] for e in entities_data))
 
-        # Fetch candidates for all unique entity texts in a single batched query.
+        # Fetch candidates for unique entity texts in bounded batches.
         # Uses the GIN trigram index on LOWER(canonical_name) for case-insensitive
         # similarity lookup. Previous version also had LIKE '%...' substring fallbacks,
         # but those forced full sequential scans of the entities table and caused
@@ -398,21 +413,35 @@ class EntityResolver:
         # to 0.15 (from default 0.3) catches most substring relationships while
         # staying fully index-based.
         await conn.execute("SET pg_trgm.similarity_threshold = 0.15")
-        rows = await conn.fetch(
-            f"""
-            SELECT DISTINCT ON (e.id)
-                e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
-                q.query_text
-            FROM unnest($2::text[]) AS q(query_text)
-            JOIN {fq_table("entities")} e ON (
-                e.bank_id = $1
-                AND LOWER(e.canonical_name) % LOWER(q.query_text)
-            )
-            """,
-            bank_id,
-            entity_texts,
-        )
-        await conn.execute("RESET pg_trgm.similarity_threshold")
+        rows = []
+        try:
+            for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
+                rows.extend(
+                    await conn.fetch(
+                        f"""
+                        SELECT DISTINCT ON (e.id)
+                            e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                            q.query_text
+                        FROM unnest($2::text[]) AS q(query_text)
+                        JOIN {fq_table("entities")} e ON (
+                            e.bank_id = $1
+                            AND LOWER(e.canonical_name) % LOWER(q.query_text)
+                        )
+                        """,
+                        bank_id,
+                        entity_text_batch,
+                    )
+                )
+        except Exception:
+            try:
+                await conn.execute("RESET pg_trgm.similarity_threshold")
+            except Exception:
+                logger.warning(
+                    "Failed to reset pg_trgm similarity threshold after candidate lookup error", exc_info=True
+                )
+            raise
+        else:
+            await conn.execute("RESET pg_trgm.similarity_threshold")
 
         # Group candidates by query_text
         all_candidates: dict[str, list] = {t: [] for t in entity_texts}

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -737,6 +737,7 @@ class MemoryEngine(MemoryEngineInterface):
         self._db_statement_timeout = config.db_statement_timeout
         self._run_migrations = run_migrations
         self._retain_entity_lookup = config.retain_entity_lookup
+        self._retain_entity_resolution_batch_size = config.retain_entity_resolution_batch_size
 
         # Webhook manager (will be created in initialize() after pool is ready)
         self._webhook_manager = None
@@ -2304,6 +2305,7 @@ class MemoryEngine(MemoryEngineInterface):
         self.entity_resolver = EntityResolver(
             self._backend,
             entity_lookup=self._retain_entity_lookup,
+            entity_resolution_batch_size=self._retain_entity_resolution_batch_size,
         )
 
         # Initialize config resolver for hierarchical configuration

--- a/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
+++ b/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
@@ -25,15 +25,20 @@ def _make_conn(pg_trgm_available: bool) -> MagicMock:
     conn.backend_type = "postgresql"
     conn.fetchval = AsyncMock(return_value=pg_trgm_available)
     conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
     conn.executemany = AsyncMock()
     conn.fetchrow = AsyncMock(return_value=None)
     return conn
 
 
-def _make_resolver(entity_lookup: str = "trigram") -> EntityResolver:
+def _make_resolver(entity_lookup: str = "trigram", entity_resolution_batch_size: int = 100) -> EntityResolver:
     """Return an EntityResolver with a mock pool (only ops attribute is needed)."""
     pool = MagicMock()
-    return EntityResolver(pool=pool, entity_lookup=entity_lookup)  # type: ignore[arg-type]
+    return EntityResolver(
+        pool=pool,
+        entity_lookup=entity_lookup,
+        entity_resolution_batch_size=entity_resolution_batch_size,
+    )  # type: ignore[arg-type]
 
 
 class TestPgTrgmAutoDetection:
@@ -166,3 +171,28 @@ class TestPgTrgmAutoDetection:
         assert mock_full.call_count == 2
         # pg_trgm check was issued exactly once
         assert conn.fetchval.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_trigram_candidate_lookup_batches_entity_texts(self):
+        """The trigram candidate query is split into bounded batches."""
+        resolver = _make_resolver(entity_lookup="trigram", entity_resolution_batch_size=2)
+        conn = _make_conn(pg_trgm_available=True)
+        entities_data = [{"text": f"Entity {idx}"} for idx in range(5)]
+
+        with (
+            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
+            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
+        ):
+            await resolver._resolve_entities_batch_trigram(
+                conn=conn,
+                bank_id="test-bank",
+                entities_data=entities_data,
+                unit_event_date=None,
+            )
+
+        assert conn.fetch.call_count == 3
+        batches = [call.args[2] for call in conn.fetch.call_args_list]
+        assert sorted(len(batch) for batch in batches) == [1, 2, 2]
+        assert {entity for batch in batches for entity in batch} == {f"Entity {idx}" for idx in range(5)}
+        conn.execute.assert_any_await("SET pg_trgm.similarity_threshold = 0.15")
+        conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")


### PR DESCRIPTION
Large retain operations can produce many unique entity names in one streaming mini-batch. The trigram resolver currently passes all unique entity texts to a single unnest(...) JOIN entities query. On large banks this can create a single expensive pg_trgm query that hits asyncpg/Postgres timeouts and fails the whole retain operation.

This change chunks trigram entity candidate lookup into bounded batches while preserving the same candidate grouping and scoring behavior.