### PR TITLE
fix(embed): launch Windows daemon via pythonw to stop ConPTY terminal tab

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -11,6 +11,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 import sysconfig
 import time
 from pathlib import Path
@@ -157,12 +158,40 @@ class DaemonEmbedManager(EmbedManager):
         except Exception:
             return False
 
-    def _find_api_command(self) -> list[str]:
-        """Find the command to run hindsight-api."""
-        # Check if we're in development mode
+    def _dev_api_command(self) -> list[str] | None:
+        """Return the dev-mode launch command when running inside the monorepo."""
         dev_api_path = Path(__file__).parent.parent.parent / "hindsight-api-slim"
         if dev_api_path.exists() and (dev_api_path / "pyproject.toml").exists():
             return ["uv", "run", "--project", str(dev_api_path), "--extra", "all", "hindsight-api"]
+        return None
+
+    @staticmethod
+    def _windows_gui_interpreter() -> str | None:
+        """Path to the GUI-subsystem Python (pythonw.exe), or None.
+
+        Returns None on non-Windows, or when pythonw.exe can't be located next
+        to the running interpreter.
+
+        On Windows 11 with Windows Terminal as the default terminal app,
+        spawning the console-subsystem (CUI, subsystem 3) hindsight-api.exe
+        launcher makes ConPTY pop a visible terminal tab on daemon start, even
+        with DETACHED_PROCESS / CREATE_NO_WINDOW (issue #1885). Launching the
+        daemon through the GUI-subsystem (subsystem 2) pythonw.exe interpreter
+        never allocates a console, so no window appears. pythonw.exe sits next
+        to sys.executable, whose environment is the one we just confirmed has
+        hindsight-api installed, so `pythonw.exe -m hindsight_api.main` resolves.
+        """
+        if platform.system() != "Windows":
+            return None
+        pythonw = Path(sys.executable).with_name("pythonw.exe")
+        return str(pythonw) if pythonw.exists() else None
+
+    def _find_api_command(self) -> list[str]:
+        """Find the command to run hindsight-api."""
+        # Check if we're in development mode
+        dev_command = self._dev_api_command()
+        if dev_command is not None:
+            return dev_command
 
         # Prefer a hindsight-api entry point installed alongside hindsight-embed.
         # Try two strategies:
@@ -177,9 +206,18 @@ class DaemonEmbedManager(EmbedManager):
         scripts_dir = Path(sysconfig.get_path("scripts"))
         candidate = scripts_dir / binary_name
         if candidate.exists():
+            # The console exe lives in sys.executable's scripts dir, so
+            # hindsight_api is importable by the GUI interpreter; prefer it on
+            # Windows to avoid ConPTY popping a terminal tab (issue #1885).
+            gui_python = self._windows_gui_interpreter()
+            if gui_python is not None:
+                return [gui_python, "-m", "hindsight_api.main"]
             return [str(candidate)]
 
-        # --target installs place binaries alongside site-packages contents
+        # --target installs place binaries alongside site-packages contents.
+        # The running interpreter usually can't import hindsight_api here (it's
+        # under the --target dir, not on sys.path), so we can't substitute
+        # pythonw.exe; run the console exe directly.
         package_root = Path(__file__).parent.parent
         for bin_dir in ("bin", "Scripts"):
             candidate = package_root / bin_dir / binary_name

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -194,16 +194,52 @@ def test_find_api_command_falls_back_to_uvx_when_no_binary(tmp_path, monkeypatch
 
 
 def test_find_api_command_windows_uses_exe_suffix(tmp_path, monkeypatch):
-    """On Windows, the installed binary has a .exe suffix."""
+    """On Windows, the installed console binary has a .exe suffix.
+
+    Pin sys.executable to an interpreter dir without a pythonw.exe sibling so the
+    GUI-interpreter swap (issue #1885) is skipped and we deterministically
+    exercise the console-exe fallback — the path that proves .exe-suffix
+    resolution. The pythonw swap itself is covered below and in
+    test_profile_daemon_config.py.
+    """
     scripts_dir = tmp_path / "Scripts"
     scripts_dir.mkdir()
     api_binary = scripts_dir / "hindsight-api.exe"
     api_binary.touch()
+    interp_dir = tmp_path / "interp"
+    interp_dir.mkdir()
+    (interp_dir / "python.exe").touch()  # deliberately no pythonw.exe sibling
 
     manager = DaemonEmbedManager()
     # Point __file__ away from monorepo so dev-mode check doesn't trigger
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(interp_dir / "python.exe"))
 
     assert manager._find_api_command() == [str(api_binary)]
+
+
+def test_find_api_command_windows_prefers_gui_interpreter(tmp_path, monkeypatch):
+    """On Windows, launch via pythonw.exe instead of the console exe (issue #1885).
+
+    The console-subsystem hindsight-api.exe makes Windows Terminal's ConPTY pop a
+    visible tab on daemon start; the GUI-subsystem pythonw.exe never allocates a
+    console. When pythonw.exe sits next to sys.executable, _find_api_command must
+    return `pythonw.exe -m hindsight_api.main`.
+    """
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "hindsight-api.exe").touch()
+    (scripts_dir / "python.exe").touch()
+    pythonw = scripts_dir / "pythonw.exe"
+    pythonw.touch()
+
+    manager = DaemonEmbedManager()
+    # Point __file__ away from monorepo so dev-mode check doesn't trigger
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(scripts_dir / "python.exe"))
+
+    assert manager._find_api_command() == [str(pythonw), "-m", "hindsight_api.main"]

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -572,3 +572,95 @@ def test_configure_from_env_accepts_providers_outside_interactive_menu(temp_home
 
     contents = (config_dir / "embed").read_text()
     assert "HINDSIGHT_API_LLM_PROVIDER=anthropic" in contents
+
+
+def _windows_scripts_dir(tmp_path: Path, *, with_pythonw: bool) -> Path:
+    """Build a fake Windows venv Scripts dir with hindsight-api.exe.
+
+    The dir holds hindsight-api.exe and python.exe; when ``with_pythonw`` is
+    True the GUI-subsystem interpreter (pythonw.exe) is created next to
+    python.exe so `_windows_gui_interpreter()` can find it.
+    """
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "hindsight-api.exe").write_bytes(b"MZ")
+    (scripts_dir / "python.exe").write_bytes(b"MZ")
+    if with_pythonw:
+        (scripts_dir / "pythonw.exe").write_bytes(b"MZ")
+    return scripts_dir
+
+
+def test_windows_daemon_launches_via_gui_interpreter(temp_home, tmp_path, monkeypatch):
+    """Regression test for issue #1885.
+
+    On Windows the daemon must be launched through the GUI-subsystem
+    pythonw.exe (`pythonw.exe -m hindsight_api.main`) rather than the
+    console-subsystem hindsight-api.exe wrapper. The CUI exe makes Windows
+    Terminal's ConPTY pop a visible terminal tab on every daemon start; the GUI
+    interpreter never allocates a console.
+    """
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    scripts_dir = _windows_scripts_dir(tmp_path, with_pythonw=True)
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(manager, "_dev_api_command", lambda: None)
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.sysconfig.get_path",
+        lambda name: str(scripts_dir),
+    )
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.sys.executable",
+        str(scripts_dir / "python.exe"),
+    )
+
+    cmd = manager._find_api_command()
+    assert cmd == [str(scripts_dir / "pythonw.exe"), "-m", "hindsight_api.main"]
+
+
+def test_windows_daemon_falls_back_to_console_exe_without_pythonw(temp_home, tmp_path, monkeypatch):
+    """When pythonw.exe is missing the daemon still launches via the console exe.
+
+    The GUI-interpreter swap is best-effort: an exotic install without
+    pythonw.exe must not break daemon startup, only forgo the no-window benefit.
+    """
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    scripts_dir = _windows_scripts_dir(tmp_path, with_pythonw=False)
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(manager, "_dev_api_command", lambda: None)
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.sysconfig.get_path",
+        lambda name: str(scripts_dir),
+    )
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.sys.executable",
+        str(scripts_dir / "python.exe"),
+    )
+
+    cmd = manager._find_api_command()
+    assert cmd == [str(scripts_dir / "hindsight-api.exe")]
+
+
+def test_posix_daemon_uses_console_entrypoint(temp_home, tmp_path, monkeypatch):
+    """On POSIX there's no pythonw substitution — run the console entry point."""
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    scripts_dir = tmp_path / "bin"
+    scripts_dir.mkdir()
+    console_bin = scripts_dir / "hindsight-api"
+    console_bin.write_text("#!/usr/bin/env python\n")
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(manager, "_dev_api_command", lambda: None)
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.sysconfig.get_path",
+        lambda name: str(scripts_dir),
+    )
+
+    cmd = manager._find_api_command()
+    assert cmd == [str(console_bin)]


### PR DESCRIPTION
## Problem

On Windows 11 with Windows Terminal set as the default terminal app, starting the embedded daemon pops a **visible Windows Terminal tab** (fixes #1885).

Root cause (confirmed by the issue): the daemon is launched via `hindsight-api.exe`, a pip console-script wrapper compiled as **console-subsystem (CUI, subsystem 3)**. ConPTY/Windows Terminal hijacks such processes even when spawned with `DETACHED_PROCESS` — and `CREATE_NO_WINDOW` is *ignored* when combined with `DETACHED_PROCESS`, so it can't suppress the tab either.

The issue's proposed `--noconsole`/PyInstaller fix doesn't apply here (this repo has no PyInstaller build — the `.exe` is a pip-generated console script), but the underlying conclusion is right: run a **GUI-subsystem** process.

## Fix

When resolving the daemon launch command on Windows, launch through the **GUI-subsystem interpreter** `pythonw.exe -m hindsight_api.main` instead of the console `hindsight-api.exe`. `pythonw.exe` (subsystem 2) never allocates a console, so ConPTY has nothing to hijack — no window appears.

- `pythonw.exe` is resolved next to `sys.executable`, whose environment is the one we just confirmed contains `hindsight-api` (the console exe was found in its scripts dir), so the `-m hindsight_api.main` import always resolves.
- Falls back to the console exe when `pythonw.exe` is missing — best-effort, never breaks startup.
- Only applied to the standard pip/venv install path. `--target` installs and the `uvx` fallback keep the console exe (their interpreter can't import `hindsight_api` without extra path wiring).
- Extracted `_dev_api_command()` and added `_windows_gui_interpreter()` for clarity/testability.

## Tests

Added 3 regression tests to `test_profile_daemon_config.py`:
- Windows + `pythonw.exe` present → uses GUI interpreter
- Windows without `pythonw.exe` → console-exe fallback
- POSIX → console entry point unchanged

Full embed suite passes (84 tests), lint + project lint hook green, `/code-review` clean.

## Caveat

Verified by reasoning + unit tests, not a live Windows run (no Windows host available here). A manual smoke test on the reporter's setup would be the final confirmation.
