### PR TITLE
fix: raise _check_health default timeout 2s→10s to stop busy-daemon kill loop

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/daemon.py
+++ b/hindsight-integrations/claude-code/scripts/lib/daemon.py
@@ -71,8 +71,17 @@ def _is_embed_available(config: dict) -> bool:
     return shutil.which("uvx") is not None or shutil.which("hindsight-embed") is not None
 
 
-def _check_health(base_url: str, timeout: int = 2) -> bool:
-    """Quick health check against a Hindsight server."""
+def _check_health(base_url: str, timeout: int = 10) -> bool:
+    """Quick health check against a Hindsight server.
+
+    Default timeout is 10s (matching the recall hook budget): under load an
+    alive-but-busy daemon mid fact-extraction may not answer /health within a
+    couple of seconds. A too-short timeout yields a false negative, so
+    get_api_url() falls through to _ensure_daemon_running() ->
+    `hindsight-embed daemon start`, whose _clear_port() then SIGTERMs the
+    live daemon -- a restart/kill loop. A 10s budget lets a busy daemon
+    respond before it is declared dead.
+    """
     try:
         url = f"{base_url.rstrip('/')}/health"
         req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})

--- a/hindsight-integrations/codex/scripts/lib/daemon.py
+++ b/hindsight-integrations/codex/scripts/lib/daemon.py
@@ -59,8 +59,17 @@ def _is_embed_available(config: dict) -> bool:
     return shutil.which("uvx") is not None or shutil.which("hindsight-embed") is not None
 
 
-def _check_health(base_url: str, timeout: int = 2) -> bool:
-    """Quick health check against a Hindsight server."""
+def _check_health(base_url: str, timeout: int = 10) -> bool:
+    """Quick health check against a Hindsight server.
+
+    Default timeout is 10s (matching the recall hook budget): under load an
+    alive-but-busy daemon mid fact-extraction may not answer /health within a
+    couple of seconds. A too-short timeout yields a false negative, so
+    get_api_url() falls through to _ensure_daemon_running() ->
+    `hindsight-embed daemon start`, whose _clear_port() then SIGTERMs the
+    live daemon -- a restart/kill loop. A 10s budget lets a busy daemon
+    respond before it is declared dead.
+    """
     try:
         url = f"{base_url.rstrip('/')}/health"
         req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})


### PR DESCRIPTION
## Problem

Under sustained load the local daemon can be killed in a restart/kill loop.

Root cause chain (claude-code & codex integrations, `scripts/lib/daemon.py`):

1. An alive-but-**busy** daemon (mid 30–60s LLM fact-extraction) sometimes
   can't answer `GET /health` within the **2s** default in `_check_health`.
2. That false negative makes `get_api_url()` skip "Mode 2: existing local
   server" and fall through to **Mode 3** → `_ensure_daemon_running()` →
   `hindsight-embed daemon start`.
3. `daemon start`'s `_clear_port()` then **SIGTERMs whatever holds the port —
   i.e. the live, busy daemon** — and a fresh one is spun up. Under continuous
   traffic this repeats: a daemon restart/kill loop.

The 2s budget is also inconsistent with `get_api_url`'s own docstring, which
notes the recall hook already allows a **10s** budget.

## Fix

Raise the `_check_health` **default** timeout `2 → 10` seconds in both the
`claude-code` and `codex` integrations (they carry the helper verbatim), so a
busy daemon has time to respond before it is declared dead and pre-empted.

- Minimal & targeted: only the default changes; callers passing an explicit
  `timeout=` keep their value.
- No behavioural change for a healthy idle daemon (responds in ms).
- Stops the false-negative → SIGTERM-live-daemon → restart loop.

## Testing

Observed in a long-running Claude Code setup: with the 2s default the daemon
on :9077 was repeatedly SIGTERM'd under load; raising the health-check budget
to 10s keeps the busy daemon alive across concurrent fact-extraction calls.
`py_compile` clean on both changed files.