### PR TITLE
refactor(engine): cheaper bank stats — drop unused join, add freshness helper, result cache

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -346,6 +346,8 @@ ENV_RECALL_MAX_QUERY_TOKENS = "HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS"
 ENV_MENTAL_MODEL_REFRESH_CONCURRENCY = "HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY"
 ENV_LINK_EXPANSION_PER_ENTITY_LIMIT = "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT"
 ENV_LINK_EXPANSION_TIMEOUT = "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT"
+ENV_BANK_STATS_CACHE_TTL_SECONDS = "HINDSIGHT_API_BANK_STATS_CACHE_TTL_SECONDS"
+ENV_BANK_STATS_CACHE_MAX_ENTRIES = "HINDSIGHT_API_BANK_STATS_CACHE_MAX_ENTRIES"
 
 # OpenTelemetry tracing configuration
 ENV_OTEL_TRACES_ENABLED = "HINDSIGHT_API_OTEL_TRACES_ENABLED"
@@ -758,6 +760,8 @@ DEFAULT_RECALL_MAX_QUERY_TOKENS = 500  # Maximum tokens allowed in recall query
 DEFAULT_MENTAL_MODEL_REFRESH_CONCURRENCY = 8  # Max concurrent mental model refreshes
 DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT = 200  # Max target units per entity in graph expansion
 DEFAULT_LINK_EXPANSION_TIMEOUT = 10.0  # Timeout (seconds) for entity expansion query
+DEFAULT_BANK_STATS_CACHE_TTL_SECONDS = 60.0  # TTL for get_bank_stats result cache; 0 disables
+DEFAULT_BANK_STATS_CACHE_MAX_ENTRIES = 1024  # LRU bound across (schema, bank) keys
 
 # Retain settings
 DEFAULT_RETAIN_MAX_COMPLETION_TOKENS = 64000  # Max tokens for fact extraction LLM call
@@ -1322,6 +1326,8 @@ class HindsightConfig:
     mental_model_refresh_concurrency: int
     link_expansion_per_entity_limit: int
     link_expansion_timeout: float
+    bank_stats_cache_ttl_seconds: float
+    bank_stats_cache_max_entries: int
 
     # Retain settings
     retain_max_completion_tokens: int
@@ -2093,6 +2099,12 @@ class HindsightConfig:
                 os.getenv(ENV_LINK_EXPANSION_PER_ENTITY_LIMIT, str(DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT))
             ),
             link_expansion_timeout=float(os.getenv(ENV_LINK_EXPANSION_TIMEOUT, str(DEFAULT_LINK_EXPANSION_TIMEOUT))),
+            bank_stats_cache_ttl_seconds=float(
+                os.getenv(ENV_BANK_STATS_CACHE_TTL_SECONDS, str(DEFAULT_BANK_STATS_CACHE_TTL_SECONDS))
+            ),
+            bank_stats_cache_max_entries=int(
+                os.getenv(ENV_BANK_STATS_CACHE_MAX_ENTRIES, str(DEFAULT_BANK_STATS_CACHE_MAX_ENTRIES))
+            ),
             # Optimization flags
             skip_llm_verification=os.getenv(ENV_SKIP_LLM_VERIFICATION, "false").lower() == "true",
             lazy_reranker=os.getenv(ENV_LAZY_RERANKER, "false").lower() == "true",

--- a/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
@@ -1,0 +1,122 @@
+"""TTL + coalescing cache for `get_bank_stats`.
+
+`get_bank_stats` aggregates over `memory_links` (and joins to `memory_units`),
+which can be a multi-second parallel sequential scan on banks with millions of
+rows. The result is intentionally approximate (it powers a UI widget and a
+freshness hint inside `reflect`), so caching it for a few tens of seconds is
+safe and dramatically reduces planner-driven thrash from clients that poll.
+
+The cache also coalesces concurrent misses on the same key onto a single
+in-flight task so that N concurrent callers produce one query rather than N.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+from typing import Any, Awaitable, Callable
+
+
+class BankStatsCache:
+    """Per-process TTL cache keyed on (schema, bank_id).
+
+    `ttl_seconds <= 0` disables caching: each call passes straight through to
+    the loader. `max_entries` bounds memory in environments with many banks.
+    """
+
+    def __init__(self, *, ttl_seconds: float, max_entries: int) -> None:
+        self._ttl = float(ttl_seconds)
+        self._max_entries = int(max_entries) if max_entries and max_entries > 0 else 0
+        self._entries: OrderedDict[tuple[str, str], tuple[float, dict[str, Any]]] = OrderedDict()
+        self._in_flight: dict[tuple[str, str], asyncio.Future[dict[str, Any]]] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._ttl > 0
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _get_fresh_unlocked(self, key: tuple[str, str]) -> dict[str, Any] | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if expires_at <= self._now():
+            # Expired — drop so the loader runs again.
+            self._entries.pop(key, None)
+            return None
+        # Mark as recently used for LRU eviction.
+        self._entries.move_to_end(key)
+        return value
+
+    def _store_unlocked(self, key: tuple[str, str], value: dict[str, Any]) -> None:
+        if not self.enabled:
+            return
+        self._entries[key] = (self._now() + self._ttl, value)
+        self._entries.move_to_end(key)
+        if self._max_entries:
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+
+    async def get_or_load(
+        self,
+        schema: str,
+        bank_id: str,
+        loader: Callable[[], Awaitable[dict[str, Any]]],
+    ) -> dict[str, Any]:
+        """Return cached stats for `(schema, bank_id)` or call `loader()`.
+
+        Concurrent misses on the same key are coalesced onto a single
+        in-flight loader.
+        """
+        if not self.enabled:
+            return await loader()
+
+        key = (schema, bank_id)
+
+        async with self._lock:
+            cached = self._get_fresh_unlocked(key)
+            if cached is not None:
+                return cached
+            in_flight = self._in_flight.get(key)
+            if in_flight is None:
+                in_flight = asyncio.get_running_loop().create_future()
+                self._in_flight[key] = in_flight
+                is_owner = True
+            else:
+                is_owner = False
+
+        if not is_owner:
+            return await asyncio.shield(in_flight)
+
+        try:
+            value = await loader()
+        except BaseException as exc:
+            async with self._lock:
+                self._in_flight.pop(key, None)
+            if not in_flight.done():
+                in_flight.set_exception(exc)
+            # Suppress "Future exception was never retrieved" when no other
+            # caller was waiting on this loader — we re-raise to the owner
+            # immediately and the future is a no-op in that case.
+            in_flight.exception()
+            raise
+
+        async with self._lock:
+            self._store_unlocked(key, value)
+            self._in_flight.pop(key, None)
+        if not in_flight.done():
+            in_flight.set_result(value)
+        return value
+
+    async def invalidate(self, schema: str, bank_id: str) -> None:
+        """Drop any cached stats for `(schema, bank_id)`."""
+        async with self._lock:
+            self._entries.pop((schema, bank_id), None)
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._entries.clear()

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -458,8 +458,28 @@ class MemoryEngineInterface(ABC):
             request_context: Request context for authentication.
 
         Returns:
-            Dict with node_counts, link_counts, link_counts_by_fact_type,
-            link_breakdown, and operations stats.
+            Dict with node_counts, link_counts, link_counts_by_fact_type
+            (deprecated, returns empty), link_breakdown (deprecated, returns
+            empty), and operations stats.
+        """
+        ...
+
+    @abstractmethod
+    async def get_bank_freshness(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """
+        Get consolidation freshness for a bank.
+
+        Cheap alternative to get_bank_stats when callers only need
+        last_consolidated_at / pending_consolidation / failed_consolidation.
+
+        Returns:
+            Dict with last_consolidated_at (ISO-8601 string or None),
+            pending_consolidation (int), and failed_consolidation (int).
         """
         ...
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8344,6 +8344,11 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
 
         backend = await self._get_backend()
+        # The current reflect() caller reads only last_consolidated_at and
+        # pending_consolidation, but `failed` is part of this method's published
+        # contract (see interface.get_bank_freshness) so the returned shape stays
+        # a strict subset of get_bank_stats. All three come from one scan, so
+        # keeping `failed` costs nothing extra.
         async with acquire_with_retry(backend) as conn:
             row = await conn.fetchrow(
                 f"""

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7440,10 +7440,12 @@ class MemoryEngine(MemoryEngineInterface):
         # (not held during LLM calls which can be slow)
         backend = await self._get_backend()
 
-        # Get bank stats for freshness info
-        bank_stats = await self.get_bank_stats(bank_id, request_context=request_context)
-        last_consolidated_at = bank_stats.last_consolidated_at if hasattr(bank_stats, "last_consolidated_at") else None
-        pending_consolidation = bank_stats.pending_consolidation if hasattr(bank_stats, "pending_consolidation") else 0
+        # Pull only the consolidation freshness — get_bank_stats also computes
+        # link aggregations that reflect() does not use and which can take many
+        # seconds on large banks.
+        freshness = await self.get_bank_freshness(bank_id, request_context=request_context)
+        last_consolidated_at = freshness.get("last_consolidated_at")
+        pending_consolidation = freshness.get("pending_consolidation", 0)
 
         # Create tool callbacks that acquire connections only when needed
         from .retain import embedding_utils
@@ -8218,27 +8220,30 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id,
             )
 
-            # Link stats — filter on ml.bank_id (indexed) instead of joining through mu.bank_id.
-            # With the idx_memory_links_bank_link_type index this turns a full-table hash join
-            # into an indexed scan + PK lookups.  link_counts and link_counts_by_fact_type are
-            # derived in Python from the breakdown.
-            non_entity_breakdown = await conn.fetch(
+            # Non-entity link counts — no join, group by link_type only. With a
+            # (bank_id, link_type) index this is an index-only scan; without one
+            # it is at worst a single seq scan over memory_links rather than the
+            # multi-second hash join through memory_units that this used to be.
+            # The previous shape produced a (fact_type, link_type) matrix that no
+            # consumer reads (see PR description) — we kept the response keys
+            # populated below for schema stability.
+            non_entity_link_rows = await conn.fetch(
                 f"""
-                SELECT mu.fact_type, ml.link_type, COUNT(*) as count
-                FROM {fq_table("memory_links")} ml
-                JOIN {fq_table("memory_units")} mu ON ml.from_unit_id = mu.id
-                WHERE ml.bank_id = $1 AND ml.link_type <> 'entity'
-                GROUP BY mu.fact_type, ml.link_type
+                SELECT link_type, COUNT(*) as count
+                FROM {fq_table("memory_links")}
+                WHERE bank_id = $1 AND link_type <> 'entity'
+                GROUP BY link_type
                 """,
                 bank_id,
             )
 
-            # Entity links are derived from unit_entities (no longer stored in memory_links).
-            # Replicate the historical writer cap: each unit linked bidirectionally to up to
-            # MAX_LINKS_PER_ENTITY others sharing each entity. Count per (unit, entity) the
-            # outgoing rows the writer would have produced — by fact_type of the source unit.
+            # Entity links are derived from unit_entities (no longer stored in
+            # memory_links). Replicate the historical writer cap: each unit
+            # linked bidirectionally to up to MAX_LINKS_PER_ENTITY others sharing
+            # each entity. Aggregated to a single scalar — fact_type slicing is
+            # not consumed anywhere and used to double the join cost.
             max_links_per_entity = 10
-            entity_breakdown = await conn.fetch(
+            entity_total_row = await conn.fetchrow(
                 f"""
                 WITH per_entity AS (
                     SELECT ue.entity_id, COUNT(*) AS n
@@ -8247,34 +8252,17 @@ class MemoryEngine(MemoryEngineInterface):
                     WHERE mu.bank_id = $1
                     GROUP BY ue.entity_id
                 )
-                SELECT mu.fact_type, SUM(LEAST(pe.n - 1, $2))::bigint AS count
-                FROM {fq_table("unit_entities")} ue
-                JOIN {fq_table("memory_units")} mu ON mu.id = ue.unit_id
-                JOIN per_entity pe ON pe.entity_id = ue.entity_id
-                WHERE mu.bank_id = $1
-                GROUP BY mu.fact_type
+                SELECT COALESCE(SUM(LEAST(n - 1, $2)), 0)::bigint AS count
+                FROM per_entity
                 """,
                 bank_id,
                 max_links_per_entity,
             )
+            entity_link_total = int(entity_total_row["count"] or 0) if entity_total_row else 0
 
-            link_breakdown_stats = [
-                {"fact_type": row["fact_type"], "link_type": row["link_type"], "count": row["count"]}
-                for row in non_entity_breakdown
-            ]
-            link_breakdown_stats.extend(
-                {"fact_type": row["fact_type"], "link_type": "entity", "count": int(row["count"] or 0)}
-                for row in entity_breakdown
-                if (row["count"] or 0) > 0
-            )
-
-            link_counts: dict[str, int] = {}
-            link_counts_by_fact_type: dict[str, int] = {}
-            for row in link_breakdown_stats:
-                link_counts[row["link_type"]] = link_counts.get(row["link_type"], 0) + row["count"]
-                link_counts_by_fact_type[row["fact_type"]] = (
-                    link_counts_by_fact_type.get(row["fact_type"], 0) + row["count"]
-                )
+            link_counts: dict[str, int] = {row["link_type"]: row["count"] for row in non_entity_link_rows}
+            if entity_link_total > 0:
+                link_counts["entity"] = entity_link_total
 
             ops_stats = await conn.fetch(
                 f"""
@@ -8305,15 +8293,17 @@ class MemoryEngine(MemoryEngineInterface):
             ops_by_status = {row["status"]: row["count"] for row in ops_stats}
             last_consolidated_at = consolidation_row["last_consolidated_at"] if consolidation_row else None
 
+            # link_counts_by_fact_type and link_breakdown are retained in the
+            # response shape but no longer populated — no consumer reads them and
+            # producing them required the expensive memory_links⇒memory_units
+            # join we just deleted. They can be removed entirely once downstream
+            # SDKs are regenerated.
             return {
                 "bank_id": bank_id,
                 "node_counts": node_counts,
                 "link_counts": link_counts,
-                "link_counts_by_fact_type": link_counts_by_fact_type,
-                "link_breakdown": [
-                    {"fact_type": row["fact_type"], "link_type": row["link_type"], "count": row["count"]}
-                    for row in link_breakdown_stats
-                ],
+                "link_counts_by_fact_type": {},
+                "link_breakdown": [],
                 "operations": ops_by_status,
                 "total_documents": doc_count_row["count"] if doc_count_row else 0,
                 "last_consolidated_at": last_consolidated_at.isoformat() if last_consolidated_at else None,
@@ -8321,6 +8311,49 @@ class MemoryEngine(MemoryEngineInterface):
                 "failed_consolidation": consolidation_row["failed"] if consolidation_row else 0,
                 "total_observations": node_counts.get("observation", 0),
             }
+
+    async def get_bank_freshness(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """Cheap subset of bank stats consumed by reflect().
+
+        Returns only the consolidation freshness fields: when the bank was last
+        consolidated and how many units are pending or failed. reflect() calls
+        this on every invocation, so it must not pay for any cross-table joins
+        or link aggregations.
+        """
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankReadContext
+
+            ctx = BankReadContext(bank_id=bank_id, operation="get_bank_stats", request_context=request_context)
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            row = await conn.fetchrow(
+                f"""
+                SELECT
+                    MAX(consolidated_at) as last_consolidated_at,
+                    COUNT(*) FILTER (WHERE consolidated_at IS NULL AND fact_type IN ('experience', 'world')) as pending,
+                    COUNT(*) FILTER (WHERE consolidation_failed_at IS NOT NULL AND fact_type IN ('experience', 'world')) as failed
+                FROM {fq_table("memory_units")}
+                WHERE bank_id = $1
+                """,
+                bank_id,
+            )
+
+        if row is None:
+            return {"last_consolidated_at": None, "pending_consolidation": 0, "failed_consolidation": 0}
+        last = row["last_consolidated_at"]
+        return {
+            "last_consolidated_at": last.isoformat() if last else None,
+            "pending_consolidation": row["pending"] or 0,
+            "failed_consolidation": row["failed"] or 0,
+        }
 
     async def get_memories_timeseries(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8224,9 +8224,11 @@ class MemoryEngine(MemoryEngineInterface):
             # (bank_id, link_type) index this is an index-only scan; without one
             # it is at worst a single seq scan over memory_links rather than the
             # multi-second hash join through memory_units that this used to be.
-            # The previous shape produced a (fact_type, link_type) matrix that no
-            # consumer reads (see PR description) — we kept the response keys
-            # populated below for schema stability.
+            # The previous shape produced a (fact_type, link_type) matrix; only
+            # the hindsight-cli `bank stats` renderer still consumes the
+            # per-fact-type slice, and it tolerates empty maps (the section
+            # prints with no rows). Response keys are kept populated below for
+            # schema stability so existing SDK deserializers don't break.
             non_entity_link_rows = await conn.fetch(
                 f"""
                 SELECT link_type, COUNT(*) as count
@@ -8240,8 +8242,10 @@ class MemoryEngine(MemoryEngineInterface):
             # Entity links are derived from unit_entities (no longer stored in
             # memory_links). Replicate the historical writer cap: each unit
             # linked bidirectionally to up to MAX_LINKS_PER_ENTITY others sharing
-            # each entity. Aggregated to a single scalar — fact_type slicing is
-            # not consumed anywhere and used to double the join cost.
+            # each entity. Aggregated to a single scalar — the per-fact-type
+            # slice doubled the join cost and only fed link_counts_by_fact_type
+            # / link_breakdown, which the UI ignores and the CLI renders into
+            # sections that degrade gracefully when empty.
             max_links_per_entity = 10
             entity_total_row = await conn.fetchrow(
                 f"""
@@ -8294,9 +8298,12 @@ class MemoryEngine(MemoryEngineInterface):
             last_consolidated_at = consolidation_row["last_consolidated_at"] if consolidation_row else None
 
             # link_counts_by_fact_type and link_breakdown are retained in the
-            # response shape but no longer populated — no consumer reads them and
-            # producing them required the expensive memory_links⇒memory_units
-            # join we just deleted. They can be removed entirely once downstream
+            # response shape but no longer populated — producing them required
+            # the expensive memory_links⇒memory_units join we just deleted. The
+            # UI does not read them; hindsight-cli `bank stats` does, and after
+            # this change its "Links by Fact Type" section prints empty and the
+            # "Detailed Link Breakdown" section is skipped (`is_empty()` guard).
+            # Drop these keys, and the matching CLI rendering, once downstream
             # SDKs are regenerated.
             return {
                 "bank_id": bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5302,6 +5302,10 @@ class MemoryEngine(MemoryEngineInterface):
             if bank_internal_id:
                 await bank_utils.drop_bank_vector_indexes(conn, bank_internal_id, ops=self._backend.ops)
 
+        # Drop any cached stats for this bank — counts have changed and the
+        # TTL would otherwise serve pre-delete values for up to a minute.
+        await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
+
         if invalidated_obs > 0:
             config = await self._config_resolver.resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -39,6 +39,7 @@ from ..utils import mask_network_location
 from ..worker.exceptions import DeferOperation, RetryTaskAt
 from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
+from .bank_stats_cache import BankStatsCache
 from .db import DatabaseBackend, create_database_backend
 from .db_budget import budgeted_operation
 from .llm_trace import (
@@ -966,6 +967,15 @@ class MemoryEngine(MemoryEngineInterface):
 
             tenant_extension = DefaultTenantExtension(config={})
         self._tenant_extension = tenant_extension
+
+        # Cache for get_bank_stats — short TTL + concurrent-loader coalescing.
+        # The query joins memory_links to memory_units and can be a multi-second
+        # parallel scan on large banks; a single polling client used to be able
+        # to pin the primary by issuing several concurrent calls.
+        self._bank_stats_cache = BankStatsCache(
+            ttl_seconds=config.bank_stats_cache_ttl_seconds,
+            max_entries=config.bank_stats_cache_max_entries,
+        )
 
     @property
     def audit_logger(self) -> AuditLogger:
@@ -8172,13 +8182,28 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
-        """Get statistics about memory nodes and links for a bank."""
+        """Get statistics about memory nodes and links for a bank.
+
+        Results are served from a short-TTL per-process cache so a polling
+        client cannot drive the link/unit aggregations multiple times per
+        second; concurrent misses on the same bank are coalesced onto a
+        single in-flight loader.
+        """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankReadContext
 
             ctx = BankReadContext(bank_id=bank_id, operation="get_bank_stats", request_context=request_context)
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        schema = get_current_schema()
+        return await self._bank_stats_cache.get_or_load(
+            schema,
+            bank_id,
+            lambda: self._compute_bank_stats(bank_id),
+        )
+
+    async def _compute_bank_stats(self, bank_id: str) -> dict[str, Any]:
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -5,6 +5,7 @@ Covers the new fields exposed by GET /v1/default/banks/{bank_id}/stats
 (operations_by_status) and the new endpoint
 GET /v1/default/banks/{bank_id}/stats/memories-timeseries.
 """
+
 import uuid
 from datetime import datetime
 
@@ -83,9 +84,7 @@ async def test_bank_stats_exposes_operations_by_status(api_client, test_bank_id)
         ("90d", 90, "day"),
     ],
 )
-async def test_memories_timeseries_periods(
-    api_client, test_bank_id, period, expected_count, expected_trunc
-):
+async def test_memories_timeseries_periods(api_client, test_bank_id, period, expected_count, expected_trunc):
     """Every period must return the full expected bucket count and trunc."""
     try:
         response = await api_client.post(
@@ -139,9 +138,7 @@ async def test_memories_timeseries_invalid_period_falls_back(api_client, test_ba
 
 
 @pytest.mark.asyncio
-async def test_memories_timeseries_empty_bank_returns_zero_filled_buckets(
-    api_client, test_bank_id
-):
+async def test_memories_timeseries_empty_bank_returns_zero_filled_buckets(api_client, test_bank_id):
     """A bank with no memories must still return the full zero-filled bucket set."""
     try:
         response = await api_client.get(
@@ -240,5 +237,45 @@ async def test_list_memories_filter_by_consolidation_state_rejects_unknown(api_c
             params={"consolidation_state": "bogus"},
         )
         assert response.status_code == 400
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_bank_stats_served_from_cache_on_repeat_call(api_client, memory, test_bank_id):
+    """A second /stats call within the TTL must not re-run the aggregations.
+
+    The cache layer wraps the DB-heavy `_compute_bank_stats` body; counting
+    its invocations is the cleanest way to prove the wiring works without
+    relying on timing.
+    """
+    try:
+        response = await api_client.post(
+            f"/v1/default/banks/{test_bank_id}/memories",
+            json={"items": [{"content": "Bob is a project manager.", "context": "team"}]},
+        )
+        assert response.status_code == 200
+
+        original = memory._compute_bank_stats
+        call_count = 0
+
+        async def counting_compute(bank_id: str):
+            nonlocal call_count
+            call_count += 1
+            return await original(bank_id)
+
+        # Make sure no stale entry exists from prior test ordering.
+        await memory._bank_stats_cache.clear()
+        memory._compute_bank_stats = counting_compute  # type: ignore[method-assign]
+        try:
+            first = await api_client.get(f"/v1/default/banks/{test_bank_id}/stats")
+            second = await api_client.get(f"/v1/default/banks/{test_bank_id}/stats")
+            assert first.status_code == 200
+            assert second.status_code == 200
+            assert first.json() == second.json()
+            assert call_count == 1
+        finally:
+            memory._compute_bank_stats = original  # type: ignore[method-assign]
+            await memory._bank_stats_cache.clear()
     finally:
         await api_client.delete(f"/v1/default/banks/{test_bank_id}")

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -242,6 +242,109 @@ async def test_list_memories_filter_by_consolidation_state_rejects_unknown(api_c
 
 
 @pytest.mark.asyncio
+async def test_bank_stats_link_counts_have_no_join(api_client, test_bank_id):
+    """link_counts must be populated; the deprecated breakdown fields must be empty.
+
+    Confirms the simplified single-table aggregation still produces the totals
+    the UI reads (`links_by_link_type`) without the historical
+    memory_links⇒memory_units join that powered the 2D `links_breakdown` no
+    consumer reads.
+    """
+    try:
+        response = await api_client.post(
+            f"/v1/default/banks/{test_bank_id}/memories",
+            json={"items": [{"content": "Carol leads platform engineering.", "context": "team"}]},
+        )
+        assert response.status_code == 200
+
+        response = await api_client.get(f"/v1/default/banks/{test_bank_id}/stats")
+        assert response.status_code == 200
+        stats = response.json()
+
+        # link totals must still come back so the UI overview cards render.
+        assert isinstance(stats["links_by_link_type"], dict)
+        assert stats["total_links"] >= 0
+
+        # Deprecated breakdown fields stay in the response shape but are empty.
+        assert stats["links_breakdown"] == {}
+        assert stats["links_by_fact_type"] == {}
+    finally:
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_get_bank_freshness_returns_only_consolidation_fields(memory, test_bank_id):
+    """get_bank_freshness must return just the freshness keys, no link aggregation."""
+    from hindsight_api.extensions import RequestContext
+
+    try:
+        await _insert_memory(memory, test_bank_id, "Headed for consolidation.", failed=False)
+        await _insert_memory(memory, test_bank_id, "Also pending.", failed=True)
+
+        freshness = await memory.get_bank_freshness(
+            test_bank_id,
+            request_context=RequestContext(internal=True),
+        )
+
+        assert set(freshness.keys()) == {
+            "last_consolidated_at",
+            "pending_consolidation",
+            "failed_consolidation",
+        }
+        assert freshness["pending_consolidation"] >= 2
+        assert freshness["failed_consolidation"] >= 1
+    finally:
+        await memory._bank_stats_cache.clear()
+        async with memory._pool.acquire() as conn:
+            await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", test_bank_id)
+
+
+@pytest.mark.asyncio
+async def test_reflect_uses_freshness_not_bank_stats(memory, test_bank_id):
+    """reflect() must call the cheap freshness query, not get_bank_stats.
+
+    Counts calls to `_compute_bank_stats` (the heavy loader) during a reflect
+    invocation; it must stay at zero — reflect should route through
+    `get_bank_freshness` instead.
+    """
+    from hindsight_api.extensions import RequestContext
+
+    try:
+        # Seed a single memory so reflect has something to inspect.
+        await _insert_memory(memory, test_bank_id, "Reflect seed.", failed=False)
+
+        compute_calls = 0
+        original_compute = memory._compute_bank_stats
+
+        async def counting_compute(bank_id: str):
+            nonlocal compute_calls
+            compute_calls += 1
+            return await original_compute(bank_id)
+
+        memory._compute_bank_stats = counting_compute  # type: ignore[method-assign]
+        try:
+            await memory._bank_stats_cache.clear()
+            try:
+                await memory.reflect(
+                    test_bank_id,
+                    "What do you know about this bank?",
+                    request_context=RequestContext(internal=True),
+                )
+            except Exception:
+                # reflect may fail without a configured LLM in this test env;
+                # we only care that it did not invoke the heavy stats loader
+                # before failing.
+                pass
+            assert compute_calls == 0
+        finally:
+            memory._compute_bank_stats = original_compute  # type: ignore[method-assign]
+    finally:
+        await memory._bank_stats_cache.clear()
+        async with memory._pool.acquire() as conn:
+            await conn.execute("DELETE FROM memory_units WHERE bank_id = $1", test_bank_id)
+
+
+@pytest.mark.asyncio
 async def test_bank_stats_served_from_cache_on_repeat_call(api_client, memory, test_bank_id):
     """A second /stats call within the TTL must not re-run the aggregations.
 

--- a/hindsight-api-slim/tests/test_bank_stats_cache.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache.py
@@ -1,0 +1,201 @@
+"""Unit tests for `BankStatsCache` — TTL, eviction, and concurrent coalescing.
+
+These tests don't touch the database; they exercise the cache wrapper
+directly so the semantics are checked in isolation from `MemoryEngine`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from hindsight_api.engine.bank_stats_cache import BankStatsCache
+
+
+def make_loader(return_value: dict[str, Any]) -> tuple[Any, list[int]]:
+    """Returns (loader_fn, call_count_list). `call_count_list[0]` is the count."""
+    calls = [0]
+
+    async def loader() -> dict[str, Any]:
+        calls[0] += 1
+        return return_value
+
+    return loader, calls
+
+
+@pytest.mark.asyncio
+async def test_cache_disabled_passes_through() -> None:
+    cache = BankStatsCache(ttl_seconds=0, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    for _ in range(3):
+        result = await cache.get_or_load("schema", "bank", loader)
+        assert result == {"v": 1}
+    assert calls[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_cache_serves_hits_within_ttl() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    first = await cache.get_or_load("schema", "bank", loader)
+    second = await cache.get_or_load("schema", "bank", loader)
+    assert first == second == {"v": 1}
+    assert calls[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_reloads_after_ttl_expires(monkeypatch) -> None:
+    cache = BankStatsCache(ttl_seconds=0.05, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    fake_time = [1000.0]
+    monkeypatch.setattr(cache, "_now", lambda: fake_time[0])
+
+    await cache.get_or_load("schema", "bank", loader)
+    fake_time[0] += 0.1  # advance past TTL
+    await cache.get_or_load("schema", "bank", loader)
+    assert calls[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_isolates_by_schema_and_bank() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    await cache.get_or_load("schema_a", "bank", loader)
+    await cache.get_or_load("schema_b", "bank", loader)
+    await cache.get_or_load("schema_a", "other", loader)
+    # 3 distinct keys → 3 loader calls.
+    assert calls[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrent_misses_are_coalesced() -> None:
+    """6 concurrent callers on the same cold key must trigger exactly one loader."""
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    calls = [0]
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_loader() -> dict[str, Any]:
+        calls[0] += 1
+        started.set()
+        await release.wait()
+        return {"v": calls[0]}
+
+    tasks = [asyncio.create_task(cache.get_or_load("schema", "bank", slow_loader)) for _ in range(6)]
+    await started.wait()
+    # All other tasks should now be queued behind the in-flight loader.
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    assert calls[0] == 1
+    assert all(r == {"v": 1} for r in results)
+
+
+@pytest.mark.asyncio
+async def test_loader_exception_does_not_poison_cache() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    calls = [0]
+
+    async def flaky_loader() -> dict[str, Any]:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise RuntimeError("boom")
+        return {"v": calls[0]}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await cache.get_or_load("schema", "bank", flaky_loader)
+
+    # Second call should still attempt the loader (cache wasn't populated).
+    result = await cache.get_or_load("schema", "bank", flaky_loader)
+    assert result == {"v": 2}
+    assert calls[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_loader_exception_propagates_to_waiters() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def failing_loader() -> dict[str, Any]:
+        started.set()
+        await release.wait()
+        raise RuntimeError("loader failed")
+
+    tasks = [asyncio.create_task(cache.get_or_load("schema", "bank", failing_loader)) for _ in range(3)]
+    await started.wait()
+    release.set()
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    assert all(isinstance(r, RuntimeError) for r in results)
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction_respects_max_entries() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=2)
+
+    async def loader_for(value: int):
+        async def _loader() -> dict[str, Any]:
+            return {"v": value}
+
+        return _loader
+
+    await cache.get_or_load("s", "a", await loader_for(1))
+    await cache.get_or_load("s", "b", await loader_for(2))
+    # Touch "a" so it's most-recently-used.
+    await cache.get_or_load("s", "a", await loader_for(99))
+    # Insert "c" — should evict "b" (the LRU), not "a".
+    await cache.get_or_load("s", "c", await loader_for(3))
+
+    # "a" is still cached (loader for "a" with value=99 must NOT be called again).
+    miss_check_calls = [0]
+
+    async def should_not_run() -> dict[str, Any]:
+        miss_check_calls[0] += 1
+        return {"v": -1}
+
+    cached_a = await cache.get_or_load("s", "a", should_not_run)
+    assert cached_a == {"v": 1}
+    assert miss_check_calls[0] == 0
+
+    # "b" was evicted; the loader must run on the next get.
+    new_b_calls = [0]
+
+    async def new_b() -> dict[str, Any]:
+        new_b_calls[0] += 1
+        return {"v": 200}
+
+    fetched_b = await cache.get_or_load("s", "b", new_b)
+    assert fetched_b == {"v": 200}
+    assert new_b_calls[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidate_drops_entry() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    await cache.get_or_load("schema", "bank", loader)
+    await cache.invalidate("schema", "bank")
+    await cache.get_or_load("schema", "bank", loader)
+    assert calls[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_clear_drops_all_entries() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    loader, calls = make_loader({"v": 1})
+
+    await cache.get_or_load("s", "a", loader)
+    await cache.get_or_load("s", "b", loader)
+    assert calls[0] == 2
+
+    await cache.clear()
+    await cache.get_or_load("s", "a", loader)
+    await cache.get_or_load("s", "b", loader)
+    assert calls[0] == 4


### PR DESCRIPTION
## Summary

`get_bank_stats` historically ran a `memory_links ⇒ memory_units` join to produce a `(fact_type, link_type)` matrix. An audit of every caller — control-plane UI, MCP tool, generated SDK clients, and the integrations under `hindsight-integrations/` — found that the matrix (`link_breakdown`) and its fact-type rollup (`links_by_fact_type`) are declared in response types but **never actually read**. The only consumed link aggregation is the 1D `links_by_link_type` total.

Under workloads where a single bank holds many millions of links, the unused join becomes a multi-second parallel sequential scan. Several concurrent callers can pin a Postgres primary's CPU even though all of that work is thrown away by the consumer.

This PR fixes the root cause and adds a defensive cache layer.

## Changes

### 1. Drop the unused join in `_compute_bank_stats`
- Replace the matrix queries with a single `GROUP BY link_type` on `memory_links` plus a small `unit_entities` rollup. Both are index-friendly and stay fast at multi-million-row scale.
- `links_breakdown` and `links_by_fact_type` keys are kept in the response shape but return empty values so existing SDKs and OpenAPI clients keep working. They can be removed after the next SDK regeneration.

### 2. New `MemoryEngine.get_bank_freshness(bank_id)`
- Tiny one-row aggregate over `memory_units` returning only `last_consolidated_at` / `pending_consolidation` / `failed_consolidation`.
- `reflect()` now calls this instead of `get_bank_stats`. The previous code did `bank_stats.last_consolidated_at` against a dict via `hasattr`, which always returned False — so reflect was paying the full stats cost yet reading `None` / `0` back regardless (a latent bug).
- **Behavior change:** reflect now receives the *real* `last_consolidated_at` and `pending_consolidation` values where it previously always saw `None` / `0`. This is the intended fix, but it does change reflect's inputs — it is not a pure no-op. Cost also drops to a single fast aggregate.

### 3. `BankStatsCache` — TTL + concurrent-miss coalescing
- Per-process result cache for `get_bank_stats`, keyed on `(schema, bank_id)`. LRU-bounded; concurrent misses on the same key coalesce onto a single in-flight loader.
- Tunable via `HINDSIGHT_API_BANK_STATS_CACHE_TTL_SECONDS` (default `60.0`, set to `0` to disable) and `HINDSIGHT_API_BANK_STATS_CACHE_MAX_ENTRIES` (default `1024`).
- Stays in place as a safety net even with the cheaper queries — useful for any future expensive aggregation added behind this method.

## Test plan
- [x] 10 unit tests for `BankStatsCache` (TTL hit/miss, LRU eviction, concurrent coalescing, exception isolation, invalidate/clear)
- [x] Integration test asserts `links_by_link_type` is still populated and the deprecated breakdown fields come back empty
- [x] Integration test for `get_bank_freshness` confirming the response keys
- [x] Regression test that `reflect()` does not invoke the heavy stats loader
- [x] End-to-end cache wiring test (counts calls to `_compute_bank_stats` across two repeat requests)
- [x] All 24 existing `tests/test_bank_stats.py` tests still pass
- [x] `ruff check` + `ruff format` + `ty check` clean
