### PR TITLE
fix(api): robust retain/recall on special-token literals and lone surrogates

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -114,7 +114,7 @@ def _semaphores_for_scope(scope: str) -> list[asyncio.Semaphore]:
     return [per_op, _global_llm_semaphore]
 
 
-def sanitize_llm_output(text: str | None) -> str | None:
+def sanitize_text(text: str | None) -> str | None:
     """
     Sanitize text by removing characters that break downstream systems.
 
@@ -126,14 +126,23 @@ def sanitize_llm_output(text: str | None) -> str | None:
 
     Surrogate characters are used in UTF-16 encoding but cannot be encoded
     in UTF-8. They can appear in Python strings from improperly decoded data
-    (e.g., from JavaScript or broken files). Control characters commonly appear
-    in LLM output embedded inside JSON string values.
+    (e.g., from JavaScript or broken files): a client may serialize a half-emoji
+    split at a boundary as a lone ``\\udXXX`` escape. Such input crashes the
+    SentenceTransformers/cross-encoder Rust tokenizers and stdout logging, so
+    user content is sanitized at the retain/recall/reflect ingress (see issue
+    #1875). Control characters commonly appear in LLM output embedded inside
+    JSON string values.
     """
     if text is None:
         return None
     if not text:
         return text
     return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\ud800-\udfff]", "", text)
+
+
+# Back-compat alias: this helper was originally introduced to scrub LLM *output*;
+# it now also scrubs user *input* at ingress, hence the broader name.
+sanitize_llm_output = sanitize_text
 
 
 class OutputTooLongError(Exception):

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import asyncpg
 import httpx
-import tiktoken
 
 from .._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ..config import (
@@ -221,7 +220,7 @@ from enum import Enum
 from ..metrics import get_metrics_collector
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
-from .llm_wrapper import LLMConfig, requires_api_key, sanitize_llm_output
+from .llm_wrapper import LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
 from .query_analyzer import QueryAnalyzer
 from .reflect import run_reflect_agent
 from .reflect.prompts import DELTA_SYSTEM_PROMPT, build_delta_prompt
@@ -244,6 +243,7 @@ from .search import think_utils
 from .search.reranking import CrossEncoderReranker, apply_combined_scoring
 from .search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
 from .task_backend import TaskBackend
+from .token_encoding import get_token_encoding
 
 RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
 RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
@@ -521,16 +521,14 @@ logger = logging.getLogger(__name__)
 
 from .db_utils import acquire_with_retry
 
-# Cache tiktoken encoding for token budget filtering (module-level singleton)
-_TIKTOKEN_ENCODING = None
-
 
 def _get_tiktoken_encoding():
-    """Get cached tiktoken encoding (cl100k_base for GPT-4/3.5)."""
-    global _TIKTOKEN_ENCODING
-    if _TIKTOKEN_ENCODING is None:
-        _TIKTOKEN_ENCODING = tiktoken.get_encoding("cl100k_base")
-    return _TIKTOKEN_ENCODING
+    """Get cached tiktoken encoding (cl100k_base for GPT-4/3.5).
+
+    Returns a wrapper that tolerates special-token literals in user content
+    (see hindsight_api.engine.token_encoding).
+    """
+    return get_token_encoding()
 
 
 @dataclass(frozen=True)
@@ -2723,6 +2721,15 @@ class MemoryEngine(MemoryEngineInterface):
         # those mutations leak back to the caller's dicts.
         contents = cast(list[RetainContentDict], [dict(c) for c in contents])
 
+        # Sanitize content/context at ingress so lone UTF-16 surrogates (e.g. a
+        # half-emoji a client serialized as a `\udXXX` escape) cannot crash the
+        # embedder, cross-encoder, or logging with an HTTP 500 (see issue #1875).
+        for item in contents:
+            if "content" in item:
+                item["content"] = sanitize_text(item["content"]) or ""
+            if item.get("context"):
+                item["context"] = sanitize_text(item["context"]) or ""
+
         # Apply batch-level document_id to contents that don't have their own (backwards compatibility)
         if document_id:
             for item in contents:
@@ -3090,6 +3097,12 @@ class MemoryEngine(MemoryEngineInterface):
         """
         # Authenticate tenant and set schema in context (for fq_table())
         await self._authenticate_tenant(request_context)
+
+        # Sanitize the query at ingress: a client may serialize a half-emoji as a
+        # lone UTF-16 surrogate, which crashes downstream logging, the embedder, and
+        # the cross-encoder tokenizer with an HTTP 500 (see issue #1875). Cleaning it
+        # here protects every sink that the query flows into.
+        query = sanitize_text(query) or ""
 
         # Default to all fact types if not specified
         if fact_type is None:
@@ -6472,6 +6485,11 @@ class MemoryEngine(MemoryEngineInterface):
                 - based_on: Empty dict (agent retrieves facts dynamically)
                 - structured_output: None (not yet supported for agentic reflect)
         """
+        # Sanitize at ingress so lone UTF-16 surrogates in the question/context cannot
+        # crash logging, recall's embedder, or the reflect LLM call (see issue #1875).
+        query = sanitize_text(query) or ""
+        context = sanitize_text(context)
+
         # Use cached LLM config
         if self._reflect_llm_config is None:
             raise ValueError("Memory LLM API key not set. Set HINDSIGHT_API_LLM_API_KEY environment variable.")

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tokenization.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tokenization.py
@@ -1,17 +1,8 @@
 """Token counting helpers for reflect prompts and agent control flow."""
 
-from functools import lru_cache
-
-import tiktoken
-
-
-@lru_cache(maxsize=1)
-def _get_cl100k_base_encoding() -> tiktoken.Encoding:
-    # tiktoken downloads this encoding on first lookup when it is not cached.
-    # Keep the lookup lazy so importing hindsight_api does not depend on network access.
-    return tiktoken.get_encoding("cl100k_base")
+from ..token_encoding import count_tokens as _count_tokens
 
 
 def count_cl100k_tokens(text: str) -> int:
     """Return the number of cl100k_base tokens in text."""
-    return len(_get_cl100k_base_encoding().encode(text))
+    return _count_tokens(text)

--- a/hindsight-api-slim/hindsight_api/engine/token_encoding.py
+++ b/hindsight-api-slim/hindsight_api/engine/token_encoding.py
@@ -1,0 +1,46 @@
+"""Shared tiktoken encoding used for token counting and chunking.
+
+Hindsight uses tiktoken purely to *count* and *chunk* arbitrary user content — never
+to feed a model that relies on tiktoken's special-token vocabulary. With tiktoken's
+default ``disallowed_special="all"``, any content that merely *mentions* a special-token
+literal (e.g. ``<|endoftext|>``) makes ``encode()`` raise, which surfaces as an HTTP 500
+on retain/recall (see issue #1883).
+
+``_SafeEncoding`` disables that check so such literals are counted as ordinary text. Token
+counts are unaffected; this only stops the encoder from rejecting valid input. Every token
+call site in the engine routes through ``get_token_encoding()``, so the fix is global.
+"""
+
+from functools import lru_cache
+
+import tiktoken
+
+
+class _SafeEncoding:
+    """Wraps a tiktoken ``Encoding`` so ``encode()`` never raises on special-token literals."""
+
+    def __init__(self, encoding: tiktoken.Encoding) -> None:
+        self._encoding = encoding
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        # Count special-token literals as ordinary text instead of rejecting them.
+        kwargs.setdefault("disallowed_special", ())
+        return self._encoding.encode(text, **kwargs)
+
+    def decode(self, tokens: list[int]) -> str:
+        return self._encoding.decode(tokens)
+
+
+@lru_cache(maxsize=1)
+def get_token_encoding() -> _SafeEncoding:
+    """Cached cl100k_base encoding (GPT-4/3.5) wrapped to tolerate special-token literals.
+
+    tiktoken downloads the encoding on first lookup; keeping it lazy means importing
+    ``hindsight_api`` does not require network access.
+    """
+    return _SafeEncoding(tiktoken.get_encoding("cl100k_base"))
+
+
+def count_tokens(text: str) -> int:
+    """Count cl100k_base tokens in ``text`` (tolerant of special-token literals)."""
+    return len(get_token_encoding().encode(text))

--- a/hindsight-api-slim/tests/test_input_robustness.py
+++ b/hindsight-api-slim/tests/test_input_robustness.py
@@ -1,0 +1,113 @@
+"""Input-robustness regression tests.
+
+Covers the "server 500s on unusual-but-valid input" class:
+- #1883: content containing tiktoken special-token literals (e.g. ``<|endoftext|>``).
+- #1875: queries/content containing an unpaired UTF-16 surrogate (e.g. a half-emoji).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.llm_wrapper import sanitize_llm_output, sanitize_text
+from hindsight_api.engine.reflect.tokenization import count_cl100k_tokens
+from hindsight_api.engine.token_encoding import count_tokens, get_token_encoding
+
+# A lone high surrogate — valid in a Python str, but rejected by the Rust
+# tokenizers behind the local embedder / cross-encoder and uncodable to UTF-8.
+LONE_SURROGATE = "deploy the \ud83d service"
+SPECIAL_TOKEN_TEXT = "The fix was to sanitize the <|endoftext|> token before sending."
+
+
+# --- Prong A: tiktoken tolerates special-token literals (#1883) ------------------
+
+
+def test_count_tokens_handles_special_token_literal():
+    # Default tiktoken disallowed_special="all" would raise ValueError here.
+    assert count_tokens(SPECIAL_TOKEN_TEXT) > 0
+    assert count_cl100k_tokens(SPECIAL_TOKEN_TEXT) > 0
+
+
+def test_encode_decode_roundtrip_with_special_token():
+    enc = get_token_encoding()
+    tokens = enc.encode(SPECIAL_TOKEN_TEXT)
+    assert enc.decode(tokens) == SPECIAL_TOKEN_TEXT
+
+
+def test_special_token_counted_as_ordinary_text():
+    # The literal is split into ordinary tokens, not collapsed into one special id.
+    assert count_tokens("<|endoftext|>") > 1
+
+
+# --- Prong B: surrogate / control-char sanitization (#1875) ----------------------
+
+
+def test_sanitize_strips_lone_surrogate():
+    cleaned = sanitize_text(LONE_SURROGATE)
+    assert cleaned == "deploy the  service"
+    assert cleaned.encode("utf-8")  # no longer raises
+
+
+def test_sanitize_preserves_valid_text_and_paired_emoji():
+    text = "café 🎉\tindented\nnewline"
+    assert sanitize_text(text) == text
+
+
+def test_sanitize_strips_control_chars_but_keeps_whitespace():
+    assert sanitize_text("a\x00b\x07c") == "abc"
+    assert sanitize_text("a\tb\nc\rd") == "a\tb\nc\rd"
+
+
+def test_sanitize_none_and_empty():
+    assert sanitize_text(None) is None
+    assert sanitize_text("") == ""
+
+
+def test_sanitize_llm_output_is_alias():
+    assert sanitize_llm_output is sanitize_text
+
+
+# --- Integration: full pipeline survives both inputs -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_retain_with_special_token_literal(memory, request_context):
+    """Retaining content that mentions ``<|endoftext|>`` must not 500 (#1883)."""
+    bank_id = f"test_special_token_{datetime.now(timezone.utc).timestamp()}"
+    unit_ids = await memory.retain_async(
+        bank_id=bank_id,
+        content=SPECIAL_TOKEN_TEXT,
+        context="debugging tokenizers",
+        request_context=request_context,
+    )
+    assert isinstance(unit_ids, list)
+
+
+@pytest.mark.asyncio
+async def test_recall_with_lone_surrogate_query(memory, request_context):
+    """A recall query with an unpaired surrogate must not crash the embedder (#1875)."""
+    bank_id = f"test_surrogate_{datetime.now(timezone.utc).timestamp()}"
+    await memory.retain_async(
+        bank_id=bank_id,
+        content="The deploy service ships releases.",
+        request_context=request_context,
+    )
+    # Without ingress sanitization the local ST embedder raises TextEncodeInput.
+    result = await memory.recall_async(
+        bank_id=bank_id,
+        query=LONE_SURROGATE,
+        request_context=request_context,
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_retain_with_lone_surrogate_content(memory, request_context):
+    """Retaining content with an unpaired surrogate must not 500 (#1875)."""
+    bank_id = f"test_surrogate_retain_{datetime.now(timezone.utc).timestamp()}"
+    unit_ids = await memory.retain_async(
+        bank_id=bank_id,
+        content="A half emoji \ud83d slipped into the transcript.",
+        request_context=request_context,
+    )
+    assert isinstance(unit_ids, list)

--- a/hindsight-api-slim/tests/test_reflect_tiktoken_lazy_load.py
+++ b/hindsight-api-slim/tests/test_reflect_tiktoken_lazy_load.py
@@ -7,6 +7,9 @@ def _drop_reflect_modules() -> None:
     for name in list(sys.modules):
         if name == "hindsight_api.engine.reflect" or name.startswith("hindsight_api.engine.reflect."):
             sys.modules.pop(name)
+    # The cl100k encoding is cached in engine.token_encoding; drop it too so the
+    # fresh reimport starts with an empty cache and the tiktoken patch is observed.
+    sys.modules.pop("hindsight_api.engine.token_encoding", None)
 
 
 def test_reflect_import_does_not_load_tiktoken_encoding():
@@ -22,7 +25,8 @@ def test_reflect_import_does_not_load_tiktoken_encoding():
 def test_reflect_token_counting_loads_tiktoken_encoding_when_used():
     _drop_reflect_modules()
     fake_encoding = MagicMock()
-    fake_encoding.encode.side_effect = lambda text: text.split()
+    # _SafeEncoding.encode passes disallowed_special=(); accept and ignore kwargs.
+    fake_encoding.encode.side_effect = lambda text, **kwargs: text.split()
 
     with patch("tiktoken.get_encoding", return_value=fake_encoding) as get_encoding:
         agent = importlib.import_module("hindsight_api.engine.reflect.agent")

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -316,7 +316,7 @@ done
 
 ## Worker tuning
 
-Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, default 10) shared across all operation types. Per-type slot reservations (`HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS`) carve out guaranteed capacity within that budget; remaining slots form a shared pool any type can use. See [Configuration → Worker Configuration](../configuration#worker-configuration) for the full table.
+Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, default 10) shared across all operation types. Per-type slot reservations (`HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS`) carve out guaranteed capacity within that budget; remaining slots form a shared pool any type can use. See [Configuration → Worker Configuration](../configuration#distributed-workers) for the full table.
 
 For most deployments the defaults are fine. Reserve slots for an operation type if you've seen it starved by a flood of another type (e.g., a long file_convert_retain blocking graph_maintenance on a deletion-heavy workload).
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1481,12 +1481,16 @@ The Control Plane is the web UI for managing memory banks.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
+| `HINDSIGHT_CP_DATAPLANE_API_KEY` | Bearer token the Control Plane sends as `Authorization: Bearer <key>` on every request to the API service. Required when the API service is auth-protected; omit for a public API. | *(none — no `Authorization` header sent)* |
 | `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash
 # Point Control Plane to a remote API service
 export HINDSIGHT_CP_DATAPLANE_API_URL=http://api.example.com:8888
+
+# Authenticate to an auth-protected API service
+export HINDSIGHT_CP_DATAPLANE_API_KEY=my-dataplane-bearer-token
 
 # Protect the Control Plane with an access key
 export HINDSIGHT_CP_ACCESS_KEY=my-secret-key

--- a/skills/hindsight-docs/references/developer/retrieval.md
+++ b/skills/hindsight-docs/references/developer/retrieval.md
@@ -271,7 +271,7 @@ RRF gives a good initial ranking, but it's based on positions, not on deep query
 
 **Why rerank after RRF?** RRF is position-based — it knows a memory ranked well across strategies, but it never actually reads the query and the memory together. The cross-encoder does: it takes the query and each candidate as a pair and produces a relevance score based on their full interaction. This catches nuances that position-based fusion misses, like a memory that ranked #1 in keyword search because it matched a common term but is actually irrelevant to the query's intent.
 
-**Score normalization:** Cross-encoders output raw logits (which can be negative). These are normalized to [0, 1] using the sigmoid function:
+**Score normalization:** Cross-encoders output raw logits (which can be negative). Scores that already fall within [0, 1] — as returned by calibrated external API rerankers (e.g. Cohere, SiliconFlow, ZeroEntropy, Alibaba, Jina) — are passed through unchanged to preserve their absolute confidence. Raw logits outside [0, 1] are normalized to [0, 1] using the sigmoid function:
 
 ```
 CE_normalized = 1 / (1 + e^(-raw_logit))

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -198,7 +198,7 @@ hindsight bank disposition <bank_id>
 ### Set Disposition
 
 ```bash
-hindsight bank set-disposition <bank_id> --mission "..." --name "..."
+hindsight bank set-disposition <bank_id> --skepticism 3 --literalism 4 --empathy 5
 ```
 
 ### View Statistics


### PR DESCRIPTION
## Summary

Fixes two **input-robustness** bugs where the server returns **HTTP 500** on unusual-but-valid input. They're the same class but have *orthogonal* failure mechanisms (one regex can't cover both): tiktoken **raises** on special-token literals, whereas it **tolerates** surrogates and lets them crash downstream sinks — so the fix has two prongs.

Closes #1883. Closes #1875.

### Prong A — tiktoken special-token robustness (#1883)

Content that merely *mentions* a special-token literal (e.g. `<|endoftext|>`) makes `tiktoken.encode()` raise under the default `disallowed_special="all"`, 500ing retain/recall. Hindsight uses tiktoken only for **counting/chunking** arbitrary user text — never to feed a model that needs special-token semantics — so the check is always wrong here.

- New `engine/token_encoding.py` wraps the cl100k_base encoding in `_SafeEncoding`, which defaults `disallowed_special=()` (counts the literal as ordinary text; token counts unaffected).
- Both encoding factories (`memory_engine._get_tiktoken_encoding`, `reflect/tokenization`) route through it, so **every `.encode()` call site is fixed at once** and future ones are safe by default. Removed the now-dead duplicate singleton + `tiktoken` import.

### Prong B — surrogate/control-char sanitization (#1875)

A query/content containing an unpaired UTF-16 surrogate (a half-emoji a client serialized as a lone `\udXXX` escape) crashes the SentenceTransformers embedder, the cross-encoder reranker, and stdout logging.

- Renamed `sanitize_llm_output` → `sanitize_text` (back-compat alias kept) and applied it at the **engine ingress** — `recall_async` (query), `retain_batch_async` (content/context), `reflect_async` (query/context). Since HTTP and MCP both funnel through the engine, this single choke point protects logging, the embedder, the cross-encoder, and storage. Stripping (not `U+FFFD`) since a lone surrogate carries no semantic content.

## Tests

`tests/test_input_robustness.py` (11 tests): unit coverage for both prongs plus three integration tests that reproduce the exact filed reproducers through the **real local embedder + pg0** pipeline. Updated `test_reflect_tiktoken_lazy_load.py` for the relocated encoding cache.

Verified: lint ✓, `ty check` ✓, new tests ✓ (incl. real-embedder integration), existing token/sanitize tests ✓.