### PR TITLE
fix(retain): apply batching to Oracle entity resolution + guarantee pg_trgm RESET

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/c1d2e3f4a5b6_merge_graph_queue_and_vchord_heads.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c1d2e3f4a5b6_merge_graph_queue_and_vchord_heads.py
@@ -1,0 +1,45 @@
+"""Merge graph_maintenance_queue and vchord_cosine_opclass heads.
+
+Revision ID: c1d2e3f4a5b6
+Revises: b5a4c3e2f1d8, b8c9d0e1f2a3
+Create Date: 2026-05-29
+
+PRs #1668 (vchord cosine opclass) and #1772 (async link recompute) both
+branched off the same parent and were merged onto main without rebasing,
+leaving two parallel Alembic heads. This is a structural merge revision
+with no schema changes — its only job is to unify the DAG so
+``alembic upgrade head`` is unambiguous again.
+"""
+
+from collections.abc import Sequence
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | Sequence[str] | None = ("b5a4c3e2f1d8", "b8c9d0e1f2a3")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_upgrade() -> None:
+    pass
+
+
+def _pg_downgrade() -> None:
+    pass
+
+
+def _oracle_upgrade() -> None:
+    pass
+
+
+def _oracle_downgrade() -> None:
+    pass
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -413,8 +413,8 @@ class EntityResolver:
         # to 0.15 (from default 0.3) catches most substring relationships while
         # staying fully index-based.
         await conn.execute("SET pg_trgm.similarity_threshold = 0.15")
-        rows = []
         try:
+            rows = []
             for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
                 rows.extend(
                     await conn.fetch(
@@ -432,16 +432,13 @@ class EntityResolver:
                         entity_text_batch,
                     )
                 )
-        except Exception:
+        finally:
+            # asyncpg returns connections to the pool with session state intact,
+            # so the lowered threshold would leak to future borrowers without RESET.
             try:
                 await conn.execute("RESET pg_trgm.similarity_threshold")
             except Exception:
-                logger.warning(
-                    "Failed to reset pg_trgm similarity threshold after candidate lookup error", exc_info=True
-                )
-            raise
-        else:
-            await conn.execute("RESET pg_trgm.similarity_threshold")
+                logger.warning("Failed to reset pg_trgm similarity threshold after candidate lookup", exc_info=True)
 
         # Group candidates by query_text
         all_candidates: dict[str, list] = {t: [] for t in entity_texts}
@@ -515,23 +512,28 @@ class EntityResolver:
         entities_table = fq_table("entities")
 
         try:
-            # Batch all entity texts into a single query using JSON_TABLE to
+            # Batch entity texts into bounded sub-queries using JSON_TABLE to
             # expand the list into rows. UTL_MATCH.JARO_WINKLER_SIMILARITY
             # returns 0-100; threshold 70 ≈ pg_trgm similarity 0.15.
-            entity_texts_json = json.dumps(entity_texts)
-            rows = await conn.fetch(
-                f"""
-                SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
-                       q.query_text
-                FROM JSON_TABLE($2, '$[*]' COLUMNS (query_text VARCHAR2(4000) PATH '$')) q
-                JOIN {entities_table} e ON (
-                    e.bank_id = $1
-                    AND UTL_MATCH.JARO_WINKLER_SIMILARITY(LOWER(e.canonical_name), LOWER(q.query_text)) > 70
+            # Bounded batches mirror the PG trigram path so very wide retain
+            # batches don't time out a single JOIN on large banks.
+            rows = []
+            for entity_text_batch in self._chunked(entity_texts, self.entity_resolution_batch_size):
+                rows.extend(
+                    await conn.fetch(
+                        f"""
+                        SELECT e.id, e.canonical_name, e.metadata, e.last_seen, e.mention_count,
+                               q.query_text
+                        FROM JSON_TABLE($2, '$[*]' COLUMNS (query_text VARCHAR2(4000) PATH '$')) q
+                        JOIN {entities_table} e ON (
+                            e.bank_id = $1
+                            AND UTL_MATCH.JARO_WINKLER_SIMILARITY(LOWER(e.canonical_name), LOWER(q.query_text)) > 70
+                        )
+                        """,
+                        bank_id,
+                        json.dumps(entity_text_batch),
+                    )
                 )
-                """,
-                bank_id,
-                entity_texts_json,
-            )
         except Exception as e:
             # UTL_MATCH may not be available (ORA-06550, ORA-00904, etc.)
             # Catch broadly because Oracle error types vary depending on driver.

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -293,6 +293,37 @@ class TestOracleFuzzyEntityResolution:
             assert bob_candidates[0][1] == "Robert Jones"
 
     @pytest.mark.asyncio
+    async def test_oracle_candidate_lookup_batches_entity_texts(self):
+        """The Oracle UTL_MATCH candidate query is split into bounded batches,
+        mirroring the PG trigram path so very wide retain batches don't time out
+        a single JSON_TABLE join on banks with many entities."""
+        resolver = EntityResolver(
+            pool=None,  # type: ignore[arg-type]
+            entity_lookup="oracle_fuzzy",
+            entity_resolution_batch_size=2,
+        )
+        conn = AsyncMock()
+        conn.backend_type = "oracle"
+        conn.fetch = AsyncMock(return_value=[])
+        entities_data = [
+            {"text": f"Entity {idx}", "nearby_entities": [], "event_date": None} for idx in range(5)
+        ]
+
+        with patch.object(resolver, "_resolve_from_candidates", new_callable=AsyncMock, return_value=[]):
+            await resolver._resolve_entities_batch_oracle_fuzzy(
+                conn=conn,
+                bank_id="bank-1",
+                entities_data=entities_data,
+                unit_event_date=None,
+            )
+
+        # 5 entities, batch size 2 → 3 candidate fetches (cooc fetch is skipped since results are empty).
+        assert conn.fetch.call_count == 3
+        batches = [json.loads(call.args[2]) for call in conn.fetch.call_args_list]
+        assert sorted(len(batch) for batch in batches) == [1, 2, 2]
+        assert {entity for batch in batches for entity in batch} == {f"Entity {idx}" for idx in range(5)}
+
+    @pytest.mark.asyncio
     async def test_cooccurrence_query_uses_candidate_ids(self, resolver, mock_conn):
         """When candidates are found, the co-occurrence query should only fetch
         relationships for the candidate entity IDs (not all entities in the bank)."""

--- a/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
+++ b/hindsight-api-slim/tests/test_entity_resolver_pg_trgm.py
@@ -196,3 +196,25 @@ class TestPgTrgmAutoDetection:
         assert {entity for batch in batches for entity in batch} == {f"Entity {idx}" for idx in range(5)}
         conn.execute.assert_any_await("SET pg_trgm.similarity_threshold = 0.15")
         conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")
+
+    @pytest.mark.asyncio
+    async def test_trigram_resets_threshold_even_when_fetch_raises(self):
+        """If a batch fetch fails, RESET must still run so the lowered threshold doesn't leak to the pooled connection."""
+        resolver = _make_resolver(entity_lookup="trigram", entity_resolution_batch_size=2)
+        conn = _make_conn(pg_trgm_available=True)
+        conn.fetch = AsyncMock(side_effect=RuntimeError("simulated timeout"))
+
+        with (
+            patch("hindsight_api.engine.entity_resolver.fq_table", side_effect=lambda table: table),
+            patch.object(resolver, "_resolve_from_candidates", new=AsyncMock(return_value=[])),
+            pytest.raises(RuntimeError, match="simulated timeout"),
+        ):
+            await resolver._resolve_entities_batch_trigram(
+                conn=conn,
+                bank_id="test-bank",
+                entities_data=[{"text": "Alice"}, {"text": "Bob"}],
+                unit_event_date=None,
+            )
+
+        conn.execute.assert_any_await("SET pg_trgm.similarity_threshold = 0.15")
+        conn.execute.assert_any_await("RESET pg_trgm.similarity_threshold")

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -886,6 +886,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |
 | `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | Entity lookup method during retain: `full` (exact match) or `trigram` (fuzzy trigram matching) | `trigram` |
+| `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -886,6 +886,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_BATCH_TOKENS` | Max characters per sub-batch for async retain auto-splitting | `10000` |
 | `HINDSIGHT_API_RETAIN_CHUNK_BATCH_SIZE` | Max chunks per streaming batch when retain ingests long documents. Each chunk produces roughly 17 facts, so the default 100 chunks ≈ 1700 facts per batch. Lower to cap memory/LLM pressure on large documents; raise for smaller chunks. Configurable per bank. | `100` |
 | `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | Entity lookup method during retain: `full` (exact match) or `trigram` (fuzzy trigram matching) | `trigram` |
+| `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 


### PR DESCRIPTION
## Summary

Follow-up to #1841, which bounded the PG trigram candidate query so wide retain batches don't time out a single `unnest(...)` JOIN. This PR addresses three gaps from that change:

- **Oracle path was unchanged.** `_resolve_entities_batch_oracle_fuzzy` has the identical "single JSON_TABLE-join over every entity_text" risk on banks with many entities. The new `entity_resolution_batch_size` knob silently did nothing there. This PR batches it the same way.
- **`try/except…else + raise` is fragile.** Collapse to `try/finally` so `RESET pg_trgm.similarity_threshold` is unconditionally issued — including on paths the previous structure missed. asyncpg returns connections to the pool with session state intact, so a leaked lowered threshold sticks around for whoever borrows the connection next.
- **Docs.** Per `CLAUDE.md` step 5 for new config flags, document `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` next to `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` in `configuration.md`.

## Test plan

- [x] `uv run pytest tests/test_entity_resolver.py tests/test_entity_resolver_pg_trgm.py` — 19 passed
- [x] `./scripts/hooks/lint.sh` — clean
- [x] New test `test_trigram_resets_threshold_even_when_fetch_raises` covers the formerly-untested error path
- [x] New test `test_oracle_candidate_lookup_batches_entity_texts` mirrors the PG batching assertion for Oracle