### PR TITLE
fix(retain): make document lock/upsert dialect-aware for Oracle (#1944)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -73,6 +73,30 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
+    async def lock_document_for_write(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        doc_id: str,
+        bank_id: str,
+    ) -> str | None:
+        """Ensure the document row exists, take a row lock on it, and return its
+        pre-existing ``content_hash``.
+
+        This serializes all concurrent writers for ``doc_id`` at the DB level
+        (so interleaved same-document retains can't corrupt each other), while
+        creating the row on first write. The returned hash is ``'__pending__'``
+        for a freshly inserted row, the stored hash for an existing one, or
+        ``None`` if the row could not be read back.
+
+        PG does this in a single statement (``INSERT ... ON CONFLICT DO UPDATE
+        ... RETURNING``), which always takes the row lock as part of the upsert.
+        Oracle can't (``MERGE`` doesn't support ``RETURNING``), so it splits the
+        work into an idempotent insert plus a ``SELECT ... FOR UPDATE``.
+        """
+        ...
+
+    @abstractmethod
     async def insert_facts_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -47,6 +47,37 @@ class OracleOps(DataAccessOps):
             column_types=["text[]", "text[]", "text[]", "text[]", "integer[]", "text[]"],
         )
 
+    async def lock_document_for_write(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        doc_id: str,
+        bank_id: str,
+    ) -> str | None:
+        # Oracle can't express the PG "INSERT ... ON CONFLICT DO UPDATE ...
+        # RETURNING" upsert in one statement — MERGE doesn't support RETURNING,
+        # so the single-statement form rewrites to a MERGE that returns no rows
+        # (DPY-1003). Split it into two statements instead:
+        #   1. Idempotent insert that silently skips an existing row. The
+        #      IGNORE_ROW_ON_DUPKEY_INDEX hint suppresses ORA-00001 server-side;
+        #      a concurrent uncommitted insert of the same key blocks here until
+        #      the other writer commits, so writers still serialize.
+        #   2. SELECT ... FOR UPDATE to take the row lock and read the hash
+        #      ('__pending__' for a row we just inserted, the stored hash for an
+        #      existing one).
+        await conn.execute(
+            f"INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX({table}, pk_documents) */ "
+            f"INTO {table} (id, bank_id, original_text, content_hash) "
+            f"VALUES ($1, $2, '', '__pending__')",
+            doc_id,
+            bank_id,
+        )
+        return await conn.fetchval(
+            f"SELECT content_hash FROM {table} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
+            doc_id,
+            bank_id,
+        )
+
     async def insert_facts_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -49,6 +49,30 @@ class PostgreSQLOps(DataAccessOps):
             content_hashes,
         )
 
+    async def lock_document_for_write(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        doc_id: str,
+        bank_id: str,
+    ) -> str | None:
+        # Single upsert that both creates the row (if absent) and locks it (if
+        # present) atomically. ON CONFLICT DO UPDATE always takes the row lock as
+        # part of the statement, so all concurrent same-document writers serialize
+        # on the document row in one consistent step (the earlier two-step form —
+        # DO NOTHING + a separate SELECT FOR UPDATE — could deadlock because
+        # DO NOTHING takes no lock on an existing row). The SET is a no-op
+        # self-assignment used only to acquire the lock; RETURNING yields the
+        # pre-existing hash (or '__pending__' for a freshly inserted row).
+        return await conn.fetchval(
+            f"INSERT INTO {table} (id, bank_id, original_text, content_hash) "
+            f"VALUES ($1, $2, '', '__pending__') "
+            f"ON CONFLICT (id, bank_id) DO UPDATE SET content_hash = {table}.content_hash "
+            f"RETURNING content_hash",
+            doc_id,
+            bank_id,
+        )
+
     async def insert_facts_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1213,30 +1213,17 @@ async def _streaming_retain_batch(
             async with acquire_with_retry(pool) as conn:
                 async with conn.transaction():
                     # --- Document ownership gate ---
-                    # Lock the document row to serialize all concurrent writers.
-                    #
-                    # We do this with a SINGLE upsert that both creates the row (if
-                    # absent) and locks it (if present) atomically. The earlier
-                    # two-step form — INSERT ... ON CONFLICT DO NOTHING followed by a
-                    # separate SELECT ... FOR UPDATE — could deadlock under concurrent
-                    # same-document retains: DO NOTHING takes no row lock on an
-                    # existing row, so writers interleaved the speculative-insert
-                    # ShareLock with the later FOR UPDATE and cascade-DELETE in
-                    # inconsistent orders, producing 3-way lock cycles in
-                    # handle_document_tracking. ON CONFLICT DO UPDATE always takes the
-                    # row lock as part of the same statement, so all writers serialize
-                    # on the document row in a single, consistent step.
-                    #
-                    # The SET is a no-op self-assignment (content_hash unchanged) used
-                    # only to acquire the lock; the real hash is written immediately
-                    # below by handle_document_tracking / upsert_document_metadata.
-                    # ``RETURNING`` yields the pre-existing hash (or '__pending__' for a
-                    # freshly inserted row).
-                    existing_hash = await conn.fetchval(
-                        f"INSERT INTO {fq_table('documents')} (id, bank_id, original_text, content_hash) "
-                        f"VALUES ($1, $2, '', '__pending__') "
-                        f"ON CONFLICT (id, bank_id) DO UPDATE SET content_hash = {fq_table('documents')}.content_hash "
-                        f"RETURNING content_hash",
+                    # Ensure the document row exists, lock it to serialize all
+                    # concurrent same-document writers, and read its pre-existing
+                    # hash. The lock prevents interleaved retains from corrupting
+                    # each other in handle_document_tracking; the returned hash
+                    # ('__pending__' for a freshly inserted row) drives the
+                    # takeover check for later batches below. The PG/Oracle split
+                    # lives in the ops layer because Oracle can't do this upsert +
+                    # RETURNING in a single statement.
+                    existing_hash = await pool.ops.lock_document_for_write(
+                        conn,
+                        fq_table("documents"),
                         effective_doc_id,
                         bank_id,
                     )

--- a/hindsight-api-slim/tests/test_lock_document_for_write.py
+++ b/hindsight-api-slim/tests/test_lock_document_for_write.py
@@ -1,0 +1,130 @@
+"""Regression tests for DataAccessOps.lock_document_for_write.
+
+Covers vectorize-io/hindsight#1944: the retain document-ownership gate used a
+single ``INSERT ... ON CONFLICT DO UPDATE ... RETURNING`` upsert. PostgreSQL
+runs it as-is, but the Oracle adapter rewrites ``ON CONFLICT DO UPDATE`` to a
+``MERGE``, which cannot carry a ``RETURNING`` clause — so every retain 500'd
+with ``DPY-1003: the executed statement does not return rows``.
+
+The lock-and-read step now lives behind ``ops.lock_document_for_write`` so each
+backend implements it natively (PG: one upsert; Oracle: idempotent insert +
+``SELECT ... FOR UPDATE``). These tests pin the contract on PG (run in the
+default suite) and the Oracle rewrite limitation that motivated the split.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.memory_engine import fq_table
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+async def _seed_bank(conn, bank_id: str) -> None:
+    await conn.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_document_for_write_returns_pending_then_existing_hash(memory):
+    """Fresh row → '__pending__'; existing row → its stored hash."""
+    bank_id = f"test_lock_doc_{_ts()}"
+    doc_id = "doc-lock-regression"
+    documents = fq_table("documents")
+
+    backend = await memory._get_backend()
+    ops = backend.ops
+    async with backend.acquire() as conn:
+        await _seed_bank(conn, bank_id)
+
+        # First call creates the row and reports the placeholder hash.
+        async with conn.transaction():
+            first = await ops.lock_document_for_write(conn, documents, doc_id, bank_id)
+        assert first == "__pending__"
+
+        # Promote the placeholder to a real content hash, as the real retain
+        # flow does immediately after taking the lock.
+        await conn.execute(
+            f"UPDATE {documents} SET content_hash = $1 WHERE id = $2 AND bank_id = $3",
+            "real-hash-v1",
+            doc_id,
+            bank_id,
+        )
+
+        # A subsequent writer sees the committed hash (and re-takes the lock).
+        async with conn.transaction():
+            second = await ops.lock_document_for_write(conn, documents, doc_id, bank_id)
+        assert second == "real-hash-v1"
+
+
+@pytest.mark.asyncio
+async def test_lock_document_for_write_isolates_by_bank(memory):
+    """The lock/read is scoped to (id, bank_id) — same doc_id in another bank
+    is a distinct row and starts at '__pending__'."""
+    suffix = _ts()
+    bank_a = f"test_lock_doc_a_{suffix}"
+    bank_b = f"test_lock_doc_b_{suffix}"
+    doc_id = "shared-doc-id"
+    documents = fq_table("documents")
+
+    backend = await memory._get_backend()
+    ops = backend.ops
+    async with backend.acquire() as conn:
+        await _seed_bank(conn, bank_a)
+        await _seed_bank(conn, bank_b)
+
+        async with conn.transaction():
+            assert await ops.lock_document_for_write(conn, documents, doc_id, bank_a) == "__pending__"
+        await conn.execute(
+            f"UPDATE {documents} SET content_hash = $1 WHERE id = $2 AND bank_id = $3",
+            "bank-a-hash",
+            doc_id,
+            bank_a,
+        )
+
+        async with conn.transaction():
+            assert await ops.lock_document_for_write(conn, documents, doc_id, bank_b) == "__pending__"
+
+
+def test_oracle_merge_rewrite_cannot_carry_returning():
+    """Root cause of #1944: PG's single-statement upsert-and-lock rewrites to an
+    Oracle MERGE, and MERGE can't RETURNING — so a ``fetchval`` on it gets no
+    rows back (DPY-1003). The dialect split in lock_document_for_write exists to
+    avoid emitting this form on Oracle."""
+    from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+    query, ignore_dup, returning_cols = _rewrite_pg_to_oracle(
+        "INSERT INTO documents (id, bank_id, original_text, content_hash) "
+        "VALUES ($1, $2, '', '__pending__') "
+        "ON CONFLICT (id, bank_id) DO UPDATE SET content_hash = documents.content_hash "
+        "RETURNING content_hash"
+    )
+
+    assert query.lstrip().upper().startswith("MERGE")
+    # The RETURNING clause is silently dropped by the MERGE rewrite — this is
+    # exactly why the old single-statement form returned no rows on Oracle.
+    assert "RETURNING" not in query.upper()
+    assert returning_cols is None
+    assert not ignore_dup
+
+
+def test_oracle_select_for_update_hash_translates_cleanly():
+    """The Oracle fallback reads the hash with a plain SELECT ... FOR UPDATE,
+    which translates without a MERGE so the scalar fetch returns the column."""
+    from hindsight_api.engine.db.oracle import _rewrite_pg_to_oracle
+
+    query, ignore_dup, returning_cols = _rewrite_pg_to_oracle(
+        "SELECT content_hash FROM documents WHERE id = $1 AND bank_id = $2 FOR UPDATE"
+    )
+
+    assert "MERGE" not in query.upper()
+    assert "FOR UPDATE" in query.upper()
+    assert ":1" in query and ":2" in query
+    assert not ignore_dup
+    assert returning_cols is None


### PR DESCRIPTION
## Summary

Fixes #1944. Retain returned 500 `DPY-1003: the executed statement does not return rows` on Oracle, turning `test-python-client-oracle` and `test-typescript-client-oracle` red.

## Cause

#1930 changed the retain document-ownership gate to a single-statement upsert:

```sql
INSERT INTO documents (...) VALUES (...)
ON CONFLICT (id, bank_id) DO UPDATE SET content_hash = documents.content_hash
RETURNING content_hash
```

PostgreSQL runs this as-is. The Oracle adapter rewrites `ON CONFLICT DO UPDATE` to a `MERGE` — and Oracle `MERGE` **cannot carry a `RETURNING` clause**, so the rewritten statement returns no rows and the `fetchval` fails with `DPY-1003`.

## Fix

Move the lock-and-read step behind a dialect-aware `DataAccessOps.lock_document_for_write` method (mirrors the existing strategy pattern that keeps `if backend_type` checks out of business logic):

- **PostgreSQL** — keeps the single-statement `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`. `DO UPDATE` always takes the row lock atomically, preserving #1930's deadlock fix.
- **Oracle** — splits into two statements: an idempotent insert (`IGNORE_ROW_ON_DUPKEY_INDEX`, the same idiom already used by `enqueue_graph_maintenance`) followed by `SELECT content_hash ... FOR UPDATE`. Concurrent same-document inserters block on the duplicate key until the holder commits, so writers still serialize.

Both return the pre-existing hash (`'__pending__'` for a freshly inserted row), driving the later-batch takeover check unchanged.

## Tests

`tests/test_lock_document_for_write.py`:
- PG functional coverage of the placeholder→stored-hash transition and `(id, bank_id)` isolation (runs in the default suite against pg).
- Translator tests pinning the root cause (the old upsert rewrites to a `MERGE` that drops `RETURNING`) and that the Oracle fallback's `SELECT ... FOR UPDATE` translates cleanly.

End-to-end Oracle coverage comes from the existing `test-*-client-oracle` CI jobs that the issue reported failing.

## Scope

Only the broken `DO UPDATE ... RETURNING` site is rerouted. The two `ON CONFLICT DO NOTHING + SELECT FOR UPDATE` sites (zero-facts / no-batch paths) already translate correctly on Oracle and are left unchanged.