### PR TITLE
perf(graph-maintenance): cast ANN seed embeddings once + add perf suite (#1919)

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -24,6 +24,7 @@ on:
           - recall
           - recall-with-observations
           - consolidation
+          - graph-maintenance
         default: ""
       locomo_conversations:
         description: "LoComo conversation IDs (space-separated). Blank = curated set (conv-26 conv-30 conv-43)."

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -599,23 +599,35 @@ async def compute_semantic_links_ann(
             t_query = time_mod.time()
             seed_count = sum(1 for ft in fact_types if ft == fact_type)
             logger.debug(f"[ANN] Querying fact_type={fact_type}: {seed_count} seeds")
+            # Cast each seed's text embedding to `vector` exactly once in a
+            # MATERIALIZED CTE. Casting inside the LATERAL (s.emb_text::vector)
+            # re-parses the ~5KB embedding string for every candidate row the
+            # probe touches — seeds × bank_units text-parses per batch, which
+            # dominated the whole job on small banks (see #1919: ~50 seeds over
+            # ~1k units took 1.5-3.7s, ~25-48x slower than casting once). The
+            # stable `vector` column also lets the planner consider an HNSW
+            # index scan, which a cast expression inhibits.
             ft_rows = await conn.fetch(
                 f"""
+                WITH seeds AS MATERIALIZED (
+                    SELECT unit_id, emb_text::vector AS emb
+                    FROM _ann_seeds
+                    WHERE fact_type = $2
+                )
                 SELECT s.unit_id       AS from_id,
                        n.id::text      AS to_id,
                        n.similarity
-                FROM _ann_seeds s
+                FROM seeds s
                 CROSS JOIN LATERAL (
                     SELECT mu.id,
-                           1 - (mu.embedding <=> s.emb_text::vector) AS similarity
+                           1 - (mu.embedding <=> s.emb) AS similarity
                     FROM {fq_table("memory_units")} mu
                     WHERE mu.bank_id = $1
                       AND mu.fact_type = $2
                       AND mu.embedding IS NOT NULL
-                    ORDER BY mu.embedding <=> s.emb_text::vector
+                    ORDER BY mu.embedding <=> s.emb
                     LIMIT $3
                 ) n
-                WHERE s.fact_type = $2
                 """,
                 bank_id,
                 fact_type,

--- a/hindsight-dev/benchmarks/perf/system_perf.py
+++ b/hindsight-dev/benchmarks/perf/system_perf.py
@@ -13,6 +13,7 @@ Usage:
     # Run specific suite
     uv run perf-test --suite retain
     uv run perf-test --suite recall
+    uv run perf-test --suite graph-maintenance
 
     # Configurable scale
     uv run perf-test --scale tiny      # ~10s, CI smoke test
@@ -62,6 +63,7 @@ SCALES: dict[str, dict[str, int]] = {
         "recall_iterations": 5,
         "recall_concurrency": 1,
         "consolidation_items": 20,
+        "graph_maintenance_bank_size": 20,
     },
     "small": {
         "retain_items": 200,
@@ -69,6 +71,7 @@ SCALES: dict[str, dict[str, int]] = {
         "recall_iterations": 20,
         "recall_concurrency": 4,
         "consolidation_items": 200,
+        "graph_maintenance_bank_size": 200,
     },
     "medium": {
         "retain_items": 1_000,
@@ -76,6 +79,7 @@ SCALES: dict[str, dict[str, int]] = {
         "recall_iterations": 50,
         "recall_concurrency": 8,
         "consolidation_items": 1_000,
+        "graph_maintenance_bank_size": 1_000,
     },
     "large": {
         "retain_items": 5_000,
@@ -83,8 +87,19 @@ SCALES: dict[str, dict[str, int]] = {
         "recall_iterations": 100,
         "recall_concurrency": 16,
         "consolidation_items": 5_000,
+        # Past the seqscan→HNSW crossover (~10k units) so this suite exercises
+        # the per-bank partial HNSW index path, not just the small-bank exact
+        # scan. Verified: at 15k real-embedding units the ANN probe is planned
+        # as an Index Scan on idx_mu_emb_*. medium (1k) stays in the exact-scan
+        # regime, so the two scales cover both planner paths.
+        "graph_maintenance_bank_size": 15_000,
     },
 }
+
+# Fraction of the populated bank deleted to generate relink victims for the
+# graph_maintenance suite. Mirrors the issue's "delete a handful of units, then
+# top up the surviving units' links" workload (see #1919).
+GRAPH_MAINTENANCE_DELETE_PCT = 0.1
 
 # Recall queries that exercise different retrieval strategies
 RECALL_QUERIES = [
@@ -165,6 +180,25 @@ class ConsolidationResult:
 
 
 @dataclass
+class GraphMaintenanceResult:
+    bank_size: int
+    deleted_units: int
+    victims_enqueued: int
+    relink_units_processed: int
+    relink_links_added: int
+    orphan_entities_pruned: int
+    stale_cooccurrences_pruned: int
+    total_duration_seconds: float
+    throughput_units_per_sec: float
+    ms_per_victim: float
+    # Where the wall-clock goes inside the relink pass — the focus of #1919.
+    semantic_ann_seconds: float
+    semantic_ann_calls: int
+    temporal_seconds: float
+    temporal_calls: int
+
+
+@dataclass
 class SuiteResult:
     name: str
     duration_seconds: float
@@ -173,6 +207,7 @@ class SuiteResult:
     retain: RetainResult | None = None
     recall: RecallResult | None = None
     consolidation: ConsolidationResult | None = None
+    graph_maintenance: GraphMaintenanceResult | None = None
 
 
 @dataclass
@@ -707,6 +742,257 @@ async def run_consolidation_suite(scale_cfg: dict[str, int]) -> SuiteResult:
 
 
 # ---------------------------------------------------------------------------
+# Suite: graph-maintenance
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _GraphMaintTimers:
+    """Accumulates time spent in the two relink probes (#1919).
+
+    ``run_graph_maintenance_job`` runs them deep inside its own connections and
+    transactions, so the only seam that doesn't perturb the path under test is
+    wrapping the functions it calls. We patch the symbol the graph_maintenance
+    module resolves (``compute_semantic_links_ann``) and the bound ops method
+    (``fetch_temporal_neighbors``), tallying wall-clock and call counts.
+    """
+
+    semantic_seconds: float = 0.0
+    semantic_calls: int = 0
+    temporal_seconds: float = 0.0
+    temporal_calls: int = 0
+
+
+@dataclass
+class _InstrumentedJob:
+    """Result of one instrumented maintenance run: the job's counter dict plus probe timings."""
+
+    result: dict[str, int]
+    timers: _GraphMaintTimers
+
+
+async def _run_graph_maintenance_instrumented(engine: Any, bank_id: str, request_context: Any) -> _InstrumentedJob:
+    """Run the maintenance job with the two relink probes timed."""
+    from hindsight_api.engine import graph_maintenance as gm
+    from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
+
+    timers = _GraphMaintTimers()
+
+    backend = await engine._get_backend()
+    ops = backend.ops
+
+    orig_ann = gm.compute_semantic_links_ann
+    orig_temporal = ops.fetch_temporal_neighbors
+
+    async def timed_ann(*args: Any, **kwargs: Any) -> Any:
+        t0 = time.perf_counter()
+        try:
+            return await orig_ann(*args, **kwargs)
+        finally:
+            timers.semantic_seconds += time.perf_counter() - t0
+            timers.semantic_calls += 1
+
+    async def timed_temporal(*args: Any, **kwargs: Any) -> Any:
+        t0 = time.perf_counter()
+        try:
+            return await orig_temporal(*args, **kwargs)
+        finally:
+            timers.temporal_seconds += time.perf_counter() - t0
+            timers.temporal_calls += 1
+
+    gm.compute_semantic_links_ann = timed_ann
+    ops.fetch_temporal_neighbors = timed_temporal
+    try:
+        result = await run_graph_maintenance_job(
+            memory_engine=engine,
+            bank_id=bank_id,
+            request_context=request_context,
+        )
+    finally:
+        gm.compute_semantic_links_ann = orig_ann
+        ops.fetch_temporal_neighbors = orig_temporal
+
+    return _InstrumentedJob(result=result, timers=timers)
+
+
+async def _delete_units_and_enqueue(engine: Any, bank_id: str, deleted_ids: list[str]) -> int:
+    """Delete ``deleted_ids`` and enqueue their surviving neighbours as relink victims.
+
+    Mirrors the capture-then-delete order ``delete_memory_unit`` uses: victims must
+    be found before the cascade removes the links that identify them.
+    Returns the queue depth (distinct victims enqueued) afterwards.
+    """
+    import uuid as uuid_module
+
+    from hindsight_api.engine.graph_maintenance import enqueue_relink_victims
+    from hindsight_api.engine.memory_engine import acquire_with_retry
+    from hindsight_api.engine.schema import fq_table
+
+    backend = await engine._get_backend()
+    ops = backend.ops
+    deleted_uuids = [uuid_module.UUID(uid) for uid in deleted_ids]
+
+    async with acquire_with_retry(backend) as conn:
+        async with conn.transaction():
+            await enqueue_relink_victims(conn, bank_id, deleted_ids, ops=ops)
+            await conn.execute(
+                f"DELETE FROM {fq_table('memory_units')} WHERE id = ANY($1::uuid[]) AND bank_id = $2",
+                deleted_uuids,
+                bank_id,
+            )
+
+    pool = await engine._get_pool()
+    depth = await pool.fetchval(
+        f"SELECT COUNT(*) FROM {fq_table('graph_maintenance_queue')} WHERE bank_id = $1",
+        bank_id,
+    )
+    return int(depth or 0)
+
+
+async def run_graph_maintenance_suite(scale_cfg: dict[str, int]) -> SuiteResult:
+    """Measure graph_maintenance (relink + entity/cooccurrence sweep) after deletes.
+
+    Background maintenance is supposed to be cheap, but #1919 reports the
+    semantic-ANN relink pass taking 10–20s per batch on ~1k-unit banks. This
+    suite reproduces that path: populate a bank with real embeddings + links,
+    delete a fraction of units to enqueue relink victims, then run the job and
+    break the wall-clock down by probe so the bottleneck is visible.
+    """
+    from hindsight_api.engine.schema import fq_table
+    from hindsight_api.models import RequestContext
+
+    bank_size = scale_cfg["graph_maintenance_bank_size"]
+    bank_id = f"perf-graphmaint-{uuid.uuid4().hex[:8]}"
+
+    console.print(f"\n[bold cyan]Suite: graph-maintenance[/bold cyan]  bank_size={bank_size}  bank={bank_id}")
+
+    engine = _build_engine(disable_observations=True)
+    await engine.initialize()
+
+    # Populate with the real retain pipeline so units get real embeddings and
+    # the temporal/semantic links the relink pass tops up.
+    await _populate_bank(engine, bank_id, bank_size)
+
+    pool = await engine._get_pool()
+    # Source memories are the only relink-eligible units (experience/world).
+    src_rows = await pool.fetch(
+        f"""
+        SELECT id::text AS id
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $1 AND fact_type IN ('experience', 'world')
+        ORDER BY id
+        """,
+        bank_id,
+    )
+    src_ids = [r["id"] for r in src_rows]
+    n_delete = max(1, int(len(src_ids) * GRAPH_MAINTENANCE_DELETE_PCT))
+    # Evenly spread the deletions across the id space so victims are drawn from
+    # across the bank rather than one cluster.
+    step = max(1, len(src_ids) // n_delete)
+    deleted_ids = src_ids[::step][:n_delete]
+
+    request_context = RequestContext()
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress.add_task(f"Deleting {len(deleted_ids):,} units + enqueuing victims…")
+        victims_enqueued = await _delete_units_and_enqueue(engine, bank_id, deleted_ids)
+
+    console.print(f"  Deleted {len(deleted_ids):,} units → {victims_enqueued:,} relink victims enqueued")
+
+    t0 = time.perf_counter()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        progress.add_task(f"Running graph_maintenance ({victims_enqueued:,} victims)…")
+        instrumented = await _run_graph_maintenance_instrumented(engine, bank_id, request_context)
+    duration = time.perf_counter() - t0
+
+    result = instrumented.result
+    timers = instrumented.timers
+    relink_processed = result.get("relink_units_processed", 0)
+    relink_added = result.get("relink_links_added", 0)
+    throughput = relink_processed / duration if duration > 0 else 0
+    ms_per_victim = (duration * 1000 / relink_processed) if relink_processed else 0.0
+
+    await engine.delete_bank(bank_id=bank_id, request_context=request_context)
+    await engine.close()
+
+    gm_result = GraphMaintenanceResult(
+        bank_size=bank_size,
+        deleted_units=len(deleted_ids),
+        victims_enqueued=victims_enqueued,
+        relink_units_processed=relink_processed,
+        relink_links_added=relink_added,
+        orphan_entities_pruned=result.get("orphan_entities_pruned", 0),
+        stale_cooccurrences_pruned=result.get("stale_cooccurrences_pruned", 0),
+        total_duration_seconds=round(duration, 3),
+        throughput_units_per_sec=round(throughput, 2),
+        ms_per_victim=round(ms_per_victim, 2),
+        semantic_ann_seconds=round(timers.semantic_seconds, 3),
+        semantic_ann_calls=timers.semantic_calls,
+        temporal_seconds=round(timers.temporal_seconds, 3),
+        temporal_calls=timers.temporal_calls,
+    )
+
+    # Print summary
+    table = Table(title="Graph Maintenance")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green", justify="right")
+    table.add_row("Bank size", f"{bank_size:,}")
+    table.add_row("Deleted units", f"{len(deleted_ids):,}")
+    table.add_row("Victims enqueued", f"{victims_enqueued:,}")
+    table.add_row("Victims processed", f"{relink_processed:,}")
+    table.add_row("Links added", f"{relink_added:,}")
+    table.add_row("Duration", f"{duration:.3f}s")
+    table.add_row("Throughput", f"{throughput:.2f} victims/s")
+    table.add_row("Latency / victim", f"{ms_per_victim:.2f} ms")
+    table.add_row("Orphan entities pruned", f"{gm_result.orphan_entities_pruned:,}")
+    table.add_row("Stale cooccurrences pruned", f"{gm_result.stale_cooccurrences_pruned:,}")
+    console.print(table)
+
+    # Probe breakdown — the #1919 investigation. Shows how much of the job is
+    # the semantic ANN relink vs the temporal probe vs everything else.
+    other = max(0.0, duration - timers.semantic_seconds - timers.temporal_seconds)
+    breakdown = Table(title="Relink Probe Breakdown")
+    breakdown.add_column("Probe", style="cyan")
+    breakdown.add_column("Total", style="green", justify="right")
+    breakdown.add_column("Calls", justify="right")
+    breakdown.add_column("Avg/call", justify="right")
+    breakdown.add_column("% of job", justify="right")
+
+    def _row(label: str, secs: float, calls: int) -> None:
+        avg = f"{secs / calls:.3f}s" if calls else "—"
+        pct = f"{secs / duration * 100:.1f}%" if duration > 0 else "—"
+        breakdown.add_row(label, f"{secs:.3f}s", str(calls), avg, pct)
+
+    _row("semantic ANN", timers.semantic_seconds, timers.semantic_calls)
+    _row("temporal", timers.temporal_seconds, timers.temporal_calls)
+    breakdown.add_row(
+        "other (claim/count/insert/sweep)",
+        f"{other:.3f}s",
+        "—",
+        "—",
+        f"{other / duration * 100:.1f}%" if duration > 0 else "—",
+    )
+    console.print(breakdown)
+
+    return SuiteResult(
+        name="graph-maintenance",
+        duration_seconds=round(duration, 3),
+        success=True,
+        graph_maintenance=gm_result,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Registry and orchestrator
 # ---------------------------------------------------------------------------
 
@@ -715,6 +1001,7 @@ SUITES = {
     "recall": run_recall_suite,
     "recall-with-observations": run_recall_with_observations_suite,
     "consolidation": run_consolidation_suite,
+    "graph-maintenance": run_graph_maintenance_suite,
 }
 
 
@@ -942,6 +1229,47 @@ def _print_summary(results: PerfTestResults) -> None:
                 "",
                 "created/updated/merged/skipped",
                 f"{c.observations_created}/{c.observations_updated}/{c.observations_merged}/{c.skipped}",
+                "",
+                "",
+                "",
+            )
+
+        if suite.graph_maintenance:
+            g = suite.graph_maintenance
+            table.add_row(
+                suite.name,
+                status,
+                "throughput",
+                f"{g.throughput_units_per_sec} victims/s",
+                "",
+                "",
+                "",
+            )
+            table.add_row("", "", "duration", f"{g.total_duration_seconds}s", "", "", "")
+            table.add_row("", "", "latency/victim", f"{g.ms_per_victim} ms", "", "", "")
+            table.add_row(
+                "",
+                "",
+                "victims (enq/proc)",
+                f"{g.victims_enqueued:,} / {g.relink_units_processed:,}",
+                "",
+                "",
+                "",
+            )
+            table.add_row(
+                "",
+                "",
+                "  semantic ANN",
+                f"{g.semantic_ann_seconds}s ({g.semantic_ann_calls} calls)",
+                "",
+                "",
+                "",
+            )
+            table.add_row(
+                "",
+                "",
+                "  temporal",
+                f"{g.temporal_seconds}s ({g.temporal_calls} calls)",
                 "",
                 "",
                 "",


### PR DESCRIPTION
Closes #1919.

## Problem

`graph_maintenance`'s Pass-1 semantic-ANN relink was disproportionately slow on small banks — #1919 reports 10-20s per batch on ~1k-unit banks. Reproduced: on a 1k-unit bank, deleting 100 units enqueues ~860 relink victims and the job took **27.3s**, of which the semantic ANN probe was **26.5s (97%)**, ~1.47s per 50-victim batch.

## Root cause

`compute_semantic_links_ann` stored seed embeddings as `text` and computed `mu.embedding <=> s.emb_text::vector` **inside the LATERAL** — so the ~5KB embedding string was re-parsed (`::vector`) for *every candidate row the probe touched*, i.e. seeds × bank_units text-parses per batch. `EXPLAIN ANALYZE` confirmed this is the entire cost; the temporal probe was negligible (0.2%).

## Fix

Cast each seed to `vector` **exactly once** in a `MATERIALIZED` CTE, then the LATERAL operates on a real vector column. Behaviour is unchanged (identical results). Shared with retain Phase 3, so retain benefits too.

| Metric (medium, 1k units) | Before | After |
|---|---|---|
| Job total | 27.3s | **2.48s** (~11×) |
| Per-batch ANN | 1.47s | **0.098s** (~15×) |
| Latency / victim | 31.9ms | **2.83ms** |

Verified across scales (50 seeds): 1k=76ms (exact scan), 6k=22ms (exact scan), 15k=26ms / 40k=47ms / 80k=20ms — at large scale the planner already auto-selects the per-bank partial HNSW index (`idx_mu_emb_*`), even with parameterized predicates; the cast fix is still ~2.4× there. The stable `vector` column (vs a cast expression) is also what lets the planner consider the HNSW index.

## Benchmark

Adds a `graph-maintenance` suite to `perf-test` (populate via mock LLM + **real** embeddings, delete 10% of units to enqueue relink victims, run the job, break wall-clock down by probe: semantic ANN vs temporal vs other). Wired into the periodic perf workflow (scheduled run already runs all suites; added to the manual suite dropdown). `large` scale = 15k units to exercise the HNSW index path; `medium` = 1k stays in the exact-scan regime, so the two scales cover both planner paths.

The companion dashboard change (rendering the new suite at the continuous-performance-monitor) is a separate PR on that repo.

## Testing

- `tests/test_graph_maintenance.py` (14) and `tests/test_link_utils.py` ANN tests pass.
- `./scripts/hooks/lint.sh` passes.
- Behaviour-preserving change; covered by existing ANN correctness tests.