### PR TITLE
docs(models): register `fireworks` so the Models grid + default-models table list it (#1860)

### DIFF
--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -17,6 +17,7 @@
   {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4-mini"},
   {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
   {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
+  {"id": "fireworks",     "label": "Fireworks AI",      "iconKey": "zap",                "defaultModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"},
   {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},
   {"id": "litellm",       "label": "LiteLLM (100+)",    "iconKey": "layers",             "defaultModel": "gpt-4o-mini"}
 ]

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -37,6 +37,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - OpenAI Codex
 - Claude Code
 - AWS Bedrock
+- Fireworks AI
 - OpenAI Compatible
 - LiteLLM (100+)
 
@@ -120,6 +121,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `openai-codex` | `gpt-5.4-mini` |
 | `claude-code` | `claude-sonnet-4-5-20250929` |
 | `bedrock` | `us.amazon.nova-2-lite-v1:0` |
+| `fireworks` | `accounts/fireworks/models/llama-v3p1-8b-instruct` |
 | `litellm` | `gpt-4o-mini` |
 
 **Example:** Setting just the provider uses its default model:


### PR DESCRIPTION
#1860 wired **Fireworks AI** as a first-class LLM provider (`PROVIDER_DEFAULT_MODELS["fireworks"]` at `config.py:535`, routing in `llm_wrapper.py`, `providers/fireworks_llm.py`, and the `HINDSIGHT_API_LLM_PROVIDER` enum in `configuration.md`) — but it didn't add the row to `hindsight-docs/src/data/llmProviders.json`.

That registry is the single source of truth rendering the Models page `<LLMProvidersGrid/>` (Supported providers) and `<LLMProvidersTable/>` (Provider Default Models). Its docstring states: *"Keep aligned with PROVIDER_DEFAULT_MODELS in hindsight-api-slim/hindsight_api/config.py."* So right now `fireworks` is a first-class provider that's invisible on the canonical Models page — users can't discover it or its default model. (The two existing "Fireworks" mentions in models.mdx refer only to the LiteLLM `fireworks_ai/…` path, not the native provider.)

**Change** (pure docs/data):
- `llmProviders.json`: one row `{"id":"fireworks","label":"Fireworks AI","iconKey":"zap","defaultModel":"accounts/fireworks/models/llama-v3p1-8b-instruct"}` — `defaultModel` matches `config.py:535`; `iconKey: zap` is already registered (used by groq/volcano).
- regenerated the agent-skill mirror (`skills/.../developer/models.md`) to match the generated grid + table output.

No code changes.