### PR TITLE
fix(api): add vchord catalogs to search_path for external Postgres (#1351)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2379,9 +2379,23 @@ class MemoryEngine(MemoryEngineInterface):
         self._dialect = create_sql_dialect(self._database_backend_type)
 
         stmt_timeout_s = self._db_statement_timeout
+        text_search_extension = get_config().text_search_extension
 
         # Per-connection initialization callback (PostgreSQL-specific for now)
         async def _init_connection(conn: asyncpg.Connection) -> None:
+            # VectorChord BM25 registers its objects in dedicated schemas
+            # (vchord_bm25 -> bm25_catalog, pg_tokenizer -> tokenizer_catalog).
+            # The BM25 distance operator `<&>` resolves its operand types via the
+            # session search_path, so a connection that lacks these schemas fails
+            # recall with `type "bm25vector" does not exist` (and retain with
+            # `function tokenize(...) does not exist`). The official vchord-suite
+            # image masks this by shipping them in search_path; an external
+            # Postgres does not, so we add them ourselves. Tenant tables are always
+            # accessed via fully-qualified names (fq_table), so this does not
+            # affect schema isolation. Only needed for the vchord backend.
+            if text_search_extension == "vchord":
+                await conn.execute('SET search_path TO "$user", public, bm25_catalog, tokenizer_catalog')
+
             # SET (not SET LOCAL) so per-backend ANN tuning persists for the
             # connection lifetime. Each backend exposes its own GUC: pgvector
             # uses hnsw.ef_search, vchord uses vchordrq.probes. The dispatcher


### PR DESCRIPTION
## Summary

Fixes #1351. With `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=vchord` against an **external** PostgreSQL (not the official `vchord-suite` image), retain and recall fail because VectorChord's objects live in dedicated schemas that aren't on the connection's `search_path`:

- `pg_tokenizer` → `tokenizer_catalog` (the `tokenize()` function) → retain fails with `function tokenize(text, unknown) does not exist`
- `vchord_bm25` → `bm25_catalog` (the `bm25vector`/`bm25query` types, `to_bm25query()`, and the `<&>` distance operator) → recall fails with `type "bm25vector" does not exist`

The official `tensorchord/vchord-suite` image masks this by shipping `search_path = "$user", public, bm25_catalog, tokenizer_catalog`. An external Postgres doesn't, so we set the same `search_path` on each connection when the vchord backend is configured.

## Why not just schema-qualify the SQL?

That was the original plan (and the issue's suggestion), but it can't fully work. Qualifying `tokenizer_catalog.tokenize(...)` fixes the retain path, but the recall query's `<&>` operator resolves its operand types (`bm25vector`/`bm25query`) via `search_path`, and **there is no SQL syntax to qualify that** — even `OPERATOR(pg_catalog.<&>)` with fully-qualified function args still fails with `type "bm25vector" does not exist` on a bare path. So recall forces `bm25_catalog` onto the `search_path` regardless. Setting `search_path` is therefore the single, complete mechanism, and it byte-for-byte matches what the official image already does.

Tenant tables are always accessed via fully-qualified names (`fq_table()` + a contextvar schema), never via `search_path`, so this does not affect schema isolation.

## Testing

Verified against the repo's `docker/docker-compose/vchord` stack (real VectorChord), with `search_path` reset to `public` to simulate an external DB:

| Path | Without fix (bare search_path) | With fix (vchord connection init) |
|---|---|---|
| retain (`tokenize ... ::bm25vector`) | ❌ `function tokenize(text, unknown) does not exist` | ✅ |
| recall (`search_vector <&> to_bm25query(...)`) | ❌ `type "bm25vector" does not exist` | ✅ returns scored rows |

The change is gated on `text_search_extension == "vchord"`; non-vchord backends are unaffected. No automated regression test is added because the repo has no vchord CI infrastructure (no test or workflow references vchord); adding one would mean standing up a VectorChord container in CI, out of scope for this fix.