### PR TITLE
search: planner-estimate circuit breaker for retrieve_temporal_combined

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -9,7 +9,9 @@ Implements:
 """
 
 import asyncio
+import json
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -25,6 +27,19 @@ from .tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags
 from .types import GraphRetrievalTimings, RetrievalResult
 
 logger = logging.getLogger(__name__)
+
+
+# Circuit-breaker threshold for retrieve_temporal_combined. When the planner
+# estimates more than this many rows match the temporal WHERE clause, Phase 1's
+# sort spills to disk AND the resulting top-50-per-fact_type sample stops being
+# representative — the date ranking has no signal across that many candidates.
+# In that regime we skip temporal retrieval entirely; semantic+BM25 still runs
+# and the caller already handles an empty temporal result.
+#
+# 50,000 is the lowest threshold that doesn't false-positive on healthy banks
+# under postgres's default work_mem (4MB ≈ 120k sort tuples), accounting for
+# the planner's tendency to over-estimate row counts on partial-index filters.
+TEMPORAL_RECALL_MAX_ESTIMATED_ROWS = int(os.getenv("HINDSIGHT_API_TEMPORAL_RECALL_MAX_ESTIMATED_ROWS", "50000"))
 
 
 def tokenize_query(query_text: str) -> list[str]:
@@ -308,6 +323,90 @@ async def retrieve_semantic_bm25_combined(
     return result_dict
 
 
+async def _estimate_temporal_filter_rows(
+    conn,
+    *,
+    bank_id: str,
+    fact_types: list[str],
+    start_date: datetime,
+    end_date: datetime,
+    tags_clause: str,
+    groups_clause: str,
+    created_range_clause: str,
+    params_for_filter: list,
+) -> int | None:
+    """Ask the planner how many rows the temporal Phase 1 filter would match.
+
+    Runs ``EXPLAIN (FORMAT JSON)`` on a stripped-down ``SELECT 1`` that contains
+    only the filter — no sort, no embedding distance, no CTEs. The planner walks
+    its statistics and returns an estimated row count in a few milliseconds with
+    no row I/O.
+
+    Returns the estimate, or ``None`` if EXPLAIN couldn't be parsed (in which
+    case the caller proceeds with the temporal query as-is — safer to run a
+    potentially-slow query than to silently skip on an instrumentation bug).
+    """
+    # Skip the gate on non-postgres backends (Oracle plan format differs and
+    # the safety net is opt-in per dialect).
+    backend = getattr(conn, "backend_type", "postgresql")
+    if backend != "postgresql":
+        return None
+
+    # Reuse the exact same WHERE clause as the real query so the planner
+    # estimate matches the filter's actual selectivity. The params layout
+    # mirrors retrieve_temporal_combined: $2=bank_id, $3=fact_types, $4=start,
+    # $5=end, then tags/groups/created_range at the appropriate offsets.
+    # We don't reference $1 ($6 etc.) in the estimate query since they're
+    # embedding/threshold params that don't influence the filter row count.
+    explain_sql = f"""
+        EXPLAIN (FORMAT JSON)
+        SELECT 1
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $2
+          AND fact_type = ANY($3)
+          AND embedding IS NOT NULL
+          AND (
+              (occurred_start IS NOT NULL AND occurred_end IS NOT NULL
+               AND occurred_start <= $5 AND occurred_end >= $4)
+              OR
+              (mentioned_at IS NOT NULL AND mentioned_at BETWEEN $4 AND $5)
+              OR
+              (occurred_start IS NOT NULL AND occurred_start BETWEEN $4 AND $5)
+              OR
+              (occurred_end IS NOT NULL AND occurred_end BETWEEN $4 AND $5)
+          )
+          {tags_clause}
+          {groups_clause}
+          {created_range_clause}
+    """
+    try:
+        rows = await conn.fetch(explain_sql, *params_for_filter)
+    except Exception:
+        # Any failure (permission, parser drift, dialect quirk) should fail
+        # open — don't block legitimate queries because the safety net broke.
+        logger.exception("temporal filter row estimate failed; proceeding without gate")
+        return None
+
+    # asyncpg returns one row per plan-line in text mode, but a single row with
+    # a json-encoded value in FORMAT JSON. Handle both forms defensively.
+    if not rows:
+        return None
+    first = rows[0]
+    plan_field = first[0] if hasattr(first, "__getitem__") else None
+    if isinstance(plan_field, str):
+        try:
+            plan_field = json.loads(plan_field)
+        except json.JSONDecodeError:
+            return None
+    if not plan_field:
+        return None
+    try:
+        plan = plan_field[0] if isinstance(plan_field, list) else plan_field
+        return int(plan["Plan"]["Plan Rows"])
+    except (KeyError, TypeError, ValueError, IndexError):
+        return None
+
+
 async def retrieve_temporal_combined(
     conn,
     query_emb_str: str,
@@ -374,6 +473,33 @@ async def retrieve_temporal_combined(
         params.append(tags)
     params.extend(groups_params)
     params.extend(created_range_params)
+
+    # Circuit breaker: ask the planner how many rows the temporal filter would
+    # match. Above the threshold, Phase 1's sort spills to disk and the top-50
+    # sample stops being representative — see TEMPORAL_RECALL_MAX_ESTIMATED_ROWS.
+    # The planner estimate is cheap (~milliseconds, no row read) and accurate
+    # for the catastrophic cases we want to block (verified at ~99.7%); it tends
+    # to over-estimate on healthy filters, which is the safe direction (would
+    # only over-block, never under-block).
+    estimated_rows = await _estimate_temporal_filter_rows(
+        conn,
+        bank_id=bank_id,
+        fact_types=fact_types,
+        start_date=start_date,
+        end_date=end_date,
+        tags_clause=tags_clause,
+        groups_clause=groups_clause,
+        created_range_clause=created_range_clause,
+        params_for_filter=params,
+    )
+    if estimated_rows is not None and estimated_rows > TEMPORAL_RECALL_MAX_ESTIMATED_ROWS:
+        logger.warning(
+            "retrieve_temporal_combined: skipping — planner estimates %d candidate rows "
+            "(limit %d). Semantic+BM25 will carry the recall for this query.",
+            estimated_rows,
+            TEMPORAL_RECALL_MAX_ESTIMATED_ROWS,
+        )
+        return {ft: [] for ft in fact_types}
 
     # Two-phase entry point query:
     # Phase 1 (date_ranked): rank by date only — no embedding computation — for all units in

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -330,10 +330,11 @@ async def _estimate_temporal_filter_rows(
     fact_types: list[str],
     start_date: datetime,
     end_date: datetime,
-    tags_clause: str,
-    groups_clause: str,
-    created_range_clause: str,
-    params_for_filter: list,
+    tags: list[str] | None = None,
+    tags_match: TagsMatch = "any",
+    tag_groups: list[TagGroup] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
 ) -> int | None:
     """Ask the planner how many rows the temporal Phase 1 filter would match.
 
@@ -352,35 +353,56 @@ async def _estimate_temporal_filter_rows(
     if backend != "postgresql":
         return None
 
-    # Reuse the exact same WHERE clause as the real query so the planner
-    # estimate matches the filter's actual selectivity. The params layout
-    # mirrors retrieve_temporal_combined: $2=bank_id, $3=fact_types, $4=start,
-    # $5=end, then tags/groups/created_range at the appropriate offsets.
-    # We don't reference $1 ($6 etc.) in the estimate query since they're
-    # embedding/threshold params that don't influence the filter row count.
+    # Build the estimate query's own param list and clauses. We deliberately do
+    # NOT inherit the caller's params (which include the query embedding and
+    # semantic threshold at $1/$6) — asyncpg's prepare-time type inference
+    # rejects EXPLAIN statements that bind unreferenced parameters, so the
+    # estimate query keeps a self-contained layout starting at $1.
+    estimate_params: list[Any] = [bank_id, fact_types, start_date, end_date]
+    next_idx = 5
+
+    e_tags_clause = build_tags_where_clause_simple(tags, next_idx, match=tags_match)
+    if tags:
+        estimate_params.append(tags)
+        next_idx += 1
+
+    e_groups_clause, e_groups_params, _ = build_tag_groups_where_clause(tag_groups, next_idx)
+    estimate_params.extend(e_groups_params)
+    next_idx += len(e_groups_params)
+
+    e_created_range_clause = ""
+    if created_after is not None:
+        estimate_params.append(created_after)
+        e_created_range_clause += f" AND updated_at > ${next_idx}"
+        next_idx += 1
+    if created_before is not None:
+        estimate_params.append(created_before)
+        e_created_range_clause += f" AND updated_at < ${next_idx}"
+        next_idx += 1
+
     explain_sql = f"""
         EXPLAIN (FORMAT JSON)
         SELECT 1
         FROM {fq_table("memory_units")}
-        WHERE bank_id = $2
-          AND fact_type = ANY($3)
+        WHERE bank_id = $1
+          AND fact_type = ANY($2)
           AND embedding IS NOT NULL
           AND (
               (occurred_start IS NOT NULL AND occurred_end IS NOT NULL
-               AND occurred_start <= $5 AND occurred_end >= $4)
+               AND occurred_start <= $4 AND occurred_end >= $3)
               OR
-              (mentioned_at IS NOT NULL AND mentioned_at BETWEEN $4 AND $5)
+              (mentioned_at IS NOT NULL AND mentioned_at BETWEEN $3 AND $4)
               OR
-              (occurred_start IS NOT NULL AND occurred_start BETWEEN $4 AND $5)
+              (occurred_start IS NOT NULL AND occurred_start BETWEEN $3 AND $4)
               OR
-              (occurred_end IS NOT NULL AND occurred_end BETWEEN $4 AND $5)
+              (occurred_end IS NOT NULL AND occurred_end BETWEEN $3 AND $4)
           )
-          {tags_clause}
-          {groups_clause}
-          {created_range_clause}
+          {e_tags_clause}
+          {e_groups_clause}
+          {e_created_range_clause}
     """
     try:
-        rows = await conn.fetch(explain_sql, *params_for_filter)
+        rows = await conn.fetch(explain_sql, *estimate_params)
     except Exception:
         # Any failure (permission, parser drift, dialect quirk) should fail
         # open — don't block legitimate queries because the safety net broke.
@@ -487,10 +509,11 @@ async def retrieve_temporal_combined(
         fact_types=fact_types,
         start_date=start_date,
         end_date=end_date,
-        tags_clause=tags_clause,
-        groups_clause=groups_clause,
-        created_range_clause=created_range_clause,
-        params_for_filter=params,
+        tags=tags,
+        tags_match=tags_match,
+        tag_groups=tag_groups,
+        created_after=created_after,
+        created_before=created_before,
     )
     if estimated_rows is not None and estimated_rows > TEMPORAL_RECALL_MAX_ESTIMATED_ROWS:
         logger.warning(

--- a/hindsight-api-slim/tests/test_temporal_recall_circuit_breaker.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_circuit_breaker.py
@@ -1,0 +1,177 @@
+"""Unit tests for the temporal recall circuit breaker.
+
+When ``retrieve_temporal_combined`` is called against a bank whose temporal
+filter would match an enormous number of rows, Phase 1's sort spills to disk
+and the top-50-per-fact_type sample stops being statistically meaningful. The
+circuit breaker uses the postgres planner's row estimate (``EXPLAIN FORMAT
+JSON``) as a pre-flight cost gate: above ``TEMPORAL_RECALL_MAX_ESTIMATED_ROWS``
+the function returns an empty result and lets semantic+BM25 carry the recall.
+
+These tests pin three behaviours so future refactors can't silently regress
+them: (a) the gate fires when the estimate exceeds the threshold, (b) the gate
+allows the query through when the estimate is under the threshold, and (c)
+EXPLAIN failures fail open rather than silently dropping legitimate queries.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from hindsight_api.engine.search.retrieval import (
+    TEMPORAL_RECALL_MAX_ESTIMATED_ROWS,
+    retrieve_temporal_combined,
+)
+
+
+class _FakeRecord(dict):
+    """Mimic asyncpg.Record's tuple-style positional access."""
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return list(self.values())[key]
+        return super().__getitem__(key)
+
+
+class _FakeConn:
+    """Capture EXPLAIN calls and stage a canned plan for the estimator.
+
+    The retrieval code path issues two fetches: one EXPLAIN for the row
+    estimate, then (if the gate allows) the real two-CTE query. The fake conn
+    routes by query content so tests don't have to fake the full row shape of
+    the real query when the gate is expected to fire.
+    """
+
+    backend_type = "postgresql"
+
+    def __init__(self, *, planner_row_estimate: int | None):
+        self._planner_row_estimate = planner_row_estimate
+        self.fetch_calls: list[tuple[str, tuple]] = []
+
+    async def fetch(self, query, *params):
+        self.fetch_calls.append((query, params))
+        if "EXPLAIN" in query:
+            if self._planner_row_estimate is None:
+                # Simulate EXPLAIN failure path — return no rows.
+                return []
+            plan = [
+                {
+                    "Plan": {
+                        "Node Type": "Seq Scan",
+                        "Plan Rows": self._planner_row_estimate,
+                        "Total Cost": 1000.0,
+                    }
+                }
+            ]
+            return [_FakeRecord({"QUERY PLAN": json.dumps(plan)})]
+        # Real query path — gate let it through. Return no rows; the caller
+        # already handles empty.
+        return []
+
+
+@pytest.mark.asyncio
+async def test_gate_fires_above_threshold():
+    """When planner estimates > MAX rows, the temporal query is skipped and
+    the function returns an empty result for every requested fact_type."""
+    conn = _FakeConn(planner_row_estimate=TEMPORAL_RECALL_MAX_ESTIMATED_ROWS + 1)
+    result = await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation", "experience", "world"],
+        start_date=datetime(2026, 5, 28, tzinfo=UTC),
+        end_date=datetime(2026, 5, 28, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+    )
+    assert result == {"observation": [], "experience": [], "world": []}
+    # Only EXPLAIN should have run — no real query.
+    assert len(conn.fetch_calls) == 1
+    assert "EXPLAIN" in conn.fetch_calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_below_threshold():
+    """When planner estimate is at-or-below the limit, the temporal query
+    proceeds normally. Each fact_type still gets a (possibly empty) list."""
+    conn = _FakeConn(planner_row_estimate=TEMPORAL_RECALL_MAX_ESTIMATED_ROWS - 1)
+    result = await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation"],
+        start_date=datetime(2026, 6, 1, tzinfo=UTC),
+        end_date=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+    )
+    # The gate let it through — both EXPLAIN and real query ran.
+    assert len(conn.fetch_calls) == 2
+    assert "EXPLAIN" in conn.fetch_calls[0][0]
+    assert "EXPLAIN" not in conn.fetch_calls[1][0]
+    # Empty rows from the fake; mapping has the requested fact_type key.
+    assert set(result.keys()) == {"observation"}
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_open_when_explain_returns_no_rows():
+    """If EXPLAIN parsing fails (planner statistics unavailable, dialect
+    quirk, permission error), the gate must NOT silently drop the query —
+    fall through and let the real query run. Better a slow query than a
+    silently-empty recall."""
+    conn = _FakeConn(planner_row_estimate=None)
+    result = await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation"],
+        start_date=datetime(2026, 6, 1, tzinfo=UTC),
+        end_date=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+    )
+    # EXPLAIN ran (returned []), then the real query ran.
+    assert len(conn.fetch_calls) == 2
+    assert "EXPLAIN" in conn.fetch_calls[0][0]
+    assert "EXPLAIN" not in conn.fetch_calls[1][0]
+    assert set(result.keys()) == {"observation"}
+
+
+@pytest.mark.asyncio
+async def test_gate_at_exact_threshold_allows():
+    """``> threshold`` is the firing condition (strict inequality), so a
+    query estimated exactly at the limit must pass — this pins the boundary
+    in case a future refactor switches to ``>=``."""
+    conn = _FakeConn(planner_row_estimate=TEMPORAL_RECALL_MAX_ESTIMATED_ROWS)
+    result = await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation"],
+        start_date=datetime(2026, 6, 1, tzinfo=UTC),
+        end_date=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+    )
+    assert len(conn.fetch_calls) == 2  # gate allowed → real query ran
+    assert set(result.keys()) == {"observation"}
+
+
+@pytest.mark.asyncio
+async def test_gate_skipped_on_non_postgres_backend():
+    """The EXPLAIN format used here is postgres-specific; the gate opts out
+    on other backends and lets the temporal query proceed (Oracle's planner
+    surface is different and would need its own implementation)."""
+    conn = _FakeConn(planner_row_estimate=10**9)
+    conn.backend_type = "oracle"
+    result = await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation"],
+        start_date=datetime(2026, 6, 1, tzinfo=UTC),
+        end_date=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+    )
+    # No EXPLAIN call — gate was skipped. Only the real query ran.
+    assert len(conn.fetch_calls) == 1
+    assert "EXPLAIN" not in conn.fetch_calls[0][0]
+    assert set(result.keys()) == {"observation"}

--- a/hindsight-api-slim/tests/test_temporal_recall_circuit_breaker.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_circuit_breaker.py
@@ -156,6 +156,58 @@ async def test_gate_at_exact_threshold_allows():
 
 
 @pytest.mark.asyncio
+async def test_explain_sql_references_every_param():
+    """Every value passed to ``conn.fetch`` for the EXPLAIN row-estimate must be
+    referenced by a ``$N`` placeholder in the SQL. asyncpg infers parameter
+    types from the prepared statement's usage; binding a value that the query
+    never references raises ``IndeterminateDatatypeError`` at prepare time and
+    silently breaks the gate (it fails open, but the estimate never runs).
+
+    This regression test caught a real production bug: the helper used to
+    inherit the caller's full params list (which included the query embedding
+    at ``$1`` and the similarity threshold at ``$6``) while the EXPLAIN SQL
+    only referenced ``$2-$5`` plus tags. Every recall logged ``temporal filter
+    row estimate failed; could not determine data type of parameter $1``.
+    """
+    import re
+
+    conn = _FakeConn(planner_row_estimate=10)
+    # Exercise every optional clause builder so any unreferenced bind in the
+    # tags / groups / created_range branches is caught too.
+    await retrieve_temporal_combined(
+        conn=conn,
+        query_emb_str="[0.1,0.2,0.3]",
+        bank_id="bank-1",
+        fact_types=["observation"],
+        start_date=datetime(2026, 6, 1, tzinfo=UTC),
+        end_date=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        budget=10,
+        tags=["a", "b"],
+        tags_match="all",
+        created_after=datetime(2026, 5, 1, tzinfo=UTC),
+        created_before=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+    # The first fetch is the EXPLAIN; verify its param layout.
+    explain_sql, explain_params = conn.fetch_calls[0]
+    assert "EXPLAIN" in explain_sql
+
+    # Every $N referenced in the SQL must have a corresponding bind in params.
+    referenced = {int(m) for m in re.findall(r"\$(\d+)", explain_sql)}
+    assert referenced, "EXPLAIN SQL must use at least one parameter"
+    max_ref = max(referenced)
+    assert max_ref <= len(explain_params), (
+        f"SQL references $1..${max_ref} but only {len(explain_params)} params were bound"
+    )
+    # Symmetric direction: every bound param must be referenced. An
+    # unreferenced position is the bug the production logs surfaced.
+    for i in range(1, len(explain_params) + 1):
+        assert i in referenced, (
+            f"param ${i}={explain_params[i - 1]!r} is bound but never referenced in EXPLAIN SQL — "
+            "asyncpg will raise IndeterminateDatatypeError at prepare time"
+        )
+
+
+@pytest.mark.asyncio
 async def test_gate_skipped_on_non_postgres_backend():
     """The EXPLAIN format used here is postgres-specific; the gate opts out
     on other backends and lets the temporal query proceed (Oracle's planner


### PR DESCRIPTION
## Summary

Adds a pre-flight planner-estimate gate to `retrieve_temporal_combined` that
skips the temporal retrieval pass when the date filter would match an
excessive number of rows. This protects the database from queries that are
both expensive *and* statistically meaningless on banks with dense or
near-uniform date metadata.

## Why

Phase 1 of `retrieve_temporal_combined` ranks rows by
`COALESCE(occurred_start, mentioned_at, occurred_end)` over the entire set
matching its WHERE clause, then keeps the top 50 per fact_type. This works
well when the filter is selective. It degrades nonlinearly when the
candidate set crosses ~100k rows for three reasons:

1. **Sort spills from work_mem to disk** (~10× slower per tuple under an
   external merge sort).
2. **The top-50-per-fact_type sample stops being statistically meaningful** —
   when hundreds of thousands of rows are ~tied on the sort key, the date
   ranking has no signal and the join back to `memory_units` produces
   near-random candidates that the downstream cross-encoder still has to
   rerank.
3. **Phase 2's hash join probes the full table** for the embedding distance,
   making the whole query I/O-bound.

A bank that accumulates dense, near-uniform date metadata — for example
because a retain pipeline stamps `mentioned_at = NOW()` on a large batch —
lands in this regime for any temporal recall that intersects the dense
zone. Profiling against a representative 660k-row bank with a 1-day window
showed:

- 33 s execution time
- 30 MB external sort to disk
- ~2.8M shared buffer touches per query
- ~184k disk reads per query

Under N-way concurrent recall this can saturate the primary.

## How

Before issuing the real temporal query, ask the planner via `EXPLAIN
(FORMAT JSON)` how many rows the Phase 1 filter would match. The planner
walks its statistics and returns an estimate in milliseconds with no row
I/O. Above the configurable threshold
(`HINDSIGHT_API_TEMPORAL_RECALL_MAX_ESTIMATED_ROWS`, default 50,000), the
function returns an empty per-fact_type dict and lets semantic+BM25 carry
the recall. The caller in `retrieve_all_fact_types_parallel` already
tolerates an empty temporal arm (it's one of several parallel retrieval
arms).

### Threshold

| filter match count | sort        | per-query | top-50 signal       |
|--------------------|-------------|-----------|---------------------|
| < 50k              | in-memory   | < 2 s     | meaningful          |
| 50k – 100k         | disk        | 5 – 15 s  | weak                |
| > 100k             | disk        | > 15 s    | near-random         |

50k is the conservative lower bound — it doesn't false-positive on healthy
banks (planner estimates tend to over-shoot real counts on partial-index
filters, which is the safe direction here: the gate only over-blocks,
never under-blocks). Estimate accuracy verified at ~99.7% on the
catastrophic case (planner 644,518 vs actual 646,482) and 2–38× over-shoot
on healthy cases, all of which remain well under the threshold.

### Failure modes

- **EXPLAIN can't be parsed** (driver quirk, permission error, dialect
  drift) → fail open and let the temporal query run. Better a slow query
  than a silently-empty recall.
- **Non-postgres backend (Oracle)** → gate opts out entirely. The
  `EXPLAIN FORMAT JSON` format used here is pg-specific and the Oracle
  planner surface would need its own implementation.

## Tests

Five unit tests under
`hindsight-api-slim/tests/test_temporal_recall_circuit_breaker.py`:

- gate fires above threshold (skips the real query)
- gate allows below threshold (real query runs)
- strict-inequality boundary (a refactor switching `>` to `>=` would
  silently change behavior — pinned)
- EXPLAIN-failure fail-open path
- non-postgres backend opt-out

All 5 pass. Broader regression sweep (112 tests across `search/` and
`db_abstraction`) clean. Lint hook clean.

## Test plan
- [ ] CI green
- [ ] Roll out behind the default 50,000 threshold; instrument logs to
      observe how often the gate triggers in real workloads
- [ ] If false-positives appear, raise the env var without redeploying