### PR TITLE
fix(mental-models): create bank before insert

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7995,6 +7995,13 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
+        # mental_models.bank_id has a FK to banks. Retain creates banks lazily;
+        # pinned model creation must do the same so a first write to a new bank
+        # does not surface as a raw database constraint error.
+        _, created = await bank_utils.get_or_create_bank_profile(backend, bank_id)
+        if created:
+            await self._apply_default_bank_template(bank_id, request_context)
+
         # Generate embedding for the content
         embedding_text = f"{name} {content}"
         embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -67,6 +67,30 @@ class TestMentalModelsCRUD:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_create_mental_model_creates_missing_bank(self, memory: MemoryEngine, request_context):
+        """Creating the first mental model in a bank should lazily create the bank."""
+        bank_id = f"test-mental-model-missing-bank-{uuid.uuid4().hex[:8]}"
+
+        mental_model = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="First Model",
+            source_query="What should this bank remember?",
+            content="Initial content",
+            request_context=request_context,
+        )
+
+        assert mental_model["bank_id"] == bank_id
+
+        profile = await memory.get_bank_profile(
+            bank_id=bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        assert profile is not None
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_list_mental_models(self, memory: MemoryEngine, request_context):
         """Test listing mental models with filters."""
         bank_id = f"test-mental-model-list-{uuid.uuid4().hex[:8]}"
@@ -240,6 +264,28 @@ class TestObservationsAPI:
 
 class TestMentalModelsAPI:
     """Test mental models API endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_create_mental_model_api_creates_missing_bank(self, api_client, test_bank_id):
+        """POST /mental-models should not FK-fail when it is the bank's first write."""
+        response = await api_client.post(
+            f"/v1/default/banks/{test_bank_id}/mental-models",
+            json={
+                "name": "First API Mental Model",
+                "source_query": "What is known in this new bank?",
+                "tags": ["api-test"],
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["mental_model_id"]
+
+        response = await api_client.get("/v1/default/banks")
+        assert response.status_code == 200
+        bank_ids = {bank["bank_id"] for bank in response.json()["banks"]}
+        assert test_bank_id in bank_ids
+
+        await api_client.delete(f"/v1/default/banks/{test_bank_id}")
 
     @pytest.mark.asyncio
     async def test_mental_models_api_crud(self, api_client, test_bank_id):


### PR DESCRIPTION
## Summary

Creating a pinned mental model is a bank-scoped write, but it inserted into `mental_models` before ensuring the target bank row existed. A first write to a new bank could therefore surface as a raw FK violation instead of behaving like retain/webhook writes that lazily create the bank.

This makes `MemoryEngine.create_mental_model()` create the bank first, apply the default bank template on first creation, then insert the mental model.

## Tests

- `uv run pytest tests/test_reflections.py::TestMentalModelsCRUD::test_create_mental_model_creates_missing_bank tests/test_reflections.py::TestMentalModelsAPI::test_create_mental_model_api_creates_missing_bank -q`
- `uv run ruff format hindsight_api/engine/memory_engine.py tests/test_reflections.py`
- `uv run ruff check hindsight_api/engine/memory_engine.py tests/test_reflections.py`
- `uv run ty check hindsight_api/engine/memory_engine.py`

Notes: `scripts/hooks/lint.sh` could not run on this Windows machine because it requires bash/WSL. Full `uv run ty check hindsight_api` still has unrelated pre-existing Windows/optional dependency diagnostics for `mlx*` and `resource`.