### PR TITLE
fix(api): harden structured output and vchord probes

### DIFF
--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -54,23 +54,20 @@ _INDEX_TYPE_KEYWORDS = {
 #   pre-dispatcher code (internal benchmarks tuned around our embedding count
 #   and recall floor; see the link_utils / pool init call sites for the
 #   latency-vs-recall framing).
-# - vchord exposes vchordrq.probes (no default; see VectorChord issue #392)
-#   and vchordrq.epsilon (default 1.9). probes = 10 / 30 are starting
-#   defaults pending a workload-specific sweep — vchordrq's recall curve
-#   shape differs from HNSW's, so the pgvector numbers don't translate
-#   directly. Revisit with a per-cluster benchmark once we have production
-#   recall data; until then these are deliberately conservative on the
-#   high-recall path. We leave epsilon at its default; tightening it is a
-#   separate trade-off.
+# - vchord exposes vchordrq.probes, but its shape must match the index's
+#   build.internal.lists hierarchy. VectorChord 1.1 added per-index fallback
+#   parameters for this reason: a session GUC overrides every vchordrq index,
+#   and a single value can be invalid for listless or mixed-layout indexes.
+#   Hindsight's built-in vchord clause does not set lists, so the safe default
+#   is no session-level probe override; deployments that partition vchordrq
+#   indexes should attach probes to the index storage parameters instead.
 # - pgvectorscale / pg_diskann / scann do not expose an equivalent per-statement
 #   knob in the engine today, so the dispatcher returns no statements for them.
 _ANN_TUNING_LOW_LATENCY: dict[str, tuple[tuple[str, str], ...]] = {
     "pgvector": (("hnsw.ef_search", "60"),),
-    "vchord": (("vchordrq.probes", "10"),),
 }
 _ANN_TUNING_HIGH_RECALL: dict[str, tuple[tuple[str, str], ...]] = {
     "pgvector": (("hnsw.ef_search", "200"),),
-    "vchord": (("vchordrq.probes", "30"),),
 }
 
 _EXTENSION_INSTALL_SQL = {

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1608,6 +1608,7 @@ async def _consolidate_batch_with_llm(
                 "messages": [{"role": "user", "content": prompt}],
                 "response_format": response_model,
                 "scope": "consolidation",
+                "strict_schema": True,
             }
             if inner_max_retries is not None:
                 call_kwargs["max_retries"] = inner_max_retries

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2363,11 +2363,9 @@ class MemoryEngine(MemoryEngineInterface):
         # Per-connection initialization callback (PostgreSQL-specific for now)
         async def _init_connection(conn: asyncpg.Connection) -> None:
             # SET (not SET LOCAL) so per-backend ANN tuning persists for the
-            # connection lifetime. Each backend exposes its own GUC: pgvector
-            # uses hnsw.ef_search, vchord uses vchordrq.probes. The dispatcher
-            # returns the right one for the configured extension, tuned for
-            # the higher recall the per-fact_type semantic queries in
-            # retrieve_semantic_bm25_combined() need.
+            # connection lifetime. The dispatcher returns only safe, portable
+            # knobs for the configured extension; VectorChord probe tuning is
+            # index-shaped and should be stored on vchordrq indexes instead.
             for guc, value in ann_search_tuning_settings(configured_vector_extension(), kind="high_recall"):
                 try:
                     await conn.execute(f"SET {guc} = {value}")

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -239,6 +239,7 @@ OUTPUT:"""
             response_format=DynamicModel,
             scope="reflect_structured",
             skip_validation=True,  # We'll handle the dict ourselves
+            strict_schema=True,
             return_usage=True,
         )
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1138,6 +1138,7 @@ async def _extract_facts_from_chunk(
                 initial_backoff=initial_backoff,
                 max_backoff=max_backoff,
                 skip_validation=True,  # Get raw JSON, we'll validate leniently
+                strict_schema=True,
                 return_usage=True,
             )
             usage = usage + call_usage  # Aggregate usage across retries
@@ -1145,6 +1146,12 @@ async def _extract_facts_from_chunk(
             # Lenient parsing of facts from raw JSON
             chunk_facts = []
             has_malformed_facts = False
+
+            # Some OpenAI-compatible providers can satisfy the item schema but
+            # drop the top-level {"facts": ...} wrapper. Treat that as the same
+            # retain payload shape, while still validating every fact below.
+            if isinstance(extraction_response_json, list):
+                extraction_response_json = {"facts": extraction_response_json}
 
             # Handle malformed LLM responses
             if not isinstance(extraction_response_json, dict):
@@ -1202,6 +1209,7 @@ async def _extract_facts_from_chunk(
                     # In verbatim mode, 'what' is intentionally absent — text is backfilled from chunk
                     if extraction_mode != "verbatim":
                         logger.warning(f"Skipping fact {i}: missing 'what' field")
+                        has_malformed_facts = True
                         continue
 
                 # Critical field: fact_type — "assistant" maps to "experience", everything else is "world".
@@ -1377,11 +1385,17 @@ async def _extract_facts_from_chunk(
                     continue
 
             # If we got malformed facts and haven't exhausted retries, try again
-            if has_malformed_facts and len(chunk_facts) < len(raw_facts) * 0.8 and attempt < llm_max_retries - 1:
-                logger.warning(
-                    f"Got {len(raw_facts) - len(chunk_facts)} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{llm_max_retries}. Retrying..."
+            if has_malformed_facts and len(chunk_facts) < len(raw_facts) * 0.8:
+                malformed_count = len(raw_facts) - len(chunk_facts)
+                if attempt < llm_max_retries - 1:
+                    logger.warning(
+                        f"Got {malformed_count} malformed facts out of {len(raw_facts)} on attempt {attempt + 1}/{llm_max_retries}. Retrying..."
+                    )
+                    continue
+                raise RuntimeError(
+                    f"Fact extraction failed: LLM returned {malformed_count} malformed facts "
+                    f"out of {len(raw_facts)} after {llm_max_retries} attempts"
                 )
-                continue
 
             return chunk_facts, usage
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -574,12 +574,10 @@ async def compute_semantic_links_ann(
     # the transaction end handles both.
     rows: list = []
     async with conn.transaction():
-        # Transaction-local ANN tuning. Each supported backend exposes its own
-        # GUC (hnsw.ef_search on pgvector, vchordrq.probes on vchord); the
-        # dispatcher returns the right knob for the configured backend with a
-        # value tuned for top-50 semantic link creation (lower recall but much
-        # lower latency than the recall-side default). SET LOCAL auto-reverts
-        # at commit, so we don't pollute the pool for subsequent queries.
+        # Transaction-local ANN tuning. The dispatcher only returns GUCs that
+        # are safe to apply at session/transaction scope for the configured
+        # backend. VectorChord probe values are index-shaped, so vchordrq uses
+        # index storage fallback parameters instead of a blanket SET LOCAL.
         for guc, value in ann_search_tuning_settings(configured_vector_extension(), kind="low_latency"):
             await conn.execute(f"SET LOCAL {guc} = {value}")
 
@@ -636,7 +634,7 @@ async def compute_semantic_links_ann(
             logger.debug(f"[ANN] fact_type={fact_type}: {len(ft_rows)} rows in {time_mod.time() - t_query:.3f}s")
             rows.extend(ft_rows)
     # Transaction commits here. _ann_seeds is dropped (ON COMMIT DROP).
-    # hnsw.ef_search reverts (SET LOCAL).
+    # Transaction-local ANN tuning reverts (SET LOCAL).
 
     for row in rows:
         sim = float(min(1.0, max(0.0, row["similarity"])))

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -1,8 +1,8 @@
 """Tests for consolidation retry budget configurability (issue #1042)."""
 
-import pytest
-
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from hindsight_api.engine.consolidation.consolidator import _consolidate_batch_with_llm
 
@@ -67,6 +67,18 @@ class TestConsolidationRetryBudget:
             config=mock_config,
         )
         assert mock_llm_config.call.call_args.kwargs.get("max_retries") == 3
+
+    @pytest.mark.asyncio
+    async def test_structured_call_uses_strict_schema(self, mock_llm_config, mock_config):
+        """Structured consolidation calls request strict schema enforcement."""
+        await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"id": "m1", "text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        assert mock_llm_config.call.call_args.kwargs["strict_schema"] is True
 
     @pytest.mark.asyncio
     async def test_max_retries_not_passed_when_none(self, mock_llm_config, mock_config):

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -1,12 +1,12 @@
 """
 Unit tests for fact extraction retry logic.
 
-When the LLM returns non-dict JSON across all retries, extraction must raise a
+When the LLM returns unusable JSON across all retries, extraction must raise a
 RuntimeError (issue #1833 — never silently return [] and let the retain commit
 the document with 0 facts). This also guards the original TypeError bug: the
 raise must be a real exception, not `raise None` ('exceptions must derive from
 BaseException'), which happened when last_error was only set in the
-BadRequestError handler and not for non-dict JSON responses.
+BadRequestError handler and not for malformed JSON responses.
 """
 
 from datetime import datetime, timezone
@@ -59,8 +59,8 @@ async def test_non_dict_json_all_retries_raises():
 
     config = _make_config(llm_max_retries=3, retain_llm_max_retries=None)
 
-    # Mock: always returns a list (non-dict), which is invalid
-    llm_config = _make_llm_config(mock_response=[{"invalid": "response"}])
+    # Mock: always returns a string (non-dict), which is invalid
+    llm_config = _make_llm_config(mock_response="not a dict")
 
     with patch(
         "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
@@ -79,6 +79,80 @@ async def test_non_dict_json_all_retries_raises():
             )
 
     assert llm_config.call.call_count == 3
+    assert llm_config.call.call_args.kwargs["strict_schema"] is True
+
+
+@pytest.mark.asyncio
+async def test_bare_fact_list_response_is_normalized():
+    """
+    Some OpenAI-compatible providers can satisfy the fact item schema but drop
+    the top-level {"facts": ...} wrapper. Treat a bare list as facts, then run
+    the normal per-fact validation path.
+    """
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=1)
+    llm_config = _make_llm_config(
+        mock_response=[
+            {
+                "what": "Alice visited Paris",
+                "when": "2023",
+                "who": "Alice",
+                "why": "vacation",
+                "fact_type": "world",
+            }
+        ]
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, usage = await _extract_facts_from_chunk(
+            chunk="Alice visited Paris in 2023.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            context="travel notes",
+            llm_config=llm_config,
+            config=config,
+            agent_name="test-agent",
+        )
+
+    assert len(facts) == 1
+    assert "Alice visited Paris" in facts[0].fact
+    assert llm_config.call.call_args.kwargs["strict_schema"] is True
+
+
+@pytest.mark.asyncio
+async def test_bare_fact_list_with_malformed_facts_raises():
+    """
+    Bare-list normalization must not reintroduce silent zero-fact commits.
+    A list whose items do not contain usable facts still raises after retries.
+    """
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=2)
+    llm_config = _make_llm_config(mock_response=[{"invalid": "response"}])
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        with pytest.raises(RuntimeError, match="malformed facts"):
+            await _extract_facts_from_chunk(
+                chunk="Alice visited Paris in 2023.",
+                chunk_index=0,
+                total_chunks=1,
+                event_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                context="travel notes",
+                llm_config=llm_config,
+                config=config,
+                agent_name="test-agent",
+            )
+
+    assert llm_config.call.call_count == 2
+    assert llm_config.call.call_args.kwargs["strict_schema"] is True
 
 
 @pytest.mark.asyncio
@@ -216,3 +290,4 @@ async def test_none_event_date_with_valid_facts_no_crash():
 
     assert len(facts) == 1
     assert "Alice visited Paris" in facts[0].fact
+    assert llm_config.call.call_args.kwargs["strict_schema"] is True

--- a/hindsight-api-slim/tests/test_link_utils.py
+++ b/hindsight-api-slim/tests/test_link_utils.py
@@ -1,17 +1,19 @@
 """Tests for link_utils datetime handling, temporal link computation, and semantic link splitting."""
-import numpy as np
-import pytest
-from datetime import datetime, timezone, timedelta
+
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
+import pytest
+
 from hindsight_api.engine.retain.link_utils import (
-    _normalize_datetime,
+    MAX_TEMPORAL_LINKS_PER_UNIT,
     _cap_links_per_unit,
-    compute_temporal_links,
-    compute_temporal_query_bounds,
+    _normalize_datetime,
     compute_semantic_links_ann,
     compute_semantic_links_within_batch,
-    MAX_TEMPORAL_LINKS_PER_UNIT,
+    compute_temporal_links,
+    compute_temporal_query_bounds,
 )
 
 
@@ -172,8 +174,8 @@ class TestComputeTemporalLinks:
         links = compute_temporal_links(units, candidates, time_window_hours=24)
 
         assert len(links) == 2
-        close_link = next(l for l in links if l[1] == "close")
-        far_link = next(l for l in links if l[1] == "far")
+        close_link = next(link for link in links if link[1] == "close")
+        far_link = next(link for link in links if link[1] == "far")
 
         assert close_link[3] > far_link[3]
 
@@ -206,8 +208,8 @@ class TestComputeTemporalLinks:
 
         # unit-1 should link to c1 only
         # unit-2 should link to c2 only
-        unit1_links = [l for l in links if l[0] == "unit-1"]
-        unit2_links = [l for l in links if l[0] == "unit-2"]
+        unit1_links = [link for link in links if link[0] == "unit-1"]
+        unit2_links = [link for link in links if link[0] == "unit-2"]
 
         assert len(unit1_links) == 1
         assert unit1_links[0][1] == "c1"
@@ -509,16 +511,13 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("ext", "guc"),
-        [("pgvector", "hnsw.ef_search"), ("vchord", "vchordrq.probes")],
-    )
-    async def test_uses_set_local_for_ann_tuning(self, mock_conn, monkeypatch, ext, guc):
+    async def test_uses_set_local_for_pgvector_ann_tuning(self, mock_conn, monkeypatch):
         """The per-backend ANN tuning GUC must be set with SET LOCAL so the
         change is scoped to the transaction. Without SET LOCAL, the setting
         would leak onto the pooled backend and affect subsequent recall
         queries that land on the same backend."""
-        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", ext)
+        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector")
+        guc = "hnsw.ef_search"
         emb = [0.1] * 384
         await compute_semantic_links_ann(
             conn=mock_conn,
@@ -530,10 +529,31 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
         tuning_statements = [s for s in executed_sql if guc in s]
-        assert tuning_statements, f"{guc} must be tuned for retain ANN under ext={ext}"
+        assert tuning_statements, f"{guc} must be tuned for retain ANN under pgvector"
         for stmt in tuning_statements:
             assert stmt.strip().startswith("SET LOCAL"), (
                 f"{guc} must use SET LOCAL, got: {stmt}"
             )
         # And there must not be a RESET — SET LOCAL handles it at commit.
         assert not any(f"RESET {guc}" in s for s in executed_sql)
+
+    @pytest.mark.asyncio
+    async def test_vchord_ann_does_not_set_fixed_probe_count(self, mock_conn, monkeypatch):
+        """VectorChord probe counts must come from index/default config.
+
+        VectorChord requires vchordrq.probes to match the index's
+        build.internal.lists shape. Hindsight must not apply one fixed session
+        GUC across listless and partitioned vchordrq indexes.
+        """
+        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "vchord")
+        emb = [0.1] * 384
+        await compute_semantic_links_ann(
+            conn=mock_conn,
+            bank_id="bank-1",
+            unit_ids=["u1"],
+            embeddings=[emb],
+            fact_types=["world"],
+        )
+
+        executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
+        assert not any("vchordrq.probes" in s for s in executed_sql)

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -17,6 +17,7 @@ from hindsight_api.engine.reflect.agent import (
     _clean_answer_text,
     _clean_done_answer,
     _count_messages_tokens,
+    _generate_structured_output,
     _is_context_overflow_error,
     _is_done_tool,
     _normalize_tool_name,
@@ -138,6 +139,41 @@ class TestCleanDoneAnswer:
         assert "Point 1" in cleaned
         assert "Point 2" in cleaned
         assert "mental_model_ids" not in cleaned
+
+
+class TestStructuredOutputExtraction:
+    """Test final structured-output extraction calls."""
+
+    @pytest.mark.asyncio
+    async def test_structured_output_uses_strict_schema(self):
+        """Reflect structured extraction requests strict schema enforcement."""
+        llm = MagicMock()
+        llm.call = AsyncMock(
+            return_value=(
+                {"summary": "Alice prefers Python.", "tags": ["python"]},
+                TokenUsage(input_tokens=12, output_tokens=8, total_tokens=20),
+            )
+        )
+        response_schema = {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Short answer summary"},
+                "tags": {"type": "array", "description": "Relevant tags"},
+            },
+            "required": ["summary"],
+        }
+
+        structured_output, input_tokens, output_tokens = await _generate_structured_output(
+            answer="Alice prefers Python for backend work.",
+            response_schema=response_schema,
+            llm_config=llm,
+            reflect_id="test-reflect",
+        )
+
+        assert structured_output == {"summary": "Alice prefers Python.", "tags": ["python"]}
+        assert input_tokens == 12
+        assert output_tokens == 8
+        assert llm.call.await_args.kwargs["strict_schema"] is True
 
 
 class TestToolNameNormalization:

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -81,15 +81,17 @@ def test_ann_search_tuning_settings_pgvector_dispatches_hnsw_ef_search():
     assert ann_search_tuning_settings("pgvector", kind="high_recall") == (("hnsw.ef_search", "200"),)
 
 
-def test_ann_search_tuning_settings_vchord_dispatches_vchordrq_probes():
-    # vchord doesn't recognize hnsw.ef_search; the dispatcher must route to
-    # the vchordrq equivalent (probes), otherwise the GUC silently does nothing.
-    assert ann_search_tuning_settings("vchord", kind="low_latency") == (("vchordrq.probes", "10"),)
-    assert ann_search_tuning_settings("vchord", kind="high_recall") == (("vchordrq.probes", "30"),)
+def test_ann_search_tuning_settings_vchord_leaves_probes_to_index_defaults():
+    # vchordrq.probes must match the index's build.internal.lists shape.
+    # VectorChord 1.1 supports per-index fallback parameters for this; a
+    # session GUC would override every index and can be invalid for listless or
+    # mixed-layout indexes.
+    assert ann_search_tuning_settings("vchord", kind="low_latency") == ()
+    assert ann_search_tuning_settings("vchord", kind="high_recall") == ()
 
 
 def test_ann_search_tuning_settings_returns_empty_for_backends_without_knob():
-    for ext in ("pgvectorscale", "pg_diskann", "scann"):
+    for ext in ("vchord", "pgvectorscale", "pg_diskann", "scann"):
         assert ann_search_tuning_settings(ext, kind="low_latency") == ()
         assert ann_search_tuning_settings(ext, kind="high_recall") == ()
 


### PR DESCRIPTION
## Summary

- Request strict structured outputs for retain fact extraction, consolidation, and reflection structured calls.
- Normalize MiniMax-style bare fact-list responses into the expected `{ "facts": [...] }` envelope and fail clearly when retry output is still mostly malformed.
- Stop applying a blanket `vchordrq.probes` GUC for VectorChord by default; VectorChord probe values must match each index's `build.internal.lists` hierarchy, and VectorChord 1.1 supports index storage fallback parameters for that case.

## Why

The structured-output call sites already have provider support for strict schemas, but retain/consolidation/reflect were not consistently passing the flag through. Some providers can also return a bare JSON array for fact extraction, which is schema-compatible in spirit but not in the envelope shape Hindsight expects.

For VectorChord, #1668 correctly moved vchord indexes to `vector_cosine_ops` and added backend-specific ANN tuning. The follow-up compatibility issue is that `vchordrq.probes` is not a universal scalar knob: its list shape must match the index's `build.internal.lists`. Hindsight's built-in vchord index clause does not set `lists`, so a non-empty session-level probe override can make otherwise valid listless indexes fail. VectorChord 1.1's fallback-parameter model is the safer place for deployments that do create partitioned vchord indexes.

## Verification

- `uv run --project hindsight-api-slim pytest hindsight-api-slim/tests/test_fact_extraction_retry.py hindsight-api-slim/tests/test_consolidation_retry_budget.py hindsight-api-slim/tests/test_reflect_agent.py::TestStructuredOutputExtraction hindsight-api-slim/tests/test_vector_index.py hindsight-api-slim/tests/test_link_utils.py::TestComputeSemanticLinksAnnPgBouncerSafety::test_uses_set_local_for_pgvector_ann_tuning hindsight-api-slim/tests/test_link_utils.py::TestComputeSemanticLinksAnnPgBouncerSafety::test_vchord_ann_does_not_set_fixed_probe_count -q` — 33 passed
- `uv run --project hindsight-api-slim ruff check ...` on changed files — passed
- Manual PostgreSQL 18 + VectorChord 1.1.1 smoke: no forced `vchordrq.probes` uses the vchord index scan; forcing an incorrectly-shaped probe value reproduces `need 0 probes, but 1 probes provided`.