### PR TITLE
fix(claude-code): default enableKnowledgeTools to true; keep MCP server alive when disabled

### DIFF
--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -278,7 +278,7 @@ authored by a specific user from a shared bank.
 
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
-| `enableKnowledgeTools` | `HINDSIGHT_ENABLE_KNOWLEDGE_TOOLS` | `false` | Enable the MCP server with `agent_knowledge_*` tools. When `false`, the MCP server exits immediately on startup and no tools are registered. Set to `true` to enable knowledge page management, memory search, and document ingestion via MCP tools. |
+| `enableKnowledgeTools` | `HINDSIGHT_ENABLE_KNOWLEDGE_TOOLS` | `true` | Enable the MCP server with `agent_knowledge_*` tools (knowledge page management, memory search, document ingestion). Set to `false` to register no tools — the MCP server stays alive as an empty server (it does not exit, which would otherwise trigger a `-32000` reconnect error). |
 
 ---
 

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -56,6 +56,7 @@ DEFAULTS = {
     "llmModel": None,
     "llmApiKeyEnv": None,
     # Misc
+    "enableKnowledgeTools": True,
     "debug": False,
 }
 

--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -35,7 +35,14 @@ _config = load_config()
 _dbg = lambda *a: debug_log(_config, *a)
 
 if not _config.get("enableKnowledgeTools"):
-    _dbg("Knowledge tools disabled (enableKnowledgeTools=false), MCP server exiting")
+    # Knowledge tools are opt-out. When disabled we must NOT exit: the plugin
+    # registers this server unconditionally in .mcp.json, and Claude Code treats
+    # a process that exits at startup as a crashed server — retrying it and
+    # surfacing a `-32000` reconnect error on every prompt. Instead, stay alive
+    # as an empty MCP server that advertises no tools. The tool definitions
+    # below are skipped entirely because mcp.run() blocks here.
+    _dbg("Knowledge tools disabled (enableKnowledgeTools=false) — running empty MCP server")
+    mcp.run(transport="stdio")
     sys.exit(0)
 
 try:

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -33,6 +33,6 @@
   "llmProvider": null,
   "llmModel": null,
   "llmApiKeyEnv": null,
-  "enableKnowledgeTools": false,
+  "enableKnowledgeTools": true,
   "debug": false
 }

--- a/hindsight-integrations/claude-code/tests/test_mcp_server.py
+++ b/hindsight-integrations/claude-code/tests/test_mcp_server.py
@@ -44,6 +44,28 @@ class TestListPagesUsesMetadataProjection:
         assert "detail=metadata" in list_pages_body
 
 
+class TestDisabledKnowledgeToolsKeepsServerAlive:
+    """When `enableKnowledgeTools` is false the server must NOT exit at startup.
+
+    `.mcp.json` registers this server unconditionally, so Claude Code expects a
+    live process. If the server exits immediately (the old behavior), Claude
+    Code treats it as a crashed server and surfaces a `-32000` reconnect error
+    on every prompt (issue #1995). The disabled path must instead run an empty
+    MCP server (`mcp.run`) so the process stays alive with no tools registered.
+    """
+
+    def test_disabled_branch_runs_empty_server_not_bare_exit(self):
+        src = _read_mcp_server_source()
+        gate = src.find('if not _config.get("enableKnowledgeTools")')
+        assert gate > 0, "expected the enableKnowledgeTools startup gate"
+        # The disabled branch ends at the next top-level statement (`try:`).
+        branch = src[gate : src.find("\ntry:", gate)]
+        assert "mcp.run(transport=\"stdio\")" in branch, (
+            "disabled path must run an empty MCP server so the process stays "
+            "alive — exiting triggers a -32000 reconnect loop (issue #1995)"
+        )
+
+
 class TestGetPageUsesContentProjection:
     """`agent_knowledge_get_page` must request the API's `content` projection.
 


### PR DESCRIPTION
## Problem

On a fresh install of the `hindsight-memory` Claude Code plugin, users immediately see:

```
Failed to reconnect to plugin:hindsight-memory:hindsight: -32000
```

`.mcp.json` registers the MCP server unconditionally, but `mcp_server.py` exited immediately when `enableKnowledgeTools` was `false` — the shipped default. Claude Code treats the dead process as a crashed server and retries it on every prompt, surfacing the `-32000` error.

## Fix

- **Default `enableKnowledgeTools` to `true`** (`settings.json` + config `DEFAULTS`) so the registered server actually stays alive and exposes the `agent_knowledge_*` tools out of the box.
- **When disabled, run an empty MCP server instead of exiting.** The registered process stays alive advertising no tools, so explicitly turning the feature off no longer triggers a reconnect loop.
- Updated README and added a regression test.

Fixes #1995