### PR TITLE
fix(retain): preserve full document body when splitter chunks oversized input

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16,7 +16,7 @@ import logging
 import time
 import uuid
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
@@ -273,10 +273,18 @@ class _SubBatchSplit:
     user (such as ``retain_batch_async``) use this mapping to merge
     results belonging to the same original content back together when
     an oversized item was chunked across multiple sub-batches.
+
+    ``document_body_overrides[i]`` is the full original body of the
+    oversized item that produced ``sub_batches[i]``, or ``None`` when
+    the sub-batch was not produced by chunking an oversized item. The
+    orchestrator uses this as the ``documents.original_text`` payload
+    so that slicing an item across sub-batches does not persist a
+    partial body (see issue #1838).
     """
 
     sub_batches: list[list[RetainContentDict]]
     origin_indices: list[list[int]]
+    document_body_overrides: list[str | None] = field(default_factory=list)
 
 
 def _split_contents_into_sub_batches(
@@ -310,6 +318,7 @@ def _split_contents_into_sub_batches(
 
     sub_batches: list[list[RetainContentDict]] = []
     origin_indices: list[list[int]] = []
+    document_body_overrides: list[str | None] = []
     current_batch: list[RetainContentDict] = []
     current_batch_origins: list[int] = []
     current_batch_tokens = 0
@@ -319,6 +328,7 @@ def _split_contents_into_sub_batches(
         if current_batch:
             sub_batches.append(current_batch)
             origin_indices.append(current_batch_origins)
+            document_body_overrides.append(None)
             current_batch = []
             current_batch_origins = []
             current_batch_tokens = 0
@@ -334,12 +344,18 @@ def _split_contents_into_sub_batches(
             # original item's document_id and metadata so the
             # orchestrator's first-batch document tracking still
             # cascade-deletes the prior document version on slice 1.
+            # Each slice carries ``content_str`` as the document body
+            # override so the orchestrator writes the full original
+            # text to documents.original_text — not just its own slice
+            # (otherwise the last slice would clobber the body with a
+            # truncated payload; see issue #1838).
             _flush()
             chunks = fact_extraction.chunk_text(content_str, char_budget)
             for chunk in chunks:
                 chunk_item = cast(RetainContentDict, {**item, "content": chunk})
                 sub_batches.append([chunk_item])
                 origin_indices.append([original_idx])
+                document_body_overrides.append(content_str)
             continue
 
         if current_batch and current_batch_tokens + item_tokens > tokens_per_batch:
@@ -349,7 +365,11 @@ def _split_contents_into_sub_batches(
         current_batch_tokens += item_tokens
 
     _flush()
-    return _SubBatchSplit(sub_batches=sub_batches, origin_indices=origin_indices)
+    return _SubBatchSplit(
+        sub_batches=sub_batches,
+        origin_indices=origin_indices,
+        document_body_overrides=document_body_overrides,
+    )
 
 
 def _split_contents_into_async_children(
@@ -2740,6 +2760,7 @@ class MemoryEngine(MemoryEngineInterface):
             split = _split_contents_into_sub_batches(contents, tokens_per_batch)
             sub_batches = split.sub_batches
             origin_indices = split.origin_indices
+            document_body_overrides = split.document_body_overrides
 
             sub_batch_sizes = [len(b) for b in sub_batches]
             # Keep the per-sub-batch sizes log compact when an oversize
@@ -2787,6 +2808,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # webhook delivery row is committed atomically with the final retain data.
                     outbox_callback=outbox_callback if i == len(sub_batches) else None,
                     outbox_callback_factory=outbox_callback_factory if i == len(sub_batches) else None,
+                    document_body_override=document_body_overrides[i - 1],
                 )
                 # sub_results aligns 1:1 with sub_batch items; map each
                 # back to its source input via origin_indices so callers
@@ -2880,6 +2902,7 @@ class MemoryEngine(MemoryEngineInterface):
         outbox_callback: RetainOutboxCallback | None = None,
         outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
         strategy: str | None = None,
+        document_body_override: str | None = None,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.
@@ -2943,6 +2966,7 @@ class MemoryEngine(MemoryEngineInterface):
                 outbox_callback=outbox_callback,
                 outbox_callback_factory=outbox_callback_factory,
                 db_semaphore=self._put_semaphore,
+                document_body_override=document_body_override,
             )
 
     def recall(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -402,6 +402,7 @@ async def retain_batch(
     outbox_callback: RetainOutboxCallback | None = None,
     outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
+    document_body_override: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage, int | None]:
     """
     Process a batch of content through the retain pipeline.
@@ -480,6 +481,7 @@ async def retain_batch(
                     outbox_callback=group_outbox_callback,
                     outbox_callback_factory=outbox_callback_factory,
                     db_semaphore=db_semaphore,
+                    document_body_override=document_body_override,
                 )
                 for group_idx, orig_idx in enumerate(original_indices[doc_key]):
                     if group_idx < len(group_ids):
@@ -621,6 +623,7 @@ async def retain_batch(
             schema,
             outbox_callback,
             db_semaphore,
+            document_body_override=document_body_override,
         )
         if delta_result is not None:
             return delta_result
@@ -677,6 +680,7 @@ async def retain_batch(
         schema=schema,
         outbox_callback=outbox_callback,
         db_semaphore=db_semaphore,
+        document_body_override=document_body_override,
     )
 
 
@@ -814,6 +818,7 @@ async def _streaming_retain_batch(
     schema: str | None = None,
     outbox_callback: Callable[["asyncpg.Connection"], Awaitable[None]] | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
+    document_body_override: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -847,7 +852,15 @@ async def _streaming_retain_batch(
     # document exists with a matching content_hash and has committed chunks,
     # the producer can skip already-extracted chunks to avoid duplicate work.
     existing_chunk_hashes: set[str] = set()
-    combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
+    # When the caller is processing a sub-batch sliced out of an oversized
+    # item (see _split_contents_into_sub_batches), document_body_override
+    # carries the full original document body. Use it for the doc-row write
+    # so documents.original_text stores the complete payload, not just this
+    # slice (issue #1838).
+    if document_body_override is not None:
+        combined_content = document_body_override
+    else:
+        combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
     # Memory: contents_dicts content strings are now captured in combined_content.
     # Clear them from the dicts to release the per-item copies (can be multi-MB each).
     for d in contents_dicts:
@@ -1490,6 +1503,8 @@ async def _try_delta_retain(
     schema,
     outbox_callback,
     db_semaphore: "asyncio.Semaphore | None" = None,
+    *,
+    document_body_override: str | None = None,
 ) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
     Attempt delta retain for a document upsert. Returns result tuple if delta
@@ -1575,6 +1590,7 @@ async def _try_delta_retain(
             log_buffer,
             start_time,
             outbox_callback,
+            document_body_override=document_body_override,
         )
 
     # Build content items for only the changed/new chunks
@@ -1591,6 +1607,7 @@ async def _try_delta_retain(
             log_buffer,
             start_time,
             outbox_callback,
+            document_body_override=document_body_override,
         )
 
     # Extract facts and generate embeddings (shared pipeline)
@@ -1650,7 +1667,13 @@ async def _try_delta_retain(
 
                 # Update document metadata (no delete)
                 step_start = time.time()
-                combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
+                # When this sub-batch is one slice of an oversized item
+                # split across multiple sub-batches, store the full body
+                # (issue #1838) instead of just the slice.
+                if document_body_override is not None:
+                    combined_content = document_body_override
+                else:
+                    combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
                 retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)
                 await fact_storage.upsert_document_metadata(
                     conn,
@@ -1775,6 +1798,8 @@ async def _delta_metadata_only(
     log_buffer,
     start_time,
     outbox_callback,
+    *,
+    document_body_override: str | None = None,
 ):
     """Handle the case where no chunks changed — just update document metadata and tags."""
     async with acquire_with_retry(pool) as conn:
@@ -1785,7 +1810,12 @@ async def _delta_metadata_only(
                 document_id,
                 bank_id,
             )
-            combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
+            # When this sub-batch is a slice of an oversized item, write the
+            # full original body (issue #1838) instead of just the slice.
+            if document_body_override is not None:
+                combined_content = document_body_override
+            else:
+                combined_content = "\n".join([c.get("content", "") for c in contents_dicts])
             retain_params, merged_tags = _build_retain_params(contents_dicts, document_tags)
             await fact_storage.upsert_document_metadata(
                 conn,

--- a/hindsight-api-slim/tests/test_large_document_replacement.py
+++ b/hindsight-api-slim/tests/test_large_document_replacement.py
@@ -1,0 +1,157 @@
+"""
+Reproduction for https://github.com/vectorize-io/hindsight/issues/1838
+
+Replacing an existing document by retaining new content with the same
+``document_id`` can leave the stored document body partial/truncated when
+``retain_batch_async`` auto-splits the submitted content into multiple
+sub-batches. Each non-first sub-batch was overwriting
+``documents.original_text`` with its own slice, so the persisted body ended
+up being one slice of the input, not the full body.
+
+These tests trigger the auto-split path by lowering
+``HINDSIGHT_API_RETAIN_BATCH_TOKENS`` to a small value, then assert that the
+stored ``original_text`` exactly matches the submitted replacement body.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@pytest.fixture(autouse=True)
+def _fast_split_env(monkeypatch):
+    """Make the splitter trigger on small content and skip consolidation work.
+
+    Auto-consolidation runs synchronously after each retain in tests; it
+    extracts/recalls/embeds across all observations and dominates wall time
+    for these tests, which only care about how the splitter persists the
+    document body. Disabling it brings the suite back to single-digit
+    seconds.
+    """
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def _make_replacement_body() -> str:
+    """Build a multi-line body comfortably above the 100-token splitter
+    threshold so ``_split_contents_into_sub_batches`` chunks it into more
+    than one sub-batch.
+    """
+    lines = [
+        f"[role: user] turn {i}: alpha bravo charlie delta echo "
+        f"foxtrot golf hotel india juliet"
+        for i in range(20)
+    ]
+    return "\n".join(lines)
+
+
+@pytest.mark.asyncio
+async def test_large_same_id_replacement_preserves_full_body(memory, request_context):
+    """
+    RED test for issue #1838.
+
+    Retain a small initial document, then replace it with a larger body
+    under the same ``document_id``. The replacement is sized to trip the
+    ``retain_batch_tokens`` threshold so ``retain_batch_async`` splits it
+    into multiple sub-batches. After retain returns, the stored
+    ``original_text`` must exactly equal the submitted replacement body.
+    """
+    bank_id = f"test_large_replace_{_ts()}"
+    document_id = "claude-code-transcript-1838"
+
+    try:
+        initial_body = "[role: user] turn 0: hello\n[role: assistant] turn 0: hi"
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=initial_body,
+            context="initial retro",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        doc_initial = await memory.get_document(
+            document_id, bank_id, request_context=request_context
+        )
+        assert doc_initial is not None
+        assert doc_initial["original_text"] == initial_body
+
+        replacement_body = _make_replacement_body()
+
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=replacement_body,
+            context="regenerated retro",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        doc_replaced = await memory.get_document(
+            document_id, bank_id, request_context=request_context
+        )
+        assert doc_replaced is not None
+
+        stored = doc_replaced["original_text"]
+        assert len(stored) == len(replacement_body), (
+            f"stored body length {len(stored)} != submitted length "
+            f"{len(replacement_body)} — partial replacement persisted"
+        )
+        assert stored == replacement_body, (
+            "stored original_text does not exactly match the submitted "
+            "replacement body"
+        )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_repeated_large_same_id_replacement_is_idempotent(memory, request_context):
+    """
+    Retrying the same large replacement (per issue #1838 acceptance criteria)
+    must converge to the exact submitted body, not a suffix/prefix subset.
+    """
+    bank_id = f"test_large_replace_retry_{_ts()}"
+    document_id = "claude-code-transcript-1838-retry"
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="[role: user] turn 0: seed",
+            context="seed",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        replacement_body = _make_replacement_body()
+
+        for attempt in range(3):
+            await memory.retain_async(
+                bank_id=bank_id,
+                content=replacement_body,
+                context=f"regenerated retro attempt {attempt}",
+                document_id=document_id,
+                request_context=request_context,
+            )
+
+            doc = await memory.get_document(
+                document_id, bank_id, request_context=request_context
+            )
+            assert doc is not None, f"attempt {attempt}: document missing after retain"
+            assert doc["original_text"] == replacement_body, (
+                f"attempt {attempt}: stored body diverged from submitted body "
+                f"(stored {len(doc['original_text'])} chars, "
+                f"submitted {len(replacement_body)} chars)"
+            )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Fixes #1838.

When a single retain content item exceeds `HINDSIGHT_API_RETAIN_BATCH_TOKENS` (~40 KB), `retain_batch_async` chunks it across multiple sub-batches. Each sub-batch passed only its own slice to `handle_document_tracking`, which unconditionally upserts `documents.original_text`. The last sub-batch overwrote the body with its slice, so the persisted body became a fragment of the input (e.g. a 62 KB transcript stored as ~30 KB on Railway 0.7.1).

## Fix

Thread a `document_body_override` parameter from `_split_contents_into_sub_batches` through `_retain_batch_async_internal`, `retain_batch`, `_streaming_retain_batch`, `_try_delta_retain` and `_delta_metadata_only`. When set, the orchestrator uses it as `combined_content` for the doc-row write so every sub-batch persists the same full body (and computes the same `content_hash`, so the FOR-UPDATE takeover check still passes).

RAM: the override is a reference to the splitter's source string — no extra copies. The orchestrator clears `combined_content` after `handle_document_tracking` finishes, same as before.

## Test plan

- [x] `tests/test_large_document_replacement.py::test_large_same_id_replacement_preserves_full_body` — small initial doc, large replacement under same `document_id`, asserts `original_text` matches exactly.
- [x] `tests/test_large_document_replacement.py::test_repeated_large_same_id_replacement_is_idempotent` — repeats the replacement 3× and asserts each retain converges to the exact submitted body (acceptance criterion 4 from the issue).
- [x] Both tests fail before the fix and pass after.
- [x] Test fixture lowers `HINDSIGHT_API_RETAIN_BATCH_TOKENS=100` and disables auto-consolidation so call time is sub-second.