### PR TITLE
docs(guides): add Hermes memory guide batch

### DIFF
--- a/hindsight-docs/guides/2026-06-02-comparison-hermes-built-in-memory-vs-hindsight-at-scale.md
+++ b/hindsight-docs/guides/2026-06-02-comparison-hermes-built-in-memory-vs-hindsight-at-scale.md
@@ -1,0 +1,135 @@
+---
+title: "Comparison: Hermes Built-In Memory vs Hindsight at Scale"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [comparison, hermes, memory, scale]
+description: "Compare Hermes built-in memory with Hindsight when usage grows beyond a single machine and a handful of hand-written notes."
+image: /img/guides/comparison-hermes-built-in-memory-vs-hindsight-at-scale.svg
+hide_table_of_contents: true
+---
+
+![Comparison: Hermes Built-In Memory vs Hindsight at Scale](/img/guides/comparison-hermes-built-in-memory-vs-hindsight-at-scale.svg)
+
+Hermes already has memory. The real question is whether Hermes's **built-in memory** is enough for your workflow, or whether you need an external memory system like **Hindsight** once usage starts to scale.
+
+For small personal workflows, the built-in memory can be perfectly fine. But once you care about cross-session continuity, structured recall, cleaner retrieval, shared memory across machines, or team workflows, the built-in approach starts to show its limits.
+
+This guide is the practical comparison: where the built-in memory is still the right choice, where it breaks down, and what changes when you move to Hindsight.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> - Use **built-in Hermes memory** for lightweight personal notes and simple local workflows.
+> - Use **Hindsight** when you need stronger retrieval, cross-device continuity, or shared memory across agents and teammates.
+> - The built-in memory is good for remembering what you wrote down. Hindsight is better for remembering what your conversations actually taught the agent.
+
+## Where the built-in memory works well
+
+Built-in memory works best when all of these are true:
+
+- one user
+- one machine
+- low memory volume
+- no need for rich retrieval
+- no need to share memory across sessions, agents, or teammates beyond the local environment
+
+That is not a bad use case. If you mainly want Hermes to keep a few durable preferences and some hand-written notes, the simplest thing often wins.
+
+## What changes at scale
+
+Scale does not just mean more memories. It means the workflow itself gets harder.
+
+The moment you need Hermes to do any of the following, the built-in path starts to feel thin:
+
+- remember context across many sessions
+- separate memory by project, customer, or team
+- recall the right fact when the query is indirect
+- share the same memory across laptop, desktop, and server
+- let multiple agents or teammates build on the same memory bank
+
+At that point, you are not looking for a notepad. You are looking for a memory system.
+
+## The main difference in practice
+
+Built-in memory is strong when the model explicitly writes something down and later retrieves it.
+
+Hindsight changes the workflow in two ways:
+
+- **retention** becomes more automatic because facts can be extracted from normal conversation flow
+- **retrieval** becomes more capable because the system can search for meaning, entities, and related context rather than relying on a thinner memory pattern
+
+That makes a big difference when you ask questions like:
+
+> What did we decide about the migration plan?
+
+or:
+
+> What do we already know about this customer?
+
+Those questions often depend on multiple prior facts, indirect wording, and context spread across time.
+
+## Local notes vs structured memory
+
+A helpful way to think about it:
+
+- **Built-in memory** is closer to a local memory notebook
+- **Hindsight** is closer to a structured long-term memory layer
+
+That difference matters most when the workflow becomes cumulative.
+
+If Hermes only needs to remember a handful of stable facts, local notes are enough. If Hermes needs to accumulate knowledge over weeks and retrieve the right part when needed, Hindsight becomes much more attractive.
+
+## Cross-device and team workflows
+
+This is usually the breaking point.
+
+Once the same person uses Hermes on more than one machine, or a team wants a shared memory for the same customer, project, or codebase, local-only memory stops being a good fit. You end up with multiple disconnected memory islands.
+
+Hindsight is the stronger option here because it can back the same bank across environments. The memory follows the workflow instead of staying trapped on one laptop.
+
+## Retrieval quality is the real scaling issue
+
+The hardest part of memory is not storing text. It is getting the right memory back at the right moment.
+
+That is why some workflows feel fine at first and then degrade later. The notes are technically there, but recall becomes less reliable as the bank grows.
+
+For production workflows, the question is not “can Hermes save something?” It is “can Hermes surface the right thing later without you re-explaining it?”
+
+That is where Hindsight tends to pull ahead.
+
+## Which one should you choose?
+
+Choose built-in memory when you want:
+
+- the simplest possible local setup
+- a lightweight personal assistant workflow
+- no extra infrastructure
+
+Choose Hindsight when you want:
+
+- memory that compounds across many sessions
+- stronger recall for real-world queries
+- bank strategies for projects, customers, or teams
+- cross-device or shared memory
+- a path that can grow with the workflow
+
+## FAQ
+
+### Is Hermes built-in memory bad?
+
+No. It is just optimized for a smaller, simpler class of workflows.
+
+### When should I switch to Hindsight?
+
+Usually when memory becomes important enough that you notice the gaps: noisy recall, weak continuity, or fragmented context across environments.
+
+### Can I start simple and migrate later?
+
+Yes. That is a sensible path for many teams.
+
+## Next Steps
+
+- Read [Hindsight is now a native memory provider in Hermes Agent](/blog/2026/04/06/hermes-native-memory-provider)
+- Review [Hermes memory bank strategy for production](/guides/2026/04/20/guide-hermes-memory-bank-strategy-for-production)
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want the shortest path to shared or cross-device memory

--- a/hindsight-docs/guides/2026-06-02-comparison-hermes-native-memory-provider-vs-mcp-memory.md
+++ b/hindsight-docs/guides/2026-06-02-comparison-hermes-native-memory-provider-vs-mcp-memory.md
@@ -1,0 +1,152 @@
+---
+title: "Comparison: Hermes Native Memory Provider vs MCP Memory with Hindsight"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [comparison, hermes, mcp, memory]
+description: "Compare Hermes native Hindsight memory provider with the MCP route: setup friction, tool surface, recall behavior, and when each path makes sense."
+image: /img/guides/comparison-hermes-native-memory-provider-vs-mcp-memory.svg
+hide_table_of_contents: true
+---
+
+![Comparison: Hermes Native Memory Provider vs MCP Memory with Hindsight](/img/guides/comparison-hermes-native-memory-provider-vs-mcp-memory.svg)
+
+If you want **Hermes persistent memory with Hindsight**, you have two real integration paths: Hermes's **native memory provider** and the **MCP route**. Both work. They just optimize for different things.
+
+The native provider is the right default for most teams. Setup is lighter, memory behavior is more predictable, and Hermes understands the provider as part of its own memory lifecycle. MCP is the better fit when you want the broader Hindsight tool surface, more explicit control, or you are already standardizing on MCP across multiple agent frameworks.
+
+This guide is the practical decision framework: which path is faster, which path is more flexible, and where each one starts to hurt.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> - Pick the **native memory provider** if you want the cleanest Hermes experience with the least setup overhead.
+> - Pick **MCP** if you want the full Hindsight toolset, richer bank management, or one integration pattern that spans multiple tools.
+> - For most day to day Hermes usage, native wins on simplicity. For power-user workflows, MCP wins on surface area.
+
+## How the two approaches differ
+
+The native memory provider plugs directly into Hermes's built-in memory abstraction. You run hermes memory setup, choose Hindsight, and Hermes starts using Hindsight for recall and retention through the same memory flow it already understands.
+
+The MCP route connects Hermes to Hindsight as an external tool server. Instead of memory being handled through Hermes's provider layer, Hermes calls Hindsight through MCP tools. That gives you more explicit control and a wider tool surface, but it also means more moving pieces.
+
+In practice, that difference matters in four places:
+
+- **Setup path** — native is quicker, MCP has more knobs
+- **Mental model** — native feels like built-in memory, MCP feels like a tool integration
+- **Tool surface** — native is narrower, MCP is broader
+- **Standardization** — native is Hermes-specific, MCP is portable across agent stacks
+
+## When the native provider is the better choice
+
+The native provider is the better default when your goal is simple: make Hermes remember across sessions without turning memory into another system to operate.
+
+It wins when you want:
+
+- **Fastest setup** — the memory wizard gets you there quickly
+- **Lower cognitive overhead** — fewer components to reason about when something goes wrong
+- **Predictable recall behavior** — memory feels like part of Hermes rather than a sidecar toolset
+- **A cleaner user story** — easier for teammates to adopt without explaining MCP first
+
+If you are setting up Hermes for yourself, for a small team, or for a specific production workflow, this is usually where you should start.
+
+## When MCP is the better choice
+
+MCP is the better path when you want Hindsight as a general purpose memory system, not just a Hermes memory backend.
+
+It wins when you want:
+
+- **The full Hindsight tool surface** such as richer bank operations and explicit memory workflows
+- **Cross-tool standardization** so Hermes, Codex, Claude Code, and other MCP clients can all hit the same memory backend the same way
+- **More manual control** over when and how memory is called
+- **A single integration layer** for teams already building around MCP infrastructure
+
+If your environment already uses MCP heavily, the portability is hard to beat. You do more setup once, then reuse the pattern everywhere.
+
+## Setup and operations tradeoff
+
+Here is the real operational tradeoff.
+
+### Native provider
+
+~~~bash
+hermes memory setup
+~~~
+
+This is the short path. Hermes owns the memory configuration, the runtime experience is straightforward, and onboarding a teammate is mostly “pick Hindsight and use the same bank strategy.”
+
+### MCP
+
+With MCP, you are configuring Hermes to talk to an MCP server, then making sure the Hindsight server configuration, auth, and bank conventions all line up.
+
+That is not bad. It is just more infrastructure.
+
+If you are a solo operator or you are optimizing for adoption speed, native usually wins. If you are a platform team and MCP is already how you expose capabilities, the extra setup is often worth it.
+
+## Capability tradeoff
+
+A useful rule of thumb:
+
+- **Native provider** = better default memory experience inside Hermes
+- **MCP** = broader Hindsight capability surface beyond the default memory loop
+
+That matters when you move beyond simple “remember what happened last week” use cases.
+
+If your workflow is mostly:
+
+- recall context before the next turn
+- retain useful facts afterward
+- keep one or more stable bank IDs
+
+then native is enough.
+
+If your workflow starts to include:
+
+- explicit bank management
+- richer reflection patterns
+- cross-tool memory orchestration
+- one Hindsight backend shared across many MCP-native clients
+
+then MCP becomes more attractive.
+
+## Which path should teams choose?
+
+For most teams, the right rollout is **native first, MCP later if needed**.
+
+That sequence keeps the adoption cost low. People learn what good memory feels like inside Hermes before they take on the extra flexibility of MCP.
+
+Go straight to MCP when at least one of these is true:
+
+- your team already operates MCP servers in production
+- Hermes is only one of several agent runtimes you need to support
+- you expect to expose more than the default Hermes memory behavior
+
+Otherwise, start native.
+
+## Migration path if you pick the wrong one first
+
+This is not a one-way decision.
+
+If you start with the native provider and later need the broader Hindsight toolset, you can move to MCP once the team has a clear reason. If you start with MCP and decide it is too much operational overhead for a single Hermes deployment, you can simplify down to the native provider.
+
+The important thing is to keep your **bank naming strategy** stable. If your bank IDs map cleanly to users, projects, or teams, switching the connection layer is much less painful.
+
+## FAQ
+
+### Which one is faster to set up?
+
+The native provider, by a lot.
+
+### Which one is more flexible?
+
+MCP, because it exposes Hindsight more directly as a tool server.
+
+### Which one should most Hermes users choose?
+
+The native provider. It is the best default unless you already know you need MCP.
+
+## Next Steps
+
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)
+- Compare a broader framework-level tradeoff in [SDK memory vs MCP memory with Hindsight](/guides/2026/04/16/comparison-mcp-vs-sdk-memory-with-hindsight)
+- Use [Hindsight Cloud](https://hindsight.vectorize.io) if you want the shortest setup path

--- a/hindsight-docs/guides/2026-06-02-comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.md
+++ b/hindsight-docs/guides/2026-06-02-comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.md
@@ -1,0 +1,114 @@
+---
+title: "Comparison: Hermes on Windows vs WSL2 for Persistent Memory"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [comparison, hermes, windows, memory]
+description: "Choose between native Windows and WSL2 for Hermes + Hindsight: setup friction, memory workflow, shell compatibility, and when each option still makes sense."
+image: /img/guides/comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.svg
+hide_table_of_contents: true
+---
+
+![Comparison: Hermes on Windows vs WSL2 for Persistent Memory](/img/guides/comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.svg)
+
+Now that Hermes runs **natively on Windows**, the default setup choice has changed. Most people no longer need WSL2 just to get Hermes + Hindsight working.
+
+That does not mean WSL2 is obsolete. It still makes sense for Linux-heavy toolchains, shell scripts, or workflows that already live there. But if your goal is simply to run Hermes with persistent memory on a Windows machine, native Windows is now the better starting point.
+
+This guide compares the two paths so you can choose the one that matches your actual workflow instead of inheriting old setup advice.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> - Start with **native Windows** if you mainly want Hermes + Hindsight working with the least setup friction.
+> - Use **WSL2** if your surrounding workflow depends on Linux-first tooling, shell scripts, or existing Linux dev environments.
+> - For most Windows users in 2026, native is now the right default.
+
+## Why the choice changed
+
+Before native Windows support, WSL2 was the obvious answer. It let you sidestep platform assumptions in shells, subprocess handling, and local tooling.
+
+Now Hermes has a native Windows path, including a real PowerShell story. Hindsight also supports Windows embedded mode. That removes the biggest reason to reach for WSL2 first.
+
+## Where native Windows wins
+
+Native Windows is better when you want:
+
+- the shortest setup path
+- PowerShell-first usage
+- fewer layers between Hermes and the host machine
+- simpler file path handling with Windows-native projects
+- one less environment to maintain
+
+If your day-to-day work already lives in Windows, that simplicity matters.
+
+## Where WSL2 still wins
+
+WSL2 is still the better choice when you want:
+
+- Linux shell parity with the rest of your engineering stack
+- existing bash-heavy scripts and tooling
+- a workflow that already assumes Linux packages and file layouts
+- consistency with server-side Linux environments
+
+In other words, WSL2 is still strong when Hermes is just one part of a larger Linux-first toolchain.
+
+## Memory behavior is mostly the same
+
+From the Hindsight perspective, both paths can provide persistent memory. The real difference is not the memory model. It is the operating environment around it.
+
+That means the decision is usually about:
+
+- setup friction
+- shell ergonomics
+- path semantics
+- tooling compatibility
+
+not whether memory itself works.
+
+## The practical recommendation
+
+Use this rule:
+
+- **Windows-first workflow** -> start native
+- **Linux-first workflow on a Windows machine** -> use WSL2
+
+Do not start in WSL2 just because old guides said to. Native Windows exists now for a reason.
+
+## What to test before you commit
+
+Run a quick trial on your actual setup:
+
+1. install Hermes natively
+2. connect Hindsight
+3. run one real workflow end to end
+4. only fall back to WSL2 if your surrounding tools require it
+
+That prevents premature complexity.
+
+## Common mistakes
+
+- defaulting to WSL2 out of habit
+- assuming native Windows means every surrounding dev tool behaves identically
+- choosing native Windows for a workflow that is deeply Linux-scripted
+- choosing WSL2 when the actual goal was just a simple Hermes setup
+
+## FAQ
+
+### Is native Windows good enough now?
+
+Yes, for most Hermes + Hindsight setups it is the right default.
+
+### Should developers still consider WSL2?
+
+Yes, if their broader workflow is Linux-native.
+
+### Does persistent memory work in both?
+
+Yes. The question is mostly which host environment fits better.
+
+## Next Steps
+
+- Read [Hermes Agent on Windows: Set Up Persistent Memory with Hindsight](/blog/2026/06/01/hermes-hindsight-windows-setup)
+- Read [Building a Hermes Coding Assistant on Windows That Remembers Your Codebase](/blog/2026/06/01/hermes-hindsight-windows)
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)

--- a/hindsight-docs/guides/2026-06-02-guide-fix-common-hermes-windows-memory-setup-issues.md
+++ b/hindsight-docs/guides/2026-06-02-guide-fix-common-hermes-windows-memory-setup-issues.md
@@ -1,0 +1,114 @@
+---
+title: "Guide: Fix Common Hermes Windows Memory Setup Issues"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, windows, troubleshooting]
+description: "Troubleshoot the most common Hermes + Hindsight issues on Windows: encoding, first boot delays, path problems, and local embedded startup confusion."
+image: /img/guides/guide-fix-common-hermes-windows-memory-setup-issues.svg
+hide_table_of_contents: true
+---
+
+![Guide: Fix Common Hermes Windows Memory Setup Issues](/img/guides/guide-fix-common-hermes-windows-memory-setup-issues.svg)
+
+Hermes on Windows is real now, but early adopters still run into a familiar class of issues: encoding quirks, first-boot delays, path edge cases, and confusion about what Local Embedded is doing behind the scenes.
+
+The good news is that most Windows problems are boring once you know what they are. This guide covers the common failure modes for **Hermes + Hindsight on Windows** and the fastest fixes.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> - If logs crash on Windows characters, force UTF-8.
+> - If Local Embedded looks hung on first boot, give it time to unpack and initialize.
+> - If paths behave strangely, shorten the install path and check long-path support.
+> - If recall is missing, verify the provider, mode, and bank ID before assuming memory is broken.
+
+## 1. Unicode or encoding errors in PowerShell
+
+This is the most recognizable issue.
+
+If Hermes or Hindsight prints status characters and you hit a UnicodeEncodeError, the fix is usually to force UTF-8 in the shell environment.
+
+A common approach is setting:
+
+~~~powershell
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8'
+~~~
+
+If that solves it, add the equivalent to your PowerShell profile.
+
+## 2. Local Embedded looks stuck on first boot
+
+Often it is not stuck. It is just doing first-run work.
+
+On Windows, Local Embedded may need time to unpack the embedded Postgres bundle and run initialization before Hermes reports ready. The first run is much slower than later runs.
+
+If the setup looks frozen, check logs before killing the process. A slow first boot is normal.
+
+## 3. Path-length weirdness
+
+Deep directory trees still create trouble on Windows.
+
+If your install path, workspace path, or cached package path is extremely long, shorten the path first. If needed, enable long path support in Windows so tooling does not trip over the legacy limit.
+
+## 4. Memory is configured, but recall still feels empty
+
+Before you assume Windows is the cause, check the basic memory loop:
+
+- is Hermes using Hindsight as the provider?
+- are you retaining into the bank you think you are?
+- are later sessions using the same bank ID?
+- did you test recall in a fresh session?
+
+A lot of “Windows recall issues” are actually bank mismatch issues.
+
+## 5. Cloud vs Local confusion
+
+Some users expect Local Embedded to behave like Cloud with zero startup cost. It does not. Local gives you more control, but it also means the local service has to start and stay healthy.
+
+If you want the least operational friction on Windows, Cloud is often the better choice.
+
+## 6. Antivirus or security tools slow startup
+
+If startup feels unusually slow after the first run, local binaries or extracted components may be getting scanned aggressively. This is environment-specific, but it is common enough to check.
+
+## 7. Mixing Windows-native and WSL paths
+
+This is an easy one to miss. If part of your workflow is native Windows and part lives in WSL2, path references can become inconsistent fast.
+
+Pick one environment per workflow when possible.
+
+## A fast troubleshooting order
+
+Use this sequence:
+
+1. verify hermes memory status
+2. confirm the provider is Hindsight
+3. confirm the bank ID
+4. test retain and recall in a fresh session
+5. check encoding
+6. check first-boot logs
+7. shorten paths if needed
+
+That catches most issues quickly.
+
+## FAQ
+
+### Is slow first boot normal on Windows local mode?
+
+Yes. First boot is usually the slowest by far.
+
+### Is Cloud easier on Windows?
+
+Usually yes, because there is less local runtime to manage.
+
+### Should I switch to WSL2 if I hit one problem?
+
+Not immediately. Most native Windows issues are fixable without abandoning the setup.
+
+## Next Steps
+
+- Read [Hermes Agent on Windows: Set Up Persistent Memory with Hindsight](/blog/2026/06/01/hermes-hindsight-windows-setup)
+- Compare [Hermes on Windows vs WSL2 for Persistent Memory](/guides/2026/06/02/comparison-hermes-on-windows-vs-wsl2-for-persistent-memory)
+- Use [Hindsight Cloud](https://hindsight.vectorize.io) if you want the least local setup friction

--- a/hindsight-docs/guides/2026-06-02-guide-hermes-coding-memory-across-repos-bugs-and-decisions.md
+++ b/hindsight-docs/guides/2026-06-02-guide-hermes-coding-memory-across-repos-bugs-and-decisions.md
@@ -1,0 +1,136 @@
+---
+title: "Guide: Hermes Coding Memory Across Repos, Bugs, and Decisions"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, coding-agents, memory]
+description: "Use Hermes with Hindsight to keep repo-specific context, recurring bug history, and engineering decisions available across coding sessions."
+image: /img/guides/guide-hermes-coding-memory-across-repos-bugs-and-decisions.svg
+hide_table_of_contents: true
+---
+
+![Guide: Hermes Coding Memory Across Repos, Bugs, and Decisions](/img/guides/guide-hermes-coding-memory-across-repos-bugs-and-decisions.svg)
+
+If you use Hermes for coding work across more than one repository, the highest leverage memory setup is not “one giant coding bank.” It is a bank strategy that keeps **repo context**, **recurring bug history**, and **engineering decisions** retrievable without letting unrelated projects bleed together.
+
+That is what Hindsight is good at. Hermes becomes much more useful when the agent can remember why a migration happened, which bug pattern keeps coming back, and which conventions belong to which codebase.
+
+This guide covers the setup pattern that works best for engineering teams and solo developers moving between multiple repos.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Connect Hermes to Hindsight.
+> 2. Use one stable bank per repo or service.
+> 3. Let Hermes retain conventions, known bugs, and technical decisions over time.
+> 4. Use a shared bank for team-owned repos when you want institutional memory.
+> 5. Avoid one all-purpose engineering bank unless you enjoy noisy recall.
+
+## Why coding memory gets messy fast
+
+A coding assistant does not just need language context. It needs project context.
+
+That includes:
+
+- architecture decisions
+- repo conventions
+- known fragile areas
+- previous debugging work
+- reasons a team chose one approach over another
+
+The problem is that these facts are highly specific. What is true in one repo is often wrong in another.
+
+That is why memory design matters so much for coding workflows.
+
+## Step 1: Use a bank per repo
+
+The safest default is one bank per repo or per service.
+
+Examples:
+
+- repo-api-gateway
+- repo-payments-service
+- repo-mobile-app
+
+That gives Hermes a clean memory space for each codebase. The agent can recall the right facts without mixing React conventions from one repo into a Python service somewhere else.
+
+## Step 2: Focus on the memories that compound
+
+The most valuable coding memories are not raw code snippets. They are the durable facts behind the work.
+
+Examples:
+
+- “Auth service fails open if refresh token verification times out”
+- “Payments repo uses asyncpg directly, not SQLAlchemy”
+- “Frontend release process depends on generating feature flags before build”
+- “Team rejected event sourcing for this service because replay cost was too high”
+
+These are the facts that save time later because they answer “what do we already know?” before the next debugging or design session starts.
+
+## Step 3: Use memory where coding agents have the most leverage
+
+### Resuming work on a repo
+
+The new session should start with the real task, not a README recap.
+
+Instead of restating the stack, conventions, and what you were doing last week, you can ask:
+
+~~~text
+Pick up the bug we were tracing in the payment retry path.
+~~~
+
+That only works when the repo memory is stable and clean.
+
+### Debugging recurring failures
+
+Some bugs come back in new forms. Memory is what lets Hermes connect the current symptom to the previous root cause.
+
+### Remembering decisions, not just outcomes
+
+A lot of engineering pain comes from forgetting *why* a team chose something. Memory helps Hermes surface the rationale behind migrations, framework choices, and rejected alternatives.
+
+## Step 4: Decide when memory should be shared
+
+For a solo repo, one bank per repo is enough.
+
+For a team-owned codebase, a shared bank turns memory into institutional knowledge. The next engineer can ask Hermes what the team already learned about the deployment pipeline, the flaky integration point, or the reason a component keeps being treated carefully.
+
+That is often more valuable than any single session.
+
+## Step 5: Keep multi-repo memory clean
+
+The temptation is to create one global engineering bank. That feels convenient at first, but recall quality usually gets worse as unrelated memories accumulate.
+
+A better pattern is:
+
+- **one bank per repo** for project-specific knowledge
+- **one personal bank** for your own coding preferences if you want them everywhere
+
+That separation gives you both precision and continuity.
+
+## Common mistakes
+
+- One giant bank for every repo
+- Storing only procedural chatter instead of durable technical facts
+- Changing bank names midway through a project
+- Sharing personal preference memory in a team codebase bank
+
+## FAQ
+
+### Should I use one bank per repo or per team?
+
+Per repo is the safer default. Use team-shared repo banks when several people work on the same codebase.
+
+### What kinds of coding facts are worth remembering?
+
+Conventions, decisions, recurring bugs, deployment gotchas, and architecture rationale.
+
+### Is this different from documentation?
+
+Yes. It captures the working knowledge that rarely makes it into docs.
+
+## Next Steps
+
+- Read [Building a Hermes Coding Assistant That Remembers Your Codebase](/blog/2026/05/25/hermes-coding-assistant-codebase-memory)
+- Review [Hermes memory bank strategy for production](/guides/2026/04/20/guide-hermes-memory-bank-strategy-for-production)
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)

--- a/hindsight-docs/guides/2026-06-02-guide-hermes-cross-device-memory-with-hindsight-cloud.md
+++ b/hindsight-docs/guides/2026-06-02-guide-hermes-cross-device-memory-with-hindsight-cloud.md
@@ -1,0 +1,127 @@
+---
+title: "Guide: Give Hermes Cross-Device Memory with Hindsight Cloud"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, cloud, memory]
+description: "Set up Hermes with Hindsight Cloud so the same memory follows you across laptop, desktop, and server sessions."
+image: /img/guides/guide-hermes-cross-device-memory-with-hindsight-cloud.svg
+hide_table_of_contents: true
+---
+
+![Guide: Give Hermes Cross-Device Memory with Hindsight Cloud](/img/guides/guide-hermes-cross-device-memory-with-hindsight-cloud.svg)
+
+If you run Hermes on more than one machine, **cross-device memory** is the difference between one assistant and three disconnected ones. Without a shared memory backend, your laptop Hermes, desktop Hermes, and server Hermes each build their own partial history. You end up re-explaining the same context everywhere.
+
+Hindsight Cloud fixes that. Point multiple Hermes installs at the same memory backend, keep a stable bank strategy, and the assistant carries context across devices instead of starting over.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Set up Hermes with Hindsight Cloud.
+> 2. Use the same bank IDs on every device that should share memory.
+> 3. Keep project or user bank naming stable.
+> 4. Verify recall from one device after retaining facts on another.
+> 5. Use separate banks when you want isolation.
+
+## Why local memory is not enough across devices
+
+Local memory works until your workflow spans machines.
+
+Maybe you research on a laptop, code on a desktop, and run automation on a server. If each environment keeps memory locally, then your context fragments immediately. The information exists, but it is scattered.
+
+Cross-device memory solves that by moving the bank behind the agent instead of inside one machine.
+
+## Step 1: Choose Hindsight Cloud
+
+The easiest path is the Hermes memory setup wizard:
+
+~~~bash
+hermes memory setup
+~~~
+
+Choose **Hindsight**, then choose **Cloud**.
+
+That gives every Hermes install a shared backend instead of a machine-local one.
+
+## Step 2: Make your bank strategy explicit
+
+A shared backend is only half the job. The other half is making sure every device points at the **same bank when it should**.
+
+Good patterns:
+
+- one bank per user assistant
+- one bank per project
+- one bank per customer or account
+
+Examples:
+
+- ben-personal
+- project-hindsight-docs
+- acct-acme
+
+The key is stability. If your laptop uses project-hindsight-docs and your desktop uses docs-project, you did not create cross-device memory. You created two separate histories with similar names.
+
+## Step 3: Verify the flow end to end
+
+A quick verification loop:
+
+1. On device A, tell Hermes one fact worth remembering.
+2. End the session.
+3. On device B, start a fresh Hermes session using the same bank.
+4. Ask for the fact.
+
+If the second device can recall it cleanly, the setup is working.
+
+## Best use cases for cross-device memory
+
+### Personal assistant workflows
+
+You might message Hermes from your phone, continue from your laptop, and later ask a follow-up from your desktop. Shared memory makes those all feel like one ongoing relationship with the same assistant.
+
+### Coding workflows
+
+Research on one machine, implementation on another, deployment or monitoring on a server. A shared bank keeps the repo context continuous.
+
+### Team operations
+
+A server-side Hermes worker can build memory that a human-operated Hermes chat can later use, and vice versa.
+
+## When not to share a bank
+
+Not everything should be in one pool.
+
+Use separate banks when:
+
+- different projects should stay isolated
+- personal context should not mix with team memory
+- customer-specific memory should not leak across accounts
+
+Cross-device should not mean cross-everything.
+
+## Common mistakes
+
+- using different bank IDs on different machines
+- reusing one giant bank for unrelated work
+- assuming Cloud alone guarantees good retrieval without a clear naming strategy
+- forgetting to test recall from a second device
+
+## FAQ
+
+### Can I share one bank across laptop and server?
+
+Yes. That is one of the main reasons to use Cloud.
+
+### Do I need the same local Hermes install path on every machine?
+
+No. What matters is the shared backend and stable bank IDs.
+
+### Should teams share one bank too?
+
+Only when the workflow itself should share memory. Otherwise, keep banks separate.
+
+## Next Steps
+
+- Read [move Hermes memory from local files to Hindsight Cloud](/guides/2026/04/20/guide-move-hermes-memory-from-local-files-to-hindsight-cloud)
+- Review [single bank vs multi-bank with Hindsight](/guides/2026/04/16/comparison-single-bank-vs-multi-bank-hindsight)
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io)

--- a/hindsight-docs/guides/2026-06-02-guide-hermes-long-term-memory-without-fine-tuning.md
+++ b/hindsight-docs/guides/2026-06-02-guide-hermes-long-term-memory-without-fine-tuning.md
@@ -1,0 +1,137 @@
+---
+title: "Guide: Give Hermes Long-Term Memory Without Fine-Tuning"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, memory, fine-tuning]
+description: "Use Hindsight to give Hermes long-term memory for facts, preferences, and project context without retraining or fine-tuning the model."
+image: /img/guides/guide-hermes-long-term-memory-without-fine-tuning.svg
+hide_table_of_contents: true
+---
+
+![Guide: Give Hermes Long-Term Memory Without Fine-Tuning](/img/guides/guide-hermes-long-term-memory-without-fine-tuning.svg)
+
+A lot of people reach for fine-tuning when what they really want is **memory**.
+
+If your goal is to make Hermes remember user preferences, project history, customer context, or prior decisions across sessions, fine-tuning is usually the wrong tool. Fine-tuning changes model behavior. Memory gives the model access to changing facts.
+
+Hindsight is the cleaner path. You keep the base model, add a persistent memory layer, and let Hermes recall the relevant context when it matters.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> - Use **fine-tuning** when you need to change how a model behaves in general.
+> - Use **memory** when you need Hermes to remember facts that change over time.
+> - For most assistant and agent workflows, Hindsight solves the actual problem faster and with less operational cost.
+
+## Why fine-tuning is usually the wrong fit
+
+Fine-tuning is a blunt instrument for a memory problem.
+
+If you fine-tune Hermes's underlying model to remember your workflow, you run into obvious issues:
+
+- preferences change
+- project state changes
+- customer information changes
+- the model does not gain session-specific recall just because you retrained it once
+
+The more dynamic the information is, the less fine-tuning helps.
+
+## What memory solves better
+
+Memory is better when the context is:
+
+- personal
+- project-specific
+- customer-specific
+- accumulated over time
+- different across users, teams, or banks
+
+That is exactly the context Hindsight is designed to retain and recall.
+
+Hermes does not need to be retrained to remember that a user prefers concise writing, that a project moved off one database client, or that an account's security review is the main blocker. It needs that information available at the next relevant turn.
+
+## The practical pattern
+
+Use Hermes as the agent layer and Hindsight as the long-term memory layer.
+
+A typical setup looks like this:
+
+~~~bash
+hermes memory setup
+~~~
+
+Choose **Hindsight**, then choose a bank strategy that matches the workflow.
+
+Examples:
+
+- one bank per user
+- one bank per project
+- one bank per customer
+
+That gives Hermes stable, scoped long-term memory without touching model weights.
+
+## When memory beats fine-tuning
+
+### User preferences
+
+Writing style, formatting preferences, repeated dislikes, scheduling habits — these are changing facts, not general model capabilities.
+
+### Project context
+
+Repo conventions, decisions, known bugs, migration history — all dynamic, all better handled by memory.
+
+### Business workflows
+
+Accounts, stakeholders, objections, internal policies, handoff context — again, dynamic facts.
+
+In all three cases, fine-tuning is overkill and underpowered at the same time.
+
+## When fine-tuning still makes sense
+
+Fine-tuning can still be useful when you want to change broad behavior:
+
+- output style for a narrow domain
+- specialized classification behavior
+- domain-specific response patterns at scale
+
+But even then, the fine-tuned model often still benefits from memory. The two are not mutually exclusive.
+
+The key is not to confuse them.
+
+## Why this matters operationally
+
+Memory is usually easier to roll out, easier to update, and easier to scope.
+
+If you want to change what Hermes remembers, you change the bank strategy or the memory layer. You do not retrain a model.
+
+If you want different teams to remember different things, you use different banks. You do not create separate fine-tunes for every context boundary.
+
+That is why memory is often the more practical production solution.
+
+## Common mistakes
+
+- trying to solve changing facts with a static fine-tune
+- using one giant memory bank for unrelated work
+- expecting memory to change general reasoning behavior
+- expecting fine-tuning to provide fresh session recall
+
+## FAQ
+
+### Can memory replace fine-tuning completely?
+
+Not always. They solve different problems.
+
+### What is the right default for Hermes users?
+
+Memory first. Fine-tune only when you have a clear behavior problem that memory cannot solve.
+
+### Does memory work across sessions and devices?
+
+Yes, if you back it with a shared Hindsight setup.
+
+## Next Steps
+
+- Read [what agent memory really means](/guides/2026/04/23/guide-what-agent-memory-really-means)
+- Review [Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)
+- Start with [Hindsight Cloud](https://hindsight.vectorize.io) if you want the shortest path to long-term memory

--- a/hindsight-docs/guides/2026-06-02-guide-hermes-sales-research-memory-with-hindsight.md
+++ b/hindsight-docs/guides/2026-06-02-guide-hermes-sales-research-memory-with-hindsight.md
@@ -1,0 +1,155 @@
+---
+title: "Guide: Use Hermes for Sales Research with Persistent Memory"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, sales, memory]
+description: "Set up Hermes with Hindsight for sales research so the agent remembers accounts, stakeholders, objections, and deal context across sessions."
+image: /img/guides/guide-hermes-sales-research-memory-with-hindsight.svg
+hide_table_of_contents: true
+---
+
+![Guide: Use Hermes for Sales Research with Persistent Memory](/img/guides/guide-hermes-sales-research-memory-with-hindsight.svg)
+
+If you want **Hermes for sales research**, persistent memory is what makes it useful after the first session. Without memory, every account brief starts from zero. With Hindsight, Hermes can retain account facts, stakeholder notes, past objections, buying signals, and the decisions you made last time you looked at the deal.
+
+That changes the workflow from “generate one-off research summaries” into “maintain an evolving understanding of the account over time.”
+
+This is the setup pattern that works best: keep one stable bank per account or per account team, use Hermes as the front end, and let Hindsight handle the long-term memory layer underneath.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Connect Hermes to Hindsight.
+> 2. Pick a bank strategy that matches your sales motion.
+> 3. Use one bank per account, territory, or rep-owned portfolio.
+> 4. Let Hermes retain research notes, call prep, objections, and stakeholder context.
+> 5. Reuse the same bank before every new account touchpoint.
+
+## Why memory matters for sales research
+
+Sales research is not a single prompt problem. It is an accumulation problem.
+
+You learn a little about an account from the website. Then more from a 10-K. Then more from LinkedIn, call notes, and internal handoff messages. The high value context is spread over days or weeks.
+
+Without memory, you either lose that context or keep re-pasting it. With memory, Hermes can carry forward facts like:
+
+- which teams the buyer cares about
+- what tools the account already uses
+- what objections came up on the last call
+- which initiative or deadline is driving urgency
+- which competitor keeps appearing in the deal
+
+That is exactly the kind of context that gets more valuable every time you talk to the account.
+
+## Step 1: Connect Hermes to Hindsight
+
+The shortest path is the native memory provider:
+
+~~~bash
+hermes memory setup
+~~~
+
+Choose **Hindsight** as the provider, then decide whether you want Cloud, Local Embedded, or Local External mode.
+
+For sales workflows, Cloud is usually the easiest choice because the same memory bank can follow you across devices and teammates.
+
+## Step 2: Pick the right bank strategy
+
+This is the most important design decision.
+
+For sales, the best default is usually **one bank per account**.
+
+That keeps account context clean. Your notes about Acme do not bleed into Globex. A simple pattern looks like this:
+
+- sales-acme
+- sales-globex
+- sales-initech
+
+If one rep owns many related accounts and wants shared context, a portfolio bank can work too. But account-scoped banks are the safer default because they prevent noisy retrieval.
+
+## Step 3: Decide what should become memory
+
+The best sales memories are not raw transcript dumps. They are the durable facts behind the motion.
+
+Good examples:
+
+- “VP of Operations is the likely champion”
+- “Renewal date is in October”
+- “Security review is the main blocker”
+- “Current stack includes Salesforce, Snowflake, and Zendesk”
+- “Buyer responded well to the compliance angle, not the automation angle”
+
+That is the information you want Hermes to recall before the next account review or prep session.
+
+## Step 4: Use Hermes in the highest leverage moments
+
+### Account prep before a call
+
+Start with:
+
+~~~text
+What do we already know about this account, and what should I ask on today's call?
+~~~
+
+Hermes can pull forward the stakeholder map, prior objections, and open questions instead of making you rebuild them.
+
+### Research between calls
+
+As you learn new facts from articles, earnings reports, job postings, and product launches, Hermes retains what matters. That makes the next session cumulative instead of repetitive.
+
+### Handoffs between teammates
+
+If multiple reps or sales engineers share the same bank, the next person picks up real context instead of reading a thin CRM summary and guessing what matters.
+
+## Step 5: Verify recall is helping, not hurting
+
+A memory setup is only good if retrieval stays sharp.
+
+A fast way to test it:
+
+1. Store a few real account facts across two or three sessions.
+2. Start a fresh session.
+3. Ask Hermes what it remembers about the account's stakeholders, timing, and blockers.
+4. Check whether the answer is specific and relevant.
+
+If recall feels noisy, the usual fix is to make the bank narrower. One bank per account is almost always cleaner than one giant bank for the whole pipeline.
+
+## What this workflow is good at
+
+Hermes + Hindsight works especially well for:
+
+- account research that compounds over time
+- multi-touch outreach and follow-up
+- multi-person deal teams
+- technical sales where product fit details matter across calls
+- founder-led sales where the same person runs discovery, follow-up, and proposal work
+
+It is much less valuable for one-off lead enrichment where you never revisit the account.
+
+## Common mistakes
+
+- **One giant sales bank for everything** — retrieval gets noisy fast
+- **Saving raw notes but not clear decisions** — the durable facts matter more than the transcript itself
+- **Changing bank names constantly** — continuity depends on stable bank IDs
+- **Expecting memory to replace your CRM** — memory helps the agent think with context; it does not replace system-of-record tooling
+
+## FAQ
+
+### Should I use one bank per rep or per account?
+
+Per account is the safer default. Use per-rep only when shared portfolio context matters more than precision.
+
+### Can a sales engineer and AE share the same bank?
+
+Yes. That is one of the strongest use cases.
+
+### Does this replace Salesforce or HubSpot?
+
+No. It complements them by giving Hermes a working memory layer during research and prep.
+
+## Next Steps
+
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)
+- Read [single bank vs multi-bank with Hindsight](/guides/2026/04/16/comparison-single-bank-vs-multi-bank-hindsight)
+- Use [Hindsight Cloud](https://hindsight.vectorize.io) if you want account memory across devices and teammates

--- a/hindsight-docs/guides/2026-06-02-guide-share-hermes-memory-across-windows-and-mac.md
+++ b/hindsight-docs/guides/2026-06-02-guide-share-hermes-memory-across-windows-and-mac.md
@@ -1,0 +1,124 @@
+---
+title: "Guide: Share Hermes Memory Across Windows and Mac"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, windows, mac, memory]
+description: "Use Hindsight Cloud to share one Hermes memory workflow across Windows and Mac without re-explaining the same context on each machine."
+image: /img/guides/guide-share-hermes-memory-across-windows-and-mac.svg
+hide_table_of_contents: true
+---
+
+![Guide: Share Hermes Memory Across Windows and Mac](/img/guides/guide-share-hermes-memory-across-windows-and-mac.svg)
+
+A lot of real workflows are mixed-platform now. You might use Hermes on a Windows workstation during the day, then pick up the same thread on a Mac laptop later. Without a shared memory backend, those feel like two separate assistants.
+
+Hindsight lets you turn that into one continuous workflow. The trick is simple: keep the same bank strategy on both machines, point both Hermes installs at the same backend, and verify recall across the platform boundary.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Set up Hermes with Hindsight on both Windows and Mac.
+> 2. Use Hindsight Cloud or another shared backend.
+> 3. Keep the same bank IDs on both platforms.
+> 4. Test recall on Mac after retaining on Windows, and vice versa.
+> 5. Separate banks when personal, project, or team context should stay isolated.
+
+## Why this matters
+
+Mixed-platform usage is one of the fastest ways to expose whether your agent really has memory.
+
+If Hermes remembers on Windows but forgets on Mac, the problem is not the model. It is the memory boundary.
+
+A shared backend fixes that by making the bank the unit of continuity instead of the machine.
+
+## Step 1: Put both installs on the same backend
+
+The easiest pattern is Hindsight Cloud.
+
+On both machines:
+
+~~~bash
+hermes memory setup
+~~~
+
+Choose **Hindsight**, then **Cloud**.
+
+Now both Hermes installs can point at the same memory service.
+
+## Step 2: Keep bank naming consistent
+
+This is the rule that matters most.
+
+If you want the same project context on both machines, use the same project bank on both machines.
+
+Examples:
+
+- project-docs
+- acct-acme
+- personal-ben
+
+Cross-platform memory is mostly a naming discipline problem once the shared backend exists.
+
+## Step 3: Test the platform handoff
+
+A quick real-world test:
+
+1. On Windows, tell Hermes a new fact about the project.
+2. End the session.
+3. Open Hermes on Mac.
+4. Ask for that context without repeating it.
+
+If Mac recalls what Windows retained, you have true cross-platform continuity.
+
+## Good use cases
+
+### Workstation plus laptop
+
+Research or coding on a desktop, planning or review on a laptop.
+
+### Team workflows across mixed operating systems
+
+One engineer uses Windows, another uses Mac, but both need the same shared project memory.
+
+### Personal assistant continuity
+
+Your preferences and ongoing tasks should not change just because the machine did.
+
+## What should stay separate
+
+Cross-platform does not mean cross-everything.
+
+Use separate banks for:
+
+- unrelated projects
+- different customers
+- personal vs team workflows
+- anything privacy-sensitive that should not be shared
+
+## Common mistakes
+
+- using slightly different bank names on each platform
+- assuming a shared backend is enough without testing recall
+- mixing personal context into a shared team bank
+- trying to share local-only memory across machines
+
+## FAQ
+
+### Does this require the same filesystem layout on both machines?
+
+No. Bank continuity does not depend on matching local paths.
+
+### Is Cloud required?
+
+A shared backend is required. Cloud is just the easiest way to get one.
+
+### Can this work for team-shared repo memory too?
+
+Yes. Mixed-platform engineering teams are a strong use case.
+
+## Next Steps
+
+- Read [give Hermes cross-device memory with Hindsight Cloud](/guides/2026/06/02/guide-hermes-cross-device-memory-with-hindsight-cloud)
+- Read [Hermes Agent on Windows: Set Up Persistent Memory with Hindsight](/blog/2026/06/01/hermes-hindsight-windows-setup)
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)

--- a/hindsight-docs/guides/2026-06-02-guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.md
+++ b/hindsight-docs/guides/2026-06-02-guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.md
@@ -1,0 +1,149 @@
+---
+title: "Guide: Turn Hermes from Stateless Chat into a Stateful Agent"
+authors: [benfrank241]
+date: 2026-06-02T15:00:00Z
+tags: [how-to, hermes, agents, memory]
+description: "Add persistent memory to Hermes so it can carry context, preferences, and project history across sessions instead of starting from zero each time."
+image: /img/guides/guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.svg
+hide_table_of_contents: true
+---
+
+![Guide: Turn Hermes from Stateless Chat into a Stateful Agent](/img/guides/guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.svg)
+
+Out of the box, a chat agent is usually **stateless**. It can reason well inside the current context window, but when the session ends, the working relationship resets. That is fine for one-off prompts. It is weak for real assistant workflows.
+
+If you want Hermes to act more like a **stateful agent**, the missing piece is persistent memory. Hindsight gives Hermes a long-term memory layer so relevant facts can survive the session boundary and come back later when needed.
+
+That is the shift from good chat to useful ongoing agent.
+
+<!-- truncate -->
+
+> **Quick answer**
+>
+> 1. Connect Hermes to Hindsight.
+> 2. Pick a stable bank strategy.
+> 3. Let memory retain what matters across sessions.
+> 4. Start fresh sessions and confirm recall still works.
+> 5. Expand from one-off chat into a reusable workflow.
+
+## What stateless chat is good at
+
+Stateless chat is good at local reasoning. Give Hermes enough context in the current session and it can do excellent work.
+
+The problem is continuity.
+
+The next time you open Hermes, it does not automatically know:
+
+- your preferences
+- your ongoing projects
+- what decisions you made last week
+- which people or accounts matter in the current workflow
+
+That is what makes many agents feel smart in the moment but forgetful across time.
+
+## What stateful behavior looks like
+
+A stateful agent does not just answer the current message. It carries forward the relationship and the work.
+
+That means Hermes can:
+
+- recall preferences without being told again
+- resume projects without a full briefing
+- carry customer or account context across conversations
+- build up operational knowledge over repeated sessions
+
+Memory is what makes that possible.
+
+## Step 1: Add a memory layer
+
+The shortest setup path is:
+
+~~~bash
+hermes memory setup
+~~~
+
+Choose **Hindsight**. Once connected, Hermes can retain and recall context across sessions instead of treating every chat as a fresh start.
+
+## Step 2: Pick a bank strategy
+
+Statefulness only works when the memory scope makes sense.
+
+Good defaults:
+
+- one bank per user assistant
+- one bank per project
+- one bank per customer or workflow
+
+Bad default:
+
+- one giant bank for unrelated work
+
+The cleaner the scope, the better recall feels.
+
+## Step 3: Let real work create the memory
+
+You do not need to manually author every memory entry.
+
+As you use Hermes naturally, the system can retain the durable facts behind the conversation: preferences, decisions, project details, recurring issues, and relationship context.
+
+That is what turns normal usage into a compounding asset.
+
+## Step 4: Verify statefulness with a fresh session
+
+A simple test:
+
+1. Tell Hermes a fact that should matter later.
+2. End the session.
+3. Start a fresh session.
+4. Ask about the earlier fact without reintroducing it.
+
+If Hermes can answer correctly, the workflow has crossed from stateless to stateful.
+
+## Where this matters most
+
+### Personal assistant workflows
+
+Preferences and ongoing plans should not need to be re-entered every time.
+
+### Customer-facing workflows
+
+Accounts, stakeholders, and prior conversations should carry forward.
+
+### Coding workflows
+
+Repo context and prior debugging work should be available in the next session.
+
+## Why this is better than bigger context windows
+
+A larger context window helps inside the current run. It does not give you durable cross-session memory by itself.
+
+Stateful behavior is not just more tokens. It is the ability to retrieve the right context from the past when the present task needs it.
+
+That is why persistent memory matters even for models with large context windows.
+
+## Common mistakes
+
+- confusing chat history with long-term memory
+- using one oversized bank for unrelated workflows
+- expecting statefulness without testing recall in a fresh session
+- trying to solve continuity only by pasting more context into each chat
+
+## FAQ
+
+### Is stateful Hermes just chat history?
+
+No. The point is usable memory across sessions, not just one long transcript.
+
+### Do I need to change the model?
+
+No. This is a memory-layer change, not a model replacement.
+
+### Can stateful memory be shared?
+
+Yes, when the workflow benefits from a shared bank.
+
+## Next Steps
+
+- Read [stateless agents vs memory-powered agents](/guides/2026/04/23/guide-stateless-agents-vs-memory-powered-agents)
+- Review [Hermes memory modes with Hindsight](/guides/2026/04/14/guide-hermes-memory-modes-with-hindsight-hybrid-context-tools)
+- Start with [the Hermes integration docs](https://hindsight.vectorize.io/sdks/integrations/hermes)

--- a/hindsight-docs/static/img/guides/comparison-hermes-built-in-memory-vs-hindsight-at-scale.svg
+++ b/hindsight-docs/static/img/guides/comparison-hermes-built-in-memory-vs-hindsight-at-scale.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Comparison: Hermes Built-In Memory vs Hindsight at Scale">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">COMPARISON</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Hermes Built-In Memory vs</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Hindsight at Scale</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/comparison-hermes-native-memory-provider-vs-mcp-memory.svg
+++ b/hindsight-docs/static/img/guides/comparison-hermes-native-memory-provider-vs-mcp-memory.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Comparison: Hermes Native Memory Provider vs MCP Memory with Hindsight">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">COMPARISON</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Hermes Native Memory Provider vs</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">MCP Memory with Hindsight</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.svg
+++ b/hindsight-docs/static/img/guides/comparison-hermes-on-windows-vs-wsl2-for-persistent-memory.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Comparison: Hermes on Windows vs WSL2 for Persistent Memory">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">COMPARISON</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Hermes on Windows vs WSL2 for</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Persistent Memory</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-fix-common-hermes-windows-memory-setup-issues.svg
+++ b/hindsight-docs/static/img/guides/guide-fix-common-hermes-windows-memory-setup-issues.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Fix Common Hermes Windows Memory Setup Issues">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Fix Common Hermes Windows Memory</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Setup Issues</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-hermes-coding-memory-across-repos-bugs-and-decisions.svg
+++ b/hindsight-docs/static/img/guides/guide-hermes-coding-memory-across-repos-bugs-and-decisions.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Hermes Coding Memory Across Repos, Bugs, and Decisions">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Hermes Coding Memory Across Repos,</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Bugs, and Decisions</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-hermes-cross-device-memory-with-hindsight-cloud.svg
+++ b/hindsight-docs/static/img/guides/guide-hermes-cross-device-memory-with-hindsight-cloud.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Give Hermes Cross-Device Memory with Hindsight Cloud">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Give Hermes Cross-Device Memory</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">with Hindsight Cloud</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-hermes-long-term-memory-without-fine-tuning.svg
+++ b/hindsight-docs/static/img/guides/guide-hermes-long-term-memory-without-fine-tuning.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Give Hermes Long-Term Memory Without Fine-Tuning">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Give Hermes Long-Term Memory</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Without Fine-Tuning</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-hermes-sales-research-memory-with-hindsight.svg
+++ b/hindsight-docs/static/img/guides/guide-hermes-sales-research-memory-with-hindsight.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Use Hermes for Sales Research with Persistent Memory">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Use Hermes for Sales Research with</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Persistent Memory</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-share-hermes-memory-across-windows-and-mac.svg
+++ b/hindsight-docs/static/img/guides/guide-share-hermes-memory-across-windows-and-mac.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Share Hermes Memory Across Windows and Mac">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Share Hermes Memory Across Windows</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">and Mac</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>

--- a/hindsight-docs/static/img/guides/guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.svg
+++ b/hindsight-docs/static/img/guides/guide-turn-hermes-from-stateless-chat-into-a-stateful-agent.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Guide: Turn Hermes from Stateless Chat into a Stateful Agent">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1320" cy="170" r="220" fill="#1d4ed8" opacity="0.22"/>
+  <circle cx="1450" cy="740" r="300" fill="#7c3aed" opacity="0.18"/>
+  <rect x="80" y="112" width="240" height="46" rx="23" fill="url(#accent)"/>
+  <text x="112" y="142" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800" fill="#08111f">GUIDE</text>
+  <text x="80" y="230" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">Turn Hermes from Stateless Chat</text><text x="80" y="294" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff">into a Stateful Agent</text>
+  <rect x="80" y="535" width="1060" height="4" rx="2" fill="url(#accent)"/>
+  <text x="80" y="620" font-family="Inter, Arial, sans-serif" font-size="28" fill="#bfdbfe">Hermes Agent + Hindsight</text>
+  <text x="80" y="700" font-family="Inter, Arial, sans-serif" font-size="22" fill="#93c5fd">Persistent memory guides</text>
+</svg>


### PR DESCRIPTION
## Summary
- add 10 Hermes-focused guides based on the requested batch
- include 7 general Hermes memory/cross-device/comparison guides
- include 3 Windows-specific guides now that Hermes has native Windows support
- add lightweight guide images for each new page to match the style of the reference guides batch

## Added guides
- Comparison: Hermes Native Memory Provider vs MCP Memory with Hindsight
- Guide: Use Hermes for Sales Research with Persistent Memory
- Comparison: Hermes Built-In Memory vs Hindsight at Scale
- Guide: Hermes Coding Memory Across Repos, Bugs, and Decisions
- Guide: Give Hermes Cross-Device Memory with Hindsight Cloud
- Guide: Give Hermes Long-Term Memory Without Fine-Tuning
- Guide: Turn Hermes from Stateless Chat into a Stateful Agent
- Comparison: Hermes on Windows vs WSL2 for Persistent Memory
- Guide: Fix Common Hermes Windows Memory Setup Issues
- Guide: Share Hermes Memory Across Windows and Mac

## Validation
- verified frontmatter + referenced image existence for all new guides
- attempted `npm ci` in `hindsight-docs` but repo-level prepare hook failed because `scripts/setup-hooks.sh` has CRLF in this clone (`/bin/bash^M`)
- reran `npm ci --ignore-scripts` successfully
- attempted `npx docusaurus build`, but the local environment hit a client bundle failure with repeated `Unexpected end of JSON input` errors under Node v23.2.0, so I am calling out the build as blocked rather than claiming a clean docs build
