### PR TITLE
fix(backup): include all 7 missing tables in backup/restore

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -166,7 +166,14 @@ If any new MCP tools were added or existing tools renamed in `hindsight-api-slim
 - **`MCP_TOOL_GROUPS`** in `hindsight-control-plane/src/components/bank-config-view.tsx` — must include the new tool in the appropriate group for the UI tool selector
 - **Tool count assertions** in tests (e.g., `test_mcp_tools.py`) — must be updated to reflect the new count
 
-### 11. Review against other coding standards
+### 11. Check backup/restore table coverage
+
+If a migration adds a new PostgreSQL table (look for `CREATE TABLE` / `op.create_table` in `hindsight-api-slim/hindsight_api/alembic/versions/`):
+- **`BACKUP_TABLES`** in `hindsight-api-slim/hindsight_api/admin/cli.py` — must include the new table, placed after any table it references via foreign key (parents before children). A missing entry is silent data loss: the table is never backed up, and restore's `TRUNCATE banks CASCADE` wipes any FK-to-banks child (e.g. `mental_models`, `directives`) on restore even though it was never saved.
+- The guard test `test_backup_tables_covers_entire_schema` in `tests/test_admin_backup_restore.py` enforces this — flag it as a **must fix** if a new table is absent from `BACKUP_TABLES`.
+- Oracle-only tables (e.g. `observation_sources`) are intentionally excluded — admin backup/restore is PostgreSQL-only.
+
+### 12. Review against other coding standards
 
 Check the diff for violations of the standards listed above:
 - Python files at project root (not allowed)
@@ -178,7 +185,7 @@ Check the diff for violations of the standards listed above:
 - Premature abstractions or speculative helpers
 - Backwards-compatibility hacks (unused vars, re-exports, "removed" comments)
 
-### 12. Report findings
+### 13. Report findings
 
 Present a clear summary organized by severity:
 
@@ -190,6 +197,7 @@ Present a clear summary organized by severity:
 - Multi-item tuple returns (including internal code)
 - Missing tests for new endpoints
 - New integration missing tests, CI job, or release-integration.sh entry
+- New PostgreSQL table missing from `BACKUP_TABLES` in `admin/cli.py` (silent data loss on restore)
 
 **Should fix** — issues that hurt code quality:
 - Dead code / unused imports missed by linter

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -30,8 +30,17 @@ logger = logging.getLogger(__name__)
 
 app = typer.Typer(name="hindsight-admin", help="Hindsight administrative commands")
 
-# Tables to backup/restore in dependency order
-# Import must happen in this order due to foreign key constraints
+# Tables to backup/restore in foreign-key dependency order (parents first).
+# Restore COPYs in this order and TRUNCATEs in reverse, so every child must
+# appear after the tables it references.
+#
+# This must cover EVERY persistent PostgreSQL table in the schema — a missing
+# entry silently drops that table's data on restore (and, worse, restore's
+# `TRUNCATE banks CASCADE` wipes any FK-to-banks child like mental_models even
+# when it was never backed up). test_admin_backup_restore.py asserts this list
+# equals the live schema's tables, so adding a migration that creates a table
+# without adding it here fails CI. Oracle-only tables (e.g. observation_sources)
+# are intentionally absent — admin backup/restore is PostgreSQL-only.
 BACKUP_TABLES = [
     "banks",
     "documents",
@@ -41,6 +50,13 @@ BACKUP_TABLES = [
     "unit_entities",
     "entity_cooccurrences",
     "memory_links",
+    "mental_models",
+    "directives",
+    "async_operations",
+    "webhooks",
+    "file_storage",
+    "audit_log",
+    "graph_maintenance_queue",
 ]
 
 MANIFEST_VERSION = "1"

--- a/hindsight-api-slim/tests/test_admin_backup_restore.py
+++ b/hindsight-api-slim/tests/test_admin_backup_restore.py
@@ -16,10 +16,9 @@ import pytest
 import pytest_asyncio
 
 import hindsight_api.admin.cli as admin_cli
-from hindsight_api.admin.cli import _backup, _restore, BACKUP_TABLES
+from hindsight_api.admin.cli import BACKUP_TABLES, _backup, _restore
 from hindsight_api.extensions import Tenant
 from hindsight_api.migrations import run_migrations
-
 
 # Run these tests sequentially since they do full DB backup/restore
 pytestmark = pytest.mark.xdist_group(name="backup_restore")
@@ -64,6 +63,46 @@ async def backup_test_schema(pg0_db_url, embeddings):
 
 
 @pytest.mark.asyncio
+async def test_backup_tables_covers_entire_schema(backup_test_schema):
+    """BACKUP_TABLES must list every persistent table in the live PG schema.
+
+    A missing entry silently drops that table's data on restore — and because
+    restore runs `TRUNCATE banks CASCADE`, any FK-to-banks child (mental_models,
+    directives, async_operations, webhooks) gets wiped even though it was never
+    backed up. This guard fails whenever a migration adds a table without adding
+    it to BACKUP_TABLES, forcing a conscious decision instead of silent dataloss.
+    """
+    db_url, schema_name, _fq, _embeddings = backup_test_schema
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = $1 AND table_type = 'BASE TABLE'
+            """,
+            schema_name,
+        )
+    finally:
+        await conn.close()
+
+    # alembic_version is migration bookkeeping, not data — never backed up.
+    schema_tables = {r["table_name"] for r in rows} - {"alembic_version"}
+    backup_tables = set(BACKUP_TABLES)
+
+    missing = schema_tables - backup_tables
+    stale = backup_tables - schema_tables
+    assert not missing, (
+        f"Tables exist in the schema but are missing from BACKUP_TABLES "
+        f"(their data would be lost on restore): {sorted(missing)}"
+    )
+    assert not stale, f"BACKUP_TABLES lists tables that no longer exist in the schema: {sorted(stale)}"
+    # No duplicates — a repeated entry would COPY/TRUNCATE the same table twice.
+    assert len(BACKUP_TABLES) == len(set(BACKUP_TABLES)), "BACKUP_TABLES has duplicate entries"
+
+
+@pytest.mark.asyncio
 async def test_backup_restore_roundtrip(backup_test_schema):
     """Test that backup and restore preserves all data correctly."""
     db_url, schema_name, _fq, embeddings = backup_test_schema
@@ -87,13 +126,24 @@ async def test_backup_restore_roundtrip(backup_test_schema):
             "The team uses PostgreSQL for their database.",
         ]:
             await conn.execute(
-                f"""INSERT INTO {_fq('memory_units')}
+                f"""INSERT INTO {_fq("memory_units")}
                     (bank_id, text, fact_type, embedding, event_date)
                     VALUES ($1, $2, 'world', $3::vector, NOW())""",
                 bank_id,
                 text,
                 embedding_str,
             )
+
+        # Insert a directive (FK -> banks). Restore TRUNCATEs banks CASCADE,
+        # which wipes FK-to-banks children, so a directive that survives the
+        # roundtrip proves those tables are actually backed up and restored.
+        await conn.execute(
+            f"""INSERT INTO {_fq("directives")} (bank_id, name, content)
+                VALUES ($1, $2, $3)""",
+            bank_id,
+            "tone",
+            "Always answer concisely.",
+        )
 
         # Get counts before backup
         counts_before = {}
@@ -103,6 +153,7 @@ async def test_backup_restore_roundtrip(backup_test_schema):
         # Verify we have data
         assert counts_before["banks"] > 0
         assert counts_before["memory_units"] > 0
+        assert counts_before["directives"] > 0
 
     finally:
         await conn.close()
@@ -161,6 +212,12 @@ async def test_backup_restore_roundtrip(backup_test_schema):
             )
             text_content = " ".join(r["text"] for r in texts)
             assert "Alice" in text_content or "software" in text_content
+
+            directive_content = await conn.fetchval(
+                f"SELECT content FROM {_fq('directives')} WHERE bank_id = $1",
+                bank_id,
+            )
+            assert directive_content == "Always answer concisely."
         finally:
             await conn.close()
 
@@ -189,7 +246,7 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
         embedding_list = embeddings.encode(["John Smith engineer"])[0]
         embedding_str = "[" + ",".join(str(x) for x in embedding_list) + "]"
         await conn.execute(
-            f"""INSERT INTO {_fq('memory_units')}
+            f"""INSERT INTO {_fq("memory_units")}
                 (bank_id, text, fact_type, embedding, event_date, metadata)
                 VALUES ($1, $2, 'world', $3::vector, NOW(), $4)""",
             bank_id,
@@ -200,7 +257,7 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
 
         # Create an entity
         await conn.execute(
-            f"""INSERT INTO {_fq('entities')}
+            f"""INSERT INTO {_fq("entities")}
                 (bank_id, canonical_name, metadata)
                 VALUES ($1, $2, $3)""",
             bank_id,
@@ -211,12 +268,12 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
         # Get original data
         original_unit = await conn.fetchrow(
             f"""SELECT id, embedding, event_date, created_at, metadata, text
-               FROM {_fq('memory_units')} WHERE bank_id = $1 LIMIT 1""",
+               FROM {_fq("memory_units")} WHERE bank_id = $1 LIMIT 1""",
             bank_id,
         )
         original_entity = await conn.fetchrow(
             f"""SELECT id, first_seen, last_seen, metadata, canonical_name
-               FROM {_fq('entities')} WHERE bank_id = $1 LIMIT 1""",
+               FROM {_fq("entities")} WHERE bank_id = $1 LIMIT 1""",
             bank_id,
         )
         original_bank = await conn.fetchrow(
@@ -252,12 +309,12 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
         try:
             restored_unit = await conn.fetchrow(
                 f"""SELECT id, embedding, event_date, created_at, metadata, text
-                   FROM {_fq('memory_units')} WHERE bank_id = $1 LIMIT 1""",
+                   FROM {_fq("memory_units")} WHERE bank_id = $1 LIMIT 1""",
                 bank_id,
             )
             restored_entity = await conn.fetchrow(
                 f"""SELECT id, first_seen, last_seen, metadata, canonical_name
-                   FROM {_fq('entities')} WHERE bank_id = $1 LIMIT 1""",
+                   FROM {_fq("entities")} WHERE bank_id = $1 LIMIT 1""",
                 bank_id,
             )
             restored_bank = await conn.fetchrow(
@@ -271,7 +328,9 @@ async def test_backup_restore_preserves_all_column_types(backup_test_schema):
         assert restored_unit is not None, "Should have restored memory unit"
         assert restored_unit["id"] == original_unit["id"], "UUID should match exactly"
         assert restored_unit["text"] == original_unit["text"], "Text should match"
-        assert list(restored_unit["embedding"]) == list(original_unit["embedding"]), "Vector embedding should match exactly"
+        assert list(restored_unit["embedding"]) == list(original_unit["embedding"]), (
+            "Vector embedding should match exactly"
+        )
         assert restored_unit["event_date"] == original_unit["event_date"], "Timestamp should match exactly"
         assert restored_unit["created_at"] == original_unit["created_at"], "Created timestamp should match"
         assert restored_unit["metadata"] == original_unit["metadata"], "JSONB metadata should match"
@@ -330,9 +389,7 @@ async def test_run_migration_without_schema_discovers_and_deduplicates_schemas(m
         schema: str | None = None,
         pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append(
-            (database_url, text_search_extension, pg_search_tokenizer, schema)
-        )
+        calls["ensure_text_search_extension"].append((database_url, text_search_extension, pg_search_tokenizer, schema))
 
     monkeypatch.setenv("HINDSIGHT_API_DATABASE_URL", "postgresql://test")
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
@@ -403,9 +460,7 @@ async def test_run_migration_without_schema_runs_optional_post_migration_hooks(m
         schema: str | None = None,
         pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append(
-            (database_url, text_search_extension, pg_search_tokenizer, schema)
-        )
+        calls["ensure_text_search_extension"].append((database_url, text_search_extension, pg_search_tokenizer, schema))
 
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
     monkeypatch.setattr(admin_cli, "resolve_database_url", fake_resolve_database_url)
@@ -475,9 +530,7 @@ async def test_run_migration_with_schema_only_runs_requested_schema(monkeypatch)
         schema: str | None = None,
         pg_search_tokenizer: str | None = None,
     ) -> None:
-        calls["ensure_text_search_extension"].append(
-            (database_url, text_search_extension, pg_search_tokenizer, schema)
-        )
+        calls["ensure_text_search_extension"].append((database_url, text_search_extension, pg_search_tokenizer, schema))
 
     monkeypatch.setattr(admin_cli, "load_extension", lambda *args, **kwargs: MockTenantExtension())
     monkeypatch.setattr(admin_cli, "resolve_database_url", fake_resolve_database_url)


### PR DESCRIPTION
## Problem

`BACKUP_TABLES` in `hindsight-api-slim/hindsight_api/admin/cli.py` listed only **8** tables, but the live PostgreSQL schema has **15** (verified by building the schema on embedded pg0 and introspecting `information_schema`).

**7 tables were never backed up:** `mental_models`, `directives`, `async_operations`, `webhooks`, `file_storage`, `audit_log`, `graph_maintenance_queue`.

This was worse than missing data. Restore runs `TRUNCATE banks CASCADE`, and `mental_models`, `directives`, `async_operations`, `webhooks` all have a FK to `banks` — so restore was **actively wiping** those tables (including core user data like mental models and directives) and never refilling them.

## Fix

- **`admin/cli.py`** — add the 7 missing tables to `BACKUP_TABLES` in FK-dependency order (verified against the live schema's actual foreign keys), with a comment explaining the completeness requirement.
- **`tests/test_admin_backup_restore.py`**
  - `test_backup_tables_covers_entire_schema` — introspects the live schema and asserts `BACKUP_TABLES` equals the real table set (minus `alembic_version`). Fails CI if a future migration adds a table without updating the list.
  - Roundtrip test now inserts a `directives` row (FK→banks) and asserts it survives restore, directly covering the cascade-wipe regression.
- **`.claude/skills/code-review/SKILL.md`** — new review step + "must fix" bullet flagging any new PG table missing from `BACKUP_TABLES`.

## Notes

- `observation_sources` is intentionally excluded — it's Oracle-only (PG uses an array column); admin backup/restore is PG-only.
- Transient queue tables (`async_operations`, `graph_maintenance_queue`) and `audit_log` are **included** so a backup is a faithful full snapshot. If we'd rather a restore not carry over another deployment's in-flight worker queue, these can move to an explicit documented exclusion set instead.

## Testing

All 6 tests in `test_admin_backup_restore.py` pass; lint + format clean.