### PR TITLE
feat(llm): opt-in strict json_schema for capable openai-compatible backends

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -448,6 +448,7 @@ ENV_LLAMACPP_GPU_LAYERS = "HINDSIGHT_API_LLAMACPP_GPU_LAYERS"
 ENV_LLAMACPP_CONTEXT_SIZE = "HINDSIGHT_API_LLAMACPP_CONTEXT_SIZE"
 ENV_LLAMACPP_CHAT_FORMAT = "HINDSIGHT_API_LLAMACPP_CHAT_FORMAT"
 ENV_LLAMACPP_NO_GRAMMAR = "HINDSIGHT_API_LLAMACPP_NO_GRAMMAR"
+ENV_LLM_STRICT_SCHEMA = "HINDSIGHT_API_LLM_STRICT_SCHEMA"
 ENV_LLAMACPP_EXTRA_ARGS = "HINDSIGHT_API_LLAMACPP_EXTRA_ARGS"
 
 # Optimization flags
@@ -575,6 +576,7 @@ DEFAULT_LLAMACPP_GPU_LAYERS = -1  # -1 = offload all layers to GPU (Metal/CUDA)
 DEFAULT_LLAMACPP_CONTEXT_SIZE = 8192
 DEFAULT_LLAMACPP_CHAT_FORMAT = None  # None = auto-detect from GGUF metadata
 DEFAULT_LLAMACPP_NO_GRAMMAR = False  # True = disable JSON grammar enforcement (faster but less reliable)
+DEFAULT_LLM_STRICT_SCHEMA = False  # True = use strict json_schema (grammar-enforced) for structured output on json-schema-capable openai-compatible backends (OpenAI, llama.cpp, vLLM); avoids fragile soft json_object parsing on weaker models
 DEFAULT_LLAMACPP_EXTRA_ARGS = None  # Space-separated extra CLI args for llama.cpp server
 
 DEFAULT_LLM_MAX_CONCURRENT = 32
@@ -1183,6 +1185,7 @@ class HindsightConfig:
     llamacpp_context_size: int  # Context window size
     llamacpp_chat_format: str | None  # Chat template format (None = auto-detect from GGUF)
     llamacpp_no_grammar: bool  # Disable JSON grammar enforcement (faster, less reliable)
+    llm_strict_schema: bool  # Use strict json_schema grammar for structured output on capable openai-compatible backends
     llamacpp_extra_args: str | None  # Space-separated extra CLI args for llama.cpp server
 
     # Per-operation LLM configuration (None = use default LLM config)
@@ -1791,6 +1794,7 @@ class HindsightConfig:
             llamacpp_chat_format=os.getenv(ENV_LLAMACPP_CHAT_FORMAT) or DEFAULT_LLAMACPP_CHAT_FORMAT,
             llamacpp_no_grammar=os.getenv(ENV_LLAMACPP_NO_GRAMMAR, str(DEFAULT_LLAMACPP_NO_GRAMMAR)).lower()
             in ("true", "1"),
+            llm_strict_schema=os.getenv(ENV_LLM_STRICT_SCHEMA, str(DEFAULT_LLM_STRICT_SCHEMA)).lower() in ("true", "1"),
             llamacpp_extra_args=os.getenv(ENV_LLAMACPP_EXTRA_ARGS) or DEFAULT_LLAMACPP_EXTRA_ARGS,
             # Per-operation LLM config (None = use default)
             retain_llm_provider=os.getenv(ENV_RETAIN_LLM_PROVIDER) or None,

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -535,7 +535,17 @@ class OpenAICompatibleLLM(LLMInterface):
             if hasattr(response_format, "model_json_schema"):
                 schema = response_format.model_json_schema()
 
-            if strict_schema and schema is not None:
+            # Opt-in (HINDSIGHT_API_LLM_STRICT_SCHEMA): backends that support
+            # response_format json_schema (OpenAI, llama.cpp, vLLM, ...) should
+            # grammar-enforce output. The soft json_object path below lets weaker
+            # instruction-followers emit prose, markdown fences, or invalid JSON
+            # that fails parsing; strict json_schema makes the output valid by
+            # construction.
+            from hindsight_api.config import get_config
+
+            use_strict_schema = strict_schema or get_config().llm_strict_schema
+
+            if use_strict_schema and schema is not None:
                 # Use OpenAI's strict JSON schema enforcement
                 call_params["response_format"] = {
                     "type": "json_schema",

--- a/hindsight-api-slim/tests/test_llm_strict_schema.py
+++ b/hindsight-api-slim/tests/test_llm_strict_schema.py
@@ -1,0 +1,77 @@
+"""
+Tests for HINDSIGHT_API_LLM_STRICT_SCHEMA / config.llm_strict_schema.
+
+When enabled, structured-output calls on the OpenAI-compatible provider use
+strict ``response_format`` ``json_schema`` (grammar-enforced) instead of the
+soft ``json_object`` path. Soft mode relies on the model *voluntarily* emitting
+valid JSON; weaker self-hosted instruction-followers (small llama.cpp models)
+return prose preambles, markdown ```json fences, or invalid JSON that fails
+parsing and wedges retain/consolidation. Backends that implement json_schema
+(OpenAI, llama.cpp, vLLM) can enforce it — this flag opts into that.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+class _Resp(BaseModel):
+    ok: bool
+
+
+def _llm() -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="openai", api_key="test-key", base_url="https://example.test/v1", model="gpt-4o-mini"
+    )
+
+
+def _response(content: str = '{"ok": true}'):
+    choice = SimpleNamespace(
+        finish_reason="stop", message=SimpleNamespace(content=content, tool_calls=None, refusal=None)
+    )
+    return SimpleNamespace(error=None, usage=None, choices=[choice])
+
+
+async def _response_format_used(*, strict_config: bool):
+    """Run a structured call and return the response_format dict sent upstream."""
+    from hindsight_api.config import get_config
+
+    real = get_config()  # captured before patching to avoid recursion
+
+    class _Cfg:
+        llm_strict_schema = strict_config
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    llm = _llm()
+    create = AsyncMock(return_value=_response())
+    llm._client.chat.completions.create = create
+
+    with (
+        patch("hindsight_api.config.get_config", lambda: _Cfg()),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=_Resp,
+            max_retries=0,
+        )
+    return create.call_args.kwargs.get("response_format")
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_enabled_uses_grammar_enforced_json_schema():
+    rf = await _response_format_used(strict_config=True)
+    assert rf is not None and rf.get("type") == "json_schema"
+    assert rf["json_schema"]["strict"] is True
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_disabled_keeps_soft_json_object_default():
+    rf = await _response_format_used(strict_config=False)
+    assert rf is not None and rf.get("type") == "json_object"


### PR DESCRIPTION
## Problem

Structured-output calls (retain's fact extraction, consolidation's observation
merge) go through the **soft `json_object`** path on the OpenAI-compatible
provider: the JSON schema is appended to the prompt and `response_format` is set
to `{"type": "json_object"}`. This relies on the model *voluntarily* emitting
valid JSON.

Strong/hosted models comply. But weaker self-hosted instruction-followers behind
an OpenAI-compatible server — small Qwen / Llama / Mistral GGUF models served by
`llama.cpp`, vLLM, etc. — routinely return:

- a prose preamble (`Sure, here is the JSON you requested:`),
- a fenced block ` ```json … ``` `,
- or subtly invalid JSON.

`_strip_code_fences` handles some of these, but not all. The failures surface as
`json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`, the async
operation retries indefinitely, and **retain / consolidation wedge** — the LLM
runs hot producing output that never parses, and the backlog never drains.

The provider already has a strict `json_schema` code path, but it only triggers
when a caller passes `strict_schema=True` (retain/consolidation don't), and its
docstring marks it *"OpenAI only"*. In practice every `json_schema`-capable
backend — OpenAI, **llama.cpp**, vLLM — will *grammar-enforce* the schema, making
the output valid by construction (no prose, no fences, no malformed JSON).

## Fix

Add an opt-in config flag **`HINDSIGHT_API_LLM_STRICT_SCHEMA`** (default `false`,
so **no behavior change** for existing deployments). When enabled, the
OpenAI-compatible provider uses strict `json_schema` for *all* structured calls,
letting operators on schema-capable self-hosted backends get reliable structured
output instead of the fragile soft path.

- `config.py`: new env `HINDSIGHT_API_LLM_STRICT_SCHEMA` → `Config.llm_strict_schema`
  (default `False`).
- `openai_compatible_llm.py`: `use_strict_schema = strict_schema or get_config().llm_strict_schema`;
  the strict `json_schema` branch is taken when either is set. The per-call
  `strict_schema=True` argument keeps working exactly as before.

## Verification

Reproduced and fixed in a live self-hosted deployment: **qwen2.5-coder-7B-instruct
(Q4_K_M) served by llama.cpp** behind an OpenAI-compatible endpoint.

- **Soft mode (default):** consolidation returned prose + fenced JSON, failed to
  parse, retried forever — backlog frozen, zero drain, GPU pinned at ~99%
  producing nothing.
- **`HINDSIGHT_API_LLM_STRICT_SCHEMA=true`:** the same model returns clean,
  grammar-enforced JSON every call; consolidation parses and drains normally.

A direct probe confirmed the model emits a valid `{"observations": [...]}`
object under `response_format: json_schema` both directly and through a gateway —
the only change needed was letting Hindsight ask for it.

## Tests

`tests/test_llm_strict_schema.py` (mirrors the existing
`test_openai_compatible_response_hardening.py` mock pattern):

- with `llm_strict_schema=True`, a structured call sends
  `response_format.type == "json_schema"` (and `strict: true`);
- with it `False` (default), the call keeps sending
  `response_format.type == "json_object"`.
