### PR TITLE
refactor(api): move audit-logs endpoint queries into MemoryEngine

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -17,7 +17,12 @@ from typing import Any, Literal
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
 
-from hindsight_api.engine.audit import AuditEntry, AuditLogger
+from hindsight_api.engine.audit import (
+    AuditEntry,
+    AuditLogger,
+    AuditLogListResponse,
+    AuditLogStatsResponse,
+)
 from hindsight_api.extensions import AuthenticationError
 
 
@@ -6202,48 +6207,8 @@ def _register_routes(app: FastAPI):
             raise HTTPException(status_code=500, detail=str(e))
 
     # ---- Audit Logs ----
-
-    class AuditLogEntry(BaseModel):
-        """A single audit log entry."""
-
-        id: str
-        action: str
-        transport: str
-        bank_id: str | None
-        started_at: str | None
-        ended_at: str | None
-        duration_ms: int | None = Field(
-            default=None,
-            description="Server-computed duration in milliseconds (started_at → ended_at). Null if not yet completed.",
-        )
-        request: dict[str, Any] | None
-        response: dict[str, Any] | None
-        metadata: dict[str, Any]
-
-    class AuditLogListResponse(BaseModel):
-        """Response model for list audit logs endpoint."""
-
-        bank_id: str
-        total: int
-        limit: int
-        offset: int
-        items: list[AuditLogEntry]
-
-    class AuditLogStatsBucket(BaseModel):
-        """A single time bucket in audit log stats."""
-
-        time: str
-        actions: dict[str, int]
-        total: int
-
-    class AuditLogStatsResponse(BaseModel):
-        """Response model for audit log stats endpoint."""
-
-        bank_id: str
-        period: str
-        trunc: str
-        start: str
-        buckets: list[AuditLogStatsBucket]
+    # Response models live in engine/audit.py so the MemoryEngine read methods
+    # (list_audit_logs / audit_log_stats) can build and return them directly.
 
     @app.get(
         "/v1/default/banks/{bank_id}/audit-logs",
@@ -6265,120 +6230,19 @@ def _register_routes(app: FastAPI):
     ):
         """List audit log entries for a bank."""
         try:
-            from hindsight_api.engine.memory_engine import fq_table
-
-            pool = await app.state.memory._get_backend()
-
-            # Read endpoint: verify bank exists without auto-creating it.
-            if (
-                await app.state.memory.get_bank_profile(
-                    bank_id, request_context=request_context, create_if_missing=False
-                )
-                is None
-            ):
+            result = await app.state.memory.list_audit_logs(
+                bank_id,
+                request_context=request_context,
+                action=action,
+                transport=transport,
+                start_date=datetime.fromisoformat(start_date.replace("Z", "+00:00")) if start_date else None,
+                end_date=datetime.fromisoformat(end_date.replace("Z", "+00:00")) if end_date else None,
+                limit=limit,
+                offset=offset,
+            )
+            if result is None:
                 raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
-
-            from hindsight_api.engine.db_utils import acquire_with_retry
-
-            async with acquire_with_retry(pool) as conn:
-                where_clauses = ["bank_id = $1"]
-                params: list[Any] = [bank_id]
-                idx = 2
-
-                if action:
-                    where_clauses.append(f"action = ${idx}")
-                    params.append(action)
-                    idx += 1
-
-                if transport:
-                    where_clauses.append(f"transport = ${idx}")
-                    params.append(transport)
-                    idx += 1
-
-                if start_date:
-                    parsed_start = datetime.fromisoformat(start_date.replace("Z", "+00:00"))
-                    where_clauses.append(f"started_at >= ${idx}")
-                    params.append(parsed_start)
-                    idx += 1
-
-                if end_date:
-                    parsed_end = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
-                    where_clauses.append(f"started_at < ${idx}")
-                    params.append(parsed_end)
-                    idx += 1
-
-                where_sql = " AND ".join(where_clauses)
-                table = fq_table("audit_log")
-
-                # Get total count
-                count_row = await conn.fetchrow(
-                    f"SELECT COUNT(*) as total FROM {table} WHERE {where_sql}",
-                    *params,
-                )
-                total = count_row["total"] if count_row else 0
-
-                # Get paginated results
-                params.append(limit)
-                params.append(offset)
-                rows = await conn.fetch(
-                    f"""
-                    SELECT id, action, transport, bank_id, started_at, ended_at,
-                           request, response, metadata
-                    FROM {table}
-                    WHERE {where_sql}
-                    ORDER BY started_at DESC
-                    LIMIT ${idx} OFFSET ${idx + 1}
-                    """,
-                    *params,
-                )
-
-                items = []
-                for row in rows:
-                    duration_ms = None
-                    started = row["started_at"]
-                    ended = row["ended_at"]
-                    if started and ended and hasattr(started, "total_seconds"):
-                        duration_ms = int((ended - started).total_seconds() * 1000)
-                    elif started and ended:
-                        try:
-                            duration_ms = int((ended - started).total_seconds() * 1000)
-                        except (TypeError, AttributeError):
-                            pass
-
-                    def _safe_iso(val):
-                        if val is None:
-                            return None
-                        return val.isoformat() if hasattr(val, "isoformat") else str(val)
-
-                    def _safe_json(val):
-                        if val is None:
-                            return None
-                        if isinstance(val, dict):
-                            return val
-                        return json.loads(val) if isinstance(val, str) else val
-
-                    items.append(
-                        {
-                            "id": str(row["id"]),
-                            "action": row["action"],
-                            "transport": row["transport"],
-                            "bank_id": row["bank_id"],
-                            "started_at": _safe_iso(started),
-                            "ended_at": _safe_iso(ended),
-                            "duration_ms": duration_ms,
-                            "request": _safe_json(row["request"]),
-                            "response": _safe_json(row["response"]),
-                            "metadata": _safe_json(row["metadata"]) or {},
-                        }
-                    )
-
-                return {
-                    "bank_id": bank_id,
-                    "total": total,
-                    "limit": limit,
-                    "offset": offset,
-                    "items": items,
-                }
+            return result
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
@@ -6405,72 +6269,15 @@ def _register_routes(app: FastAPI):
     ):
         """Get audit log counts grouped by time bucket."""
         try:
-            from hindsight_api.engine.db_utils import acquire_with_retry
-            from hindsight_api.engine.memory_engine import fq_table
-
-            pool = await app.state.memory._get_backend()
-            # Read endpoint: verify bank exists without auto-creating it.
-            if (
-                await app.state.memory.get_bank_profile(
-                    bank_id, request_context=request_context, create_if_missing=False
-                )
-                is None
-            ):
+            result = await app.state.memory.audit_log_stats(
+                bank_id,
+                request_context=request_context,
+                action=action,
+                period=period,
+            )
+            if result is None:
                 raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
-
-            # Determine time range (always per-day buckets)
-            from datetime import timedelta as _td
-
-            now = datetime.now(timezone.utc)
-            trunc = "day"
-            if period == "1d":
-                start = now - _td(days=1)
-            elif period == "30d":
-                start = now - _td(days=30)
-            else:  # 7d default
-                start = now - _td(days=7)
-
-            table = fq_table("audit_log")
-
-            async with acquire_with_retry(pool) as conn:
-                where_clauses = ["bank_id = $1", "started_at >= $2"]
-                params: list[Any] = [bank_id, start]
-                idx = 3
-
-                if action:
-                    where_clauses.append(f"action = ${idx}")
-                    params.append(action)
-                    idx += 1
-
-                where_sql = " AND ".join(where_clauses)
-
-                rows = await conn.fetch(
-                    f"""
-                    SELECT date_trunc('{trunc}', started_at) AS bucket,
-                           action,
-                           COUNT(*) AS count
-                    FROM {table}
-                    WHERE {where_sql}
-                    GROUP BY bucket, action
-                    ORDER BY bucket ASC
-                    """,
-                    *params,
-                )
-
-                buckets: dict[str, dict[str, int]] = {}
-                for row in rows:
-                    bucket_key = row["bucket"].isoformat()
-                    if bucket_key not in buckets:
-                        buckets[bucket_key] = {}
-                    buckets[bucket_key][row["action"]] = row["count"]
-
-                return {
-                    "bank_id": bank_id,
-                    "period": period,
-                    "trunc": trunc,
-                    "start": start.isoformat(),
-                    "buckets": [{"time": k, "actions": v, "total": sum(v.values())} for k, v in buckets.items()],
-                }
+            return result
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/engine/audit.py
+++ b/hindsight-api-slim/hindsight_api/engine/audit.py
@@ -16,9 +16,57 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 from ..engine.db_utils import acquire_with_retry
 
 logger = logging.getLogger(__name__)
+
+
+class AuditLogEntry(BaseModel):
+    """A single audit log entry."""
+
+    id: str
+    action: str
+    transport: str
+    bank_id: str | None
+    started_at: str | None
+    ended_at: str | None
+    duration_ms: int | None = Field(
+        default=None,
+        description="Server-computed duration in milliseconds (started_at → ended_at). Null if not yet completed.",
+    )
+    request: dict[str, Any] | None
+    response: dict[str, Any] | None
+    metadata: dict[str, Any]
+
+
+class AuditLogListResponse(BaseModel):
+    """Response model for list audit logs endpoint."""
+
+    bank_id: str
+    total: int
+    limit: int
+    offset: int
+    items: list[AuditLogEntry]
+
+
+class AuditLogStatsBucket(BaseModel):
+    """A single time bucket in audit log stats."""
+
+    time: str
+    actions: dict[str, int]
+    total: int
+
+
+class AuditLogStatsResponse(BaseModel):
+    """Response model for audit log stats endpoint."""
+
+    bank_id: str
+    period: str
+    trunc: str
+    start: str
+    buckets: list[AuditLogStatsBucket]
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -214,6 +214,8 @@ if TYPE_CHECKING:
     from hindsight_api.extensions import OperationValidatorExtension, TenantExtension
     from hindsight_api.models import RequestContext
 
+    from .audit import AuditLogListResponse, AuditLogStatsResponse
+
 
 from enum import Enum
 
@@ -6259,6 +6261,167 @@ class MemoryEngine(MemoryEngineInterface):
         )
 
         return result
+
+    # ==================== Audit log read methods ====================
+
+    async def list_audit_logs(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+        action: str | None = None,
+        transport: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> "AuditLogListResponse | None":
+        """List audit log entries for a bank, newest first.
+
+        Returns None when the bank does not exist (the HTTP layer maps this to a
+        404). Authentication and tenant-schema resolution happen inside
+        ``get_bank_profile`` before any query runs, so the SELECT below is scoped
+        to the authenticated tenant's schema.
+        """
+        from .audit import AuditLogEntry, AuditLogListResponse
+
+        if await self.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False) is None:
+            return None
+
+        where_clauses = ["bank_id = $1"]
+        params: list[Any] = [bank_id]
+        idx = 2
+        for column, value in (("action", action), ("transport", transport)):
+            if value:
+                where_clauses.append(f"{column} = ${idx}")
+                params.append(value)
+                idx += 1
+        if start_date is not None:
+            where_clauses.append(f"started_at >= ${idx}")
+            params.append(start_date)
+            idx += 1
+        if end_date is not None:
+            where_clauses.append(f"started_at < ${idx}")
+            params.append(end_date)
+            idx += 1
+
+        where_sql = " AND ".join(where_clauses)
+        table = fq_table("audit_log")
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            count_row = await conn.fetchrow(f"SELECT COUNT(*) AS total FROM {table} WHERE {where_sql}", *params)
+            total = count_row["total"] if count_row else 0
+
+            params.append(limit)
+            params.append(offset)
+            rows = await conn.fetch(
+                f"""
+                SELECT id, action, transport, bank_id, started_at, ended_at,
+                       request, response, metadata
+                FROM {table}
+                WHERE {where_sql}
+                ORDER BY started_at DESC
+                LIMIT ${idx} OFFSET ${idx + 1}
+                """,
+                *params,
+            )
+
+            items = []
+            for row in rows:
+                started = row["started_at"]
+                ended = row["ended_at"]
+                duration_ms = int((ended - started).total_seconds() * 1000) if started and ended else None
+                items.append(
+                    AuditLogEntry(
+                        id=str(row["id"]),
+                        action=row["action"],
+                        transport=row["transport"],
+                        bank_id=row["bank_id"],
+                        started_at=started.isoformat() if started else None,
+                        ended_at=ended.isoformat() if ended else None,
+                        duration_ms=duration_ms,
+                        request=conn.parse_json(row["request"]) if row["request"] is not None else None,
+                        response=conn.parse_json(row["response"]) if row["response"] is not None else None,
+                        metadata=conn.parse_json(row["metadata"]) if row["metadata"] is not None else {},
+                    )
+                )
+
+        return AuditLogListResponse(bank_id=bank_id, total=total, limit=limit, offset=offset, items=items)
+
+    async def audit_log_stats(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+        action: str | None = None,
+        period: str = "7d",
+    ) -> "AuditLogStatsResponse | None":
+        """Audit log counts grouped by day and action, for charting.
+
+        Returns None when the bank does not exist (mapped to 404 by the HTTP
+        layer). Auth/tenant resolution happen in ``get_bank_profile``.
+        """
+        from .audit import AuditLogStatsBucket, AuditLogStatsResponse
+
+        if await self.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False) is None:
+            return None
+
+        now = datetime.now(timezone.utc)
+        trunc = "day"
+        if period == "1d":
+            start = now - timedelta(days=1)
+        elif period == "30d":
+            start = now - timedelta(days=30)
+        else:  # 7d default
+            start = now - timedelta(days=7)
+
+        where_clauses = ["bank_id = $1", "started_at >= $2"]
+        params: list[Any] = [bank_id, start]
+        idx = 3
+        if action:
+            where_clauses.append(f"action = ${idx}")
+            params.append(action)
+            idx += 1
+        where_sql = " AND ".join(where_clauses)
+        table = fq_table("audit_log")
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            rows = await conn.fetch(
+                f"""
+                SELECT date_trunc('{trunc}', started_at) AS bucket,
+                       action,
+                       COUNT(*) AS count
+                FROM {table}
+                WHERE {where_sql}
+                GROUP BY bucket, action
+                ORDER BY bucket ASC
+                """,
+                *params,
+            )
+
+        # Aggregate per bucket: counts by action name (dynamic keys, so a plain
+        # dict here; materialized into typed models below).
+        actions_by_bucket: dict[str, dict[str, int]] = {}
+        order: list[str] = []
+        for row in rows:
+            key = row["bucket"].isoformat()
+            if key not in actions_by_bucket:
+                actions_by_bucket[key] = {}
+                order.append(key)
+            actions_by_bucket[key][row["action"]] = row["count"]
+
+        return AuditLogStatsResponse(
+            bank_id=bank_id,
+            period=period,
+            trunc=trunc,
+            start=start.isoformat(),
+            buckets=[
+                AuditLogStatsBucket(time=k, actions=actions_by_bucket[k], total=sum(actions_by_bucket[k].values()))
+                for k in order
+            ],
+        )
 
     # ==================== bank profile Methods ====================
 

--- a/hindsight-api-slim/tests/test_extensions.py
+++ b/hindsight-api-slim/tests/test_extensions.py
@@ -636,6 +636,30 @@ class TestMemoryEngineTenantAuth:
             )
 
     @pytest.mark.asyncio
+    async def test_list_audit_logs_fails_with_invalid_api_key(self, memory_with_tenant):
+        """Audit log listing goes through tenant auth like other ops."""
+        memory = memory_with_tenant
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            await memory.list_audit_logs(
+                "test-bank",
+                request_context=RequestContext(api_key="wrong-key"),
+            )
+
+        assert "Invalid API key" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_audit_log_stats_fails_with_invalid_api_key(self, memory_with_tenant):
+        """Audit log stats goes through tenant auth like other ops."""
+        memory = memory_with_tenant
+
+        with pytest.raises(AuthenticationError):
+            await memory.audit_log_stats(
+                "test-bank",
+                request_context=RequestContext(api_key="wrong-key"),
+            )
+
+    @pytest.mark.asyncio
     async def test_no_tenant_request_needed_without_extension(self, memory):
         """Operations work with empty RequestContext when no tenant extension configured."""
         # Should not raise - no tenant extension configured, just pass empty RequestContext


### PR DESCRIPTION
## Summary

The `/audit-logs` and `/audit-logs/stats` handlers ran raw SQL directly in the HTTP layer (`acquire_with_retry` + `fq_table`) instead of going through a `MemoryEngine` method. This violated the API-layer data-access standard (queries belong in the engine; auth/tenancy enforced there). This PR refactors them to follow the same pattern as the `llm-requests` endpoints in #1922.

Closes #1923.

## Changes

- **`engine/memory_engine.py`** — add `list_audit_logs(...)` and `audit_log_stats(...)`. Both start with `get_bank_profile(..., create_if_missing=False)`, which calls `_authenticate_tenant(request_context)` **before any query runs** — so the SQL is now gated behind the same tenant authentication every other op uses and scoped to the authenticated tenant's schema. They return `None` for a missing bank, which the HTTP layer maps to 404.
- **`engine/audit.py`** — move the audit response models (`AuditLogEntry`, `AuditLogListResponse`, `AuditLogStatsBucket`, `AuditLogStatsResponse`) here so the engine can build and return them directly (previously inline in `http.py`).
- **`api/http.py`** — the two handlers now just delegate to the engine methods; all raw SQL / connection handling removed.
- **`tests/test_extensions.py`** — add tenant-auth regression tests (`test_list_audit_logs_fails_with_invalid_api_key`, `test_audit_log_stats_fails_with_invalid_api_key`) verifying the reads reject an invalid API key like other ops.

## Verification

- Auth: the issue's "verify they go through authentication as other ops" concern is satisfied — auth is enforced via `_authenticate_tenant` inside `get_bank_profile`, now reached before the query, and covered by the two new tests.
- Lint (`./scripts/hooks/lint.sh`), `ruff`, and `ty` all pass.
- OpenAPI regenerated → **byte-identical** (model names/fields unchanged), so no client SDK regeneration needed; control-plane proxy routes unchanged.
- Tests: 13 existing audit integration tests + 7 tenant-auth tests (incl. 2 new) all pass.