### PR TITLE
fix(reflect): gate mental-model retrieval by policy

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -14,6 +14,8 @@ import re
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from pydantic import BaseModel, Field
+
 from .models import DirectiveInfo, LLMCall, ReflectAgentResult, TokenUsageSummary, ToolCall
 from .prompts import (
     _extract_directive_rules,
@@ -302,6 +304,217 @@ def _is_context_overflow_error(exc: Exception) -> bool:
     )
 
 
+class MentalModelRetrievalDecision(BaseModel):
+    """Structured policy decision after the mental-model retrieval layer."""
+
+    mental_models_sufficient: bool = Field(
+        description="Whether the retrieved mental models are enough to allow the agent to stop forced lower-level retrieval."
+    )
+    needs_observations: bool = Field(description="Whether consolidated observations should be searched next.")
+    needs_recall: bool = Field(description="Whether raw world/experience facts should be searched next.")
+    reason: str = Field(description="Short explanation for the retrieval decision.")
+    follow_up_query: str | None = Field(
+        default=None,
+        description="Targeted lower-level retrieval query to verify the mental-model conclusion or gap.",
+    )
+
+
+class MentalModelRetrievalPolicyResult(BaseModel):
+    """Retrieval policy decision plus token usage."""
+
+    decision: MentalModelRetrievalDecision
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+def _fallback_retrieval_decision(
+    reason: str, include_observations: bool, include_recall: bool, follow_up_query: str | None = None
+) -> MentalModelRetrievalDecision:
+    return MentalModelRetrievalDecision(
+        mental_models_sufficient=False,
+        needs_observations=include_observations,
+        needs_recall=include_recall,
+        reason=reason,
+        follow_up_query=follow_up_query,
+    )
+
+
+def _all_mental_models_are_usable_and_fresh(tool_output: dict[str, Any]) -> bool:
+    """Return whether every retrieved mental model is explicitly fresh and has answerable content."""
+    for model in tool_output.get("mental_models", []):
+        if model.get("is_stale") is not False:
+            return False
+        content = str(model.get("content") or "").strip()
+        if not content:
+            return False
+    return True
+
+
+def _mental_model_decision_payload(tool_output: dict[str, Any], *, max_chars: int = 8000) -> dict[str, Any]:
+    """Trim mental-model content for the retrieval-policy LLM call."""
+    payload_models: list[dict[str, Any]] = []
+    remaining = max_chars
+    for model in tool_output.get("mental_models", []):
+        content = str(model.get("content") or "")
+        if remaining <= 0:
+            content_preview = ""
+        else:
+            content_preview = content[:remaining]
+            remaining -= len(content_preview)
+        payload_models.append(
+            {
+                "id": model.get("id"),
+                "name": model.get("name"),
+                "relevance": model.get("relevance"),
+                "is_stale": model.get("is_stale"),
+                "staleness_reason": model.get("staleness_reason"),
+                "updated_at": model.get("updated_at"),
+                "content": content_preview,
+                "content_truncated": len(content_preview) < len(content),
+            }
+        )
+    return {
+        "query": tool_output.get("query"),
+        "count": tool_output.get("count", len(payload_models)),
+        "mental_models": payload_models,
+    }
+
+
+async def _decide_after_mental_models(
+    llm_config: "LLMProvider",
+    *,
+    user_query: str,
+    context: str | None,
+    mental_model_output: dict[str, Any],
+    budget: str | None,
+    include_observations: bool,
+    include_recall: bool,
+    reflect_id: str,
+) -> MentalModelRetrievalPolicyResult:
+    """Ask the LLM whether lower-level retrieval should remain forced.
+
+    The LLM makes the semantic sufficiency call; system code still enforces
+    budget boundaries and falls back to deeper retrieval on malformed/uncertain
+    decisions.
+    """
+    if (budget or "low").lower() == "high":
+        return MentalModelRetrievalPolicyResult(
+            decision=_fallback_retrieval_decision(
+                "High budget keeps the full verification path.",
+                include_observations,
+                include_recall,
+                mental_model_output.get("query") or user_query,
+            )
+        )
+
+    if not mental_model_output.get("mental_models"):
+        return MentalModelRetrievalPolicyResult(
+            decision=_fallback_retrieval_decision(
+                "No mental models were retrieved.",
+                include_observations,
+                include_recall,
+                mental_model_output.get("query") or user_query,
+            )
+        )
+
+    if not _all_mental_models_are_usable_and_fresh(mental_model_output):
+        return MentalModelRetrievalPolicyResult(
+            decision=_fallback_retrieval_decision(
+                "At least one retrieved mental model was stale or had no usable content.",
+                include_observations,
+                include_recall,
+                mental_model_output.get("query") or user_query,
+            )
+        )
+
+    decision_input = {
+        "user_query": user_query,
+        "context": context,
+        "budget": (budget or "low").lower(),
+        "lower_level_tools_enabled": {
+            "search_observations": include_observations,
+            "recall": include_recall,
+        },
+        "mental_model_results": _mental_model_decision_payload(mental_model_output),
+    }
+    prompt = f"""Decide whether the retrieved mental models are sufficient for answering the user's reflect query, or whether lower-level retrieval must remain forced.
+
+You are not answering the user. You are making a retrieval-policy decision.
+
+Rules:
+- Use relevance as metadata only. Do not apply a fixed score threshold.
+- If the mental models are stale, missing, ambiguous, or only loosely related, request lower-level retrieval.
+- If the user asks for latest/current status, exact counts, timelines, examples, sources, evidence, contradictions, or raw details, request lower-level retrieval.
+- If the query is broad and the fresh mental models directly answer it, mark them sufficient.
+- If uncertain, prefer lower-level retrieval.
+- Only request tools that are enabled in lower_level_tools_enabled.
+- If lower-level retrieval is needed, set follow_up_query to a concise query targeting the mental-model conclusion, gap, or stale point to verify. Use the original user query only if no better targeted query exists.
+
+Return a structured decision.
+
+Input:
+```json
+{json.dumps(decision_input, ensure_ascii=False, default=str)}
+```"""
+
+    try:
+        decision_result, usage = await llm_config.call(
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a precise retrieval policy classifier. Return only the requested structured decision.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            response_format=MentalModelRetrievalDecision,
+            scope="reflect_retrieval_policy",
+            temperature=0,
+            max_completion_tokens=700,
+            max_retries=1,
+            initial_backoff=0.25,
+            max_backoff=1.0,
+            return_usage=True,
+        )
+        if isinstance(decision_result, MentalModelRetrievalDecision):
+            decision = decision_result
+        elif isinstance(decision_result, dict):
+            decision = MentalModelRetrievalDecision.model_validate(decision_result)
+        else:
+            decision = MentalModelRetrievalDecision.model_validate_json(str(decision_result))
+    except Exception as e:
+        logger.warning(f"[REFLECT {reflect_id}] Mental-model retrieval decision failed: {e}")
+        return MentalModelRetrievalPolicyResult(
+            decision=_fallback_retrieval_decision(
+                "Retrieval policy decision failed; using conservative deeper retrieval.",
+                include_observations,
+                include_recall,
+                mental_model_output.get("query") or user_query,
+            ),
+        )
+
+    if decision.mental_models_sufficient:
+        decision.needs_observations = False
+        decision.needs_recall = False
+        decision.follow_up_query = None
+    else:
+        decision.needs_observations = decision.needs_observations and include_observations
+        decision.needs_recall = decision.needs_recall and include_recall
+        decision.follow_up_query = (
+            (decision.follow_up_query or "").strip() or mental_model_output.get("query") or user_query
+        )
+        if not decision.needs_observations and not decision.needs_recall and (include_observations or include_recall):
+            # A non-sufficient answer with no enabled follow-up is contradictory.
+            # Prefer the safe path by forcing the next enabled lower layer.
+            decision.needs_observations = include_observations
+            decision.needs_recall = include_recall and not include_observations
+
+    return MentalModelRetrievalPolicyResult(
+        decision=decision,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+    )
+
+
 async def run_reflect_agent(
     llm_config: "LLMProvider",
     bank_id: str,
@@ -464,6 +677,9 @@ async def run_reflect_agent(
         )
 
     consecutive_errors = 0
+    forced_sequence_override: list[str] | None = None
+    forced_sequence_override_start_iteration = 0
+    forced_query_overrides: dict[str, str] = {}
     for iteration in range(max_iterations):
         is_last = iteration == max_iterations - 1
 
@@ -591,9 +807,16 @@ async def run_reflect_agent(
             forced_sequence.append("search_observations")
         if include_recall:
             forced_sequence.append("recall")
+        forced_sequence_index = iteration
+        if forced_sequence_override is not None:
+            forced_sequence = forced_sequence_override
+            forced_sequence_index = iteration - forced_sequence_override_start_iteration
 
-        if iteration < len(forced_sequence):
-            iter_tool_choice: str | dict = {"type": "function", "function": {"name": forced_sequence[iteration]}}
+        if 0 <= forced_sequence_index < len(forced_sequence):
+            iter_tool_choice: str | dict = {
+                "type": "function",
+                "function": {"name": forced_sequence[forced_sequence_index]},
+            }
         else:
             iter_tool_choice = "auto"
 
@@ -880,18 +1103,27 @@ async def run_reflect_agent(
             # Partition into enabled vs hallucinated (not in enabled_tools set)
             allowed_tools = []
             hallucinated_tools = []
+            history_tool_calls = []
+            query_override_originals = {}
             for tc in other_tools:
                 norm = _normalize_tool_name(tc.name)
                 if enabled_tools is not None and norm not in enabled_tools and norm not in ("done", "expand"):
                     hallucinated_tools.append(tc)
+                    history_tool_calls.append(tc)
                 else:
+                    query_override = forced_query_overrides.pop(norm, None)
+                    if query_override and norm in ("search_observations", "recall"):
+                        original_query = tc.arguments.get("query")
+                        tc = tc.model_copy(update={"arguments": {**tc.arguments, "query": query_override}})
+                        query_override_originals[tc.id] = original_query
                     allowed_tools.append(tc)
+                    history_tool_calls.append(tc)
 
             # Build assistant message with all tool calls (LLM requires them for history)
             messages.append(
                 {
                     "role": "assistant",
-                    "tool_calls": [_tool_call_to_dict(tc) for tc in other_tools],
+                    "tool_calls": [_tool_call_to_dict(tc) for tc in history_tool_calls],
                 }
             )
 
@@ -948,6 +1180,7 @@ async def run_reflect_agent(
                     )
 
                 # Track available IDs from tool results (only for successful responses)
+                should_decide_after_mental_models = False
                 if (
                     normalized_tool_name == "search_mental_models"
                     and isinstance(output, dict)
@@ -956,6 +1189,11 @@ async def run_reflect_agent(
                     for mm in output["mental_models"]:
                         if "id" in mm:
                             available_mental_model_ids.add(mm["id"])
+                    should_decide_after_mental_models = (
+                        (budget or "low").lower() != "high"
+                        and forced_sequence_override is None
+                        and iteration < len(forced_sequence) - 1
+                    )
 
                 if (
                     normalized_tool_name == "search_observations"
@@ -983,6 +1221,9 @@ async def run_reflect_agent(
 
                 # Track for logging and context history
                 input_dict = {"tool": tc.name, **tc.arguments}
+                if tc.id in query_override_originals:
+                    input_dict["original_query"] = query_override_originals[tc.id]
+                    input_dict["query_overridden_by"] = "retrieval_policy"
                 input_summary = _summarize_input(tc.name, tc.arguments)
 
                 # Extract reason from tool arguments (if provided)
@@ -1015,6 +1256,72 @@ async def run_reflect_agent(
 
                 # Keep context history for fallback final prompt
                 context_history.append({"tool": tc.name, "input": input_dict, "output": output})
+
+                if should_decide_after_mental_models:
+                    decision_start = time.time()
+                    policy_result = await _decide_after_mental_models(
+                        llm_config,
+                        user_query=query,
+                        context=context,
+                        mental_model_output=output,
+                        budget=budget,
+                        include_observations=include_observations,
+                        include_recall=include_recall,
+                        reflect_id=reflect_id,
+                    )
+                    decision = policy_result.decision
+                    decision_duration_ms = int((time.time() - decision_start) * 1000)
+                    total_input_tokens += policy_result.input_tokens
+                    total_output_tokens += policy_result.output_tokens
+                    llm_trace.append(
+                        {
+                            "scope": "retrieval_policy",
+                            "duration_ms": decision_duration_ms,
+                            "input_tokens": policy_result.input_tokens,
+                            "output_tokens": policy_result.output_tokens,
+                        }
+                    )
+
+                    next_forced_sequence = []
+                    if decision.needs_observations:
+                        next_forced_sequence.append("search_observations")
+                    if decision.needs_recall:
+                        next_forced_sequence.append("recall")
+                    forced_sequence_override = next_forced_sequence
+                    forced_sequence_override_start_iteration = iteration + 1
+                    forced_query_overrides = {
+                        tool_name: decision.follow_up_query
+                        for tool_name in next_forced_sequence
+                        if decision.follow_up_query
+                    }
+
+                    decision_output = decision.model_dump()
+                    decision_input = {
+                        "tool": "retrieval_policy",
+                        "after_tool": "search_mental_models",
+                        "budget": (budget or "low").lower(),
+                    }
+                    tool_trace.append(
+                        ToolCall(
+                            tool="retrieval_policy",
+                            reason=decision.reason,
+                            input=decision_input,
+                            output=decision_output,
+                            duration_ms=decision_duration_ms,
+                            iteration=iteration + 1,
+                        )
+                    )
+                    tool_trace_summary.append(
+                        {
+                            "tool": "retrieval_policy",
+                            "input_summary": f"(budget={(budget or 'low').lower()})",
+                            "duration_ms": decision_duration_ms,
+                            "output_chars": len(json.dumps(decision_output, ensure_ascii=False)),
+                        }
+                    )
+                    context_history.append(
+                        {"tool": "retrieval_policy", "input": decision_input, "output": decision_output}
+                    )
 
     # Should not reach here
     answer = "I was unable to formulate a complete answer within the iteration limit."

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -9,14 +9,18 @@ These tests verify:
 """
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from hindsight_api import LLMConfig, get_config
+from hindsight_api.engine.llm_wrapper import requires_api_key
 from hindsight_api.engine.reflect.agent import (
     _clean_answer_text,
     _clean_done_answer,
     _count_messages_tokens,
+    _decide_after_mental_models,
     _is_context_overflow_error,
     _is_done_tool,
     _normalize_tool_name,
@@ -218,6 +222,315 @@ class TestReflectAgentMocked:
             "recall_fn": AsyncMock(return_value={"memories": [{"id": "mem-1", "content": "test memory"}]}),
             "expand_fn": AsyncMock(return_value={"memories": []}),
         }
+
+    @pytest.mark.asyncio
+    async def test_mental_model_policy_allows_auto_when_sufficient(self, mock_llm, mock_functions):
+        """A sufficient mental model should cancel the remaining forced retrieval path."""
+        mock_functions["search_mental_models_fn"].return_value = {
+            "query": "test query",
+            "count": 1,
+            "mental_models": [
+                {
+                    "id": "mm-1",
+                    "name": "User preferences",
+                    "content": "The user prefers concise engineering answers.",
+                    "relevance": 0.31,
+                    "is_stale": False,
+                }
+            ],
+        }
+        mock_llm.call.return_value = (
+            {
+                "mental_models_sufficient": True,
+                "needs_observations": False,
+                "needs_recall": False,
+                "reason": "Fresh mental model directly answers the broad preference question.",
+            },
+            TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30),
+        )
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="1",
+                        name="search_mental_models",
+                        arguments={"reason": "check curated knowledge", "query": "test query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="done",
+                        arguments={"answer": "Use concise engineering answers.", "mental_model_ids": ["mm-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            has_mental_models=True,
+            budget="low",
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        assert result.text == "Use concise engineering answers."
+        mock_functions["search_observations_fn"].assert_not_called()
+        mock_functions["recall_fn"].assert_not_called()
+        assert mock_llm.call_with_tools.await_args_list[1].kwargs["tool_choice"] == "auto"
+        policy_trace = next(tc for tc in result.tool_trace if tc.tool == "retrieval_policy")
+        assert policy_trace.output["mental_models_sufficient"] is True
+
+    @pytest.mark.asyncio
+    async def test_stale_or_empty_mental_models_cannot_short_circuit(self, mock_llm, mock_functions):
+        """Deterministic freshness/content guards should override an overconfident policy path."""
+        mock_functions["search_mental_models_fn"].return_value = {
+            "query": "test query",
+            "count": 2,
+            "mental_models": [
+                {
+                    "id": "mm-stale",
+                    "name": "Old project status",
+                    "content": "The old status said launch was complete.",
+                    "relevance": 0.92,
+                    "is_stale": True,
+                    "staleness_reason": "newer source facts exist",
+                },
+                {
+                    "id": "mm-empty",
+                    "name": "Empty project status",
+                    "content": "   ",
+                    "relevance": 0.81,
+                    "is_stale": False,
+                },
+            ],
+        }
+        mock_llm.call.return_value = (
+            {
+                "mental_models_sufficient": True,
+                "needs_observations": False,
+                "needs_recall": False,
+                "reason": "This should not be trusted.",
+            },
+            TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30),
+        )
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="1",
+                        name="search_mental_models",
+                        arguments={"reason": "check curated knowledge", "query": "test query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="search_observations",
+                        arguments={"reason": "verify stale summaries", "query": "generic query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="3", name="recall", arguments={"reason": "verify raw facts", "query": "generic"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="4",
+                        name="done",
+                        arguments={"answer": "Verified from lower-level retrieval.", "memory_ids": ["mem-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            has_mental_models=True,
+            budget="low",
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        assert result.text == "Verified from lower-level retrieval."
+        mock_llm.call.assert_not_called()
+        mock_functions["search_observations_fn"].assert_called_once()
+        mock_functions["recall_fn"].assert_called_once()
+        policy_trace = next(tc for tc in result.tool_trace if tc.tool == "retrieval_policy")
+        assert policy_trace.output["mental_models_sufficient"] is False
+        assert policy_trace.output["reason"] == "At least one retrieved mental model was stale or had no usable content."
+
+    @pytest.mark.asyncio
+    async def test_high_budget_keeps_full_forced_retrieval_path(self, mock_llm, mock_functions):
+        """High budget should not run the sufficiency policy or skip lower layers."""
+        mock_functions["search_mental_models_fn"].return_value = {
+            "query": "test query",
+            "count": 1,
+            "mental_models": [
+                {
+                    "id": "mm-1",
+                    "name": "User preferences",
+                    "content": "The user prefers concise engineering answers.",
+                    "relevance": 0.99,
+                    "is_stale": False,
+                }
+            ],
+        }
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="1",
+                        name="search_mental_models",
+                        arguments={"reason": "check curated knowledge", "query": "test query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="search_observations",
+                        arguments={"reason": "verify summaries", "query": "test query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="3", name="recall", arguments={"reason": "verify raw facts", "query": "test query"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="4",
+                        name="done",
+                        arguments={"answer": "Verified answer.", "mental_model_ids": ["mm-1"], "memory_ids": ["mem-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            has_mental_models=True,
+            budget="high",
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        assert result.text == "Verified answer."
+        mock_llm.call.assert_not_called()
+        mock_functions["search_observations_fn"].assert_called_once()
+        mock_functions["recall_fn"].assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mental_model_policy_can_skip_observations_but_force_recall(self, mock_llm, mock_functions):
+        """The policy can partially rewrite the forced path instead of only all-or-nothing skipping."""
+        mock_functions["search_mental_models_fn"].return_value = {
+            "query": "test query",
+            "count": 1,
+            "mental_models": [
+                {
+                    "id": "mm-1",
+                    "name": "Project status",
+                    "content": "The project status may need raw fact verification.",
+                    "relevance": 0.8,
+                    "is_stale": False,
+                }
+            ],
+        }
+        mock_llm.call.return_value = (
+            {
+                "mental_models_sufficient": False,
+                "needs_observations": False,
+                "needs_recall": True,
+                "reason": "The question asks for exact current status, so raw facts are needed.",
+                "follow_up_query": "current project status raw facts",
+            },
+            TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30),
+        )
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="1",
+                        name="search_mental_models",
+                        arguments={"reason": "check curated knowledge", "query": "test query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="recall",
+                        arguments={"reason": "verify raw facts", "query": "generic project query"},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="3",
+                        name="done",
+                        arguments={"answer": "Raw facts verified it.", "memory_ids": ["mem-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            has_mental_models=True,
+            budget="mid",
+            max_iterations=5,
+            **mock_functions,
+        )
+
+        assert result.text == "Raw facts verified it."
+        mock_functions["search_observations_fn"].assert_not_called()
+        mock_functions["recall_fn"].assert_called_once()
+        assert mock_functions["recall_fn"].await_args.args[0] == "current project status raw facts"
+        second_tool_choice = mock_llm.call_with_tools.await_args_list[1].kwargs["tool_choice"]
+        assert second_tool_choice == {"type": "function", "function": {"name": "recall"}}
+        recall_trace = next(tc for tc in result.tool_trace if tc.tool == "recall")
+        assert recall_trace.input["query"] == "current project status raw facts"
+        assert recall_trace.input["original_query"] == "generic project query"
+        assert recall_trace.input["query_overridden_by"] == "retrieval_policy"
 
     @pytest.mark.asyncio
     async def test_handles_functions_prefix_in_done(self, mock_llm, mock_functions):
@@ -699,6 +1012,119 @@ class TestDirectiveLeakageOnEmptyBank:
             )
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.hs_llm_core
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
+class TestMentalModelRetrievalPolicyRealLLM:
+    """Real-LLM coverage for the mental-model retrieval policy classifier."""
+
+    @pytest.fixture
+    def real_reflect_llm(self):
+        config = get_config()
+        provider = config.reflect_llm_provider or config.llm_provider
+        api_key = config.reflect_llm_api_key or config.llm_api_key or ""
+        model = config.reflect_llm_model or config.llm_model
+        base_url = config.reflect_llm_base_url or config.llm_base_url
+
+        if not provider or provider == "none":
+            pytest.skip("real reflect LLM provider is not configured")
+        if requires_api_key(provider) and not api_key:
+            pytest.skip("real reflect LLM API key is not configured")
+        if not base_url:
+            if provider.lower() == "groq":
+                base_url = "https://api.groq.com/openai/v1"
+            elif provider.lower() == "ollama":
+                base_url = "http://localhost:11434/v1"
+            elif provider.lower() == "ollama-cloud":
+                base_url = "https://ollama.com/v1"
+            else:
+                base_url = ""
+
+        return LLMConfig(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=config.llm_reasoning_effort,
+            extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
+            litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_policy_accepts_direct_fresh_mental_model(self, real_reflect_llm):
+        result = await _decide_after_mental_models(
+            real_reflect_llm,
+            user_query="According to the mental model, what communication style does the team prefer for architecture decisions?",
+            context=None,
+            mental_model_output={
+                "query": "architecture decision communication style",
+                "count": 1,
+                "mental_models": [
+                    {
+                        "id": "mm-communication",
+                        "name": "Architecture Communication Preference",
+                        "content": (
+                            "For architecture decisions, the team prefers async written communication. "
+                            "They use concise ADRs and avoid deciding complex design questions in live meetings."
+                        ),
+                        "relevance": 0.94,
+                        "is_stale": False,
+                    }
+                ],
+            },
+            budget="low",
+            include_observations=True,
+            include_recall=True,
+            reflect_id="test-real-policy-sufficient",
+        )
+
+        decision = result.decision
+        assert result.input_tokens > 0
+        assert result.output_tokens > 0
+        assert decision.mental_models_sufficient is True, decision.model_dump()
+        assert decision.needs_observations is False
+        assert decision.needs_recall is False
+        assert decision.follow_up_query is None
+
+    @pytest.mark.asyncio
+    async def test_real_policy_requests_targeted_verification_for_current_evidence(self, real_reflect_llm):
+        result = await _decide_after_mental_models(
+            real_reflect_llm,
+            user_query="What is the current Project Aurora launch status, and which raw fact proves it?",
+            context=None,
+            mental_model_output={
+                "query": "Project Aurora launch status",
+                "count": 1,
+                "mental_models": [
+                    {
+                        "id": "mm-aurora",
+                        "name": "Project Aurora Launch Plan",
+                        "content": (
+                            "Project Aurora had a planned Friday launch in the last planning summary. "
+                            "This summary does not include current completion evidence or raw source facts."
+                        ),
+                        "relevance": 0.91,
+                        "is_stale": False,
+                    }
+                ],
+            },
+            budget="low",
+            include_observations=True,
+            include_recall=True,
+            reflect_id="test-real-policy-verify",
+        )
+
+        decision = result.decision
+        assert result.input_tokens > 0
+        assert result.output_tokens > 0
+        assert decision.mental_models_sufficient is False, decision.model_dump()
+        assert decision.needs_observations or decision.needs_recall
+        assert decision.follow_up_query
+        follow_up = decision.follow_up_query.lower()
+        assert "aurora" in follow_up
+        assert "status" in follow_up or "launch" in follow_up or "evidence" in follow_up
 
 
 @pytest.mark.hs_llm_core


### PR DESCRIPTION
## Summary

Fixes #1971.

This PR makes the forced `reflect` retrieval path conditional after the mental-model layer. When `search_mental_models` returns fresh, usable mental models that are sufficient for the user query, low- and mid-budget reflect calls can stop forcing lower-level retrieval and let the agent answer or choose the next action normally.

When lower-level retrieval is still needed, the policy can provide a targeted follow-up query for `search_observations` or `recall`, so deeper retrieval focuses on the mental-model conclusion, gap, or stale point that needs verification instead of blindly repeating the original query.

## Motivation

Before this change, the reflect agent forced the same retrieval sequence whenever all layers were enabled:

```text
search_mental_models -> search_observations -> recall
```

Because each forced iteration uses `tool_choice` with a specific function, the agent could not answer after a sufficient mental-model result. It still had to call `search_observations` and then `recall`.

That weakens the value of mental models as reusable synthesized knowledge:

- fresh and relevant mental models cannot act as an answer boundary;
- low-budget reflect calls still pay for the full three-layer retrieval path;
- later retrieval can duplicate evidence already summarized by the mental model;
- the deeper retrieval query is not guaranteed to verify the specific conclusion or gap that matters.

## Changes

- Adds a structured retrieval-policy decision after `search_mental_models`.
- Keeps `high` budget on the full verification path.
- Allows low- and mid-budget calls to stop forced lower-level retrieval when fresh mental models are sufficient.
- Treats stale, missing-staleness, or empty mental models as unsafe for short-circuiting and falls back to lower-level retrieval.
- Falls back to conservative lower-level retrieval if the policy LLM call or structured output parsing fails.
- Uses retrieval relevance as metadata only, without adding a fixed score threshold.
- Carries a policy-generated `follow_up_query` into forced `search_observations` and `recall` calls when deeper retrieval is needed.
- Records the retrieval-policy decision in the reflect trace.
- Removes the old forced-sequence alignment workaround that inserted an already-executed `search_mental_models` entry into the override sequence.

## Behavior

After this change:

- If no mental models are found, reflect continues to the enabled lower layers.
- If any retrieved mental model is stale or has no usable content, reflect continues to the enabled lower layers.
- If the budget is `high`, reflect preserves the fuller verification path.
- If fresh mental models are sufficient, forced lower-layer retrieval stops and the next agent iteration uses normal `auto` tool choice.
- If fresh mental models are not sufficient, reflect forces only the lower layers requested by the policy and uses the policy's targeted query when available.

## Tests

- `uv run ruff check tests/test_reflect_agent.py`
- `uv run ty check hindsight_api/engine/reflect/agent.py`
- `./scripts/hooks/lint.sh`
- `uv run pytest tests/test_reflect_agent.py::TestMentalModelRetrievalPolicyRealLLM -q`
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 uv run pytest tests/test_reflect_agent.py -q`

The new tests cover:

- stopping forced retrieval when fresh mental models are sufficient;
- preventing stale or empty mental models from short-circuiting;
- preserving full retrieval for `high` budget;
- using a targeted follow-up query for forced lower-layer retrieval;
- real-LLM behavior for both sufficient and verification-needed policy decisions.