### PR TITLE
fix(retain): offset chunk_index across sub-batches of an oversized document (#1888)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2791,6 +2791,21 @@ class MemoryEngine(MemoryEngineInterface):
             # multiple sub-batches, unit_ids from every chunk get
             # appended back into that input's result slot.
             per_input_results: list[list[str]] = [[] for _ in contents]
+
+            # Per-document chunk_index offsets. When an oversized single item is
+            # sliced into several sub-batches that all share one document_id and
+            # run sequentially, each sub-batch must continue the document's
+            # chunk_index sequence rather than restart at 0 — otherwise the
+            # derived chunk_id ({bank}_{doc}_{index}) collides and later
+            # sub-batches overwrite earlier chunks, leaving only one sub-batch's
+            # worth of chunks/memories (issue #1888). Counting uses the same
+            # bank-resolved, strategy-applied chunk size the orchestrator chunks
+            # with, so the offsets match the chunk_index values it assigns.
+            from .retain import fact_extraction
+
+            sub_chunk_size = await self._resolve_retain_chunk_size(bank_id, request_context, strategy)
+            chunk_offsets: dict[str, int] = {}
+
             for i, (sub_batch, sub_origins) in enumerate(zip(sub_batches, origin_indices), 1):
                 # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
                 if operation_id and not await self._check_op_alive(operation_id):
@@ -2805,6 +2820,14 @@ class MemoryEngine(MemoryEngineInterface):
                 logger.info(
                     f"Processing sub-batch {i}/{len(sub_batches)}: {len(sub_batch)} items, {sub_batch_tokens:,} tokens"
                 )
+
+                # Resolve the document this sub-batch writes to so we can offset
+                # its chunk_index past chunks already stored by earlier
+                # sub-batches of the same document. Only the oversized-single-item
+                # split shares a document_id across sub-batches; packed multi-item
+                # sub-batches carry distinct document_ids (offset stays 0).
+                sub_doc_id = document_id or (sub_batch[0].get("document_id") if len(sub_batch) == 1 else None)
+                sub_offset = chunk_offsets.get(sub_doc_id, 0) if sub_doc_id else 0
 
                 sub_results, sub_usage, sub_processed = await self._retain_batch_async_internal(
                     bank_id=bank_id,
@@ -2821,7 +2844,19 @@ class MemoryEngine(MemoryEngineInterface):
                     outbox_callback=outbox_callback if i == len(sub_batches) else None,
                     outbox_callback_factory=outbox_callback_factory if i == len(sub_batches) else None,
                     document_body_override=document_body_overrides[i - 1],
+                    chunk_index_offset=sub_offset,
                 )
+
+                # Advance the document's chunk_index cursor by the number of
+                # chunks this sub-batch produced (computed with the same chunk
+                # size the orchestrator uses), so the next sub-batch sharing the
+                # document continues the sequence.
+                if sub_doc_id:
+                    sub_chunk_count = sum(
+                        len(fact_extraction.chunk_text(item.get("content", "") or "", sub_chunk_size))
+                        for item in sub_batch
+                    )
+                    chunk_offsets[sub_doc_id] = sub_offset + sub_chunk_count
                 # sub_results aligns 1:1 with sub_batch items; map each
                 # back to its source input via origin_indices so callers
                 # iterating with ``zip(contents, results)`` still align.
@@ -2901,6 +2936,28 @@ class MemoryEngine(MemoryEngineInterface):
             return result, total_usage
         return result
 
+    async def _resolve_retain_chunk_size(
+        self,
+        bank_id: str,
+        request_context: "RequestContext",
+        strategy: str | None,
+    ) -> int:
+        """Resolve the effective ``retain_chunk_size`` for a bank.
+
+        Mirrors the bank-config + strategy resolution that
+        ``_retain_batch_async_internal`` applies before handing config to the
+        orchestrator, so chunk-count estimates used for per-document
+        chunk_index offsets match the chunk_index values the orchestrator
+        actually assigns.
+        """
+        from hindsight_api.config_resolver import apply_strategy
+
+        resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+        effective_strategy = strategy or resolved_config.retain_default_strategy
+        if effective_strategy:
+            resolved_config = apply_strategy(resolved_config, effective_strategy)
+        return getattr(resolved_config, "retain_chunk_size", 3000)
+
     async def _retain_batch_async_internal(
         self,
         bank_id: str,
@@ -2915,6 +2972,7 @@ class MemoryEngine(MemoryEngineInterface):
         outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
         strategy: str | None = None,
         document_body_override: str | None = None,
+        chunk_index_offset: int = 0,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.
@@ -2979,6 +3037,7 @@ class MemoryEngine(MemoryEngineInterface):
                 outbox_callback_factory=outbox_callback_factory,
                 db_semaphore=self._put_semaphore,
                 document_body_override=document_body_override,
+                chunk_index_offset=chunk_index_offset,
             )
 
     def recall(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2801,10 +2801,33 @@ class MemoryEngine(MemoryEngineInterface):
             # worth of chunks/memories (issue #1888). Counting uses the same
             # bank-resolved, strategy-applied chunk size the orchestrator chunks
             # with, so the offsets match the chunk_index values it assigns.
-            from .retain import fact_extraction
+            from .retain import fact_extraction, fact_storage
 
             sub_chunk_size = await self._resolve_retain_chunk_size(bank_id, request_context, strategy)
             chunk_offsets: dict[str, int] = {}
+
+            # In update_mode="append", retain_batch prepends the existing document
+            # body to the FIRST sub-batch as an extra content item before chunking
+            # (see orchestrator.retain_batch), consuming chunks(existing_body)
+            # additional chunk_index slots ahead of that sub-batch's own content.
+            # Capture that chunk count per document up front — the first sub-batch
+            # overwrites documents.original_text when it commits, so it can't be
+            # read back afterwards — and fold it into the offset so later
+            # sub-batches continue past the prepended chunks instead of colliding.
+            append_prepend_chunks: dict[str, int] = {}
+            backend = await self._get_backend()
+            append_doc_ids: set[str] = set()
+            for item in contents:
+                item_doc_id = item.get("document_id")
+                if item.get("update_mode") == "append" and item_doc_id:
+                    append_doc_ids.add(item_doc_id)
+            for append_doc_id in append_doc_ids:
+                async with acquire_with_retry(backend) as conn:
+                    existing_text = await fact_storage.get_document_content(conn, bank_id, append_doc_id)
+                if existing_text:
+                    append_prepend_chunks[append_doc_id] = len(
+                        fact_extraction.chunk_text(existing_text, sub_chunk_size)
+                    )
 
             for i, (sub_batch, sub_origins) in enumerate(zip(sub_batches, origin_indices), 1):
                 # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
@@ -2856,6 +2879,11 @@ class MemoryEngine(MemoryEngineInterface):
                         len(fact_extraction.chunk_text(item.get("content", "") or "", sub_chunk_size))
                         for item in sub_batch
                     )
+                    # retain_batch only prepends the existing body on the global
+                    # first sub-batch (is_first_batch == i == 1), so fold its chunk
+                    # count in only there.
+                    if i == 1:
+                        sub_chunk_count += append_prepend_chunks.get(sub_doc_id, 0)
                     chunk_offsets[sub_doc_id] = sub_offset + sub_chunk_count
                 # sub_results aligns 1:1 with sub_batch items; map each
                 # back to its source input via origin_indices so callers

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -403,6 +403,7 @@ async def retain_batch(
     outbox_callback_factory: RetainOutboxCallbackFactory | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
     document_body_override: str | None = None,
+    chunk_index_offset: int = 0,
 ) -> tuple[list[list[str]], TokenUsage, int | None]:
     """
     Process a batch of content through the retain pipeline.
@@ -410,6 +411,14 @@ async def retain_batch(
     Supports delta retain: when upserting a document that already has chunks,
     only re-processes chunks whose content has changed. Unchanged chunks keep
     their existing facts, entities, and links.
+
+    ``chunk_index_offset`` shifts the chunk_index (and therefore the derived
+    ``chunk_id = {bank}_{doc}_{index}``) of every chunk this call stores. The
+    in-process splitter slices an oversized single item into several
+    sub-batches that all share one document_id and run sequentially; without
+    a per-document offset each sub-batch would restart chunk_index at 0, so
+    their chunk_ids collide and later sub-batches overwrite earlier chunks —
+    leaving only one sub-batch's worth of chunks/memories behind (issue #1888).
 
     Returns a three-tuple of:
       * per-content-item unit ID lists
@@ -482,6 +491,7 @@ async def retain_batch(
                     outbox_callback_factory=outbox_callback_factory,
                     db_semaphore=db_semaphore,
                     document_body_override=document_body_override,
+                    chunk_index_offset=chunk_index_offset,
                 )
                 for group_idx, orig_idx in enumerate(original_indices[doc_key]):
                     if group_idx < len(group_ids):
@@ -681,6 +691,7 @@ async def retain_batch(
         outbox_callback=outbox_callback,
         db_semaphore=db_semaphore,
         document_body_override=document_body_override,
+        chunk_index_offset=chunk_index_offset,
     )
 
 
@@ -819,6 +830,7 @@ async def _streaming_retain_batch(
     outbox_callback: Callable[["asyncpg.Connection"], Awaitable[None]] | None = None,
     db_semaphore: "asyncio.Semaphore | None" = None,
     document_body_override: str | None = None,
+    chunk_index_offset: int = 0,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -1040,14 +1052,20 @@ async def _streaming_retain_batch(
             # Adjust chunk indices to use the original global position (global_idx)
             # so that chunk_id = {bank}_{doc}_{chunk_index} is deterministic regardless
             # of task completion order. content_index is batch-relative for result grouping.
+            #
+            # chunk_index_offset continues the document's chunk_index sequence
+            # when this call is one of several sequential sub-batches sliced
+            # from a single oversized item sharing one document_id — without it
+            # each sub-batch restarts at 0 and their chunk_ids collide (#1888).
+            doc_chunk_index = global_idx + chunk_index_offset
             for fact in extracted:
                 fact.content_index = content_idx_in_batch
                 if fact.chunk_index is not None:
-                    fact.chunk_index = global_idx
+                    fact.chunk_index = doc_chunk_index
             for pf in processed:
                 pf.content_index = content_idx_in_batch
             for cm in chunk_meta:
-                cm.chunk_index = global_idx
+                cm.chunk_index = doc_chunk_index
 
             batch_contents.append(content)
             batch_extracted.extend(extracted)

--- a/hindsight-api-slim/tests/test_subbatch_chunk_coverage.py
+++ b/hindsight-api-slim/tests/test_subbatch_chunk_coverage.py
@@ -1,0 +1,126 @@
+"""
+Regression tests for https://github.com/vectorize-io/hindsight/issues/1888
+
+Follow-up to #1838 / #1855. #1855 made same-document_id large retains store the
+full body in ``documents.original_text``, but fact extraction / chunking still
+only covered the FIRST sub-batch: when ``retain_batch_async`` slices an oversized
+single item into multiple sub-batches that share one ``document_id``, each
+sub-batch re-chunked its slice starting at ``chunk_index`` 0, so the derived
+``chunk_id = {bank}_{doc}_{index}`` collided and later sub-batches overwrote
+earlier chunks. ``Σ chunk_text`` ended up equal to a single sub-batch while
+``original_text`` held the whole body — the two disagreed.
+
+These tests trip the auto-split path by lowering
+``HINDSIGHT_API_RETAIN_BATCH_TOKENS`` and assert chunk coverage spans the whole
+document body.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@pytest.fixture(autouse=True)
+def _fast_split_env(monkeypatch):
+    # Small batch-token budget so a modest body trips the sub-batch splitter,
+    # and skip consolidation/observations so the test stays fast.
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", "100")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def _make_body(turns: int = 40) -> str:
+    # Distinct lines so each sub-batch slice has unique text (no spurious
+    # content-hash dedup) and comfortably above the splitter threshold.
+    return "\n".join(
+        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november"
+        for i in range(turns)
+    )
+
+
+async def _chunk_coverage(memory, bank_id, document_id, request_context):
+    doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+    assert doc is not None
+    original_len = len(doc["original_text"])
+    chunks = await memory.list_document_chunks(bank_id, document_id, limit=10000, request_context=request_context)
+    sum_chunk_text = sum(len(c["chunk_text"]) for c in chunks["items"])
+    indices = sorted(c["chunk_index"] for c in chunks["items"])
+    return original_len, sum_chunk_text, indices
+
+
+@pytest.mark.asyncio
+async def test_oversized_document_chunks_cover_full_body(memory, request_context):
+    """An oversized single-document retain must chunk/extract the ENTIRE body,
+    not just the first sub-batch (issue #1888)."""
+    bank_id = f"test_1888_{_ts()}"
+    document_id = "doc-1888"
+
+    try:
+        body = _make_body()
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=body,
+            context="big doc",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        original_len, sum_chunk_text, indices = await _chunk_coverage(memory, bank_id, document_id, request_context)
+
+        # Chunks must span (roughly) the whole body — small slack for chunk
+        # boundary whitespace handling.
+        assert sum_chunk_text >= original_len * 0.9, (
+            f"chunks cover only {sum_chunk_text}/{original_len} chars "
+            f"(~{100 * sum_chunk_text // original_len}%) — body after the first "
+            f"sub-batch was dropped (issue #1888)"
+        )
+        # chunk_index must be a contiguous 0..N-1 sequence (no collisions that
+        # collapse multiple sub-batches onto the same indices).
+        assert indices == list(range(len(indices))), (
+            f"chunk_index sequence is not contiguous: {indices} — sub-batches collided on chunk_id"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_replacement_chunks_cover_full_body(memory, request_context):
+    """Replacing an existing document with an oversized body must leave chunks
+    covering the full replacement, not a single sub-batch."""
+    bank_id = f"test_1888_replace_{_ts()}"
+    document_id = "doc-1888-replace"
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="[role: user] turn 0: seed",
+            context="seed",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        body = _make_body(50)
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=body,
+            context="regenerated",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        original_len, sum_chunk_text, indices = await _chunk_coverage(memory, bank_id, document_id, request_context)
+        assert sum_chunk_text >= original_len * 0.9, (
+            f"replacement chunks cover only {sum_chunk_text}/{original_len} chars"
+        )
+        assert indices == list(range(len(indices)))
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_subbatch_chunk_coverage.py
+++ b/hindsight-api-slim/tests/test_subbatch_chunk_coverage.py
@@ -124,3 +124,57 @@ async def test_oversized_replacement_chunks_cover_full_body(memory, request_cont
         assert indices == list(range(len(indices)))
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_append_chunks_cover_existing_plus_new(memory, request_context):
+    """Appending an oversized body to an existing document must keep chunks
+    covering BOTH the existing body and the full new content.
+
+    retain_batch prepends the existing body to the first sub-batch before
+    chunking, so without accounting for those prepended chunks in the
+    per-document offset, the second sub-batch collides with the first
+    sub-batch's tail and overwrites it (issue #1888, append variant)."""
+    bank_id = f"test_1888_append_{_ts()}"
+    document_id = "doc-1888-append"
+
+    try:
+        # Existing body spans several chunks so the prepended-chunk offset error
+        # corrupts a detectable fraction of the document (a 1-chunk existing body
+        # only collides by one slot, which slack thresholds would miss).
+        existing = _make_body(130)
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=existing,
+            context="seed",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        new_content = _make_body(40)
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": new_content,
+                    "context": "appended",
+                    "document_id": document_id,
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+
+        _, sum_chunk_text, indices = await _chunk_coverage(memory, bank_id, document_id, request_context)
+
+        # Chunks must cover the existing body plus the full appended content,
+        # not just one sub-batch of the new content.
+        expected = len(existing) + len(new_content)
+        assert sum_chunk_text >= expected * 0.85, (
+            f"append chunks cover only {sum_chunk_text}/{expected} chars (existing+new) "
+            f"— a sub-batch was overwritten (issue #1888, append variant)"
+        )
+        # No collisions: chunk_index values are unique.
+        assert len(indices) == len(set(indices)), f"duplicate chunk_index values: {indices}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

Closes #1888.

When `retain_batch_async` splits a single oversized item into multiple sub-batches (the in-process memory bound from #1571), all sub-batches share one `document_id` but each re-chunked its slice **starting at `chunk_index` 0**. Since `chunk_id = {bank}_{document_id}_{chunk_index}`, the sub-batches collided and `store_chunks_batch`'s `ON CONFLICT` upsert overwrote earlier chunks. Only one sub-batch's worth of chunks/memories survived.

This was masked by #1855, which made every sub-batch persist the full body to `documents.original_text`. The result: `original_text` held the whole document while `Σ chunk_text` equaled a single `RETAIN_BATCH_TOKENS` slice — the two disagreed, and most of the body produced no memories.

## Root cause

Two chunking layers with different sizes:
- `_split_contents_into_sub_batches` slices an oversized item by `RETAIN_BATCH_TOKENS`.
- `_streaming_retain_batch` then re-chunks each sub-batch by `retain_chunk_size`, numbering `chunk_index` from 0 **per sub-batch**.

Because the sub-batches share a `document_id`, their `chunk_id`s collided.

## Fix

Thread a per-document `chunk_index_offset` from the `retain_batch_async` sub-batch loop → `_retain_batch_async_internal` → `retain_batch` → `_streaming_retain_batch`. Each sequential sub-batch sharing a `document_id` now continues the document's `chunk_index` sequence instead of restarting at 0, so `chunk_id`s stay unique and every slice's chunks/memories are preserved.

The offset is advanced by counting chunks with the **same bank-resolved, strategy-applied `retain_chunk_size`** the orchestrator chunks with (new `_resolve_retain_chunk_size` helper), so the offsets line up with the `chunk_index` values the orchestrator assigns. Packed multi-item sub-batches carry distinct `document_id`s, so their offset stays 0 — only the oversized-single-item split is affected.

## Verification

Before/after on the new regression tests:
- **`main`:** `Σ chunk_text` = 217 / 4349 chars (~4%) → fail
- **this branch:** full-body coverage + contiguous `chunk_index` → pass

Suites run locally (serial, embedded PG):
- `test_subbatch_chunk_coverage.py` (new) — 2 passed
- `test_large_document_replacement.py` (#1855) + `test_batch_chunking.py` (#1571/#1795) — 16 passed
- `test_retain.py` — 49 passed (the 8 skipped/errored require `HINDSIGHT_API_LLM_API_KEY`; identical on `main`)
- `ruff check` / `ruff format` / `ty` clean on changed modules

## Known limitation

`update_mode="append"` on an oversized item split across sub-batches: sub-batch 1 prepends the existing body, so the recomputed offset undercounts its real chunk count and sub-batch 2 could partially collide. Still strictly better than the prior all-collide behavior; candidate for a follow-up.