### PR TITLE
fix(api-slim): gracefully handle model init failures

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13,6 +13,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -753,6 +754,8 @@ class MemoryEngine(MemoryEngineInterface):
             config.read_database_url if self._database_backend_type == "postgresql" else None
         )
         self._initialized = False
+        self._embeddings_initialized = False
+        self._reranker_initialized = False
         self._pool_min_size = pool_min_size if pool_min_size is not None else config.db_pool_min_size
         self._pool_max_size = pool_max_size if pool_max_size is not None else config.db_pool_max_size
         self._read_pool_min_size = config.read_db_pool_min_size
@@ -2071,12 +2074,30 @@ class MemoryEngine(MemoryEngineInterface):
 
         Loads models (embeddings, cross-encoder) in parallel with pg0 startup
         for faster overall initialization.
+
+        Model initialization failures (e.g. HuggingFace downloads blocked by
+        firewall) are handled gracefully: the daemon logs a warning and starts
+        with degraded functionality rather than crashing. Set
+        HINDSIGHT_MODEL_INIT_TIMEOUT (seconds, default 300) to control the
+        per-task timeout.
         """
         if self._initialized:
             return
 
+        # Track which optional components initialized successfully
+        self._embeddings_initialized = False
+        self._reranker_initialized = False
+
         # Run model loading in thread pool (CPU-bound) in parallel with pg0 startup
         loop = asyncio.get_event_loop()
+
+        def _run_in_sub_loop(coro):
+            """Run coroutine in a dedicated asyncio event loop via the thread pool.
+
+            This avoids blocking the main event loop with CPU-bound model loading
+            and isolates the temporary sub-loop from parent-loop cancellations.
+            """
+            return loop.run_in_executor(None, lambda: asyncio.run(coro))
 
         async def start_pg0():
             """Start pg0 if configured."""
@@ -2093,22 +2114,30 @@ class MemoryEngine(MemoryEngineInterface):
                     self._pg0 = pg0
 
         async def init_embeddings():
-            """Initialize embedding model."""
+            """Initialize embedding model.
+
+            Raises on failure — the caller (_with_timeout) handles the exception
+            and sets self._embeddings_initialized = False.
+            """
             # For local providers, run in thread pool to avoid blocking event loop
             if self.embeddings.provider_name == "local":
-                await loop.run_in_executor(None, lambda: asyncio.run(self.embeddings.initialize()))
+                await _run_in_sub_loop(self.embeddings.initialize())
             else:
                 await self.embeddings.initialize()
 
         async def init_cross_encoder():
-            """Initialize cross-encoder model."""
+            """Initialize cross-encoder model.
+
+            Raises on failure — the caller (_with_timeout) handles the exception
+            and sets self._reranker_initialized = False.
+            """
             cross_encoder = self._cross_encoder_reranker.cross_encoder
             # For local providers, run in thread pool to avoid blocking event loop
             if cross_encoder.provider_name == "local":
-                await loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
+                await _run_in_sub_loop(cross_encoder.initialize())
             else:
                 await cross_encoder.initialize()
-            # Mark reranker as initialized
+            # Mark reranker as initialized only on success
             self._cross_encoder_reranker._initialized = True
 
         async def init_query_analyzer():
@@ -2191,23 +2220,87 @@ class MemoryEngine(MemoryEngineInterface):
                             f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
                         )
 
-        # Build list of initialization tasks
-        init_tasks = [
-            start_pg0(),
-            init_embeddings(),
-            init_query_analyzer(),
+        # Run pg0 and selected model initializations in parallel.
+        # Model init failures are degraded gracefully (warning + continue),
+        # but infrastructure failures (pg0) are fatal.
+        model_init_timeout = float(os.environ.get("HINDSIGHT_MODEL_INIT_TIMEOUT", "300"))
+
+        async def _with_timeout(task, name="task", *, fatal=False):
+            """Run a single init task with a timeout.
+
+            Args:
+                task: The awaitable to run.
+                name: Human-readable name for log messages.
+                fatal: If True, re-raise the exception after logging so the
+                       caller (and ultimately initialize()) aborts. Use for
+                       infrastructure tasks where continuing is meaningless.
+            """
+            try:
+                await asyncio.wait_for(task, timeout=model_init_timeout)
+            except asyncio.TimeoutError:
+                logger.warning("%s timed out after %.0fs", name, model_init_timeout)
+                if fatal:
+                    raise
+            except Exception as e:
+                logger.warning("%s failed: %s", name, e)
+                if fatal:
+                    raise
+
+        # Fatal tasks abort initialization if they fail. Model tasks degrade.
+        fatal_tasks = [
+            _with_timeout(start_pg0(), "pg0 startup", fatal=True),
         ]
 
-        # Only init cross-encoder eagerly if not using lazy initialization
+        # Optional model tasks — failure is degraded (warning + continue)
+        model_tasks = [
+            _with_timeout(init_embeddings(), "embedding model init"),
+            _with_timeout(init_query_analyzer(), "query analyzer init"),
+        ]
         if not self._lazy_reranker:
-            init_tasks.append(init_cross_encoder())
-
-        # Only verify LLM if not skipping
+            model_tasks.append(_with_timeout(init_cross_encoder(), "cross-encoder init"))
         if not self._skip_llm_verification:
-            init_tasks.append(verify_llm())
+            # verify_llm raises RuntimeError for config errors (e.g. batch API
+            # incompatibility) which MUST propagate. Regular connection failures
+            # are already logged as warnings inside verify_llm itself.
+            fatal_tasks.append(_with_timeout(verify_llm(), "LLM verification", fatal=True))
 
-        # Run pg0 and selected model initializations in parallel
-        await asyncio.gather(*init_tasks)
+        # Run everything in parallel. Fatal task exceptions are collected and
+        # re-raised below; model task exceptions are logged and degraded.
+        all_results = await asyncio.gather(
+            *fatal_tasks, *model_tasks, return_exceptions=True
+        )
+
+        # Re-raise all fatal task exceptions (pg0 startup, LLM config validation).
+        # This includes TimeoutError and non-RuntimeError failures, not just
+        # RuntimeError, because _with_timeout(..., fatal=True) means abort.
+        for result in all_results[: len(fatal_tasks)]:
+            if isinstance(result, BaseException):
+                raise result
+
+        # Track which model components initialized successfully.
+        # _with_timeout swallowed their exceptions, so we probe the objects.
+        # Embeddings: if initialize() succeeded, LocalSTEmbeddings._model is set;
+        # for remote providers, _client is set. A simple probe: check dimension.
+        try:
+            _ = self.embeddings.dimension
+            self._embeddings_initialized = True
+        except Exception:
+            self._embeddings_initialized = False
+            logger.warning(
+                "Embedding model not available. Semantic search and retain "
+                "operations will fail until the model is loaded. "
+                "If behind a firewall, set HF_ENDPOINT=https://hf-mirror.com "
+                "or HF_HUB_OFFLINE=1 and pre-download models."
+            )
+
+        self._reranker_initialized = self._cross_encoder_reranker._initialized
+        if not self._reranker_initialized and not self._lazy_reranker:
+            logger.warning(
+                "Cross-encoder reranker not available. Recall will fall back "
+                "to embedding-only scoring. If behind a firewall, set "
+                "HF_ENDPOINT=https://hf-mirror.com or HF_HUB_OFFLINE=1 "
+                "and pre-download models."
+            )
 
         # Run database migrations if enabled
         if self._run_migrations:
@@ -2242,15 +2335,24 @@ class MemoryEngine(MemoryEngineInterface):
                 )
 
                 if tenants:
-                    for tenant in tenants:
-                        schema = tenant.schema
-                        if schema:
-                            ensure_embedding_dimension(
-                                self.db_url,
-                                self.embeddings.dimension,
-                                schema=schema,
-                                vector_extension=config.vector_extension,
-                            )
+                    # Skip embedding dimension migration if the embedding model
+                    # failed to initialize — we don't have a valid dimension to
+                    # enforce, and writing a stale value would corrupt the schema.
+                    if self._embeddings_initialized:
+                        for tenant in tenants:
+                            schema = tenant.schema
+                            if schema:
+                                ensure_embedding_dimension(
+                                    self.db_url,
+                                    self.embeddings.dimension,
+                                    schema=schema,
+                                    vector_extension=config.vector_extension,
+                                )
+                    else:
+                        logger.warning(
+                            "Skipping embedding dimension migration: "
+                            "embedding model not initialized."
+                        )
 
                     for tenant in tenants:
                         schema = tenant.schema
@@ -3392,6 +3494,12 @@ class MemoryEngine(MemoryEngineInterface):
             embedding_span.set_attribute("hindsight.query", query[:100])
 
             try:
+                if not self._embeddings_initialized:
+                    raise RuntimeError(
+                        "Embedding model is not initialized; recall requires embeddings. "
+                        "If behind a firewall, set HF_ENDPOINT=https://hf-mirror.com "
+                        "or HF_HUB_OFFLINE=1 and pre-download models."
+                    )
                 query_embeddings = await embedding_utils.generate_embeddings_batch(
                     self.embeddings,
                     [query],

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -2,10 +2,14 @@
 Cross-encoder neural reranking for search results.
 """
 
+import logging
 import math
+import os
 from datetime import datetime, timezone
 
 from .types import MergedCandidate, ScoredResult
+
+logger = logging.getLogger(__name__)
 
 UTC = timezone.utc
 
@@ -154,20 +158,69 @@ class CrossEncoderReranker:
         self._initialized = False
 
     async def ensure_initialized(self):
-        """Ensure the cross-encoder model is initialized (for lazy initialization)."""
+        """Ensure the cross-encoder model is initialized (for lazy initialization).
+
+        If initialization fails (e.g. HuggingFace model download blocked by
+        firewall), logs a warning and leaves ``_initialized`` as False so
+        rerank() can fall back to RRF-based scoring instead of crashing.
+        """
         if self._initialized:
             return
 
         import asyncio
 
-        cross_encoder = self.cross_encoder
-        # For local providers, run in thread pool to avoid blocking event loop
-        if cross_encoder.provider_name == "local":
-            loop = asyncio.get_event_loop()
-            await loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
-        else:
-            await cross_encoder.initialize()
+        async def _initialize_cross_encoder():
+            cross_encoder = self.cross_encoder
+            # For local providers, run in thread pool to avoid blocking event loop
+            if cross_encoder.provider_name == "local":
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
+            else:
+                await cross_encoder.initialize()
+
+        timeout = float(os.environ.get("HINDSIGHT_MODEL_INIT_TIMEOUT", "300"))
+        try:
+            await asyncio.wait_for(_initialize_cross_encoder(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Cross-encoder initialization timed out after %.0fs during lazy init. "
+                "Reranking operations will fall back to RRF-based scoring.",
+                timeout,
+            )
+            return
+        except Exception as e:
+            logger.warning(
+                "Cross-encoder initialization failed during lazy init: %s. "
+                "Reranking operations will fall back to RRF-based scoring. "
+                "If behind a firewall, set HF_ENDPOINT=https://hf-mirror.com "
+                "or HF_HUB_OFFLINE=1 and pre-download models.",
+                e,
+            )
+            return
         self._initialized = True
+
+    def _fallback_rerank(self, candidates: list[MergedCandidate]) -> list[ScoredResult]:
+        """Fallback reranking based on RRF order when cross-encoder is unavailable."""
+        if not candidates:
+            return []
+
+        sorted_candidates = sorted(candidates, key=lambda candidate: candidate.rrf_score, reverse=True)
+        denom = max(1, len(sorted_candidates) - 1)
+        scored_results = []
+        for rank, candidate in enumerate(sorted_candidates):
+            # Map RRF rank to [0.1, 1.0] so downstream combined scoring can still
+            # apply recency / temporal / proof-count nudges without losing the
+            # retrieval relevance signal.
+            normalized_score = 1.0 - (0.9 * rank / denom)
+            scored_results.append(
+                ScoredResult(
+                    candidate=candidate,
+                    cross_encoder_score=normalized_score,
+                    cross_encoder_score_normalized=normalized_score,
+                    weight=normalized_score,
+                )
+            )
+        return scored_results
 
     async def rerank(self, query: str, candidates: list[MergedCandidate]) -> list[ScoredResult]:
         """
@@ -182,6 +235,10 @@ class CrossEncoderReranker:
         """
         if not candidates:
             return []
+
+        if not self._initialized:
+            logger.warning("Cross-encoder is not initialized; using RRF-based fallback reranking")
+            return self._fallback_rerank(candidates)
 
         # Prepare query-document pairs with date information
         pairs = []
@@ -210,7 +267,12 @@ class CrossEncoderReranker:
             pairs.append([query, doc_text])
 
         # Get cross-encoder scores
-        scores = await self.cross_encoder.predict(pairs)
+        try:
+            scores = await self.cross_encoder.predict(pairs)
+        except Exception as e:
+            logger.warning("Cross-encoder prediction failed: %s. Using RRF-based fallback reranking", e)
+            self._initialized = False
+            return self._fallback_rerank(candidates)
 
         # Normalize scores to [0, 1] range.
         # External API rerankers (Cohere, Jina, llama.cpp/Qwen, etc.) return

--- a/hindsight-api-slim/tests/test_cross_encoder_reranker_fallback.py
+++ b/hindsight-api-slim/tests/test_cross_encoder_reranker_fallback.py
@@ -1,0 +1,96 @@
+"""Regression tests for reranker initialization/prediction fallback behavior."""
+
+import asyncio
+
+import pytest
+
+from hindsight_api.engine.search.reranking import CrossEncoderReranker
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult
+
+
+class FailingInitCrossEncoder:
+    provider_name = "remote-test"
+
+    async def initialize(self):
+        raise RuntimeError("init failed")
+
+    async def predict(self, pairs):
+        raise AssertionError("predict should not be called when init failed")
+
+
+class FailingPredictCrossEncoder:
+    provider_name = "remote-test"
+
+    async def initialize(self):
+        return None
+
+    async def predict(self, pairs):
+        raise RuntimeError("predict failed")
+
+
+class SlowInitCrossEncoder:
+    provider_name = "remote-test"
+
+    async def initialize(self):
+        await asyncio.sleep(1)
+
+    async def predict(self, pairs):
+        raise AssertionError("predict should not be called when init timed out")
+
+
+def _candidate(memory_id: str, text: str, rrf_score: float) -> MergedCandidate:
+    return MergedCandidate(
+        retrieval=RetrievalResult(
+            id=memory_id,
+            text=text,
+            fact_type="observation",
+        ),
+        rrf_score=rrf_score,
+    )
+
+
+def _candidates() -> list[MergedCandidate]:
+    return [
+        _candidate("low", "less relevant", 0.1),
+        _candidate("high", "more relevant", 0.9),
+        _candidate("mid", "middle relevant", 0.5),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lazy_init_failure_falls_back_to_rrf_order():
+    reranker = CrossEncoderReranker(cross_encoder=FailingInitCrossEncoder())
+
+    await reranker.ensure_initialized()
+    assert reranker._initialized is False
+
+    results = await reranker.rerank("query", _candidates())
+
+    assert [result.id for result in results] == ["high", "mid", "low"]
+    assert [result.cross_encoder_score_normalized for result in results] == [1.0, 0.55, 0.09999999999999998]
+
+
+@pytest.mark.asyncio
+async def test_prediction_failure_falls_back_to_rrf_order_and_marks_uninitialized():
+    reranker = CrossEncoderReranker(cross_encoder=FailingPredictCrossEncoder())
+
+    await reranker.ensure_initialized()
+    assert reranker._initialized is True
+
+    results = await reranker.rerank("query", _candidates())
+
+    assert reranker._initialized is False
+    assert [result.id for result in results] == ["high", "mid", "low"]
+
+
+@pytest.mark.asyncio
+async def test_lazy_init_timeout_falls_back_to_rrf_order(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_MODEL_INIT_TIMEOUT", "0.01")
+    reranker = CrossEncoderReranker(cross_encoder=SlowInitCrossEncoder())
+
+    await reranker.ensure_initialized()
+    assert reranker._initialized is False
+
+    results = await reranker.rerank("query", _candidates())
+
+    assert [result.id for result in results] == ["high", "mid", "low"]


### PR DESCRIPTION
## Summary

This PR hardens api-slim startup and reranking against local model initialization failures.

Previously, failures or hangs while loading local embedding/cross-encoder models could abort or block daemon startup. In Hermes integration, this can leave the client waiting on memory operations indefinitely.

This change adds per-task initialization timeouts, separates fatal infrastructure/config validation from optional model initialization, and lets cross-encoder reranking fall back to RRF-based scoring when initialization or prediction fails.

## Changes

- Add per-task timeout for startup model initialization via `HINDSIGHT_MODEL_INIT_TIMEOUT`.
- Treat pg0 startup and LLM batch API config validation as fatal initialization tasks.
- Treat embeddings, query analyzer, and cross-encoder initialization as degradable startup tasks.
- Track embedding and reranker initialization state.
- Skip embedding dimension migration when embeddings are unavailable.
- Add lazy cross-encoder initialization timeout/error handling.
- Add RRF-based reranking fallback when cross-encoder initialization or prediction fails.
- Add regression tests for reranker fallback behavior.

## Testing

```bash
uv run --extra test pytest tests/test_cross_encoder_reranker_fallback.py
```



Related to NousResearch/hermes-agent#35195.

This PR addresses one Hindsight-side failure mode where local embedding or cross-encoder model initialization can fail or hang, leaving Hermes waiting on post-response memory operations.
