### PR TITLE
fix(autogen): default to Cloud + gated E2E + bucketing + ADD missing CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       integrations-litellm: ${{ steps.filter.outputs.integrations-litellm }}
       integrations-pydantic-ai: ${{ steps.filter.outputs.integrations-pydantic-ai }}
       integrations-ag2: ${{ steps.filter.outputs.integrations-ag2 }}
+      integrations-autogen: ${{ steps.filter.outputs.integrations-autogen }}
       integrations-llamaindex: ${{ steps.filter.outputs.integrations-llamaindex }}
       integrations-paperclip: ${{ steps.filter.outputs.integrations-paperclip }}
       integrations-opencode: ${{ steps.filter.outputs.integrations-opencode }}
@@ -123,6 +124,8 @@ jobs:
             - 'hindsight-integrations/pydantic-ai/**'
           integrations-ag2:
             - 'hindsight-integrations/ag2/**'
+          integrations-autogen:
+            - 'hindsight-integrations/autogen/**'
           integrations-llamaindex:
             - 'hindsight-integrations/llamaindex/**'
           integrations-paperclip:
@@ -2758,6 +2761,45 @@ jobs:
       working-directory: ./hindsight-integrations/ag2
       run: uv run pytest tests -v
 
+  test-autogen-integration:
+    needs: [detect-changes]
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.integrations-autogen == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        prune-cache: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: ".python-version"
+
+    - name: Build autogen integration
+      working-directory: ./hindsight-integrations/autogen
+      run: uv build
+
+    - name: Install dependencies
+      working-directory: ./hindsight-integrations/autogen
+      run: uv sync --frozen
+
+    - name: Run tests
+      working-directory: ./hindsight-integrations/autogen
+      # PR CI runs only the deterministic bucket; the real-LLM E2E bucket
+      # (requires_real_llm) needs a live Hindsight server and runs separately.
+      run: uv run pytest tests -v -m "not requires_real_llm"
+
   test-smolagents-integration:
     needs: [detect-changes]
     if: >-
@@ -3946,6 +3988,7 @@ jobs:
       - test-openclaw-integration
       - test-integration
       - test-ag2-integration
+      - test-autogen-integration
       - test-smolagents-integration
       - test-dify-integration
       - test-crewai-integration

--- a/hindsight-integrations/autogen/hindsight_autogen/_client.py
+++ b/hindsight-integrations/autogen/hindsight_autogen/_client.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from importlib import metadata
 from typing import Any
 
 from hindsight_client import Hindsight
 
-from .config import get_config
-from .errors import HindsightError
+from .config import DEFAULT_HINDSIGHT_API_URL, HINDSIGHT_API_KEY_ENV, get_config
 
 try:
     _VERSION = metadata.version("hindsight-autogen")
@@ -22,18 +22,22 @@ def resolve_client(
     hindsight_api_url: str | None,
     api_key: str | None,
 ) -> Hindsight:
-    """Resolve a Hindsight client from explicit args or global config."""
+    """Resolve a Hindsight client from explicit args or global config.
+
+    Falls back to the default API URL and the ``HINDSIGHT_API_KEY`` env var
+    when neither an explicit argument nor a prior ``configure()`` call supplied
+    them, so the tools work with nothing but the env var set. Self-hosted users
+    override the URL. The API key is optional at construction time — a missing
+    key only fails when a call is actually made.
+    """
     if client is not None:
         return client
 
     config = get_config()
-    url = hindsight_api_url or (config.hindsight_api_url if config else None)
-    key = api_key or (config.api_key if config else None)
-
-    if url is None:
-        raise HindsightError(
-            "No Hindsight API URL configured. Pass client= or hindsight_api_url=, or call configure() first."
-        )
+    url = hindsight_api_url or (config.hindsight_api_url if config else DEFAULT_HINDSIGHT_API_URL)
+    # Read HINDSIGHT_API_KEY directly so the no-configure() path still honours
+    # the env var — the base Hindsight client doesn't fall back to it on its own.
+    key = api_key or (config.api_key if config else None) or os.environ.get(HINDSIGHT_API_KEY_ENV)
 
     kwargs: dict[str, Any] = {"base_url": url, "timeout": 30.0, "user_agent": _USER_AGENT}
     if key:

--- a/hindsight-integrations/autogen/pyproject.toml
+++ b/hindsight-integrations/autogen/pyproject.toml
@@ -49,6 +49,9 @@ line-length = 120
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "requires_real_llm: end-to-end test that needs live external services (a running Hindsight server and/or real LLM provider keys). Excluded from the deterministic PR-CI bucket via -m 'not requires_real_llm'; run on its own via -m requires_real_llm.",
+]
 
 [dependency-groups]
 dev = [

--- a/hindsight-integrations/autogen/tests/test_e2e.py
+++ b/hindsight-integrations/autogen/tests/test_e2e.py
@@ -1,0 +1,122 @@
+"""End-to-end tests for the Hindsight-AutoGen integration.
+
+Exercises the retain/recall/reflect tools against a live Hindsight server. The
+tools talk to Hindsight directly (the server's LLM does fact extraction), so
+only a running Hindsight instance is required — no provider key. By default
+these tests are skipped; point ``HINDSIGHT_API_URL`` at a reachable server to
+enable them.
+
+The whole module is the real-LLM bucket (``requires_real_llm``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import urllib.request
+import uuid
+
+import pytest
+import pytest_asyncio
+from autogen_core import CancellationToken
+from hindsight_client import Hindsight
+
+from hindsight_autogen import create_hindsight_tools
+
+HINDSIGHT_API_URL = os.getenv("HINDSIGHT_API_URL", "http://localhost:8888")
+_NO_MEMORIES = "No relevant memories found."
+
+
+def _hindsight_available() -> bool:
+    try:
+        with urllib.request.urlopen(f"{HINDSIGHT_API_URL}/health", timeout=3) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+requires_hindsight = pytest.mark.skipif(
+    not _hindsight_available(),
+    reason=f"Hindsight not reachable at {HINDSIGHT_API_URL}",
+)
+
+pytestmark = [requires_hindsight, pytest.mark.requires_real_llm]
+
+
+def _tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+async def _run(tool, args: dict) -> str:
+    return str(await tool.run_json(args, CancellationToken()))
+
+
+async def _recall_until_nonempty(recall_tool, query, attempts=12, delay=1.0):
+    for _ in range(attempts):
+        text = await _run(recall_tool, {"query": query})
+        if text and text != _NO_MEMORIES:
+            return text
+        await asyncio.sleep(delay)
+    pytest.fail(
+        f"recall({query!r}) returned no memories after {attempts * delay:.0f}s — "
+        "either retain failed to surface or the query no longer matches."
+    )
+
+
+@pytest_asyncio.fixture
+async def live():
+    client = Hindsight(base_url=HINDSIGHT_API_URL)
+    bank_id = f"autogen-e2e-{uuid.uuid4().hex[:8]}"
+    await client.acreate_bank(bank_id, name=f"AutoGen E2E {bank_id}")
+    try:
+        yield client, bank_id
+    finally:
+        try:
+            await client.adelete_bank(bank_id)
+        except Exception:
+            pass
+        await client.aclose()
+
+
+class TestE2ETools:
+    @pytest.mark.asyncio
+    async def test_retain_and_recall_roundtrip(self, live):
+        client, bank_id = live
+        tools = create_hindsight_tools(bank_id=bank_id, client=client)
+        retain, recall = _tool(tools, "hindsight_retain"), _tool(tools, "hindsight_recall")
+
+        result = await _run(retain, {"content": "The team uses PostgreSQL 16 and deploys to us-east-1."})
+        assert result == "Memory stored successfully."
+
+        recalled = await _recall_until_nonempty(recall, "What technologies does the team use?")
+        lowered = recalled.lower()
+        assert "postgresql" in lowered or "us-east-1" in lowered, (
+            f"recall surfaced results but none referenced the stored content: {recalled}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reflect_synthesizes_from_memory(self, live):
+        client, bank_id = live
+        tools = create_hindsight_tools(bank_id=bank_id, client=client)
+        retain = _tool(tools, "hindsight_retain")
+        recall = _tool(tools, "hindsight_recall")
+        reflect = _tool(tools, "hindsight_reflect")
+
+        await _run(retain, {"content": "The team uses PostgreSQL 16 and deploys to us-east-1."})
+        await _recall_until_nonempty(recall, "What technologies does the team use?")
+
+        result = await _run(reflect, {"query": "What do I know about the team's tech stack?"})
+        assert result and result != _NO_MEMORIES, "reflect should synthesise non-empty text"
+        lowered = result.lower()
+        assert "postgresql" in lowered or "us-east" in lowered, (
+            f"reflect text didn't reference the stored memory: {result[:300]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_recall_empty_bank(self, live):
+        client, bank_id = live
+        tools = create_hindsight_tools(
+            bank_id=bank_id, client=client, include_retain=False, include_reflect=False
+        )
+        result = await _run(_tool(tools, "hindsight_recall"), {"query": "anything at all"})
+        assert result == _NO_MEMORIES

--- a/hindsight-integrations/autogen/tests/test_tools.py
+++ b/hindsight-integrations/autogen/tests/test_tools.py
@@ -115,9 +115,25 @@ class TestCreateHindsightTools:
         )
         assert len(tools) == 0
 
-    def test_raises_without_client_or_config(self):
-        with pytest.raises(HindsightError, match="No Hindsight API URL"):
+    def test_defaults_to_cloud_without_config(self, monkeypatch):
+        """With no client, config, or explicit URL, defaults to the cloud URL."""
+        from hindsight_autogen.config import DEFAULT_HINDSIGHT_API_URL
+
+        monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+        with patch("hindsight_autogen._client.Hindsight") as mock_cls:
+            mock_cls.return_value = _mock_client()
+            tools = create_hindsight_tools(bank_id="test")
+            assert len(tools) == 3
+            assert mock_cls.call_args.kwargs["base_url"] == DEFAULT_HINDSIGHT_API_URL
+            assert "api_key" not in mock_cls.call_args.kwargs
+
+    def test_reads_api_key_from_env_without_config(self, monkeypatch):
+        """HINDSIGHT_API_KEY is honoured even when configure() was never called."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "sk-from-env")
+        with patch("hindsight_autogen._client.Hindsight") as mock_cls:
+            mock_cls.return_value = _mock_client()
             create_hindsight_tools(bank_id="test")
+            assert mock_cls.call_args.kwargs["api_key"] == "sk-from-env"
 
     def test_falls_back_to_global_config(self):
         configure(hindsight_api_url="http://localhost:8888")
@@ -125,14 +141,18 @@ class TestCreateHindsightTools:
             mock_cls.return_value = _mock_client()
             tools = create_hindsight_tools(bank_id="test")
             assert len(tools) == 3
-            mock_cls.assert_called_once_with(base_url="http://localhost:8888", timeout=30.0)
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://localhost:8888"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
     def test_explicit_url_overrides_config(self):
         configure(hindsight_api_url="http://config:8888")
         with patch("hindsight_autogen._client.Hindsight") as mock_cls:
             mock_cls.return_value = _mock_client()
             create_hindsight_tools(bank_id="test", hindsight_api_url="http://explicit:9999")
-            mock_cls.assert_called_once_with(base_url="http://explicit:9999", timeout=30.0)
+            mock_cls.assert_called_once()
+            assert mock_cls.call_args.kwargs["base_url"] == "http://explicit:9999"
+            assert mock_cls.call_args.kwargs["timeout"] == 30.0
 
 
 class TestRetainTool:


### PR DESCRIPTION
## Summary
- **resolve_client cloud-default fix** — was raising \"No Hindsight API URL configured\" when \`configure()\` wasn't called; now falls back to \`DEFAULT_HINDSIGHT_API_URL\` and reads \`HINDSIGHT_API_KEY\` from env. Satisfies the \"default to Cloud\" framework goal.
- **Fix two pre-existing broken tests** — \`test_falls_back_to_global_config\` / \`test_explicit_url_overrides_config\` used \`mock_cls.assert_called_once_with\` without \`user_agent\` and were failing on main. Switched to loose \`call_args.kwargs\` checks.
- **Gated E2E suite** — new \`tests/test_e2e.py\` (3 tests: retain/recall/reflect roundtrip via \`tool.run_json\` against a live Hindsight server). Marked \`requires_real_llm\`; register the marker.
- **ADD missing CI job** — the \`autogen/\` package had **zero CI coverage** (only the parallel \`ag2/\` package had a \`test-ag2-integration\` job). Added in four places: detect-changes output, path filter, \`test-autogen-integration\` job (runs \`-m \"not requires_real_llm\"\`), and aggregate-gate entry.

## Test plan
- [x] \`uv run pytest tests -v -m \"not requires_real_llm\"\` — 32 passed, 3 deselected
- [x] \`HINDSIGHT_API_URL=http://127.0.0.1:8888 uv run pytest tests/test_e2e.py -v\` — 3 passed live
- [x] \`uvx ruff check hindsight_autogen/\` — clean
- [x] \`test.yml\` validates as YAML (61 jobs, \`test-autogen-integration\` present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)