### PR TITLE
docs(retrieval): document calibrated [0,1] reranker score passthrough

### DIFF
--- a/hindsight-docs/docs/developer/retrieval.md
+++ b/hindsight-docs/docs/developer/retrieval.md
@@ -271,7 +271,7 @@ RRF gives a good initial ranking, but it's based on positions, not on deep query
 
 **Why rerank after RRF?** RRF is position-based — it knows a memory ranked well across strategies, but it never actually reads the query and the memory together. The cross-encoder does: it takes the query and each candidate as a pair and produces a relevance score based on their full interaction. This catches nuances that position-based fusion misses, like a memory that ranked #1 in keyword search because it matched a common term but is actually irrelevant to the query's intent.
 
-**Score normalization:** Cross-encoders output raw logits (which can be negative). These are normalized to [0, 1] using the sigmoid function:
+**Score normalization:** Cross-encoders output raw logits (which can be negative). Scores that already fall within [0, 1] — as returned by calibrated external API rerankers (e.g. Cohere, SiliconFlow, ZeroEntropy, Alibaba, Jina) — are passed through unchanged to preserve their absolute confidence. Raw logits outside [0, 1] are normalized to [0, 1] using the sigmoid function:
 
 ```
 CE_normalized = 1 / (1 + e^(-raw_logit))


### PR DESCRIPTION
## What

The **Score normalization** section states that cross-encoder scores are *always* sigmoid-normalized (`CE_normalized = 1/(1+e^(-raw_logit))`). Since the reranker gained a dual path, that is now misleading for external-API rerankers.

In `hindsight-api-slim/.../search/reranking.py`, scores that are already in `[0, 1]` (calibrated relevance scores from external API rerankers — Cohere / SiliconFlow / ZeroEntropy / Alibaba / Jina, all listed in `models.mdx`) are passed through unchanged to preserve absolute confidence; only scores outside `[0, 1]` (raw logits from local cross-encoders) get the sigmoid.

With the sigmoid-only wording, a developer would expect a calibrated `0.007` to be inflated toward `~0.5` — it is not. This documents the actual behavior.

## File

- `hindsight-docs/docs/developer/retrieval.md`