### PR TITLE
docs(cookbook): drop removed opinion memory type from quickstart Memory Types

### DIFF
--- a/hindsight-docs/src/pages/cookbook/recipes/quickstart.md
+++ b/hindsight-docs/src/pages/cookbook/recipes/quickstart.md
@@ -142,11 +142,10 @@ print(response)
 
 ## Memory Types
 
-Hindsight organizes memory into four networks to mimic human memory:
+Hindsight organizes memory into three networks to mimic human memory:
 
 - **World**: Facts about the world ("The stove gets hot")
 - **Experiences**: Agent's own experiences ("I touched the stove and it really hurt")
-- **Opinion**: Beliefs with confidence scores ("I shouldn't touch the stove again" - .99 confidence)
 - **Observation**: Complex mental models derived by reflecting on facts and experiences
 
 ## Cleanup


### PR DESCRIPTION
The cookbook quickstart's **Memory Types** section still lists "four networks" including `Opinion: Beliefs with confidence scores`, but the `opinion` fact_type was removed — migrations `remove_opinion_fact_type` + `delete_opinions` deleted the opinion rows and dropped the `confidence_score` column. The canonical recallable set is now `world` / `experience` / `observation` (`VALID_RECALL_FACT_TYPES` in `response_models.py`).

Since this is the highest-traffic onboarding page, a new user currently learns a memory type that the server silently no-ops. This brings it in line with the same cleanup already merged for the integration/SDK references (#1893, #1905) and CLI fact-type values (#1881).

- "four networks" → "three networks"
- drop the `Opinion` bullet (removed fact_type + dropped `confidence_score` column)

Scoped to the recallable Memory Types list only — the Reflect section's "opinions formed during reflection" wording is intentionally left as-is, since `ReflectResult` still forms opinions during reflection.