### PR TITLE
docs(cli): replace removed `opinion` fact-type with `observation` in recall example

### DIFF
--- a/hindsight-docs/examples/api/cli-reference.sh
+++ b/hindsight-docs/examples/api/cli-reference.sh
@@ -65,7 +65,7 @@ hindsight memory recall $BANK_ID "hiking recommendations" \
 
 
 # [docs:cli-recall-fact-type]
-hindsight memory recall $BANK_ID "query" --fact-type world,opinion
+hindsight memory recall $BANK_ID "query" --fact-type world,observation
 # [/docs:cli-recall-fact-type]
 
 


### PR DESCRIPTION
The `hindsight memory recall` example in `cli-reference.sh` filters by `--fact-type world,opinion`, but `opinion` was removed from the fact-type enum — the CLI now accepts only `world`/`experience`/`observation` (`hindsight-cli/src/main.rs`). Since this snippet is CI-validated and rendered in the docs, the documented command silently returns no results. Replace `opinion` with its v0.4+ successor `observation`.