### PR TITLE
chore(control-plane): move tests out of src/ into tests/

### DIFF
--- a/hindsight-control-plane/tests/app/api/files/retain/route.test.ts
+++ b/hindsight-control-plane/tests/app/api/files/retain/route.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/hindsight-client", () => ({
   getDataplaneHeaders: vi.fn(() => ({})),
 }));
 
-import { POST } from "./route";
+import { POST } from "@/app/api/files/retain/route";
 
 describe("POST /api/files/retain", () => {
   beforeEach(() => {

--- a/hindsight-control-plane/tests/lib/auth/session.test.ts
+++ b/hindsight-control-plane/tests/lib/auth/session.test.ts
@@ -6,7 +6,7 @@ import {
   createSessionToken,
   isSecureRequest,
   verifySessionToken,
-} from "./session";
+} from "@/lib/auth/session";
 
 const ACCESS_KEY = "super-secret-access-key";
 

--- a/hindsight-control-plane/tests/lib/base-path.test.ts
+++ b/hindsight-control-plane/tests/lib/base-path.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { normalizeBasePath, sanitizeReturnTo, stripBasePath, withBasePath } from "./base-path";
+import { normalizeBasePath, sanitizeReturnTo, stripBasePath, withBasePath } from "@/lib/base-path";
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/hindsight-control-plane/tests/lib/sdk-response.test.ts
+++ b/hindsight-control-plane/tests/lib/sdk-response.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { respondWithSdk, type SdkResult } from "./sdk-response";
+import { respondWithSdk, type SdkResult } from "@/lib/sdk-response";
 
 const HTTP_OK = 200;
 const HTTP_CREATED = 201;

--- a/hindsight-control-plane/tests/messages/messages.test.ts
+++ b/hindsight-control-plane/tests/messages/messages.test.ts
@@ -19,7 +19,7 @@ import { locales, defaultLocale } from "@/i18n/config";
 
 type Catalog = Record<string, unknown>;
 
-const MESSAGES_DIR = join(__dirname);
+const MESSAGES_DIR = join(__dirname, "..", "..", "src", "messages");
 
 function readCatalog(locale: string): Catalog {
   const raw = readFileSync(join(MESSAGES_DIR, `${locale}.json`), "utf-8");

--- a/hindsight-control-plane/vitest.config.ts
+++ b/hindsight-control-plane/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Move all 5 Vitest test files from `hindsight-control-plane/src/**/*.test.ts` to a sibling `hindsight-control-plane/tests/` tree that mirrors the source layout. Keeps test code out of the directory that ships in the standalone build.
- Switch relative test imports (`./base-path`, `./session`, `./route`, `./sdk-response`) to the existing `@/` alias so tests don't have to track their own depth.
- Update `vitest.config.ts` include glob to `tests/**/*.test.ts`.
- `messages.test.ts` resolves its catalog dir relative to `src/messages/` (the catalogs themselves are still source).

> Stacked on #1848 so the new `sanitizeReturnTo` tests come along for the ride. GitHub will retarget the base to `main` once #1848 merges; the diff against `main` will then reduce to just the move.

## Test plan
- [x] `npx vitest run` — all 5 files, 65 tests pass.
- [x] `./scripts/hooks/lint.sh` — clean.