### PR TITLE
fix(search): escape pgroonga BM25 query text

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -201,13 +201,14 @@ class PostgreSQLDialect(SQLDialect):
             bm25_order_by = f"text <@> to_bm25query({text_param}, 'idx_memory_units_text_search') ASC"
             bm25_where_filter = ""
         elif text_search_extension == "pgroonga":
-            # &@~ accepts pgroonga's query syntax (raw query text). pgroonga_score
-            # returns a non-negative relevance score (higher = better).
+            # &@~ accepts pgroonga's query syntax. Escape the bind parameter so
+            # literal memory text containing operators like ">" or "(" is not
+            # parsed as a malformed query expression.
             bm25_score_expr = "pgroonga_score(tableoid, ctid)"
             bm25_order_by = f"{bm25_score_expr} DESC"
             bm25_where_filter = (
                 f"AND (COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, '')) "
-                f"&@~ {text_param}"
+                f"&@~ pgroonga_query_escape({text_param})"
             )
         elif text_search_extension == "pg_search":
             # ParadeDB pg_search: BM25 index over (id, text, context, text_signals)

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -260,10 +260,11 @@ class TestPostgreSQLDialect:
             bank_id_param="$2", limit_param="$3", text_param="$4",
             text_search_extension="pgroonga",
         )
-        # pgroonga uses the &@~ operator + pgroonga_score for ranking. The
-        # configured bm25_language is intentionally NOT used here — pgroonga's
-        # tokenizer is set at index creation, not query time.
-        assert "&@~ $4" in arm
+        # pgroonga uses the &@~ operator + pgroonga_score for ranking. Escape
+        # the query parameter so literal text containing pgroonga operators is
+        # not parsed as query syntax.
+        assert "&@~ pgroonga_query_escape($4)" in arm
+        assert "&@~ $4" not in arm
         assert "pgroonga_score(tableoid, ctid)" in arm
         assert "to_tsquery" not in arm
 
@@ -303,8 +304,8 @@ class TestPostgreSQLDialect:
         assert result == "hello world"
 
     def test_prepare_bm25_text_pgroonga(self, d):
-        # pgroonga accepts raw query text via &@~ and parses it with its own
-        # query syntax; we pass the original query through unchanged.
+        # Keep the user's text unchanged here; the SQL builder escapes the bind
+        # parameter at query time before invoking pgroonga's query parser.
         result = d.prepare_bm25_text(["hello", "world"], "hello world", text_search_extension="pgroonga")
         assert result == "hello world"
 


### PR DESCRIPTION
## Summary

- escape pgroonga BM25 query parameters with `pgroonga_query_escape(...)` before using `&@~`
- keep pgroonga query text unchanged at preparation time while making the SQL builder responsible for escaping
- update PostgreSQL dialect regression coverage for the escaped pgroonga query expression

Closes #1955.

## Tests

- `uv run --project hindsight-api-slim pytest hindsight-api-slim/tests/test_db_abstraction.py -q`
- `uv run --project hindsight-api-slim ruff check hindsight-api-slim/hindsight_api/engine/sql/postgresql.py hindsight-api-slim/tests/test_db_abstraction.py`
- `./scripts/hooks/lint.sh`