### PR TITLE
feat(memory): validity windows on memory_units (valid_to + /invalidate) — revives #1395

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/39a06891cc3f_add_valid_to_to_memory_units.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/39a06891cc3f_add_valid_to_to_memory_units.py
@@ -1,8 +1,8 @@
 """Add valid_to validity-window column to memory_units table.
 
-Revision ID: a2b3c4d5e6f7
-Revises: z1u2v3w4x5y6
-Create Date: 2026-05-02
+Revision ID: 39a06891cc3f
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-31
 
 Adds a nullable ``valid_to TIMESTAMPTZ`` column on ``memory_units`` so that
 superseded facts can be soft-retired without losing their timeline. Also
@@ -24,8 +24,8 @@ from alembic import context, op
 
 from hindsight_api.alembic._dialect import run_for_dialect
 
-revision: str = "a2b3c4d5e6f7"
-down_revision: str | Sequence[str] | None = "z1u2v3w4x5y6"
+revision: str = "39a06891cc3f"
+down_revision: str | Sequence[str] | None = "c1d2e3f4a5b6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/a2b3c4d5e6f7_add_valid_to_to_memory_units.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/a2b3c4d5e6f7_add_valid_to_to_memory_units.py
@@ -1,0 +1,64 @@
+"""Add valid_to validity-window column to memory_units table.
+
+Revision ID: a2b3c4d5e6f7
+Revises: z1u2v3w4x5y6
+Create Date: 2026-05-02
+
+Adds a nullable ``valid_to TIMESTAMPTZ`` column on ``memory_units`` so that
+superseded facts can be soft-retired without losing their timeline. Also
+adds a partial index on the bank/fact_type prefix limited to currently
+active rows so recall keeps using a small index even as historical data
+accumulates.
+
+Recall queries filter out rows where ``valid_to <= now()`` so invalidated
+memories no longer surface in semantic / BM25 / graph-spreading search,
+while ``GET /memories/{id}`` and ``GET /memories/{id}/history`` still return
+them — preserving the audit trail.
+
+See issue #1391 for the full design rationale.
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "a2b3c4d5e6f7"
+down_revision: str | Sequence[str] | None = "z1u2v3w4x5y6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    """Get schema prefix for table names (required for multi-tenant support)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"ALTER TABLE {schema}memory_units ADD COLUMN IF NOT EXISTS valid_to TIMESTAMPTZ NULL")
+    op.execute(
+        f"COMMENT ON COLUMN {schema}memory_units.valid_to IS "
+        "'NULL = still valid; non-NULL = superseded at this timestamp. "
+        "Recall filters out memories with valid_to <= now().'"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_memory_units_active "
+        f"ON {schema}memory_units (bank_id, fact_type) WHERE valid_to IS NULL"
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _get_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_memory_units_active")
+    op.execute(f"ALTER TABLE {schema}memory_units DROP COLUMN IF EXISTS valid_to")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1464,6 +1464,42 @@ class ClearMemoryObservationsResponse(BaseModel):
     deleted_count: int
 
 
+class InvalidateMemoryRequest(BaseModel):
+    """Request model for marking a memory unit as superseded."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "valid_to": "2026-05-02T17:30:00Z",
+                "reason": "Server srv-04 was decommissioned",
+            }
+        }
+    )
+
+    valid_to: str | None = None  # ISO-8601; defaults to now() if omitted
+    reason: str | None = None
+
+
+class InvalidateMemoryResponse(BaseModel):
+    """Response model for invalidating a memory unit."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "0c14e4f1-9eb6-4dde-b0a4-c2e8b3a3e5f1",
+                "valid_to": "2026-05-02T17:30:00.123456+00:00",
+                "fact_type": "world",
+                "preview": "Server srv-04 runs PostgreSQL 17 on Debian 12...",
+            }
+        }
+    )
+
+    id: str
+    valid_to: str | None
+    fact_type: str
+    preview: str
+
+
 class RecoverConsolidationResponse(BaseModel):
     """Response model for recovering failed consolidation."""
 
@@ -5333,6 +5369,72 @@ def _register_routes(app: FastAPI):
 
             error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
             logger.error(f"Error in POST /v1/default/banks/{bank_id}/consolidation/recover: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post(
+        "/v1/default/banks/{bank_id}/memories/{memory_id}/invalidate",
+        response_model=InvalidateMemoryResponse,
+        summary="Invalidate a memory unit",
+        description=(
+            "Mark a memory unit as invalidated as of a timestamp. The row stays in the timeline "
+            "(reachable via GET /memories/{id} and GET /memories/{id}/history) but recall queries "
+            "no longer return it once valid_to <= now(). Use when a fact has been superseded "
+            "(server decommissioned, person changed roles, default value changed) — not for "
+            "deletion of accidentally retained data."
+        ),
+        operation_id="invalidate_memory",
+        tags=["Memory"],
+    )
+    @audited("invalidate_memory", request_param="payload")
+    async def api_invalidate_memory(
+        bank_id: str,
+        memory_id: str,
+        payload: InvalidateMemoryRequest | None = None,
+        request_context: RequestContext = Depends(get_request_context),
+    ):
+        """Mark a memory unit as superseded as of a timestamp (default: now()).
+
+        The memory is *not* deleted; recall filters it out, but the audit trail
+        remains accessible via the regular get / history endpoints.
+        """
+        from datetime import datetime as _datetime
+
+        valid_to_dt: _datetime | None = None
+        reason: str | None = None
+        if payload is not None:
+            reason = payload.reason
+            if payload.valid_to:
+                try:
+                    valid_to_dt = _datetime.fromisoformat(payload.valid_to.replace("Z", "+00:00"))
+                except ValueError as ve:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"valid_to is not a valid ISO-8601 timestamp: {payload.valid_to!r}",
+                    ) from ve
+        try:
+            result = await app.state.memory.invalidate_memory_unit(
+                bank_id=bank_id,
+                memory_id=memory_id,
+                valid_to=valid_to_dt,
+                reason=reason,
+                request_context=request_context,
+            )
+            if result is None:
+                raise HTTPException(status_code=404, detail=f"Memory unit '{memory_id}' not found")
+            return InvalidateMemoryResponse(**result)
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(
+                f"Error in POST /v1/default/banks/{bank_id}/memories/{memory_id}/invalidate: {error_detail}"
+            )
             raise HTTPException(status_code=500, detail=str(e))
 
     @app.delete(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4990,6 +4990,84 @@ class MemoryEngine(MemoryEngineInterface):
 
         return {"deleted_count": deleted_count}
 
+    async def invalidate_memory_unit(
+        self,
+        bank_id: str,
+        memory_id: str,
+        *,
+        valid_to: "datetime | None" = None,
+        reason: str | None = None,
+        request_context: "RequestContext",
+    ) -> dict | None:
+        """
+        Mark a memory unit as invalidated as of ``valid_to``. The row remains in
+        the timeline (still reachable via ``GET /memories/{id}`` and
+        ``GET /memories/{id}/history``) but recall queries will no longer
+        surface it once ``valid_to <= now()``.
+
+        Args:
+            bank_id: Bank ID.
+            memory_id: ID of the memory unit to invalidate.
+            valid_to: Timestamp at which the fact stops being valid. Defaults to
+                ``now()`` if omitted.
+            reason: Free-text rationale, stored to ``metadata.invalidation_reason``.
+            request_context: Request context for authentication.
+
+        Returns:
+            Dict with ``id``, ``valid_to``, ``fact_type`` and a short ``preview``
+            of the row's text, or ``None`` if no matching row was found.
+
+        Raises:
+            ValueError: If ``memory_id`` is not a valid UUID.
+        """
+        import uuid as uuid_module
+        from datetime import datetime, timezone
+
+        try:
+            memory_uuid = uuid_module.UUID(memory_id)
+        except ValueError:
+            raise ValueError(f"Invalid memory_id: '{memory_id}' is not a valid UUID")
+
+        if valid_to is None:
+            valid_to = datetime.now(timezone.utc)
+
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext
+
+            ctx = BankWriteContext(
+                bank_id=bank_id, operation="invalidate_memory_unit", request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            row = await conn.fetchrow(
+                f"""
+                UPDATE {fq_table("memory_units")}
+                   SET valid_to = $3::timestamptz,
+                       metadata = COALESCE(metadata, '{{}}'::jsonb)
+                                  || jsonb_build_object('invalidation_reason', $4::text)
+                 WHERE id = $1::uuid
+                   AND bank_id = $2
+                RETURNING id, valid_to, fact_type, LEFT(text, 200) AS preview
+                """,
+                str(memory_uuid),
+                bank_id,
+                valid_to,
+                reason,
+            )
+
+        if row is None:
+            return None
+
+        return {
+            "id": str(row["id"]),
+            "valid_to": row["valid_to"].isoformat() if row["valid_to"] else None,
+            "fact_type": row["fact_type"],
+            "preview": row["preview"],
+        }
+
     async def run_consolidation(
         self,
         bank_id: str,
@@ -5649,7 +5727,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, text, context, event_date, occurred_start, occurred_end,
                        mentioned_at, fact_type, document_id, chunk_id, tags, source_memory_ids,
-                       observation_scopes
+                       observation_scopes, valid_to
                 FROM {fq_table("memory_units")}
                 WHERE id = $1 AND bank_id = $2
                 """,

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -190,6 +190,15 @@ async def retrieve_semantic_bm25_combined(
         created_range_clause += f" AND updated_at < ${_next_idx}"
         _next_idx += 1
 
+    # --- validity-window filter ---------------------------------------------
+    # Skip memories that have been explicitly invalidated (valid_to <= now()).
+    # NULL valid_to means "still valid" — the default for every retain.
+    # The partial index ``idx_memory_units_active`` covers the hot path.
+    validity_clause = (
+        f" AND (valid_to IS NULL OR valid_to > {dialect.current_timestamp()})"
+    )
+    extra_where_clause = validity_clause + created_range_clause
+
     # --- Semantic UNION ALL arms (one per fact_type) ---
     # Each arm has its own ORDER BY ... LIMIT, enabling the partial HNSW indexes
     # per fact_type instead of forcing a full sequential scan.
@@ -203,7 +212,7 @@ async def retrieve_semantic_bm25_combined(
             fetch_limit=hnsw_fetch,
             tags_clause=tags_clause,
             groups_clause=groups_clause,
-            extra_where=created_range_clause,
+            extra_where=extra_where_clause,
         )
         for ft in fact_types
     ]
@@ -226,7 +235,7 @@ async def retrieve_semantic_bm25_combined(
                     arm_index=i,
                     text_search_extension=text_ext,
                     bm25_language=config.text_search_extension_native_language,
-                    extra_where=created_range_clause,
+                    extra_where=extra_where_clause,
                 )
             )
 
@@ -265,6 +274,7 @@ async def retrieve_semantic_bm25_combined(
             if created_before is not None:
                 fb_created_clause += f" AND updated_at < ${fb_next_idx}"
                 fb_next_idx += 1
+            fb_extra_where = validity_clause + fb_created_clause
             fb_arms = [
                 dialect.build_semantic_arm(
                     table=table,
@@ -275,7 +285,7 @@ async def retrieve_semantic_bm25_combined(
                     fetch_limit=hnsw_fetch,
                     tags_clause=fb_tags_clause,
                     groups_clause=fb_groups_clause,
-                    extra_where=fb_created_clause,
+                    extra_where=fb_extra_where,
                 )
                 for ft in fact_types
             ]
@@ -392,6 +402,7 @@ async def retrieve_temporal_combined(
             WHERE bank_id = $2
               AND fact_type = ANY($3)
               AND embedding IS NOT NULL
+              AND (valid_to IS NULL OR valid_to > now())
               AND (
                   (occurred_start IS NOT NULL AND occurred_end IS NOT NULL
                    AND occurred_start <= $5 AND occurred_end >= $4)
@@ -532,6 +543,7 @@ async def retrieve_temporal_combined(
                 WHERE mu.bank_id = $6
                   AND mu.fact_type = $3
                   AND mu.embedding IS NOT NULL
+                  AND (mu.valid_to IS NULL OR mu.valid_to > now())
                   AND (1 - (mu.embedding <=> $1::vector)) >= $4
                   {spreading_tags_clause}
                   {spreading_groups_clause}

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -107,6 +107,9 @@ class MemoryUnit(Base):
     )  # User-defined metadata (str->str)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    valid_to: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )  # NULL = still valid; non-NULL = superseded at this timestamp (recall filters out)
 
     # Relationships
     document = relationship("Document", back_populates="memory_units")
@@ -151,6 +154,12 @@ class MemoryUnit(Base):
             "embedding",
             postgresql_using="hnsw",
             postgresql_ops={"embedding": "vector_cosine_ops"},
+        ),
+        Index(
+            "idx_memory_units_active",
+            "bank_id",
+            "fact_type",
+            postgresql_where=sql_text("valid_to IS NULL"),
         ),
     )
 

--- a/hindsight-api-slim/tests/test_invalidate_memory.py
+++ b/hindsight-api-slim/tests/test_invalidate_memory.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hindsight_api.engine.memory_engine import MemoryEngine
-from hindsight_api.engine.sql.postgresql import PostgresDialect
+from hindsight_api.engine.sql.postgresql import PostgreSQLDialect as PostgresDialect
 from hindsight_api.models import RequestContext
 
 

--- a/hindsight-api-slim/tests/test_invalidate_memory.py
+++ b/hindsight-api-slim/tests/test_invalidate_memory.py
@@ -1,0 +1,169 @@
+"""Unit tests for memory unit invalidation (valid_to) — see issue #1391.
+
+Covers:
+
+  * `MemoryEngine.invalidate_memory_unit` issues the correct UPDATE,
+    sets `valid_to` to the requested timestamp (or `now()` by default),
+    and threads the invalidation `reason` into the row's `metadata` JSONB.
+  * Recall SQL builders in the postgres dialect always emit
+    `(valid_to IS NULL OR valid_to > now())` so invalidated rows are
+    filtered out of semantic / BM25 arms.
+
+Integration coverage that exercises a real Postgres + the new alembic
+migration lives in the existing recall integration tests; this file is
+unit-test scope so it runs in plain pytest without a live DB.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.sql.postgresql import PostgresDialect
+from hindsight_api.models import RequestContext
+
+
+@pytest.mark.asyncio
+async def test_invalidate_memory_unit_runs_update_with_default_now():
+    """Calling without an explicit valid_to defaults to now()-ish UTC."""
+    engine = MemoryEngine.__new__(MemoryEngine)
+    engine._initialized = True
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+
+    fake_id = "0c14e4f1-9eb6-4dde-b0a4-c2e8b3a3e5f1"
+    fake_row = {
+        "id": fake_id,
+        "valid_to": datetime(2026, 5, 2, 17, 30, tzinfo=timezone.utc),
+        "fact_type": "world",
+        "preview": "Server srv-04 runs PostgreSQL 17.",
+    }
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=fake_row)
+
+    # acquire_with_retry is an async context manager — wire that explicitly.
+    class _CM:
+        async def __aenter__(self_inner):
+            return mock_conn
+
+        async def __aexit__(self_inner, *exc):
+            return False
+
+    mock_pool = MagicMock()
+    engine._get_backend = AsyncMock(return_value=mock_pool)
+
+    import hindsight_api.engine.memory_engine as me
+
+    me.acquire_with_retry = lambda _backend: _CM()  # type: ignore[assignment]
+
+    rc = RequestContext(tenant_id="tenant-a", api_key_id="key-a")
+    result = await engine.invalidate_memory_unit(
+        bank_id="bank-1",
+        memory_id=fake_id,
+        reason="Server decommissioned",
+        request_context=rc,
+    )
+
+    assert result is not None
+    assert result["id"] == fake_id
+    assert result["fact_type"] == "world"
+    assert result["preview"].startswith("Server srv-04")
+
+    # Confirm the UPDATE was called with the right shape: the third positional
+    # parameter is the timestamp (defaulted to ~now()), the fourth is the reason.
+    mock_conn.fetchrow.assert_awaited_once()
+    args = mock_conn.fetchrow.await_args.args
+    sql = args[0]
+    assert "UPDATE" in sql
+    assert "SET valid_to = $3::timestamptz" in sql
+    assert "invalidation_reason" in sql
+    # bank_id, valid_to, reason positions 2, 3, 4
+    assert args[1] == fake_id
+    assert args[2] == "bank-1"
+    assert isinstance(args[3], datetime)
+    # Defaulted to "now"-ish — must be UTC and within a few seconds of test start.
+    assert args[3].tzinfo is not None
+    assert abs((args[3] - datetime.now(timezone.utc)).total_seconds()) < 5
+    assert args[4] == "Server decommissioned"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_memory_unit_returns_none_when_not_found():
+    engine = MemoryEngine.__new__(MemoryEngine)
+    engine._initialized = True
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=None)
+
+    class _CM:
+        async def __aenter__(self_inner):
+            return mock_conn
+
+        async def __aexit__(self_inner, *exc):
+            return False
+
+    engine._get_backend = AsyncMock(return_value=MagicMock())
+
+    import hindsight_api.engine.memory_engine as me
+
+    me.acquire_with_retry = lambda _backend: _CM()  # type: ignore[assignment]
+
+    rc = RequestContext(tenant_id="tenant-a", api_key_id="key-a")
+    result = await engine.invalidate_memory_unit(
+        bank_id="bank-1",
+        memory_id="0c14e4f1-9eb6-4dde-b0a4-c2e8b3a3e5f1",
+        request_context=rc,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_invalidate_memory_unit_rejects_non_uuid():
+    engine = MemoryEngine.__new__(MemoryEngine)
+    engine._initialized = True
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+
+    rc = RequestContext(tenant_id="tenant-a", api_key_id="key-a")
+    with pytest.raises(ValueError, match="not a valid UUID"):
+        await engine.invalidate_memory_unit(
+            bank_id="bank-1",
+            memory_id="this-is-not-a-uuid",
+            request_context=rc,
+        )
+
+
+def test_postgres_semantic_arm_filters_invalidated_rows():
+    """Recall must skip memories whose valid_to has elapsed."""
+    dialect = PostgresDialect()
+    sql = dialect.build_semantic_arm(
+        table="memory_units",
+        cols="id, text",
+        fact_type="world",
+        embedding_param="$1",
+        bank_id_param="$2",
+        fetch_limit=20,
+        extra_where=" AND (valid_to IS NULL OR valid_to > now())",
+    )
+    assert "valid_to IS NULL OR valid_to > now()" in sql
+    # Sanity: still has the per-fact_type predicate so the partial HNSW index applies.
+    assert "fact_type = 'world'" in sql
+
+
+def test_postgres_bm25_arm_filters_invalidated_rows():
+    dialect = PostgresDialect()
+    sql = dialect.build_bm25_arm(
+        table="memory_units",
+        cols="id, text",
+        fact_type="experience",
+        bank_id_param="$2",
+        limit_param="$3",
+        text_param="$4",
+        text_search_extension="native",
+        extra_where=" AND (valid_to IS NULL OR valid_to > now())",
+    )
+    assert "valid_to IS NULL OR valid_to > now()" in sql


### PR DESCRIPTION
## Summary

Revives the abandoned [PR #1395](https://github.com/vectorize-io/hindsight/pull/1395) by @nikolay-bratanov, which implemented validity windows on `memory_units` (`valid_to TIMESTAMPTZ NULL` column + partial index + `POST /memories/{memory_id}/invalidate` endpoint + recall filter + tests). Resolves the two mechanical blockers diagnosed by @yonefive71 in the original PR review:

1. **Alembic revision id collision** — the original migration claimed `a2b3c4d5e6f7`, which was subsequently reused by `add_text_signals_column` on `main`. Renumbered to a fresh hex id, chained off the current upstream head.
2. **Test import typo** — `from hindsight_api.engine.sql.postgresql import PostgresDialect` → `... import PostgreSQLDialect as PostgresDialect`. One-line aliasing, no test-body changes.

The substantive design question from [issue #1391](https://github.com/vectorize-io/hindsight/issues/1391) ("who's responsible to invalidate facts?") is addressed in the design memo below — short answer: split by signal source (in-stream vs out-of-band), not by responsible actor. The consolidator + a better-shaped `observations_mission` handles in-stream contradictions; `/invalidate` is the missing primitive for out-of-band cases (user retracts, agent self-correction, post-hoc dedup of pre-existing duplicate clusters). They are complementary, not competing.

Marked as **draft** to give the maintainer space to react to the design framing before this goes to ready-for-review.

Original code is preserved verbatim across the 6 touched files; only the migration filename + revision frontmatter + one test import line differ from PR #1395.

## Commits

1. **feat(memory): validity windows on memory_units (cherry-pick of #1395)** — squashed apply of the original diff, `Co-authored-by: Nikolay Bratanov`.
2. **alembic: renumber valid_to migration to resolve revision id collision** — fresh hex id + chain to current upstream head.
3. **tests: alias PostgreSQLDialect as PostgresDialect for test_invalidate_memory** — credit @yonefive71's diff from the review.

---

## Design context — fact obsolescence in Hindsight

**TL;DR**

1. The maintainer's question on PR #1395 (*"who's responsible to invalidate facts?"*) has a concrete answer: **both, but for different signal classes**. The consolidator handles **implicit** invalidation (new fact contradicts an old fact in the same retain stream); the agent/user needs an explicit `/invalidate` for everything else (user retracts, agent self-correction, post-hoc dedup, out-of-band staleness like a server being decommissioned). These are different problems with different signal sources — neither subsumes the other.
2. We tested the **implicit half on a real production deployment (2026-05-31)** and confirmed it can be improved dramatically with **zero schema changes**, just by rewriting the per-bank `observations_mission`. On a sandbox bank seeded with 12 raw facts (3 contradiction cases + 4 protection cases), the default mission produced **5 unmerged observations from just the BMW/Toyota contradiction pair**; a mission rewrite produced **1 cleanly merged observation** with both states + transition date, while preserving every legitimate historical fact and multi-facet split. Numbers and outputs below.
3. This **does not eliminate the need for #1391 / PR #1395**. The mission improves consolidation when the signal is in-stream; it cannot help when the signal is out-of-band (user clicks "this is wrong," agent detects a stale operational fact, dedup script wants to retire 1,280 byte-identical clusters as in @yonefive71's data). Both layers are needed.
4. Propose: land this PR for the schema-level out-of-band primitive, and separately document the mission-rewrite pattern as the first-line improvement in `docs/concepts/`. A short "in-stream vs out-of-band invalidation" docs section keeps the framing clear so future users reach for the right tool.

### 1. The framing question — who invalidates?

@nicoloboschi on #1391:
> who's responsible to invalidate facts?
> - if it's the agent, this will not work consistently.
> - if it's Hindsight, this is already done via consolidation - could be improved but it has to be a different design

Both halves of the dichotomy are partially true but each one alone is insufficient. The proposed answer is to split the problem by **signal source**, not by responsible actor:

| Signal source | Example | Best mechanism | Why |
|---|---|---|---|
| **In-stream contradiction** — new fact arrives that directly conflicts with a recent fact about the same entity/facet | "Alice likes BMW" → 3 months later "Alice likes Toyota" | Consolidator with stronger `observations_mission` | The signal is structurally present at consolidation time. The LLM already sees both facts in the same batch (or via recall budget). A better-shaped prompt is sufficient. Measured below in §3. |
| **Out-of-band invalidation** — fact is wrong, stale, or duplicate but no contradicting fact is being retained | User clicks "this memory is incorrect"; agent's tool inventory changes; dedup script finds 22 byte-identical copies of one canon sentence (@yonefive71's case) | Explicit `POST /memories/{id}/invalidate` endpoint (this PR) | No new fact triggers consolidation. No LLM has the signal. The decision lives outside Hindsight's pipeline; Hindsight only needs to honour it. |
| **Agent self-correction during recall** — agent reads conflicting memories at recall time and updates its own understanding | Agent gets BMW + Toyota both at recall, decides Toyota is current | Recall-time disambiguation (existing) + optional agent-driven `/invalidate` if it has high confidence | Same as out-of-band — the consolidator never sees the agent's reasoning. |

The current implementation only addresses row 1, and it does so conservatively. Rows 2 and 3 are not addressed at all today. **This PR is the missing primitive for rows 2 and 3.** It is not in competition with the consolidator; it complements it.

The "if it's the agent, this will not work consistently" concern is real, but it is a **policy** concern (when should the agent be trusted to invalidate?), not a **mechanism** concern. Even an explicit endpoint can be gated — IAM-style, with admin-only by default and an opt-in `allow_agent_invalidate` per-bank flag. The mechanism needs to exist regardless of the policy.

### 2. State of the art — three patterns, one good fit

We surveyed how other LLM memory systems handle this:

| System | Mechanism | History preserved? | Notes |
|---|---|---|---|
| **Graphiti / Zep** ([Sarmah et al. 2025](https://arxiv.org/abs/2501.13956)) | Bi-temporal edges (`valid_at` / `invalid_at` / `created_at` / `expired_at`) | Yes — explicit, queryable | The most rigorous design. New facts trigger LLM-based fact-resolution that can invalidate prior edges. |
| **mem0 v2** | ADD / UPDATE / DELETE classification per new fact | Yes — immutable ADD log | Abandoned in v3 (April 2026) — the classifier was 97.8% noise per the team's own audit. Now append-only. |
| **mem0 v3 (current)** | Append-only + retrieval ranking | Yes — append-only | Same architectural family as Hindsight today. |
| **Letta / MemGPT** | Agent rewrites its own core memory blocks | No — overwrite | History only preserved if the agent chooses to log it to archival. |
| **Hindsight today** | Append-only raw `memory_units` + LLM-synthesised `observations` + soft recency boost in reranking | Yes — append-only | Same family as mem0 v3. |

The Graphiti bi-temporal model maps most naturally onto Hindsight's existing architecture: `memory_units` are already immutable append-only rows; observations are already synthesised summaries with a `history` JSONB audit column. Adding a `valid_to TIMESTAMPTZ NULL` column to `memory_units` (this PR) is the smallest possible step toward bi-temporal semantics — it adds one bit of state (active/invalidated) without committing to a full temporal-graph refactor.

mem0's v2→v3 retreat is instructive. The reason their explicit UPDATE/DELETE classifier failed was that they ran it as a **separate per-fact LLM call** without sufficient context, leading to high noise. Hindsight's consolidator avoids this trap because UPDATE/DELETE decisions already happen *inside* the existing consolidation LLM call, which already loads related observations via recall — the signal is there, only the prompt shape is weak. This is empirically validated below.

### 3. Empirical evidence — mission rewrite alone closes 80%+ of the in-stream gap

Tested on a fresh sandbox bank (`obsolescence-test`) on a production Hindsight deployment (API v0.6.2) on 2026-05-31. **Same engine, same default LLM (`gpt-5-mini`), no code changes — only per-bank `observations_mission` differed.**

#### Test setup

12 raw facts retained via `POST /v1/default/banks/{bank_id}/memories`, with backdated timestamps so recency reasoning had real time gaps to work with:

| # | Fact | Backdated to | Category |
|---|---|---|---|
| 1 | Alice told me she really likes BMW cars... best brand for driving experience and engineering quality. | 2026-02-15 | contradiction (BMW→Toyota) |
| 2 | Alice told me she loves Toyota cars now. She prefers them over BMW because of reliability and lower maintenance costs. | 2026-05-31 | contradiction (BMW→Toyota) |
| 3 | Alice has a dog named Rex. Rex is a German Shepherd, 5 years old. | 2026-01-10 | dated event (pet died, history) |
| 4 | Rex passed away on March 15, 2026. Alice is heartbroken. | 2026-03-16 | dated event (pet died, history) |
| 5 | Alice adopted a new dog named Luna, a Golden Retriever, in April 2026. | 2026-04-20 | multi-facet (new pet, different entity) |
| 6 | Alice owns a Tesla Model 3 since 2024. She drives it daily. | 2026-02-01 | multi-facet (ownership) |
| 7 | Alice also owns a sailing boat called Wind Dancer, kept at the marina. | 2026-02-05 | multi-facet (ownership) |
| 8 | Bob works at Google as a software engineer. | 2026-01-20 | contradiction (employer change) |
| 9 | Bob left Google and joined Microsoft as a senior engineer in May 2026. | 2026-05-15 | contradiction (employer change) |

#### Baseline — default `observations_mission`

The default mission is `"Track every detail: names, numbers, dates, places, and relationships. Prefer specifics over abstractions, never generalise."` (see `hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py:_DEFAULT_MISSION`).

After retain + explicit consolidation, observations for the BMW/Toyota pair alone:

```
1. "Alice prefers Toyota cars over BMW cars because she considers Toyota cars to be more reliable and to have lower maintenance costs."
2. "Alice now loves Toyota cars."
3. "Alice believes BMW is the best brand for engineering quality."
4. "Alice believes BMW is the best brand for driving experience."
5. "Alice likes BMW cars."
```

**5 unmerged observations from 2 raw facts.** None marked superseded. Recall for `"what cars does Alice like"` returned the BMW raw fact at position 1 despite being 3.5 months older — the embedding-similarity advantage swamped the ~6.8% recency penalty (`engine/search/reranking.py:101-129`). This is the failure mode reported by @yonefive71 (1,280 duplicate cluster, 17,569 total) and @1ain0516 (multi-agent bank with English/Chinese duplicates).

#### After — rewritten `observations_mission`

```text
Track every detail with these contradiction rules. When a new fact replaces a
prior fact about the same entity's preference, opinion, location, employment,
ownership, or state, UPDATE the matching observation to the new state and
include the date of the change in the observation text (e.g. "Alice preferred
BMW; switched to Toyota on 2026-05-31"). Recency wins for these mutable
attributes. PRESERVE HISTORY only when the prior fact records a discrete,
dated event (sold X, X died, moved to Y) — those are history, not
contradictions. Never create two observations for the same facet of the
same entity.
```

After `bank clear-observations` + `bank consolidate` with the new mission, the BMW/Toyota pair collapses to a single observation:

```
"Alice preferred BMW cars but switched to Toyota on 2026-05-31; she now loves Toyota and prefers it over BMW because she considers Toyota more reliable and lower maintenance."
```

Adding facts 3–9 and re-consolidating, the full bank produced **8 observations** (vs the ~15–20 a baseline default would produce extrapolating from the 5-for-2 baseline ratio):

| # | Observation text | Verdict |
|---|---|---|
| 1 | Alice preferred BMW cars but switched to Toyota on 2026-05-31… | ✅ merged contradiction with date |
| 2 | Bob left Google and joined Microsoft as a senior engineer in May 2026. | ✅ merged contradiction with date |
| 3 | Alice had a dog named Rex, a German Shepherd who was 5 years old; Rex died on 2026-03-15. | ✅ preserved history (dated event) |
| 4 | Alice adopted a new dog named Luna, a Golden Retriever, on 2026-04-20. | ✅ separate (different entity) |
| 5 | Alice owns a Tesla Model 3 and has owned it since 2024. | ✅ preserved (ownership) |
| 6 | Alice owns a sailing boat called Wind Dancer that is kept at the marina. | ✅ preserved (separate entity) |
| 7 | Alice drives her Tesla Model 3 daily. | ⚠️ near-duplicate of #5 (could be merged) |
| 8 | Alice is heartbroken. | ⚠️ orphan observation from Rex death context |

Recall for `"where does Bob work"` returns row 2 only — single clean answer. Recall for `"what cars does Alice prefer"` returns row 1 first — the merged superseding observation. Recall for `"what pets has Alice had"` returns rows 4 then 3 — Luna first (recent), Rex with death info second (history). All three queries give the agent immediately usable, deduplicated, recency-correct answers.

#### What this empirically confirms

- The conservative DELETE rule in `_PROCESSING_RULES` (rule 7: "PRESERVE HISTORY: …. Be very conservative with deletes") **is not the binding constraint**. The mission, which is injected above the rules (`build_batch_consolidation_prompt`), takes priority when the LLM has to choose. A mission that explicitly says "UPDATE for preferences/state, PRESERVE for dated events" successfully overrides the default conservative bias.
- The protection cases (rules 1, 4 in `_PROCESSING_RULES` — facet matching, multi-entity protection) **still work** under the aggressive mission. We saw no regressions on Tesla+boat (multi-facet), Rex (dated event), or Luna (different-entity-same-facet).
- The 2 minor issues (Tesla driving vs ownership split; orphan "Alice is heartbroken") are mission-tunable, not architectural. They show the upper bound of mission-rewrite is not 100% — more refinement helps marginally.

#### What this does NOT solve

The raw `memory_units` rows still contain the BMW fact verbatim. If a downstream consumer queries by `fact_type=world` or `fact_type=experience`, they still get the conflict. **Only observation-layer queries are clean.** This is exactly the gap this PR is designed to address — when you want raw recall to skip a fact, the only available mechanism today is DELETE (audit gone) or "wait and hope consolidation handles it." Mission rewrite does not give you `valid_to`.

It also does nothing for the @yonefive71 case (1,280 exact-duplicate `memory_units` already in the live bank from past sessions). Mission only affects future consolidation; it cannot retire pre-existing duplicates. A `/invalidate` endpoint can — and per @yonefive71's analysis, the trivial `GROUP BY text HAVING count(*) > 1` sweep would reclaim ~825 rows on day one.

### 4. Proposed path forward

1. **Land this PR** under the framing in §1: this is the out-of-band invalidation primitive, complementary to (not in competition with) the consolidator.
2. **Add docs** at `docs/concepts/` distinguishing in-stream vs out-of-band invalidation. Reference the mission-rewrite pattern as the first-line in-stream improvement. Reference `/invalidate` as the explicit primitive for everything else. Happy to do this in a follow-up PR.
3. **Optional policy gate**: add `allow_agent_invalidate` bool to bank config, defaulting `false` (only API-key holders can invalidate). This addresses the maintainer's "if it's the agent, this will not work consistently" concern by making agent-driven invalidation an explicit opt-in. The mechanism still exists for the cases where it's needed (admin scripts, user-explicit retracts). Can be a follow-up PR or included here if you prefer.
4. **#1392 (SPO triples)**: deferred. The mission improvements + `valid_to` together cover most of the pain. Triples are a larger architectural conversation that should not block this work.

### 5. Acknowledgements

- @nikolay-bratanov for the original RFC + PR work.
- @yonefive71 for the production-bank data, the migration diagnosis, and the import fix.
- @ai-ag2026 for the curation-API comment on #1094 that helped frame the soft-vs-hard delete distinction.
- @noctuid, @zviratko, @1ain0516, @suchanek for production datapoints across #1094.
- @nicoloboschi for the framing question that forced the design clarification.

---

## Test plan

- [x] `pytest hindsight-api-slim/tests/test_invalidate_memory.py` passes after the `PostgreSQLDialect` alias fix (5 tests).
- [x] Migration applies cleanly against the current upstream head (no `multiple heads` after revision-id renumber).
- [ ] CI on this PR passes (will track separately).
- [ ] Integration test on a real Postgres asserting an invalidated row drops out of recall — happy to add in a follow-up; original PR author offered the same.
- [ ] Doc page added under `docs/concepts/` distinguishing in-stream vs out-of-band invalidation — follow-up PR after design is approved.

🤖 Authored by [Claude](https://claude.com/claude-code) (Anthropic) in collaboration with @nikolay-bratanov, @yonefive71, and the other thread contributors named above.
