### PR TITLE
docs(configuration): document HINDSIGHT_CP_DATAPLANE_API_KEY for Control Plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,11 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Dataplane API URL - where the CP proxies requests to
 # HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888
 
+# Optional: Bearer token the CP sends as `Authorization: Bearer <key>` to the
+# dataplane API. Required when the API service is auth-protected; omit for a
+# public/unauthenticated API.
+# HINDSIGHT_CP_DATAPLANE_API_KEY=your-dataplane-bearer-token
+
 # Optional: Require a shared access key to view the Control Plane UI.
 # When set, visitors see a login page and must enter the key before
 # accessing the dashboard or any /api/* routes (except /api/health).

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1478,12 +1478,16 @@ The Control Plane is the web UI for managing memory banks.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
+| `HINDSIGHT_CP_DATAPLANE_API_KEY` | Bearer token the Control Plane sends as `Authorization: Bearer <key>` on every request to the API service. Required when the API service is auth-protected; omit for a public API. | *(none — no `Authorization` header sent)* |
 | `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash
 # Point Control Plane to a remote API service
 export HINDSIGHT_CP_DATAPLANE_API_URL=http://api.example.com:8888
+
+# Authenticate to an auth-protected API service
+export HINDSIGHT_CP_DATAPLANE_API_KEY=my-dataplane-bearer-token
 
 # Protect the Control Plane with an access key
 export HINDSIGHT_CP_ACCESS_KEY=my-secret-key


### PR DESCRIPTION
## What

The Control Plane reads `HINDSIGHT_CP_DATAPLANE_API_KEY` and, when set, sends it as `Authorization: Bearer <key>` on every Control Plane → API-service request (`hindsight-control-plane/src/lib/hindsight-client.ts`). It is the required companion to the documented `HINDSIGHT_CP_DATAPLANE_API_URL`, but the Control Plane config table and `.env.example` omit it entirely. Without it, a Control Plane pointed at an auth-protected API service silently 401s with no documented cause.

This adds the one missing row + `.env.example` entry, matching the existing pattern.

## Files

- `hindsight-docs/docs/developer/configuration.md`
- `.env.example`