### PR TITLE
feat(admin): add offline embedding reembed command

### DIFF
--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+from collections.abc import Collection
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
@@ -22,6 +24,7 @@ RESOLVED_EXTENSIONS = (*CONFIGURABLE_EXTENSIONS, "pg_diskann")
 VALID_EXTENSIONS = CONFIGURABLE_EXTENSIONS
 
 SCANN_MIN_ROWS_FOR_AUTO_INDEX = 10_000
+PGVECTOR_HNSW_MAX_DIMENSIONS = 2_000
 
 
 _EXTENSION_NAMES = {
@@ -31,12 +34,12 @@ _EXTENSION_NAMES = {
     "scann": "alloydb_scann",
 }
 
-_INDEX_USING_CLAUSES = {
-    "pgvector": "USING hnsw (embedding vector_cosine_ops)",
-    "pgvectorscale": "USING diskann (embedding vector_cosine_ops) WITH (num_neighbors = 50)",
-    "pg_diskann": "USING diskann (embedding vector_cosine_ops) WITH (max_neighbors = 50)",
-    "vchord": "USING vchordrq (embedding vector_cosine_ops)",
-    "scann": "USING scann (embedding cosine) WITH (mode = 'AUTO')",
+_INDEX_USING_TEMPLATES = {
+    "pgvector": "USING hnsw ({column} vector_cosine_ops)",
+    "pgvectorscale": "USING diskann ({column} vector_cosine_ops) WITH (num_neighbors = 50)",
+    "pg_diskann": "USING diskann ({column} vector_cosine_ops) WITH (max_neighbors = 50)",
+    "vchord": "USING vchordrq ({column} vector_cosine_ops)",
+    "scann": "USING scann ({column} cosine) WITH (mode = 'AUTO')",
 }
 
 _INDEX_TYPE_KEYWORDS = {
@@ -130,9 +133,11 @@ def pg_extension_name(ext: str) -> str:
     return _EXTENSION_NAMES[validate_extension(ext)]
 
 
-def index_using_clause(ext: str) -> str:
+def index_using_clause(ext: str, *, column: str = "embedding") -> str:
     """Return the CREATE INDEX USING clause for the vector backend."""
-    return _INDEX_USING_CLAUSES[_normalize_resolved(ext)]
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", column):
+        raise ValueError(f"Invalid vector index column name: {column!r}")
+    return _INDEX_USING_TEMPLATES[_normalize_resolved(ext)].format(column=column)
 
 
 def index_type_keyword(ext: str) -> str:
@@ -149,6 +154,18 @@ def should_defer_index_creation(ext: str, row_count: int) -> bool:
     """Return True when index creation should wait for more embeddings."""
     minimum_rows = minimum_rows_for_index(ext)
     return minimum_rows > 0 and row_count < minimum_rows
+
+
+def validate_vector_index_dimension(ext: str, dimension: int, *, table_name: str | None = None) -> None:
+    """Raise if the backend cannot index vectors of the requested dimension."""
+    if _normalize_resolved(ext) == "pgvector" and dimension > PGVECTOR_HNSW_MAX_DIMENSIONS:
+        location = f" on {table_name}" if table_name else ""
+        raise RuntimeError(
+            f"Embedding dimension {dimension}{location} exceeds pgvector HNSW index limit of "
+            f"{PGVECTOR_HNSW_MAX_DIMENSIONS}. Use an embedding model with <= "
+            f"{PGVECTOR_HNSW_MAX_DIMENSIONS} dimensions, or switch to a vector extension that supports higher "
+            "dimensions (e.g., pgvectorscale/DiskANN or AlloyDB ScaNN)."
+        )
 
 
 def ann_search_tuning_settings(ext: str, *, kind: str) -> tuple[tuple[str, str], ...]:
@@ -182,28 +199,21 @@ def bootstrap_extension(conn: Connection, ext: str) -> None:
         conn.execute(text(statement))
 
 
-def detect_vector_extension(conn: Connection, vector_extension: str = "pgvector") -> str:
-    """Validate the configured vector extension exists and return the index backend."""
+def resolve_vector_extension_from_installed(vector_extension: str, installed_extensions: Collection[str]) -> str:
+    """Return the resolved backend from the configured value and installed PG extensions."""
     configured_ext = validate_extension(vector_extension)
+    installed = set(installed_extensions)
 
     if configured_ext == "pgvectorscale":
-        pgvector_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")).scalar()
-        if not pgvector_check:
+        if "vector" not in installed:
             raise RuntimeError(
                 "DiskANN (pgvectorscale/pg_diskann) requires pgvector to be installed. "
                 f"Install it with: {_INSTALL_HINTS['pgvectorscale']}"
             )
-
-        vectorscale_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'")).scalar()
-        pg_diskann_check = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_diskann'")).scalar()
-
-        if vectorscale_check:
-            logger.debug("Using vector extension: pgvectorscale (DiskANN)")
+        if "vectorscale" in installed:
             return "pgvectorscale"
-        if pg_diskann_check:
-            logger.debug("Using vector extension: pg_diskann (Azure DiskANN)")
+        if "pg_diskann" in installed:
             return "pg_diskann"
-
         raise RuntimeError(
             "Configured vector extension 'pgvectorscale' not found. Install either:\n"
             "  - pgvectorscale (open source): CREATE EXTENSION vectorscale CASCADE;\n"
@@ -211,15 +221,30 @@ def detect_vector_extension(conn: Connection, vector_extension: str = "pgvector"
         )
 
     extension_name = pg_extension_name(configured_ext)
-    extension_check = conn.execute(
-        text("SELECT 1 FROM pg_extension WHERE extname = :extension_name"),
-        {"extension_name": extension_name},
-    ).scalar()
-    if not extension_check:
+    if extension_name not in installed:
         raise RuntimeError(
             f"Configured vector extension '{configured_ext}' not found. "
             f"Install it with: {_INSTALL_HINTS[configured_ext]}"
         )
-
-    logger.debug("Using configured vector extension: %s", configured_ext)
     return configured_ext
+
+
+def detect_vector_extension(conn: Connection, vector_extension: str = "pgvector") -> str:
+    """Validate the configured vector extension exists and return the index backend."""
+    configured_ext = validate_extension(vector_extension)
+
+    if configured_ext == "pgvectorscale":
+        extension_names = ("vector", "vectorscale", "pg_diskann")
+    else:
+        extension_names = (pg_extension_name(configured_ext),)
+    installed_extensions = {
+        name
+        for name in extension_names
+        if conn.execute(
+            text("SELECT 1 FROM pg_extension WHERE extname = :extension_name"),
+            {"extension_name": name},
+        ).scalar()
+    }
+    resolved = resolve_vector_extension_from_installed(configured_ext, installed_extensions)
+    logger.debug("Using vector extension: %s", resolved)
+    return resolved

--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -9,6 +9,8 @@ import io
 import json
 import logging
 import zipfile
+from collections.abc import Callable
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -22,6 +24,15 @@ from ..engine.schema import fq_table_explicit as _fq_table
 from ..engine.transfer import export_bank
 from ..extensions import TenantExtension, load_extension
 from ..pg0 import parse_pg0_url, resolve_database_url
+from .reembed import (
+    ReembedOptions,
+    ReembedProgress,
+    abandon_reembed,
+    discover_hindsight_schemas,
+    ensure_no_active_reembed_state,
+    reembed_schema,
+    reembed_status,
+)
 
 # Setup logging
 logging.basicConfig(
@@ -62,6 +73,8 @@ BACKUP_TABLES = [
     "audit_log",
     "llm_requests",
     "graph_maintenance_queue",
+    "embedding_reembed_migrations",
+    "embedding_reembed_semantic_links",
 ]
 
 MANIFEST_VERSION = "1"
@@ -88,6 +101,8 @@ async def _backup(database_url: str, output_path: Path, schema: str = "public") 
     """Backup all tables to a zip file using binary COPY protocol."""
     conn = await asyncpg.connect(database_url)
     try:
+        await ensure_no_active_reembed_state(conn, schema, "backup")
+
         tables: dict[str, Any] = {}
         manifest: dict[str, Any] = {
             "version": MANIFEST_VERSION,
@@ -135,6 +150,8 @@ async def _restore(database_url: str, input_path: Path, schema: str = "public") 
     """Restore all tables from a zip file using binary COPY protocol."""
     conn = await asyncpg.connect(database_url)
     try:
+        await ensure_no_active_reembed_state(conn, schema, "restore")
+
         with zipfile.ZipFile(input_path, "r") as zf:
             # Read and validate manifest
             manifest: dict[str, Any] = json.loads(zf.read("manifest.json"))
@@ -467,6 +484,242 @@ def import_bank_command(
         f"{result.mental_model_history_imported} mm-history row(s), {result.directives_imported} directive(s), "
         f"{result.webhooks_imported} webhook(s), {result.history_rows_imported} history row(s)"
     )
+
+
+async def _resolve_reembed_schemas(
+    database_url: str,
+    config: HindsightConfig,
+    schemas: list[str] | None,
+    all_schemas: bool,
+) -> list[str]:
+    if schemas and all_schemas:
+        raise ValueError("Use either --schema or --all-schemas, not both")
+    if schemas:
+        return list(dict.fromkeys(schemas))
+    if not all_schemas:
+        raise ValueError("Specify --schema or --all-schemas for reembed")
+
+    is_pg0, instance_name, _ = parse_pg0_url(database_url)
+    if is_pg0:
+        typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
+    resolved_url = await resolve_database_url(database_url)
+
+    conn = await asyncpg.connect(resolved_url)
+    try:
+        discovered = await discover_hindsight_schemas(
+            conn,
+            config.database_schema or DEFAULT_DATABASE_SCHEMA,
+        )
+    finally:
+        await conn.close()
+    return discovered
+
+
+async def _run_reembed(
+    database_url: str,
+    config: HindsightConfig,
+    schemas: list[str],
+    options: ReembedOptions,
+    progress_callback: Callable[[ReembedProgress], None] | None = None,
+):
+    resolved_url = await resolve_database_url(database_url)
+    reports = []
+    for schema in schemas:
+        reports.append(await reembed_schema(resolved_url, schema, config, options, progress_callback))
+    return reports
+
+
+def _format_reembed_progress(progress: ReembedProgress) -> str:
+    parts = [f"{progress.schema}: {progress.phase}"]
+    if progress.migration_id:
+        parts.append(f"migration={progress.migration_id}")
+    if progress.memory_units_total is not None and progress.memory_units_done is not None:
+        parts.append(f"memory_units={progress.memory_units_done}/{progress.memory_units_total}")
+    if progress.mental_models_total is not None and progress.mental_models_done is not None:
+        parts.append(f"mental_models={progress.mental_models_done}/{progress.mental_models_total}")
+    if progress.semantic_links_staged is not None:
+        parts.append(f"semantic_links_staged={progress.semantic_links_staged}")
+    if progress.group_total is not None:
+        group_index = progress.group_index if progress.group_index is not None else 0
+        parts.append(f"groups={group_index}/{progress.group_total}")
+    if progress.message:
+        parts.append(progress.message)
+    return " ".join(parts)
+
+
+@app.command(name="reembed")
+def reembed(
+    schemas: list[str] | None = typer.Option(
+        None,
+        "--schema",
+        "-s",
+        help="Database schema to reembed. Can be supplied multiple times. Required unless --all-schemas is used.",
+    ),
+    all_schemas: bool = typer.Option(
+        False,
+        "--all-schemas",
+        help="Discover and reembed all Hindsight schemas in the current PostgreSQL database.",
+    ),
+    batch_size: int = typer.Option(100, "--batch-size", help="Rows to embed per provider batch."),
+    max_retries: int = typer.Option(3, "--max-retries", help="Embedding batch retry count."),
+    index_max_parallel_maintenance_workers: int | None = typer.Option(
+        None,
+        "--index-max-parallel-maintenance-workers",
+        help="Temporarily override max_parallel_maintenance_workers while building shadow vector indexes.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Report planned work without modifying the database."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Recompute stored embeddings offline and cut over atomically."""
+    if batch_size < 1:
+        typer.echo("Error: --batch-size must be at least 1", err=True)
+        raise typer.Exit(1)
+    if max_retries < 0:
+        typer.echo("Error: --max-retries must be at least 0", err=True)
+        raise typer.Exit(1)
+    if index_max_parallel_maintenance_workers is not None and index_max_parallel_maintenance_workers < 0:
+        typer.echo("Error: --index-max-parallel-maintenance-workers must be at least 0", err=True)
+        raise typer.Exit(1)
+
+    config = HindsightConfig.from_env()
+
+    if not config.database_url:
+        typer.echo("Error: Database URL not configured.", err=True)
+        typer.echo("Set HINDSIGHT_API_DATABASE_URL environment variable.", err=True)
+        raise typer.Exit(1)
+
+    try:
+        target_schemas = asyncio.run(
+            _resolve_reembed_schemas(
+                config.database_url,
+                config,
+                schemas,
+                all_schemas,
+            )
+        )
+    except Exception as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    if not target_schemas:
+        typer.echo("No schemas matched the requested reembed scope")
+        return
+
+    if not dry_run and not yes:
+        typer.confirm(
+            f"This will recompute embeddings and cut over schema(s): {', '.join(target_schemas)}. Continue?",
+            abort=True,
+        )
+
+    options = ReembedOptions(
+        batch_size=batch_size,
+        dry_run=dry_run,
+        max_retries=max_retries,
+        index_max_parallel_maintenance_workers=index_max_parallel_maintenance_workers,
+    )
+    try:
+        reports = asyncio.run(
+            _run_reembed(
+                config.database_url,
+                config,
+                target_schemas,
+                options,
+                lambda progress: typer.echo(_format_reembed_progress(progress)),
+            )
+        )
+    except Exception as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    for report in reports:
+        typer.echo(
+            f"{report.schema}: status={report.status} migration={report.migration_id or '-'} "
+            f"memory_units={report.memory_units_done}/{report.memory_units_total} "
+            f"mental_models={report.mental_models_done}/{report.mental_models_total} "
+            f"semantic_links_staged={report.semantic_links_staged} "
+            f"shadow_indexes={report.shadow_indexes_state or '-'}"
+        )
+        if report.message:
+            typer.echo(f"  {report.message}")
+
+
+@app.command(name="reembed-status")
+def reembed_status_cmd(
+    schema: str | None = typer.Option(
+        None,
+        "--schema",
+        "-s",
+        help="Database schema. Required.",
+    ),
+):
+    """Show embedding re-materialization status."""
+    if not schema:
+        typer.echo("Error: Specify --schema for reembed-status", err=True)
+        raise typer.Exit(1)
+
+    config = HindsightConfig.from_env()
+
+    if not config.database_url:
+        typer.echo("Error: Database URL not configured.", err=True)
+        typer.echo("Set HINDSIGHT_API_DATABASE_URL environment variable.", err=True)
+        raise typer.Exit(1)
+
+    async def _run():
+        resolved_url = await resolve_database_url(config.database_url)
+        return await reembed_status(resolved_url, schema)
+
+    status = asyncio.run(_run())
+    typer.echo(json.dumps(asdict(status), indent=2, default=str))
+
+
+@app.command(name="reembed-abandon")
+def reembed_abandon_cmd(
+    schema: str | None = typer.Option(
+        None,
+        "--schema",
+        "-s",
+        help="Database schema. Required.",
+    ),
+    orphan_shadow_state: bool = typer.Option(
+        False,
+        "--orphan-shadow-state",
+        help="Remove shadow columns/indexes/staging rows even without an active migration row.",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Abandon a failed reembed migration and remove shadow state."""
+    if not schema:
+        typer.echo("Error: Specify --schema for reembed-abandon", err=True)
+        raise typer.Exit(1)
+
+    config = HindsightConfig.from_env()
+
+    if not config.database_url:
+        typer.echo("Error: Database URL not configured.", err=True)
+        typer.echo("Set HINDSIGHT_API_DATABASE_URL environment variable.", err=True)
+        raise typer.Exit(1)
+
+    if not yes:
+        typer.confirm(
+            f"This will remove reembed shadow state from schema '{schema}'. Continue?",
+            abort=True,
+        )
+
+    async def _run():
+        resolved_url = await resolve_database_url(config.database_url)
+        return await abandon_reembed(
+            resolved_url,
+            schema,
+            orphan_shadow_state=orphan_shadow_state,
+        )
+
+    try:
+        report = asyncio.run(_run())
+    except Exception as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    typer.echo(f"{report.schema}: status={report.status} migration={report.migration_id or '-'}")
+    typer.echo(report.message)
 
 
 async def _decommission_worker(db_url: str, worker_id: str, schema: str = "public") -> int:

--- a/hindsight-api-slim/hindsight_api/admin/reembed.py
+++ b/hindsight-api-slim/hindsight_api/admin/reembed.py
@@ -1,0 +1,1410 @@
+"""PostgreSQL embedding re-materialization helpers for hindsight-admin."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import uuid
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+
+from .._vector_index import (
+    ann_search_tuning_settings,
+    index_type_keyword,
+    index_using_clause,
+    minimum_rows_for_index,
+    resolve_vector_extension_from_installed,
+    should_defer_index_creation,
+    uses_per_bank_vector_indexes,
+    validate_vector_index_dimension,
+)
+from ..config import (
+    DEFAULT_DATABASE_SCHEMA,
+    DEFAULT_EMBEDDINGS_OPENAI_MODEL,
+    ENV_EMBEDDINGS_OPENAI_MODEL,
+    HindsightConfig,
+    clear_config_cache,
+)
+from ..engine.embeddings import create_embeddings_from_env
+from ..engine.retain import embedding_processing, embedding_utils
+from ..engine.retain.link_utils import SEMANTIC_LINK_THRESHOLD, STREAMING_SEMANTIC_LINK_TOP_K
+
+REEMBED_MIGRATIONS_TABLE = "embedding_reembed_migrations"
+REEMBED_SEMANTIC_LINKS_TABLE = "embedding_reembed_semantic_links"
+SHADOW_COLUMN = "embedding_reembed"
+ACTIVE_REEMBED_STATUSES = ("running", "prepared", "failed")
+_MEMORY_UNIT_FACT_TYPES = {"world": "worl", "experience": "expr", "observation": "obsv"}
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReembedOptions:
+    batch_size: int = 100
+    dry_run: bool = False
+    max_retries: int = 3
+    index_max_parallel_maintenance_workers: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be at least 0")
+        if self.index_max_parallel_maintenance_workers is not None and self.index_max_parallel_maintenance_workers < 0:
+            raise ValueError("index_max_parallel_maintenance_workers must be at least 0")
+
+
+@dataclass(frozen=True)
+class ReembedReport:
+    schema: str
+    migration_id: str | None
+    status: str
+    memory_units_total: int
+    memory_units_done: int
+    mental_models_total: int
+    mental_models_done: int
+    semantic_links_staged: int
+    shadow_indexes_state: str | None
+    message: str
+
+
+@dataclass(frozen=True)
+class ReembedProgress:
+    schema: str
+    phase: str
+    migration_id: str | None = None
+    memory_units_done: int | None = None
+    memory_units_total: int | None = None
+    mental_models_done: int | None = None
+    mental_models_total: int | None = None
+    semantic_links_staged: int | None = None
+    group_index: int | None = None
+    group_total: int | None = None
+    message: str | None = None
+
+
+@dataclass
+class ReembedProgressCounts:
+    memory_units_total: int
+    memory_units_done: int
+    mental_models_total: int
+    mental_models_done: int
+
+
+@dataclass(frozen=True)
+class ShadowEmbeddingCounts:
+    memory_units: int
+    mental_models: int
+
+
+@dataclass(frozen=True)
+class ReembedStatusMigration:
+    migration_id: uuid.UUID
+    status: str
+    embedding_state: str | None
+    shadow_indexes_state: str | None
+    semantic_links_state: str | None
+    started_at: datetime | None
+    updated_at: datetime | None
+    error_message: str | None
+
+
+@dataclass(frozen=True)
+class ReembedStatusReport:
+    schema: str
+    status: str
+    migrations: list[ReembedStatusMigration]
+    state: ReembedState | None
+
+
+ProgressCallback = Callable[[ReembedProgress], None]
+
+
+class _ReembedLockUnavailable(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class _WorklistIndexSpec:
+    name: str
+    table: str
+
+
+_REEMBED_WORKLIST_INDEXES = (
+    _WorklistIndexSpec("idx_memory_units_reembed_worklist", "memory_units"),
+    _WorklistIndexSpec("idx_mental_models_reembed_worklist", "mental_models"),
+)
+
+_EMBEDDING_IDENTITY_FIELDS_BY_PROVIDER = {
+    "local": ("embeddings_local_model", "embeddings_local_trust_remote_code"),
+    "tei": ("embeddings_tei_url",),
+    "openai": ("embeddings_openai_model", "embeddings_openai_base_url", "embeddings_openai_dimensions"),
+    "openai-codex": ("embeddings_openai_model", "embeddings_openai_dimensions"),
+    "openrouter": ("embeddings_openrouter_model", "embeddings_openai_dimensions"),
+    "zeroentropy": (
+        "embeddings_zeroentropy_model",
+        "embeddings_zeroentropy_base_url",
+        "embeddings_zeroentropy_dimensions",
+        "embeddings_zeroentropy_encoding_format",
+        "embeddings_zeroentropy_latency",
+    ),
+    "cohere": ("embeddings_cohere_model", "embeddings_cohere_base_url", "embeddings_cohere_output_dimensions"),
+    "litellm": ("embeddings_litellm_model", "embeddings_litellm_api_base"),
+    "litellm-sdk": (
+        "embeddings_litellm_sdk_model",
+        "embeddings_litellm_sdk_api_base",
+        "embeddings_litellm_sdk_output_dimensions",
+        "embeddings_litellm_sdk_encoding_format",
+    ),
+    "google": (
+        "embeddings_gemini_model",
+        "embeddings_gemini_output_dimensionality",
+        "embeddings_vertexai_project_id",
+        "embeddings_vertexai_region",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReembedState:
+    active_migration_id: str | None
+    active_status: str | None
+    embedding_state: str | None
+    shadow_indexes_state: str | None
+    semantic_links_state: str | None
+    shadow_columns: list[str]
+    shadow_indexes: list[str]
+    staging_rows: int
+
+    @property
+    def has_active_migration(self) -> bool:
+        return self.active_migration_id is not None
+
+    @property
+    def has_shadow_state(self) -> bool:
+        return bool(self.shadow_columns or self.shadow_indexes or self.staging_rows)
+
+
+def _quote_ident(name: str) -> str:
+    if not name or "\x00" in name:
+        raise ValueError(f"Invalid SQL identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _emit_progress(callback: ProgressCallback | None, progress: ReembedProgress) -> None:
+    if callback is not None:
+        callback(progress)
+
+
+def _reembed_lock_key(schema: str) -> str:
+    return f"hindsight-reembed:{schema}"
+
+
+async def _try_acquire_reembed_lock(conn: asyncpg.Connection, schema: str) -> None:
+    acquired = bool(await conn.fetchval("SELECT pg_try_advisory_lock(hashtext($1))", _reembed_lock_key(schema)))
+    if not acquired:
+        raise _ReembedLockUnavailable(f"Another reembed command is already running for schema '{schema}'")
+
+
+async def _release_reembed_lock(conn: asyncpg.Connection, schema: str) -> None:
+    await conn.execute("SELECT pg_advisory_unlock(hashtext($1))", _reembed_lock_key(schema))
+
+
+def _fq(schema: str, table: str) -> str:
+    return f"{_quote_ident(schema)}.{_quote_ident(table)}"
+
+
+def _format_embedding(values: list[float]) -> str:
+    return "[" + ",".join(str(v) for v in values) + "]"
+
+
+def _embedding_identity_field(config: HindsightConfig, name: str) -> Any:
+    if name == "embeddings_openai_model":
+        return os.getenv(ENV_EMBEDDINGS_OPENAI_MODEL, DEFAULT_EMBEDDINGS_OPENAI_MODEL)
+    return getattr(config, name)
+
+
+def _model_name(config: HindsightConfig) -> str:
+    provider = config.embeddings_provider.lower()
+    if provider == "local":
+        return config.embeddings_local_model
+    if provider == "tei":
+        return config.embeddings_tei_url or "tei"
+    if provider in {"openai", "openai-codex"}:
+        return _embedding_identity_field(config, "embeddings_openai_model")
+    if provider == "openrouter":
+        return config.embeddings_openrouter_model
+    if provider == "zeroentropy":
+        return config.embeddings_zeroentropy_model
+    if provider == "cohere":
+        return config.embeddings_cohere_model
+    if provider == "litellm":
+        return config.embeddings_litellm_model
+    if provider == "litellm-sdk":
+        return config.embeddings_litellm_sdk_model
+    if provider == "google":
+        return config.embeddings_gemini_model
+    return provider
+
+
+def _model_identity(config: HindsightConfig, dimension: int) -> dict[str, Any]:
+    provider = config.embeddings_provider.lower()
+    identity: dict[str, Any] = {
+        "provider": config.embeddings_provider,
+        "model": _model_name(config),
+        "dimension": dimension,
+        "vector_extension": config.vector_extension,
+    }
+    for name in _EMBEDDING_IDENTITY_FIELDS_BY_PROVIDER.get(provider, ()):
+        identity[name] = _embedding_identity_field(config, name)
+    return identity
+
+
+def _config_fingerprint(identity: dict[str, Any]) -> str:
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _memory_unit_embedding_text(row: asyncpg.Record) -> str:
+    source_count = row["source_count"] or 0
+    if row["fact_type"] == "observation" and source_count > 0:
+        return row["text"]
+
+    return embedding_processing.build_fact_embedding_text(
+        fact_text=row["text"],
+        occurred_start=row["occurred_start"],
+        occurred_end=row["occurred_end"],
+        mentioned_at=row["mentioned_at"],
+        entities=row["entities"] or [],
+        format_date_fn=embedding_processing.format_readable_date,
+    )
+
+
+async def _table_exists(conn: asyncpg.Connection, schema: str, table: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = $1 AND table_name = $2 AND table_type = 'BASE TABLE'
+            )
+            """,
+            schema,
+            table,
+        )
+    )
+
+
+async def _existing_tables(conn: asyncpg.Connection, schema: str, tables: tuple[str, ...]) -> set[str]:
+    rows = await conn.fetch(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = $1
+          AND table_name = ANY($2::text[])
+          AND table_type = 'BASE TABLE'
+        """,
+        schema,
+        list(tables),
+    )
+    return {row["table_name"] for row in rows}
+
+
+async def _column_exists(conn: asyncpg.Connection, schema: str, table: str, column: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = $1 AND table_name = $2 AND column_name = $3
+            )
+            """,
+            schema,
+            table,
+            column,
+        )
+    )
+
+
+def _coerce_migration_id(migration_id: str | uuid.UUID) -> uuid.UUID:
+    return migration_id if isinstance(migration_id, uuid.UUID) else uuid.UUID(migration_id)
+
+
+async def _fetch_migration(
+    conn: asyncpg.Connection,
+    schema: str,
+    migration_id: str | uuid.UUID,
+) -> asyncpg.Record | None:
+    return await conn.fetchrow(
+        f"SELECT * FROM {_fq(schema, REEMBED_MIGRATIONS_TABLE)} WHERE migration_id = $1",
+        _coerce_migration_id(migration_id),
+    )
+
+
+async def _fetch_active_migration(conn: asyncpg.Connection, schema: str) -> asyncpg.Record | None:
+    rows = await conn.fetch(
+        f"""
+        SELECT *
+        FROM {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+        WHERE status = ANY($1::text[])
+        ORDER BY updated_at DESC
+        """,
+        list(ACTIVE_REEMBED_STATUSES),
+    )
+    if len(rows) > 1:
+        migration_ids = ", ".join(str(row["migration_id"]) for row in rows)
+        raise RuntimeError(
+            f"Schema '{schema}' has multiple active reembed migrations: {migration_ids}. "
+            "Resolve or abandon the extra active migrations before continuing."
+        )
+    return rows[0] if rows else None
+
+
+def _semantic_seed_filter(alias: str) -> str:
+    prefix = f"{alias}." if alias else ""
+    return f"NOT ({prefix}fact_type = 'observation' AND COALESCE(cardinality({prefix}source_memory_ids), 0) > 0)"
+
+
+async def _ensure_reembed_worklist_indexes(conn: asyncpg.Connection, schema: str) -> None:
+    for spec in _REEMBED_WORKLIST_INDEXES:
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS {_quote_ident(spec.name)}
+            ON {_fq(schema, spec.table)} (bank_id, id)
+            WHERE embedding IS NOT NULL AND {SHADOW_COLUMN} IS NULL
+            """
+        )
+
+
+async def _drop_reembed_worklist_indexes(conn: asyncpg.Connection, schema: str) -> None:
+    for spec in _REEMBED_WORKLIST_INDEXES:
+        await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(spec.name)}")
+
+
+async def discover_hindsight_schemas(
+    conn: asyncpg.Connection,
+    base_schema: str = DEFAULT_DATABASE_SCHEMA,
+) -> list[str]:
+    """Discover initialized Hindsight schemas from the database catalog."""
+    rows = await conn.fetch(
+        """
+        SELECT n.nspname AS schema_name
+        FROM pg_namespace n
+        WHERE n.nspname NOT LIKE 'pg_%'
+          AND n.nspname <> 'information_schema'
+          AND EXISTS (
+              SELECT 1 FROM information_schema.tables t
+              WHERE t.table_schema = n.nspname AND t.table_name = 'alembic_version'
+          )
+          AND EXISTS (
+              SELECT 1 FROM information_schema.tables t
+              WHERE t.table_schema = n.nspname AND t.table_name IN ('banks', 'memory_units')
+          )
+        ORDER BY n.nspname
+        """
+    )
+    discovered_schemas = [row["schema_name"] for row in rows]
+    base = base_schema or DEFAULT_DATABASE_SCHEMA
+    return list(dict.fromkeys([base, *discovered_schemas] if base in discovered_schemas else discovered_schemas))
+
+
+async def inspect_reembed_state(conn: asyncpg.Connection, schema: str) -> ReembedState:
+    migrations_exists = await _table_exists(conn, schema, REEMBED_MIGRATIONS_TABLE)
+    active = None
+    if migrations_exists:
+        active = await _fetch_active_migration(conn, schema)
+
+    shadow_column_rows = await conn.fetch(
+        """
+        SELECT table_name
+        FROM information_schema.columns
+        WHERE table_schema = $1
+          AND table_name IN ('memory_units', 'mental_models')
+          AND column_name = $2
+        ORDER BY table_name
+        """,
+        schema,
+        SHADOW_COLUMN,
+    )
+    shadow_index_rows = await conn.fetch(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = $1
+          AND tablename IN ('memory_units', 'mental_models')
+          AND indexdef ILIKE '%' || $2 || '%'
+        ORDER BY indexname
+        """,
+        schema,
+        SHADOW_COLUMN,
+    )
+    staging_rows = 0
+    if await _table_exists(conn, schema, REEMBED_SEMANTIC_LINKS_TABLE):
+        staging_rows = int(await conn.fetchval(f"SELECT COUNT(*) FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)}"))
+    return ReembedState(
+        active_migration_id=str(active["migration_id"]) if active else None,
+        active_status=active["status"] if active else None,
+        embedding_state=active["embedding_state"] if active else None,
+        shadow_indexes_state=active["shadow_indexes_state"] if active else None,
+        semantic_links_state=active["semantic_links_state"] if active else None,
+        shadow_columns=[row["table_name"] for row in shadow_column_rows],
+        shadow_indexes=[row["indexname"] for row in shadow_index_rows],
+        staging_rows=staging_rows,
+    )
+
+
+async def ensure_no_active_reembed_state(conn: asyncpg.Connection, schema: str, operation: str) -> None:
+    state = await inspect_reembed_state(conn, schema)
+    if state.has_active_migration or state.has_shadow_state:
+        details = {
+            "active_migration_id": state.active_migration_id,
+            "active_status": state.active_status,
+            "embedding_state": state.embedding_state,
+            "shadow_indexes_state": state.shadow_indexes_state,
+            "semantic_links_state": state.semantic_links_state,
+            "shadow_columns": state.shadow_columns,
+            "shadow_indexes": state.shadow_indexes,
+            "staging_rows": state.staging_rows,
+        }
+        raise RuntimeError(
+            f"Cannot {operation} while reembed migration state exists in schema '{schema}': "
+            f"{json.dumps(details, default=str)}. Complete or abandon the reembed first."
+        )
+
+
+async def _validate_schema_for_reembed(conn: asyncpg.Connection, schema: str) -> None:
+    required_tables = (
+        "banks",
+        "memory_units",
+        "mental_models",
+        "entities",
+        "unit_entities",
+        "memory_links",
+        REEMBED_MIGRATIONS_TABLE,
+        REEMBED_SEMANTIC_LINKS_TABLE,
+    )
+    existing_tables = await _existing_tables(conn, schema, required_tables)
+    missing = [table for table in required_tables if table not in existing_tables]
+    if missing:
+        raise RuntimeError(
+            f"Schema '{schema}' is missing required table(s): {', '.join(missing)}. "
+            "Run the reembed admin-table/Alembic migration path before reembed."
+        )
+
+    orphan_bank_ids = await conn.fetch(
+        f"""
+        WITH referenced AS (
+            SELECT DISTINCT bank_id FROM {_fq(schema, "memory_units")}
+            UNION
+            SELECT DISTINCT bank_id FROM {_fq(schema, "mental_models")}
+        )
+        SELECT r.bank_id
+        FROM referenced r
+        LEFT JOIN {_fq(schema, "banks")} b ON b.bank_id = r.bank_id
+        WHERE b.bank_id IS NULL
+        ORDER BY r.bank_id
+        LIMIT 20
+        """
+    )
+    if orphan_bank_ids:
+        ids = ", ".join(row["bank_id"] for row in orphan_bank_ids)
+        raise RuntimeError(
+            f"Schema '{schema}' has memory rows whose bank_id is absent from banks: {ids}. "
+            "Fix orphan bank rows before reembedding."
+        )
+
+
+async def _progress_counts(conn: asyncpg.Connection, schema: str) -> ReembedProgressCounts:
+    memory_total = int(
+        await conn.fetchval(f"SELECT COUNT(*) FROM {_fq(schema, 'memory_units')} WHERE embedding IS NOT NULL")
+    )
+    if await _column_exists(conn, schema, "memory_units", SHADOW_COLUMN):
+        memory_remaining = int(
+            await conn.fetchval(
+                f"""
+                SELECT COUNT(*)
+                FROM {_fq(schema, "memory_units")}
+                WHERE embedding IS NOT NULL AND {SHADOW_COLUMN} IS NULL
+                """
+            )
+        )
+    else:
+        memory_remaining = 0
+    mental_total = int(
+        await conn.fetchval(f"SELECT COUNT(*) FROM {_fq(schema, 'mental_models')} WHERE embedding IS NOT NULL")
+    )
+    if await _column_exists(conn, schema, "mental_models", SHADOW_COLUMN):
+        mental_remaining = int(
+            await conn.fetchval(
+                f"""
+                SELECT COUNT(*)
+                FROM {_fq(schema, "mental_models")}
+                WHERE embedding IS NOT NULL AND {SHADOW_COLUMN} IS NULL
+                """
+            )
+        )
+    else:
+        mental_remaining = 0
+    return ReembedProgressCounts(
+        memory_units_total=memory_total,
+        memory_units_done=memory_total - memory_remaining,
+        mental_models_total=mental_total,
+        mental_models_done=mental_total - mental_remaining,
+    )
+
+
+async def _with_retries(coro_factory, *, max_retries: int):
+    delay = 1.0
+    for attempt in range(max_retries + 1):
+        try:
+            return await coro_factory()
+        except Exception as exc:
+            if attempt >= max_retries:
+                raise
+            logger.warning(
+                "Reembed embedding batch failed on attempt %s/%s; retrying in %.1fs: %s",
+                attempt + 1,
+                max_retries + 1,
+                delay,
+                exc,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 10.0)
+    raise AssertionError("unreachable")
+
+
+async def _initialize_or_resume_migration(
+    conn: asyncpg.Connection,
+    schema: str,
+    config: HindsightConfig,
+    dimension: int,
+) -> asyncpg.Record:
+    identity = _model_identity(config, dimension)
+    fingerprint = _config_fingerprint(identity)
+
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", _reembed_lock_key(schema))
+
+        row = await _fetch_active_migration(conn, schema)
+
+        if row:
+            if row["config_fingerprint"] != fingerprint:
+                raise RuntimeError(
+                    "Refusing to resume reembed with a different embedding configuration. "
+                    f"Existing fingerprint={row['config_fingerprint']}, current fingerprint={fingerprint}."
+                )
+            if row["status"] == "prepared":
+                return row
+            if row["status"] not in ACTIVE_REEMBED_STATUSES:
+                raise RuntimeError(f"Cannot resume migration {row['migration_id']} with status {row['status']}")
+            return row
+
+        state = await inspect_reembed_state(conn, schema)
+        if state.has_shadow_state:
+            raise RuntimeError(
+                f"Schema '{schema}' has orphan reembed shadow state. "
+                "Run reembed-abandon --orphan-shadow-state before starting a new migration."
+            )
+
+        new_id = uuid.uuid4()
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'memory_units')} ADD COLUMN {SHADOW_COLUMN} vector({dimension})")
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'mental_models')} ADD COLUMN {SHADOW_COLUMN} vector({dimension})")
+        await conn.execute(
+            f"""
+            INSERT INTO {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+            (migration_id, schema_name, provider, model, dimension, vector_extension,
+             config_fingerprint, model_identity, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, 'running')
+            """,
+            new_id,
+            schema,
+            config.embeddings_provider,
+            _model_name(config),
+            dimension,
+            config.vector_extension,
+            fingerprint,
+            json.dumps(identity, sort_keys=True, default=str),
+        )
+        return await conn.fetchrow(
+            f"SELECT * FROM {_fq(schema, REEMBED_MIGRATIONS_TABLE)} WHERE migration_id = $1",
+            new_id,
+        )
+
+
+async def _reembed_memory_units(conn: asyncpg.Connection, schema: str, embeddings, options: ReembedOptions) -> int:
+    rows = await conn.fetch(
+        f"""
+        SELECT mu.id, mu.text, mu.fact_type, mu.occurred_start, mu.occurred_end, mu.mentioned_at,
+               COALESCE(cardinality(mu.source_memory_ids), 0) AS source_count,
+               ent.entities
+        FROM {_fq(schema, "memory_units")} mu
+        LEFT JOIN LATERAL (
+            SELECT array_agg(e.canonical_name ORDER BY lower(e.canonical_name), e.id) AS entities
+            FROM {_fq(schema, "unit_entities")} ue
+            JOIN {_fq(schema, "entities")} e ON e.id = ue.entity_id
+            WHERE ue.unit_id = mu.id
+        ) ent ON TRUE
+        WHERE mu.embedding IS NOT NULL AND mu.{SHADOW_COLUMN} IS NULL
+        ORDER BY mu.bank_id, mu.id
+        LIMIT $1
+        """,
+        options.batch_size,
+    )
+    if not rows:
+        return 0
+
+    texts = [_memory_unit_embedding_text(row) for row in rows]
+    vectors = await _with_retries(
+        lambda: embedding_utils.generate_embeddings_batch(embeddings, texts),
+        max_retries=options.max_retries,
+    )
+    await conn.executemany(
+        f"UPDATE {_fq(schema, 'memory_units')} SET {SHADOW_COLUMN} = $2::vector WHERE id = $1",
+        [(row["id"], _format_embedding(vector)) for row, vector in zip(rows, vectors, strict=True)],
+    )
+    return len(rows)
+
+
+async def _reembed_mental_models(conn: asyncpg.Connection, schema: str, embeddings, options: ReembedOptions) -> int:
+    rows = await conn.fetch(
+        f"""
+        SELECT id, bank_id, name, content
+        FROM {_fq(schema, "mental_models")}
+        WHERE embedding IS NOT NULL AND {SHADOW_COLUMN} IS NULL
+        ORDER BY bank_id, id
+        LIMIT $1
+        """,
+        options.batch_size,
+    )
+    if not rows:
+        return 0
+
+    texts = [embedding_processing.build_mental_model_embedding_text(row["name"], row["content"]) for row in rows]
+    vectors = await _with_retries(
+        lambda: embedding_utils.generate_embeddings_batch(embeddings, texts),
+        max_retries=options.max_retries,
+    )
+    await conn.executemany(
+        f"""
+        UPDATE {_fq(schema, "mental_models")}
+        SET {SHADOW_COLUMN} = $3::vector
+        WHERE id = $1 AND bank_id = $2
+        """,
+        [(row["id"], row["bank_id"], _format_embedding(vector)) for row, vector in zip(rows, vectors, strict=True)],
+    )
+    return len(rows)
+
+
+async def _resolve_vector_extension(conn: asyncpg.Connection, vector_extension: str) -> str:
+    rows = await conn.fetch("SELECT extname FROM pg_extension")
+    return resolve_vector_extension_from_installed(vector_extension, {row["extname"] for row in rows})
+
+
+async def _shadow_embedding_counts(conn: asyncpg.Connection, schema: str) -> ShadowEmbeddingCounts:
+    row = await conn.fetchrow(
+        f"""
+        SELECT
+            (SELECT COUNT(*) FROM {_fq(schema, "memory_units")} WHERE {SHADOW_COLUMN} IS NOT NULL) AS memory_units,
+            (SELECT COUNT(*) FROM {_fq(schema, "mental_models")} WHERE {SHADOW_COLUMN} IS NOT NULL) AS mental_models
+        """
+    )
+    return ShadowEmbeddingCounts(
+        memory_units=int(row["memory_units"]),
+        mental_models=int(row["mental_models"]),
+    )
+
+
+async def _create_shadow_indexes(
+    conn: asyncpg.Connection,
+    schema: str,
+    resolved_extension: str,
+    migration_id: uuid.UUID,
+    index_max_parallel_maintenance_workers: int | None = None,
+) -> str:
+    embedding_counts = await _shadow_embedding_counts(conn, schema)
+    deferred_tables = {
+        table_name: row_count
+        for table_name, row_count in (
+            ("memory_units", embedding_counts.memory_units),
+            ("mental_models", embedding_counts.mental_models),
+        )
+        if should_defer_index_creation(resolved_extension, row_count)
+    }
+    if deferred_tables:
+        minimum_rows = minimum_rows_for_index(resolved_extension)
+        table_counts = ", ".join(
+            f"{table_name}={row_count}" for table_name, row_count in sorted(deferred_tables.items())
+        )
+        await conn.execute(
+            f"""
+            UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+            SET shadow_indexes_state = 'deferred', updated_at = now()
+            WHERE migration_id = $1
+            """,
+            migration_id,
+        )
+        return (
+            f"deferred: {resolved_extension} index creation requires at least {minimum_rows} rows "
+            f"per indexed table; found {table_counts}"
+        )
+
+    index_type = index_type_keyword(resolved_extension)
+    clause = index_using_clause(resolved_extension, column=SHADOW_COLUMN)
+    override_parallel_workers = index_max_parallel_maintenance_workers is not None
+    if override_parallel_workers:
+        await conn.execute(
+            "SELECT set_config('max_parallel_maintenance_workers', $1, false)",
+            str(index_max_parallel_maintenance_workers),
+        )
+
+    try:
+        if uses_per_bank_vector_indexes(resolved_extension):
+            banks = await conn.fetch(f"SELECT bank_id, internal_id FROM {_fq(schema, 'banks')} ORDER BY bank_id")
+            for bank in banks:
+                uid = str(bank["internal_id"]).replace("-", "")[:16]
+                escaped_bank_id = str(bank["bank_id"]).replace("'", "''")
+                for fact_type, suffix in _MEMORY_UNIT_FACT_TYPES.items():
+                    index_name = f"idx_mu_reemb_{suffix}_{uid}"
+                    await conn.execute(
+                        f"""
+                        CREATE INDEX IF NOT EXISTS {_quote_ident(index_name)}
+                        ON {_fq(schema, "memory_units")}
+                        {clause}
+                        WHERE {SHADOW_COLUMN} IS NOT NULL
+                          AND fact_type = '{fact_type}'
+                          AND bank_id = '{escaped_bank_id}'
+                        """
+                    )
+        else:
+            await conn.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS idx_memory_units_embedding_reembed_{index_type}
+                ON {_fq(schema, "memory_units")}
+                {clause}
+                """
+            )
+
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_mental_models_embedding_reembed_{index_type}
+            ON {_fq(schema, "mental_models")}
+            {clause}
+            """
+        )
+    finally:
+        if override_parallel_workers:
+            await conn.execute("RESET max_parallel_maintenance_workers")
+
+    await conn.execute(
+        f"""
+        UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+        SET shadow_indexes_state = 'ready', updated_at = now()
+        WHERE migration_id = $1
+        """,
+        migration_id,
+    )
+    return "ready"
+
+
+async def _stage_semantic_links(
+    conn: asyncpg.Connection,
+    schema: str,
+    migration_id: uuid.UUID,
+    resolved_extension: str,
+    progress_callback: ProgressCallback | None = None,
+) -> int:
+    await conn.execute(
+        f"DELETE FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)} WHERE migration_id = $1",
+        migration_id,
+    )
+    await conn.execute(
+        f"""
+        UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+        SET semantic_links_state = 'pending', updated_at = now()
+        WHERE migration_id = $1
+        """,
+        migration_id,
+    )
+
+    groups = await conn.fetch(
+        f"""
+        SELECT bank_id, fact_type
+        FROM {_fq(schema, "memory_units")}
+        WHERE {SHADOW_COLUMN} IS NOT NULL
+          AND {_semantic_seed_filter("")}
+        GROUP BY bank_id, fact_type
+        ORDER BY bank_id, fact_type
+        """
+    )
+
+    staged = 0
+    logger.info(
+        "Staging reembed semantic links for schema=%s migration_id=%s groups=%s",
+        schema,
+        migration_id,
+        len(groups),
+    )
+    _emit_progress(
+        progress_callback,
+        ReembedProgress(
+            schema=schema,
+            phase="staging-semantic-links",
+            migration_id=str(migration_id),
+            semantic_links_staged=0,
+            group_total=len(groups),
+            message="staging semantic links",
+        ),
+    )
+    for group_index, group in enumerate(groups, start=1):
+        async with conn.transaction():
+            for guc, value in ann_search_tuning_settings(resolved_extension, kind="low_latency"):
+                await conn.execute(f"SET LOCAL {guc} = {value}")
+
+            group_staged = await conn.fetchval(
+                f"""
+                WITH inserted AS (
+                    INSERT INTO {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)}
+                    (migration_id, bank_id, from_unit_id, to_unit_id, weight)
+                    SELECT $1, seed.bank_id, seed.id, candidate.id, candidate.similarity
+                    FROM {_fq(schema, "memory_units")} seed
+                    JOIN LATERAL (
+                        SELECT mu.id,
+                               GREATEST(0.0, LEAST(1.0, 1.0 - (seed.{SHADOW_COLUMN} <=> mu.{SHADOW_COLUMN}))) AS similarity
+                        FROM {_fq(schema, "memory_units")} mu
+                        WHERE mu.bank_id = $2
+                          AND mu.fact_type = $3
+                          AND mu.{SHADOW_COLUMN} IS NOT NULL
+                          AND mu.id <> seed.id
+                        ORDER BY seed.{SHADOW_COLUMN} <=> mu.{SHADOW_COLUMN}
+                        LIMIT {STREAMING_SEMANTIC_LINK_TOP_K}
+                    ) candidate ON candidate.similarity >= {SEMANTIC_LINK_THRESHOLD}
+                    WHERE seed.{SHADOW_COLUMN} IS NOT NULL
+                      AND seed.bank_id = $2
+                      AND seed.fact_type = $3
+                      AND {_semantic_seed_filter("seed")}
+                    ON CONFLICT DO NOTHING
+                    RETURNING 1
+                )
+                SELECT COUNT(*)::int FROM inserted
+                """,
+                migration_id,
+                group["bank_id"],
+                group["fact_type"],
+            )
+            staged += int(group_staged or 0)
+        _emit_progress(
+            progress_callback,
+            ReembedProgress(
+                schema=schema,
+                phase="staging-semantic-links",
+                migration_id=str(migration_id),
+                semantic_links_staged=staged,
+                group_index=group_index,
+                group_total=len(groups),
+                message=f"bank_id={group['bank_id']} fact_type={group['fact_type']}",
+            ),
+        )
+        logger.info(
+            "Staged %s reembed semantic links for schema=%s migration_id=%s group=%s/%s bank_id=%s fact_type=%s",
+            int(group_staged or 0),
+            schema,
+            migration_id,
+            group_index,
+            len(groups),
+            group["bank_id"],
+            group["fact_type"],
+        )
+
+    await conn.execute(
+        f"""
+        UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+        SET semantic_links_state = 'complete', updated_at = now()
+        WHERE migration_id = $1
+        """,
+        migration_id,
+    )
+    return staged
+
+
+async def _mark_prepared_if_ready(conn: asyncpg.Connection, schema: str, migration_id: uuid.UUID) -> bool:
+    row = await conn.fetchrow(
+        f"""
+        SELECT embedding_state, shadow_indexes_state, semantic_links_state
+        FROM {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+        WHERE migration_id = $1
+        """,
+        migration_id,
+    )
+    if (
+        row
+        and row["embedding_state"] == "complete"
+        and row["shadow_indexes_state"] in {"ready", "deferred"}
+        and row["semantic_links_state"] == "complete"
+    ):
+        await conn.execute(
+            f"""
+            UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+            SET status = 'prepared', updated_at = now()
+            WHERE migration_id = $1
+            """,
+            migration_id,
+        )
+        return True
+    return False
+
+
+async def _rename_shadow_indexes(conn: asyncpg.Connection, schema: str, resolved_extension: str) -> None:
+    index_type = index_type_keyword(resolved_extension)
+    if uses_per_bank_vector_indexes(resolved_extension):
+        banks = await conn.fetch(f"SELECT internal_id FROM {_fq(schema, 'banks')} ORDER BY bank_id")
+        for bank in banks:
+            uid = str(bank["internal_id"]).replace("-", "")[:16]
+            for suffix in _MEMORY_UNIT_FACT_TYPES.values():
+                await conn.execute(
+                    f"DROP INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(f'idx_mu_emb_{suffix}_{uid}')}"
+                )
+                await conn.execute(
+                    f"""
+                    ALTER INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(f"idx_mu_reemb_{suffix}_{uid}")}
+                    RENAME TO {_quote_ident(f"idx_mu_emb_{suffix}_{uid}")}
+                    """
+                )
+    else:
+        await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.idx_memory_units_embedding")
+        await conn.execute(
+            f"""
+            ALTER INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(f"idx_memory_units_embedding_reembed_{index_type}")}
+            RENAME TO idx_memory_units_embedding
+            """
+        )
+
+    await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.idx_mental_models_embedding")
+    await conn.execute(
+        f"""
+        ALTER INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(f"idx_mental_models_embedding_reembed_{index_type}")}
+        RENAME TO idx_mental_models_embedding
+        """
+    )
+
+
+async def _cutover(conn: asyncpg.Connection, schema: str, migration_id: uuid.UUID, resolved_extension: str) -> None:
+    row = await _fetch_migration(conn, schema, migration_id)
+    if row is None or row["status"] != "prepared":
+        raise RuntimeError(f"Migration {migration_id} is not prepared for cutover")
+
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", _reembed_lock_key(schema))
+        await _drop_reembed_worklist_indexes(conn, schema)
+        if row["shadow_indexes_state"] == "ready":
+            await _rename_shadow_indexes(conn, schema, resolved_extension)
+        else:
+            await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.idx_memory_units_embedding")
+            await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.idx_mental_models_embedding")
+
+        await conn.execute(
+            f"""
+            DELETE FROM {_fq(schema, "memory_links")} ml
+            USING {_fq(schema, "memory_units")} mu
+            WHERE ml.from_unit_id = mu.id
+              AND ml.link_type = 'semantic'
+              AND mu.{SHADOW_COLUMN} IS NOT NULL
+              AND {_semantic_seed_filter("mu")}
+            """
+        )
+        await conn.execute(
+            f"""
+            INSERT INTO {_fq(schema, "memory_links")}
+            (from_unit_id, to_unit_id, link_type, entity_id, weight, bank_id)
+            SELECT from_unit_id, to_unit_id, 'semantic', NULL, weight, bank_id
+            FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)}
+            WHERE migration_id = $1
+            ON CONFLICT DO NOTHING
+            """,
+            migration_id,
+        )
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'memory_units')} DROP COLUMN embedding")
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'memory_units')} RENAME COLUMN {SHADOW_COLUMN} TO embedding")
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'mental_models')} DROP COLUMN embedding")
+        await conn.execute(f"ALTER TABLE {_fq(schema, 'mental_models')} RENAME COLUMN {SHADOW_COLUMN} TO embedding")
+        await conn.execute(
+            f"DELETE FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)} WHERE migration_id = $1",
+            migration_id,
+        )
+        await conn.execute(
+            f"""
+            UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+            SET status = 'completed', updated_at = now()
+            WHERE migration_id = $1
+            """,
+            migration_id,
+        )
+
+
+async def reembed_schema(
+    database_url: str,
+    schema: str,
+    config: HindsightConfig,
+    options: ReembedOptions,
+    progress_callback: ProgressCallback | None = None,
+) -> ReembedReport:
+    conn = await asyncpg.connect(database_url)
+    lock_acquired = False
+    try:
+        if not options.dry_run:
+            await _try_acquire_reembed_lock(conn, schema)
+            lock_acquired = True
+
+        _emit_progress(
+            progress_callback,
+            ReembedProgress(schema=schema, phase="validating", message="validating schema"),
+        )
+        if options.dry_run:
+            migrations_exists = await _table_exists(conn, schema, REEMBED_MIGRATIONS_TABLE)
+            if not migrations_exists:
+                return ReembedReport(
+                    schema=schema,
+                    migration_id=None,
+                    status="dry-run",
+                    memory_units_total=0,
+                    memory_units_done=0,
+                    mental_models_total=0,
+                    mental_models_done=0,
+                    semantic_links_staged=0,
+                    shadow_indexes_state=None,
+                    message="admin tables are missing; dry-run did not create them",
+                )
+
+        await _validate_schema_for_reembed(conn, schema)
+
+        clear_config_cache()
+        embeddings = create_embeddings_from_env()
+        await embeddings.initialize()
+        dimension = embeddings.dimension
+        resolved_vector_extension = await _resolve_vector_extension(conn, config.vector_extension)
+        validate_vector_index_dimension(resolved_vector_extension, dimension)
+        _emit_progress(
+            progress_callback,
+            ReembedProgress(
+                schema=schema,
+                phase="initialized",
+                message=f"dimension={dimension} vector_extension={resolved_vector_extension}",
+            ),
+        )
+
+        if options.dry_run:
+            state = await inspect_reembed_state(conn, schema)
+            if await _column_exists(conn, schema, "memory_units", SHADOW_COLUMN):
+                counts = await _progress_counts(conn, schema)
+            else:
+                counts = ReembedProgressCounts(
+                    memory_units_total=int(
+                        await conn.fetchval(
+                            f"SELECT COUNT(*) FROM {_fq(schema, 'memory_units')} WHERE embedding IS NOT NULL"
+                        )
+                    ),
+                    memory_units_done=0,
+                    mental_models_total=int(
+                        await conn.fetchval(
+                            f"SELECT COUNT(*) FROM {_fq(schema, 'mental_models')} WHERE embedding IS NOT NULL"
+                        )
+                    ),
+                    mental_models_done=0,
+                )
+            return ReembedReport(
+                schema=schema,
+                migration_id=state.active_migration_id,
+                status="dry-run",
+                memory_units_total=counts.memory_units_total,
+                memory_units_done=counts.memory_units_done,
+                mental_models_total=counts.mental_models_total,
+                mental_models_done=counts.mental_models_done,
+                semantic_links_staged=state.staging_rows,
+                shadow_indexes_state=state.shadow_indexes_state,
+                message=f"would use embedding dimension={dimension}",
+            )
+
+        migration = await _initialize_or_resume_migration(conn, schema, config, dimension)
+        migration_id = migration["migration_id"]
+        _emit_progress(
+            progress_callback,
+            ReembedProgress(
+                schema=schema,
+                phase="migration-ready",
+                migration_id=str(migration_id),
+                message=f"status={migration['status']}",
+            ),
+        )
+
+        if migration["status"] != "prepared":
+            await _ensure_reembed_worklist_indexes(conn, schema)
+            counts = await _progress_counts(conn, schema)
+            _emit_progress(
+                progress_callback,
+                ReembedProgress(
+                    schema=schema,
+                    phase="embedding",
+                    migration_id=str(migration_id),
+                    memory_units_done=counts.memory_units_done,
+                    memory_units_total=counts.memory_units_total,
+                    mental_models_done=counts.mental_models_done,
+                    mental_models_total=counts.mental_models_total,
+                    message="embedding rows",
+                ),
+            )
+            while True:
+                memory_processed = await _reembed_memory_units(conn, schema, embeddings, options)
+                mental_processed = await _reembed_mental_models(conn, schema, embeddings, options)
+                processed = memory_processed + mental_processed
+                if processed == 0:
+                    break
+                counts.memory_units_done += memory_processed
+                counts.mental_models_done += mental_processed
+                _emit_progress(
+                    progress_callback,
+                    ReembedProgress(
+                        schema=schema,
+                        phase="embedding",
+                        migration_id=str(migration_id),
+                        memory_units_done=counts.memory_units_done,
+                        memory_units_total=counts.memory_units_total,
+                        mental_models_done=counts.mental_models_done,
+                        mental_models_total=counts.mental_models_total,
+                        message=f"processed_batch={processed}",
+                    ),
+                )
+
+            counts = await _progress_counts(conn, schema)
+            if (
+                counts.memory_units_done == counts.memory_units_total
+                and counts.mental_models_done == counts.mental_models_total
+            ):
+                await conn.execute(
+                    f"""
+                    UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+                    SET embedding_state = 'complete', updated_at = now()
+                    WHERE migration_id = $1
+                    """,
+                    migration_id,
+                )
+                _emit_progress(
+                    progress_callback,
+                    ReembedProgress(
+                        schema=schema,
+                        phase="building-shadow-indexes",
+                        migration_id=str(migration_id),
+                        message="building shadow indexes",
+                    ),
+                )
+                index_message = await _create_shadow_indexes(
+                    conn,
+                    schema,
+                    resolved_vector_extension,
+                    migration_id,
+                    options.index_max_parallel_maintenance_workers,
+                )
+                _emit_progress(
+                    progress_callback,
+                    ReembedProgress(
+                        schema=schema,
+                        phase="shadow-indexes-ready",
+                        migration_id=str(migration_id),
+                        message=index_message,
+                    ),
+                )
+                semantic_count = await _stage_semantic_links(
+                    conn,
+                    schema,
+                    migration_id,
+                    resolved_vector_extension,
+                    progress_callback,
+                )
+                await _mark_prepared_if_ready(conn, schema, migration_id)
+            else:
+                index_message = "pending"
+                semantic_count = 0
+        else:
+            counts = await _progress_counts(conn, schema)
+            index_message = migration["shadow_indexes_state"]
+            semantic_count = int(
+                await conn.fetchval(
+                    f"SELECT COUNT(*) FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)} WHERE migration_id = $1",
+                    migration_id,
+                )
+            )
+
+        prepared = await _fetch_migration(conn, schema, migration_id)
+        if prepared and prepared["status"] == "prepared":
+            _emit_progress(
+                progress_callback,
+                ReembedProgress(
+                    schema=schema,
+                    phase="cutover",
+                    migration_id=str(migration_id),
+                    message="cutting over",
+                ),
+            )
+            await _cutover(conn, schema, migration_id, resolved_vector_extension)
+
+        final = await _fetch_migration(conn, schema, migration_id)
+        final_counts = await _progress_counts(conn, schema)
+        _emit_progress(
+            progress_callback,
+            ReembedProgress(
+                schema=schema,
+                phase="completed" if final and final["status"] == "completed" else "finished",
+                migration_id=str(migration_id),
+                memory_units_done=final_counts.memory_units_done,
+                memory_units_total=final_counts.memory_units_total,
+                mental_models_done=final_counts.mental_models_done,
+                mental_models_total=final_counts.mental_models_total,
+                semantic_links_staged=semantic_count,
+                message=f"status={final['status'] if final else 'unknown'}",
+            ),
+        )
+        return ReembedReport(
+            schema=schema,
+            migration_id=str(migration_id),
+            status=final["status"] if final else "unknown",
+            memory_units_total=final_counts.memory_units_total,
+            memory_units_done=final_counts.memory_units_done,
+            mental_models_total=final_counts.mental_models_total,
+            mental_models_done=final_counts.mental_models_done,
+            semantic_links_staged=semantic_count,
+            shadow_indexes_state=final["shadow_indexes_state"] if final else None,
+            message=index_message,
+        )
+    except _ReembedLockUnavailable:
+        raise
+    except Exception as exc:
+        if await _table_exists(conn, schema, REEMBED_MIGRATIONS_TABLE):
+            active = await _fetch_active_migration(conn, schema)
+            if active:
+                await conn.execute(
+                    f"""
+                    UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+                    SET status = 'failed', error_message = $2, updated_at = now()
+                    WHERE migration_id = $1 AND status <> 'completed'
+                    """,
+                    active["migration_id"],
+                    str(exc),
+                )
+        raise
+    finally:
+        if lock_acquired:
+            try:
+                await _release_reembed_lock(conn, schema)
+            except Exception:
+                logger.warning("Failed to release reembed advisory lock for schema=%s", schema, exc_info=True)
+        await conn.close()
+
+
+async def reembed_status(database_url: str, schema: str) -> ReembedStatusReport:
+    conn = await asyncpg.connect(database_url)
+    try:
+        if not await _table_exists(conn, schema, REEMBED_MIGRATIONS_TABLE):
+            return ReembedStatusReport(
+                schema=schema,
+                status="not-initialized",
+                migrations=[],
+                state=None,
+            )
+        rows = await conn.fetch(
+            f"""
+            SELECT migration_id, status, embedding_state, shadow_indexes_state,
+                   semantic_links_state, started_at, updated_at, error_message
+            FROM {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+            ORDER BY updated_at DESC
+            LIMIT 5
+            """
+        )
+        state = await inspect_reembed_state(conn, schema)
+        return ReembedStatusReport(
+            schema=schema,
+            status="initialized",
+            migrations=[
+                ReembedStatusMigration(
+                    migration_id=row["migration_id"],
+                    status=row["status"],
+                    embedding_state=row["embedding_state"],
+                    shadow_indexes_state=row["shadow_indexes_state"],
+                    semantic_links_state=row["semantic_links_state"],
+                    started_at=row["started_at"],
+                    updated_at=row["updated_at"],
+                    error_message=row["error_message"],
+                )
+                for row in rows
+            ],
+            state=state,
+        )
+    finally:
+        await conn.close()
+
+
+async def abandon_reembed(
+    database_url: str,
+    schema: str,
+    *,
+    orphan_shadow_state: bool,
+) -> ReembedReport:
+    conn = await asyncpg.connect(database_url)
+    try:
+        if not await _table_exists(conn, schema, REEMBED_MIGRATIONS_TABLE):
+            if not orphan_shadow_state:
+                raise RuntimeError(f"Schema '{schema}' has no reembed admin table")
+            target_id = None
+        else:
+            row = await _fetch_active_migration(conn, schema)
+            target_id = row["migration_id"] if row else None
+            if target_id is None and not orphan_shadow_state:
+                raise RuntimeError(f"Schema '{schema}' has no active reembed migration")
+
+        async with conn.transaction():
+            await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", _reembed_lock_key(schema))
+            state = await inspect_reembed_state(conn, schema)
+            for index_name in state.shadow_indexes:
+                await conn.execute(f"DROP INDEX IF EXISTS {_quote_ident(schema)}.{_quote_ident(index_name)}")
+            for table in ("memory_units", "mental_models"):
+                if await _column_exists(conn, schema, table, SHADOW_COLUMN):
+                    await conn.execute(f"ALTER TABLE {_fq(schema, table)} DROP COLUMN {SHADOW_COLUMN}")
+            if await _table_exists(conn, schema, REEMBED_SEMANTIC_LINKS_TABLE):
+                if target_id is not None:
+                    await conn.execute(
+                        f"DELETE FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)} WHERE migration_id = $1",
+                        target_id,
+                    )
+                elif orphan_shadow_state:
+                    await conn.execute(f"DELETE FROM {_fq(schema, REEMBED_SEMANTIC_LINKS_TABLE)}")
+            if target_id is not None:
+                await conn.execute(
+                    f"""
+                    UPDATE {_fq(schema, REEMBED_MIGRATIONS_TABLE)}
+                    SET status = 'abandoned', updated_at = now()
+                    WHERE migration_id = $1 AND status = ANY($2::text[])
+                    """,
+                    target_id,
+                    list(ACTIVE_REEMBED_STATUSES),
+                )
+
+        return ReembedReport(
+            schema=schema,
+            migration_id=str(target_id) if target_id else None,
+            status="abandoned",
+            memory_units_total=0,
+            memory_units_done=0,
+            mental_models_total=0,
+            mental_models_done=0,
+            semantic_links_staged=0,
+            shadow_indexes_state=None,
+            message="reembed shadow state removed",
+        )
+    finally:
+        await conn.close()

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c3efa30f38c9_add_reembed_admin_tables.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c3efa30f38c9_add_reembed_admin_tables.py
@@ -1,0 +1,113 @@
+"""Add reembed admin metadata tables.
+
+Revision ID: c3efa30f38c9
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-01
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "c3efa30f38c9"
+down_revision: str | Sequence[str] | None = "c1d2e3f4a5b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _pg_schema_prefix() -> str:
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}embedding_reembed_migrations (
+            migration_id UUID PRIMARY KEY,
+            schema_name TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            model TEXT NOT NULL,
+            dimension INTEGER NOT NULL,
+            vector_extension TEXT NOT NULL,
+            config_fingerprint TEXT NOT NULL,
+            model_identity JSONB NOT NULL,
+            embedding_state TEXT NOT NULL DEFAULT 'pending',
+            shadow_indexes_state TEXT NOT NULL DEFAULT 'pending',
+            semantic_links_state TEXT NOT NULL DEFAULT 'pending',
+            status TEXT NOT NULL,
+            started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            error_message TEXT,
+            CHECK (embedding_state IN ('pending', 'complete')),
+            CHECK (shadow_indexes_state IN ('pending', 'ready', 'deferred')),
+            CHECK (semantic_links_state IN ('pending', 'complete')),
+            CHECK (status IN ('running', 'prepared', 'completed', 'failed', 'abandoned'))
+        )
+        """
+    )
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {schema}embedding_reembed_semantic_links (
+            migration_id UUID NOT NULL,
+            bank_id TEXT NOT NULL,
+            from_unit_id UUID NOT NULL,
+            to_unit_id UUID NOT NULL,
+            weight DOUBLE PRECISION NOT NULL,
+            PRIMARY KEY (migration_id, from_unit_id, to_unit_id),
+            FOREIGN KEY (migration_id)
+                REFERENCES {schema}embedding_reembed_migrations(migration_id)
+                ON DELETE CASCADE,
+            CHECK (weight >= 0.0 AND weight <= 1.0)
+        )
+        """
+    )
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_embedding_reembed_migrations_status
+        ON {schema}embedding_reembed_migrations (status, updated_at)
+        """
+    )
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_embedding_reembed_migrations_one_active
+        ON {schema}embedding_reembed_migrations (schema_name)
+        WHERE status IN ('running', 'prepared', 'failed')
+        """
+    )
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_embedding_reembed_semantic_links_bank
+        ON {schema}embedding_reembed_semantic_links (migration_id, bank_id)
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    schema = _pg_schema_prefix()
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_embedding_reembed_semantic_links_bank")
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_embedding_reembed_migrations_one_active")
+    op.execute(f"DROP INDEX IF EXISTS {schema}idx_embedding_reembed_migrations_status")
+    op.execute(f"DROP TABLE IF EXISTS {schema}embedding_reembed_semantic_links")
+    op.execute(f"DROP TABLE IF EXISTS {schema}embedding_reembed_migrations")
+
+
+def _oracle_upgrade() -> None:
+    # Re-embedding migration is PostgreSQL-only; Oracle admin CLI does not
+    # expose this command path.
+    pass
+
+
+def _oracle_downgrade() -> None:
+    pass
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade, oracle=_oracle_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade, oracle=_oracle_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -43,6 +43,7 @@ from ..models import RequestContext
 from .db.base import DatabaseConnection
 from .retain.link_utils import (
     MAX_TEMPORAL_LINKS_PER_UNIT,
+    SEMANTIC_LINK_DEFAULT_TOP_K,
     _bulk_insert_links,
     _normalize_datetime,
     compute_semantic_links_ann,
@@ -58,7 +59,7 @@ logger = logging.getLogger(__name__)
 # time. If you change one, change the other — otherwise victims would either
 # never reach the cap (probe returns less than the cap) or stay perpetually
 # under it (cap is higher than retain creates).
-MAX_SEMANTIC_LINKS_PER_UNIT = 50
+MAX_SEMANTIC_LINKS_PER_UNIT = SEMANTIC_LINK_DEFAULT_TOP_K
 
 # Worker fetches this many rows per relink-loop iteration. Bounds
 # per-iteration probe/insert latency so a 10k-row backlog doesn't hold a

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -256,6 +256,7 @@ from .response_models import (
 )
 from .response_models import RecallResult as RecallResultModel
 from .retain import bank_utils, embedding_utils
+from .retain.embedding_processing import build_mental_model_embedding_text, format_readable_date
 from .retain.types import RetainContentDict
 from .search import think_utils
 from .search.reranking import CrossEncoderReranker, apply_combined_scoring
@@ -2786,14 +2787,7 @@ class MemoryEngine(MemoryEngineInterface):
         Returns:
             Readable date string
         """
-        # Format as "Month Year" for most cases
-        # Could be extended to include day for very specific dates if needed
-        month_name = dt.strftime("%B")  # Full month name (e.g., "June")
-        year = dt.strftime("%Y")  # Year (e.g., "2024")
-
-        # For now, use "Month Year" format
-        # Could check if day is significant (not 1st or 15th) and include it
-        return f"{month_name} {year}"
+        return format_readable_date(dt)
 
     def retain(
         self,
@@ -9237,7 +9231,7 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
 
         # Generate embedding for the content
-        embedding_text = f"{name} {content}"
+        embedding_text = build_mental_model_embedding_text(name, content)
         embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
         # Convert embedding to string for asyncpg vector type
         embedding_str = str(embedding[0]) if embedding else None
@@ -9763,7 +9757,7 @@ class MemoryEngine(MemoryEngineInterface):
                             slim_reflect_response = {"based_on": based_on}
                     record_mm_history = True
                 # Also update embedding (convert to string for asyncpg vector type)
-                embedding_text = f"{name or ''} {content}"
+                embedding_text = build_mental_model_embedding_text(name, content)
                 embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
                 if embedding:
                     updates.append(f"embedding = ${param_idx}")

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_processing.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_processing.py
@@ -5,11 +5,51 @@ Handles augmenting fact texts with temporal information and generating embedding
 """
 
 import logging
+from collections.abc import Callable, Sequence
+from datetime import datetime
 
 from . import embedding_utils
 from .types import ExtractedFact
 
 logger = logging.getLogger(__name__)
+
+
+def format_readable_date(value: datetime) -> str:
+    """Format a date for temporal embedding text."""
+    return f"{value.strftime('%B')} {value.strftime('%Y')}"
+
+
+def build_fact_embedding_text(
+    *,
+    fact_text: str,
+    occurred_start: datetime | None,
+    occurred_end: datetime | None,
+    mentioned_at: datetime | None,
+    entities: Sequence[str],
+    format_date_fn: Callable[[datetime], str],
+) -> str:
+    """Build the embedding input for a retained fact."""
+    # Use occurred_start as the representative date, fall back to mentioned_at.
+    fact_date = occurred_start or mentioned_at
+    if fact_date is not None:
+        readable_date = format_date_fn(fact_date)
+        if occurred_end and occurred_end != occurred_start:
+            readable_end = format_date_fn(occurred_end)
+            text = f"{fact_text} (happened from {readable_date} to {readable_end})"
+        else:
+            text = f"{fact_text} (happened in {readable_date})"
+    else:
+        text = fact_text
+
+    entity_names = [entity for entity in entities if entity]
+    if entity_names:
+        text = f"{text} [{', '.join(entity_names)}]"
+    return text
+
+
+def build_mental_model_embedding_text(name: str | None, content: str | None) -> str:
+    """Build the canonical embedding input for the current mental-model row."""
+    return f"{name or ''} {content or ''}"
 
 
 def augment_texts_with_dates(facts: list[ExtractedFact], format_date_fn) -> list[str]:
@@ -27,22 +67,17 @@ def augment_texts_with_dates(facts: list[ExtractedFact], format_date_fn) -> list
     """
     augmented_texts = []
     for fact in facts:
-        # Use occurred_start as the representative date, fall back to mentioned_at
-        fact_date = fact.occurred_start or fact.mentioned_at
-        # Augment text with date and entity names for embedding (but store original text in DB)
-        # Entity names (including key:value labels) improve retrieval without polluting stored content
-        if fact_date is not None:
-            readable_date = format_date_fn(fact_date)
-            if fact.occurred_end and fact.occurred_end != fact.occurred_start:
-                readable_end = format_date_fn(fact.occurred_end)
-                augmented_text = f"{fact.fact_text} (happened from {readable_date} to {readable_end})"
-            else:
-                augmented_text = f"{fact.fact_text} (happened in {readable_date})"
-        else:
-            augmented_text = fact.fact_text
-        if fact.entities:
-            augmented_text = f"{augmented_text} [{', '.join(fact.entities)}]"
-        augmented_texts.append(augmented_text)
+        # Entity names (including key:value labels) improve retrieval without polluting stored content.
+        augmented_texts.append(
+            build_fact_embedding_text(
+                fact_text=fact.fact_text,
+                occurred_start=fact.occurred_start,
+                occurred_end=fact.occurred_end,
+                mentioned_at=fact.mentioned_at,
+                entities=fact.entities,
+                format_date_fn=format_date_fn,
+            )
+        )
     return augmented_texts
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -19,6 +19,13 @@ _NIL_ENTITY_UUID = "00000000-0000-0000-0000-000000000000"
 # more is wasted storage and write amplification.
 MAX_TEMPORAL_LINKS_PER_UNIT = 20
 
+# Semantic link policy. The helper default is used by non-streaming callers
+# and graph maintenance top-up. Streaming retain uses a lower cap because
+# recall reads at most 20 neighbors, and reembed follows that write path.
+SEMANTIC_LINK_DEFAULT_TOP_K = 50
+STREAMING_SEMANTIC_LINK_TOP_K = 20
+SEMANTIC_LINK_THRESHOLD = 0.7
+
 
 def _cap_links_per_unit(links: list[tuple], max_per_unit: int = MAX_TEMPORAL_LINKS_PER_UNIT) -> list[tuple]:
     """Keep only the top-N links per from_unit_id, ranked by weight descending.
@@ -511,8 +518,8 @@ async def compute_semantic_links_ann(
     unit_ids: list[str],
     embeddings: list[list[float]],
     fact_types: list[str] | None = None,
-    top_k: int = 50,
-    threshold: float = 0.7,
+    top_k: int = SEMANTIC_LINK_DEFAULT_TOP_K,
+    threshold: float = SEMANTIC_LINK_THRESHOLD,
     log_buffer: list[str] = None,
 ) -> list[tuple]:
     """
@@ -652,8 +659,8 @@ async def compute_semantic_links_ann(
 def compute_semantic_links_within_batch(
     unit_ids: list[str],
     embeddings: list[list[float]],
-    top_k: int = 50,
-    threshold: float = 0.7,
+    top_k: int = SEMANTIC_LINK_DEFAULT_TOP_K,
+    threshold: float = SEMANTIC_LINK_THRESHOLD,
 ) -> list[tuple]:
     """
     Compute semantic links between units within the same batch (no DB needed).
@@ -702,8 +709,8 @@ async def create_semantic_links_batch(
     bank_id: str,
     unit_ids: list[str],
     embeddings: list[list[float]],
-    top_k: int = 50,
-    threshold: float = 0.7,
+    top_k: int = SEMANTIC_LINK_DEFAULT_TOP_K,
+    threshold: float = SEMANTIC_LINK_THRESHOLD,
     log_buffer: list[str] = None,
     pre_computed_ann_links: list[tuple] | None = None,
     ops=None,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -741,7 +741,7 @@ async def _run_final_semantic_ann(
     seeds. This replaces per-batch within-batch + fire-and-forget ANN with
     one efficient pass that sees the full bank.
     """
-    from .link_utils import _bulk_insert_links, compute_semantic_links_ann
+    from .link_utils import STREAMING_SEMANTIC_LINK_TOP_K, _bulk_insert_links, compute_semantic_links_ann
 
     if not unit_ids:
         return
@@ -808,7 +808,7 @@ async def _run_final_semantic_ann(
                     chunk_ids,
                     chunk_embs,
                     fact_types=chunk_ftypes,
-                    top_k=20,  # Recall uses at most 20 neighbors
+                    top_k=STREAMING_SEMANTIC_LINK_TOP_K,
                     log_buffer=log_buffer,
                 )
                 if ann_links:

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -36,6 +36,7 @@ from ._vector_index import (
     minimum_rows_for_index,
     should_defer_index_creation,
     uses_per_bank_vector_indexes,
+    validate_vector_index_dimension,
 )
 from .db_url import is_oracle_url, to_libpq_url
 from .utils import mask_network_location
@@ -476,6 +477,8 @@ def _migrate_table_embedding_dimension(
             f"  2. Use a model with {current_dim}-dimensional embeddings"
         )
 
+    validate_vector_index_dimension(vector_ext, required_dimension, table_name=table_name)
+
     logger.info(f"Altering {table_name}.embedding column dimension from {current_dim} to {required_dimension}")
 
     # Drop existing vector index (works for HNSW, DiskANN, vchordrq, and ScaNN)
@@ -509,13 +512,6 @@ def _migrate_table_embedding_dimension(
     conn.commit()
 
     # Recreate index with appropriate type based on detected extension
-    if vector_ext == "pgvector" and required_dimension > 2000:
-        raise RuntimeError(
-            f"Embedding dimension {required_dimension} exceeds pgvector HNSW index limit of 2000. "
-            f"Use an embedding model with <= 2000 dimensions, or switch to a vector extension "
-            f"that supports higher dimensions (e.g., pgvectorscale/DiskANN or AlloyDB ScaNN)."
-        )
-
     index_type = index_type_keyword(vector_ext)
     if should_defer_index_creation(vector_ext, row_count):
         minimum_rows = minimum_rows_for_index(vector_ext)
@@ -625,8 +621,7 @@ def ensure_vector_extension(
         # Tables with vector indexes to check
         tables_to_check = [
             ("memory_units", "idx_memory_units_embedding"),
-            ("learnings", "idx_learnings_embedding"),
-            ("pinned_reflections", "idx_pinned_reflections_embedding"),
+            ("mental_models", "idx_mental_models_embedding"),
         ]
 
         target_index_type = index_type_keyword(target_ext)
@@ -739,14 +734,26 @@ def ensure_vector_extension(
                 f"Cannot change vector extension from {current_index_type} to {target_index_type}: "
                 f"the following tables contain data: {table_list}. "
                 f"To change vector extension, you must either:\n"
-                f"  1. Re-embed all data: DELETE FROM {schema_name}.memory_units; "
-                f"DELETE FROM {schema_name}.learnings; DELETE FROM {schema_name}.pinned_reflections; then restart\n"
+                f"  1. Re-embed all data with hindsight-admin reembed, then restart\n"
                 f"  2. Use the current vector extension (set HINDSIGHT_API_VECTOR_EXTENSION='{current_ext_name}')"
             )
 
         logger.info(f"Reconciling vector indexes for {target_ext}")
 
         for table_name, index_name, current_type, row_count in mismatched_tables:
+            embed_dim = conn.execute(
+                text("""
+                    SELECT atttypmod
+                    FROM pg_attribute a
+                    JOIN pg_class c ON a.attrelid = c.oid
+                    JOIN pg_namespace n ON c.relnamespace = n.oid
+                    WHERE n.nspname = :schema AND c.relname = :table_name AND a.attname = 'embedding'
+                """),
+                {"schema": schema_name, "table_name": table_name},
+            ).scalar()
+            if embed_dim:
+                validate_vector_index_dimension(target_ext, int(embed_dim), table_name=table_name)
+
             if should_defer_index_creation(target_ext, row_count):
                 minimum_rows = minimum_rows_for_index(target_ext)
                 logger.warning(
@@ -763,27 +770,6 @@ def ensure_vector_extension(
             if current_type:
                 logger.info(f"Dropping {current_type} index on {table_name}")
                 conn.execute(text(f"DROP INDEX IF EXISTS {schema_name}.{index_name}"))
-
-            # Create new index with appropriate type
-            if target_ext == "pgvector":
-                # Check embedding dimension — pgvector HNSW indexes only support up to 2000 dims
-                embed_dim = conn.execute(
-                    text("""
-                        SELECT atttypmod
-                        FROM pg_attribute a
-                        JOIN pg_class c ON a.attrelid = c.oid
-                        JOIN pg_namespace n ON c.relnamespace = n.oid
-                        WHERE n.nspname = :schema AND c.relname = :table_name AND a.attname = 'embedding'
-                    """),
-                    {"schema": schema_name, "table_name": table_name},
-                ).scalar()
-
-                if embed_dim and embed_dim > 2000:
-                    raise RuntimeError(
-                        f"Embedding dimension {embed_dim} on {table_name} exceeds pgvector HNSW index limit of 2000. "
-                        f"Use an embedding model with <= 2000 dimensions, or switch to a vector extension "
-                        f"that supports higher dimensions (e.g., pgvectorscale/DiskANN or AlloyDB ScaNN)."
-                    )
 
             logger.info(f"Creating {target_index_type} index on {table_name}")
             conn.execute(

--- a/hindsight-api-slim/tests/test_admin_reembed.py
+++ b/hindsight-api-slim/tests/test_admin_reembed.py
@@ -1,0 +1,732 @@
+import uuid
+
+import asyncpg
+import pytest
+from typer.testing import CliRunner
+
+from hindsight_api._vector_index import SCANN_MIN_ROWS_FOR_AUTO_INDEX
+from hindsight_api.admin import cli as admin_cli
+from hindsight_api.admin import reembed as reembed_module
+from hindsight_api.admin.reembed import ReembedOptions, abandon_reembed, reembed_schema
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.retain.embedding_processing import augment_texts_with_dates, format_readable_date
+from hindsight_api.engine.retain.types import ExtractedFact
+from hindsight_api.migrations import run_migrations
+
+
+class FakeEmbeddings:
+    def __init__(self, dimension: int):
+        self._dimension = dimension
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    async def initialize(self) -> None:
+        return None
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[float(index + 1)] * self._dimension for index, _text in enumerate(texts)]
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return self.encode_documents(texts)
+
+
+class ShadowIndexConn:
+    def __init__(
+        self,
+        *,
+        extensions: set[str],
+        memory_units_count: int,
+        mental_models_count: int,
+        banks: list[dict] | None = None,
+    ):
+        self.extensions = extensions
+        self.counts = {
+            "memory_units": memory_units_count,
+            "mental_models": mental_models_count,
+        }
+        self.banks = banks or []
+        self.statements: list[tuple[str, tuple]] = []
+
+    async def fetchval(self, query, *args):
+        if "FROM pg_extension" in query:
+            return 1 if args[0] in self.extensions else None
+        raise AssertionError(f"Unexpected fetchval query: {query}")
+
+    async def fetchrow(self, query, *args):
+        if "COUNT(*)" in query and "embedding_reembed" in query:
+            return self.counts
+        raise AssertionError(f"Unexpected fetchrow query: {query}")
+
+    async def fetch(self, query, *args):
+        if "FROM pg_extension" in query:
+            return [{"extname": extension} for extension in self.extensions]
+        if "banks" in query and "ORDER BY bank_id" in query:
+            return self.banks
+        raise AssertionError(f"Unexpected fetch query: {query}")
+
+    async def execute(self, query, *args):
+        self.statements.append((query, args))
+        return "UPDATE 1"
+
+
+class _Transaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class SemanticStageConn:
+    def __init__(self):
+        self.statements: list[tuple[str, tuple]] = []
+
+    async def fetch(self, query, *args):
+        if "FROM pg_extension" in query:
+            return [{"extname": "vchord"}]
+        if "GROUP BY bank_id, fact_type" in query:
+            return [
+                {"bank_id": "bank-a", "fact_type": "world"},
+                {"bank_id": "bank-a", "fact_type": "experience"},
+            ]
+        raise AssertionError(f"Unexpected fetch query: {query}")
+
+    async def execute(self, query, *args):
+        self.statements.append((query, args))
+        return "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.statements.append((query, args))
+        if "INSERT INTO" in query and "embedding_reembed_semantic_links" in query:
+            return 2
+        raise AssertionError(f"Unexpected fetchval query: {query}")
+
+    def transaction(self):
+        return _Transaction()
+
+
+class SchemaDiscoveryConn:
+    def __init__(self, schemas: list[str]):
+        self.schemas = schemas
+
+    async def fetch(self, query, *args):
+        assert "FROM pg_namespace" in query
+        return [{"schema_name": schema} for schema in self.schemas]
+
+
+class ActiveMigrationConn:
+    async def fetch(self, query, *args):
+        assert "LIMIT 1" not in query
+        return [
+            {"migration_id": uuid.UUID("00000000-0000-0000-0000-000000000001")},
+            {"migration_id": uuid.UUID("00000000-0000-0000-0000-000000000002")},
+        ]
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["reembed-status"], "Specify --schema for reembed-status"),
+        (["reembed-abandon", "--yes"], "Specify --schema for reembed-abandon"),
+    ],
+)
+def test_reembed_schema_scoped_commands_require_explicit_schema(args, message):
+    result = CliRunner().invoke(admin_cli.app, args)
+
+    assert result.exit_code == 1
+    assert message in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--batch-size", "0"], "batch-size must be at least 1"),
+        (["--max-retries", "-1"], "max-retries must be at least 0"),
+        (
+            ["--index-max-parallel-maintenance-workers", "-1"],
+            "index-max-parallel-maintenance-workers must be at least 0",
+        ),
+    ],
+)
+def test_reembed_cli_rejects_invalid_batch_options(args, message):
+    result = CliRunner().invoke(admin_cli.app, ["reembed", "--schema", "public", *args, "--yes"])
+
+    assert result.exit_code == 1
+    assert message in result.output
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch_size": 0}, "batch_size must be at least 1"),
+        ({"max_retries": -1}, "max_retries must be at least 0"),
+        (
+            {"index_max_parallel_maintenance_workers": -1},
+            "index_max_parallel_maintenance_workers must be at least 0",
+        ),
+    ],
+)
+def test_reembed_options_reject_invalid_values(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        ReembedOptions(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_discover_hindsight_schemas_returns_all_schemas_with_base_first():
+    conn = SchemaDiscoveryConn(["user_acme", "public", "tenant_beta"])
+
+    schemas = await reembed_module.discover_hindsight_schemas(conn, "public")
+
+    assert schemas == ["public", "user_acme", "tenant_beta"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_active_migration_detects_multiple_active_rows():
+    with pytest.raises(RuntimeError, match="multiple active reembed migrations"):
+        await reembed_module._fetch_active_migration(ActiveMigrationConn(), "public")
+
+
+@pytest.mark.asyncio
+async def test_resolve_reembed_schemas_requires_explicit_scope():
+    with pytest.raises(ValueError, match="Specify --schema or --all-schemas"):
+        await admin_cli._resolve_reembed_schemas(
+            "postgresql://unused",
+            HindsightConfig.from_env(),
+            schemas=None,
+            all_schemas=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_reembed_schema_rejects_concurrent_runner(pg0_db_url):
+    schema = f"reembed_locked_{uuid.uuid4().hex[:8]}"
+    lock_key = reembed_module._reembed_lock_key(schema)
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute("SELECT pg_advisory_lock(hashtext($1))", lock_key)
+
+        with pytest.raises(RuntimeError, match=f"Another reembed command is already running for schema '{schema}'"):
+            await reembed_schema(
+                pg0_db_url,
+                schema,
+                HindsightConfig.from_env(),
+                ReembedOptions(batch_size=10),
+            )
+    finally:
+        await conn.execute("SELECT pg_advisory_unlock(hashtext($1))", lock_key)
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_migrations_allow_only_one_active_row_per_schema(pg0_db_url):
+    schema = f"reembed_active_unique_{uuid.uuid4().hex[:8]}"
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema)
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        index_exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE schemaname = $1
+                  AND indexname = 'idx_embedding_reembed_migrations_one_active'
+                  AND indexdef ILIKE '%WHERE (status = ANY%'
+            )
+            """,
+            schema,
+        )
+        migration_id = uuid.uuid4()
+        await conn.execute(
+            f"""
+            INSERT INTO {schema}.embedding_reembed_migrations
+            (migration_id, schema_name, provider, model, dimension, vector_extension,
+             config_fingerprint, model_identity, status)
+            VALUES ($1, $2, 'local', 'test-model', 384, 'pgvector', 'fingerprint-a', '{{}}'::jsonb, 'running')
+            """,
+            migration_id,
+            schema,
+        )
+
+        with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+            await conn.execute(
+                f"""
+                INSERT INTO {schema}.embedding_reembed_migrations
+                (migration_id, schema_name, provider, model, dimension, vector_extension,
+                 config_fingerprint, model_identity, status)
+                VALUES ($1, $2, 'local', 'test-model', 384, 'pgvector', 'fingerprint-b', '{{}}'::jsonb, 'failed')
+                """,
+                uuid.uuid4(),
+                schema,
+            )
+
+        await conn.execute(
+            f"""
+            INSERT INTO {schema}.embedding_reembed_migrations
+            (migration_id, schema_name, provider, model, dimension, vector_extension,
+             config_fingerprint, model_identity, status)
+            VALUES ($1, $2, 'local', 'test-model', 384, 'pgvector', 'fingerprint-c', '{{}}'::jsonb, 'completed')
+            """,
+            uuid.uuid4(),
+            schema,
+        )
+
+        assert index_exists is True
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_create_shadow_indexes_defers_scann_when_one_indexed_table_is_too_small():
+    conn = ShadowIndexConn(
+        extensions={"alloydb_scann"},
+        memory_units_count=SCANN_MIN_ROWS_FOR_AUTO_INDEX,
+        mental_models_count=0,
+    )
+
+    message = await reembed_module._create_shadow_indexes(conn, "public", "scann", uuid.uuid4())
+
+    assert "deferred: scann" in message
+    assert "mental_models=0" in message
+    assert any("shadow_indexes_state = 'deferred'" in statement for statement, _args in conn.statements)
+    assert not any("CREATE INDEX" in statement for statement, _args in conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_create_shadow_indexes_uses_resolved_azure_diskann_clause():
+    conn = ShadowIndexConn(
+        extensions={"vector", "pg_diskann"},
+        memory_units_count=1,
+        mental_models_count=1,
+        banks=[{"bank_id": "bank-a", "internal_id": uuid.UUID("00000000-0000-0000-0000-000000000001")}],
+    )
+
+    message = await reembed_module._create_shadow_indexes(conn, "public", "pg_diskann", uuid.uuid4())
+
+    create_index_sql = "\n".join(statement for statement, _args in conn.statements if "CREATE INDEX" in statement)
+    assert message == "ready"
+    assert "max_neighbors = 50" in create_index_sql
+    assert "num_neighbors = 50" not in create_index_sql
+    assert create_index_sql.count('ON "public"."memory_units"') == 3
+    assert "idx_mu_reemb_worl_0000000000000000" in create_index_sql
+    assert "idx_mu_reemb_expr_0000000000000000" in create_index_sql
+    assert "idx_mu_reemb_obsv_0000000000000000" in create_index_sql
+
+
+@pytest.mark.asyncio
+async def test_create_shadow_indexes_overrides_parallel_maintenance_workers_only_when_requested():
+    conn = ShadowIndexConn(
+        extensions={"vector"},
+        memory_units_count=1,
+        mental_models_count=1,
+    )
+
+    await reembed_module._create_shadow_indexes(conn, "public", "pgvector", uuid.uuid4())
+
+    assert not any("max_parallel_maintenance_workers" in statement for statement, _args in conn.statements)
+
+    conn = ShadowIndexConn(
+        extensions={"vector"},
+        memory_units_count=1,
+        mental_models_count=1,
+    )
+
+    await reembed_module._create_shadow_indexes(
+        conn,
+        "public",
+        "pgvector",
+        uuid.uuid4(),
+        index_max_parallel_maintenance_workers=0,
+    )
+
+    assert conn.statements[0] == (
+        "SELECT set_config('max_parallel_maintenance_workers', $1, false)",
+        ("0",),
+    )
+    assert conn.statements[-2] == ("RESET max_parallel_maintenance_workers", ())
+    assert any("shadow_indexes_state = 'ready'" in statement for statement, _args in conn.statements)
+
+
+@pytest.mark.asyncio
+async def test_stage_semantic_links_batches_by_bank_and_fact_type_with_ann_tuning():
+    conn = SemanticStageConn()
+    migration_id = uuid.uuid4()
+
+    staged = await reembed_module._stage_semantic_links(conn, "public", migration_id, "pgvector")
+
+    insert_statements = [
+        (query, args)
+        for query, args in conn.statements
+        if "INSERT INTO" in query and "embedding_reembed_semantic_links" in query
+    ]
+    assert staged == 4
+    assert len(insert_statements) == 2
+    assert any("SET LOCAL hnsw.ef_search = 60" in query for query, _args in conn.statements)
+    assert all("mu.bank_id = $2" in query for query, _args in insert_statements)
+    assert all("mu.fact_type = $3" in query for query, _args in insert_statements)
+    assert all("mu.bank_id = seed.bank_id" not in query for query, _args in insert_statements)
+    assert [args[1:] for _query, args in insert_statements] == [
+        ("bank-a", "world"),
+        ("bank-a", "experience"),
+    ]
+
+
+def test_reembed_memory_unit_embedding_text_matches_retain_fact_helper():
+    from datetime import UTC, datetime
+
+    occurred_start = datetime(2024, 6, 1, tzinfo=UTC)
+    occurred_end = datetime(2024, 6, 3, tzinfo=UTC)
+    mentioned_at = datetime(2024, 6, 5, tzinfo=UTC)
+    entities = ["pedagogy:scaffolding", "user"]
+    fact = ExtractedFact(
+        fact_text="User attended workshop",
+        fact_type="world",
+        entities=entities,
+        occurred_start=occurred_start,
+        occurred_end=occurred_end,
+        mentioned_at=mentioned_at,
+    )
+    row = {
+        "text": fact.fact_text,
+        "fact_type": fact.fact_type,
+        "occurred_start": occurred_start,
+        "occurred_end": occurred_end,
+        "mentioned_at": mentioned_at,
+        "entities": entities,
+        "source_count": 0,
+    }
+
+    retain_text = augment_texts_with_dates([fact], format_readable_date)[0]
+    reembed_text = reembed_module._memory_unit_embedding_text(row)
+
+    assert reembed_text == retain_text
+
+
+def test_reembed_consolidation_observation_embedding_text_stays_bare():
+    row = {
+        "text": "Alice prefers handwritten notes",
+        "fact_type": "observation",
+        "occurred_start": None,
+        "occurred_end": None,
+        "mentioned_at": None,
+        "entities": ["Alice"],
+        "source_count": 2,
+    }
+
+    assert reembed_module._memory_unit_embedding_text(row) == "Alice prefers handwritten notes"
+
+
+def test_model_identity_uses_active_provider_whitelist(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "local")
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL", "identity-test-model")
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE", "17")
+    reembed_module.clear_config_cache()
+    config = HindsightConfig.from_env()
+
+    identity = reembed_module._model_identity(config, dimension=384)
+
+    assert identity["provider"] == config.embeddings_provider
+    assert identity["model"] == "identity-test-model"
+    assert identity["embeddings_local_model"] == "identity-test-model"
+    assert "embeddings_openai_batch_size" not in identity
+    assert not any(key.endswith("_api_key") or "service_account_key" in key for key in identity)
+    reembed_module.clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_reembed_schema_recomputes_embeddings_and_cuts_over(pg0_db_url, embeddings, monkeypatch):
+    await embeddings.initialize()
+    monkeypatch.setattr(reembed_module, "create_embeddings_from_env", lambda: embeddings)
+
+    schema = f"reembed_test_{uuid.uuid4().hex[:8]}"
+    bank_id = f"bank-{uuid.uuid4().hex[:8]}"
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema)
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"INSERT INTO {schema}.banks (bank_id) VALUES ($1)", bank_id)
+        embedding = embeddings.encode(["old embedding seed"])[0]
+        embedding_str = "[" + ",".join(str(value) for value in embedding) + "]"
+        for _ in range(2):
+            await conn.execute(
+                f"""
+                INSERT INTO {schema}.memory_units (bank_id, text, fact_type, embedding, event_date)
+                VALUES ($1, 'Alice likes chess', 'world', $2::vector, now())
+                """,
+                bank_id,
+                embedding_str,
+            )
+    finally:
+        await conn.close()
+
+    progress_events = []
+    report = await reembed_schema(
+        pg0_db_url,
+        schema,
+        HindsightConfig.from_env(),
+        ReembedOptions(batch_size=1),
+        progress_events.append,
+    )
+
+    assert report.status == "completed"
+    assert report.memory_units_total == 2
+    assert report.memory_units_done == 2
+    assert report.mental_models_total == 0
+    assert report.semantic_links_staged == 2
+    assert any(event.phase == "embedding" and event.memory_units_done == 1 for event in progress_events)
+    assert any(event.phase == "embedding" and event.memory_units_done == 2 for event in progress_events)
+    assert any(event.phase == "building-shadow-indexes" for event in progress_events)
+    assert any(event.phase == "staging-semantic-links" and event.group_total == 1 for event in progress_events)
+    assert any(event.phase == "cutover" for event in progress_events)
+    assert any(event.phase == "completed" for event in progress_events)
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        shadow_column_exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = $1
+                  AND table_name = 'memory_units'
+                  AND column_name = 'embedding_reembed'
+            )
+            """,
+            schema,
+        )
+        assert shadow_column_exists is False
+
+        link_rows = await conn.fetch(
+            f"""
+            SELECT from_unit_id, to_unit_id, link_type, entity_id, bank_id
+            FROM {schema}.memory_links
+            WHERE link_type = 'semantic'
+            """
+        )
+        assert len(link_rows) == 2
+        assert all(row["from_unit_id"] != row["to_unit_id"] for row in link_rows)
+        assert all(row["entity_id"] is None for row in link_rows)
+        assert all(row["bank_id"] == bank_id for row in link_rows)
+
+        staging_rows = await conn.fetchval(f"SELECT COUNT(*) FROM {schema}.embedding_reembed_semantic_links")
+        assert staging_rows == 0
+        worklist_indexes = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM pg_indexes
+            WHERE schemaname = $1
+              AND indexname IN ('idx_memory_units_reembed_worklist', 'idx_mental_models_reembed_worklist')
+            """,
+            schema,
+        )
+        assert worklist_indexes == 0
+
+        migration_status = await conn.fetchval(
+            f"SELECT status FROM {schema}.embedding_reembed_migrations WHERE migration_id = $1",
+            uuid.UUID(report.migration_id),
+        )
+        assert migration_status == "completed"
+
+        with pytest.raises(RuntimeError, match=f"Schema '{schema}' has no active reembed migration"):
+            await abandon_reembed(
+                pg0_db_url,
+                schema,
+                orphan_shadow_state=False,
+            )
+        migration_status_after_abandon_attempt = await conn.fetchval(
+            f"SELECT status FROM {schema}.embedding_reembed_migrations WHERE migration_id = $1",
+            uuid.UUID(report.migration_id),
+        )
+        assert migration_status_after_abandon_attempt == "completed"
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_schema_dry_run_reports_shadow_index_phase_state(pg0_db_url, monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector")
+    new_embeddings = FakeEmbeddings(dimension=384)
+    monkeypatch.setattr(reembed_module, "create_embeddings_from_env", lambda: new_embeddings)
+
+    schema = f"reembed_dry_run_{uuid.uuid4().hex[:8]}"
+    migration_id = uuid.uuid4()
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema)
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(
+            f"""
+            INSERT INTO {schema}.embedding_reembed_migrations
+            (migration_id, schema_name, provider, model, dimension, vector_extension,
+             config_fingerprint, model_identity, status)
+            VALUES ($1, $2, 'local', 'test-model', 384, 'pgvector', 'fingerprint', '{{}}'::jsonb, 'running')
+            """,
+            migration_id,
+            schema,
+        )
+    finally:
+        await conn.close()
+
+    report = await reembed_schema(
+        pg0_db_url,
+        schema,
+        HindsightConfig.from_env(),
+        ReembedOptions(batch_size=10, dry_run=True),
+    )
+
+    assert report.status == "dry-run"
+    assert report.migration_id == str(migration_id)
+    assert report.shadow_indexes_state == "pending"
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_schema_can_change_embedding_dimension(pg0_db_url, monkeypatch):
+    new_embeddings = FakeEmbeddings(dimension=8)
+    monkeypatch.setattr(reembed_module, "create_embeddings_from_env", lambda: new_embeddings)
+
+    schema = f"reembed_dim_{uuid.uuid4().hex[:8]}"
+    bank_id = f"bank-{uuid.uuid4().hex[:8]}"
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema)
+
+    old_embedding = "[" + ",".join("0.1" for _ in range(384)) + "]"
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"INSERT INTO {schema}.banks (bank_id) VALUES ($1)", bank_id)
+        await conn.execute(
+            f"""
+            INSERT INTO {schema}.memory_units (bank_id, text, fact_type, embedding, event_date)
+            VALUES ($1, 'Alice likes chess', 'world', $2::vector, now())
+            """,
+            bank_id,
+            old_embedding,
+        )
+    finally:
+        await conn.close()
+
+    report = await reembed_schema(
+        pg0_db_url,
+        schema,
+        HindsightConfig.from_env(),
+        ReembedOptions(batch_size=10),
+    )
+
+    assert report.status == "completed"
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        memory_units_embedding_type = await conn.fetchval(
+            """
+            SELECT format_type(a.atttypid, a.atttypmod)
+            FROM pg_attribute a
+            JOIN pg_class c ON a.attrelid = c.oid
+            JOIN pg_namespace n ON c.relnamespace = n.oid
+            WHERE n.nspname = $1
+              AND c.relname = 'memory_units'
+              AND a.attname = 'embedding'
+            """,
+            schema,
+        )
+        mental_models_embedding_type = await conn.fetchval(
+            """
+            SELECT format_type(a.atttypid, a.atttypmod)
+            FROM pg_attribute a
+            JOIN pg_class c ON a.attrelid = c.oid
+            JOIN pg_namespace n ON c.relnamespace = n.oid
+            WHERE n.nspname = $1
+              AND c.relname = 'mental_models'
+              AND a.attname = 'embedding'
+            """,
+            schema,
+        )
+        migration_dimension = await conn.fetchval(
+            f"SELECT dimension FROM {schema}.embedding_reembed_migrations WHERE migration_id = $1",
+            uuid.UUID(report.migration_id),
+        )
+
+        assert memory_units_embedding_type == "vector(8)"
+        assert mental_models_embedding_type == "vector(8)"
+        assert migration_dimension == 8
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_reembed_schema_rejects_pgvector_dimensions_above_hnsw_limit_before_shadow_state(
+    pg0_db_url,
+    monkeypatch,
+):
+    monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector")
+    new_embeddings = FakeEmbeddings(dimension=2001)
+    monkeypatch.setattr(reembed_module, "create_embeddings_from_env", lambda: new_embeddings)
+
+    schema = f"reembed_pgvector_dim_{uuid.uuid4().hex[:8]}"
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        await conn.execute(f"CREATE SCHEMA {schema}")
+    finally:
+        await conn.close()
+
+    run_migrations(pg0_db_url, schema=schema)
+
+    with pytest.raises(RuntimeError, match="exceeds pgvector HNSW index limit"):
+        await reembed_schema(
+            pg0_db_url,
+            schema,
+            HindsightConfig.from_env(),
+            ReembedOptions(batch_size=10),
+        )
+
+    conn = await asyncpg.connect(pg0_db_url)
+    try:
+        shadow_columns = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name IN ('memory_units', 'mental_models')
+              AND column_name = 'embedding_reembed'
+            """,
+            schema,
+        )
+        migration_rows = await conn.fetchval(f"SELECT COUNT(*) FROM {schema}.embedding_reembed_migrations")
+
+        assert shadow_columns == 0
+        assert migration_rows == 0
+    finally:
+        await conn.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        await conn.close()

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -8,9 +8,11 @@ from hindsight_api._vector_index import (
     index_type_keyword,
     index_using_clause,
     pg_extension_name,
+    resolve_vector_extension_from_installed,
     should_defer_index_creation,
     uses_per_bank_vector_indexes,
     validate_extension,
+    validate_vector_index_dimension,
 )
 from hindsight_api.engine.retain import bank_utils
 
@@ -41,6 +43,15 @@ def test_index_using_clause_scann_uses_cosine_auto_mode():
 
 def test_index_using_clause_pgvector_matches_existing_clause():
     assert index_using_clause("pgvector") == "USING hnsw (embedding vector_cosine_ops)"
+
+
+def test_index_using_clause_can_target_shadow_column():
+    assert index_using_clause("pgvector", column="embedding_reembed") == (
+        "USING hnsw (embedding_reembed vector_cosine_ops)"
+    )
+    assert index_using_clause("scann", column="embedding_reembed") == (
+        "USING scann (embedding_reembed cosine) WITH (mode = 'AUTO')"
+    )
 
 
 def test_index_using_clause_vchord_uses_cosine_ops():
@@ -74,6 +85,23 @@ def test_scann_index_creation_defers_until_table_is_large_enough():
     assert should_defer_index_creation("scann", SCANN_MIN_ROWS_FOR_AUTO_INDEX - 1)
     assert not should_defer_index_creation("scann", SCANN_MIN_ROWS_FOR_AUTO_INDEX)
     assert not should_defer_index_creation("pgvector", 0)
+
+
+def test_validate_vector_index_dimension_rejects_pgvector_hnsw_over_limit():
+    import pytest
+
+    validate_vector_index_dimension("pgvector", 2000)
+    with pytest.raises(RuntimeError, match="exceeds pgvector HNSW index limit"):
+        validate_vector_index_dimension("pgvector", 2001, table_name="memory_units")
+    validate_vector_index_dimension("pgvectorscale", 2001)
+    validate_vector_index_dimension("pg_diskann", 2001)
+    validate_vector_index_dimension("scann", 2001)
+
+
+def test_resolve_vector_extension_from_installed_handles_azure_diskann():
+    assert resolve_vector_extension_from_installed("pgvectorscale", {"vector", "pg_diskann"}) == "pg_diskann"
+    assert resolve_vector_extension_from_installed("pgvectorscale", {"vector", "vectorscale"}) == "pgvectorscale"
+    assert resolve_vector_extension_from_installed("pgvector", {"vector"}) == "pgvector"
 
 
 def test_ann_search_tuning_settings_pgvector_dispatches_hnsw_ef_search():

--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -66,6 +66,108 @@ To disable automatic migrations on API startup, set `HINDSIGHT_API_RUN_MIGRATION
 
 ---
 
+### reembed
+
+Recompute stored embeddings offline after changing the embedding provider, model, dimensions, or vector extension. The command writes new vectors into shadow columns, rebuilds shadow vector indexes and semantic links, then cuts over in a transaction. Stop API traffic and workers before running it so no reads or writes race the migration.
+
+```bash
+hindsight-admin reembed [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema to reembed. Can be supplied multiple times. Required unless `--all-schemas` is used. | Required |
+| `--all-schemas` | Discover and reembed all Hindsight schemas in the current PostgreSQL database. Mutually exclusive with `--schema`. | `false` |
+| `--batch-size` | Rows to send to the embedding provider per batch. Must be at least `1`. | `100` |
+| `--max-retries` | Embedding batch retry count. Must be at least `0`. | `3` |
+| `--index-max-parallel-maintenance-workers` | Temporarily override PostgreSQL `max_parallel_maintenance_workers` while building shadow vector indexes. If omitted, reembed leaves the PostgreSQL setting unchanged. Use `0` to force serial index builds on containers with small `/dev/shm`. | PostgreSQL default |
+| `--dry-run` | Report planned work without modifying the database. | `false` |
+| `--yes`, `-y` | Skip confirmation prompt. | `false` |
+
+**Examples:**
+
+For a single-tenant deployment, use the configured Hindsight database schema. This is `public` unless you set `HINDSIGHT_API_DATABASE_SCHEMA` to another schema name.
+
+```bash
+# Reembed the default single-tenant schema
+hindsight-admin reembed --schema public --yes
+
+# Reembed a custom single-tenant schema
+hindsight-admin reembed --schema hindsight --yes
+
+# Reembed one explicit tenant schema
+hindsight-admin reembed --schema tenant_acme --yes
+
+# Reembed multiple explicit schemas
+hindsight-admin reembed --schema public --schema tenant_acme --yes
+
+# Reembed all catalog-discovered Hindsight schemas
+hindsight-admin reembed --all-schemas --yes
+
+# Preview the work without changing the database
+hindsight-admin reembed --schema tenant_acme --dry-run
+
+# Avoid parallel index-build shared-memory pressure in constrained containers
+hindsight-admin reembed --schema public --index-max-parallel-maintenance-workers 0 --yes
+```
+
+:::warning Stop traffic first
+`reembed` is an offline operation. Stop the API/worker container or otherwise block retain, recall, reflect, consolidation, and backup/restore operations for the target schema before running it. For Docker Compose deployments, set the new embedding configuration on the service, stop it, run a one-off `hindsight-admin reembed ...` command in the same image/environment, then start the service again.
+:::
+
+`reembed` does not rerun LLM extraction. It rebuilds embedding input from stored rows using the same runtime text builders as new writes: retained facts use stored text plus retained date/entity context, consolidation observations keep bare observation text, and mental models use the current `name + " " + content` row representation.
+
+---
+
+### reembed-status
+
+Show recent embedding migration rows and any active shadow state for a schema.
+
+```bash
+hindsight-admin reembed-status [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema to inspect. | Required |
+
+**Example:**
+
+```bash
+hindsight-admin reembed-status --schema tenant_acme
+```
+
+---
+
+### reembed-abandon
+
+Abandon a failed or unwanted reembed migration and remove shadow columns, shadow indexes, and staged semantic links. Use `--orphan-shadow-state` when a prior crash left shadow state without an active migration row.
+
+```bash
+hindsight-admin reembed-abandon [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema whose active reembed should be abandoned. | Required |
+| `--orphan-shadow-state` | Remove orphan shadow state even without an active migration row | `false` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
+
+**Examples:**
+
+```bash
+hindsight-admin reembed-abandon --schema tenant_acme --yes
+hindsight-admin reembed-abandon --schema tenant_acme --orphan-shadow-state --yes
+```
+
+---
+
 ### backup
 
 Create a backup of all Hindsight data to a zip file.
@@ -110,6 +212,10 @@ The backup includes:
 Backups are created within a database transaction with `REPEATABLE READ` isolation, ensuring a consistent snapshot across all tables.
 :::
 
+:::warning Reembed state
+Backup refuses to run while an active reembed migration, shadow column/index, or staged semantic link state exists in the target schema. Complete or abandon the reembed before backing up.
+:::
+
 ---
 
 ### restore
@@ -148,6 +254,10 @@ hindsight-admin restore /backups/tenant-acme.zip --schema tenant_acme --yes
 
 :::warning Data Loss
 Restore will **delete all existing data** in the target schema before importing the backup. Always verify you have a recent backup before performing a restore.
+:::
+
+:::warning Reembed state
+Restore refuses to run while an active reembed migration, shadow column/index, or staged semantic link state exists in the target schema. Complete or abandon the reembed before restoring.
 :::
 
 ---

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -66,6 +66,108 @@ To disable automatic migrations on API startup, set `HINDSIGHT_API_RUN_MIGRATION
 
 ---
 
+### reembed
+
+Recompute stored embeddings offline after changing the embedding provider, model, dimensions, or vector extension. The command writes new vectors into shadow columns, rebuilds shadow vector indexes and semantic links, then cuts over in a transaction. Stop API traffic and workers before running it so no reads or writes race the migration.
+
+```bash
+hindsight-admin reembed [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema to reembed. Can be supplied multiple times. Required unless `--all-schemas` is used. | Required |
+| `--all-schemas` | Discover and reembed all Hindsight schemas in the current PostgreSQL database. Mutually exclusive with `--schema`. | `false` |
+| `--batch-size` | Rows to send to the embedding provider per batch. Must be at least `1`. | `100` |
+| `--max-retries` | Embedding batch retry count. Must be at least `0`. | `3` |
+| `--index-max-parallel-maintenance-workers` | Temporarily override PostgreSQL `max_parallel_maintenance_workers` while building shadow vector indexes. If omitted, reembed leaves the PostgreSQL setting unchanged. Use `0` to force serial index builds on containers with small `/dev/shm`. | PostgreSQL default |
+| `--dry-run` | Report planned work without modifying the database. | `false` |
+| `--yes`, `-y` | Skip confirmation prompt. | `false` |
+
+**Examples:**
+
+For a single-tenant deployment, use the configured Hindsight database schema. This is `public` unless you set `HINDSIGHT_API_DATABASE_SCHEMA` to another schema name.
+
+```bash
+# Reembed the default single-tenant schema
+hindsight-admin reembed --schema public --yes
+
+# Reembed a custom single-tenant schema
+hindsight-admin reembed --schema hindsight --yes
+
+# Reembed one explicit tenant schema
+hindsight-admin reembed --schema tenant_acme --yes
+
+# Reembed multiple explicit schemas
+hindsight-admin reembed --schema public --schema tenant_acme --yes
+
+# Reembed all catalog-discovered Hindsight schemas
+hindsight-admin reembed --all-schemas --yes
+
+# Preview the work without changing the database
+hindsight-admin reembed --schema tenant_acme --dry-run
+
+# Avoid parallel index-build shared-memory pressure in constrained containers
+hindsight-admin reembed --schema public --index-max-parallel-maintenance-workers 0 --yes
+```
+
+:::warning Stop traffic first
+`reembed` is an offline operation. Stop the API/worker container or otherwise block retain, recall, reflect, consolidation, and backup/restore operations for the target schema before running it. For Docker Compose deployments, set the new embedding configuration on the service, stop it, run a one-off `hindsight-admin reembed ...` command in the same image/environment, then start the service again.
+:::
+
+`reembed` does not rerun LLM extraction. It rebuilds embedding input from stored rows using the same runtime text builders as new writes: retained facts use stored text plus retained date/entity context, consolidation observations keep bare observation text, and mental models use the current `name + " " + content` row representation.
+
+---
+
+### reembed-status
+
+Show recent embedding migration rows and any active shadow state for a schema.
+
+```bash
+hindsight-admin reembed-status [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema to inspect. | Required |
+
+**Example:**
+
+```bash
+hindsight-admin reembed-status --schema tenant_acme
+```
+
+---
+
+### reembed-abandon
+
+Abandon a failed or unwanted reembed migration and remove shadow columns, shadow indexes, and staged semantic links. Use `--orphan-shadow-state` when a prior crash left shadow state without an active migration row.
+
+```bash
+hindsight-admin reembed-abandon [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Database schema whose active reembed should be abandoned. | Required |
+| `--orphan-shadow-state` | Remove orphan shadow state even without an active migration row | `false` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
+
+**Examples:**
+
+```bash
+hindsight-admin reembed-abandon --schema tenant_acme --yes
+hindsight-admin reembed-abandon --schema tenant_acme --orphan-shadow-state --yes
+```
+
+---
+
 ### backup
 
 Create a backup of all Hindsight data to a zip file.
@@ -110,6 +212,10 @@ The backup includes:
 Backups are created within a database transaction with `REPEATABLE READ` isolation, ensuring a consistent snapshot across all tables.
 :::
 
+:::warning Reembed state
+Backup refuses to run while an active reembed migration, shadow column/index, or staged semantic link state exists in the target schema. Complete or abandon the reembed before backing up.
+:::
+
 ---
 
 ### restore
@@ -148,6 +254,10 @@ hindsight-admin restore /backups/tenant-acme.zip --schema tenant_acme --yes
 
 :::warning Data Loss
 Restore will **delete all existing data** in the target schema before importing the backup. Always verify you have a recent backup before performing a restore.
+:::
+
+:::warning Reembed state
+Restore refuses to run while an active reembed migration, shadow column/index, or staged semantic link state exists in the target schema. Complete or abandon the reembed before restoring.
 :::
 
 ---


### PR DESCRIPTION
## Summary

Adds a PostgreSQL-only `hindsight-admin reembed` workflow for migrating stored embeddings after changing the configured embedding provider, model, endpoint, or output dimension.

The command recomputes existing `memory_units` and `mental_models` embeddings using the current Hindsight embedding configuration, writes the new vectors into shadow columns, prepares compatible shadow vector indexes, stages semantic links for the new embedding space, and then atomically cuts over the live embedding columns.

Fixes #1884
Fixes #2073


## Motivation

Today Hindsight validates the configured embedding dimension at startup. If the database already contains stored vectors and the new embedding model uses a different dimension, startup fails because the existing `embedding` columns cannot be safely altered in place.

That blocks normal model migrations such as:

- local 384-dimensional embeddings to a 1024-dimensional OpenAI-compatible model;
- 1024-dimensional embeddings back to a 384-dimensional model;
- same-dimension model or endpoint changes where vectors are still in a different embedding space.

The database already stores enough text to regenerate embeddings without rerunning LLM extraction, so this PR adds an explicit offline admin path instead of asking operators to drop data or rebuild banks from scratch.

## User-Facing Commands

This PR adds three admin entry points:

```bash
# Plan only. This is read-only and does not require --yes.
hindsight-admin reembed --schema public --dry-run

# Recompute embeddings and cut over before the command exits.
hindsight-admin reembed --schema public --yes
hindsight-admin reembed --schema public --schema tenant_acme --yes

# Discover all Hindsight schemas in the configured PostgreSQL database.
hindsight-admin reembed --all-schemas --yes

# Inspect or abandon the single active migration for a schema.
hindsight-admin reembed-status --schema public
hindsight-admin reembed-abandon --schema public --yes
hindsight-admin reembed-abandon --schema public --orphan-shadow-state --yes
```

Command behavior:

- `reembed` is a foreground maintenance command. It prints progress for validation, embedding batches, shadow index creation, semantic link staging, cutover, and completion, then exits with either a completed report or an error.
- The target embedding model is intentionally not passed as a CLI argument. `reembed` reads the normal Hindsight environment, so operators update the service configuration first, run the admin command with that same environment, and restart the service with the same settings.
- If a run is interrupted, running `reembed` again for the same schema resumes the active migration when the embedding configuration fingerprint still matches.
- Only one active migration is allowed per schema, enforced by both a runtime session advisory lock and a partial unique index on active migration rows. A second mutating command fails fast instead of resuming the same migration concurrently.
- `reembed-status` is read-only and reports the active migration and any shadow state for one schema.
- `reembed-abandon` removes incomplete shadow state without modifying the live `embedding` columns. It is not a rollback for completed cutovers.

Key options:

- `reembed --schema`, `-s <schema>`: database schema to reembed. Can be supplied multiple times. Required unless `--all-schemas` is used.
- `reembed --all-schemas`: discover and reembed all Hindsight schemas in the current PostgreSQL database. Mutually exclusive with `--schema`.
- `reembed --batch-size <int>`: rows to embed per provider batch. Must be at least `1`. Default: `100`.
- `reembed --max-retries <int>`: outer retry count for each embedding batch. Must be at least `0`. Default: `3`.
- `reembed --index-max-parallel-maintenance-workers <int>`: optional session override for PostgreSQL `max_parallel_maintenance_workers` while building shadow vector indexes. Default: unset, so PostgreSQL keeps its configured value. Passing `0` forces serial index builds, which avoids dynamic shared-memory pressure in constrained containers.
- `reembed --dry-run`: read-only planning mode. It does not create admin tables, shadow columns, migration rows, indexes, or staging rows, and it does not require `--yes`.
- `reembed-status --schema`, `-s <schema>`: read-only status inspection for one database schema. Required.
- `reembed-abandon --schema`, `-s <schema>`: abandon the active reembed for one database schema. Required.
- `reembed-abandon --orphan-shadow-state`: clean orphan shadow state even when there is no active migration row. This is for recovery from leftover `embedding_reembed` columns, shadow indexes, or staging rows.
- `--yes`, `-y`: skip the confirmation prompt for mutating commands.

## Schema Selection

The command operates inside the single PostgreSQL database selected by `HINDSIGHT_API_DATABASE_URL`.

For single-tenant deployments, operators should pass the configured Hindsight database schema explicitly. That is usually `public`, or the value of `HINDSIGHT_API_DATABASE_SCHEMA` if the deployment overrides it.

The `--all-schemas` catalog discovery check is deliberately persistent-state based. It looks for `alembic_version` plus early core tables such as `banks` or `memory_units`, returns the configured base schema first when present, and does not depend on `TenantExtension.list_tenants()`, whose Supabase implementation is an in-process cache and can be empty in a one-off admin container.

## Operational Model

This is intentionally an offline maintenance workflow.

Recommended Docker/Compose flow:

```bash
# 1. Update the service environment to the new embedding configuration.
# 2. Stop the Hindsight service and any worker service that can write the schema.
docker compose stop <hindsight-service>

# 3. Run the admin command in a one-off container that reuses the same env,
#    network, and database volume/connection.
docker compose run --rm --no-deps <hindsight-service> \
  hindsight-admin reembed --schema public --yes

# 4. Restart the service with the same new embedding configuration.
docker compose up -d <hindsight-service>
```

The command does not provide online dual-write or recall quiescing. Operators should stop retain/update/recall traffic and workers for the target schema while the migration is running.

`docker exec` into a live service container is not the recommended way to run the mutating command. It can be useful for read-only `reembed-status`, but the write path should run while the service/worker processes for that schema are stopped. A one-off Compose container is safer because it uses the same image, environment, network, and volumes while replacing the normal service command with just `hindsight-admin ...`.

For embedded pg0 deployments, the service must have a persistent mount for the pg0 data directory. If pg0 data only lives in the container writable layer, a one-off container will not necessarily see the same database.

If the upgraded service has already started successfully, the new Alembic admin tables should already exist and this extra step can be skipped. If the upgraded image has not been started yet, or `reembed` reports missing `embedding_reembed_migrations` / `embedding_reembed_semantic_links`, insert this schema-preparation command after `docker compose stop` and before `reembed`. Do not pass `--embedding-dimension`, because dimension changes are handled by `reembed` through shadow columns and cutover.

```bash
docker compose run --rm --no-deps <hindsight-service> \
  hindsight-admin run-db-migration --schema public
```

Recommended pip/uv and hindsight-embed flow:

```bash
# 1. Update the environment used by the service to the new embedding configuration.
# 2. Stop the API/worker process that can read or write the target schema.
systemctl stop hindsight-api  # example; use the deployment's actual supervisor

# 3. Run admin from the same installation with the same target DB and embedding env.
export HINDSIGHT_API_DATABASE_URL=<same-database-url-used-by-service>
export HINDSIGHT_API_EMBEDDINGS_PROVIDER=<new-provider>
export HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=<new-model>  # if applicable
hindsight-admin reembed --schema public --yes

# 4. Restart the service with the same new embedding configuration.
systemctl start hindsight-api
```

The same schema-preparation rule applies outside Docker: if the upgraded service has not run migrations yet, run the migration entrypoint against the same database before `reembed`:

```bash
hindsight-admin run-db-migration --schema public
```

For `hindsight-embed` / `hindsight-all`, stop the profile daemon first and run `hindsight-admin` with the same profile-derived environment. `hindsight-admin` does not have a `--profile` flag and does not automatically read `~/.hindsight/embed` or `~/.hindsight/profiles/<name>.env`, so the database URL and embedding settings must be provided explicitly. For a named profile without `HINDSIGHT_EMBED_API_DATABASE_URL`, the default embedded DB URL is `pg0://hindsight-embed-<profile>`; if the profile overrides the DB URL, use that override instead.

Example named-profile flow:

```bash
profile=myapp

hindsight-embed -p "$profile" daemon stop

set -a
. "$HOME/.hindsight/profiles/$profile.env"
set +a

export HINDSIGHT_API_DATABASE_URL="${HINDSIGHT_EMBED_API_DATABASE_URL:-pg0://hindsight-embed-$profile}"
hindsight-admin reembed --schema public --yes

hindsight-embed -p "$profile" daemon start
```

## Database Changes

Adds a new Alembic revision:

```text
c3efa30f38c9_add_reembed_admin_tables.py
```

PostgreSQL schemas receive two persistent admin tables:

- `embedding_reembed_migrations`
- `embedding_reembed_semantic_links`

The Oracle branch is a deliberate no-op because the current admin CLI is PostgreSQL-only.

The migration table stores:

- `migration_id`;
- target provider/model/dimension/vector extension;
- a non-secret `model_identity` JSON payload;
- a `config_fingerprint` hash of that identity;
- phase state for embeddings, shadow indexes, and semantic links;
- overall status and timestamps;
- the last error message.

The semantic-link staging table stores only the columns needed to populate the current PostgreSQL `memory_links` schema:

- `migration_id`;
- `bank_id`;
- `from_unit_id`;
- `to_unit_id`;
- `weight`.

It intentionally does not contain a `metadata` column because current PostgreSQL `memory_links` does not have one.

The Alembic revision is the source of truth for these persistent admin tables. The mutating `reembed` command requires the tables to already exist and fails fast with an Alembic/admin-table migration hint if they are missing. `--dry-run` only reports that the tables are missing; it does not create or modify database objects.

The runtime shadow state is not part of Alembic:

- `memory_units.embedding_reembed`
- `mental_models.embedding_reembed`
- shadow vector indexes
- rows in `embedding_reembed_semantic_links`

These are created, resumed, cut over, or abandoned by the admin command.

## Migration Flow

For each schema, `reembed`:

1. resolves the target schema set;
2. validates that the core Hindsight tables exist;
3. initializes the current embedding provider and detects its output dimension;
4. creates or resumes a migration row;
5. adds `embedding_reembed vector(<target_dim>)` shadow columns;
6. creates runtime worklist indexes for rows where the live `embedding` is non-null and the shadow embedding is still null;
7. batches rows through those worklist indexes;
8. regenerates embeddings outside the database transaction;
9. writes each completed batch into the shadow columns;
10. creates compatible shadow vector indexes or marks ScaNN indexes deferred;
11. rebuilds semantic links against `embedding_reembed`;
12. marks the migration `prepared` once embedding, index, and semantic-link phases are complete;
13. cuts over inside a transaction by swapping columns, replacing semantic links, cleaning staging rows, dropping worklist indexes, and marking the migration `completed`.

If the process fails before cutover, the old live columns, old vector indexes, and old semantic links remain in place. The same command can be rerun to resume.

The state machine is persisted in `embedding_reembed_migrations`:

- new migration: `status = 'running'`;
- after every source row with a live embedding has a shadow embedding: `embedding_state = 'complete'`;
- after shadow vector indexes are ready, or explicitly deferred for ScaNN: `shadow_indexes_state = 'ready'` or `deferred`;
- after semantic-link staging finishes, even if it stages zero rows: `semantic_links_state = 'complete'`;
- only when all three phases are complete/ready/deferred does the command mark `status = 'prepared'`;
- a prepared migration is then cut over immediately in the same run;
- successful cutover marks `status = 'completed'`;
- failures mark the active migration `failed` and keep phase progress for resume.

The actual embedding API calls are outside the cutover transaction. The database-visible switch happens in a PostgreSQL transaction that renames/drops columns, swaps indexes, replaces eligible semantic links, clears staging rows, and marks the migration complete.

## Resume and Abandon Semantics

Each migration stores a non-sensitive embedding configuration fingerprint based on provider/model/endpoint/dimension identity. Resume refuses to continue if the current embedding configuration no longer matches the active migration. This prevents mixing vectors from different models or endpoints in the same shadow column.

Progress is database-backed:

- committed shadow vectors are skipped on rerun;
- source rows with `embedding IS NULL` remain null and are not counted as work;
- semantic-link staging is keyed by `migration_id`;
- completed cutovers are not abandoned or rolled back by `reembed-abandon`.

`reembed-abandon --orphan-shadow-state` exists for recovery from manual or crash-created shadow state when there is no active migration row.

The fingerprint includes non-secret `embeddings_*` configuration fields along with provider/model/dimension/vector-extension identity. It excludes API keys, service-account keys, and other credential-like fields. This is meant to catch same-dimension changes such as switching OpenAI-compatible base URLs or model aliases, where the table type would still match but the embedding space would not.

`reembed-abandon` is intentionally not a rollback. If a migration already completed, the live `embedding` column has been cut over and the correct recovery path is a new reembed or restoring from backup.

## Preflight Checks

Before work starts, the command checks:

- required tables exist in the target schema;
- no active migration with a different config fingerprint is being resumed;
- no orphan shadow state exists without a migration row;
- target rows do not reference `bank_id` values missing from `banks`;
- the configured vector extension can be resolved before shadow indexes are created.

The orphan-bank check matters because `memory_units` does not have a foreign key to `banks`. Without this check, per-bank shadow indexes and cutover bookkeeping could silently ignore rows that still contain embeddings.

## Embedding Input Reconstruction

The command does not rerun LLM extraction. It reconstructs embedding input from the stored database state:

- regular retain facts use the stored `memory_units.text` plus retained date and entity context where available;
- consolidation observations keep the current bare observation-text semantics and are identified by `fact_type = 'observation'` with non-empty `source_memory_ids`;
- mental models use the current canonical database state: `name + " " + content`.

This keeps the operation focused on encoder migration while avoiding a new fact extraction pass.

The retain-fact path shares the same embedding-text builder used by runtime retain. `augment_texts_with_dates()` now delegates to a common helper, and the reembed row adapter only maps database fields into that helper. This avoids keeping a second hand-written date/entity augmentation rule in the admin migration path.

For regular retain facts, the reconstruction mirrors the current retain-side shape as closely as the database allows:

- base text comes from `memory_units.text`;
- date context uses `occurred_start`, `occurred_end`, and `mentioned_at`;
- date strings use the existing month/year readable form;
- entity context is recovered through `unit_entities -> entities`;
- entity names are sorted deterministically by lower-cased canonical name and id.

The original extracted entity list order is not stored, so this path cannot perfectly reconstruct that order. The deterministic canonical-entity ordering is an explicit compromise that stays closer to retain-time embedding input than using bare text alone.

For mental models, the command uses current database state:

```text
name + " " + content
```

The runtime create/update paths and reembed share the same mental-model embedding-text helper. That intentionally normalizes historical update quirks where content-only or name-only updates may have left embeddings derived from a slightly different string than the current row representation.

## Semantic Links

The old `memory_links.link_type = 'semantic'` rows describe the old embedding space, so the migration stages new semantic links using `embedding_reembed` before cutover.

Notable details:

- staging aligns with the current `memory_links` schema and does not write a nonexistent `metadata` column;
- staging is batched by `bank_id + fact_type`, making those values constants in the ANN query so PostgreSQL can use the matching non-ScaNN partial vector index;
- each staging group applies backend-specific low-latency ANN tuning with transaction-local `SET LOCAL`;
- semantic links are inserted with `entity_id = NULL`;
- self-links are excluded;
- consolidation observations are excluded as seed rows, so the migration does not create new outgoing semantic links from observations that currently rely on `source_memory_ids`;
- staging rows are deleted after a successful cutover.

Cutover deletes old outgoing semantic links for reembedded, eligible `memory_units` and inserts the staged replacements. It does not delete unrelated non-semantic links, and it does not use a nonexistent staging `metadata` field.

The rebuild mirrors the current streaming retain final ANN pass:

```text
top_k = 20
threshold = 0.7
```

Current normal retain writes use the streaming pipeline, and that path creates semantic links in a final ANN pass with `top_k = 20`. Reembed imports the same retain semantic-link policy constants instead of defining separate rebuild values. Graph maintenance can later top up victims after deletes using a higher cap, but reembed is an embedding-space migration rather than a full graph-repair command. Using the streaming retain cap avoids expanding every eligible row to graph-maintenance density during model migration.

## Vector Index Handling

`_vector_index.index_using_clause()` now accepts a column name so the same backend dispatcher can create indexes on either `embedding` or `embedding_reembed`.

The reembed path:

- preserves existing live vector indexes during preparation;
- creates runtime partial btree worklist indexes on `(bank_id, id)` for `memory_units` and `mental_models` so each batch can find unfinished rows without repeatedly scanning already-completed rows;
- builds shadow indexes on `embedding_reembed`;
- creates non-ScaNN per-bank/fact-type memory-unit shadow vector indexes for every existing bank and supported fact type, matching runtime index provisioning so empty fact-type indexes are not lost at cutover;
- renames ready shadow indexes during cutover;
- removes old indexes during cutover, either by explicit drop/rename or by dropping the old `embedding` column when ScaNN shadow index creation is deferred;
- uses per-bank partial memory-unit indexes for non-ScaNN backends;
- keeps ScaNN as a global-index backend;
- validates pgvector HNSW dimensional limits before creating shadow columns or migration rows;
- resolves Azure `pg_diskann` when the configured extension is `pgvectorscale`, so shadow DiskANN indexes use the Azure-compatible `max_neighbors` clause.

ScaNN AUTO index creation is deferred per indexed table. If either `memory_units` or `mental_models` is below the minimum row count, the migration marks shadow indexes as `deferred` instead of attempting to create an invalid ScaNN index on a small table.

This per-table ScaNN check is important because the ScaNN AUTO minimum applies to each index/table, not to the combined row count across all embedding tables. For example, a schema may have enough `memory_units` but very few `mental_models`; in that case trying to create a ScaNN mental-model index would fail even though the combined count is large.

By default, reembed does not override PostgreSQL parallel index-build settings. Operators who run PostgreSQL in containers with small `/dev/shm` can pass `--index-max-parallel-maintenance-workers 0` to force serial shadow index builds for this admin session. Operators who provision larger shared memory can omit the flag and keep PostgreSQL's configured parallelism.

For Azure DiskANN, the configured value remains `pgvectorscale`, but the actual installed extension can be `pg_diskann`. The shadow-index path now resolves that before generating SQL, matching the runtime migration/index reconciliation path. That prevents creating open-source pgvectorscale SQL with `num_neighbors` on an Azure deployment that expects `max_neighbors`.

## Backup and Restore Guardrails

The new admin tables are included in `BACKUP_TABLES`.

Backup and restore now fail fast if the target schema has active or incomplete reembed state, including:

- active/failed/prepared reembed migration rows;
- `embedding_reembed` shadow columns;
- shadow vector indexes;
- semantic-link staging rows.

This avoids taking or restoring a binary table copy while the schema has temporary columns that are not part of a stable serving state.

Restore has the same guard as backup because restore uses whole-table binary COPY. If the target schema still has a temporary `embedding_reembed` column, the binary COPY column layout may not match the backup.

## Operational Cost

This is a storage-heavy offline migration. During preparation, PostgreSQL stores the old vector, the new shadow vector, worklist indexes, shadow vector indexes, and semantic-link staging rows at the same time. Operators should reserve substantially more disk and WAL capacity than the current embedding table and index footprint.

Cutover is atomic at the database level, but it is not free: it deletes old semantic links, inserts staged semantic links, drops/renames indexes and columns, clears staging rows, and marks the migration complete in one transaction. The service should remain stopped for the target schema while this transaction runs. Larger schemas will hold locks and generate WAL for longer.

Dropping the old `embedding` column does not immediately return heap space to the operating system. PostgreSQL can reuse that space for future writes after vacuuming, but shrinking the table file usually requires an explicit table rewrite strategy such as `VACUUM FULL`, `pg_repack`, or dump/restore, depending on the deployment's maintenance policy.

## Schema and Extension Fixes Included

This PR also aligns vector-extension reconciliation with the current embedding tables:

- `ensure_vector_extension()` now checks `memory_units` and `mental_models`;
- it no longer treats legacy `learnings` / `pinned_reflections` as the active embedding tables for this reconciliation path.

## Scope and Limitations

This PR intentionally does not add:

- an online HTTP reembed endpoint;
- background async-operation scheduling for reembed;
- online dual-write;
- online recall quiescing;
- bank-scoped dimension-changing migrations;
- cross-database orchestration;
- user-facing retry backoff tuning;
- Oracle admin support.

The admin CLI remains PostgreSQL-only.

Retry behavior is intentionally simple in this PR: each embedding batch is retried by the admin command with bounded exponential backoff. This PR does not introduce a full typed embedding error hierarchy or user-facing retry backoff parameters.

## Validation

Automated checks run locally:

```bash
uv run pytest hindsight-api-slim/tests/test_admin_reembed.py -q
uv run pytest hindsight-api-slim/tests/test_vector_index.py -q
uv run ruff format --check \
  hindsight-api-slim/hindsight_api/_vector_index.py \
  hindsight-api-slim/hindsight_api/admin/reembed.py \
  hindsight-api-slim/hindsight_api/admin/cli.py \
  hindsight-api-slim/hindsight_api/migrations.py \
  hindsight-api-slim/tests/test_admin_reembed.py \
  hindsight-api-slim/tests/test_vector_index.py
uv run ruff check \
  hindsight-api-slim/hindsight_api/_vector_index.py \
  hindsight-api-slim/hindsight_api/admin/reembed.py \
  hindsight-api-slim/hindsight_api/admin/cli.py \
  hindsight-api-slim/hindsight_api/migrations.py \
  hindsight-api-slim/tests/test_admin_reembed.py \
  hindsight-api-slim/tests/test_vector_index.py
```

The pre-commit hook also ran successfully during commit:

```text
generate-docs-skill.sh
lint.sh
All lints passed
```

Manual Docker validation with a locally built full image:

1. PostgreSQL runtime using pg_search for text search and pgvector for vector search.
2. Seeded existing 1024-dimensional embeddings with an initial embedding configuration.
3. Reembedded to a new 1024-dimensional OpenAI-compatible embedding configuration:

   ```text
   status=completed
   memory_units=3/3
   mental_models=1/1
   dimension=1024
   staging_rows=0
   no temporary embedding_reembed shadow columns remain
   API restarted healthy with the new embedding configuration
   ```

4. Repeated the migration from 1024 dimensions to a different 384-dimensional embedding configuration:

   ```text
   status=completed
   memory_units.embedding=vector(384)
   mental_models.embedding=vector(384)
   dimension=384
   staging_rows=0
   no temporary embedding_reembed shadow columns remain
   API restarted healthy with the new embedding configuration
   ```

Manual pip/uv and hindsight-embed validation:

1. Created an isolated `hindsight-embed` named profile under a temporary `HOME`.
2. Started the profile daemon, which used an embedded pg0 database and automatically ran Alembic through `c3efa30f38c9`.
3. Seeded the embedded database with 2 `memory_units` and 1 `mental_models` row with existing vectors.
4. Stopped the `hindsight-embed` daemon.
5. Ran `hindsight-admin reembed --schema public --yes` against the same `pg0://hindsight-embed-reembed-smoke` database and embedding configuration.
6. Verified:

   ```text
   status=completed
   memory_units=2/2
   mental_models=1/1
   semantic_links_staged=2
   staging_rows=0
   shadow_columns=0
   memory_units.embedding=vector(384)
   mental_models.embedding=vector(384)
   ```

Unit/integration coverage added in this PR includes:

- full `reembed_schema` cutover with semantic-link staging;
- dimension-changing reembed;
- retain/reembed embedding-input parity for retained facts with dates and entities;
- consolidation observation reembed keeps bare observation text;
- early rejection of pgvector HNSW dimensions above 2000 before shadow state is created;
- refusal to abandon completed reembed migrations;
- worklist index cleanup after cutover;
- semantic-link staging grouped by bank/fact type with backend ANN tuning;
- ScaNN deferred shadow-index behavior when one indexed table is too small;
- Azure `pg_diskann` resolution for a configured `pgvectorscale` backend;
- vector-index helper coverage for shadow columns.

Existing admin backup/restore coverage also exercises the `BACKUP_TABLES` schema coverage rule, so adding the reembed admin tables to that list is guarded by the existing introspection test.
