### PR TITLE
docs(cli): correct bank set-disposition flags to --skepticism/--literalism/--empathy

### DIFF
--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -198,7 +198,7 @@ hindsight bank disposition <bank_id>
 ### Set Disposition
 
 ```bash
-hindsight bank set-disposition <bank_id> --mission "..." --name "..."
+hindsight bank set-disposition <bank_id> --skepticism 3 --literalism 4 --empathy 5
 ```
 
 ### View Statistics


### PR DESCRIPTION
## What

The CLI docs show:

```bash
hindsight bank set-disposition <bank_id> --mission "..." --name "..."
```

but `set-disposition` accepts neither `--mission` nor `--name`. Per `hindsight-cli/src/main.rs` (`SetDisposition { bank_id, skepticism: u64, literalism: u64, empathy: u64 }`), it takes three required reasoning-trait flags (`1`–`5`). Following the documented command fails with a clap error, and the documented flags actually belong to `create`/`update`.

This corrects the example to the real flags.

## File

- `hindsight-docs/docs/sdks/cli.md`