### PR TITLE
docs(integrations): drop removed `opinion` fact_type from recall_types

### DIFF
--- a/hindsight-docs/docs-integrations/llamaindex.md
+++ b/hindsight-docs/docs-integrations/llamaindex.md
@@ -168,7 +168,7 @@ tools = create_hindsight_tools(bank_id="user-123")
 | `retain_metadata` | `dict[str, str]` | `None` | Default metadata for retain operations |
 | `retain_document_id` | `str` | `None` | Document ID for retain. Auto-generates `{session}-{timestamp}` if not set |
 | `retain_context` | `str` | `"llamaindex"` | Source label for retain operations |
-| `recall_types` | `list[str]` | `None` | Fact types: `world`, `experience`, `opinion`, `observation` |
+| `recall_types` | `list[str]` | `None` | Fact types: `world`, `experience`, `observation` |
 | `recall_include_entities` | `bool` | `False` | Include entity info in recall results |
 | `reflect_context` | `str` | `None` | Additional context for reflect |
 | `reflect_max_tokens` | `int` | `None` | Max tokens for reflect (defaults to `max_tokens`) |

--- a/hindsight-docs/docs-integrations/openai-agents.md
+++ b/hindsight-docs/docs-integrations/openai-agents.md
@@ -215,7 +215,7 @@ shared_tools = create_hindsight_tools(
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any\_strict/all\_strict) |
 | `retain_metadata` | `None` | Default metadata dict for retain operations |
 | `retain_document_id` | `None` | Default document\_id for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `None` | Max tokens for reflect results (defaults to `max_tokens`) |


### PR DESCRIPTION
The OpenAI-Agents and LlamaIndex integration docs still list `opinion` as a valid `recall_types` value, but the backend constrains `fact_type` to `world`/`experience`/`observation` (`hindsight-api-slim/hindsight_api/models.py:128`, `CheckConstraint("fact_type IN ('world', 'experience', 'observation')")`). Following `recall_types=['opinion']` from these tables now raises a check-constraint violation.

#1893 already removed `opinion` from the ag2/autogen/langgraph/litellm docs and the MCP server reference; these two integration pages were outside that change's scope. This drops the stale `opinion` token from both so all integration docs match the schema.