### PR TITLE
feat(api): add Fireworks AI batch inference provider

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -172,6 +172,17 @@ ENV_RETAIN_LLM_MAX_BACKOFF = "HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF"
 ENV_RETAIN_LLM_TIMEOUT = "HINDSIGHT_API_RETAIN_LLM_TIMEOUT"
 ENV_RETAIN_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_RETAIN_LLM_LITELLMROUTER_CONFIG"
 
+# Fireworks AI batch inference. Fireworks' batch API is a proprietary
+# account-scoped dataset/job REST API on a control-plane host, distinct from the
+# OpenAI-compatible inference host. account_id is REQUIRED for batch retain
+# (the control-plane endpoints are /v1/accounts/{account_id}/...). Static,
+# server-level config — it pairs with the Fireworks API key.
+ENV_FIREWORKS_ACCOUNT_ID = "HINDSIGHT_API_FIREWORKS_ACCOUNT_ID"
+ENV_FIREWORKS_BATCH_BASE_URL = "HINDSIGHT_API_FIREWORKS_BATCH_BASE_URL"
+ENV_FIREWORKS_BATCH_MAX_WAIT_SECONDS = "HINDSIGHT_API_FIREWORKS_BATCH_MAX_WAIT_SECONDS"
+DEFAULT_FIREWORKS_BATCH_BASE_URL = "https://api.fireworks.ai"
+DEFAULT_FIREWORKS_BATCH_MAX_WAIT_SECONDS = 86_400  # 24h — Fireworks' max job timeout
+
 ENV_REFLECT_LLM_PROVIDER = "HINDSIGHT_API_REFLECT_LLM_PROVIDER"
 ENV_REFLECT_LLM_API_KEY = "HINDSIGHT_API_REFLECT_LLM_API_KEY"
 ENV_REFLECT_LLM_MODEL = "HINDSIGHT_API_REFLECT_LLM_MODEL"
@@ -518,6 +529,7 @@ PROVIDER_DEFAULT_MODELS = {
     "bedrock": "us.amazon.nova-2-lite-v1:0",
     "volcano": "doubao-pro-32k",
     "openrouter": "qwen/qwen3.5-9b",
+    "fireworks": "accounts/fireworks/models/llama-v3p1-8b-instruct",
 }
 DEFAULT_LLM_MODEL = "gpt-4o-mini"  # Fallback if provider not in table
 # Built-in llama.cpp defaults
@@ -1065,6 +1077,11 @@ class HindsightConfig:
     retain_llm_max_backoff: float | None
     retain_llm_timeout: float | None
     retain_llm_litellmrouter_config: dict | None
+
+    # Fireworks AI batch inference (static, server-level)
+    fireworks_account_id: str | None
+    fireworks_batch_base_url: str
+    fireworks_batch_max_wait_seconds: int
 
     reflect_llm_provider: str | None
     reflect_llm_api_key: str | None
@@ -1645,6 +1662,11 @@ class HindsightConfig:
                 else None
             ),
             retain_llm_base_url=os.getenv(ENV_RETAIN_LLM_BASE_URL) or None,
+            fireworks_account_id=os.getenv(ENV_FIREWORKS_ACCOUNT_ID) or None,
+            fireworks_batch_base_url=os.getenv(ENV_FIREWORKS_BATCH_BASE_URL) or DEFAULT_FIREWORKS_BATCH_BASE_URL,
+            fireworks_batch_max_wait_seconds=int(
+                os.getenv(ENV_FIREWORKS_BATCH_MAX_WAIT_SECONDS, str(DEFAULT_FIREWORKS_BATCH_MAX_WAIT_SECONDS))
+            ),
             retain_llm_max_concurrent=int(os.getenv(ENV_RETAIN_LLM_MAX_CONCURRENT))
             if os.getenv(ENV_RETAIN_LLM_MAX_CONCURRENT)
             else None,

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -249,6 +249,7 @@ def create_llm_provider(
         AnthropicLLM,
         ClaudeCodeLLM,
         CodexLLM,
+        FireworksLLM,
         GeminiLLM,
         LiteLLMLLM,
         LiteLLMRouterLLM,
@@ -374,6 +375,19 @@ def create_llm_provider(
             extra_args=config.llamacpp_extra_args,
         )
 
+    elif provider_lower == "fireworks":
+        # Fireworks online inference is OpenAI-compatible; FireworksLLM adds the
+        # native (non-OpenAI) batch API on top. The existing LiteLLM
+        # ``fireworks_ai/...`` online path (provider="litellm") is untouched.
+        return FireworksLLM(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            extra_body=extra_body,
+        )
+
     elif provider_lower in (
         "openai",
         "groq",
@@ -495,6 +509,7 @@ class LLMProvider:
             "openrouter",
             "zai",
             "opencode-go",
+            "fireworks",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")

--- a/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/__init__.py
@@ -7,6 +7,7 @@ This package contains concrete implementations of the LLMInterface for various p
 from .anthropic_llm import AnthropicLLM
 from .claude_code_llm import ClaudeCodeLLM
 from .codex_llm import CodexLLM
+from .fireworks_llm import FireworksLLM
 from .gemini_llm import GeminiLLM
 from .litellm_llm import LiteLLMLLM
 from .litellm_router_llm import LiteLLMRouterLLM
@@ -19,6 +20,7 @@ __all__ = [
     "AnthropicLLM",
     "ClaudeCodeLLM",
     "CodexLLM",
+    "FireworksLLM",
     "GeminiLLM",
     "LlamaCppLLM",
     "LiteLLMLLM",

--- a/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
@@ -124,14 +124,18 @@ class FireworksLLM(OpenAICompatibleLLM):
         output_dataset_id = f"hs-batch-out-{uuid.uuid4().hex}"
         headers = self._auth_headers()
 
-        # The `dataset` resource takes display/format metadata on create. CHAT is
-        # the format for chat-completion batch input. (`userUploaded` is an
-        # output-only source marker, not a create field — sending it 400s.)
+        # The `dataset` resource takes format + exampleCount on create. CHAT is
+        # the format for chat-completion batch input; exampleCount is the JSONL
+        # line count (Fireworks rejects uploaded datasets without it) and is an
+        # int64 proto field, so it goes over the wire as a string.
         await self._request(
             "POST",
             self._datasets_url(),
             headers=headers,
-            json={"datasetId": input_dataset_id, "dataset": {"format": "CHAT"}},
+            json={
+                "datasetId": input_dataset_id,
+                "dataset": {"format": "CHAT", "exampleCount": str(len(requests))},
+            },
         )
 
         await self._request(

--- a/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
@@ -124,11 +124,14 @@ class FireworksLLM(OpenAICompatibleLLM):
         output_dataset_id = f"hs-batch-out-{uuid.uuid4().hex}"
         headers = self._auth_headers()
 
+        # The `dataset` resource takes display/format metadata on create. CHAT is
+        # the format for chat-completion batch input. (`userUploaded` is an
+        # output-only source marker, not a create field — sending it 400s.)
         await self._request(
             "POST",
             self._datasets_url(),
             headers=headers,
-            json={"datasetId": input_dataset_id, "dataset": {"userUploaded": {}}},
+            json={"datasetId": input_dataset_id, "dataset": {"format": "CHAT"}},
         )
 
         await self._request(
@@ -332,7 +335,15 @@ class FireworksLLM(OpenAICompatibleLLM):
         files: dict[str, Any] | None = None,
     ) -> httpx.Response:
         resp = await self._http().request(method, url, headers=headers, json=json, files=files)
-        resp.raise_for_status()
+        if resp.is_error:
+            # Surface the API's error body. Fireworks returns JSON describing why a
+            # 4xx/5xx happened; raise_for_status() alone discards it, which makes
+            # failures (e.g. a malformed dataset/job request) undebuggable.
+            raise httpx.HTTPStatusError(
+                f"Fireworks API {resp.status_code} for {method} {url}: {resp.text[:2000]}",
+                request=resp.request,
+                response=resp,
+            )
         return resp
 
     def _accounts_base(self) -> str:

--- a/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/fireworks_llm.py
@@ -1,0 +1,381 @@
+"""Fireworks AI provider with batch-inference support.
+
+Fireworks' *online* inference endpoint (``/inference/v1``) is OpenAI-compatible,
+so ``FireworksLLM`` subclasses :class:`OpenAICompatibleLLM` and reuses its entire
+chat path. Only the *batch* mechanism differs: Fireworks does NOT implement the
+OpenAI ``/v1/batches`` API. Instead it exposes a proprietary, account-scoped
+dataset -> job -> download REST workflow on a separate control-plane host. This
+class overrides only the four batch members of the interface, translating that
+workflow to/from the OpenAI-batch shapes the retain orchestrator and
+``fact_extraction`` consumer expect — so nothing downstream changes.
+
+Interface contract preserved (see ``fact_extraction.py`` result handling)::
+
+    result["response"]["body"]["choices"][0]["message"]["content"]
+
+Workflow (control-plane host, e.g. ``https://api.fireworks.ai``)::
+
+    POST /v1/accounts/{acct}/datasets                      create input dataset
+    POST /v1/accounts/{acct}/datasets/{id}:upload          upload input JSONL
+    POST /v1/accounts/{acct}/batchInferenceJobs            create job
+    GET  /v1/accounts/{acct}/batchInferenceJobs/{jobId}    poll status
+    GET  /v1/accounts/{acct}/datasets/{out}:getDownloadEndpoint   signed URLs
+    GET  <signed-url>                                      download output JSONL
+
+NOTE: the exact *output JSONL line* nesting is not verbatim-documented by
+Fireworks. ``_normalize_output_line`` handles both the observed shape
+(``{custom_id, response: {...completion...}, error}``) and a ``response.body``
+nesting defensively. Confirm against a live key via the integration path.
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from .openai_compatible_llm import OpenAICompatibleLLM
+
+logger = logging.getLogger(__name__)
+
+# Normalized statuses the retain driver treats as fatal (it raises) vs. keeps
+# polling on. "completed" ends the poll; anything else not in this set means
+# "keep polling".
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "expired"})
+
+# Default per-request timeout for control-plane HTTP calls (not the job wait).
+_HTTP_TIMEOUT_SECONDS = 60.0
+
+# Fallback max job wait if neither a constructor arg nor config supplies one
+# (24h matches Fireworks' maximum job timeout).
+_DEFAULT_MAX_WAIT_SECONDS = 86_400
+
+
+class FireworksLLM(OpenAICompatibleLLM):
+    """Fireworks provider: OpenAI-compatible online inference + native batch."""
+
+    def __init__(
+        self,
+        provider: str = "fireworks",
+        *,
+        api_key: str,
+        base_url: str = "",
+        model: str,
+        reasoning_effort: str = "low",
+        account_id: str | None = None,
+        batch_base_url: str | None = None,
+        max_wait_seconds: int | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            **kwargs,
+        )
+
+        # Batch settings are static, server-level config. Resolve any unset
+        # values from the global config lazily so the online inference path
+        # works even when batch is never configured.
+        if account_id is None or batch_base_url is None or max_wait_seconds is None:
+            from ...config import get_config
+
+            cfg = get_config()
+            if account_id is None:
+                account_id = cfg.fireworks_account_id
+            if batch_base_url is None:
+                batch_base_url = cfg.fireworks_batch_base_url
+            if max_wait_seconds is None:
+                max_wait_seconds = cfg.fireworks_batch_max_wait_seconds
+
+        self._account_id = account_id
+        self._batch_base_url = (batch_base_url or "https://api.fireworks.ai").rstrip("/")
+        self._max_wait_seconds: int = (
+            int(max_wait_seconds) if max_wait_seconds is not None else _DEFAULT_MAX_WAIT_SECONDS
+        )
+        self._http_client = http_client
+        self._owns_http_client = http_client is None
+
+    # ----- interface: batch members -------------------------------------
+
+    async def supports_batch_api(self) -> bool:
+        return True
+
+    async def submit_batch(
+        self,
+        requests: list[dict[str, Any]],
+        endpoint: str = "/v1/chat/completions",
+        completion_window: str = "24h",
+    ) -> dict[str, Any]:
+        # endpoint/completion_window are part of the LLMInterface batch contract
+        # (used by the OpenAI path) but have no analogue in Fireworks' job API:
+        # the request shape is fixed (chat) and the job timeout is server-side.
+        # Kept for signature compatibility with the shared retain driver.
+        self._require_account_id()
+        logger.info(f"Submitting Fireworks batch with {len(requests)} requests")
+
+        jsonl = self._translate_requests(requests)
+        input_dataset_id = f"hs-batch-in-{uuid.uuid4().hex}"
+        output_dataset_id = f"hs-batch-out-{uuid.uuid4().hex}"
+        headers = self._auth_headers()
+
+        await self._request(
+            "POST",
+            self._datasets_url(),
+            headers=headers,
+            json={"datasetId": input_dataset_id, "dataset": {"userUploaded": {}}},
+        )
+
+        await self._request(
+            "POST",
+            f"{self._datasets_url()}/{input_dataset_id}:upload",
+            headers=headers,
+            files={"file": ("batch_input.jsonl", jsonl.encode("utf-8"), "application/jsonl")},
+        )
+
+        job_resp = await self._request(
+            "POST",
+            self._jobs_url(),
+            headers=headers,
+            json={
+                "model": self.model,
+                "inputDatasetId": self._dataset_resource(input_dataset_id),
+                "outputDatasetId": self._dataset_resource(output_dataset_id),
+            },
+        )
+        job = job_resp.json()
+        job_id = self._last_segment(job.get("name")) or output_dataset_id
+
+        logger.info(f"Fireworks batch job submitted: {job_id}, state={job.get('state')}")
+
+        return {
+            "batch_id": job_id,
+            "status": self._normalize_state(job.get("state", "")),
+            "input_dataset_id": input_dataset_id,
+            "output_dataset_id": output_dataset_id,
+            "created_at": job.get("createTime"),
+            "request_count": len(requests),
+        }
+
+    async def get_batch_status(self, batch_id: str) -> dict[str, Any]:
+        self._require_account_id()
+        job = (await self._request("GET", self._job_url(batch_id), headers=self._auth_headers())).json()
+
+        status = self._normalize_state(job.get("state", ""))
+        progress = job.get("jobProgress") or {}
+        result: dict[str, Any] = {
+            "batch_id": batch_id,
+            "status": status,
+            "created_at": job.get("createTime"),
+            "request_counts": {
+                "total": _to_int(progress.get("totalInputRequests")),
+                "completed": _to_int(progress.get("successfullyProcessedRequests")),
+                "failed": _to_int(progress.get("failedRequests")),
+            },
+        }
+
+        output_dataset_id = job.get("outputDatasetId")
+        if output_dataset_id:
+            result["output_dataset_id"] = output_dataset_id
+        # Fireworks reports terminal failure detail in the `status` {code,message}.
+        if job.get("status"):
+            result["errors"] = job["status"]
+
+        # PENDING-forever guard: the shared retain poll loop has no max-wait, so
+        # if a (likely non-batch-eligible) job never reaches a terminal state we
+        # surface "expired" once createTime is older than the cap. Derived from
+        # the server's createTime so it survives crash-recovery polling resumes.
+        if status not in _TERMINAL_STATUSES:
+            elapsed = self._elapsed_seconds(job.get("createTime"))
+            if elapsed is not None and elapsed > self._max_wait_seconds:
+                result["status"] = "expired"
+                result["errors"] = (
+                    f"Fireworks batch {batch_id} exceeded max wait of {self._max_wait_seconds}s "
+                    f"in state {job.get('state')!r}. The model may not be batch-eligible "
+                    f"(such jobs stay PENDING indefinitely)."
+                )
+                logger.error(result["errors"])
+
+        return result
+
+    async def retrieve_batch_results(self, batch_id: str) -> list[dict[str, Any]]:
+        self._require_account_id()
+        job = (await self._request("GET", self._job_url(batch_id), headers=self._auth_headers())).json()
+
+        status = self._normalize_state(job.get("state", ""))
+        if status != "completed":
+            raise ValueError(f"Fireworks batch {batch_id} is not completed yet (state: {job.get('state')!r})")
+
+        output_dataset_id = job.get("outputDatasetId")
+        if not output_dataset_id:
+            raise ValueError(f"Fireworks batch {batch_id} completed but reported no output dataset")
+
+        output_short_id = self._last_segment(output_dataset_id)
+        if not output_short_id:
+            raise ValueError(
+                f"Fireworks batch {batch_id} reported an unparseable output dataset: {output_dataset_id!r}"
+            )
+        download = (
+            await self._request("GET", self._download_endpoint_url(output_short_id), headers=self._auth_headers())
+        ).json()
+        signed_urls = (download or {}).get("filenameToSignedUrls") or {}
+        if not signed_urls:
+            raise ValueError(f"Fireworks batch {batch_id} returned no downloadable output files")
+
+        # The output dataset contains a results file plus a separate error file.
+        # Download every file and normalize each line; error-file lines carry an
+        # `error` so partial failures surface per custom_id instead of vanishing.
+        results: list[dict[str, Any]] = []
+        for url in signed_urls.values():
+            # Signed URLs are pre-authenticated — do not attach the bearer token.
+            file_resp = await self._request("GET", url)
+            for line in file_resp.text.strip().split("\n"):
+                if line.strip():
+                    results.append(self._normalize_output_line(json.loads(line)))
+
+        logger.info(f"Retrieved {len(results)} results for Fireworks batch {batch_id}")
+        return results
+
+    async def cleanup(self) -> None:
+        await super().cleanup()
+        if self._owns_http_client and self._http_client is not None:
+            await self._http_client.aclose()
+
+    # ----- pure translation/normalization helpers (unit-tested) ----------
+
+    @staticmethod
+    def _translate_requests(requests: list[dict[str, Any]]) -> str:
+        """OpenAI batch request -> Fireworks input JSONL.
+
+        Fireworks lines are ``{"custom_id", "body"}`` — the OpenAI ``method`` and
+        ``url`` keys are dropped; ``body`` is kept verbatim.
+        """
+        lines = [
+            json.dumps({"custom_id": req.get("custom_id"), "body": req.get("body")}, ensure_ascii=False)
+            for req in requests
+        ]
+        return "\n".join(lines)
+
+    @staticmethod
+    def _normalize_state(fw_state: str) -> str:
+        """Fireworks job state -> the retain driver's expected status strings.
+
+        Handles both the API enum (``JOB_STATE_*``) and the guide's bare names
+        (``COMPLETED``/``VALIDATING``/``EXPIRED``). Unknown / in-flight states map
+        to ``in_progress`` so the driver keeps polling.
+        """
+        state = (fw_state or "").upper()
+        if state.startswith("JOB_STATE_"):
+            state = state[len("JOB_STATE_") :]
+        if state == "COMPLETED":
+            return "completed"
+        if state == "FAILED":
+            return "failed"
+        if state in ("CANCELLED", "CANCELED"):
+            return "cancelled"
+        if state == "EXPIRED":
+            return "expired"
+        return "in_progress"
+
+    @staticmethod
+    def _normalize_output_line(line: dict[str, Any]) -> dict[str, Any]:
+        """Fireworks output JSONL line -> OpenAI-batch-output shape.
+
+        Target: ``{"custom_id", "response": {"body": <chat-completion>}, "error"}``
+        so the consumer's ``result["response"]["body"]["choices"][0]...`` works.
+        """
+        custom_id = line.get("custom_id")
+        error = line.get("error")
+        if error:
+            return {"custom_id": custom_id, "response": None, "error": error}
+
+        response = line.get("response")
+        if response is None:
+            response = line.get("body")
+        # If Fireworks already nests the completion under `body`, unwrap it;
+        # otherwise the `response` object *is* the completion.
+        if isinstance(response, dict) and "body" in response:
+            body = response["body"]
+        else:
+            body = response
+        return {"custom_id": custom_id, "response": {"body": body}, "error": None}
+
+    # ----- low-level HTTP + URL helpers ----------------------------------
+
+    def _require_account_id(self) -> None:
+        if not self._account_id:
+            raise ValueError(
+                "Fireworks batch inference requires an account id. "
+                "Set HINDSIGHT_API_FIREWORKS_ACCOUNT_ID to your Fireworks account id."
+            )
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _http(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=httpx.Timeout(_HTTP_TIMEOUT_SECONDS))
+        return self._http_client
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        resp = await self._http().request(method, url, headers=headers, json=json, files=files)
+        resp.raise_for_status()
+        return resp
+
+    def _accounts_base(self) -> str:
+        return f"{self._batch_base_url}/v1/accounts/{self._account_id}"
+
+    def _datasets_url(self) -> str:
+        return f"{self._accounts_base()}/datasets"
+
+    def _jobs_url(self) -> str:
+        return f"{self._accounts_base()}/batchInferenceJobs"
+
+    def _job_url(self, job_id: str) -> str:
+        return f"{self._jobs_url()}/{job_id}"
+
+    def _download_endpoint_url(self, dataset_short_id: str) -> str:
+        return f"{self._datasets_url()}/{dataset_short_id}:getDownloadEndpoint"
+
+    def _dataset_resource(self, dataset_id: str) -> str:
+        return f"accounts/{self._account_id}/datasets/{dataset_id}"
+
+    @staticmethod
+    def _last_segment(resource_name: str | None) -> str | None:
+        if not resource_name:
+            return None
+        return resource_name.rstrip("/").split("/")[-1]
+
+    @staticmethod
+    def _elapsed_seconds(create_time: str | None) -> float | None:
+        if not create_time:
+            return None
+        try:
+            normalized = create_time.replace("Z", "+00:00")
+            created = datetime.fromisoformat(normalized)
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+            return (datetime.now(timezone.utc) - created).total_seconds()
+        except (ValueError, TypeError):
+            return None
+
+
+def _to_int(value: Any) -> int:
+    """Coerce Fireworks' string/int counts to int, defaulting to 0."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return 0

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -279,6 +279,7 @@ class OpenAICompatibleLLM(LLMInterface):
             "openrouter",
             "zai",
             "opencode-go",
+            "fireworks",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"OpenAICompatibleLLM only supports: {', '.join(valid_providers)}. Got: {self.provider}")
@@ -303,6 +304,10 @@ class OpenAICompatibleLLM(LLMInterface):
                 self.base_url = "https://api.z.ai/api/coding/paas/v4"
             elif self.provider == "opencode-go":
                 self.base_url = "https://opencode.ai/zen/go/v1"
+            elif self.provider == "fireworks":
+                # OpenAI-compatible inference host (online path). The batch API
+                # lives on a separate control-plane host — see FireworksLLM.
+                self.base_url = "https://api.fireworks.ai/inference/v1"
 
         # For ollama/lmstudio, use dummy key if not provided
         if self.provider in ("ollama", "lmstudio") and not self.api_key:

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -143,6 +143,8 @@ markers = [
     "oracle: Oracle 23ai integration tests (require ORACLE_TEST_DSN env var)",
     "hs_llm_mat: LLM minimum acceptance tests — run in CI matrix across multiple providers",
     "hs_llm_core: Core pipeline tests that need a real LLM but only one provider",
+    "integration: Live external-API integration tests (require provider credentials; skipped without)",
+    "slow: Slow tests (minutes); not run in fast CI",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/hindsight-api-slim/tests/test_fireworks_batch.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch.py
@@ -290,6 +290,25 @@ async def test_submit_batch_without_account_id_fails_fast():
         await llm.submit_batch([{"custom_id": "c0", "method": "POST", "url": "/v1/chat/completions", "body": {}}])
 
 
+@pytest.mark.asyncio
+async def test_api_errors_surface_the_response_body():
+    """A 4xx must include Fireworks' error body in the raised error — otherwise a
+    malformed dataset/job request is undebuggable (raise_for_status drops it)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "invalid field 'userUploaded' in dataset"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client)
+
+    with pytest.raises(httpx.HTTPStatusError, match="invalid field 'userUploaded'"):
+        await llm.submit_batch(
+            [{"custom_id": "c0", "method": "POST", "url": "/v1/chat/completions", "body": {}}]
+        )
+
+    await client.aclose()
+
+
 # --------------------------------------------------------------------------
 # get_batch_status: state + counts mapping, and the PENDING-forever timeout
 # --------------------------------------------------------------------------

--- a/hindsight-api-slim/tests/test_fireworks_batch.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch.py
@@ -1,0 +1,468 @@
+"""Tests for the Fireworks AI batch-inference provider (``FireworksLLM``).
+
+Fireworks' batch API is NOT OpenAI ``/v1/batches``-compatible — it is a
+proprietary dataset -> job -> download REST workflow on a control-plane host.
+``FireworksLLM`` subclasses ``OpenAICompatibleLLM`` (so online inference reuses
+the OpenAI-compatible path) and overrides only the four batch members, mapping
+the Fireworks workflow back onto the OpenAI-batch interface contract that the
+retain orchestrator + ``fact_extraction`` consumer depend on.
+
+The interface contract that MUST be preserved (see fact_extraction.py:1843):
+    result["response"]["body"]["choices"][0]["message"]["content"]
+
+API shapes (endpoints, ``state`` enum, ``jobProgress`` counts, download
+endpoint) are grounded in the Fireworks docs. The exact *output JSONL line*
+nesting is not verbatim-documented, so the normalizer is defensive and these
+tests pin the behavior we rely on; the real shape is confirmed by the
+integration/manual path with a live key.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from hindsight_api.engine.providers.fireworks_llm import FireworksLLM
+
+
+def _make_fireworks(
+    *,
+    account_id: str | None = "acct-test",
+    http_client: httpx.AsyncClient | None = None,
+    max_wait_seconds: int = 86_400,
+    batch_base_url: str = "https://api.fireworks.ai",
+    model: str = "accounts/fireworks/models/llama-v3p1-8b-instruct",
+) -> FireworksLLM:
+    return FireworksLLM(
+        provider="fireworks",
+        api_key="fw-test-key",
+        base_url="",
+        model=model,
+        reasoning_effort="low",
+        account_id=account_id,
+        batch_base_url=batch_base_url,
+        max_wait_seconds=max_wait_seconds,
+        http_client=http_client,
+    )
+
+
+# --------------------------------------------------------------------------
+# Structural: capability, routing, key requirement, default model
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fireworks_supports_batch_api_is_true():
+    llm = _make_fireworks()
+    assert await llm.supports_batch_api() is True
+
+
+def test_wrapper_routes_fireworks_to_fireworks_llm_with_inference_base_url():
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    llm = LLMProvider(
+        provider="fireworks",
+        api_key="fw-test-key",
+        base_url="",
+        model="accounts/fireworks/models/llama-v3p1-8b-instruct",
+    )
+
+    assert isinstance(llm._provider_impl, FireworksLLM)
+    # Online inference uses the OpenAI-compatible Fireworks inference host,
+    # which is distinct from the batch control-plane host.
+    assert llm._provider_impl.base_url == "https://api.fireworks.ai/inference/v1"
+
+
+def test_openai_compatible_accepts_fireworks_provider():
+    """Subclassing requires the parent's ``valid_providers`` to accept fireworks."""
+    from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+    llm = OpenAICompatibleLLM(
+        provider="fireworks",
+        api_key="fw-test-key",
+        base_url="",
+        model="accounts/fireworks/models/llama-v3p1-8b-instruct",
+    )
+    assert llm.base_url == "https://api.fireworks.ai/inference/v1"
+
+
+def test_fireworks_requires_api_key():
+    from hindsight_api.engine.llm_wrapper import requires_api_key
+
+    assert requires_api_key("fireworks") is True
+
+
+def test_fireworks_has_default_model():
+    from hindsight_api.config import PROVIDER_DEFAULT_MODELS
+
+    assert PROVIDER_DEFAULT_MODELS["fireworks"] == "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+
+# --------------------------------------------------------------------------
+# §6.5 input translation: OpenAI request -> Fireworks JSONL (drop method/url)
+# --------------------------------------------------------------------------
+
+
+def test_translate_requests_drops_method_and_url_keeps_custom_id_and_body():
+    requests = [
+        {
+            "custom_id": "chunk_0",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {"model": "m", "messages": [{"role": "user", "content": "hi"}]},
+        },
+        {
+            "custom_id": "chunk_1",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {"model": "m", "messages": [{"role": "user", "content": "bye"}]},
+        },
+    ]
+
+    jsonl = FireworksLLM._translate_requests(requests)
+    lines = [json.loads(line) for line in jsonl.strip().split("\n")]
+
+    assert len(lines) == 2
+    for line, original in zip(lines, requests):
+        assert set(line.keys()) == {"custom_id", "body"}
+        assert "method" not in line
+        assert "url" not in line
+        assert line["custom_id"] == original["custom_id"]
+        assert line["body"] == original["body"]
+
+
+# --------------------------------------------------------------------------
+# §6.4 status normalization: Fireworks state -> orchestrator status string
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fw_state, expected",
+    [
+        ("JOB_STATE_COMPLETED", "completed"),
+        ("COMPLETED", "completed"),
+        ("JOB_STATE_FAILED", "failed"),
+        ("FAILED", "failed"),
+        ("JOB_STATE_CANCELLED", "cancelled"),
+        ("CANCELED", "cancelled"),
+        ("EXPIRED", "expired"),
+        ("JOB_STATE_RUNNING", "in_progress"),
+        ("RUNNING", "in_progress"),
+        ("JOB_STATE_PENDING", "in_progress"),
+        ("VALIDATING", "in_progress"),
+        ("JOB_STATE_CREATING", "in_progress"),
+        ("JOB_STATE_UNSPECIFIED", "in_progress"),
+        ("", "in_progress"),
+    ],
+)
+def test_normalize_state_table(fw_state, expected):
+    assert FireworksLLM._normalize_state(fw_state) == expected
+
+
+# --------------------------------------------------------------------------
+# §6.6 output normalization: Fireworks output -> OpenAI-batch-output shape
+# --------------------------------------------------------------------------
+
+
+def test_normalize_output_line_wraps_response_under_body():
+    """Fireworks puts the chat completion at ``response`` directly; the consumer
+    reads ``result["response"]["body"]["choices"]`` so we must re-nest it."""
+    fw_line = {
+        "custom_id": "chunk_0",
+        "response": {
+            "id": "chatcmpl-abc",
+            "choices": [{"message": {"role": "assistant", "content": '{"facts": []}'}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        },
+        "error": None,
+    }
+
+    out = FireworksLLM._normalize_output_line(fw_line)
+
+    assert out["custom_id"] == "chunk_0"
+    assert out["error"] is None
+    # The exact accessor the retain consumer uses:
+    assert out["response"]["body"]["choices"][0]["message"]["content"] == '{"facts": []}'
+    assert out["response"]["body"]["usage"]["total_tokens"] == 15
+
+
+def test_normalize_output_line_handles_already_body_nested():
+    """Defensive: if Fireworks ever nests under response.body, don't double-wrap."""
+    fw_line = {
+        "custom_id": "chunk_1",
+        "response": {"body": {"choices": [{"message": {"content": "ok"}}]}},
+    }
+
+    out = FireworksLLM._normalize_output_line(fw_line)
+
+    assert out["response"]["body"]["choices"][0]["message"]["content"] == "ok"
+
+
+def test_normalize_output_line_surfaces_errors():
+    """A failed request (error-file line) must yield a truthy ``error`` so the
+    consumer's ``result.get("error")`` branch fires instead of vanishing."""
+    fw_line = {
+        "custom_id": "chunk_2",
+        "response": None,
+        "error": {"code": "model_error", "message": "boom"},
+    }
+
+    out = FireworksLLM._normalize_output_line(fw_line)
+
+    assert out["custom_id"] == "chunk_2"
+    assert out["error"] == {"code": "model_error", "message": "boom"}
+
+
+# --------------------------------------------------------------------------
+# submit_batch: dataset create -> upload -> job create (httpx MockTransport)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_runs_dataset_upload_job_workflow():
+    paths: list[str] = []
+    upload_body: list[str] = []
+    job_body: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        paths.append(f"{request.method} {path}")
+        assert request.headers["authorization"] == "Bearer fw-test-key"
+
+        if request.method == "POST" and path.endswith("/datasets"):
+            body = json.loads(request.content)
+            return httpx.Response(200, json={"name": f"accounts/acct-test/datasets/{body['datasetId']}"})
+        if request.method == "POST" and path.endswith(":upload"):
+            upload_body.append(request.content.decode("utf-8", errors="replace"))
+            return httpx.Response(200, json={})
+        if request.method == "POST" and path.endswith("/batchInferenceJobs"):
+            job_body.append(json.loads(request.content))
+            return httpx.Response(
+                200,
+                json={
+                    "name": "accounts/acct-test/batchInferenceJobs/job-xyz",
+                    "state": "JOB_STATE_CREATING",
+                    "createTime": "2026-05-28T00:00:00Z",
+                },
+            )
+        raise AssertionError(f"unexpected request: {request.method} {path}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client)
+
+    requests = [
+        {
+            "custom_id": "chunk_0",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {"model": "m", "messages": []},
+        },
+    ]
+    result = await llm.submit_batch(requests)
+
+    # batch_id is the Fireworks jobId, used as the polling handle.
+    assert result["batch_id"]
+    assert result["request_count"] == 1
+
+    # All control-plane calls are account-scoped.
+    assert all("/v1/accounts/acct-test/" in p for p in paths)
+    # Workflow order: create dataset, upload, create job.
+    assert paths[0].endswith("/datasets")
+    assert ":upload" in paths[1]
+    assert paths[2].endswith("/batchInferenceJobs")
+
+    # Uploaded JSONL is Fireworks-shaped (no method/url leaked through).
+    assert "custom_id" in upload_body[0]
+    assert '"method"' not in upload_body[0]
+    assert '"url"' not in upload_body[0]
+
+    # Job references the configured model.
+    assert job_body[0]["model"] == "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_without_account_id_fails_fast():
+    llm = _make_fireworks(account_id=None)
+    with pytest.raises(ValueError, match="account.id"):
+        await llm.submit_batch([{"custom_id": "c0", "method": "POST", "url": "/v1/chat/completions", "body": {}}])
+
+
+# --------------------------------------------------------------------------
+# get_batch_status: state + counts mapping, and the PENDING-forever timeout
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_status_maps_state_and_counts():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/v1/accounts/acct-test/batchInferenceJobs/job-xyz"
+        return httpx.Response(
+            200,
+            json={
+                "name": "accounts/acct-test/batchInferenceJobs/job-xyz",
+                "state": "JOB_STATE_COMPLETED",
+                "createTime": "2026-05-28T00:00:00Z",
+                "outputDatasetId": "accounts/acct-test/datasets/out-1",
+                "jobProgress": {
+                    "totalInputRequests": "2",
+                    "successfullyProcessedRequests": "2",
+                    "failedRequests": "0",
+                },
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client)
+
+    status = await llm.get_batch_status("job-xyz")
+
+    assert status["batch_id"] == "job-xyz"
+    assert status["status"] == "completed"
+    assert status["request_counts"]["total"] == 2
+    assert status["request_counts"]["completed"] == 2
+    assert status["request_counts"]["failed"] == 0
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_batch_status_times_out_when_stuck_pending():
+    """The Fireworks gotcha: a non-batch-eligible model leaves the job PENDING
+    forever. The shared poll loop is ``while True`` with no max-wait, so the
+    provider must surface a terminal status once createTime is too old."""
+    stale = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "name": "accounts/acct-test/batchInferenceJobs/job-stuck",
+                "state": "JOB_STATE_PENDING",
+                "createTime": stale,
+                "jobProgress": {"totalInputRequests": "1"},
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client, max_wait_seconds=60)
+
+    status = await llm.get_batch_status("job-stuck")
+
+    # Driver treats expired/failed/cancelled as fatal and raises — no infinite poll.
+    assert status["status"] in ("expired", "failed")
+    assert status.get("errors")
+
+    await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# retrieve_batch_results: download + normalize + merge separate error file
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retrieve_batch_results_normalizes_and_merges_error_file():
+    results_url = "https://signed.example/results.jsonl"
+    errors_url = "https://signed.example/errors.jsonl"
+
+    results_jsonl = json.dumps(
+        {
+            "custom_id": "chunk_0",
+            "response": {
+                "choices": [{"message": {"content": '{"facts": [{"what": "x"}]}'}}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+            "error": None,
+        }
+    )
+    errors_jsonl = json.dumps({"custom_id": "chunk_1", "response": None, "error": {"code": "oops", "message": "bad"}})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/batchInferenceJobs/job-done"):
+            return httpx.Response(
+                200,
+                json={
+                    "state": "JOB_STATE_COMPLETED",
+                    "createTime": "2026-05-28T00:00:00Z",
+                    "outputDatasetId": "accounts/acct-test/datasets/out-1",
+                },
+            )
+        if path.endswith(":getDownloadEndpoint"):
+            return httpx.Response(
+                200,
+                json={"filenameToSignedUrls": {"results.jsonl": results_url, "errors.jsonl": errors_url}},
+            )
+        if str(request.url) == results_url:
+            return httpx.Response(200, text=results_jsonl)
+        if str(request.url) == errors_url:
+            return httpx.Response(200, text=errors_jsonl)
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client)
+
+    results = await llm.retrieve_batch_results("job-done")
+    by_id = {r["custom_id"]: r for r in results}
+
+    assert set(by_id) == {"chunk_0", "chunk_1"}
+    # Success line normalized to the consumer's accessor.
+    assert by_id["chunk_0"]["response"]["body"]["choices"][0]["message"]["content"] == '{"facts": [{"what": "x"}]}'
+    assert not by_id["chunk_0"].get("error")
+    # Error-file line merged in as a per-custom_id error (not dropped).
+    assert by_id["chunk_1"]["error"] == {"code": "oops", "message": "bad"}
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_batch_results_raises_when_not_completed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"state": "JOB_STATE_RUNNING", "createTime": "2026-05-28T00:00:00Z"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = _make_fireworks(http_client=client)
+
+    with pytest.raises(ValueError, match="not completed"):
+        await llm.retrieve_batch_results("job-running")
+
+    await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# Config: account id / batch base url / max wait from env
+# --------------------------------------------------------------------------
+
+
+def test_config_reads_fireworks_settings_from_env(monkeypatch):
+    from hindsight_api.config import HindsightConfig, clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_FIREWORKS_ACCOUNT_ID", "acct-from-env")
+    monkeypatch.setenv("HINDSIGHT_API_FIREWORKS_BATCH_BASE_URL", "https://batch.example")
+    monkeypatch.setenv("HINDSIGHT_API_FIREWORKS_BATCH_MAX_WAIT_SECONDS", "120")
+    clear_config_cache()
+    try:
+        config = HindsightConfig.from_env()
+        assert config.fireworks_account_id == "acct-from-env"
+        assert config.fireworks_batch_base_url == "https://batch.example"
+        assert config.fireworks_batch_max_wait_seconds == 120
+    finally:
+        clear_config_cache()
+
+
+def test_config_fireworks_defaults(monkeypatch):
+    from hindsight_api.config import HindsightConfig, clear_config_cache
+
+    monkeypatch.delenv("HINDSIGHT_API_FIREWORKS_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_FIREWORKS_BATCH_BASE_URL", raising=False)
+    clear_config_cache()
+    try:
+        config = HindsightConfig.from_env()
+        assert config.fireworks_account_id is None
+        assert config.fireworks_batch_base_url == "https://api.fireworks.ai"
+    finally:
+        clear_config_cache()

--- a/hindsight-api-slim/tests/test_fireworks_batch.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch.py
@@ -224,6 +224,7 @@ async def test_submit_batch_runs_dataset_upload_job_workflow():
     paths: list[str] = []
     upload_body: list[str] = []
     job_body: list[dict] = []
+    dataset_body: list[dict] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -232,6 +233,7 @@ async def test_submit_batch_runs_dataset_upload_job_workflow():
 
         if request.method == "POST" and path.endswith("/datasets"):
             body = json.loads(request.content)
+            dataset_body.append(body)
             return httpx.Response(200, json={"name": f"accounts/acct-test/datasets/{body['datasetId']}"})
         if request.method == "POST" and path.endswith(":upload"):
             upload_body.append(request.content.decode("utf-8", errors="replace"))
@@ -279,6 +281,11 @@ async def test_submit_batch_runs_dataset_upload_job_workflow():
 
     # Job references the configured model.
     assert job_body[0]["model"] == "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+    # Dataset create declares format + exampleCount (Fireworks rejects uploaded
+    # datasets without example_count; it's the JSONL line count, as a string).
+    assert dataset_body[0]["dataset"]["format"] == "CHAT"
+    assert dataset_body[0]["dataset"]["exampleCount"] == str(len(requests))
 
     await client.aclose()
 

--- a/hindsight-api-slim/tests/test_fireworks_batch_integration.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch_integration.py
@@ -1,0 +1,124 @@
+"""Live integration test for the Fireworks AI batch-inference provider.
+
+This makes REAL calls to Fireworks' batch API and runs the full retain fact
+extraction pipeline end-to-end (submit -> poll -> download -> normalize ->
+parse facts). It is the only test that validates the one assumption the unit
+tests (which use mocked httpx responses) cannot: that Fireworks' real output
+JSONL shape matches what ``_normalize_output_line`` produces and what
+``fact_extraction`` consumes. If the shape is wrong, this returns zero facts.
+
+Skipped automatically unless credentials are present. To run:
+
+    export HINDSIGHT_API_FIREWORKS_API_KEY=fw_xxx     # or FIREWORKS_API_KEY
+    export HINDSIGHT_API_FIREWORKS_ACCOUNT_ID=your-account-id
+    # optional: override the (must be batch-eligible) model
+    export HINDSIGHT_API_FIREWORKS_TEST_MODEL=accounts/fireworks/models/llama-v3p1-8b-instruct
+    uv run pytest tests/test_fireworks_batch_integration.py -v -s
+
+It is slow (minutes, depending on Fireworks' queue) and costs money, so it does
+not run in CI (no key there). No database is required — it calls the extraction
+function directly with ``pool=None``.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+from dotenv import load_dotenv
+
+from hindsight_api.config import HindsightConfig, clear_config_cache
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.retain.fact_extraction import (
+    RetainContent,
+    extract_facts_from_contents_batch_api,
+)
+
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+_DEFAULT_TEST_MODEL = "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+
+@dataclass
+class FireworksTestEnv:
+    api_key: str
+    account_id: str
+    model: str
+
+
+@pytest.fixture
+def fireworks_env(monkeypatch) -> FireworksTestEnv:
+    api_key = os.getenv("HINDSIGHT_API_FIREWORKS_API_KEY") or os.getenv("FIREWORKS_API_KEY")
+    account_id = os.getenv("HINDSIGHT_API_FIREWORKS_ACCOUNT_ID")
+    if not api_key or not account_id:
+        pytest.skip(
+            "Set HINDSIGHT_API_FIREWORKS_API_KEY (or FIREWORKS_API_KEY) and "
+            "HINDSIGHT_API_FIREWORKS_ACCOUNT_ID to run the live Fireworks batch test"
+        )
+
+    # FireworksLLM resolves the account id from global config, so make sure the
+    # cached config picks it up for this run.
+    monkeypatch.setenv("HINDSIGHT_API_FIREWORKS_ACCOUNT_ID", account_id)
+    clear_config_cache()
+
+    return FireworksTestEnv(
+        api_key=api_key,
+        account_id=account_id,
+        model=os.getenv("HINDSIGHT_API_FIREWORKS_TEST_MODEL", _DEFAULT_TEST_MODEL),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_real_fireworks_batch_end_to_end(fireworks_env):
+    config = HindsightConfig.from_env()
+    config.retain_batch_enabled = True
+    config.retain_batch_poll_interval_seconds = 30
+    config.retain_chunk_size = 4000
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = False
+
+    llm_config = LLMProvider(
+        provider="fireworks",
+        api_key=fireworks_env.api_key,
+        base_url="",  # defaults to the Fireworks inference host
+        model=fireworks_env.model,
+        reasoning_effort="low",
+    )
+    assert await llm_config._provider_impl.supports_batch_api() is True
+
+    contents = [
+        RetainContent(
+            content=(
+                "Alice is a senior software engineer at TechCorp. She specializes in "
+                "distributed systems and graduated from MIT in 2015."
+            ),
+            event_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            context="team member profile",
+        )
+    ]
+
+    logger.info("Submitting a real Fireworks batch (this can take several minutes)...")
+    facts, chunks, usage = await extract_facts_from_contents_batch_api(
+        contents=contents,
+        llm_config=llm_config,
+        agent_name="test_agent",
+        config=config,
+        pool=None,
+        operation_id=None,
+        schema=None,
+    )
+
+    # The end-to-end proof: if the real output shape doesn't match the normalizer,
+    # the consumer extracts nothing and this is empty.
+    assert len(facts) > 0, (
+        "Fireworks batch returned no facts. The live output JSONL shape likely "
+        "differs from what _normalize_output_line produces — inspect a raw output "
+        "line and adjust the normalizer."
+    )
+    assert any("Alice" in fact.fact_text for fact in facts)
+    logger.info(f"Extracted {len(facts)} facts; usage={usage.total_tokens} tokens")

--- a/hindsight-api-slim/tests/test_fireworks_batch_integration.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch_integration.py
@@ -71,6 +71,10 @@ def fireworks_env(monkeypatch) -> FireworksTestEnv:
     )
 
 
+# Override the suite-wide --timeout 300: a real batch job queues and runs for
+# minutes (Fireworks' SLA is minutes-to-hours), well past the default cap. The
+# provider has its own createTime-derived max-wait as the real backstop.
+@pytest.mark.timeout(3600)
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_fireworks_batch_integration.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch_integration.py
@@ -71,10 +71,6 @@ def fireworks_env(monkeypatch) -> FireworksTestEnv:
     )
 
 
-# Override the suite-wide --timeout 300: a real batch job queues and runs for
-# minutes (Fireworks' SLA is minutes-to-hours), well past the default cap. The
-# provider has its own createTime-derived max-wait as the real backstop.
-@pytest.mark.timeout(3600)
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.asyncio

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -162,7 +162,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -888,6 +888,27 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_ENTITY_LOOKUP` | Entity lookup method during retain: `full` (exact match) or `trigram` (fuzzy trigram matching) | `trigram` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
+
+> **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
+
+#### Fireworks batch inference
+
+Fireworks AI's batch API is **not** OpenAI `/v1/batches`-compatible — it is a proprietary, account-scoped dataset/job workflow on a separate control-plane host (`https://api.fireworks.ai`), distinct from the OpenAI-compatible inference host (`https://api.fireworks.ai/inference/v1`). Hindsight adapts it transparently, so enabling batch is the same as any other provider plus one required setting: your Fireworks **account id**. (This is separate from the existing LiteLLM `fireworks_ai/...` online path, which is unaffected.)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_FIREWORKS_ACCOUNT_ID` | Fireworks account id. **Required** for `fireworks` batch retain — the control-plane endpoints are `/v1/accounts/{account_id}/...`. Static, server-level. | - |
+| `HINDSIGHT_API_FIREWORKS_BATCH_BASE_URL` | Fireworks batch control-plane host. | `https://api.fireworks.ai` |
+| `HINDSIGHT_API_FIREWORKS_BATCH_MAX_WAIT_SECONDS` | Max time to wait for a batch job before surfacing a failure. Guards against the Fireworks gotcha where a non-batch-eligible model leaves the job `PENDING` forever. | `86400` (24h) |
+
+```bash
+# Fireworks batch retain (50% cost savings, async only)
+export HINDSIGHT_API_RETAIN_LLM_PROVIDER=fireworks
+export HINDSIGHT_API_RETAIN_LLM_API_KEY=fw_xxxxxxxxxxxx
+export HINDSIGHT_API_RETAIN_LLM_MODEL=accounts/fireworks/models/llama-v3p1-8b-instruct
+export HINDSIGHT_API_FIREWORKS_ACCOUNT_ID=your-account-id
+export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
+```
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
 


### PR DESCRIPTION
## What

Adds a `fireworks` LLM provider with native batch-retain support. `FireworksLLM` subclasses `OpenAICompatibleLLM`, so online inference reuses the existing OpenAI-compatible path, and overrides only the four batch members.

## Why

Batch retain (50% cost savings on fact extraction) is currently gated to `openai` and `groq`. Fireworks has the same async pricing, but its batch API is not OpenAI `/v1/batches`-compatible: it's a proprietary, account-scoped dataset -> job -> download REST workflow on a separate control-plane host. So it can't be a one-line allowlist add the way Groq was. This PR adds an adapter that maps Fireworks' input, output, and status shapes back onto the existing batch interface, so the retain orchestrator and `fact_extraction` consumer are unchanged.

## Notes

- Verified end-to-end against the live Fireworks batch API: a real retain run submits the dataset, creates the job, polls to completion, downloads, and extracts facts. The request/response shapes (dataset `exampleCount`/`format`, the output-JSONL nesting) were validated against the real API, not just the docs.
- The existing LiteLLM `fireworks_ai/...` online path is untouched.
- Batch requires `HINDSIGHT_API_FIREWORKS_ACCOUNT_ID` (the control-plane endpoints are `/v1/accounts/{id}/...`) and fails fast without it.
- A `createTime`-derived max-wait guards the documented Fireworks gotcha where a non-batch-eligible model leaves the job `PENDING` forever (the shared poll loop has no timeout of its own).
- Tests: unit tests over the normalizers + the dataset/job/download workflow (mocked httpx), plus a credentials-gated live integration test (`test_fireworks_batch_integration.py`) that runs the real batch end-to-end and skips without a key.
