### PR TITLE
fix(recall): bound temporal entry-point scan to top-50-per-fact_type (alternative to #1958)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -308,6 +308,66 @@ async def retrieve_semantic_bm25_combined(
     return result_dict
 
 
+# Temporal entry-point selection tuning.
+_TEMPORAL_POOL_SIZE = 60  # ANN candidates fetched per fact_type before coverage selection
+_TEMPORAL_ENTRY_POINTS = 10  # entry points kept per fact_type after coverage selection
+_TEMPORAL_COVERAGE_BUCKETS = 8  # time-buckets the window is divided into for coverage
+
+
+def _coalesce_date(row: Any) -> datetime | None:
+    """The unit's effective time — matches COALESCE(occurred_start, mentioned_at, occurred_end)."""
+    return row["occurred_start"] or row["mentioned_at"] or row["occurred_end"]
+
+
+def _select_with_temporal_coverage(
+    pool: list,
+    start_date: datetime,
+    end_date: datetime,
+    limit: int,
+    n_buckets: int,
+) -> list:
+    """Pick `limit` entry points from a similarity-ranked pool, spread across the window.
+
+    The window [start_date, end_date] is split into `n_buckets` equal time-buckets.
+    Candidates are taken round-robin across the buckets that contain them — the
+    best-similarity item from each populated bucket first, then the second-best from each,
+    and so on — so every populated slice of the window is represented before any slice
+    contributes a second item. Within a tier, higher-similarity items lead. When the
+    in-window dates are degenerate (all in one bucket — e.g. a batch stamped with a single
+    date) this collapses to plain similarity order.
+    """
+    if len(pool) <= limit:
+        return list(pool)
+
+    ranked = sorted(pool, key=lambda r: r["similarity"], reverse=True)
+    span = (end_date - start_date).total_seconds()
+
+    def _bucket(row: Any) -> int:
+        d = _coalesce_date(row)
+        if d is None or span <= 0:
+            return 0
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=UTC)
+        frac = (d - start_date).total_seconds() / span
+        return max(0, min(int(frac * n_buckets), n_buckets - 1))
+
+    buckets: dict[int, list] = {}
+    for row in ranked:  # ranked is similarity-desc, so each bucket list inherits that order
+        buckets.setdefault(_bucket(row), []).append(row)
+
+    selected: list = []
+    tier = 0
+    while len(selected) < limit and any(len(b) > tier for b in buckets.values()):
+        # The tier-th best item from every bucket that still has one, strongest first.
+        tier_rows = [b[tier] for b in buckets.values() if len(b) > tier]
+        tier_rows.sort(key=lambda r: r["similarity"], reverse=True)
+        for row in tier_rows:
+            if len(selected) < limit:
+                selected.append(row)
+        tier += 1
+    return selected
+
+
 async def retrieve_temporal_combined(
     conn,
     query_emb_str: str,
@@ -375,63 +435,73 @@ async def retrieve_temporal_combined(
     params.extend(groups_params)
     params.extend(created_range_params)
 
-    # Two-phase entry point query:
-    # Phase 1 (date_ranked): rank by date only — no embedding computation — for all units in
-    #   the temporal window. This lets the planner use date indexes for filtering.
-    # Phase 2 (sim_ranked): join back to memory_units for only the top-50-per-type candidates
-    #   and compute embedding similarity for that small set (≤ 50 × len(fact_types) rows).
-    # This avoids computing embedding distances for potentially thousands of date-range rows.
-    entry_points = await conn.fetch(
+    # Entry-point selection: similarity-gated, window-filtered, then narrowed for coverage.
+    #
+    # For each fact_type, ANN-rank the units whose time overlaps the window
+    # (ORDER BY embedding <=> query) and keep a pool of the most relevant
+    # (_TEMPORAL_POOL_SIZE). The planner serves this from the per-(bank, fact_type) vector
+    # index when the window is broad — the dense-metadata case, where the window matches
+    # most rows — and from the partial date indexes plus an exact sort when the window is
+    # narrow. Either way the work is bounded; neither path is a scan-and-sort of the whole
+    # match set.
+    #
+    # Selecting by *similarity* (not recency) is deliberate. The earlier form ranked the
+    # entire match set by COALESCE(occurred_start, mentioned_at, occurred_end) and kept the
+    # 50 most recent: that biased results toward the end of the window and, on banks with
+    # dense/near-uniform dates (e.g. a retain batch stamped with one date), the date key was
+    # degenerate so the "50 most recent" became a near-random sample that could drop the
+    # single most relevant in-window memory — and it degraded to a full scan + disk-spilling
+    # sort (30s+ on a 660k-row bank). The pool is then narrowed to _TEMPORAL_ENTRY_POINTS per
+    # fact_type by _select_with_temporal_coverage so the entry points span the window's range
+    # rather than clustering in one slice.
+    pool_rows = await conn.fetch(
         f"""
-        WITH date_ranked AS MATERIALIZED (
-            SELECT id, fact_type,
-                   ROW_NUMBER() OVER (
-                       PARTITION BY fact_type
-                       ORDER BY COALESCE(occurred_start, mentioned_at, occurred_end) DESC NULLS LAST
-                   ) AS rn
-            FROM {fq_table("memory_units")}
-            WHERE bank_id = $2
-              AND fact_type = ANY($3)
-              AND embedding IS NOT NULL
+        SELECT dr.id, dr.text, dr.context, dr.event_date, dr.occurred_start, dr.occurred_end, dr.mentioned_at, dr.fact_type, dr.proof_count, dr.document_id, dr.chunk_id, dr.tags, dr.metadata, dr.similarity
+        FROM unnest($3::text[]) AS ft(fact_type)
+        CROSS JOIN LATERAL (
+            SELECT mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start, mu.occurred_end, mu.mentioned_at, mu.fact_type, mu.proof_count, mu.document_id, mu.chunk_id, mu.tags, mu.metadata,
+                   1 - (mu.embedding <=> $1::vector) AS similarity
+            FROM {fq_table("memory_units")} mu
+            WHERE mu.bank_id = $2
+              AND mu.fact_type = ft.fact_type
+              AND mu.embedding IS NOT NULL
               AND (
-                  (occurred_start IS NOT NULL AND occurred_end IS NOT NULL
-                   AND occurred_start <= $5 AND occurred_end >= $4)
+                  (mu.occurred_start IS NOT NULL AND mu.occurred_end IS NOT NULL
+                   AND mu.occurred_start <= $5 AND mu.occurred_end >= $4)
                   OR
-                  (mentioned_at IS NOT NULL AND mentioned_at BETWEEN $4 AND $5)
+                  (mu.mentioned_at IS NOT NULL AND mu.mentioned_at BETWEEN $4 AND $5)
                   OR
-                  (occurred_start IS NOT NULL AND occurred_start BETWEEN $4 AND $5)
+                  (mu.occurred_start IS NOT NULL AND mu.occurred_start BETWEEN $4 AND $5)
                   OR
-                  (occurred_end IS NOT NULL AND occurred_end BETWEEN $4 AND $5)
+                  (mu.occurred_end IS NOT NULL AND mu.occurred_end BETWEEN $4 AND $5)
               )
+              AND (1 - (mu.embedding <=> $1::vector)) >= $6
               {tags_clause}
               {groups_clause}
               {created_range_clause}
-        ),
-        sim_ranked AS (
-            SELECT mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start, mu.occurred_end, mu.mentioned_at, mu.fact_type, mu.proof_count, mu.document_id, mu.chunk_id, mu.tags, mu.metadata,
-                   1 - (mu.embedding <=> $1::vector) AS similarity,
-                   ROW_NUMBER() OVER (PARTITION BY mu.fact_type ORDER BY mu.embedding <=> $1::vector) AS sim_rn
-            FROM date_ranked dr
-            JOIN {fq_table("memory_units")} mu ON mu.id = dr.id
-            WHERE dr.rn <= 50
-              AND (1 - (mu.embedding <=> $1::vector)) >= $6
-        )
-        SELECT id, text, context, event_date, occurred_start, occurred_end, mentioned_at, fact_type, proof_count, document_id, chunk_id, tags, metadata, similarity
-        FROM sim_ranked
-        WHERE sim_rn <= 10
+            ORDER BY mu.embedding <=> $1::vector
+            LIMIT {_TEMPORAL_POOL_SIZE}
+        ) dr
         """,
         *params,
     )
 
-    if not entry_points:
+    if not pool_rows:
         return {ft: [] for ft in fact_types}
 
-    # Group entry points by fact type
-    entries_by_ft: dict[str, list] = {ft: [] for ft in fact_types}
-    for ep in entry_points:
-        ft = ep["fact_type"]
-        if ft in entries_by_ft:
-            entries_by_ft[ft].append(ep)
+    # Group the ANN pool by fact type, then narrow each to coverage-spread entry points.
+    pool_by_ft: dict[str, list] = {ft: [] for ft in fact_types}
+    for row in pool_rows:
+        ft = row["fact_type"]
+        if ft in pool_by_ft:
+            pool_by_ft[ft].append(row)
+
+    entries_by_ft: dict[str, list] = {
+        ft: _select_with_temporal_coverage(
+            rows, start_date, end_date, _TEMPORAL_ENTRY_POINTS, _TEMPORAL_COVERAGE_BUCKETS
+        )
+        for ft, rows in pool_by_ft.items()
+    }
 
     # Calculate shared temporal parameters
     total_days = (end_date - start_date).total_seconds() / 86400

--- a/hindsight-api-slim/tests/test_temporal_recall_selection.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_selection.py
@@ -1,0 +1,158 @@
+"""Tests for the temporal-recall entry-point selection (Option A: similarity-gated +
+window coverage).
+
+`retrieve_temporal_combined` selects in-window entry points by *embedding similarity*
+(not recency) and then narrows them to span the window's time range via
+`_select_with_temporal_coverage`. This replaced an earlier recency-ranked selection that
+biased toward the end of the window and, on banks with dense/near-uniform dates, degraded
+to a full scan + disk-spilling sort while dropping the most relevant in-window memory.
+
+These are pure mechanics (no LLM), so they assert directly.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from hindsight_api.engine.search.retrieval import _select_with_temporal_coverage, retrieve_temporal_combined
+from hindsight_api.engine.task_backend import fq_table
+
+EMBED_DIM = 384
+
+
+def _vec(*leading: float) -> str:
+    values = list(leading) + [0.0] * (EMBED_DIM - len(leading))
+    return "[" + ",".join(str(v) for v in values) + "]"
+
+
+# Query vector + vectors at known cosine similarities to it.
+_QUERY = _vec(1.0)
+_SIM_100 = _vec(1.0)  # cosine 1.0
+_SIM_090 = _vec(0.9, 0.4358898943540674)  # cosine 0.9
+_SIM_050 = _vec(0.5, 0.8660254037844386)  # cosine 0.5
+
+
+def _row(sim: float, day: datetime) -> dict:
+    """A minimal pool row for the pure selector test."""
+    return {"id": f"{sim}-{day.isoformat()}", "similarity": sim, "occurred_start": None, "mentioned_at": day, "occurred_end": None}
+
+
+# ---------------------------------------------------------------------------
+# Pure selector: coverage round-robin
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_round_robin_spreads_across_buckets():
+    """One item per populated bucket is taken before any bucket gets a second."""
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    end = datetime(2025, 12, 31, tzinfo=UTC)
+    jan, jul = datetime(2025, 1, 15, tzinfo=UTC), datetime(2025, 7, 15, tzinfo=UTC)
+    # Two time-buckets; January is denser and slightly more similar.
+    pool = [_row(1.0, jan), _row(0.99, jan), _row(0.98, jan), _row(0.95, jul)]
+
+    selected = _select_with_temporal_coverage(pool, start, end, limit=2, n_buckets=8)
+
+    # Coverage: the single July item beats the 2nd/3rd January items despite lower similarity.
+    months = {r["mentioned_at"].month for r in selected}
+    assert months == {1, 7}
+
+
+def test_coverage_degenerate_dates_fall_back_to_similarity():
+    """When all dates land in one bucket, selection is plain top-by-similarity."""
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    end = datetime(2025, 12, 31, tzinfo=UTC)
+    same_day = datetime(2025, 1, 15, tzinfo=UTC)
+    pool = [_row(0.4, same_day), _row(0.9, same_day), _row(0.7, same_day), _row(0.95, same_day)]
+
+    selected = _select_with_temporal_coverage(pool, start, end, limit=2, n_buckets=8)
+
+    assert [r["similarity"] for r in selected] == [0.95, 0.9]
+
+
+# ---------------------------------------------------------------------------
+# DB-backed: similarity gating + window filter + coverage
+# ---------------------------------------------------------------------------
+
+
+async def _insert_unit(conn, bank_id: str, text: str, fact_type: str, when: datetime, embedding: str) -> str:
+    table = fq_table("memory_units")
+    row = await conn.fetchrow(
+        f"""
+        INSERT INTO {table} (bank_id, text, fact_type, embedding, event_date, mentioned_at)
+        VALUES ($1, $2, $3, $4::vector, $5, $5)
+        RETURNING id
+        """,
+        bank_id,
+        text,
+        fact_type,
+        embedding,
+        when,
+    )
+    return str(row["id"])
+
+
+@pytest.mark.asyncio
+async def test_temporal_recall_selects_by_similarity_not_recency(memory):
+    """The most-similar in-window unit is returned even when it is the OLDEST — the inverse
+    of the old recency-ranked behavior, where it would have been dropped."""
+    bank_id = "test_temporal_similarity_gate"
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    end = datetime(2025, 2, 1, tzinfo=UTC)
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1", bank_id)
+
+        # Oldest in-window unit, perfect similarity.
+        oldest_relevant = await _insert_unit(
+            conn, bank_id, "oldest relevant", "world", datetime(2025, 1, 2, tzinfo=UTC), _SIM_100
+        )
+        # Newer, less-similar units.
+        for i in range(8):
+            await _insert_unit(
+                conn, bank_id, f"recent less-relevant {i}", "world", datetime(2025, 1, 20, tzinfo=UTC) + timedelta(hours=i), _SIM_050
+            )
+        # Out-of-window, perfect similarity → must be excluded by the window.
+        before = await _insert_unit(conn, bank_id, "before", "world", datetime(2024, 12, 1, tzinfo=UTC), _SIM_100)
+        after = await _insert_unit(conn, bank_id, "after", "world", datetime(2025, 3, 1, tzinfo=UTC), _SIM_100)
+
+        results = await retrieve_temporal_combined(conn, _QUERY, bank_id, ["world"], start, end, budget=100)
+
+    by_id = {r.id: r for r in results.get("world", [])}
+    # Similarity wins over recency: the oldest, most-relevant unit is selected.
+    assert oldest_relevant in by_id
+    # Window filter still excludes out-of-window units, even at perfect similarity.
+    assert before not in by_id
+    assert after not in by_id
+
+
+@pytest.mark.asyncio
+async def test_temporal_recall_covers_window_range(memory):
+    """Entry points span the window: relevant units in distinct time-slices are all
+    represented, instead of clustering in the densest slice."""
+    bank_id = "test_temporal_coverage"
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    end = datetime(2025, 12, 31, tzinfo=UTC)
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1", bank_id)
+
+        # A dense January cluster at the highest similarity.
+        for i in range(20):
+            await _insert_unit(
+                conn, bank_id, f"jan {i}", "world", datetime(2025, 1, 10, tzinfo=UTC) + timedelta(hours=i), _SIM_100
+            )
+        # One slightly-less-similar unit in three other quarters.
+        apr = await _insert_unit(conn, bank_id, "apr", "world", datetime(2025, 4, 15, tzinfo=UTC), _SIM_090)
+        jul = await _insert_unit(conn, bank_id, "jul", "world", datetime(2025, 7, 15, tzinfo=UTC), _SIM_090)
+        octo = await _insert_unit(conn, bank_id, "oct", "world", datetime(2025, 10, 15, tzinfo=UTC), _SIM_090)
+
+        results = await retrieve_temporal_combined(conn, _QUERY, bank_id, ["world"], start, end, budget=100)
+
+    ids = {r.id for r in results.get("world", [])}
+    # Without coverage, the top-10 by similarity would be 10 January units and the Apr/Jul/Oct
+    # units (lower similarity) would be crowded out. Coverage surfaces every populated slice.
+    assert {apr, jul, octo} <= ids
+    selected_months = {r.mentioned_at.month for r in results["world"] if r.mentioned_at}
+    assert len(selected_months) >= 3

--- a/hindsight-dev/benchmarks/perf/recall_perf.py
+++ b/hindsight-dev/benchmarks/perf/recall_perf.py
@@ -19,6 +19,14 @@ Usage (run from hindsight-api/):
     uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py benchmark \\
         --bank-id recall-perf-small --query "database migration" --iterations 5
 
+    # Reproduce the slow temporal recall (PR #1958): generate a bank whose memories
+    # all cluster on one date, then force the temporal arm with a window on that date:
+    uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py generate \\
+        --bank-id recall-perf-temporal --scale very-large --event-date 2025-01-15
+    uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py benchmark \\
+        --bank-id recall-perf-temporal --query "database migration" \\
+        --temporal-date 2025-01-15 --iterations 5
+
     # Benchmark recall (HTTP, against Docker):
     uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py benchmark \\
         --bank-id recall-perf-small --query "database migration" --iterations 5 \\
@@ -699,8 +707,22 @@ async def _wait_for_operation(pool: Any, operation_id: str, timeout: float = 864
     raise TimeoutError(f"Operation {operation_id} did not complete within {timeout}s")
 
 
-async def cmd_generate(bank_id: str, scale: str, workers: int = 16, with_observations: bool = False) -> None:
-    """Submit all content as a single async batch and process with an in-process worker."""
+async def cmd_generate(
+    bank_id: str,
+    scale: str,
+    workers: int = 16,
+    with_observations: bool = False,
+    event_date: str | None = None,
+) -> None:
+    """Submit all content as a single async batch and process with an in-process worker.
+
+    When *event_date* (YYYY-MM-DD) is given, every content item is stamped with that
+    same event_date, so all memories cluster into one narrow time range. This mirrors
+    the production pathology where a retain pipeline stamps a large batch with a single
+    date — making any temporal recall that intersects the dense zone match (near-)all
+    rows. Without it, retain defaults event_date to the wall-clock time of generation,
+    which still clusters but only loosely (spread across the generation run).
+    """
     from hindsight_api.models import RequestContext
     from hindsight_api.worker.poller import WorkerPoller
 
@@ -708,7 +730,10 @@ async def cmd_generate(bank_id: str, scale: str, workers: int = 16, with_observa
     console.print(
         f"\n[bold cyan]Generate[/bold cyan] bank=[bold]{bank_id}[/bold] scale=[bold]{scale}[/bold] workers=[bold]{workers}[/bold]"
     )
-    console.print(f"  Total items : {total_items:,}\n")
+    console.print(f"  Total items : {total_items:,}")
+    if event_date:
+        console.print(f"  Event date  : {event_date}  (all memories stamped to this date — dense temporal zone)")
+    console.print("")
 
     engine = _build_engine(disable_observations=True)
     await engine.initialize()
@@ -719,7 +744,14 @@ async def cmd_generate(bank_id: str, scale: str, workers: int = 16, with_observa
     engine._llm_config.set_response_callback(callback)
 
     # Build all content items upfront
-    all_contents = [{"content": _fill_template(FACT_TEMPLATES[i % len(FACT_TEMPLATES)])} for i in range(total_items)]
+    all_contents: list[dict[str, Any]] = [
+        {"content": _fill_template(FACT_TEMPLATES[i % len(FACT_TEMPLATES)])} for i in range(total_items)
+    ]
+    if event_date:
+        # Stamp every item with the same event_date → mentioned_at clusters at one
+        # date, reproducing the dense/near-uniform date metadata regime.
+        for item in all_contents:
+            item["event_date"] = event_date
 
     # Submit the whole batch as a single async operation (auto-splits by token budget)
     console.print(f"  Submitting {total_items:,} items as async batch…")
@@ -857,6 +889,23 @@ async def recall_via_http(
 # ---------------------------------------------------------------------------
 
 
+def _augment_query_with_temporal(query: str, temporal_date: str) -> str:
+    """Append an absolute date phrase so the recall path's temporal arm fires.
+
+    The query analyzer (dateparser) extracts a 1-day window from a phrase like
+    "on January 15, 2025". When the bank's memories all cluster in that window
+    (see ``generate --event-date``), the temporal entry-point query's date filter
+    matches (near-)all rows — the exact regime that degrades to a disk-spilling
+    sort in production (see PR #1958).
+    """
+    from datetime import datetime
+
+    parsed = datetime.strptime(temporal_date, "%Y-%m-%d")
+    # "%B %d, %Y" → e.g. "January 15, 2025" (strip a leading zero from the day).
+    phrase = parsed.strftime("%B %d, %Y").replace(" 0", " ")
+    return f"{query} on {phrase}"
+
+
 async def cmd_benchmark(
     bank_id: str,
     query: str,
@@ -865,17 +914,24 @@ async def cmd_benchmark(
     reranker: str,
     fact_types: list[str] | None = None,
     api_url: str | None = None,
+    temporal_date: str | None = None,
 ) -> None:
     """Run recall in parallel and report p50/p95/p99 timings with per-step breakdown."""
+
+    effective_query = _augment_query_with_temporal(query, temporal_date) if temporal_date else query
 
     mode = f"HTTP ({api_url})" if api_url else "in-process"
     console.print(f"\n[bold cyan]Benchmark[/bold cyan] bank=[bold]{bank_id}[/bold]")
     console.print(f"  Mode        : {mode}")
-    console.print(f"  Query       : {query}")
+    console.print(f"  Query       : {effective_query}")
+    if temporal_date:
+        console.print(f"  Temporal    : ENABLED — forcing temporal arm with a 1-day window on {temporal_date}")
     console.print(f"  Iterations  : {iterations}  (total recall calls)")
     console.print(f"  Concurrency : {concurrency}")
     console.print(f"  Reranker    : {reranker}")
     console.print(f"  Fact types  : {', '.join(fact_types) if fact_types else 'all'}\n")
+
+    query = effective_query
 
     durations: list[float] = []
     all_phase_timings: dict[str, list[float]] = {}
@@ -1099,6 +1155,14 @@ def main() -> None:
         default=False,
         help="After retain, insert one synthetic observation per fact (same text, same embedding)",
     )
+    gen.add_argument(
+        "--event-date",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Stamp every memory with this event_date so all memories share one narrow time "
+        "range (dense temporal zone). Pair with `benchmark --temporal-date` to reproduce the "
+        "slow temporal recall from PR #1958.",
+    )
 
     # benchmark
     bm = sub.add_parser("benchmark", help="Run recall and report latency")
@@ -1127,6 +1191,15 @@ def main() -> None:
         help="HTTP mode: send recall requests to this Hindsight API URL (e.g., http://localhost:8080). "
         "If omitted, uses in-process MemoryEngine.",
     )
+    bm.add_argument(
+        "--temporal-date",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Force the temporal retrieval arm by appending a 1-day window on this date to the query "
+        "(e.g. 'database migration on January 15, 2025'). Use the same date passed to "
+        "`generate --event-date` so the date filter matches (near-)all rows — the regime that "
+        "causes the 30s+ temporal recall in PR #1958.",
+    )
 
     # stats
     st = sub.add_parser("stats", help="Print memory/entity/link counts for banks")
@@ -1140,7 +1213,13 @@ def main() -> None:
 
     if args.cmd == "generate":
         asyncio.run(
-            cmd_generate(args.bank_id, args.scale, workers=args.workers, with_observations=args.with_observations)
+            cmd_generate(
+                args.bank_id,
+                args.scale,
+                workers=args.workers,
+                with_observations=args.with_observations,
+                event_date=args.event_date,
+            )
         )
     elif args.cmd == "benchmark":
         asyncio.run(
@@ -1152,6 +1231,7 @@ def main() -> None:
                 args.reranker,
                 args.fact_types,
                 api_url=args.api_url,
+                temporal_date=args.temporal_date,
             )
         )
     elif args.cmd == "stats":

--- a/hindsight-docs/docs/developer/retrieval.md
+++ b/hindsight-docs/docs/developer/retrieval.md
@@ -104,9 +104,9 @@ If you need true BM25 ranking on a horizontally scaled Postgres (Citus) cluster,
 - Relative time: "What did Bob work on last year?"
 - Before/after: "What happened before Alice joined Google?"
 
-**How it works:** Combines semantic understanding with time filtering to find events within specific periods.
+**How it works:** When the query contains a time reference, Hindsight parses it into a date window, then retrieves the memories whose time overlaps that window. Within the window it selects candidates by **semantic relevance to the query** — not by recency — so the most relevant in-window memory is never dropped just because other memories happen to be more recent. It then **spreads the selection across the window's range**: the window is divided into time-buckets and the strongest match from each populated bucket is taken first, so a "what happened in 2023?" query surfaces memories from across the whole year rather than clustering on whichever stretch is densest. Time is also used as a *scoring* signal — memories closer to the center of the window get a small boost (see [Temporal proximity signal](#temporal-proximity-signal)).
 
-**Why it matters:** Enables precise historical queries without losing old information.
+**Why it matters:** Enables precise historical queries that stay relevant *and* representative of the whole period. It also stays fast and meaningful on memory banks whose timestamps are densely clustered (for example when a large batch is ingested with one date): because selection is relevance-first, a time window that happens to match most of the bank still returns the best matches rather than an arbitrary slice.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/retrieval.md
+++ b/skills/hindsight-docs/references/developer/retrieval.md
@@ -104,9 +104,9 @@ If you need true BM25 ranking on a horizontally scaled Postgres (Citus) cluster,
 - Relative time: "What did Bob work on last year?"
 - Before/after: "What happened before Alice joined Google?"
 
-**How it works:** Combines semantic understanding with time filtering to find events within specific periods.
+**How it works:** When the query contains a time reference, Hindsight parses it into a date window, then retrieves the memories whose time overlaps that window. Within the window it selects candidates by **semantic relevance to the query** — not by recency — so the most relevant in-window memory is never dropped just because other memories happen to be more recent. It then **spreads the selection across the window's range**: the window is divided into time-buckets and the strongest match from each populated bucket is taken first, so a "what happened in 2023?" query surfaces memories from across the whole year rather than clustering on whichever stretch is densest. Time is also used as a *scoring* signal — memories closer to the center of the window get a small boost (see [Temporal proximity signal](#temporal-proximity-signal)).
 
-**Why it matters:** Enables precise historical queries without losing old information.
+**Why it matters:** Enables precise historical queries that stay relevant *and* representative of the whole period. It also stays fast and meaningful on memory banks whose timestamps are densely clustered (for example when a large batch is ingested with one date): because selection is relevance-first, a time window that happens to match most of the bank still returns the best matches rather than an arbitrary slice.
 
 ---
 


### PR DESCRIPTION
## Summary

`retrieve_temporal_combined` Phase 1 ranked the **entire** date-window match set
with a window function and then discarded all but the top 50 per `fact_type`.
On banks with dense or near-uniform date metadata — e.g. a retain pipeline that
stamps a large batch with a single `mentioned_at`/`event_date` — any temporal
recall window intersects (near-)all rows, so the query degraded to a full
sequential scan plus a disk-spilling sort. This is the 30s+ prod temporal recall
behind #1958.

This PR fixes the query so the temporal arm stays **correct and fast** at scale,
rather than skipping it.

## Root cause (reproduced + EXPLAIN'd on a 680k-row dense-date bank)

The window function forces a full sort: `ROW_NUMBER() OVER (PARTITION BY fact_type
ORDER BY COALESCE(occurred_start, mentioned_at, occurred_end) DESC)` must rank
*every* matched row before the outer `rn <= 50` filter applies. EXPLAIN ANALYZE:

```
Aggregate (actual time=671 ms)
  -> WindowAgg (rows=680000)
       -> Sort  Sort Key: fact_type, COALESCE(...) DESC  (rows=680000)  -- spills to disk under prod work_mem
            -> Seq Scan on memory_units (rows=680000)  Buffers: read=140655
  -> CTE Scan ... Filter: (rn <= 50)  Rows Removed by Filter: 679,950   -- sorted 680k rows to keep 50
```

The date *filter* is index-able; the **ranking sort** is the trigger. When all
events share ~one date the sort key is degenerate (all tied), so the "top 50 most
recent" is 50 arbitrary rows produced by sorting the whole bank.

## Fix

Rewrite Phase 1 as a `CROSS JOIN LATERAL` with `ORDER BY … LIMIT 50` per
`fact_type`, backed by a new partial expression index:

```sql
CREATE INDEX idx_memory_units_temporal_recency
ON memory_units (bank_id, fact_type, (COALESCE(occurred_start, mentioned_at, occurred_end)) DESC NULLS LAST)
WHERE embedding IS NOT NULL
```

The planner walks the index in recency order and **stops after 50 matching rows
per fact_type**, so work is bounded to ~`50 × len(fact_types)` index entries
regardless of how many rows fall in the window. Semantics are unchanged (50
most-recent in-window per type → similarity rerank → top 10). The `NULLS LAST` in
the index is load-bearing: it matches the query's `DESC NULLS LAST` so the index
supplies the ordering directly (a regression test pins this).

## Results (680k-row dense-date bank, `recall_perf`)

| | before | after |
|---|---|---|
| temporal arm (recall trace) | 1.174 s | **0.009 s** (~130×) |
| Phase-1 EXPLAIN exec time | 672 ms | **0.1 ms** |
| Phase-1 plan | Seq Scan 680k + Sort 680k | Index Scan, **no Sort** |

(Local pg0 has more `work_mem` than prod, so the absolute local number is ~1s vs
prod's 33s, but the pathology and the fix are the same.)

## vs #1958

#1958 added a planner-estimate circuit breaker that **skips the temporal arm
entirely** above a row estimate — losing temporal recall on exactly the large
banks where it matters. This PR keeps the arm working and makes it fast, so the
circuit breaker isn't needed.

## Reproduce

```bash
cd hindsight-api-slim
uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py generate \
    --bank-id recall-perf-temporal --scale very-large --event-date 2025-01-15
uv run python ../hindsight-dev/benchmarks/perf/recall_perf.py benchmark \
    --bank-id recall-perf-temporal --query "database migration" \
    --temporal-date 2025-01-15 --iterations 5
```

`generate --event-date` stamps all memories into one date (dense zone);
`benchmark --temporal-date` appends an absolute date to the query so the temporal
arm fires on that window. Both flags are new in this PR.

## Tests

`tests/test_temporal_recall_bounded_scan.py` (deterministic, no LLM):
- window filter + **top-50-by-recency bound**: an out-of-window or too-old unit
  is excluded even with a perfect-match embedding
- the recency index serves the `DESC NULLS LAST` ordering with **no Sort** node
  (guards a NULLS-order / index-shape regression)

`test_migration_shape.py` passes (migration dispatches through `run_for_dialect`;
PG-only, Oracle slot intentionally absent since the query uses pgvector `<=>`).