### PR TITLE
fix(control-plane): validate login returnTo to prevent open redirect

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/login/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/login/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { LanguageSwitcher } from "@/components/language-switcher";
-import { stripBasePath, withBasePath } from "@/lib/base-path";
+import { sanitizeReturnTo, withBasePath } from "@/lib/base-path";
 import Image from "next/image";
 
 function LoginForm() {
@@ -18,8 +18,8 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // Get the returnTo URL from query params
-  const returnTo = stripBasePath(searchParams.get("returnTo") || "/dashboard");
+  // Validate returnTo to prevent open-redirect via crafted login links.
+  const returnTo = sanitizeReturnTo(searchParams.get("returnTo"));
 
   useEffect(() => {
     // Focus the input on mount

--- a/hindsight-control-plane/src/lib/base-path.test.ts
+++ b/hindsight-control-plane/src/lib/base-path.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { normalizeBasePath, stripBasePath, withBasePath } from "./base-path";
+import { normalizeBasePath, sanitizeReturnTo, stripBasePath, withBasePath } from "./base-path";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -46,6 +46,40 @@ describe("base path helpers", () => {
     loginUrl.searchParams.set("returnTo", stripBasePath("/ai-memory/dashboard"));
 
     expect(loginUrl.toString()).toBe("https://example.com/ai-memory/login?returnTo=%2Fdashboard");
+  });
+
+  describe("sanitizeReturnTo", () => {
+    it("falls back when value is missing or empty", () => {
+      expect(sanitizeReturnTo(null)).toBe("/dashboard");
+      expect(sanitizeReturnTo(undefined)).toBe("/dashboard");
+      expect(sanitizeReturnTo("")).toBe("/dashboard");
+    });
+
+    it("accepts safe app-relative paths and strips the base path", () => {
+      vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/ai-memory");
+
+      expect(sanitizeReturnTo("/dashboard")).toBe("/dashboard");
+      expect(sanitizeReturnTo("/dashboard?view=data")).toBe("/dashboard?view=data");
+      expect(sanitizeReturnTo("/ai-memory/dashboard")).toBe("/dashboard");
+    });
+
+    it("rejects open-redirect payloads", () => {
+      expect(sanitizeReturnTo("//evil.com/phish")).toBe("/dashboard");
+      expect(sanitizeReturnTo("https://evil.com")).toBe("/dashboard");
+      expect(sanitizeReturnTo("javascript:alert(1)")).toBe("/dashboard");
+      expect(sanitizeReturnTo("data:text/html,<script>1</script>")).toBe("/dashboard");
+      expect(sanitizeReturnTo("/\\evil.com")).toBe("/dashboard");
+      expect(sanitizeReturnTo("dashboard")).toBe("/dashboard");
+    });
+
+    it("strips browser-ignored leading control chars before validating", () => {
+      expect(sanitizeReturnTo(" \t\n//evil.com")).toBe("/dashboard");
+      expect(sanitizeReturnTo("  /dashboard")).toBe("/dashboard");
+    });
+
+    it("honors a custom fallback", () => {
+      expect(sanitizeReturnTo("//evil.com", "/home")).toBe("/home");
+    });
   });
 
   it("leaves absolute URLs unchanged", () => {

--- a/hindsight-control-plane/src/lib/base-path.ts
+++ b/hindsight-control-plane/src/lib/base-path.ts
@@ -33,6 +33,26 @@ export function withBasePath(path: string): string {
   return `${basePath}${normalizedPath}`;
 }
 
+// Validates a `returnTo` query parameter to prevent open-redirect attacks
+// (e.g. ?returnTo=//evil.com, ?returnTo=javascript:...). Returns the fallback
+// when the value isn't a safe same-origin app path. Leading control chars are
+// stripped because browsers ignore them when resolving URLs.
+export function sanitizeReturnTo(
+  rawValue: string | null | undefined,
+  fallback = "/dashboard"
+): string {
+  if (!rawValue) return fallback;
+  // Strip leading C0 controls and space — the WHATWG URL parser ignores these,
+  // so a value like " //evil.com" would still resolve off-origin if we didn't.
+  // eslint-disable-next-line no-control-regex
+  const trimmed = rawValue.replace(/^[\x00-\x20]+/, "");
+  if (!trimmed.startsWith("/")) return fallback;
+  if (trimmed.startsWith("//") || trimmed.startsWith("/\\") || ABSOLUTE_URL_PATTERN.test(trimmed)) {
+    return fallback;
+  }
+  return stripBasePath(trimmed);
+}
+
 export function stripBasePath(path: string): string {
   if (ABSOLUTE_URL_PATTERN.test(path) || path.startsWith("//")) {
     return path;


### PR DESCRIPTION
## Summary
- `SearchParams.get("returnTo")` was passed straight to `router.push` on the login page, so a crafted link like `/login?returnTo=//evil.com` or `?returnTo=javascript:…` could redirect users off-origin after sign-in. Spotted while reviewing #1845.
- Add `sanitizeReturnTo` in `lib/base-path.ts` that rejects protocol-relative URLs, any scheme (`javascript:`, `data:`, `https:`…), backslash variants (`/\evil.com`), schemeless paths (`dashboard`), and leading C0-control/whitespace bypasses, falling back to `/dashboard`.
- Use it on the login page in place of `stripBasePath`. BasePath is still stripped for accepted values so subpath deployments keep working after sign-in.

## Test plan
- [x] `npx vitest run src/lib/base-path.test.ts` — new `sanitizeReturnTo` suite covers null/empty, safe paths (with and without basePath), `//evil.com`, `https://evil.com`, `javascript:`/`data:` URLs, `/\evil.com`, schemeless `dashboard`, leading-control-char bypass, and custom fallback.
- [x] `./scripts/hooks/lint.sh`
- [ ] Manually verify login flow under both `NEXT_PUBLIC_BASE_PATH=""` and `NEXT_PUBLIC_BASE_PATH=/ai-memory`: valid `returnTo=/dashboard` still works; `returnTo=//evil.com` lands on `/dashboard`.