### PR TITLE
fix(control-plane): honor basePath for auth redirects

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/login/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/login/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { stripBasePath, withBasePath } from "@/lib/base-path";
 import Image from "next/image";
 
 function LoginForm() {
@@ -18,7 +19,7 @@ function LoginForm() {
   const searchParams = useSearchParams();
 
   // Get the returnTo URL from query params
-  const returnTo = searchParams.get("returnTo") || "/dashboard";
+  const returnTo = stripBasePath(searchParams.get("returnTo") || "/dashboard");
 
   useEffect(() => {
     // Focus the input on mount
@@ -32,7 +33,7 @@ function LoginForm() {
     setLoading(true);
 
     try {
-      const res = await fetch("/api/auth/login", {
+      const res = await fetch(withBasePath("/api/auth/login"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ key }),
@@ -61,7 +62,7 @@ function LoginForm() {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <Image
-            src="/logo.png"
+            src={withBasePath("/logo.png")}
             alt="Hindsight"
             width={160}
             height={160}

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useBank } from "@/lib/bank-context";
 import { bankRoute } from "@/lib/bank-url";
+import { withBasePath } from "@/lib/base-path";
 import { client } from "@/lib/api";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { Button } from "@/components/ui/button";
@@ -464,7 +465,7 @@ function BankSelectorInner() {
       <div className="flex items-center gap-4 text-sm">
         {/* Logo */}
         <Image
-          src="/logo.png"
+          src={withBasePath("/logo.png")}
           alt="Hindsight"
           width={40}
           height={40}
@@ -639,9 +640,9 @@ function BankSelectorInner() {
               title="Logout"
               onClick={async () => {
                 try {
-                  await fetch("/api/auth/logout", { method: "POST" });
+                  await fetch(withBasePath("/api/auth/logout"), { method: "POST" });
                 } finally {
-                  window.location.href = "/login";
+                  window.location.href = withBasePath("/login");
                 }
               }}
             >
@@ -1332,7 +1333,7 @@ export function BankSelector() {
         <div className="bg-card text-card-foreground px-5 py-3 border-b-4 border-primary-gradient">
           <div className="flex items-center gap-4 text-sm">
             <Image
-              src="/logo.png"
+              src={withBasePath("/logo.png")}
               alt="Hindsight"
               width={40}
               height={40}

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -5,6 +5,7 @@
 
 import { toast } from "sonner";
 import { bankApi, bankStatsApi, documentApi, memoryApi } from "./bank-url";
+import { stripBasePath, withBasePath } from "./base-path";
 
 export interface WebhookHttpConfig {
   method: string;
@@ -120,7 +121,7 @@ export interface BankTemplateImportResponse {
 export class ControlPlaneClient {
   private async fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
     try {
-      const response = await fetch(path, {
+      const response = await fetch(withBasePath(path), {
         ...options,
         headers: {
           "Content-Type": "application/json",
@@ -130,8 +131,9 @@ export class ControlPlaneClient {
 
       if (!response.ok) {
         // Redirect to login on 401 (session expired or not authenticated)
-        if (response.status === 401 && !window.location.pathname.startsWith("/login")) {
-          window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`;
+        const currentPath = stripBasePath(`${window.location.pathname}${window.location.search}`);
+        if (response.status === 401 && !currentPath.startsWith("/login")) {
+          window.location.href = withBasePath(`/login?returnTo=${encodeURIComponent(currentPath)}`);
           throw new Error("Unauthorized");
         }
 
@@ -1270,7 +1272,7 @@ export class ControlPlaneClient {
     formData.append("request", JSON.stringify(requestData));
 
     // Use fetch directly for multipart/form-data
-    const response = await fetch(`/api/files/retain`, {
+    const response = await fetch(withBasePath("/api/files/retain"), {
       method: "POST",
       body: formData,
       // Don't set Content-Type - browser will set it with boundary

--- a/hindsight-control-plane/src/lib/base-path.test.ts
+++ b/hindsight-control-plane/src/lib/base-path.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { normalizeBasePath, stripBasePath, withBasePath } from "./base-path";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("base path helpers", () => {
+  it("normalizes missing, root, and slash variants", () => {
+    expect(normalizeBasePath(undefined)).toBe("");
+    expect(normalizeBasePath("")).toBe("");
+    expect(normalizeBasePath("/")).toBe("");
+    expect(normalizeBasePath("ai-memory/")).toBe("/ai-memory");
+    expect(normalizeBasePath("/ai-memory///")).toBe("/ai-memory");
+  });
+
+  it("prefixes app-relative paths when NEXT_PUBLIC_BASE_PATH is set", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+    expect(withBasePath("/login")).toBe("/ai-memory/login");
+    expect(withBasePath("api/auth/login")).toBe("/ai-memory/api/auth/login");
+  });
+
+  it("does not double-prefix paths that already include the base path", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+    expect(withBasePath("/ai-memory/login")).toBe("/ai-memory/login");
+    expect(withBasePath("/ai-memory/login?returnTo=%2Fdashboard")).toBe(
+      "/ai-memory/login?returnTo=%2Fdashboard"
+    );
+  });
+
+  it("strips the base path from returnTo-style paths while preserving query strings", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+    expect(stripBasePath("/ai-memory/dashboard")).toBe("/dashboard");
+    expect(stripBasePath("/ai-memory/dashboard?view=data")).toBe("/dashboard?view=data");
+    expect(stripBasePath("/dashboard")).toBe("/dashboard");
+  });
+
+  it("builds a base-prefixed middleware login redirect with an app-relative returnTo", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+    const loginUrl = new URL(withBasePath("/login"), "https://example.com/ai-memory/dashboard");
+    loginUrl.searchParams.set("returnTo", stripBasePath("/ai-memory/dashboard"));
+
+    expect(loginUrl.toString()).toBe("https://example.com/ai-memory/login?returnTo=%2Fdashboard");
+  });
+
+  it("leaves absolute URLs unchanged", () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+    expect(withBasePath("https://example.com/login")).toBe("https://example.com/login");
+    expect(stripBasePath("https://example.com/ai-memory/login")).toBe(
+      "https://example.com/ai-memory/login"
+    );
+  });
+});

--- a/hindsight-control-plane/src/lib/base-path.ts
+++ b/hindsight-control-plane/src/lib/base-path.ts
@@ -1,0 +1,60 @@
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+\-.]*:\/\//i;
+
+function ensureLeadingSlash(path: string): string {
+  if (!path) return "/";
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function normalizeBasePath(value = process.env.NEXT_PUBLIC_BASE_PATH): string {
+  if (!value || value === "/") return "";
+  const withSlash = ensureLeadingSlash(value.trim());
+  return withSlash.replace(/\/+$/, "");
+}
+
+export function withBasePath(path: string): string {
+  if (ABSOLUTE_URL_PATTERN.test(path) || path.startsWith("//")) {
+    return path;
+  }
+
+  const basePath = normalizeBasePath();
+  const normalizedPath = ensureLeadingSlash(path);
+
+  if (!basePath) {
+    return normalizedPath;
+  }
+  if (
+    normalizedPath === basePath ||
+    normalizedPath.startsWith(`${basePath}/`) ||
+    normalizedPath.startsWith(`${basePath}?`)
+  ) {
+    return normalizedPath;
+  }
+
+  return `${basePath}${normalizedPath}`;
+}
+
+export function stripBasePath(path: string): string {
+  if (ABSOLUTE_URL_PATTERN.test(path) || path.startsWith("//")) {
+    return path;
+  }
+
+  const basePath = normalizeBasePath();
+  const normalizedPath = ensureLeadingSlash(path);
+
+  if (!basePath) {
+    return normalizedPath;
+  }
+
+  const match = normalizedPath.match(/^([^?#]*)(.*)$/);
+  const pathname = match?.[1] || "/";
+  const suffix = match?.[2] || "";
+
+  if (pathname === basePath) {
+    return `/${suffix}`;
+  }
+  if (pathname.startsWith(`${basePath}/`)) {
+    return `${pathname.slice(basePath.length)}${suffix}`;
+  }
+
+  return normalizedPath;
+}

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -4,6 +4,7 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 import createIntlMiddleware from "next-intl/middleware";
 
 import { ACCESS_KEY_COOKIE, verifySessionToken } from "@/lib/auth/session";
+import { stripBasePath, withBasePath } from "@/lib/base-path";
 import { routing } from "@/i18n/routing";
 
 // Routes that don't require authentication
@@ -35,14 +36,15 @@ function stripLocalePrefix(pathname: string): string {
 export async function middleware(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
   const { pathname } = request.nextUrl;
+  const appPathname = stripBasePath(pathname);
 
   // API routes are not locale-prefixed — handle auth directly without i18n routing.
-  if (pathname.startsWith("/api/")) {
+  if (appPathname.startsWith("/api/")) {
     if (!accessKey) {
       return NextResponse.next();
     }
 
-    const isPublic = PUBLIC_PATTERNS.some((pattern) => pathname.startsWith(pattern));
+    const isPublic = PUBLIC_PATTERNS.some((pattern) => appPathname.startsWith(pattern));
     if (isPublic) {
       return NextResponse.next();
     }
@@ -66,7 +68,7 @@ export async function middleware(request: NextRequest) {
   // Page routes: enforce auth first (using locale-stripped path), then delegate
   // to the i18n middleware for locale negotiation and rewriting.
   if (accessKey) {
-    const canonicalPath = stripLocalePrefix(pathname);
+    const canonicalPath = stripLocalePrefix(appPathname);
     const isPublic = PUBLIC_PATTERNS.some((pattern) => canonicalPath.startsWith(pattern));
 
     if (!isPublic) {
@@ -74,8 +76,11 @@ export async function middleware(request: NextRequest) {
       const isAuthenticated = await verifySessionToken(sessionCookie, accessKey);
 
       if (!isAuthenticated) {
-        const loginUrl = new URL("/login", request.url);
-        loginUrl.searchParams.set("returnTo", pathname);
+        // Next.js middleware redirects do not automatically inherit next.config basePath.
+        // Prefix the target explicitly, but keep returnTo as the app-relative path so
+        // client-side router.push() does not double-prefix after login.
+        const loginUrl = new URL(withBasePath("/login"), request.url);
+        loginUrl.searchParams.set("returnTo", appPathname);
         return NextResponse.redirect(loginUrl);
       }
     }


### PR DESCRIPTION
Summary
- add shared Control Plane basePath helpers for prefixing app-relative URLs and stripping returnTo paths
- prefix middleware auth redirects with NEXT_PUBLIC_BASE_PATH while keeping returnTo app-relative
- prefix client login/logout/API fetches and logo assets for subpath deployments

Closes #1844.

Tests
- npm test
- ./scripts/hooks/lint.sh
