### PR TITLE
docs(performance): expand local-LLM concurrency guidance into a Local & Small Environments tuning section

### DIFF
--- a/hindsight-docs/docs/developer/performance.md
+++ b/hindsight-docs/docs/developer/performance.md
@@ -136,6 +136,12 @@ If your model exposes a reasoning/thinking budget, keep it low (the default) —
 export HINDSIGHT_API_LLM_REASONING_EFFORT=low
 ```
 
+Consolidation sends multiple facts to the LLM in a single call (default 8). On a small model with a limited context window, a large batch produces an oversized prompt and a long, error-prone response. Shrink the batch so each consolidation call stays small and reliable:
+
+```bash
+export HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=2   # default 8; lower = smaller prompts, more calls
+```
+
 ### Built-in llama.cpp tuning
 
 The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:
@@ -169,6 +175,12 @@ export HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=2
 # export HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true
 ```
 
+The biggest single win on CPU is reranking fewer candidates. By default Hindsight reranks up to 300 candidates per recall — shrink that pool to cut cross-encoder work proportionally:
+
+```bash
+export HINDSIGHT_API_RERANKER_MAX_CANDIDATES=100   # default 300; RRF pre-filters the rest
+```
+
 For a pure-CPU box that struggles with the cross-encoder, `flashrank` is a lighter ONNX-based reranker:
 
 ```bash
@@ -176,14 +188,6 @@ export HINDSIGHT_API_RERANKER_PROVIDER=flashrank
 ```
 
 You can also reduce recall work directly: use a lower `budget` (`low`/`mid`) for everyday queries and reserve `high` for comprehensive reasoning. See [Recall Performance](#recall-performance) below.
-
-### Embeddings on CPU
-
-The default local embedding model (`BAAI/bge-small-en-v1.5`, 384-dim) is already small and CPU-friendly. On macOS, if MPS causes hangs or crashes, force CPU:
-
-```bash
-export HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true
-```
 
 ---
 

--- a/hindsight-docs/docs/developer/performance.md
+++ b/hindsight-docs/docs/developer/performance.md
@@ -86,6 +86,121 @@ Factors affecting throughput:
 
 ---
 
+## Tuning for Local & Small Environments
+
+Hindsight's defaults are tuned for cloud LLM providers and multi-core servers. When you run it on a laptop, a single GPU box, or against a **local LLM server** (llama.cpp, vLLM, LM Studio, Ollama) with a small fixed slot pool, those defaults can saturate the backend, time out, or thrash the CPU. This section collects the knobs that matter for low-resource setups.
+
+### LLM concurrency
+
+The default `HINDSIGHT_API_LLM_MAX_CONCURRENT=32` assumes a cloud provider that can absorb dozens of parallel requests. A local server with a handful of slots cannot — Hindsight will fill every slot and **starve any other client sharing the endpoint** (your main agent, another app, or a second Hindsight operation).
+
+```bash
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=2
+```
+
+A value of `2` lets retain and consolidation run concurrently without blocking each other. If the endpoint is **shared** with other clients (other applications, agents, or workflows hitting the same llama-server / vLLM / LM Studio instance), reserve slots for them by lowering further — leave at least one slot free per shared client.
+
+You can also split the budget per operation so background work never crowds out live reads. The per-operation caps compose *on top of* the global cap:
+
+```bash
+# global=4, with retain/consolidation capped low so reflect always has headroom
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=4
+export HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=1
+export HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT=1
+```
+
+**Symptom of saturation:** other clients sharing the endpoint appear to "hang" or queue indefinitely while Hindsight occupies all slots with retain/recall/consolidation calls. Verify with:
+
+```bash
+# llama.cpp default port is 8080; adjust if your server uses a different port
+curl -s http://127.0.0.1:8080/slots | jq '.[] | {id, is_processing, n_decoded}'
+ss -tnp 'dst :8080'   # count connections per client PID
+```
+
+### Timeouts and retries
+
+Small models on modest hardware generate tokens slowly, and the first request after startup pays a model-load cost. The default `HINDSIGHT_API_LLM_TIMEOUT=120` (seconds) can be too tight for a large local model on CPU — raise it to avoid spurious timeouts and wasted retries:
+
+```bash
+export HINDSIGHT_API_LLM_TIMEOUT=300        # allow slow local generation
+export HINDSIGHT_API_LLM_MAX_RETRIES=2      # fail faster locally — retries rarely help a slow box
+```
+
+A local endpoint isn't rate-limited, so aggressive retry/backoff mostly adds latency on real failures. Lower retries and let genuine errors surface quickly.
+
+### Smaller, faster models — and reasoning effort
+
+Retain (fact extraction) is structured work that does not need a frontier model; reflect can use a lighter model still. On a constrained box, point each operation at the smallest model that holds up:
+
+```bash
+# Reflect on a small/fast model; retain on a slightly stronger structured-output model
+export HINDSIGHT_API_REFLECT_LLM_MODEL=<small-fast-model>
+export HINDSIGHT_API_RETAIN_LLM_MODEL=<structured-output-model>
+```
+
+If your model exposes a reasoning/thinking budget, keep it low (the default) — extra reasoning tokens are pure latency for the extraction and consolidation paths:
+
+```bash
+export HINDSIGHT_API_LLM_REASONING_EFFORT=low
+```
+
+If you only need chunk storage + semantic search and no fact extraction, you can drop the LLM entirely (retain falls back to chunk mode, recall still works, reflect is disabled):
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=none
+```
+
+### Built-in llama.cpp tuning
+
+The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=llamacpp
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=2        # retain + consolidation without blocking
+export HINDSIGHT_API_LLAMACPP_GPU_LAYERS=-1      # -1 = offload all layers to GPU; 0 = CPU only
+export HINDSIGHT_API_LLAMACPP_CONTEXT_SIZE=8192  # lower to save RAM/VRAM; raise for big batches
+export HINDSIGHT_API_LLAMACPP_EXTRA_ARGS="--n_threads 8"  # match physical cores on CPU-only boxes
+# export HINDSIGHT_API_LLAMACPP_NO_GRAMMAR=true  # faster, but less reliable JSON output
+```
+
+See [Built-in llama.cpp](./configuration#built-in-llamacpp) for the full option list.
+
+### Reranker on CPU
+
+Recall's bottleneck on a machine without a GPU is the cross-encoder reranker. The local reranker has several CPU/Apple-Silicon knobs that are quality-neutral but materially faster:
+
+```bash
+# Apple Silicon (MPS): half precision is 27–36% faster, quality-identical
+export HINDSIGHT_API_RERANKER_LOCAL_FP16=true
+
+# Sort pairs by length before batching — 36–54% faster, quality-identical by construction
+export HINDSIGHT_API_RERANKER_LOCAL_BUCKET_BATCHING=true
+
+# Cap reranker parallelism so it doesn't thrash a small CPU under load (default 4)
+export HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=2
+
+# On macOS, force CPU if MPS/XPC causes instability
+# export HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true
+```
+
+For a pure-CPU box that struggles with the cross-encoder, `flashrank` is a lighter ONNX-based reranker:
+
+```bash
+export HINDSIGHT_API_RERANKER_PROVIDER=flashrank
+```
+
+You can also reduce recall work directly: use a lower `budget` (`low`/`mid`) for everyday queries and reserve `high` for comprehensive reasoning. See [Recall Performance](#recall-performance) below.
+
+### Embeddings on CPU
+
+The default local embedding model (`BAAI/bge-small-en-v1.5`, 384-dim) is already small and CPU-friendly. On macOS, if MPS causes hangs or crashes, force CPU:
+
+```bash
+export HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true
+```
+
+---
+
 ## Recall Performance
 
 ### Budget

--- a/hindsight-docs/docs/developer/performance.md
+++ b/hindsight-docs/docs/developer/performance.md
@@ -109,14 +109,6 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=1
 export HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT=1
 ```
 
-**Symptom of saturation:** other clients sharing the endpoint appear to "hang" or queue indefinitely while Hindsight occupies all slots with retain/recall/consolidation calls. Verify with:
-
-```bash
-# llama.cpp default port is 8080; adjust if your server uses a different port
-curl -s http://127.0.0.1:8080/slots | jq '.[] | {id, is_processing, n_decoded}'
-ss -tnp 'dst :8080'   # count connections per client PID
-```
-
 ### Timeouts and retries
 
 Small models on modest hardware generate tokens slowly, and the first request after startup pays a model-load cost. The default `HINDSIGHT_API_LLM_TIMEOUT=120` (seconds) can be too tight for a large local model on CPU — raise it to avoid spurious timeouts and wasted retries:

--- a/hindsight-docs/docs/developer/performance.md
+++ b/hindsight-docs/docs/developer/performance.md
@@ -136,12 +136,6 @@ If your model exposes a reasoning/thinking budget, keep it low (the default) —
 export HINDSIGHT_API_LLM_REASONING_EFFORT=low
 ```
 
-If you only need chunk storage + semantic search and no fact extraction, you can drop the LLM entirely (retain falls back to chunk mode, recall still works, reflect is disabled):
-
-```bash
-export HINDSIGHT_API_LLM_PROVIDER=none
-```
-
 ### Built-in llama.cpp tuning
 
 The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:

--- a/skills/hindsight-docs/references/developer/performance.md
+++ b/skills/hindsight-docs/references/developer/performance.md
@@ -136,6 +136,12 @@ If your model exposes a reasoning/thinking budget, keep it low (the default) —
 export HINDSIGHT_API_LLM_REASONING_EFFORT=low
 ```
 
+Consolidation sends multiple facts to the LLM in a single call (default 8). On a small model with a limited context window, a large batch produces an oversized prompt and a long, error-prone response. Shrink the batch so each consolidation call stays small and reliable:
+
+```bash
+export HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=2   # default 8; lower = smaller prompts, more calls
+```
+
 ### Built-in llama.cpp tuning
 
 The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:
@@ -169,6 +175,12 @@ export HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=2
 # export HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true
 ```
 
+The biggest single win on CPU is reranking fewer candidates. By default Hindsight reranks up to 300 candidates per recall — shrink that pool to cut cross-encoder work proportionally:
+
+```bash
+export HINDSIGHT_API_RERANKER_MAX_CANDIDATES=100   # default 300; RRF pre-filters the rest
+```
+
 For a pure-CPU box that struggles with the cross-encoder, `flashrank` is a lighter ONNX-based reranker:
 
 ```bash
@@ -176,14 +188,6 @@ export HINDSIGHT_API_RERANKER_PROVIDER=flashrank
 ```
 
 You can also reduce recall work directly: use a lower `budget` (`low`/`mid`) for everyday queries and reserve `high` for comprehensive reasoning. See [Recall Performance](#recall-performance) below.
-
-### Embeddings on CPU
-
-The default local embedding model (`BAAI/bge-small-en-v1.5`, 384-dim) is already small and CPU-friendly. On macOS, if MPS causes hangs or crashes, force CPU:
-
-```bash
-export HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true
-```
 
 ---
 

--- a/skills/hindsight-docs/references/developer/performance.md
+++ b/skills/hindsight-docs/references/developer/performance.md
@@ -86,6 +86,121 @@ Factors affecting throughput:
 
 ---
 
+## Tuning for Local & Small Environments
+
+Hindsight's defaults are tuned for cloud LLM providers and multi-core servers. When you run it on a laptop, a single GPU box, or against a **local LLM server** (llama.cpp, vLLM, LM Studio, Ollama) with a small fixed slot pool, those defaults can saturate the backend, time out, or thrash the CPU. This section collects the knobs that matter for low-resource setups.
+
+### LLM concurrency
+
+The default `HINDSIGHT_API_LLM_MAX_CONCURRENT=32` assumes a cloud provider that can absorb dozens of parallel requests. A local server with a handful of slots cannot — Hindsight will fill every slot and **starve any other client sharing the endpoint** (your main agent, another app, or a second Hindsight operation).
+
+```bash
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=2
+```
+
+A value of `2` lets retain and consolidation run concurrently without blocking each other. If the endpoint is **shared** with other clients (other applications, agents, or workflows hitting the same llama-server / vLLM / LM Studio instance), reserve slots for them by lowering further — leave at least one slot free per shared client.
+
+You can also split the budget per operation so background work never crowds out live reads. The per-operation caps compose *on top of* the global cap:
+
+```bash
+# global=4, with retain/consolidation capped low so reflect always has headroom
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=4
+export HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=1
+export HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT=1
+```
+
+**Symptom of saturation:** other clients sharing the endpoint appear to "hang" or queue indefinitely while Hindsight occupies all slots with retain/recall/consolidation calls. Verify with:
+
+```bash
+# llama.cpp default port is 8080; adjust if your server uses a different port
+curl -s http://127.0.0.1:8080/slots | jq '.[] | {id, is_processing, n_decoded}'
+ss -tnp 'dst :8080'   # count connections per client PID
+```
+
+### Timeouts and retries
+
+Small models on modest hardware generate tokens slowly, and the first request after startup pays a model-load cost. The default `HINDSIGHT_API_LLM_TIMEOUT=120` (seconds) can be too tight for a large local model on CPU — raise it to avoid spurious timeouts and wasted retries:
+
+```bash
+export HINDSIGHT_API_LLM_TIMEOUT=300        # allow slow local generation
+export HINDSIGHT_API_LLM_MAX_RETRIES=2      # fail faster locally — retries rarely help a slow box
+```
+
+A local endpoint isn't rate-limited, so aggressive retry/backoff mostly adds latency on real failures. Lower retries and let genuine errors surface quickly.
+
+### Smaller, faster models — and reasoning effort
+
+Retain (fact extraction) is structured work that does not need a frontier model; reflect can use a lighter model still. On a constrained box, point each operation at the smallest model that holds up:
+
+```bash
+# Reflect on a small/fast model; retain on a slightly stronger structured-output model
+export HINDSIGHT_API_REFLECT_LLM_MODEL=<small-fast-model>
+export HINDSIGHT_API_RETAIN_LLM_MODEL=<structured-output-model>
+```
+
+If your model exposes a reasoning/thinking budget, keep it low (the default) — extra reasoning tokens are pure latency for the extraction and consolidation paths:
+
+```bash
+export HINDSIGHT_API_LLM_REASONING_EFFORT=low
+```
+
+If you only need chunk storage + semantic search and no fact extraction, you can drop the LLM entirely (retain falls back to chunk mode, recall still works, reflect is disabled):
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=none
+```
+
+### Built-in llama.cpp tuning
+
+The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=llamacpp
+export HINDSIGHT_API_LLM_MAX_CONCURRENT=2        # retain + consolidation without blocking
+export HINDSIGHT_API_LLAMACPP_GPU_LAYERS=-1      # -1 = offload all layers to GPU; 0 = CPU only
+export HINDSIGHT_API_LLAMACPP_CONTEXT_SIZE=8192  # lower to save RAM/VRAM; raise for big batches
+export HINDSIGHT_API_LLAMACPP_EXTRA_ARGS="--n_threads 8"  # match physical cores on CPU-only boxes
+# export HINDSIGHT_API_LLAMACPP_NO_GRAMMAR=true  # faster, but less reliable JSON output
+```
+
+See [Built-in llama.cpp](./configuration#built-in-llamacpp) for the full option list.
+
+### Reranker on CPU
+
+Recall's bottleneck on a machine without a GPU is the cross-encoder reranker. The local reranker has several CPU/Apple-Silicon knobs that are quality-neutral but materially faster:
+
+```bash
+# Apple Silicon (MPS): half precision is 27–36% faster, quality-identical
+export HINDSIGHT_API_RERANKER_LOCAL_FP16=true
+
+# Sort pairs by length before batching — 36–54% faster, quality-identical by construction
+export HINDSIGHT_API_RERANKER_LOCAL_BUCKET_BATCHING=true
+
+# Cap reranker parallelism so it doesn't thrash a small CPU under load (default 4)
+export HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=2
+
+# On macOS, force CPU if MPS/XPC causes instability
+# export HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true
+```
+
+For a pure-CPU box that struggles with the cross-encoder, `flashrank` is a lighter ONNX-based reranker:
+
+```bash
+export HINDSIGHT_API_RERANKER_PROVIDER=flashrank
+```
+
+You can also reduce recall work directly: use a lower `budget` (`low`/`mid`) for everyday queries and reserve `high` for comprehensive reasoning. See [Recall Performance](#recall-performance) below.
+
+### Embeddings on CPU
+
+The default local embedding model (`BAAI/bge-small-en-v1.5`, 384-dim) is already small and CPU-friendly. On macOS, if MPS causes hangs or crashes, force CPU:
+
+```bash
+export HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true
+```
+
+---
+
 ## Recall Performance
 
 ### Budget

--- a/skills/hindsight-docs/references/developer/performance.md
+++ b/skills/hindsight-docs/references/developer/performance.md
@@ -109,14 +109,6 @@ export HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=1
 export HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT=1
 ```
 
-**Symptom of saturation:** other clients sharing the endpoint appear to "hang" or queue indefinitely while Hindsight occupies all slots with retain/recall/consolidation calls. Verify with:
-
-```bash
-# llama.cpp default port is 8080; adjust if your server uses a different port
-curl -s http://127.0.0.1:8080/slots | jq '.[] | {id, is_processing, n_decoded}'
-ss -tnp 'dst :8080'   # count connections per client PID
-```
-
 ### Timeouts and retries
 
 Small models on modest hardware generate tokens slowly, and the first request after startup pays a model-load cost. The default `HINDSIGHT_API_LLM_TIMEOUT=120` (seconds) can be too tight for a large local model on CPU — raise it to avoid spurious timeouts and wasted retries:

--- a/skills/hindsight-docs/references/developer/performance.md
+++ b/skills/hindsight-docs/references/developer/performance.md
@@ -136,12 +136,6 @@ If your model exposes a reasoning/thinking budget, keep it low (the default) —
 export HINDSIGHT_API_LLM_REASONING_EFFORT=low
 ```
 
-If you only need chunk storage + semantic search and no fact extraction, you can drop the LLM entirely (retain falls back to chunk mode, recall still works, reflect is disabled):
-
-```bash
-export HINDSIGHT_API_LLM_PROVIDER=none
-```
-
 ### Built-in llama.cpp tuning
 
 The bundled `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external server needed. Key knobs for small machines:


### PR DESCRIPTION
## What

Adds a dedicated **"Tuning for Local & Small Environments"** section to `hindsight-docs/docs/developer/performance.md`, covering the config knobs that matter when running Hindsight on a laptop, a single-GPU box, or against a local LLM server (llama.cpp, vLLM, LM Studio, Ollama).

## Why — supersedes #1721

#1721 documented the single most common local-setup footgun: the default `HINDSIGHT_API_LLM_MAX_CONCURRENT=32` saturating a small local LLM and starving other clients sharing the endpoint. That guidance is preserved verbatim here (the export, the shared-client advice, the saturation symptom, and the `curl /slots` + `ss` diagnostics).

This PR keeps that section but expands it into a one-stop reference for low-resource deployments, since the concurrency cap is rarely the only thing you need to tune. New advice:

- **Per-operation concurrency caps** — split the budget so background retain/consolidation never crowds out live reflect (composes on top of the global cap).
- **Timeouts & retries** — raise `HINDSIGHT_API_LLM_TIMEOUT` for slow local generation; lower retries since a local endpoint isn't rate-limited.
- **Smaller models & reasoning effort** — per-operation model split, keep `HINDSIGHT_API_LLM_REASONING_EFFORT=low`, and `HINDSIGHT_API_LLM_PROVIDER=none` for chunk-only mode.
- **Built-in llama.cpp tuning** — GPU layers, context size, threads, grammar.
- **Reranker on CPU** — `RERANKER_LOCAL_FP16`, `BUCKET_BATCHING`, `MAX_CONCURRENT`, `FORCE_CPU`, and the `flashrank` provider.
- **Embeddings on CPU** — `EMBEDDINGS_LOCAL_FORCE_CPU` for macOS MPS issues.

All values cross-checked against `configuration.md`; internal links point to the existing Recall Performance and Built-in llama.cpp sections.

## No code change

Pure docs PR — no code changes, no tests required. (The docs-skill mirror under `skills/hindsight-docs/` is regenerated by the pre-commit hook.)

Closes #1720