### PR TITLE
fix: preserve raw reranker scores for calibrated [0,1] providers

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -213,42 +213,20 @@ class CrossEncoderReranker:
         scores = await self.cross_encoder.predict(pairs)
 
         # Normalize scores to [0, 1] range.
+        # External API rerankers (Cohere, Jina, llama.cpp/Qwen, etc.) return
+        # calibrated relevance_score already in [0, 1]. These are used as-is
+        # so that absolute confidence is preserved — a top candidate scoring
+        # 0.007 stays low rather than being inflated to 1.0 by rank normalization.
         # Local models return logits (any real number) — sigmoid is appropriate.
-        # External API rerankers (SiliconFlow, Cohere, etc.) return pre-normalized
-        # relevance_score in [0, 1] with very small absolute values. Applying
-        # sigmoid to these compresses everything to ~0.5, destroying the ranking
-        # signal and making recency the sole sorting factor. We detect the score range
-        # and choose the appropriate normalization.
         import numpy as np
 
         def _sigmoid(x: float) -> float:
             return 1 / (1 + np.exp(-x))
 
-        def _rank_normalize_with_ties(score_list: list[float]) -> list[float]:
-            """Rank-based normalization that assigns equal ranks to equal scores."""
-            n = len(score_list)
-            if n <= 1:
-                return [1.0] * n
-            indexed = sorted(enumerate(score_list), key=lambda x: x[1], reverse=True)
-            result = [0.0] * n
-            i = 0
-            while i < n:
-                j = i
-                while j < n and indexed[j][1] == indexed[i][1]:
-                    j += 1
-                # Average rank for tied scores
-                avg_rank = (i + j - 1) / 2.0
-                norm = 1.0 - (avg_rank / (n - 1))
-                for k in range(i, j):
-                    result[indexed[k][0]] = norm
-                i = j
-            return result
-
         if scores and min(scores) >= 0.0 and max(scores) <= 1.0:
-            # Scores are already in [0, 1] (e.g. SiliconFlow, Cohere relevance_score).
-            # Use rank-based normalization to preserve relative ordering without
-            # depending on absolute score magnitudes.
-            normalized_scores = _rank_normalize_with_ties(scores)
+            # Scores already in [0, 1] — pass through to preserve absolute
+            # confidence signal from calibrated rerankers.
+            normalized_scores = list(scores)
         else:
             # Scores are logits (e.g. local sentence-transformers models).
             # Sigmoid maps (-inf, +inf) to (0, 1).

--- a/hindsight-api-slim/tests/test_reranker_score_normalization.py
+++ b/hindsight-api-slim/tests/test_reranker_score_normalization.py
@@ -2,10 +2,10 @@
 Unit tests for CrossEncoderReranker.rerank() score normalization logic.
 
 Covers:
-1. Rank-based normalization when scores are already in [0, 1].
-2. Tied scores receiving identical normalized values.
-3. Sigmoid normalization when scores are logits outside [0, 1].
-4. Empty candidates returning an empty list without calling predict().
+1. Passthrough normalization when scores are already in [0, 1].
+2. Sigmoid normalization when scores are logits outside [0, 1].
+3. Empty candidates returning an empty list without calling predict().
+4. Low-confidence scores are preserved (not inflated by rank normalization).
 """
 
 from __future__ import annotations
@@ -54,9 +54,8 @@ def _make_cross_encoder(predict_return: list[float]):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_rank_normalization_for_0_1_scores():
-    """Scores already in [0, 1] should use rank-based normalization."""
-    # Scores in [0, 1] but NOT logit-shaped — rank normalization preserves order
+async def test_passthrough_for_0_1_scores():
+    """Scores already in [0, 1] should be passed through as-is."""
     raw_scores = [0.1, 0.5, 0.9]
     ce = _make_cross_encoder(raw_scores)
     reranker = CrossEncoderReranker(cross_encoder=ce)
@@ -66,44 +65,33 @@ async def test_rank_normalization_for_0_1_scores():
     results = await reranker.rerank("test query", candidates)
 
     assert len(results) == 3
-    # Top-ranked (0.9) gets normalized 1.0
+    # Results sorted by score descending; normalized == raw
     assert results[0].cross_encoder_score == pytest.approx(0.9)
-    assert results[0].cross_encoder_score_normalized == pytest.approx(1.0)
-    # Bottom-ranked (0.1) gets normalized 0.0
-    assert results[-1].cross_encoder_score == pytest.approx(0.1)
-    assert results[-1].cross_encoder_score_normalized == pytest.approx(0.0)
-    # Middle gets 0.5
+    assert results[0].cross_encoder_score_normalized == pytest.approx(0.9)
+    assert results[1].cross_encoder_score == pytest.approx(0.5)
     assert results[1].cross_encoder_score_normalized == pytest.approx(0.5)
-    # predict was called exactly once
+    assert results[2].cross_encoder_score == pytest.approx(0.1)
+    assert results[2].cross_encoder_score_normalized == pytest.approx(0.1)
     ce.predict.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_tied_scores_get_same_normalized_value():
-    """When raw scores contain ties, tied entries must receive the same normalized score."""
-    # Two scores tied at 0.7, one distinct at 0.3
-    raw_scores = [0.7, 0.3, 0.7]
+async def test_low_confidence_scores_preserved():
+    """When all candidates have low scores, they should stay low (not inflated)."""
+    # Simulates a recall where no candidate is truly relevant
+    raw_scores = [0.0077, 0.0033, 0.0021, 0.0003]
     ce = _make_cross_encoder(raw_scores)
     reranker = CrossEncoderReranker(cross_encoder=ce)
     reranker._initialized = True
 
-    candidates = _make_candidates(3)
+    candidates = _make_candidates(4)
     results = await reranker.rerank("test query", candidates)
 
-    # The two 0.7 entries should share the same normalized value.
-    # With rank-based normalization over 3 items (indices 0,1,2 sorted desc):
-    #   rank 0 & 1 tied → avg_rank = 0.5 → norm = 1 - 0.5/2 = 0.75
-    #   rank 2          → norm = 1 - 2/2 = 0.0
-    # After sorting by normalized score descending, the two 0.7 entries are
-    # at indices 0 and 1; the 0.3 entry is at index 2.
-    scores_by_raw = {r.cross_encoder_score: r.cross_encoder_score_normalized for r in results}
-    tied_norm = scores_by_raw[0.7]
-    assert tied_norm == pytest.approx(0.75)
-    assert scores_by_raw[0.3] == pytest.approx(0.0)
-    # Both 0.7 results have identical normalized scores
-    assert results[0].cross_encoder_score_normalized == pytest.approx(
-        results[1].cross_encoder_score_normalized
-    )
+    # All normalized scores should remain low — not inflated to 1.0
+    for result in results:
+        assert result.cross_encoder_score_normalized < 0.01
+    # Top candidate stays at its raw score
+    assert results[0].cross_encoder_score_normalized == pytest.approx(0.0077)
 
 
 @pytest.mark.asyncio
@@ -146,8 +134,8 @@ async def test_empty_candidates_returns_empty_without_predict():
 
 
 @pytest.mark.asyncio
-async def test_mixed_boundary_scores_use_rank():
-    """Boundary values 0.0 and 1.0 (still in [0,1]) should trigger rank normalization."""
+async def test_boundary_scores_passthrough():
+    """Boundary values 0.0 and 1.0 (still in [0,1]) should pass through."""
     raw_scores = [0.0, 1.0, 0.5]
     ce = _make_cross_encoder(raw_scores)
     reranker = CrossEncoderReranker(cross_encoder=ce)
@@ -156,7 +144,6 @@ async def test_mixed_boundary_scores_use_rank():
     candidates = _make_candidates(3)
     results = await reranker.rerank("test query", candidates)
 
-    # Rank-based: 1.0 → 1.0, 0.5 → 0.5, 0.0 → 0.0
     by_score = {r.cross_encoder_score: r.cross_encoder_score_normalized for r in results}
     assert by_score[1.0] == pytest.approx(1.0)
     assert by_score[0.5] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Replace rank-based normalization with passthrough for reranker scores already in `[0, 1]`. Calibrated rerankers (Cohere, Jina, llama.cpp/Qwen) return meaningful absolute confidence — rank normalization was inflating weak candidates (e.g. `0.007 → 1.0`) simply for being top-ranked among bad results.
- Sigmoid normalization for logit-based local models is unchanged.
- Downstream multiplicative boosts (recency, temporal, proof count) are scale-invariant and require no adjustment.

Closes #1823

## Test plan
- [x] Updated `test_reranker_score_normalization.py` — passthrough tests replace rank normalization tests
- [x] New `test_low_confidence_scores_preserved` validates the core issue scenario (all-weak candidates stay low)
- [x] `test_combined_scoring.py` passes unchanged (boosts are scale-invariant)
- [ ] Verify with a calibrated external reranker (Cohere/llama.cpp) that recall scores reflect actual confidence