### PR TITLE
fix(retain): never silently drop memory on a fact-extraction failure (#1833)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1142,11 +1142,14 @@ async def _extract_facts_from_chunk(
                     )
                     continue
                 else:
-                    logger.warning(
-                        f"LLM returned non-dict JSON after {llm_max_retries} attempts: {type(extraction_response_json).__name__}. "
-                        f"Raw: {str(extraction_response_json)[:500]}"
+                    # A non-dict response is malformed (the schema is {"facts": [...]}).
+                    # Raise instead of returning [] so the failure propagates to the
+                    # worker's retry machinery and ultimately fails loudly — never
+                    # silently commit the document with 0 facts. See issue #1833.
+                    raise RuntimeError(
+                        f"Fact extraction failed: LLM returned non-dict JSON after {llm_max_retries} attempts "
+                        f"({type(extraction_response_json).__name__}). Raw: {str(extraction_response_json)[:500]}"
                     )
-                    return [], usage
 
             raw_facts = extraction_response_json.get("facts", [])
 
@@ -2211,7 +2214,9 @@ async def extract_facts_from_contents(
         fact_extraction_tasks.append(task)
 
     # Step 2: Wait for all fact extractions to complete.
-    # Use return_exceptions=True so one content item failure doesn't discard the rest.
+    # return_exceptions=True so a failing item doesn't cancel its still-running
+    # siblings (which would leave orphaned LLM calls / partial work); we await
+    # them all, then propagate.
     all_fact_results = await asyncio.gather(*fact_extraction_tasks, return_exceptions=True)
 
     # Step 3: Flatten and convert to typed objects
@@ -2222,14 +2227,18 @@ async def extract_facts_from_contents(
     global_chunk_idx = 0
     global_fact_idx = 0
 
-    # Filter out failed content items
+    # Never silently drop a document's memory. Any extraction failure (provider
+    # rate-limit / timeout / 5xx, malformed response, token-limit, etc.)
+    # propagates so the streaming producer surfaces it and the worker's
+    # RetryTaskAt machinery retries the task — and ultimately fails it *loudly*
+    # if the problem persists. Swallowing the error and substituting an empty
+    # result here used to commit the document with 0 facts and mark the
+    # operation `completed`, losing the memory with no signal. See issue #1833.
     valid_results = []
     for content, result in zip(contents, all_fact_results):
         if isinstance(result, Exception):
-            logger.warning(f"Content extraction failed (skipping): {type(result).__name__}: {result}")
-            valid_results.append((content, ([], [], TokenUsage())))
-        else:
-            valid_results.append((content, result))
+            raise result
+        valid_results.append((content, result))
 
     for content_index, (content, (facts_from_llm, chunks_from_llm, content_usage)) in enumerate(valid_results):
         total_usage = total_usage + content_usage

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -1,9 +1,12 @@
 """
 Unit tests for fact extraction retry logic.
 
-Tests the fix for the TypeError when LLM returns invalid JSON across all retries.
-Previously, `raise last_error` would raise None (TypeError) because last_error was
-only set in the BadRequestError handler, not when the LLM returned non-dict JSON.
+When the LLM returns non-dict JSON across all retries, extraction must raise a
+RuntimeError (issue #1833 — never silently return [] and let the retain commit
+the document with 0 facts). This also guards the original TypeError bug: the
+raise must be a real exception, not `raise None` ('exceptions must derive from
+BaseException'), which happened when last_error was only set in the
+BadRequestError handler and not for non-dict JSON responses.
 """
 
 from datetime import datetime, timezone
@@ -43,19 +46,17 @@ def _make_llm_config(mock_response):
 
 
 @pytest.mark.asyncio
-async def test_non_dict_json_all_retries_returns_empty():
+async def test_non_dict_json_all_retries_raises():
     """
-    When LLM returns non-dict JSON on every attempt, extraction should return []
-    without raising TypeError ('exceptions must derive from BaseException').
+    When LLM returns non-dict JSON on every attempt, extraction must RAISE after
+    exhausting retries — never silently return [] (which would let the retain
+    commit the document with 0 facts; see issue #1833).
 
-    This was the bug: the loop ran range(2) times (hardcoded), but comparisons
-    used config.llm_max_retries (default 10). On the last loop iteration (attempt=1),
-    `attempt < 10 - 1` was True, so the code called `continue`, the loop
-    exhausted, and `raise last_error` raised None → TypeError.
+    Regression guard for the original TypeError too: the raise must be a real
+    RuntimeError, not `raise None` ('exceptions must derive from BaseException').
     """
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
 
-    # llm_max_retries=3 ensures the bug triggers with the old code (3 != 2 hardcoded)
     config = _make_config(llm_max_retries=3, retain_llm_max_retries=None)
 
     # Mock: always returns a list (non-dict), which is invalid
@@ -65,26 +66,26 @@ async def test_non_dict_json_all_retries_returns_empty():
         "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
         return_value=("system prompt", MagicMock()),
     ):
-        facts, usage = await _extract_facts_from_chunk(
-            chunk="Alice visited Paris in 2023.",
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            context="travel notes",
-            llm_config=llm_config,
-            config=config,
-            agent_name="test-agent",
-        )
+        with pytest.raises(RuntimeError, match="non-dict JSON"):
+            await _extract_facts_from_chunk(
+                chunk="Alice visited Paris in 2023.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="travel notes",
+                llm_config=llm_config,
+                config=config,
+                agent_name="test-agent",
+            )
 
-    assert facts == []
+    assert llm_config.call.call_count == 3
 
 
 @pytest.mark.asyncio
-async def test_non_dict_json_with_default_max_retries_returns_empty():
+async def test_non_dict_json_with_default_max_retries_raises():
     """
-    Same scenario with the default llm_max_retries=10 (matching real default config).
-    The old code ran range(2) but checked against 10, always continuing until
-    the loop exhausted, then raised None → TypeError.
+    Same scenario with the default llm_max_retries=10 (matching real default config):
+    must raise after exhausting all retries rather than returning [].
     """
     from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
 
@@ -95,18 +96,19 @@ async def test_non_dict_json_with_default_max_retries_returns_empty():
         "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
         return_value=("system prompt", MagicMock()),
     ):
-        facts, usage = await _extract_facts_from_chunk(
-            chunk="Some text.",
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
-            context="",
-            llm_config=llm_config,
-            config=config,
-            agent_name="agent",
-        )
+        with pytest.raises(RuntimeError, match="non-dict JSON"):
+            await _extract_facts_from_chunk(
+                chunk="Some text.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
 
-    assert facts == []
+    assert llm_config.call.call_count == 10
 
 
 @pytest.mark.asyncio
@@ -125,18 +127,18 @@ async def test_retain_llm_max_retries_overrides_global():
         "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
         return_value=("system prompt", MagicMock()),
     ):
-        facts, usage = await _extract_facts_from_chunk(
-            chunk="Bob likes Python.",
-            chunk_index=0,
-            total_chunks=1,
-            event_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
-            context="",
-            llm_config=llm_config,
-            config=config,
-            agent_name="agent",
-        )
+        with pytest.raises(RuntimeError, match="non-dict JSON"):
+            await _extract_facts_from_chunk(
+                chunk="Bob likes Python.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                context="",
+                llm_config=llm_config,
+                config=config,
+                agent_name="agent",
+            )
 
-    assert facts == []
     # Verify it retried exactly retain_llm_max_retries times
     assert llm_config.call.call_count == 5
 
@@ -184,16 +186,18 @@ async def test_none_event_date_with_valid_facts_no_crash():
 
     config = _make_config(llm_max_retries=1)
 
-    llm_config = _make_llm_config(mock_response={
-        "facts": [
-            {
-                "what": "Alice visited Paris",
-                "when": "2023",
-                "who": "Alice",
-                "why": "vacation",
-            }
-        ]
-    })
+    llm_config = _make_llm_config(
+        mock_response={
+            "facts": [
+                {
+                    "what": "Alice visited Paris",
+                    "when": "2023",
+                    "who": "Alice",
+                    "why": "vacation",
+                }
+            ]
+        }
+    )
 
     with patch(
         "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",

--- a/hindsight-api-slim/tests/test_retain_transient_extraction_failure.py
+++ b/hindsight-api-slim/tests/test_retain_transient_extraction_failure.py
@@ -1,0 +1,152 @@
+"""Regression tests for issue #1833.
+
+When fact extraction failed during an async retain, the engine used to silently
+drop the document's memory: ``extract_facts_from_contents`` ran per-content
+extractions with ``asyncio.gather(..., return_exceptions=True)`` and converted
+*every* exception — including the error the inner ``extract_facts_from_text``
+deliberately raises to trigger a retry — into an empty ``([], [], TokenUsage())``
+result. The streaming producer therefore never saw an error, the worker's
+``RetryTaskAt`` machinery never fired, and the operation was marked ``completed``
+with 0 facts saved.
+
+The fix never swallows: *any* extraction failure propagates so the worker
+retries the task and ultimately fails it loudly if the problem persists, instead
+of committing the document with 0 facts. This is provider-agnostic — it does not
+depend on recognizing a specific provider's exception types.
+
+These tests drive a ``batch_retain`` task through the *real* ``WorkerPoller`` +
+``MemoryEngine.execute_task`` (the production path) with a mock LLM that fails
+only on the ``retain_extract_facts`` scope, and assert the operation is retried
+(reset to ``pending`` with ``retry_count`` bumped) rather than silently completed.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from hindsight_api.engine.providers.mock_llm import MockLLM
+from hindsight_api.worker import WorkerPoller
+from hindsight_api.worker.poller import ClaimedTask
+
+# Worker tests share the async_operations table; keep them on one xdist worker.
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+
+class RateLimitLikeError(Exception):
+    """Stand-in for a provider rate-limit / 429 raised mid-extraction."""
+
+
+class GeminiLikeAPIError(Exception):
+    """Stand-in for a non-OpenAI provider error (e.g. Gemini ``APIError``).
+
+    Included to prove the fix is provider-agnostic: it propagates without the
+    engine needing to recognize any specific provider's exception types.
+    """
+
+
+async def _count_memory_units(memory, bank_id: str) -> int:
+    pool = await memory._get_pool()
+    return await pool.fetchval(
+        "SELECT COUNT(*) FROM memory_units WHERE bank_id = $1",
+        bank_id,
+    )
+
+
+async def _run_retain_through_worker(memory, extraction_error: Exception):
+    """Enqueue a one-item retain and run it through the real poller + executor.
+
+    ``extraction_error`` is raised by the mock LLM on the ``retain_extract_facts``
+    scope only; every other scope keeps its normal mock behavior. Returns the
+    final ``async_operations`` row and the bank_id.
+    """
+    bank_id = f"test-worker-extract-fail-{uuid.uuid4().hex[:8]}"
+    operation_id = uuid.uuid4()
+
+    # Retain resolves its own LLM config (``_retain_llm_config.with_config(...)``),
+    # so patching a single engine attribute misses it. Patch the mock provider's
+    # ``call`` at the class level and gate on the extraction scope.
+    original_call = MockLLM.call
+
+    async def call_raising_on_extract(self, *args, **kwargs):
+        if kwargs.get("scope") == "retain_extract_facts":
+            raise extraction_error
+        return await original_call(self, *args, **kwargs)
+
+    MockLLM.call = call_raising_on_extract
+
+    backend = await memory._get_backend()
+    pool = await memory._get_pool()
+
+    # Bank row must exist before async_operations (FK), then enqueue a child
+    # retain task exactly as submit_async_retain() would persist it.
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+    task_payload = {
+        "type": "batch_retain",
+        "operation_id": str(operation_id),
+        "bank_id": bank_id,
+        "contents": [{"content": "Alice moved to Berlin in March 2024 and joined Acme as a staff engineer."}],
+    }
+    await pool.execute(
+        """
+        INSERT INTO async_operations
+            (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at)
+        VALUES ($1, $2, 'retain', 'processing', $3::jsonb, 'test-worker-1', now())
+        """,
+        operation_id,
+        bank_id,
+        json.dumps(task_payload),
+    )
+
+    poller = WorkerPoller(
+        backend=backend,
+        worker_id="test-worker-1",
+        executor=memory.execute_task,
+    )
+    claimed = ClaimedTask(operation_id=str(operation_id), task_dict=task_payload, schema=None)
+    try:
+        await poller.execute_task(claimed)
+        completed = await poller.wait_for_active_tasks(timeout=30.0)
+        assert completed, "Worker task did not settle within timeout"
+    finally:
+        MockLLM.call = original_call
+
+    final = await pool.fetchrow(
+        "SELECT status, retry_count, error_message FROM async_operations WHERE operation_id = $1",
+        operation_id,
+    )
+    return final, bank_id
+
+
+@pytest.mark.parametrize(
+    "extraction_error",
+    [
+        RateLimitLikeError("429 Too Many Requests: rate limit exceeded"),
+        GeminiLikeAPIError("503 Service Unavailable: model overloaded"),
+        ValueError("Model does not support the required output token limit."),
+    ],
+    ids=["rate_limit", "non_openai_provider_5xx", "value_error"],
+)
+@pytest.mark.asyncio
+async def test_extraction_failure_is_retried_never_silently_completed(memory, extraction_error):
+    """An extraction-LLM failure must NEVER complete the op with 0 facts.
+
+    Regardless of the failure type or provider, the error propagates into the
+    worker's ``RetryTaskAt`` machinery, which resets the task to ``pending`` and
+    bumps ``retry_count``. The pre-fix bug marked the op ``completed`` with 0
+    memory_units and ``retry_count`` 0, silently losing the document's memory.
+    """
+    final, bank_id = await _run_retain_through_worker(memory, extraction_error)
+    unit_count = await _count_memory_units(memory, bank_id)
+
+    assert final["status"] != "completed", (
+        "BUG (#1833): extraction failure was swallowed — operation marked 'completed' with "
+        f"{unit_count} memory_units saved. The document's memory was silently dropped and the "
+        "RetryTaskAt machinery never fired."
+    )
+    assert final["status"] == "pending", f"expected task reset to 'pending' for retry, got {final['status']!r}"
+    assert final["retry_count"] == 1, f"expected retry_count bumped to 1, got {final['retry_count']}"


### PR DESCRIPTION
## Summary

Fixes #1833 — a fact-extraction LLM failure during an async retain silently dropped the document's memory. Two code paths committed a document with **0 facts** while marking the op `completed` (no error row, no retry, no alert):

1. **`extract_facts_from_contents`** ran per-content extractions with `asyncio.gather(..., return_exceptions=True)` and converted **every** exception — including the `RuntimeError` that the inner `extract_facts_from_text` deliberately raises *to trigger a retry* — into an empty `([], [], TokenUsage())` result. The streaming producer never saw an error, so the worker's `RetryTaskAt` machinery never fired.
2. **`_extract_facts_from_chunk`** returned `[]` (instead of raising) when the LLM returned **non-dict JSON** after exhausting all retries.

This was the single chain that broke the engine's own documented retry path (inner function raises on chunk failure → producer re-raises → executor classifies → `RetryTaskAt(+60s)` up to the retry budget, then a loud `failed`).

## Fix

**Never swallow.** Any extraction failure now propagates so the worker retries the task and ultimately fails it **loudly** if the problem persists, instead of committing the document with 0 facts.

The earlier draft of this PR tried to classify failures as transient-vs-deterministic and only re-raise the transient ones. That was wrong for two reasons, both raised in review:

1. It was **provider-coupled** — it only recognized `openai.BadRequestError`; Anthropic / Gemini / LiteLLM raise entirely different exception types, so most providers' deterministic errors would have fallen through to "retryable" anyway (and any provider's transient error we didn't enumerate would still have been silently dropped).
2. Keeping a skip-and-substitute-empty path at all means **silently completing a retain with 0 facts** — the precise data-loss behavior this issue is about.

So the classification is gone. `gather` keeps `return_exceptions=True` only so a failing item doesn't cancel its still-running siblings (which would orphan in-flight LLM calls); we await them all, then raise the first exception. The non-dict-JSON path now raises a `RuntimeError` after exhausting retries instead of returning `[]`.

Deterministic failures (e.g. a model that can't honor the output-token limit, or persistently malformed JSON) now retry up to the budget and then fail loudly — the desired outcome: **a loud failure is always better than silently losing memory.** A legitimately empty extraction (`{"facts": []}` from gibberish content) is unchanged — that's a valid 0-fact result, not a failure.

## Tests

- `tests/test_retain_transient_extraction_failure.py` — a **full worker-level** regression test driving a `batch_retain` task through the real `WorkerPoller` + `MemoryEngine.execute_task` (production streaming path, `retain_batch_enabled=False`) with a mock LLM that fails only on the `retain_extract_facts` scope. Parametrized over a rate-limit error, a **non-OpenAI** provider 5xx (proves provider-agnostic behavior), and a `ValueError` — each asserting the op ends up **retried** (`pending`, `retry_count == 1`) rather than `completed` with 0 units.
- `tests/test_fact_extraction_retry.py` — updated the non-dict-JSON unit tests to assert a `RuntimeError` is raised after exhausting retries (was: asserts `[]`), while preserving the original `raise None` → `TypeError` guard.

## Notes / scope

- Only the live **streaming** retain path is in scope, matching the issue. The OpenAI Batch API extraction path (`extract_facts_from_contents_batch_api`) is separate and untouched.
- Complementary to #1798 (which governs *how many times* a propagated failure is retried) and #1579 (which is about *detecting* a silent drop after the fact — this PR *prevents* it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
