### PR TITLE
docs(admin-cli): document full backup table coverage from #1903

### DIFF
--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -80,6 +80,9 @@ The backup includes:
 - Entities and their relationships
 - Memory units (facts, experiences, observations)
 - Entity cooccurrences and memory links
+- Mental models and directives
+- Webhooks and file storage
+- Internal operational tables (async operations, audit log, graph-maintenance queue, and similar bookkeeping) so a restore reproduces a faithful full-database snapshot
 
 :::note Consistency
 Backups are created within a database transaction with `REPEATABLE READ` isolation, ensuring a consistent snapshot across all tables.

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -80,6 +80,9 @@ The backup includes:
 - Entities and their relationships
 - Memory units (facts, experiences, observations)
 - Entity cooccurrences and memory links
+- Mental models and directives
+- Webhooks and file storage
+- Internal operational tables (async operations, audit log, graph-maintenance queue, and similar bookkeeping) so a restore reproduces a faithful full-database snapshot
 
 :::note Consistency
 Backups are created within a database transaction with `REPEATABLE READ` isolation, ensuring a consistent snapshot across all tables.


### PR DESCRIPTION
#1903 expanded `BACKUP_TABLES` to cover all 15 tables — adding the 7 that were previously missing (`mental_models`, `directives`, `async_operations`, `webhooks`, `file_storage`, `audit_log`, `graph_maintenance_queue`) and could be silently dropped on restore. The user-facing "The backup includes:" list in `admin-cli.md` still described the old ~8-table coverage.

This updates that list to match the fixed behavior:
- adds **Mental models and directives**, **Webhooks and file storage**
- adds a line noting internal operational tables (async operations, audit log, graph-maintenance queue, and similar bookkeeping) are included for a faithful full-database snapshot

Oracle-only `observation_sources` stays excluded (admin backup/restore is PostgreSQL-only). Pure docs; the `skills/hindsight-docs` mirror is regenerated (plain `.md` → byte-identical copy, keeps `verify-generated-files` green).