### PR TITLE
docs(docker): drop --rm, add --name + restart policy in run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you need more control over how and when your agent stores and recalls memorie
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/hindsight-api-slim/README.md
+++ b/hindsight-api-slim/README.md
@@ -99,7 +99,7 @@ hindsight-api
 ## Docker
 
 ```bash
-docker run --rm -it -p 8888:8888 \
+docker run -it --name hindsight --restart unless-stopped -p 8888:8888 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/hindsight-api/README.md
+++ b/hindsight-api/README.md
@@ -99,7 +99,7 @@ hindsight-api
 ## Docker
 
 ```bash
-docker run --rm -it -p 8888:8888 \
+docker run -it --name hindsight --restart unless-stopped -p 8888:8888 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/hindsight-docs/docs/developer/api/quickstart.mdx
+++ b/hindsight-docs/docs/developer/api/quickstart.mdx
@@ -43,7 +43,7 @@ API available at [http://localhost:8888](http://localhost:8888/docs)
 
 export OPENAI_API_KEY=sk-xxx
 
-docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -76,7 +76,7 @@ Run everything in one container with embedded PostgreSQL:
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/skills/hindsight-docs/references/developer/api/quickstart.md
+++ b/skills/hindsight-docs/references/developer/api/quickstart.md
@@ -29,7 +29,7 @@ API available at [http://localhost:8888](http://localhost:8888/docs)
 
 export OPENAI_API_KEY=sk-xxx
 
-docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -76,7 +76,7 @@ Run everything in one container with embedded PostgreSQL:
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run --rm -it --pull always -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest


### PR DESCRIPTION
## Summary

Addresses the resilience half of #1918. A single child segfault under load propagates through `start-all.sh`'s cleanup and exits the whole container; with the documented `docker run --rm` invocation there is no recovery, so a transient crash becomes indefinite downtime.

Replaces `--rm` with `--name hindsight --restart unless-stopped` in the documented **server-run** commands so a transient crash self-heals:

- `README.md`
- `hindsight-api-slim/README.md`, `hindsight-api/README.md` (no `--pull`/`-p 9999` here — kept as-is)
- `hindsight-docs/docs/developer/installation.md`, `hindsight-docs/docs/developer/api/quickstart.mdx`
- `skills/hindsight-docs/**` — regenerated mirror (pre-commit hook), tracks the source edits

Left untouched: the throwaway `docker run --rm --entrypoint sh` model-inspection command in `docker/docker-compose/custom-models/README.md` (ephemeral; `--rm` is correct there), plus cookbook recipes, blog posts, and frozen `versioned_docs` snapshots.

## On the pydantic suggestion in the issue

Investigated the suggested `pydantic-core` bump — **it is not actionable today**:

- pydantic enforces its exact `pydantic-core` pin at import time (`SystemError` if mismatched), so you can't just swap the core.
- Stable `pydantic 2.13.4` hard-requires `pydantic-core==2.46.4` (the crashing build); the only release pairing with `2.47.0` is the alpha `pydantic 2.14.0a1`.
- No evidence `2.47.0` fixes this specific concurrent-recall GPF.

Also note the published image resolves pydantic fresh at build time (the Dockerfile copies only `pyproject.toml` and runs `uv sync` without `--frozen`), so a lockfile pin wouldn't reach the image regardless. Deferred per maintainer decision; revisit when a stable pydantic pairs with a fixed `pydantic-core`.

## Note

With a fixed `--name hindsight`, re-running the quickstart errors with "name in use" until `docker rm hindsight` — the expected tradeoff for a stable name + restart policy on a single-instance deployment.

Refs #1918