### PR TITLE
feat(control-plane): "not enabled" splash for disabled audit logs & LLM requests (+ bank name fix)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2382,6 +2382,8 @@ class FeaturesInfo(BaseModel):
     file_upload_api: bool = Field(description="Whether file upload/conversion API is enabled")
     document_export_api: bool = Field(description="Whether the document export endpoint is enabled")
     document_import_api: bool = Field(description="Whether the document import endpoint is enabled")
+    audit_log: bool = Field(description="Whether audit logging is enabled")
+    llm_trace: bool = Field(description="Whether per-bank LLM request tracing is enabled")
 
 
 class VersionResponse(BaseModel):
@@ -3047,6 +3049,8 @@ def _register_routes(app: FastAPI):
                 file_upload_api=config.enable_file_upload_api,
                 document_export_api=config.enable_document_export_api,
                 document_import_api=config.enable_document_import_api,
+                audit_log=config.audit_log_enabled,
+                llm_trace=config.llm_trace_enabled,
             ),
         )
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -147,12 +147,13 @@ async def ensure_bank_exists(conn, bank_id: str, ops=None) -> None:
     internal_id = uuid.uuid4()
     inserted = await conn.fetchval(
         f"""
-        INSERT INTO {fq_table("banks")} (bank_id, disposition, mission, internal_id)
-        VALUES ($1, $2::jsonb, $3, $4)
+        INSERT INTO {fq_table("banks")} (bank_id, name, disposition, mission, internal_id)
+        VALUES ($1, $2, $3::jsonb, $4, $5)
         ON CONFLICT (bank_id) DO NOTHING
         RETURNING bank_id
         """,
         bank_id,
+        bank_id,  # Default name is the bank_id (matches get_or_create_bank_profile)
         json.dumps(DEFAULT_DISPOSITION),
         "",
         internal_id,

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1344,6 +1344,12 @@ async def test_patch_config_persists_override_for_uncreated_bank(api_client, fie
     assert body["config"][field] is False
     assert body["overrides"].get(field) is False
 
+    # The auto-created bank must have a name (defaults to bank_id). A NULL name
+    # would 500 the profile endpoint, whose response types name as a required str.
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/profile")
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == test_bank_id
+
 
 @pytest.mark.hs_llm_core
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1104,6 +1104,8 @@ async def test_version_endpoint_returns_correct_version(api_client):
     assert isinstance(features["observations"], bool)
     assert isinstance(features["mcp"], bool)
     assert isinstance(features["worker"], bool)
+    assert isinstance(features["audit_log"], bool)
+    assert isinstance(features["llm_trace"], bool)
 
     print(f"Version endpoint returned: api_version={result['api_version']}, features={features}")
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5418,11 +5418,21 @@ components:
           description: Whether the document import endpoint is enabled
           title: Document Import Api
           type: boolean
+        audit_log:
+          description: Whether audit logging is enabled
+          title: Audit Log
+          type: boolean
+        llm_trace:
+          description: Whether per-bank LLM request tracing is enabled
+          title: Llm Trace
+          type: boolean
       required:
+      - audit_log
       - bank_config_api
       - document_export_api
       - document_import_api
       - file_upload_api
+      - llm_trace
       - mcp
       - observations
       - worker

--- a/hindsight-clients/go/model_features_info.go
+++ b/hindsight-clients/go/model_features_info.go
@@ -35,6 +35,10 @@ type FeaturesInfo struct {
 	DocumentExportApi bool `json:"document_export_api"`
 	// Whether the document import endpoint is enabled
 	DocumentImportApi bool `json:"document_import_api"`
+	// Whether audit logging is enabled
+	AuditLog bool `json:"audit_log"`
+	// Whether per-bank LLM request tracing is enabled
+	LlmTrace bool `json:"llm_trace"`
 }
 
 type _FeaturesInfo FeaturesInfo
@@ -43,7 +47,7 @@ type _FeaturesInfo FeaturesInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, fileUploadApi bool, documentExportApi bool, documentImportApi bool) *FeaturesInfo {
+func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, fileUploadApi bool, documentExportApi bool, documentImportApi bool, auditLog bool, llmTrace bool) *FeaturesInfo {
 	this := FeaturesInfo{}
 	this.Observations = observations
 	this.Mcp = mcp
@@ -52,6 +56,8 @@ func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi boo
 	this.FileUploadApi = fileUploadApi
 	this.DocumentExportApi = documentExportApi
 	this.DocumentImportApi = documentImportApi
+	this.AuditLog = auditLog
+	this.LlmTrace = llmTrace
 	return &this
 }
 
@@ -231,6 +237,54 @@ func (o *FeaturesInfo) SetDocumentImportApi(v bool) {
 	o.DocumentImportApi = v
 }
 
+// GetAuditLog returns the AuditLog field value
+func (o *FeaturesInfo) GetAuditLog() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.AuditLog
+}
+
+// GetAuditLogOk returns a tuple with the AuditLog field value
+// and a boolean to check if the value has been set.
+func (o *FeaturesInfo) GetAuditLogOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.AuditLog, true
+}
+
+// SetAuditLog sets field value
+func (o *FeaturesInfo) SetAuditLog(v bool) {
+	o.AuditLog = v
+}
+
+// GetLlmTrace returns the LlmTrace field value
+func (o *FeaturesInfo) GetLlmTrace() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.LlmTrace
+}
+
+// GetLlmTraceOk returns a tuple with the LlmTrace field value
+// and a boolean to check if the value has been set.
+func (o *FeaturesInfo) GetLlmTraceOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LlmTrace, true
+}
+
+// SetLlmTrace sets field value
+func (o *FeaturesInfo) SetLlmTrace(v bool) {
+	o.LlmTrace = v
+}
+
 func (o FeaturesInfo) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -248,6 +302,8 @@ func (o FeaturesInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["file_upload_api"] = o.FileUploadApi
 	toSerialize["document_export_api"] = o.DocumentExportApi
 	toSerialize["document_import_api"] = o.DocumentImportApi
+	toSerialize["audit_log"] = o.AuditLog
+	toSerialize["llm_trace"] = o.LlmTrace
 	return toSerialize, nil
 }
 
@@ -263,6 +319,8 @@ func (o *FeaturesInfo) UnmarshalJSON(data []byte) (err error) {
 		"file_upload_api",
 		"document_export_api",
 		"document_import_api",
+		"audit_log",
+		"llm_trace",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/hindsight-clients/python/hindsight_client_api/models/features_info.py
+++ b/hindsight-clients/python/hindsight_client_api/models/features_info.py
@@ -33,7 +33,9 @@ class FeaturesInfo(BaseModel):
     file_upload_api: StrictBool = Field(description="Whether file upload/conversion API is enabled")
     document_export_api: StrictBool = Field(description="Whether the document export endpoint is enabled")
     document_import_api: StrictBool = Field(description="Whether the document import endpoint is enabled")
-    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "file_upload_api", "document_export_api", "document_import_api"]
+    audit_log: StrictBool = Field(description="Whether audit logging is enabled")
+    llm_trace: StrictBool = Field(description="Whether per-bank LLM request tracing is enabled")
+    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "file_upload_api", "document_export_api", "document_import_api", "audit_log", "llm_trace"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -92,7 +94,9 @@ class FeaturesInfo(BaseModel):
             "bank_config_api": obj.get("bank_config_api"),
             "file_upload_api": obj.get("file_upload_api"),
             "document_export_api": obj.get("document_export_api"),
-            "document_import_api": obj.get("document_import_api")
+            "document_import_api": obj.get("document_import_api"),
+            "audit_log": obj.get("audit_log"),
+            "llm_trace": obj.get("llm_trace")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1676,6 +1676,18 @@ export type FeaturesInfo = {
    * Whether the document import endpoint is enabled
    */
   document_import_api: boolean;
+  /**
+   * Audit Log
+   *
+   * Whether audit logging is enabled
+   */
+  audit_log: boolean;
+  /**
+   * Llm Trace
+   *
+   * Whether per-bank LLM request tracing is enabled
+   */
+  llm_trace: boolean;
 };
 
 /**

--- a/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/banks/[bankId]/page.tsx
@@ -19,6 +19,7 @@ import { MentalModelsView } from "@/components/mental-models-view";
 import { WebhooksView } from "@/components/webhooks-view";
 import { AuditLogsView } from "@/components/audit-logs-view";
 import { LLMRequestsView } from "@/components/llm-requests-view";
+import { FeatureNotEnabled } from "@/components/feature-not-enabled";
 import { useFeatures } from "@/lib/features-context";
 import { useBank } from "@/lib/bank-context";
 import { bankRoute } from "@/lib/bank-url";
@@ -61,6 +62,8 @@ export default function BankPage() {
   const bankConfigTab = (searchParams.get("bankConfigTab") || "general") as BankConfigTab;
   const observationsEnabled = features?.observations ?? false;
   const bankConfigEnabled = features?.bank_config_api ?? false;
+  const auditLogEnabled = features?.audit_log ?? false;
+  const llmTraceEnabled = features?.llm_trace ?? false;
 
   // Bank actions state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -331,6 +334,11 @@ export default function BankPage() {
                       }`}
                     >
                       {t("auditLogs")}
+                      {!auditLogEnabled && (
+                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                          Off
+                        </span>
+                      )}
                       {bankConfigTab === "audit-logs" && (
                         <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
                       )}
@@ -344,6 +352,11 @@ export default function BankPage() {
                       }`}
                     >
                       {t("llmRequests")}
+                      {!llmTraceEnabled && (
+                        <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                          Off
+                        </span>
+                      )}
                       {bankConfigTab === "llm-requests" && (
                         <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
                       )}
@@ -378,22 +391,46 @@ export default function BankPage() {
                       <WebhooksView />
                     </div>
                   )}
-                  {bankConfigTab === "audit-logs" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("auditLogsDescription")}
-                      </p>
-                      <AuditLogsView />
-                    </div>
-                  )}
-                  {bankConfigTab === "llm-requests" && (
-                    <div>
-                      <p className="text-sm text-muted-foreground mb-4">
-                        {t("llmRequestsDescription")}
-                      </p>
-                      <LLMRequestsView />
-                    </div>
-                  )}
+                  {bankConfigTab === "audit-logs" &&
+                    (auditLogEnabled ? (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("auditLogsDescription")}
+                        </p>
+                        <AuditLogsView />
+                      </div>
+                    ) : (
+                      <FeatureNotEnabled
+                        title={t("auditLogsNotEnabled")}
+                        description={t.rich("auditLogsDisabledMessage", {
+                          envVar: () => (
+                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                              HINDSIGHT_API_AUDIT_LOG_ENABLED=true
+                            </code>
+                          ),
+                        })}
+                      />
+                    ))}
+                  {bankConfigTab === "llm-requests" &&
+                    (llmTraceEnabled ? (
+                      <div>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          {t("llmRequestsDescription")}
+                        </p>
+                        <LLMRequestsView />
+                      </div>
+                    ) : (
+                      <FeatureNotEnabled
+                        title={t("llmRequestsNotEnabled")}
+                        description={t.rich("llmRequestsDisabledMessage", {
+                          envVar: () => (
+                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                              HINDSIGHT_API_LLM_TRACE_ENABLED=true
+                            </code>
+                          ),
+                        })}
+                      />
+                    ))}
                 </div>
               </div>
             )}
@@ -510,37 +547,16 @@ export default function BankPage() {
                         <DataView key="observations" factType="observation" />
                       </div>
                     ) : (
-                      <div className="flex flex-col items-center justify-center py-16 text-center">
-                        <div className="text-muted-foreground mb-2">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="48"
-                            height="48"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          >
-                            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Z" />
-                            <path d="M12 8v4" />
-                            <path d="M12 16h.01" />
-                          </svg>
-                        </div>
-                        <h3 className="text-lg font-semibold text-foreground mb-1">
-                          {t("observationsNotEnabled")}
-                        </h3>
-                        <p className="text-sm text-muted-foreground max-w-md">
-                          {t.rich("observationsDisabledMessage", {
-                            envVar: () => (
-                              <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                                HINDSIGHT_API_ENABLE_OBSERVATIONS=true
-                              </code>
-                            ),
-                          })}
-                        </p>
-                      </div>
+                      <FeatureNotEnabled
+                        title={t("observationsNotEnabled")}
+                        description={t.rich("observationsDisabledMessage", {
+                          envVar: () => (
+                            <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                              HINDSIGHT_API_ENABLE_OBSERVATIONS=true
+                            </code>
+                          ),
+                        })}
+                      />
                     ))}
                   {subTab === "mental-models" && (
                     <div>

--- a/hindsight-control-plane/src/components/feature-not-enabled.tsx
+++ b/hindsight-control-plane/src/components/feature-not-enabled.tsx
@@ -1,0 +1,32 @@
+import type { LucideIcon } from "lucide-react";
+import { PowerOff } from "lucide-react";
+
+interface FeatureNotEnabledProps {
+  /** Headline, e.g. "Audit Logs Not Enabled". */
+  title: string;
+  /** Supporting copy. Accepts rich nodes so callers can embed an env-var <code> snippet. */
+  description: React.ReactNode;
+  /** Splash icon. Defaults to a "power off" glyph. */
+  icon?: LucideIcon;
+}
+
+/**
+ * Centered splash shown in place of a feature's view when that feature is
+ * disabled on the server. Reused across observations, audit logs, LLM
+ * requests, and any other server-gated feature.
+ */
+export function FeatureNotEnabled({
+  title,
+  description,
+  icon: Icon = PowerOff,
+}: FeatureNotEnabledProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="text-muted-foreground mb-2">
+        <Icon width={48} height={48} strokeWidth={1.5} />
+      </div>
+      <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
+      <p className="text-sm text-muted-foreground max-w-md">{description}</p>
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1288,6 +1288,8 @@ export class ControlPlaneClient {
         file_upload_api: boolean;
         document_export_api: boolean;
         document_import_api: boolean;
+        audit_log: boolean;
+        llm_trace: boolean;
       };
     }>("/api/version");
   }

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -11,6 +11,8 @@ interface Features {
   access_key_auth: boolean;
   document_export_api: boolean;
   document_import_api: boolean;
+  audit_log: boolean;
+  llm_trace: boolean;
 }
 
 interface FeaturesContextType {
@@ -27,6 +29,8 @@ const defaultFeatures: Features = {
   access_key_auth: false,
   document_export_api: false,
   document_import_api: false,
+  audit_log: false,
+  llm_trace: false,
 };
 
 const FeaturesContext = createContext<FeaturesContextType | undefined>(undefined);

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "Alle Beobachtungs-Erinnerungen werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
     "observationsNotEnabled": "Beobachtungen nicht aktiviert",
     "observationsDisabledMessage": "Die Beobachtungskonsolidierung ist auf diesem Server deaktiviert. Setzen Sie <envVar></envVar>, um sie zu aktivieren.",
+    "auditLogsNotEnabled": "Audit-Protokolle nicht aktiviert",
+    "auditLogsDisabledMessage": "Die Audit-Protokollierung ist auf diesem Server deaktiviert. Setzen Sie <envVar></envVar>, um sie zu aktivieren.",
+    "llmRequestsNotEnabled": "LLM Requests nicht aktiviert",
+    "llmRequestsDisabledMessage": "Das Tracing von LLM-Anfragen ist auf diesem Server deaktiviert. Setzen Sie <envVar></envVar>, um es zu aktivieren.",
     "deleteWillDeleteDetails": "Dadurch werden {memories, plural, one {# Erinnerung} other {# Erinnerungen}}, {documents, plural, one {# Dokument} other {# Dokumente}} und {links, plural, one {# Verknüpfung} other {# Verknüpfungen}} gelöscht.",
     "deleteWillDeleteObservations": "Dadurch werden {count, plural, one {# Beobachtung} other {# Beobachtungen}} gelöscht."
   },

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "All observation memories will be permanently deleted. This action cannot be undone.",
     "observationsNotEnabled": "Observations Not Enabled",
     "observationsDisabledMessage": "Observations consolidation is disabled on this server. Set <envVar></envVar> to enable.",
+    "auditLogsNotEnabled": "Audit Logs Not Enabled",
+    "auditLogsDisabledMessage": "Audit logging is disabled on this server. Set <envVar></envVar> to enable.",
+    "llmRequestsNotEnabled": "LLM Requests Not Enabled",
+    "llmRequestsDisabledMessage": "LLM request tracing is disabled on this server. Set <envVar></envVar> to enable.",
     "deleteWillDeleteDetails": "This will delete {memories, plural, one {# memory} other {# memories}}, {documents, plural, one {# document} other {# documents}}, and {links, plural, one {# link} other {# links}}.",
     "deleteWillDeleteObservations": "This will delete {count, plural, one {# observation} other {# observations}}."
   },

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "Todas las memorias de observación se eliminarán permanentemente. Esta acción no se puede deshacer.",
     "observationsNotEnabled": "Observaciones no habilitadas",
     "observationsDisabledMessage": "La consolidación de observaciones está deshabilitada en este servidor. Establece <envVar></envVar> para habilitarla.",
+    "auditLogsNotEnabled": "Registros de auditoría no habilitados",
+    "auditLogsDisabledMessage": "El registro de auditoría está deshabilitado en este servidor. Establece <envVar></envVar> para habilitarlo.",
+    "llmRequestsNotEnabled": "Solicitudes LLM no habilitadas",
+    "llmRequestsDisabledMessage": "El rastreo de solicitudes LLM está deshabilitado en este servidor. Establece <envVar></envVar> para habilitarlo.",
     "deleteWillDeleteDetails": "Esto eliminará {memories, plural, one {# memoria} other {# memorias}}, {documents, plural, one {# documento} other {# documentos}} y {links, plural, one {# enlace} other {# enlaces}}.",
     "deleteWillDeleteObservations": "Esto eliminará {count, plural, one {# observación} other {# observaciones}}."
   },

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "Tous les souvenirs d'observation seront définitivement supprimés. Cette action est irréversible.",
     "observationsNotEnabled": "Observations non activées",
     "observationsDisabledMessage": "La consolidation des observations est désactivée sur ce serveur. Définissez <envVar></envVar> pour l'activer.",
+    "auditLogsNotEnabled": "Journaux d'audit non activés",
+    "auditLogsDisabledMessage": "La journalisation d'audit est désactivée sur ce serveur. Définissez <envVar></envVar> pour l'activer.",
+    "llmRequestsNotEnabled": "Requêtes LLM non activées",
+    "llmRequestsDisabledMessage": "Le traçage des requêtes LLM est désactivé sur ce serveur. Définissez <envVar></envVar> pour l'activer.",
     "deleteWillDeleteDetails": "Cela supprimera {memories, plural, one {# mémoire} other {# mémoires}}, {documents, plural, one {# document} other {# documents}} et {links, plural, one {# lien} other {# liens}}.",
     "deleteWillDeleteObservations": "Cela supprimera {count, plural, one {# observation} other {# observations}}."
   },

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "すべての観測メモリが完全に削除されます。この操作は元に戻せません。",
     "observationsNotEnabled": "観測は有効になっていません",
     "observationsDisabledMessage": "このサーバーでは観測の統合が無効になっています。有効にするには <envVar></envVar> を設定してください。",
+    "auditLogsNotEnabled": "監査ログは有効になっていません",
+    "auditLogsDisabledMessage": "このサーバーでは監査ログが無効になっています。有効にするには <envVar></envVar> を設定してください。",
+    "llmRequestsNotEnabled": "LLMリクエストは有効になっていません",
+    "llmRequestsDisabledMessage": "このサーバーではLLMリクエストのトレースが無効になっています。有効にするには <envVar></envVar> を設定してください。",
     "deleteWillDeleteDetails": "{memories, plural, other {# 件のメモリ}}、{documents, plural, other {# 件のドキュメント}}、および {links, plural, other {# 件のリンク}} が削除されます。",
     "deleteWillDeleteObservations": "{count, plural, other {# 件の観測}} が削除されます。"
   },

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "모든 관찰 메모리가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
     "observationsNotEnabled": "관찰이 활성화되지 않음",
     "observationsDisabledMessage": "이 서버에서는 관찰 통합이 비활성화되어 있습니다. 활성화하려면 <envVar></envVar>를 설정하세요.",
+    "auditLogsNotEnabled": "감사 로그가 활성화되지 않음",
+    "auditLogsDisabledMessage": "이 서버에서는 감사 로깅이 비활성화되어 있습니다. 활성화하려면 <envVar></envVar>를 설정하세요.",
+    "llmRequestsNotEnabled": "LLM 요청이 활성화되지 않음",
+    "llmRequestsDisabledMessage": "이 서버에서는 LLM 요청 추적이 비활성화되어 있습니다. 활성화하려면 <envVar></envVar>를 설정하세요.",
     "deleteWillDeleteDetails": "{memories, plural, other {# 메모리}}, {documents, plural, other {# 문서}}, {links, plural, other {# 링크}}가 삭제됩니다.",
     "deleteWillDeleteObservations": "{count, plural, other {# 관찰}}이 삭제됩니다."
   },

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "Todas as memórias de observação serão permanentemente excluídas. Esta ação não pode ser desfeita.",
     "observationsNotEnabled": "Observações não habilitadas",
     "observationsDisabledMessage": "A consolidação de observações está desabilitada neste servidor. Defina <envVar></envVar> para habilitar.",
+    "auditLogsNotEnabled": "Registros de auditoria não habilitados",
+    "auditLogsDisabledMessage": "O registro de auditoria está desabilitado neste servidor. Defina <envVar></envVar> para habilitar.",
+    "llmRequestsNotEnabled": "Requisições LLM não habilitadas",
+    "llmRequestsDisabledMessage": "O rastreamento de requisições LLM está desabilitado neste servidor. Defina <envVar></envVar> para habilitar.",
     "deleteWillDeleteDetails": "Isso excluirá {memories, plural, one {# memória} other {# memórias}}, {documents, plural, one {# documento} other {# documentos}} e {links, plural, one {# link} other {# links}}.",
     "deleteWillDeleteObservations": "Isso excluirá {count, plural, one {# observação} other {# observações}}."
   },

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "所有觀察記憶都會永久刪除。此操作無法還原。",
     "observationsNotEnabled": "觀察未啟用",
     "observationsDisabledMessage": "此伺服器上的觀察整合已停用。請設定 <envVar></envVar> 以啟用。",
+    "auditLogsNotEnabled": "稽核記錄未啟用",
+    "auditLogsDisabledMessage": "此伺服器上的稽核記錄已停用。請設定 <envVar></envVar> 以啟用。",
+    "llmRequestsNotEnabled": "LLM 請求未啟用",
+    "llmRequestsDisabledMessage": "此伺服器上的 LLM 請求追蹤已停用。請設定 <envVar></envVar> 以啟用。",
     "deleteWillDeleteDetails": "將刪除 {memories, plural, other {# 條記憶}}、{documents, plural, other {# 個文件}} 和 {links, plural, other {# 個連結}}。",
     "deleteWillDeleteObservations": "將刪除 {count, plural, other {# 個觀察}}。"
   },

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "所有观察记忆都将永久删除。此操作无法撤销。",
     "observationsNotEnabled": "观察未启用",
     "observationsDisabledMessage": "此服务器上的观察整合已禁用。请设置 <envVar></envVar> 以启用。",
+    "auditLogsNotEnabled": "审计日志未启用",
+    "auditLogsDisabledMessage": "此服务器上的审计日志已禁用。请设置 <envVar></envVar> 以启用。",
+    "llmRequestsNotEnabled": "LLM Requests 未启用",
+    "llmRequestsDisabledMessage": "此服务器上的 LLM 请求追踪已禁用。请设置 <envVar></envVar> 以启用。",
     "deleteWillDeleteDetails": "这将删除 {memories, plural, other {# 条记忆}}、{documents, plural, other {# 个文档}} 和 {links, plural, other {# 个链接}}。",
     "deleteWillDeleteObservations": "这将删除 {count, plural, other {# 个观察}}。"
   },

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -149,6 +149,10 @@
     "clearObservationsDetailedWarning": "所有觀察記憶都將永久刪除。此操作無法還原。",
     "observationsNotEnabled": "觀察未啟用",
     "observationsDisabledMessage": "此伺服器上的觀察整合已停用。請設定 <envVar></envVar> 以啟用。",
+    "auditLogsNotEnabled": "稽核記錄未啟用",
+    "auditLogsDisabledMessage": "此伺服器上的稽核記錄已停用。請設定 <envVar></envVar> 以啟用。",
+    "llmRequestsNotEnabled": "LLM 請求未啟用",
+    "llmRequestsDisabledMessage": "此伺服器上的 LLM 請求追蹤已停用。請設定 <envVar></envVar> 以啟用。",
     "deleteWillDeleteDetails": "這將刪除 {memories, plural, other {# 條記憶}}、{documents, plural, other {# 個文件}} 和 {links, plural, other {# 個連結}}。",
     "deleteWillDeleteObservations": "這將刪除 {count, plural, other {# 個觀察}}。"
   },

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -8229,6 +8229,16 @@
             "type": "boolean",
             "title": "Document Import Api",
             "description": "Whether the document import endpoint is enabled"
+          },
+          "audit_log": {
+            "type": "boolean",
+            "title": "Audit Log",
+            "description": "Whether audit logging is enabled"
+          },
+          "llm_trace": {
+            "type": "boolean",
+            "title": "Llm Trace",
+            "description": "Whether per-bank LLM request tracing is enabled"
           }
         },
         "type": "object",
@@ -8239,7 +8249,9 @@
           "bank_config_api",
           "file_upload_api",
           "document_export_api",
-          "document_import_api"
+          "document_import_api",
+          "audit_log",
+          "llm_trace"
         ],
         "title": "FeaturesInfo",
         "description": "Feature flags indicating which capabilities are enabled."

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -8229,6 +8229,16 @@
             "type": "boolean",
             "title": "Document Import Api",
             "description": "Whether the document import endpoint is enabled"
+          },
+          "audit_log": {
+            "type": "boolean",
+            "title": "Audit Log",
+            "description": "Whether audit logging is enabled"
+          },
+          "llm_trace": {
+            "type": "boolean",
+            "title": "Llm Trace",
+            "description": "Whether per-bank LLM request tracing is enabled"
           }
         },
         "type": "object",
@@ -8239,7 +8249,9 @@
           "bank_config_api",
           "file_upload_api",
           "document_export_api",
-          "document_import_api"
+          "document_import_api",
+          "audit_log",
+          "llm_trace"
         ],
         "title": "FeaturesInfo",
         "description": "Feature flags indicating which capabilities are enabled."


### PR DESCRIPTION
## Summary

Two related changes for the bank-configuration area of the control plane:

### 1. "Feature not enabled" splash for Audit Logs & LLM Requests
The **Audit Logs** and **LLM Requests** tabs were always rendered, even though both features are server-gated and disabled by default. Now, when disabled, each tab shows a clear splash explaining how to enable it, and the tab carries an **"Off"** badge.

- New reusable **`FeatureNotEnabled`** component (centered icon + title + description). The existing **Observations** splash was refactored to reuse it, so all three server-gated views share one component.
- Exposed `audit_log` and `llm_trace` in the `/version` `features` object (from `config.audit_log_enabled` / `config.llm_trace_enabled`) so the UI can detect the gating — these were previously unreported.
- Wired the flags through `features-context` and the control-plane SDK type; added i18n keys for all 10 locales.

### 2. Fix: nameless banks 500 the profile endpoint
There are two bank-creation insert paths, and only one set the name:
- `get_or_create_bank_profile` → inserts `name = bank_id` ✅
- `ensure_bank_exists` → omitted `name` → **NULL** ❌

Since #1940 wired `PATCH /config` to `ensure_bank_exists`, a config PATCH on a never-retained bank (and any retain-only bank) produced a NULL name, which then **500'd** the deprecated `GET /profile` endpoint (its response types `name` as a required `str`). Fixed at the source: `ensure_bank_exists` now defaults `name` to `bank_id`, matching the other creation path. No migration — the only NULL rows in practice were ephemeral test artifacts.

## Testing
- Extended the #1940 regression test to assert the auto-created bank's `/profile` returns 200 with `name == bank_id` (both params pass).
- `./scripts/hooks/lint.sh` → all passed.
- Verified end-to-end locally with both features disabled: config-PATCH on a never-retained bank → 200 + named bank + profile 200; Audit Logs / LLM Requests tabs render the splash.