### PR TITLE
fix(retain): retry transient extraction failures

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+from collections.abc import Iterator
 from datetime import datetime, timedelta
 from typing import Literal, cast
 
@@ -1616,7 +1617,7 @@ async def extract_facts_from_text(
         raise RuntimeError(
             f"Fact extraction failed: {len(failed_chunks)}/{len(chunks)} chunks failed. "
             f"First failures: {failed_summary}"
-        )
+        ) from failed_chunks[0][1]
 
     return all_facts, chunk_metadata, total_usage
 
@@ -1635,6 +1636,84 @@ logger = logging.getLogger(__name__)
 
 # Each fact gets 10ms offset to preserve ordering within a document
 SECONDS_PER_FACT = 0.01
+_RETRYABLE_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
+_RETRYABLE_ERROR_NAME_MARKERS = (
+    "apiconnectionerror",
+    "apitimeouterror",
+    "connectionerror",
+    "connecterror",
+    "ratelimit",
+    "readerror",
+    "timeouterror",
+    "timeout",
+)
+_RETRYABLE_ERROR_MESSAGE_MARKERS = (
+    "apiconnectionerror",
+    "apitimeouterror",
+    "ratelimiterror",
+    "rate limit",
+    "rate_limit",
+    "too many requests",
+    "timed out",
+    "timeout",
+    "connection",
+    "temporarily unavailable",
+    "service unavailable",
+    "internal server error",
+    "bad gateway",
+    "gateway timeout",
+    "http 408",
+    "http 409",
+    "http 425",
+    "http 429",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+)
+
+
+def _iter_exception_chain(error: BaseException) -> Iterator[BaseException]:
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _status_code_for_error(error: BaseException) -> int | None:
+    for attr in ("status_code", "status"):
+        value = getattr(error, attr, None)
+        if isinstance(value, int):
+            return value
+    response = getattr(error, "response", None)
+    value = getattr(response, "status_code", None)
+    return value if isinstance(value, int) else None
+
+
+def _is_retryable_content_extraction_error(error: BaseException) -> bool:
+    """Detect provider/transient failures that should use the worker retry path."""
+    for chained in _iter_exception_chain(error):
+        retryable = getattr(chained, "retryable", None)
+        if retryable is True:
+            return True
+        if retryable is False:
+            return False
+
+        status_code = _status_code_for_error(chained)
+        if status_code in _RETRYABLE_STATUS_CODES:
+            return True
+
+        error_name = type(chained).__name__.lower()
+        if any(marker in error_name for marker in _RETRYABLE_ERROR_NAME_MARKERS):
+            return True
+
+        error_text = str(chained).lower()
+        if any(marker in error_text for marker in _RETRYABLE_ERROR_MESSAGE_MARKERS):
+            return True
+
+    return False
 
 
 async def extract_facts_from_contents_batch_api(
@@ -2226,6 +2305,9 @@ async def extract_facts_from_contents(
     valid_results = []
     for content, result in zip(contents, all_fact_results):
         if isinstance(result, Exception):
+            if _is_retryable_content_extraction_error(result):
+                logger.warning(f"Content extraction failed with retryable error: {type(result).__name__}: {result}")
+                raise result
             logger.warning(f"Content extraction failed (skipping): {type(result).__name__}: {result}")
             valid_results.append((content, ([], [], TokenUsage())))
         else:

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -17,6 +17,7 @@ def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = 
     from hindsight_api.config import HindsightConfig
 
     cfg = MagicMock(spec=HindsightConfig)
+    cfg.retain_batch_enabled = False
     cfg.retain_llm_max_retries = retain_llm_max_retries
     cfg.llm_max_retries = llm_max_retries
     cfg.retain_llm_initial_backoff = None
@@ -28,6 +29,10 @@ def _make_config(llm_max_retries: int = 3, retain_llm_max_retries: int | None = 
     cfg.retain_extract_causal_links = False
     cfg.retain_mission = None
     return cfg
+
+
+class _TransientProviderError(Exception):
+    status_code = 503
 
 
 def _make_llm_config(mock_response):
@@ -212,3 +217,87 @@ async def test_none_event_date_with_valid_facts_no_crash():
 
     assert len(facts) == 1
     assert "Alice visited Paris" in facts[0].fact
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_from_contents_reraises_retryable_content_failure():
+    """
+    Retryable chunk failures must escape extract_facts_from_contents so the
+    worker poller can schedule the retain task for retry instead of completing
+    it with zero facts.
+    """
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_contents
+    from hindsight_api.engine.retain.types import RetainContent
+
+    async def fail_with_retryable_error(**_kwargs):
+        raise RuntimeError("Fact extraction failed: 1/1 chunks failed. First failures: chunk 0: APIStatusError") from (
+            _TransientProviderError("HTTP 503: service unavailable")
+        )
+
+    config = _make_config(llm_max_retries=1)
+    content = RetainContent(content="Alice updated the incident runbook.")
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction.extract_facts_from_text",
+        side_effect=fail_with_retryable_error,
+    ):
+        with pytest.raises(RuntimeError, match="Fact extraction failed"):
+            await extract_facts_from_contents(
+                contents=[content],
+                llm_config=MagicMock(),
+                agent_name="agent",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_from_contents_reraises_retryable_failure_summary_without_cause():
+    """The chunk failure summary alone is enough to identify common retryable provider errors."""
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_contents
+    from hindsight_api.engine.retain.types import RetainContent
+
+    async def fail_with_retryable_summary(**_kwargs):
+        raise RuntimeError("Fact extraction failed: 1/1 chunks failed. First failures: chunk 0: RateLimitError")
+
+    config = _make_config(llm_max_retries=1)
+    content = RetainContent(content="Alice updated the incident runbook.")
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction.extract_facts_from_text",
+        side_effect=fail_with_retryable_summary,
+    ):
+        with pytest.raises(RuntimeError, match="RateLimitError"):
+            await extract_facts_from_contents(
+                contents=[content],
+                llm_config=MagicMock(),
+                agent_name="agent",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_from_contents_still_skips_non_retryable_content_failure():
+    """Deterministic extraction failures keep the existing skip-and-continue behavior."""
+    from hindsight_api.engine.retain.fact_extraction import extract_facts_from_contents
+    from hindsight_api.engine.retain.types import RetainContent
+
+    async def fail_with_non_retryable_error(**_kwargs):
+        raise RuntimeError("Fact extraction failed after 1 attempts: LLM did not return valid JSON")
+
+    config = _make_config(llm_max_retries=1)
+    content = RetainContent(content="Alice updated the incident runbook.")
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction.extract_facts_from_text",
+        side_effect=fail_with_non_retryable_error,
+    ):
+        facts, chunks, usage = await extract_facts_from_contents(
+            contents=[content],
+            llm_config=MagicMock(),
+            agent_name="agent",
+            config=config,
+        )
+
+    assert facts == []
+    assert chunks == []
+    assert usage.total_tokens == 0


### PR DESCRIPTION
Summary
- preserve the chunk-level exception cause when fact extraction fails
- classify retryable content extraction failures (rate limit, timeout, connection, 5xx) and re-raise them so worker retry handling can run
- keep the existing skip-and-empty behavior for deterministic/non-retryable extraction failures

Closes #1833.

Tests
- uv run ruff check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_retry.py
- uv run pytest tests/test_fact_extraction_retry.py tests/test_experience_fact_type_passthrough.py -q
- ./scripts/hooks/lint.sh
