### PR TITLE
fix(api): bound native ML thread pools to available CPUs

### DIFF
--- a/hindsight-api-slim/hindsight_api/__init__.py
+++ b/hindsight-api-slim/hindsight_api/__init__.py
@@ -4,6 +4,13 @@ Memory System for AI Agents.
 Temporal + Semantic Memory Architecture using PostgreSQL with pgvector.
 """
 
+# Cap native ML thread pools (OpenBLAS/OpenMP/MKL) before any import pulls in
+# numpy/torch/onnxruntime — they read these env vars only at load time. See
+# hindsight_api/_thread_limits.py for the rationale.
+from ._thread_limits import apply_default_thread_limits
+
+apply_default_thread_limits()
+
 from .config import HindsightConfig, get_config
 from .engine.cross_encoder import CrossEncoderModel, LocalSTCrossEncoder, RemoteTEICrossEncoder
 from .engine.embeddings import Embeddings, LocalSTEmbeddings, RemoteTEIEmbeddings

--- a/hindsight-api-slim/hindsight_api/_thread_limits.py
+++ b/hindsight-api-slim/hindsight_api/_thread_limits.py
@@ -1,0 +1,107 @@
+"""Process-level caps for native ML thread pools.
+
+OpenBLAS, OpenMP, and MKL each spawn a worker pool sized to the host CPU count
+the first time they are loaded (numpy pulls in OpenBLAS eagerly; torch and
+onnxruntime load their pools lazily on first inference). Hindsight already
+parallelizes at the request level via thread-pool executors (embeddings on the
+default executor, the reranker on its own pool), so these native intra-op pools
+oversubscribe the CPU: on a many-core host the process accumulates 100+ native
+threads, which inflates memory and, under contention, can degrade throughput.
+
+We bound each pool to ``_MAX_NATIVE_THREADS`` (or the available CPU count, if
+smaller). "Available" is the CPU budget actually granted to the process, not
+``os.cpu_count()``: in a CPU-limited container ``os.cpu_count()`` still reports
+the host's cores, so sizing pools by it oversubscribes the container's real
+quota — the exact failure mode this guards against. We therefore take the
+smallest of the CPU-affinity set, the cgroup CPU quota, and ``os.cpu_count()``.
+
+Every cap is applied with ``setdefault`` so an operator who has deliberately
+tuned one of these variables keeps their value. This must run *before* numpy,
+torch, or onnxruntime are imported — those libraries read the variables only at
+load time — which is why it is invoked at the very top of
+``hindsight_api/__init__.py``, ahead of the package's other imports.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Native threading env vars, each read by the respective library at load time.
+_NATIVE_THREAD_VARS = (
+    "OMP_NUM_THREADS",  # OpenMP — torch, onnxruntime, some BLAS builds
+    "OPENBLAS_NUM_THREADS",  # OpenBLAS — numpy's default BLAS
+    "MKL_NUM_THREADS",  # Intel MKL — numpy/torch when MKL-backed
+    "NUMEXPR_NUM_THREADS",  # numexpr expression engine
+)
+
+# Upper bound on intra-op threads per native pool. Bounds runaway growth on
+# many-core hosts without serialising single-request inference.
+_MAX_NATIVE_THREADS = 16
+
+
+def _quota_to_cpus(quota: int, period: int) -> int | None:
+    """Whole CPUs from a CFS quota/period pair, or None if unlimited."""
+    if quota > 0 and period > 0:
+        # Floor (never round up) so we never exceed the granted budget.
+        return max(1, quota // period)
+    return None
+
+
+def _parse_cgroup_v2_cpu_max(text: str) -> int | None:
+    """Parse cgroup v2 ``cpu.max`` ("<quota> <period>", or "max <period>")."""
+    parts = text.split()
+    if len(parts) >= 2 and parts[0] != "max":
+        try:
+            return _quota_to_cpus(int(parts[0]), int(parts[1]))
+        except ValueError:
+            return None
+    return None
+
+
+def _cgroup_cpu_quota() -> int | None:
+    """Effective CPUs from the cgroup CPU quota, or None if unlimited/unknown."""
+    try:  # cgroup v2
+        with open("/sys/fs/cgroup/cpu.max") as fh:
+            return _parse_cgroup_v2_cpu_max(fh.read())
+    except OSError:
+        pass
+    try:  # cgroup v1
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as fh:
+            quota = int(fh.read())
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as fh:
+            period = int(fh.read())
+        return _quota_to_cpus(quota, period)
+    except (OSError, ValueError):
+        return None
+
+
+def _available_cpu_count() -> int:
+    """CPUs actually available to this process.
+
+    The smallest of the CPU-affinity set (cpuset / ``--cpuset-cpus``), the
+    cgroup CPU quota (``--cpus``), and ``os.cpu_count()`` — each captures a
+    different way the budget can be constrained, and the last alone overcounts
+    inside a limited container.
+    """
+    candidates = [os.cpu_count() or 1]
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            candidates.append(len(os.sched_getaffinity(0)))
+        except OSError:
+            pass
+    quota = _cgroup_cpu_quota()
+    if quota is not None:
+        candidates.append(quota)
+    return max(1, min(candidates))
+
+
+def default_native_thread_count() -> int:
+    """Per-pool cap: ``_MAX_NATIVE_THREADS``, or available CPUs if fewer."""
+    return min(_MAX_NATIVE_THREADS, _available_cpu_count())
+
+
+def apply_default_thread_limits() -> None:
+    """Cap native ML thread pools unless the operator has set the var already."""
+    value = str(default_native_thread_count())
+    for var in _NATIVE_THREAD_VARS:
+        os.environ.setdefault(var, value)

--- a/hindsight-api-slim/tests/test_thread_limits.py
+++ b/hindsight-api-slim/tests/test_thread_limits.py
@@ -1,0 +1,132 @@
+"""Tests for native ML thread-pool caps (hindsight_api/_thread_limits.py)."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from hindsight_api._thread_limits import (
+    _MAX_NATIVE_THREADS,
+    _NATIVE_THREAD_VARS,
+    _available_cpu_count,
+    _parse_cgroup_v2_cpu_max,
+    _quota_to_cpus,
+    apply_default_thread_limits,
+    default_native_thread_count,
+)
+
+
+def test_default_is_bounded_by_available_cpus() -> None:
+    """The default is the thread ceiling, or the available CPU budget if smaller."""
+    assert default_native_thread_count() == min(_MAX_NATIVE_THREADS, _available_cpu_count())
+
+
+def test_available_cpu_count_within_host_bound() -> None:
+    """Available CPUs is at least 1 and never exceeds the host's logical CPU count."""
+    assert 1 <= _available_cpu_count() <= (os.cpu_count() or 1)
+
+
+def test_quota_to_cpus() -> None:
+    """CFS quota/period maps to whole CPUs, flooring and never below 1."""
+    assert _quota_to_cpus(400000, 100000) == 4
+    assert _quota_to_cpus(50000, 100000) == 1  # 0.5 CPU floors to 1, not 0
+    assert _quota_to_cpus(-1, 100000) is None  # unlimited
+    assert _quota_to_cpus(0, 100000) is None
+
+
+def test_parse_cgroup_v2_cpu_max() -> None:
+    """cgroup v2 cpu.max parsing: a CPU-limited container reports its quota."""
+    assert _parse_cgroup_v2_cpu_max("400000 100000") == 4  # --cpus=4
+    assert _parse_cgroup_v2_cpu_max("150000 100000") == 1  # 1.5 CPU floors to 1
+    assert _parse_cgroup_v2_cpu_max("max 100000") is None  # unlimited
+    assert _parse_cgroup_v2_cpu_max("") is None
+    assert _parse_cgroup_v2_cpu_max("garbage") is None
+
+
+def test_applies_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each cap is set to the default when the operator has not set it."""
+    for var in _NATIVE_THREAD_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    apply_default_thread_limits()
+
+    expected = str(default_native_thread_count())
+    for var in _NATIVE_THREAD_VARS:
+        assert os.environ[var] == expected
+
+
+def test_respects_operator_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicitly-set value is preserved rather than overwritten."""
+    for var in _NATIVE_THREAD_VARS:
+        monkeypatch.setenv(var, "3")
+
+    apply_default_thread_limits()
+
+    for var in _NATIVE_THREAD_VARS:
+        assert os.environ[var] == "3"
+
+
+def test_covers_the_documented_native_libraries() -> None:
+    """Lock in the set of vars so a future edit can't silently drop one."""
+    assert set(_NATIVE_THREAD_VARS) == {
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    }
+
+
+# A BLAS-heavy snippet that forces OpenBLAS to create its worker pool, then
+# reports this process's OS thread count from /proc (which, unlike
+# threading.active_count(), includes native threads). It imports hindsight_api
+# first so the real __init__ ordering is exercised: the caps must be applied
+# before numpy pulls in OpenBLAS, otherwise the pool is already sized.
+_OPENBLAS_THREAD_PROBE = """
+import hindsight_api  # noqa: F401 -- __init__ applies thread caps (no-op if vars preset)
+import numpy as np
+a = np.random.rand(1024, 1024)
+for _ in range(3):
+    a = a @ a
+    a /= (a.max() or 1.0)
+with open("/proc/self/status") as status:
+    print(next(int(line.split()[1]) for line in status if line.startswith("Threads:")))
+"""
+
+
+def _probe_native_thread_count(var_overrides: dict[str, str]) -> int:
+    """Run the BLAS probe in a fresh interpreter and return its OS thread count."""
+    env = {k: v for k, v in os.environ.items() if k not in _NATIVE_THREAD_VARS}
+    env.update(var_overrides)
+    proc = subprocess.run(
+        [sys.executable, "-c", _OPENBLAS_THREAD_PROBE],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"probe failed: {proc.stderr}"
+    return int(proc.stdout.strip().splitlines()[-1])
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="reads /proc (Linux only)")
+@pytest.mark.skipif(
+    (os.cpu_count() or 1) <= _MAX_NATIVE_THREADS,
+    reason=f"cap only observable on hosts with > {_MAX_NATIVE_THREADS} cores",
+)
+def test_import_caps_native_thread_oversubscription() -> None:
+    """Reproduce the native-thread buildup and prove the import cap bounds it.
+
+    A single BLAS workload makes OpenBLAS fan its pool out to one thread per
+    core. Importing hindsight_api applies the cap before numpy loads, holding
+    the pool at the configured ceiling; an operator who sets the vars to the
+    core count keeps the full per-core fan-out. Only observable when the host
+    has more cores than the ceiling — otherwise the cap equals the core count.
+    """
+    ncpu = os.cpu_count() or 4
+    capped = _probe_native_thread_count({})  # vars unset -> hindsight caps to the ceiling
+    uncapped = _probe_native_thread_count({var: str(ncpu) for var in _NATIVE_THREAD_VARS})
+
+    if uncapped <= capped:
+        pytest.skip(f"numpy BLAS is not multi-threaded here (capped={capped}, uncapped={uncapped})")
+
+    assert capped < uncapped, f"thread cap had no effect: capped={capped}, uncapped={uncapped}"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1392,6 +1392,23 @@ This ensures `shadow-*` banks are always consolidated before others, even if the
 | `HINDSIGHT_API_SKIP_LLM_VERIFICATION` | Skip LLM connection check on startup | `false` |
 | `HINDSIGHT_API_LAZY_RERANKER` | Lazy-load reranker model (faster startup) | `false` |
 
+#### Native thread pools
+
+When local embeddings or reranking run in-process, the underlying BLAS/ML libraries (OpenBLAS, OpenMP, MKL) each spawn a worker pool sized to the host CPU count. Because Hindsight already parallelizes across requests via its own thread-pool executors, those native pools oversubscribe the CPU — on a many-core host the process can accumulate well over 100 native threads. This inflates memory and, under contention, can degrade throughput. Hindsight therefore bounds each native pool to **16 threads** (or the number of *available* CPUs, whichever is smaller) by default, capping runaway growth on large hosts while leaving within-call parallelism intact.
+
+"Available" CPUs is the budget actually granted to the process — the smallest of the CPU-affinity set, the cgroup CPU quota (`--cpus` / cpuset), and the host core count. This matters in containers: the BLAS libraries otherwise size their pools to the *host's* cores even when the container is limited to a few, so a `--cpus=4` container on a 64-core host would spawn far more BLAS threads than it can run.
+
+To tune, set any of these to the desired thread count; the value you set is always honored (the default applies only when the variable is unset):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OMP_NUM_THREADS` | OpenMP worker threads (torch, ONNX Runtime, some BLAS builds) | `min(16, available CPUs)` |
+| `OPENBLAS_NUM_THREADS` | OpenBLAS worker threads (numpy's default BLAS) | `min(16, available CPUs)` |
+| `MKL_NUM_THREADS` | Intel MKL worker threads (numpy/torch when MKL-backed) | `min(16, available CPUs)` |
+| `NUMEXPR_NUM_THREADS` | numexpr expression-engine threads | `min(16, available CPUs)` |
+
+For a server handling many concurrent requests, lower values (down to `1`) favor request-level parallelism and minimize thread count; for low-concurrency deployments running large local-model batches, the default leaves room for within-call parallelism. These must be set in the process environment before startup (the libraries read them once, at load time), so they cannot be overridden per-tenant or per-bank.
+
 ### Webhooks
 
 | Variable | Description | Default |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1392,6 +1392,23 @@ This ensures `shadow-*` banks are always consolidated before others, even if the
 | `HINDSIGHT_API_SKIP_LLM_VERIFICATION` | Skip LLM connection check on startup | `false` |
 | `HINDSIGHT_API_LAZY_RERANKER` | Lazy-load reranker model (faster startup) | `false` |
 
+#### Native thread pools
+
+When local embeddings or reranking run in-process, the underlying BLAS/ML libraries (OpenBLAS, OpenMP, MKL) each spawn a worker pool sized to the host CPU count. Because Hindsight already parallelizes across requests via its own thread-pool executors, those native pools oversubscribe the CPU — on a many-core host the process can accumulate well over 100 native threads. This inflates memory and, under contention, can degrade throughput. Hindsight therefore bounds each native pool to **16 threads** (or the number of *available* CPUs, whichever is smaller) by default, capping runaway growth on large hosts while leaving within-call parallelism intact.
+
+"Available" CPUs is the budget actually granted to the process — the smallest of the CPU-affinity set, the cgroup CPU quota (`--cpus` / cpuset), and the host core count. This matters in containers: the BLAS libraries otherwise size their pools to the *host's* cores even when the container is limited to a few, so a `--cpus=4` container on a 64-core host would spawn far more BLAS threads than it can run.
+
+To tune, set any of these to the desired thread count; the value you set is always honored (the default applies only when the variable is unset):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OMP_NUM_THREADS` | OpenMP worker threads (torch, ONNX Runtime, some BLAS builds) | `min(16, available CPUs)` |
+| `OPENBLAS_NUM_THREADS` | OpenBLAS worker threads (numpy's default BLAS) | `min(16, available CPUs)` |
+| `MKL_NUM_THREADS` | Intel MKL worker threads (numpy/torch when MKL-backed) | `min(16, available CPUs)` |
+| `NUMEXPR_NUM_THREADS` | numexpr expression-engine threads | `min(16, available CPUs)` |
+
+For a server handling many concurrent requests, lower values (down to `1`) favor request-level parallelism and minimize thread count; for low-concurrency deployments running large local-model batches, the default leaves room for within-call parallelism. These must be set in the process environment before startup (the libraries read them once, at load time), so they cannot be overridden per-tenant or per-bank.
+
 ### Webhooks
 
 | Variable | Description | Default |

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -185,7 +185,7 @@ Search memories to provide personalized responses.
 | `query` | string | Yes | Natural language search query |
 | `max_tokens` | integer | No | Maximum tokens to return (default: 4096) |
 | `budget` | string | No | Search thoroughness: `low`, `mid`, or `high` (default: `high`) |
-| `types` | list[string] | No | Filter by fact type: `world`, `experience`, `opinion`. Defaults to all |
+| `types` | list[string] | No | Filter by fact type: `world`, `experience`, `observation`. Defaults to all |
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
@@ -396,7 +396,7 @@ Browse stored memories with optional filtering and pagination.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `type` | string | No | Filter by fact type: `world`, `experience`, or `opinion` |
+| `type` | string | No | Filter by fact type: `world`, `experience`, or `observation` |
 | `q` | string | No | Search query to filter memories |
 | `limit` | integer | No | Maximum number of results (default: 100) |
 | `offset` | integer | No | Number of results to skip for pagination (default: 0) |
@@ -541,7 +541,7 @@ Clear all memories from a bank without deleting the bank itself. Optionally filt
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `type` | string | No | Fact type to clear: `world`, `experience`, or `opinion`. If not specified, clears all |
+| `type` | string | No | Fact type to clear: `world`, `experience`, or `observation`. If not specified, clears all |
 
 ---
 


### PR DESCRIPTION
## Problem

A user reported that the container accumulates excessive native threads from C-extension ML libraries (OpenBLAS, ONNX Runtime, sentence-transformers) and eventually stops responding on all ports while still appearing "running" (v0.5.3–v0.5.6), typically after 6–12h.

## Verification

Confirmed against the code:
- Local embeddings (`engine/embeddings.py`) and reranker (`engine/cross_encoder.py`) run **in-process** via sentence-transformers/torch (+ optional FlashRank/ONNX).
- **No** native-thread bound exists anywhere — no `OMP_NUM_THREADS`/`OPENBLAS_NUM_THREADS`/`MKL_NUM_THREADS`, no `torch.set_num_threads`, no ONNX `intra_op/inter_op`. Each native pool sizes to the host CPU count.
- Hindsight already parallelizes across requests via its own thread-pool executors, so the native intra-op pools **oversubscribe** the CPU; on a many-core host that is 100+ threads.

## What this PR is — and isn't

This is a **mitigation**, not a proven deadlock fix. Bounding the native pools caps runaway thread growth on large hosts, the conditions that make the reported buildup worse. I could **not** confirm the exact low-level mechanism that wedges the event loop from static analysis, so pinning that down needs a thread dump from a wedged container (`py-spy dump` + `gdb -p <pid> -batch -ex "thread apply all bt"`); tracked separately.

> Note: a high `futex_do_wait` ratio is the *normal idle state* of OpenMP/OpenBLAS worker pools, so it is not on its own a reliable deadlock signal.

## Change

- New `hindsight_api/_thread_limits.py`, applied as the first statement in `__init__.py` (before numpy/OpenBLAS load), bounding `OMP/OPENBLAS/MKL/NUMEXPR_NUM_THREADS` to **`min(16, available CPUs)`** via `setdefault`, where "available" is the smallest of the CPU-affinity set, the cgroup CPU quota (`--cpus`/cpuset), and `os.cpu_count()`. This is container-correct: `os.cpu_count()` reports the *host* cores even in a CPU-limited container, so a `--cpus=4` container on a 64-core host would otherwise spawn far more BLAS threads than it can run (verified in Docker: `--cpus=2` -> cap 2, not 16).
- A finite ceiling of 16 caps runaway growth on large hosts while leaving within-call parallelism intact (`1` would serialise single-request inference; unbounded is the current behaviour). On hosts with ≤16 cores it is a no-op.
- `setdefault` means any operator-set value wins. Verified the ordering in a fresh process: applying the cap **before** numpy imports yields a bounded OpenBLAS pool, applying it **after** does not — which is why it's the first statement in `__init__.py`.

## Tunable

These are read once at library load time, so they are **process-level** (not per-tenant/bank) — the libraries' own env vars are the only correct interface, so there's no `HindsightConfig` field. A server fielding many concurrent requests can lower them (down to `1`) to favor request-level parallelism; a low-concurrency, large-batch deployment can leave the default. Documented in `configuration.md`.

## Out of scope (deliberately dropped from earlier revisions)

- **Docker `HEALTHCHECK`** — redundant/off-convention: the Helm chart already probes `/health`, Compose stacks define a `healthcheck`, and Kubernetes ignores the image `HEALTHCHECK`. Health policy stays with the deployment layer.
- **Thread count in `/health`** — `/health` stays a binary liveness probe. Process metrics belong in the existing `/metrics` (Prometheus) endpoint, not the health body.

## Tests

`tests/test_thread_limits.py` — default equals `min(16, cores)`, applied-when-unset, operator-override honored, var set locked in, plus a Linux subprocess regression test (gated to hosts with >16 cores, where the cap is observable) that proves importing `hindsight_api` bounds the OpenBLAS pool below the per-core fan-out.

