### PR TITLE
fix(consolidation): shorten retry backoff base from 60s to 5s

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -115,12 +115,17 @@ _VALIDATE_SQL_SCHEMAS = True
 # filtered upstream by `_is_non_retryable_task_error` and never reach the
 # retry path. The dedup-by-bank guard prevents per-op retries from
 # multiplying when a peer consolidation is already pending for the bank.
-_CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS = 60
+#
+# Base is intentionally short so a momentary 5xx clears in seconds, not
+# minutes; the cap is preserved so a genuine multi-hour outage doesn't hammer
+# the upstream. Issue #1842 observed banks sitting idle for whole minutes on
+# transient LLM blips because the prior 60s base overshot recovery by 10x+.
+_CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS = 5
 _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS = 1800  # 30 min cap
 
 
 def _consolidation_retry_backoff_seconds(retry_count: int) -> int:
-    """Capped exponential backoff: 60, 120, 240, 480, 960, 1800, 1800, …"""
+    """Capped exponential backoff: 5, 10, 20, 40, 80, 160, 320, 640, 1280, 1800, 1800, …"""
     return min(
         _CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS * (2**retry_count),
         _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS,

--- a/hindsight-api-slim/tests/test_consolidation_reschedule_after_round.py
+++ b/hindsight-api-slim/tests/test_consolidation_reschedule_after_round.py
@@ -1,0 +1,176 @@
+"""Round-limit re-queue regression guard (related to issue #1842).
+
+The consolidator calls ``submit_async_consolidation`` at the end of a
+round-limited run (consolidator.py:600). The existing
+``test_consolidation_round_limit.py`` patches that call away and only checks
+it was invoked, so it does not exercise the actual DB-row creation.
+
+This test exercises the full end-to-end path:
+
+  1. Build a backlog > max_memories_per_round with auto-consolidation
+     disabled at retain time.
+  2. Insert a pending consolidation op row (as the API would on
+     ``POST /consolidate``) and execute it through ``MemoryEngine.execute_task``
+     exactly as the worker poller does.
+  3. After ``execute_task`` returns, assert:
+       - the first op is marked ``completed``
+       - a *new* pending consolidation row exists for the same bank
+         (the round-limit re-queue actually landed in the DB)
+       - unconsolidated rows remain (the backlog isn't drained in one round)
+
+The engine's task_backend is swapped to ``WorkerTaskBackend`` for the
+duration of the run so the in-task ``submit_async_consolidation`` call does
+NOT recursively execute (which is what ``SyncTaskBackend`` would do). That
+matches production worker semantics, where ``submit_task`` is a no-op and
+the worker poller picks up the new row on its next cycle.
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.task_backend import WorkerTaskBackend
+
+
+def _make_config(**overrides):
+    raw = _get_raw_config()
+    return type(raw)(
+        **{
+            **{f: getattr(raw, f) for f in raw.__dataclass_fields__},
+            **overrides,
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+async def _count_unconsolidated(memory, bank_id: str) -> int:
+    async with memory._pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM memory_units
+            WHERE bank_id = $1 AND consolidated_at IS NULL
+              AND consolidation_failed_at IS NULL AND fact_type IN ('experience', 'world')
+            """,
+            bank_id,
+        )
+
+
+async def _pending_consolidation_ops(memory, bank_id: str) -> list[str]:
+    async with memory._pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT operation_id::text AS oid FROM async_operations
+            WHERE bank_id = $1 AND operation_type = 'consolidation' AND status = 'pending'
+            """,
+            bank_id,
+        )
+    return [r["oid"] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_round_limited_consolidation_leaves_followup_pending_op(
+    memory: MemoryEngine, request_context
+):
+    """A round-limited consolidation must leave a new ``pending`` consolidation
+    op in ``async_operations`` for the same bank so the worker poller can
+    drain the backlog without external intervention."""
+    bank_id = f"test-reschedule-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    round_limit = 5
+    backlog_size = 12  # > 2x round_limit so we expect multiple re-queues
+
+    # 1. Build the backlog with consolidation disabled during retain.
+    fake_config_no_obs = _make_config(enable_observations=False)
+    with patch.object(memory._config_resolver, "resolve_full_config", return_value=fake_config_no_obs):
+        for i in range(backlog_size):
+            await memory.retain_async(
+                bank_id=bank_id,
+                content=f"Fact {i}: the user did activity number {i} on day {i}.",
+                request_context=request_context,
+            )
+
+    unconsolidated_before = await _count_unconsolidated(memory, bank_id)
+    assert unconsolidated_before >= backlog_size, (
+        f"Expected at least {backlog_size} unconsolidated memories, got {unconsolidated_before}"
+    )
+
+    # 2. Insert a pending consolidation op (simulating POST /consolidate)
+    op_id = uuid.uuid4()
+    payload = {
+        "type": "consolidation",
+        "operation_id": str(op_id),
+        "bank_id": bank_id,
+    }
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb)
+            """,
+            op_id,
+            bank_id,
+            json.dumps(payload),
+        )
+
+    # Swap to WorkerTaskBackend so the in-task submit_async_consolidation does
+    # NOT recursively execute (matches production worker semantics — the row
+    # is left for the poller's next cycle).
+    original_backend = memory._task_backend
+    memory._task_backend = WorkerTaskBackend()
+    await memory._task_backend.initialize()
+
+    fake_config = _make_config(consolidation_max_memories_per_round=round_limit)
+
+    try:
+        with patch.object(memory._config_resolver, "resolve_full_config", return_value=fake_config):
+            await memory.execute_task(payload)
+    finally:
+        memory._task_backend = original_backend
+
+    # 3. Verify the first op completed
+    async with memory._pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+    assert row is not None
+    assert row["status"] == "completed", (
+        f"first consolidation op should be marked completed, got {row['status']}"
+    )
+
+    # 4. Backlog must remain (round limit kept one round under the total)
+    unconsolidated_after = await _count_unconsolidated(memory, bank_id)
+    assert 0 < unconsolidated_after < unconsolidated_before, (
+        f"expected backlog to shrink but still remain after one round; "
+        f"before={unconsolidated_before}, after={unconsolidated_after}"
+    )
+
+    # 5. KEY ASSERTION — a new pending consolidation op must exist for this bank.
+    #    The worker poller will pick this up on its next cycle. If this assertion
+    #    fails, the bank is silently stuck: it has unconsolidated rows but no
+    #    queued work.
+    pending_ops = await _pending_consolidation_ops(memory, bank_id)
+    assert len(pending_ops) == 1, (
+        f"After a round-limited consolidation finishes, exactly one pending "
+        f"consolidation op must remain so the worker can continue draining the "
+        f"backlog. Found {len(pending_ops)} pending ops; backlog still has "
+        f"{unconsolidated_after} unconsolidated memory_units."
+    )
+    assert pending_ops[0] != str(op_id), (
+        "The pending op must be a NEW row, not the original op we just executed."
+    )
+
+    await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_dedup_by_bank.py
@@ -180,27 +180,33 @@ async def test_peer_only_dedups_when_same_bank(memory):
 
 def test_backoff_helper_schedule():
     """
-    The backoff helper produces capped exponential growth:
-    60, 120, 240, 480, 960, then pinned at the 1800s cap.
+    The backoff helper produces capped exponential growth starting at 5s so a
+    transient blip (LLM 503 that clears in a few seconds) doesn't park the
+    bank for a full minute: 5, 10, 20, 40, 80, 160, 320, 640, 1280, then
+    pinned at the 1800s cap.
     """
-    assert _consolidation_retry_backoff_seconds(0) == 60
-    assert _consolidation_retry_backoff_seconds(1) == 120
-    assert _consolidation_retry_backoff_seconds(2) == 240
-    assert _consolidation_retry_backoff_seconds(3) == 480
-    assert _consolidation_retry_backoff_seconds(4) == 960
-    assert _consolidation_retry_backoff_seconds(5) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
+    assert _consolidation_retry_backoff_seconds(0) == 5
+    assert _consolidation_retry_backoff_seconds(1) == 10
+    assert _consolidation_retry_backoff_seconds(2) == 20
+    assert _consolidation_retry_backoff_seconds(3) == 40
+    assert _consolidation_retry_backoff_seconds(4) == 80
+    assert _consolidation_retry_backoff_seconds(5) == 160
+    assert _consolidation_retry_backoff_seconds(6) == 320
+    assert _consolidation_retry_backoff_seconds(7) == 640
+    assert _consolidation_retry_backoff_seconds(8) == 1280
+    assert _consolidation_retry_backoff_seconds(9) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
     # Cap holds at arbitrarily high attempt counts (we never give up).
     assert _consolidation_retry_backoff_seconds(50) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
     assert _consolidation_retry_backoff_seconds(1000) == _CONSOLIDATION_RETRY_BACKOFF_MAX_SECONDS
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("retry_count", [0, 1, 2, 5])
+@pytest.mark.parametrize("retry_count", [0, 1, 2, 9])
 async def test_backoff_matches_schedule_by_retry_count(memory, retry_count):
     """
     Each retry schedules `retry_at = now + backoff(retry_count)`. The tolerance
     covers the few seconds between ``now()`` capture in the test and inside
-    the retry handler. Includes retry_count=5 to verify the cap branch.
+    the retry handler. Includes retry_count=9 to verify the cap branch.
     """
     bank_id = f"test-backoff-{uuid.uuid4().hex[:8]}"
     op_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

Reported in #1842: with a backlog of >50k unconsolidated memories across 17 banks, "active consolidation rises toward the slot limit, then decays back toward 1 over a few minutes" on bursts of transient LLM errors. The current retry schedule treats every failure like a multi-minute outage:

```
60s → 120s → 240s → 480s → 960s → 1800s (cap)
```

A momentary LLM 503 that clears in a second still parks the bank for at least 60s. With 24 worker slots, a burst of transient errors across 17 banks compounds into the "decay to 1" pattern the issue describes.

This PR drops `_CONSOLIDATION_RETRY_BACKOFF_BASE_SECONDS` from 60 → 5. New schedule:

```
5s → 10s → 20s → 40s → 80s → 160s → 320s → 640s → 1280s → 1800s (cap)
```

The 1800s cap is preserved so a genuine multi-hour outage still doesn't hammer the upstream. Dedup-by-bank and the indefinite-retry policy (no attempt cap) are unchanged — only the base interval moves.

## What this does NOT address

This is one of multiple symptoms in #1842 — the most directly tunable one. The "ops finish a round and disappear entirely with backlog remaining" symptom is still under investigation (it doesn't reproduce with the new `tests/test_consolidation_reschedule_after_round.py` regression guard, which exercises the round-limit re-queue end-to-end against the real DB and asserts a fresh pending row lands).

Issue #1842 stays open pending that investigation; this PR is the safe, isolated piece that helps now.

## Test plan

- [x] `uv run pytest tests/test_consolidation_retry_dedup_by_bank.py tests/test_consolidation_round_limit.py tests/test_consolidation_reschedule_after_round.py -v` — all 12 pass
- [x] `./scripts/hooks/lint.sh`
- [x] Backoff schedule asserted in `test_backoff_helper_schedule` (5/10/20/40/80/160/320/640/1280, cap at 9th retry)
- [x] Cap branch covered in `test_retry_is_indefinite` (retry_count=100)
- [x] Per-retry-count timing tolerance verified by `test_backoff_matches_schedule_by_retry_count[0,1,2,9]`

## New regression guard

`tests/test_consolidation_reschedule_after_round.py` exercises the round-limit re-queue end-to-end (the existing `test_consolidation_round_limit.py` mocks `submit_async_consolidation`, so it doesn't validate the DB row actually lands). Useful regardless of this PR — if the re-queue path ever regresses silently, this catches it.

Closes — partial relief for #1842