### PR TITLE
fix(config): persist bank config PATCH for never-retained banks (#1940)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -266,12 +266,20 @@ class ConfigResolver:
         # Validate recall budget fields
         _validate_recall_budget_updates(normalized_updates)
 
-        # Merge with existing config (JSONB || operator)
+        # Persist the override. Banks are created lazily (on first retain), so a
+        # PATCH that precedes any ingestion would otherwise UPDATE zero rows and
+        # silently no-op while returning 200. Ensure the bank row exists first
+        # (this also creates its per-bank vector indexes), then merge defensively:
+        # COALESCE guards against a NULL config column (NULL || jsonb is NULL),
+        # which would drop the override even when a row is updated.
+        from .engine.retain.fact_storage import ensure_bank_exists
+
         async with self._backend.acquire() as conn:
+            await ensure_bank_exists(conn, bank_id, ops=self._backend.ops)
             await conn.execute(
                 f"""
                 UPDATE {fq_table("banks")}
-                SET config = config || $1::jsonb,
+                SET config = COALESCE(config, '{{}}'::jsonb) || $1::jsonb,
                     updated_at = now()
                 WHERE bank_id = $2
                 """,

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -38,11 +38,17 @@ class MockTenantExtension(TenantExtension):
         return self.tenant_config
 
 
+class _FakeBankOps:
+    async def create_bank_vector_indexes(self, *args, **kwargs):
+        return None
+
+
 class FakeBankConfigBackend:
     """Minimal backend for ConfigResolver bank-config tests."""
 
     def __init__(self):
         self.config: dict[str, object] = {}
+        self.ops = _FakeBankOps()
 
     def acquire(self):
         return FakeBankConfigConnection(self)
@@ -60,6 +66,11 @@ class FakeBankConfigConnection:
 
     async def fetchrow(self, query, bank_id):
         return {"config": self.backend.config}
+
+    async def fetchval(self, query, *args):
+        # ensure_bank_exists INSERT ... ON CONFLICT DO NOTHING RETURNING bank_id.
+        # Return None to simulate the bank already existing (no index creation).
+        return None
 
     async def execute(self, query, updates_json, bank_id):
         self.backend.config.update(json.loads(updates_json))

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1315,6 +1315,36 @@ async def test_unknown_params_not_rejected(api_client):
     assert "X-Ignored-Params" not in response.headers
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["enable_observations", "enable_auto_consolidation"])
+async def test_patch_config_persists_override_for_uncreated_bank(api_client, field):
+    """PATCH config must persist the override even when the bank was never retained.
+
+    Banks are created lazily on first retain, so a PATCH that precedes any
+    ingestion previously UPDATE-d zero rows and silently no-op'd while returning
+    200 (issue #1940). The endpoint must auto-create the bank and round-trip the
+    override in the same response.
+    """
+    test_bank_id = f"patch_uncreated_{field}_{datetime.now().timestamp()}"
+
+    # PATCH config without ever creating the bank (no PUT, no retain).
+    response = await api_client.patch(
+        f"/v1/default/banks/{test_bank_id}/config",
+        json={"updates": {field: False}},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["config"][field] is False
+    assert body["overrides"].get(field) is False
+
+    # GET reads back the persisted override (proves it was written, not just echoed).
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/config")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["config"][field] is False
+    assert body["overrides"].get(field) is False
+
+
 @pytest.mark.hs_llm_core
 @pytest.mark.asyncio
 async def test_full_api_workflow_llm_quality(api_client_real_llm):


### PR DESCRIPTION
## Summary

Fixes #1940. `PATCH /v1/default/banks/{bank_id}/config` could return **HTTP 200 without persisting anything** when the target bank had no row yet.

Banks are created **lazily** (only on first retain, via `ensure_bank_exists`). So a PATCH that precedes any ingestion — exactly the reporter's "disable observations before bulk retro ingestion" workflow — ran `UPDATE banks SET config = ... WHERE bank_id = $2`, matched **zero rows**, and silently no-op'd. The endpoint then re-read config and returned global defaults with `overrides: {}`.

## Fix (`config_resolver.py`)

1. **Auto-create the bank** before the merge, reusing the same idempotent `ensure_bank_exists` the retain path uses. This matters beyond inserting a row: `ensure_bank_exists` also creates the **per-bank vector indexes**. Inserting a bare row here would mean the later retain-time call hits `ON CONFLICT DO NOTHING` and never creates those indexes.
2. **Defensive JSONB merge**: `COALESCE(config, '{}'::jsonb) || $1::jsonb`. In Postgres `NULL || jsonb` is `NULL`, so a NULL `config` column (schema drift / restore / old data) would drop the override even when a row exists. The migration defaults the column to `'{}'` non-null, so this is hardening.

### Contract note
With auto-create, a typo'd `bank_id` now creates a bank instead of erroring. That's the deliberate trade-off vs. the 404 the issue proposed: it unblocks the legitimate configure-before-ingest workflow and is consistent with how retain already auto-creates banks. Happy to switch to 404 if reviewers prefer the stricter contract.

`reset_bank_config` was left as-is: it sets `config = '{}'` unconditionally (no NULL hazard), and auto-creating a bank just to reset it to defaults would be pointless.

## Tests

- New parametrized API-level regression test (`test_http_api_integration.py`) for both `enable_observations` and `enable_auto_consolidation`: PATCH on a never-created bank → asserts 200, `config[field] is False`, `overrides[field] is False`, then a follow-up **GET** to prove the override was *persisted*, not just echoed. Genuine RED-before / GREEN-after.
- Updated the unit-test fake backend (`test_hierarchical_config.py`) with `.ops` + `fetchval` to satisfy the new `ensure_bank_exists` call.

## Verification

- New integration tests pass (both params).
- All 12 hierarchical-config unit tests pass.
- `./scripts/hooks/lint.sh` clean; `uv run ty check` clean.

No API request/response schema change → no OpenAPI/client regeneration needed.
