### PR TITLE
docs(configuration): document link_expansion per-entity-limit and timeout knobs

### DIFF
--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -836,6 +836,8 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_GRAPH_RETRIEVER` | Graph retrieval algorithm | `link_expansion` |
+| `HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT` | Max target units expanded per entity in `link_expansion` graph retrieval (LATERAL fanout cap per entity; bounds high-fanout entities). | `200` |
+| `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT` | Timeout (seconds) for the per-entity graph expansion query in `link_expansion` retrieval. | `10` |
 | `HINDSIGHT_API_RECALL_MAX_CONCURRENT` | Max concurrent recall operations per worker (backpressure) | `32` |
 | `HINDSIGHT_API_RECALL_CONNECTION_BUDGET` | Max concurrent DB connections per recall operation | `4` |
 | `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -836,6 +836,8 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_GRAPH_RETRIEVER` | Graph retrieval algorithm | `link_expansion` |
+| `HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT` | Max target units expanded per entity in `link_expansion` graph retrieval (LATERAL fanout cap per entity; bounds high-fanout entities). | `200` |
+| `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT` | Timeout (seconds) for the per-entity graph expansion query in `link_expansion` retrieval. | `10` |
 | `HINDSIGHT_API_RECALL_MAX_CONCURRENT` | Max concurrent recall operations per worker (backpressure) | `32` |
 | `HINDSIGHT_API_RECALL_CONNECTION_BUDGET` | Max concurrent DB connections per recall operation | `4` |
 | `HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS` | Maximum token length of a recall query; requests exceeding this limit are rejected with HTTP 400 | `500` |


### PR DESCRIPTION
The `### Retrieval` table documents `HINDSIGHT_API_GRAPH_RETRIEVER` (default `link_expansion`) and analogous perf knobs (`RECALL_MAX_CONCURRENT`, `RECALL_CONNECTION_BUDGET`, `RERANKER_MAX_CANDIDATES`), and the `#### Graph Retrieval Algorithm` note promises `link_expansion` has "Target latency under 100ms" — but the two env vars that directly govern that latency/recall are undocumented:

- `HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT` (default `200`) — LATERAL fanout cap per entity
- `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT` (default `10`) — per-entity expansion query timeout

Operators tuning the default graph retriever currently have no documented surface for either knob. Adds the two rows to the Retrieval table immediately after `GRAPH_RETRIEVER`, in both the canonical doc and the skills mirror.

Names/defaults verified against `hindsight-api-slim/hindsight_api/config.py` (`ENV_LINK_EXPANSION_PER_ENTITY_LIMIT`/`ENV_LINK_EXPANSION_TIMEOUT`, defaults `200`/`10.0`; consumed in `engine/search/link_expansion_retrieval.py`). Pure docs.
