### PR TITLE
docs(api): fix broken Worker Configuration anchor in operations page

### DIFF
--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -209,7 +209,7 @@ Submit a batch asynchronously and poll until the operation completes:
 
 ## Worker tuning
 
-Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, default 10) shared across all operation types. Per-type slot reservations (`HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS`) carve out guaranteed capacity within that budget; remaining slots form a shared pool any type can use. See [Configuration → Worker Configuration](../configuration#worker-configuration) for the full table.
+Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, default 10) shared across all operation types. Per-type slot reservations (`HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS`) carve out guaranteed capacity within that budget; remaining slots form a shared pool any type can use. See [Configuration → Worker Configuration](../configuration#distributed-workers) for the full table.
 
 For most deployments the defaults are fine. Reserve slots for an operation type if you've seen it starved by a flood of another type (e.g., a long file_convert_retain blocking graph_maintenance on a deletion-heavy workload).
 


### PR DESCRIPTION
## What

The Operations API page links **Configuration → Worker Configuration** to `../configuration#worker-configuration`, but `configuration.md` has no heading that slugifies to `worker-configuration`. The worker slot-tuning table lives under `### Distributed Workers` (slug `distributed-workers`). Clicking the link currently lands at the top of the 1700+-line config page instead of the worker table.

Single-line anchor fix. Two sibling docs already link the same table via the correct anchor:
- `api/admin-cli.md` → `./configuration#distributed-workers`
- `api/services.md` → `./configuration#distributed-workers`

## File

- `hindsight-docs/docs/developer/api/operations.mdx` (anchor only)