### PR TITLE
docs(api/bank-templates): fix entity_labels manifest example — label-group objects, not string[]

### DIFF
--- a/hindsight-docs/docs/developer/api/bank-templates.mdx
+++ b/hindsight-docs/docs/developer/api/bank-templates.mdx
@@ -44,7 +44,7 @@ Browse the [Bank Templates Hub](/templates) for ready-to-use templates.
     "disposition_empathy": 3,
     "enable_observations": true,
     "observations_mission": "...",
-    "entity_labels": ["PERSON", "ORGANIZATION"],
+    "entity_labels": [{ "key": "sentiment", "type": "value", "values": [{ "value": "positive" }, { "value": "negative" }] }],
     "entities_allow_free_form": true
   },
   "mental_models": [
@@ -101,7 +101,7 @@ All fields in `bank` are optional. Only the fields you include will be set as pe
 | `disposition_empathy` | integer (1-5) | How empathetic the disposition is |
 | `enable_observations` | boolean | Toggle observation consolidation |
 | `observations_mission` | string | Controls what gets synthesised into observations |
-| `entity_labels` | string[] | Controlled vocabulary for entity labels |
+| `entity_labels` | object[] | Controlled vocabulary as label groups — see [Memory Banks → entity_labels](./memory-banks#entity-labels) |
 | `entities_allow_free_form` | boolean | Allow entities outside the label vocabulary |
 
 ### Mental Model Fields

--- a/skills/hindsight-docs/references/developer/api/bank-templates.md
+++ b/skills/hindsight-docs/references/developer/api/bank-templates.md
@@ -33,7 +33,7 @@ Browse the Bank Templates Hub for ready-to-use templates.
     "disposition_empathy": 3,
     "enable_observations": true,
     "observations_mission": "...",
-    "entity_labels": ["PERSON", "ORGANIZATION"],
+    "entity_labels": [{ "key": "sentiment", "type": "value", "values": [{ "value": "positive" }, { "value": "negative" }] }],
     "entities_allow_free_form": true
   },
   "mental_models": [
@@ -90,7 +90,7 @@ All fields in `bank` are optional. Only the fields you include will be set as pe
 | `disposition_empathy` | integer (1-5) | How empathetic the disposition is |
 | `enable_observations` | boolean | Toggle observation consolidation |
 | `observations_mission` | string | Controls what gets synthesised into observations |
-| `entity_labels` | string[] | Controlled vocabulary for entity labels |
+| `entity_labels` | object[] | Controlled vocabulary as label groups — see [Memory Banks → entity_labels](./memory-banks#entity-labels) |
 | `entities_allow_free_form` | boolean | Allow entities outside the label vocabulary |
 
 ### Mental Model Fields


### PR DESCRIPTION
The **Manifest Schema** example in `bank-templates.mdx` documents `entity_labels` as a bare string array:

```json
"entity_labels": ["PERSON", "ORGANIZATION"],
```

But `BankTemplateConfig.entity_labels` is `list[dict[str, Any]]` (`api/http.py`), and each entry is parsed via `LabelGroup` (`engine/retain/entity_labels.py`), which requires a `key`. A bare string is passed through `_migrate_label_group` unchanged and then `LabelGroup.model_validate("PERSON")` raises a `ValidationError` — so copy-pasting the documented manifest fails import.

This aligns the example (and the field-table type) with the engine and with the already-correct label-group shape documented in `memory-banks.mdx`.

- example: bare `string[]` → a minimal valid label group (`key`/`type`/`values`)
- field table: `string[]` → `object[]`, linking to the `entity_labels` reference in Memory Banks

Docs-only. The `skills/hindsight-docs` mirror was regenerated via `scripts/generate-docs-skill.sh`.