### PR TITLE
docs(models): vertexai default model gemini-2.0-flash-001 is retired — sync to gemini-2.5-flash-lite

### DIFF
--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -2,7 +2,7 @@
   {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini", "batchApi": true},
   {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5-20251001"},
   {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-2.5-flash", "promptCaching": true},
-  {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "gemini-2.0-flash-001", "promptCaching": true},
+  {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "gemini-2.5-flash-lite", "promptCaching": true},
   {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b", "batchApi": true},
   {"id": "ollama",        "label": "Ollama",            "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
   {"id": "ollama-cloud",  "label": "Ollama Cloud",      "iconKey": "ollama",             "defaultModel": "gemma3:12b"},

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -136,7 +136,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `openai` | `gpt-4o-mini` |
 | `anthropic` | `claude-haiku-4-5-20251001` |
 | `gemini` | `gemini-2.5-flash` |
-| `vertexai` | `gemini-2.0-flash-001` |
+| `vertexai` | `gemini-2.5-flash-lite` |
 | `groq` | `openai/gpt-oss-120b` |
 | `ollama` | `gemma3:12b` |
 | `ollama-cloud` | `gemma3:12b` |


### PR DESCRIPTION
The **Provider Default Models** table advertises `vertexai`'s default as `gemini-2.0-flash-001`, which #1972 confirms is **retired on Vertex AI** (404 `NOT_FOUND`). The live config default is `google/gemini-2.5-flash-lite`.

Source of truth — `hindsight-api-slim/hindsight_api/config.py:562`:
```python
PROVIDER_DEFAULT_MODELS = {
    ...
    "vertexai": "google/gemini-2.5-flash-lite",
}
```
The `google/` prefix is stripped automatically for display, so the table value is `gemini-2.5-flash-lite` (matching the table's existing no-prefix convention for this row).

Without this, a user trusting the default-models table for `vertexai` is pointed at a model that 404s on Vertex AI — the exact failure #1972 just hit in CI.

- `hindsight-docs/src/data/llmProviders.json`: vertexai `defaultModel` → `gemini-2.5-flash-lite`
- `skills/hindsight-docs/references/developer/models.md`: regenerated via `scripts/generate-docs-skill.sh` (so `verify-generated-files` stays green)

Pure docs.