### PR TITLE
fix(test): use current default model in Vertex AI integration test

### DIFF
--- a/hindsight-api-slim/tests/test_vertexai_provider.py
+++ b/hindsight-api-slim/tests/test_vertexai_provider.py
@@ -227,7 +227,7 @@ async def test_vertexai_integration_actual_api():
         provider="vertexai",
         api_key="",
         base_url="",
-        model="google/gemini-2.0-flash-001",
+        model="google/gemini-2.5-flash-lite",
     )
 
     try:


### PR DESCRIPTION
## Problem

CI was failing on `tests/test_vertexai_provider.py::test_vertexai_integration_actual_api`:

```
google.genai.errors.ClientError: 404 NOT_FOUND ... Publisher Model
`projects/.../publishers/google/models/gemini-2.0-flash-001` was not found
or your project does not have access to it.
```

`gemini-2.0-flash-001` has been retired on Vertex AI.

## Fix

Switch the live integration test to `google/gemini-2.5-flash-lite`, which is already the vertexai provider default in `config.py` (`PROVIDER_DEFAULT_MODELS`). The other tests in the file are mocked and don't hit the API, so they're left unchanged.