### PR TITLE
fix(consolidation): make per-bank consolidation submit atomic + scope-aware (#1842)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -352,6 +352,10 @@ def _rewrite_pg_to_oracle(query: str) -> RewriteResult:
     # Boolean literals: Oracle uses NUMBER(1) for booleans
     query = re.sub(r"\b=\s*TRUE\b", "= 1", query, flags=re.IGNORECASE)
     query = re.sub(r"\b=\s*FALSE\b", "= 0", query, flags=re.IGNORECASE)
+    # FOR NO KEY UPDATE → FOR UPDATE (Oracle has only FOR UPDATE; it does not block
+    # indexed-FK child inserts the way PG's FOR UPDATE would, so plain FOR UPDATE is
+    # the correct equivalent). Must run before the FOR SHARE rule below.
+    query = re.sub(r"\bFOR\s+NO\s+KEY\s+UPDATE\b", "FOR UPDATE", query, flags=re.IGNORECASE)
     # FOR SHARE → FOR UPDATE (Oracle doesn't support FOR SHARE)
     query = re.sub(r"\bFOR\s+SHARE\b", "FOR UPDATE", query, flags=re.IGNORECASE)
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -9886,31 +9886,6 @@ class MemoryEngine(MemoryEngineInterface):
 
         backend = await self._get_backend()
 
-        # Check for existing pending task if deduplication is enabled
-        # Note: We only check 'pending', not 'processing', because a processing task
-        # uses a watermark from when it started - new memories added after that point
-        # would need another consolidation run to be processed.
-        if dedupe_by_bank:
-            async with acquire_with_retry(backend) as conn:
-                existing = await conn.fetchrow(
-                    f"""
-                    SELECT operation_id FROM {fq_table("async_operations")}
-                    WHERE bank_id = $1 AND operation_type = $2 AND status = 'pending'
-                    LIMIT 1
-                    """,
-                    bank_id,
-                    operation_type,
-                )
-                if existing:
-                    logger.debug(
-                        f"{operation_type} task already pending for bank_id={bank_id}, "
-                        f"skipping duplicate (existing operation_id={existing['operation_id']})"
-                    )
-                    return {
-                        "operation_id": str(existing["operation_id"]),
-                        "deduplicated": True,
-                    }
-
         operation_id = uuid.uuid4()
 
         # Build full payload before INSERT so task_payload is included atomically.
@@ -9924,20 +9899,73 @@ class MemoryEngine(MemoryEngineInterface):
             **task_payload,
         }
 
-        # Insert operation record with task_payload in a single atomic statement
         async with acquire_with_retry(backend) as conn:
-            await conn.execute(
-                f"""
-                INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
-                VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-                """,
-                operation_id,
-                bank_id,
-                operation_type,
-                json.dumps(result_metadata or {}, default=_json_default),
-                "pending",
-                json.dumps(full_payload, default=_json_default),
-            )
+            async with conn.transaction():
+                if dedupe_by_bank:
+                    # Serialize concurrent submits for this bank so the dedup
+                    # check-and-insert is atomic. A bare check-then-INSERT races
+                    # under READ COMMITTED: two /consolidate calls (or a manual
+                    # trigger racing a retain-driven submit / round-limit re-queue)
+                    # both see no pending row and both insert, leaking duplicate
+                    # pending ops that then pile up as retry_blocked and starve the
+                    # bank (issue #1842). Locking the bank row serializes submits for
+                    # this bank; it releases on commit below.
+                    #
+                    # FOR NO KEY UPDATE, not FOR UPDATE: async_operations has an FK to
+                    # banks, so every async-op insert for this bank (a scoped
+                    # consolidation, a batch-retain op, a webhook delivery, ...) takes a
+                    # FOR KEY SHARE lock on the bank row. FOR UPDATE conflicts with
+                    # FOR KEY SHARE and would block all of those during the submit;
+                    # FOR NO KEY UPDATE still conflicts with itself (so two submits
+                    # serialize) but not with FOR KEY SHARE (so those inserts proceed).
+                    # On Oracle this rewrites to FOR UPDATE, which there does not block
+                    # indexed-FK child inserts.
+                    await conn.execute(
+                        f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+                        bank_id,
+                    )
+                    # Only check 'pending', not 'processing': a processing task uses a
+                    # watermark from when it started, so memories added after that need
+                    # a fresh run regardless.
+                    pending = await conn.fetch(
+                        f"""
+                        SELECT operation_id, task_payload FROM {fq_table("async_operations")}
+                        WHERE bank_id = $1 AND operation_type = $2 AND status = 'pending'
+                        """,
+                        bank_id,
+                        operation_type,
+                    )
+                    # Dedup only against an existing *unscoped* (full-bank) pending op.
+                    # A pending scoped consolidation covers only its tag subset, so it
+                    # must not swallow a full-bank sweep (#1842). The scope check is in
+                    # Python because the JSON predicate isn't portable — Oracle's
+                    # JSON_VALUE returns NULL for the array-valued observation_scopes.
+                    # (Scoped submits never reach here: they pass dedupe_by_bank=False.)
+                    for row in pending:
+                        row_payload = row["task_payload"]
+                        row_dict = json.loads(row_payload) if isinstance(row_payload, str) else (row_payload or {})
+                        if row_dict.get("observation_scopes") is None:
+                            logger.debug(
+                                f"{operation_type} task already pending for bank_id={bank_id}, "
+                                f"skipping duplicate (existing operation_id={row['operation_id']})"
+                            )
+                            return {
+                                "operation_id": str(row["operation_id"]),
+                                "deduplicated": True,
+                            }
+
+                await conn.execute(
+                    f"""
+                    INSERT INTO {fq_table("async_operations")} (operation_id, bank_id, operation_type, result_metadata, status, task_payload)
+                    VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                    """,
+                    operation_id,
+                    bank_id,
+                    operation_type,
+                    json.dumps(result_metadata or {}, default=_json_default),
+                    "pending",
+                    json.dumps(full_payload, default=_json_default),
+                )
 
         # For SyncTaskBackend: executes the task immediately.
         # For BrokerTaskBackend: no-op (submit_task's UPDATE skips rows whose

--- a/hindsight-api-slim/tests/test_consolidation_submit_atomic_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_submit_atomic_dedup.py
@@ -1,0 +1,138 @@
+"""Regression tests for issue #1842: submitting consolidation is atomic per bank.
+
+`submit_async_consolidation` promises "at most one pending full-bank consolidation
+per bank", but the dedup was a check-then-INSERT that raced under READ COMMITTED —
+concurrent submits (a manual `/consolidate` loop racing retain-driven submits and
+the round-limit re-queue) each saw no pending row and each inserted, leaking
+duplicate pending ops that then piled up as `retry_blocked` and starved the bank.
+
+The submit now serializes per bank (SELECT ... FOR UPDATE on the bank row) so the
+check-and-insert is atomic. Scoped runs (`observation_scopes` set) are exempt and
+may have multiple pending ops.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def no_inline_execution(memory):
+    """Stop the SyncTaskBackend from executing submitted ops inline so the pending
+    rows survive for inspection (we're testing the submit/dedup path, not execution)."""
+
+    async def _noop(_payload):
+        return None
+
+    original = memory._task_backend.submit_task
+    memory._task_backend.submit_task = _noop
+    yield
+    memory._task_backend.submit_task = original
+
+
+async def _ensure_bank(pool, bank_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+async def _count_pending(pool, bank_id: str) -> int:
+    return await pool.fetchval(
+        """
+        SELECT COUNT(*) FROM async_operations
+        WHERE bank_id = $1 AND operation_type = 'consolidation' AND status = 'pending'
+        """,
+        bank_id,
+    )
+
+
+async def _cleanup(pool, bank_id: str) -> None:
+    await pool.execute("DELETE FROM async_operations WHERE bank_id = $1", bank_id)
+    await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_submits_leave_one_pending(memory, request_context, no_inline_execution):
+    """Five concurrent unscoped submits on a bank with no pending op must end with
+    exactly one pending row, and all calls must resolve to that one operation_id."""
+    bank_id = f"test-atomic-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        results = await asyncio.gather(
+            *(
+                memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+                for _ in range(5)
+            )
+        )
+        assert await _count_pending(pool, bank_id) == 1
+        op_ids = {r["operation_id"] for r in results}
+        assert len(op_ids) == 1, f"all submits should share one op, got {op_ids}"
+        # Exactly one call created the op; the other four were deduplicated.
+        assert sum(1 for r in results if r.get("deduplicated")) == 4
+    finally:
+        await _cleanup(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_sequential_submit_dedups(memory, request_context, no_inline_execution):
+    """A second submit while one is already pending returns the existing op."""
+    bank_id = f"test-atomic-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        first = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        second = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        assert second["operation_id"] == first["operation_id"]
+        assert second.get("deduplicated") is True
+        assert await _count_pending(pool, bank_id) == 1
+    finally:
+        await _cleanup(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_unscoped_not_deduped_against_scoped_pending(memory, request_context, no_inline_execution):
+    """A full-bank (unscoped) submit must still run when only a scoped op is pending —
+    a scoped run covers a tag subset and must not swallow the full-bank sweep."""
+    bank_id = f"test-atomic-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        scoped = await memory.submit_async_consolidation(
+            bank_id=bank_id, request_context=request_context, observation_scopes=[["proj-a"]]
+        )
+        unscoped = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        assert not unscoped.get("deduplicated"), "full-bank submit must not dedup against a scoped pending op"
+        assert unscoped["operation_id"] != scoped["operation_id"]
+        assert await _count_pending(pool, bank_id) == 2
+
+        # A second unscoped submit, however, dedups against the now-pending unscoped op.
+        unscoped2 = await memory.submit_async_consolidation(bank_id=bank_id, request_context=request_context)
+        assert unscoped2["operation_id"] == unscoped["operation_id"]
+        assert unscoped2.get("deduplicated") is True
+        assert await _count_pending(pool, bank_id) == 2
+    finally:
+        await _cleanup(pool, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_scoped_submits_are_not_deduped(memory, request_context, no_inline_execution):
+    """Scoped runs are targeted and intentionally exempt — they may pile up pending."""
+    bank_id = f"test-atomic-{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+    try:
+        r1 = await memory.submit_async_consolidation(
+            bank_id=bank_id, request_context=request_context, observation_scopes=[["proj-a"]]
+        )
+        r2 = await memory.submit_async_consolidation(
+            bank_id=bank_id, request_context=request_context, observation_scopes=[["proj-b"]]
+        )
+        assert r1["operation_id"] != r2["operation_id"]
+        assert not r2.get("deduplicated")
+        assert await _count_pending(pool, bank_id) == 2
+    finally:
+        await _cleanup(pool, bank_id)

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -456,6 +456,14 @@ class TestOracleQueryRewriter:
         assert "'true'" in query
         assert "->>" not in query
 
+    def test_for_no_key_update_rewrite(self):
+        """FOR NO KEY UPDATE (PG-only) maps to plain FOR UPDATE on Oracle."""
+        from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+        query, _, _ = _rewrite_pg_to_oracle("SELECT 1 FROM banks WHERE bank_id = $1 FOR NO KEY UPDATE")
+        assert "FOR UPDATE" in query
+        assert "NO KEY" not in query
+
     def test_jsonb_arrow_text_quoted(self):
         """Verify ->> works with quoted column names."""
         from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle


### PR DESCRIPTION
## Summary

Fixes the duplicate-pending-consolidation pile-up in #1842 (reporter saw
`PENDING_BREAKDOWN: total=3 claimable=0 retry_blocked=3` — several pending ops for
one bank, all parked on backoff, leaving the bank with no claimable work).

**Root cause — a non-atomic endpoint.** `_submit_async_operation`'s dedup is a
check-then-INSERT split across **two separate connection acquisitions** (pre-check
`SELECT` then a later `INSERT` in a different block) — not even one transaction. Under
READ COMMITTED, two concurrent submits both see no pending row and both insert. A
manual `POST /consolidate` loop racing retain-driven submits and the round-limit
re-queue therefore leaks duplicate pending consolidation ops for a bank; those extras
each enter retry-backoff and pile up as `retry_blocked`. Everything downstream — the
dedup-guard failing ops, the idle banks — is a consequence of the endpoint creating
duplicates it promised not to.

**Fix — make the submit atomic.** Run the dedup check-and-insert in a single
transaction that first locks the bank row, so concurrent submits for the same bank
serialize and the second observes the first's pending row. The lock releases on
commit, before `submit_task` runs.

This enforces the intended invariant — **at most one pending full-bank consolidation
per bank** — at the point of creation, rather than cleaning up duplicates downstream.
Combined with the already-merged #1857 (rounds auto-continue) and #1854 (5s backoff),
the pile-up can't form and the external re-POST workaround is no longer needed.

## Lock choice — `FOR NO KEY UPDATE`, not `FOR UPDATE`

`async_operations` has an FK to `banks`, so every async-op insert for the bank (a
scoped consolidation, a batch-retain op, a webhook delivery, …) takes a `FOR KEY SHARE`
lock on the bank row. `FOR UPDATE` conflicts with `FOR KEY SHARE` and would briefly
block all of those during the submit. `FOR NO KEY UPDATE` conflicts only with itself —
so two submits serialize (what we want) while those inserts proceed unblocked. The
Oracle SQL rewriter maps `FOR NO KEY UPDATE` → `FOR UPDATE` (Oracle has only the
latter, and there it does not block indexed-FK child inserts).

## Scopes

Consolidation scopes are handled in both directions so a full-bank sweep and a scoped
run never suppress each other:

- **Scoped submits** (`observation_scopes` set) pass `dedupe_by_bank=False` — they skip
  the lock and dedup entirely and **always run** (existing intent: "a targeted run
  should not be merged into a pending full-bank sweep").
- **Unscoped submits** dedup only against an existing **unscoped** pending op. A pending
  scoped consolidation covers only its tag subset, so it must not swallow a full-bank
  sweep. The scope check is done in Python because the JSON predicate isn't portable
  (Oracle's `JSON_VALUE` returns NULL for the array-valued `observation_scopes`).

`SELECT … FOR NO KEY UPDATE` keeps this app-level, cross-dialect, and consistent with
existing locking in the engine. **No schema change.**

## Testing

- `tests/test_consolidation_submit_atomic_dedup.py`:
  - 5 concurrent unscoped submits on an empty bank → exactly **one** pending row, all calls share the op id, four deduplicated
  - sequential submit while one is pending → returns the existing op
  - **unscoped submit is NOT deduped against a pending scoped op** (full-bank still runs); a second unscoped then dedups against the unscoped pending
  - two scoped submits → **two** pending rows (exemption preserved)
- `tests/test_db_abstraction.py::TestOracleQueryRewriter::test_for_no_key_update_rewrite` — `FOR NO KEY UPDATE` → `FOR UPDATE` on Oracle

All pass; ruff + ty clean. (The `submit_task` inline executor is neutralized in-test so the pending rows survive inspection under the sync backend.)
