### PR TITLE
docs: drop removed `opinion`/`agent` fact_type from MCP/SDK/integration references

### DIFF
--- a/hindsight-docs/docs-integrations/ag2.md
+++ b/hindsight-docs/docs-integrations/ag2.md
@@ -166,7 +166,7 @@ for tool_fn in tools:
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any_strict/all_strict) |
 | `retain_metadata` | `None` | Metadata dict for retain operations |
 | `retain_document_id` | `None` | Document ID for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `max_tokens` | Max tokens for reflect results |

--- a/hindsight-docs/docs-integrations/autogen.md
+++ b/hindsight-docs/docs-integrations/autogen.md
@@ -194,7 +194,7 @@ shared_tools = create_hindsight_tools(
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any\_strict/all\_strict) |
 | `retain_metadata` | `None` | Default metadata dict for retain operations |
 | `retain_document_id` | `None` | Default document\_id for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `None` | Max tokens for reflect results (defaults to `max_tokens`) |

--- a/hindsight-docs/docs-integrations/langgraph.md
+++ b/hindsight-docs/docs-integrations/langgraph.md
@@ -249,7 +249,7 @@ recall = create_recall_node(
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any\_strict/all\_strict) |
 | `retain_metadata` | `None` | Default metadata dict for retain operations |
 | `retain_document_id` | `None` | Default document\_id for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `None` | Max tokens for reflect results (defaults to `max_tokens`) |

--- a/hindsight-docs/docs-integrations/litellm.md
+++ b/hindsight-docs/docs-integrations/litellm.md
@@ -107,7 +107,7 @@ hindsight_litellm.set_defaults(
 
     # Optional - Memory retrieval
     budget="mid",                  # Budget level: "low", "mid", "high"
-    fact_types=["world", "opinion"],  # Filter fact types to retrieve
+    fact_types=["world", "observation"],  # Filter fact types to retrieve
     max_memories=10,               # Maximum memories to inject (None = unlimited)
     max_memory_tokens=4096,        # Maximum tokens for memory context
     include_entities=True,         # Include entity observations in recall
@@ -159,7 +159,7 @@ hindsight_litellm.set_bank_mission(
 ```python
 # Recall mode - raw memories
 hindsight_litellm.set_defaults(bank_id="my-agent", use_reflect=False)
-# Injects: "1. [WORLD] User prefers Python\n2. [OPINION] User dislikes Java..."
+# Injects: "1. [WORLD] User prefers Python\n2. [OBSERVATION] User dislikes Java..."
 
 # Reflect mode - synthesized context
 hindsight_litellm.set_defaults(bank_id="my-agent", use_reflect=True)

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -185,7 +185,7 @@ Search memories to provide personalized responses.
 | `query` | string | Yes | Natural language search query |
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 | `budget` | string | No | Search thoroughness: `low`, `mid`, or `high` (default: `high`) |
-| `types` | list[string] | No | Filter by fact type: `world`, `experience`, `opinion`. Defaults to all |
+| `types` | list[string] | No | Filter by fact type: `world`, `experience`, `observation`. Defaults to all |
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
@@ -396,7 +396,7 @@ Browse stored memories with optional filtering and pagination.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `type` | string | No | Filter by fact type: `world`, `experience`, or `opinion` |
+| `type` | string | No | Filter by fact type: `world`, `experience`, or `observation` |
 | `q` | string | No | Search query to filter memories |
 | `limit` | integer | No | Maximum number of results (default: 100) |
 | `offset` | integer | No | Number of results to skip for pagination (default: 0) |
@@ -541,7 +541,7 @@ Clear all memories from a bank without deleting the bank itself. Optionally filt
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `type` | string | No | Fact type to clear: `world`, `experience`, or `opinion`. If not specified, clears all |
+| `type` | string | No | Fact type to clear: `world`, `experience`, or `observation`. If not specified, clears all |
 
 ---
 


### PR DESCRIPTION
The `opinion` fact_type was removed from the backend — `memory_units.fact_type` is now constrained to `world` / `experience` / `observation` (`hindsight-api-slim/hindsight_api/models.py` CheckConstraint). #1881 just corrected the Rust CLI help strings the same way, leaving these doc surfaces as the last place that still presents `opinion` (and the invalid `agent`) as a valid `fact_type` filter value — passing it now violates the CheckConstraint or returns empty recall.

- `docs/developer/mcp-server.md` — `recall` / `recall_facts` / `clear_memories` filter values: `opinion` → `observation`
- `docs-integrations/litellm.md` — `set_defaults(fact_types=...)` example + injected-output label
- `docs-integrations/{ag2,autogen,langgraph}.md` — `recall_types` table: drop the removed `opinion`

I left `cookbook/applications/openai-fitness-coach.md` out of scope: it uses the old `opinion`/`agent` types but woven through its narrative and `store_memory(type=...)` flow, so a clean fix there is a separate rewrite rather than a reference correction.
