### PR TITLE
docs(admin-cli): document decommission-worker --yes/-y confirmation-skip flag

### DIFF
--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -146,6 +146,7 @@ hindsight-admin decommission-worker WORKER_ID [OPTIONS]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--schema`, `-s` | Database schema | `public` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
 
 **Examples:**
 

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -146,6 +146,7 @@ hindsight-admin decommission-worker WORKER_ID [OPTIONS]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--schema`, `-s` | Database schema | `public` |
+| `--yes`, `-y` | Skip confirmation prompt | `false` |
 
 **Examples:**
 


### PR DESCRIPTION
`decommission-worker` accepts a `--yes`/`-y` flag to skip the destructive confirmation prompt (`hindsight_api/admin/cli.py`, `decommission_worker()` — the option gates the "release all tasks owned by worker … Continue?" `typer.confirm`), but its **Options** table only lists `--schema`. The two sibling destructive commands already document it: `restore` and `decommission-workers` both have `| --yes, -y | Skip confirmation prompt | false |`, so `decommission-worker` is the lone gap.

Adds the missing row so scripted/non-interactive decommissioning (e.g. a Kubernetes scale-down hook) has a documented way to skip the prompt.

Updated the generated agent-skill mirror `skills/hindsight-docs/references/developer/admin-cli.md` alongside the canonical doc so `verify-generated-files` stays green.