### PR TITLE
fix(clients): expose reflect tool_calls/llm_calls trace in python + typescript wrappers

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -39,6 +39,7 @@ from hindsight_client_api.models import (
     retain_request,
 )
 from hindsight_client_api.models.reflect_include_options import ReflectIncludeOptions
+from hindsight_client_api.models.tool_calls_include_options import ToolCallsIncludeOptions
 from hindsight_client_api.models.bank_profile_response import BankProfileResponse
 from hindsight_client_api.models.file_retain_response import FileRetainResponse
 from hindsight_client_api.models.list_memory_units_response import ListMemoryUnitsResponse
@@ -361,7 +362,11 @@ class Hindsight:
 
         request_body = json.dumps({"files_metadata": meta})
 
-        return _run_async(self._files_api.file_retain(bank_id=bank_id, files=file_data, request=request_body, _request_timeout=self._timeout))
+        return _run_async(
+            self._files_api.file_retain(
+                bank_id=bank_id, files=file_data, request=request_body, _request_timeout=self._timeout
+            )
+        )
 
     def recall(
         self,
@@ -440,6 +445,8 @@ class Hindsight:
         tags: list[str] | None = None,
         tags_match: Literal["any", "all", "any_strict", "all_strict"] = "any",
         include_facts: bool = False,
+        include_tool_calls: bool = False,
+        include_tool_call_output: bool = True,
         tag_groups: list[dict[str, Any]] | None = None,
         fact_types: list[str] | None = None,
         exclude_mental_models: bool = False,
@@ -462,14 +469,21 @@ class Hindsight:
                 "any_strict" (OR, excludes untagged), "all_strict" (AND, excludes untagged). Default: "any"
             include_facts: If True, the response will include a 'based_on' field listing
                 the memories, mental models, and directives used to construct the answer.
+            include_tool_calls: If True, the response will include a 'trace' field with the
+                tool calls and LLM calls made during reflection (``trace.tool_calls`` and
+                ``trace.llm_calls``).
+            include_tool_call_output: When ``include_tool_calls`` is True, controls whether tool
+                outputs are included in the trace. Set to False for a smaller payload (inputs only).
+                Ignored when ``include_tool_calls`` is False (default: True).
             tag_groups: Optional list of tag group filters for advanced boolean tag matching.
             fact_types: Optional list of fact types to include (world, experience, observation).
             exclude_mental_models: If True, exclude all mental models from reflection (default: False).
             exclude_mental_model_ids: Optional list of specific mental model IDs to exclude.
 
         Returns:
-            ReflectResponse with answer text, optionally facts used, and optionally
-            structured_output if response_schema was provided
+            ReflectResponse with answer text, optionally facts used, optionally a 'trace' with
+            tool/LLM calls (if include_tool_calls), and optionally structured_output if
+            response_schema was provided
         """
         return _run_async(
             self.areflect(
@@ -482,6 +496,8 @@ class Hindsight:
                 tags=tags,
                 tags_match=tags_match,
                 include_facts=include_facts,
+                include_tool_calls=include_tool_calls,
+                include_tool_call_output=include_tool_call_output,
                 tag_groups=tag_groups,
                 fact_types=fact_types,
                 exclude_mental_models=exclude_mental_models,
@@ -911,6 +927,8 @@ class Hindsight:
         tags: list[str] | None = None,
         tags_match: Literal["any", "all", "any_strict", "all_strict"] = "any",
         include_facts: bool = False,
+        include_tool_calls: bool = False,
+        include_tool_call_output: bool = True,
         tag_groups: list[dict[str, Any]] | None = None,
         fact_types: list[str] | None = None,
         exclude_mental_models: bool = False,
@@ -933,16 +951,28 @@ class Hindsight:
                 "any_strict" (OR, excludes untagged), "all_strict" (AND, excludes untagged). Default: "any"
             include_facts: If True, the response will include a 'based_on' field listing
                 the memories, mental models, and directives used to construct the answer.
+            include_tool_calls: If True, the response will include a 'trace' field with the
+                tool calls and LLM calls made during reflection (``trace.tool_calls`` and
+                ``trace.llm_calls``).
+            include_tool_call_output: When ``include_tool_calls`` is True, controls whether tool
+                outputs are included in the trace. Set to False for a smaller payload (inputs only).
+                Ignored when ``include_tool_calls`` is False (default: True).
             tag_groups: Optional list of tag group filters for advanced boolean tag matching.
             fact_types: Optional list of fact types to include (world, experience, observation).
             exclude_mental_models: If True, exclude all mental models from reflection (default: False).
             exclude_mental_model_ids: Optional list of specific mental model IDs to exclude.
 
         Returns:
-            ReflectResponse with answer text, optionally facts used, and optionally
-            structured_output if response_schema was provided
+            ReflectResponse with answer text, optionally facts used, optionally a 'trace' with
+            tool/LLM calls (if include_tool_calls), and optionally structured_output if
+            response_schema was provided
         """
-        include = ReflectIncludeOptions(facts={}) if include_facts else None
+        include = None
+        if include_facts or include_tool_calls:
+            include = ReflectIncludeOptions(
+                facts={} if include_facts else None,
+                tool_calls=ToolCallsIncludeOptions(output=include_tool_call_output) if include_tool_calls else None,
+            )
 
         tag_groups_objs = None
         if tag_groups is not None:
@@ -1009,7 +1039,9 @@ class Hindsight:
             trigger=trigger_obj,
         )
 
-        return _run_async(self._mental_models_api.create_mental_model(bank_id, request_obj, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.create_mental_model(bank_id, request_obj, _request_timeout=self._timeout)
+        )
 
     def list_mental_models(self, bank_id: str, tags: list[str] | None = None):
         """
@@ -1022,7 +1054,9 @@ class Hindsight:
         Returns:
             ListMentalModelsResponse with items
         """
-        return _run_async(self._mental_models_api.list_mental_models(bank_id, tags=tags, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.list_mental_models(bank_id, tags=tags, _request_timeout=self._timeout)
+        )
 
     def get_mental_model(self, bank_id: str, mental_model_id: str):
         """
@@ -1035,7 +1069,9 @@ class Hindsight:
         Returns:
             MentalModelResponse
         """
-        return _run_async(self._mental_models_api.get_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.get_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        )
 
     def refresh_mental_model(self, bank_id: str, mental_model_id: str):
         """
@@ -1048,7 +1084,9 @@ class Hindsight:
         Returns:
             RefreshMentalModelResponse with operation_id
         """
-        return _run_async(self._mental_models_api.refresh_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.refresh_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        )
 
     def clear_mental_model(self, bank_id: str, mental_model_id: str):
         """
@@ -1061,7 +1099,9 @@ class Hindsight:
         Returns:
             MentalModelResponse with cleared content
         """
-        return _run_async(self._mental_models_api.clear_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.clear_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        )
 
     def update_mental_model(
         self,
@@ -1102,7 +1142,11 @@ class Hindsight:
             trigger=trigger_obj,
         )
 
-        return _run_async(self._mental_models_api.update_mental_model(bank_id, mental_model_id, request_obj, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.update_mental_model(
+                bank_id, mental_model_id, request_obj, _request_timeout=self._timeout
+            )
+        )
 
     def delete_mental_model(self, bank_id: str, mental_model_id: str):
         """
@@ -1112,7 +1156,9 @@ class Hindsight:
             bank_id: The memory bank ID
             mental_model_id: The mental model ID
         """
-        return _run_async(self._mental_models_api.delete_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.delete_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        )
 
     def get_mental_model_history(self, bank_id: str, mental_model_id: str):
         """
@@ -1125,7 +1171,9 @@ class Hindsight:
             bank_id: The memory bank ID
             mental_model_id: The mental model ID
         """
-        return _run_async(self._mental_models_api.get_mental_model_history(bank_id, mental_model_id, _request_timeout=self._timeout))
+        return _run_async(
+            self._mental_models_api.get_mental_model_history(bank_id, mental_model_id, _request_timeout=self._timeout)
+        )
 
     # Directives methods
 
@@ -1225,7 +1273,9 @@ class Hindsight:
             tags=tags,
         )
 
-        return _run_async(self._directives_api.update_directive(bank_id, directive_id, request_obj, _request_timeout=self._timeout))
+        return _run_async(
+            self._directives_api.update_directive(bank_id, directive_id, request_obj, _request_timeout=self._timeout)
+        )
 
     def delete_directive(self, bank_id: str, directive_id: str):
         """

--- a/hindsight-clients/python/tests/test_reflect_include_tool_calls.py
+++ b/hindsight-clients/python/tests/test_reflect_include_tool_calls.py
@@ -1,0 +1,88 @@
+"""
+Test that reflect()/areflect() forward include_tool_calls into the ReflectRequest.
+
+The high-level wrapper previously only exposed include_facts, so there was no way
+to request the reflect trace (tool_calls / llm_calls) without dropping down to the
+generated API. These tests pin the wrapper -> ReflectRequest.include mapping so the
+trace stays reachable from the convenience layer.
+"""
+
+from unittest.mock import AsyncMock
+
+from hindsight_client import Hindsight
+
+
+def _make_client():
+    return Hindsight(base_url="http://localhost:8888")
+
+
+def _captured_include(mock):
+    """Pull the ReflectRequest.include built by the wrapper from the mock call."""
+    request_obj = mock.call_args.args[1]
+    return request_obj.include
+
+
+async def test_areflect_no_includes_by_default():
+    """Without any include flags, include should be None (smallest request)."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    await client.areflect("bank", "query")
+    assert _captured_include(client._memory_api.reflect) is None
+
+
+async def test_areflect_include_tool_calls_sets_trace_request():
+    """include_tool_calls=True should populate include.tool_calls with output on by default."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    await client.areflect("bank", "query", include_tool_calls=True)
+    include = _captured_include(client._memory_api.reflect)
+    assert include is not None
+    assert include.tool_calls is not None
+    assert include.tool_calls.output is True
+    # facts stays disabled when only tool calls are requested
+    assert include.facts is None
+
+
+async def test_areflect_include_tool_call_output_false():
+    """include_tool_call_output=False should request inputs-only trace."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    await client.areflect("bank", "query", include_tool_calls=True, include_tool_call_output=False)
+    include = _captured_include(client._memory_api.reflect)
+    assert include.tool_calls is not None
+    assert include.tool_calls.output is False
+
+
+async def test_areflect_facts_and_tool_calls_combine():
+    """include_facts and include_tool_calls should both be representable in one request."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    await client.areflect("bank", "query", include_facts=True, include_tool_calls=True)
+    include = _captured_include(client._memory_api.reflect)
+    assert include.facts is not None
+    assert include.tool_calls is not None
+
+
+async def test_areflect_tool_call_output_ignored_without_tool_calls():
+    """include_tool_call_output is a no-op unless include_tool_calls is set."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    await client.areflect("bank", "query", include_tool_call_output=False)
+    assert _captured_include(client._memory_api.reflect) is None
+
+
+def test_reflect_sync_forwards_include_tool_calls():
+    """The sync wrapper should forward include_tool_calls through to the request."""
+    client = _make_client()
+    client._memory_api.reflect = AsyncMock()
+
+    client.reflect("bank", "query", include_tool_calls=True)
+    include = _captured_include(client._memory_api.reflect)
+    assert include is not None
+    assert include.tool_calls is not None
+    assert include.tool_calls.output is True

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -382,9 +382,24 @@ export class HindsightClient {
       excludeMentalModels?: boolean;
       /** Exclude specific mental models by ID from reflection. */
       excludeMentalModelIds?: string[];
+      /** If true, the response includes a 'based_on' field listing the memories, mental models, and directives used. */
+      includeFacts?: boolean;
+      /** If true, the response includes a 'trace' field with the tool calls and LLM calls made during reflection (trace.tool_calls / trace.llm_calls). */
+      includeToolCalls?: boolean;
+      /** When includeToolCalls is true, set to false for an inputs-only trace (smaller payload). Ignored otherwise. Default: true. */
+      includeToolCallOutput?: boolean;
       signal?: AbortSignal;
     }
   ): Promise<ReflectResponse> {
+    const include =
+      options?.includeFacts || options?.includeToolCalls
+        ? {
+            facts: options?.includeFacts ? {} : undefined,
+            tool_calls: options?.includeToolCalls
+              ? { output: options?.includeToolCallOutput ?? true }
+              : undefined,
+          }
+        : undefined;
     const response = await sdk.reflect({
       client: this.client,
       path: { bank_id: bankId },
@@ -399,6 +414,7 @@ export class HindsightClient {
         fact_types: options?.factTypes,
         exclude_mental_models: options?.excludeMentalModels,
         exclude_mental_model_ids: options?.excludeMentalModelIds,
+        include,
       },
       signal: options?.signal,
     });

--- a/hindsight-clients/typescript/tests/reflect_include.test.ts
+++ b/hindsight-clients/typescript/tests/reflect_include.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests that reflect() forwards include flags into the ReflectRequest body.
+ *
+ * The wrapper previously never sent `include`, so the reflect trace
+ * (trace.tool_calls / trace.llm_calls) and based_on facts were unreachable
+ * from the convenience layer. These tests pin the option -> request.include
+ * mapping. No server required: sdk.reflect is mocked.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+function makeClient(): HindsightClient {
+  return new HindsightClient({ baseUrl: "http://localhost:8888" });
+}
+
+function capturedInclude(spy: jest.SpyInstance): any {
+  return (spy.mock.calls[0][0] as any).body.include;
+}
+
+describe("reflect include options", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = jest.spyOn(sdk, "reflect").mockResolvedValue({ data: { text: "ok" } } as any);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  test("no include flags omits include", async () => {
+    await makeClient().reflect("bank", "query");
+    expect(capturedInclude(spy)).toBeUndefined();
+  });
+
+  test("includeToolCalls sets tool_calls with output on by default", async () => {
+    await makeClient().reflect("bank", "query", { includeToolCalls: true });
+    const include = capturedInclude(spy);
+    expect(include).toBeDefined();
+    expect(include.tool_calls).toEqual({ output: true });
+    expect(include.facts).toBeUndefined();
+  });
+
+  test("includeToolCallOutput false requests inputs-only trace", async () => {
+    await makeClient().reflect("bank", "query", {
+      includeToolCalls: true,
+      includeToolCallOutput: false,
+    });
+    expect(capturedInclude(spy).tool_calls).toEqual({ output: false });
+  });
+
+  test("includeFacts sets facts", async () => {
+    await makeClient().reflect("bank", "query", { includeFacts: true });
+    const include = capturedInclude(spy);
+    expect(include.facts).toEqual({});
+    expect(include.tool_calls).toBeUndefined();
+  });
+
+  test("includeFacts and includeToolCalls combine", async () => {
+    await makeClient().reflect("bank", "query", {
+      includeFacts: true,
+      includeToolCalls: true,
+    });
+    const include = capturedInclude(spy);
+    expect(include.facts).toEqual({});
+    expect(include.tool_calls).toEqual({ output: true });
+  });
+
+  test("includeToolCallOutput is a no-op without includeToolCalls", async () => {
+    await makeClient().reflect("bank", "query", { includeToolCallOutput: false });
+    expect(capturedInclude(spy)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

A user on Python client `0.7.2` reported that `include_tool_calls=True` / `include={"tool_calls": True}` raise *unexpected keyword argument*, so they can't reach the reflect `trace` / `llm_calls` (only `usage` works).

Root cause: the trace lives on the **reflect** endpoint as `ReflectResponse.trace` (`trace.tool_calls`, `trace.llm_calls`), populated only when the request sets `include.tool_calls`. The wire API and the generated models (`ReflectIncludeOptions.tool_calls`, `ToolCallsIncludeOptions`, `ReflectTrace`, `ReflectLLMCall`) already support this in `0.7.2`. The gap is purely in the **maintained high-level wrapper** (`hindsight_client.py`), whose `reflect()`/`areflect()` only exposed `include_facts` and never set `tool_calls`. Not environment-gated, not a partial rollout.

## Fix

Add `include_tool_calls` and `include_tool_call_output` parameters to both `reflect()` and `areflect()`, mapping them onto `ReflectIncludeOptions.tool_calls`. Now:

```python
resp = client.reflect("my_bank", "What do you think about X?", include_tool_calls=True)
for lc in resp.trace.llm_calls:   # .scope, .duration_ms
    print(lc.scope, lc.duration_ms)
for tc in resp.trace.tool_calls:  # .tool, .input, .output, .duration_ms, .iteration
    print(tc.tool, tc.duration_ms)
```

Use `include_tool_call_output=False` for an inputs-only (smaller) trace.

## Workaround for existing 0.7.2 (no upgrade needed)

The capability is in the generated API today — drop down to it via `_memory_api`:

```python
from hindsight_client import HindsightClient
from hindsight_client_api.models.reflect_request import ReflectRequest
from hindsight_client_api.models.reflect_include_options import ReflectIncludeOptions
from hindsight_client_api.models.tool_calls_include_options import ToolCallsIncludeOptions

client = HindsightClient(base_url="...", api_key="...")

req = ReflectRequest(
    query="What do you think about X?",
    budget="low",
    include=ReflectIncludeOptions(
        facts={},                                        # optional: based_on
        tool_calls=ToolCallsIncludeOptions(output=True), # {} full trace; output=False = inputs only
    ),
)

resp = await client._memory_api.reflect("my_bank_id", req)

print(resp.usage)
for lc in resp.trace.llm_calls:    # ReflectLLMCall: .scope, .duration_ms
    print(lc.scope, lc.duration_ms)
for tc in resp.trace.tool_calls:   # ReflectToolCall: .tool, .input, .output, .duration_ms, .iteration
    print(tc.tool, tc.duration_ms)
```

Equivalent raw REST body: `{"include": {"tool_calls": {}}}` POSTed to `/v1/default/banks/{bank_id}/reflect`.

Notes:
- `trace` is only non-null when `include.tool_calls` is set; it's populated from reflect's agent loop regardless of budget.
- `_memory_api` is internal (leading underscore) — this PR is the clean replacement.

## Tests

`tests/test_reflect_include_tool_calls.py` — mock-based, no server required — pins the wrapper → `ReflectRequest.include` mapping (default none, tool_calls on, output=False, facts+tool_calls combined, sync forwarding). All pass.
