### PR TITLE
ci(obs): enable consolidation dedup (0.97) in the observation benchmark

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -223,6 +223,10 @@ jobs:
       HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY: /tmp/gcp-credentials.json
       HINDSIGHT_API_LLM_MODEL: google/gemini-2.5-flash-lite
       HINDSIGHT_API_ENABLE_OBSERVATIONS: "true"
+      # Exercise create+update semantic dedup (the benchmark's whole point). Safe here because
+      # the benchmark runs on embedded pg0 (Postgres); the merge path is Postgres-only, which is
+      # why the feature stays opt-in / disabled by default rather than enabled globally.
+      HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD: "0.97"
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
The observation benchmark exists to track consolidation's near-duplicate rate, but the job ran with dedup **disabled** (default threshold `1.0`), so it measured the baseline rather than the shipped create+update dedup feature (#1977).

Enable it at `0.97` in the obs job env so the benchmark + CPM dashboard track the feature going forward. Safe here because the benchmark runs on embedded pg0 (Postgres); the merge path is Postgres-only, which is why the feature stays opt-in / disabled by default rather than enabled globally (enabling it as the global default would break Oracle deployments).

Dispatched a run on this branch to capture the dedup-on number.