### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # Example: MiniMax configuration (1M context window)
 # HINDSIGHT_API_LLM_PROVIDER=minimax
 # HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
-# HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+# HINDSIGHT_API_LLM_MODEL=MiniMax-M3  # or MiniMax-M2.7 for the previous generation
 
 # Example: DeepSeek configuration (https://api.deepseek.com)
 # HINDSIGHT_API_LLM_PROVIDER=deepseek

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -515,7 +515,7 @@ PROVIDER_DEFAULT_MODELS = {
     "anthropic": "claude-haiku-4-5",
     "gemini": "gemini-2.5-flash",
     "groq": "openai/gpt-oss-120b",
-    "minimax": "MiniMax-M2.7",
+    "minimax": "MiniMax-M3",
     "deepseek": "deepseek-v4-flash",
     "zai": "glm-4.5-flash",
     "opencode-go": "deepseek-v4-flash",

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -7,7 +7,7 @@ This provider handles all OpenAI API-compatible models including:
 - Groq: Fast inference with seed control and service tiers
 - Ollama: Local models with native streaming API support
 - LMStudio: Local models with OpenAI-compatible API
-- MiniMax: MiniMax-M2.7 models with 1M context window
+- MiniMax: MiniMax-M3 / MiniMax-M2.7 models with 1M context window
 - DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via api.deepseek.com
 - Opencode Go: deepseek-v4-flash via https://opencode.ai/zen/go/v1
 
@@ -232,7 +232,7 @@ class OpenAICompatibleLLM(LLMInterface):
     - Groq: Fast inference with seed control and service tiers
     - Ollama: Local models with native streaming API for better structured output
     - LMStudio: Local models with OpenAI-compatible API
-    - MiniMax: MiniMax-M2.7 models via OpenAI-compatible API (https://api.minimax.io/v1)
+    - MiniMax: MiniMax-M3 / MiniMax-M2.7 models via OpenAI-compatible API (https://api.minimax.io/v1)
     - DeepSeek: deepseek-v4-flash / deepseek-v4-pro / deepseek-chat / deepseek-reasoner via https://api.deepseek.com
     - opencode-go: deepseek-v4-flash via https://opencode.ai/zen/go/v1
     """

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -41,7 +41,7 @@ def two_step_config() -> dict[str, Any]:
             {
                 "model_name": "default",
                 "litellm_params": {
-                    "model": "openai/MiniMax-M2.7",
+                    "model": "openai/MiniMax-M3",
                     "api_key": "sk-primary",
                     "api_base": "https://api.minimax.io/v1",
                 },

--- a/hindsight-docs/docs-integrations/hermes.md
+++ b/hindsight-docs/docs-integrations/hermes.md
@@ -116,7 +116,7 @@ All settings are in `~/.hermes/hindsight/config.json`. Every setting can also be
 | `llm_api_key` | — | `HINDSIGHT_LLM_API_KEY` | API key for the chosen LLM provider |
 | `llm_model` | provider default | `HINDSIGHT_LLM_MODEL` | Model override (auto-defaults per provider) |
 
-Default models per provider: `openai` → `gpt-4o-mini`, `anthropic` → `claude-haiku-4-5`, `gemini` → `gemini-2.5-flash`, `groq` → `openai/gpt-oss-120b`, `minimax` → `MiniMax-M2.7`, `ollama` → `gemma3:12b`.
+Default models per provider: `openai` → `gpt-4o-mini`, `anthropic` → `claude-haiku-4-5`, `gemini` → `gemini-2.5-flash`, `groq` → `openai/gpt-oss-120b`, `minimax` → `MiniMax-M3`, `ollama` → `gemma3:12b`.
 
 ### Memory Bank
 

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -173,7 +173,7 @@ export HINDSIGHT_API_LLM_MODEL=your-local-model
 # MiniMax (1M context window)
 export HINDSIGHT_API_LLM_PROVIDER=minimax
 export HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
-export HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+export HINDSIGHT_API_LLM_MODEL=MiniMax-M3  # or MiniMax-M2.7 for the previous generation
 
 # DeepSeek (https://api.deepseek.com)
 export HINDSIGHT_API_LLM_PROVIDER=deepseek

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -8,7 +8,7 @@
   {"id": "ollama-cloud",  "label": "Ollama Cloud",      "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
   {"id": "lmstudio",      "label": "LM Studio",         "iconKey": "brain",              "defaultModel": "local-model"},
   {"id": "llamacpp",      "label": "llama.cpp",         "iconKey": "terminal",           "defaultModel": "gemma-4-e2b-it", "defaultModelNote": "auto-downloaded GGUF"},
-  {"id": "minimax",       "label": "MiniMax",           "iconKey": "sparkles",           "defaultModel": "MiniMax-M2.7"},
+  {"id": "minimax",       "label": "MiniMax",           "iconKey": "sparkles",           "defaultModel": "MiniMax-M3"},
   {"id": "deepseek",      "label": "DeepSeek",          "iconKey": "brain",              "defaultModel": "deepseek-v4-flash"},
   {"id": "zai",           "label": "z.ai",              "iconKey": "sparkles",           "defaultModel": "glm-4.5-flash"},
   {"id": "opencode-go",   "label": "opencode-go",       "iconKey": "openai-compatible",  "defaultModel": "deepseek-v4-flash"},

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -111,7 +111,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `ollama-cloud` | `gemma3:12b` |
 | `lmstudio` | `local-model` |
 | `llamacpp` | `gemma-4-e2b-it` (auto-downloaded GGUF) |
-| `minimax` | `MiniMax-M2.7` |
+| `minimax` | `MiniMax-M3` |
 | `deepseek` | `deepseek-v4-flash` |
 | `zai` | `glm-4.5-flash` |
 | `opencode-go` | `deepseek-v4-flash` |
@@ -204,7 +204,7 @@ export HINDSIGHT_API_LLM_MODEL=your-local-model
 # MiniMax (1M context window)
 export HINDSIGHT_API_LLM_PROVIDER=minimax
 export HINDSIGHT_API_LLM_API_KEY=your-minimax-api-key
-export HINDSIGHT_API_LLM_MODEL=MiniMax-M2.7
+export HINDSIGHT_API_LLM_MODEL=MiniMax-M3  # or MiniMax-M2.7 for the previous generation
 
 # DeepSeek (https://api.deepseek.com)
 export HINDSIGHT_API_LLM_PROVIDER=deepseek


### PR DESCRIPTION
## Summary

Bump the `minimax` provider default from `MiniMax-M2.7` to `MiniMax-M3` and refresh the surrounding docs/tests so the new flagship model is the out-of-the-box choice.

## Changes

- `hindsight-api-slim/hindsight_api/config.py` — update `PROVIDER_DEFAULT_MODELS["minimax"]` to `MiniMax-M3`.
- `hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py` — update the provider docstrings to mention `MiniMax-M3 / MiniMax-M2.7`.
- `hindsight-api-slim/tests/test_llm_router_provider.py` — update the LiteLLM router fixture to use `openai/MiniMax-M3`.
- `.env.example`, `hindsight-docs/docs/developer/models.mdx`, `hindsight-docs/docs-integrations/hermes.md`, `hindsight-docs/src/data/llmProviders.json`, `skills/hindsight-docs/references/developer/models.md` — document `MiniMax-M3` as the default and note `MiniMax-M2.7` as the previous-generation option.

`MiniMax-M2.7` remains available as an explicit `HINDSIGHT_API_LLM_MODEL` override. There were no references to the older `M2.5 / M2.1 / M2 / M1` IDs in the active code paths (historical mentions in `versioned_docs/`, blog posts, and the published changelog are intentionally left untouched).

## Why

`MiniMax-M3` is the new flagship: 512K context, 128K max output, and image-input support, available through both the OpenAI-compatible and Anthropic-compatible endpoints at `https://api.minimax.io`. Promoting it as the provider default gives users the best capabilities without forcing them to change config.

## Testing

- \`uv run pytest tests/test_llm_router_provider.py\` — 17 passed.
- \`uv run ruff check\` on the modified Python files — clean.