### PR TITLE
fix(ci): repair zeroentropy embedding tests and regenerate drifted clients

### DIFF
--- a/hindsight-api-slim/tests/test_zeroentropy_embeddings.py
+++ b/hindsight-api-slim/tests/test_zeroentropy_embeddings.py
@@ -245,6 +245,11 @@ async def test_embedding_utils_routes_query_embeddings_to_provider_hook():
     from hindsight_api.engine.retain.embedding_utils import generate_embeddings_batch
 
     class QueryAwareEmbeddings:
+        # 1-element vectors below — declare a matching dimension so the
+        # post-encode validation in generate_embeddings_batch passes (the
+        # EmbeddingsBackend Protocol requires a `dimension` property).
+        dimension = 1
+
         def encode(self, texts: list[str]) -> list[list[float]]:
             raise AssertionError("query embeddings should not use the generic encode method")
 
@@ -261,6 +266,11 @@ async def test_embedding_utils_routes_document_embeddings_to_provider_hook():
     from hindsight_api.engine.retain.embedding_utils import generate_embeddings_batch
 
     class DocumentAwareEmbeddings:
+        # 1-element vectors below — declare a matching dimension so the
+        # post-encode validation in generate_embeddings_batch passes (the
+        # EmbeddingsBackend Protocol requires a `dimension` property).
+        dimension = 1
+
         def encode(self, texts: list[str]) -> list[list[float]]:
             raise AssertionError("document embeddings should not use the generic encode method")
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5513,7 +5513,6 @@ components:
           input: ""
           ctx: "{}"
           type: type
-          url: url
         - msg: msg
           loc:
           - ValidationError_loc_inner
@@ -5521,7 +5520,6 @@ components:
           input: ""
           ctx: "{}"
           type: type
-          url: url
       properties:
         detail:
           items:
@@ -7491,7 +7489,6 @@ components:
         input: ""
         ctx: "{}"
         type: type
-        url: url
       properties:
         loc:
           items:
@@ -7507,9 +7504,6 @@ components:
         ctx:
           title: Context
           type: object
-        url:
-          title: URL
-          type: string
       required:
       - loc
       - msg

--- a/hindsight-clients/go/model_validation_error.go
+++ b/hindsight-clients/go/model_validation_error.go
@@ -26,7 +26,6 @@ type ValidationError struct {
 	Type string `json:"type"`
 	Input interface{} `json:"input,omitempty"`
 	Ctx map[string]interface{} `json:"ctx,omitempty"`
-	Url *string `json:"url,omitempty"`
 }
 
 type _ValidationError ValidationError
@@ -188,38 +187,6 @@ func (o *ValidationError) SetCtx(v map[string]interface{}) {
 	o.Ctx = v
 }
 
-// GetUrl returns the Url field value if set, zero value otherwise.
-func (o *ValidationError) GetUrl() string {
-	if o == nil || IsNil(o.Url) {
-		var ret string
-		return ret
-	}
-	return *o.Url
-}
-
-// GetUrlOk returns a tuple with the Url field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ValidationError) GetUrlOk() (*string, bool) {
-	if o == nil || IsNil(o.Url) {
-		return nil, false
-	}
-	return o.Url, true
-}
-
-// HasUrl returns a boolean if a field has been set.
-func (o *ValidationError) HasUrl() bool {
-	if o != nil && !IsNil(o.Url) {
-		return true
-	}
-
-	return false
-}
-
-// SetUrl gets a reference to the given string and assigns it to the Url field.
-func (o *ValidationError) SetUrl(v string) {
-	o.Url = &v
-}
-
 func (o ValidationError) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -238,9 +205,6 @@ func (o ValidationError) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Ctx) {
 		toSerialize["ctx"] = o.Ctx
-	}
-	if !IsNil(o.Url) {
-		toSerialize["url"] = o.Url
 	}
 	return toSerialize, nil
 }

--- a/hindsight-clients/python/hindsight_client_api/models/validation_error.py
+++ b/hindsight-clients/python/hindsight_client_api/models/validation_error.py
@@ -32,8 +32,7 @@ class ValidationError(BaseModel):
     type: StrictStr
     input: Optional[Any] = None
     ctx: Optional[Dict[str, Any]] = None
-    url: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["loc", "msg", "type", "input", "ctx", "url"]
+    __properties: ClassVar[List[str]] = ["loc", "msg", "type", "input", "ctx"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -102,8 +101,7 @@ class ValidationError(BaseModel):
             "msg": obj.get("msg"),
             "type": obj.get("type"),
             "input": obj.get("input"),
-            "ctx": obj.get("ctx"),
-            "url": obj.get("url")
+            "ctx": obj.get("ctx")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3506,10 +3506,6 @@ export type ValidationError = {
   ctx?: {
     [key: string]: unknown;
   };
-  /**
-   * URL
-   */
-  url?: string;
 };
 
 /**

--- a/hindsight-dev/hindsight_dev/generate_openapi.py
+++ b/hindsight-dev/hindsight_dev/generate_openapi.py
@@ -14,6 +14,32 @@ from hindsight_api import MemoryEngine
 from hindsight_api.api import create_app
 
 
+def _restore_binary_format(node: object) -> None:
+    """Rewrite OpenAPI-3.1 binary string fields back to the 3.0 ``format: binary`` form.
+
+    FastAPI/Pydantic (>=0.136 / >=2.12) serialize binary upload fields as
+    ``{"type": "string", "contentMediaType": "application/octet-stream"}`` — valid
+    OpenAPI 3.1, but openapi-generator v7.10.0 (used by generate-clients.sh) does
+    NOT recognize ``contentMediaType`` as a file upload. It then generates the
+    ``files``/``file`` params as plain strings instead of binary multipart uploads,
+    silently breaking the Go/Python/TypeScript clients of the Files and
+    document-transfer endpoints. Earlier FastAPI emitted ``format: binary`` (still
+    under ``openapi: 3.1.0``), which the generator handles correctly, so we restore
+    that exact representation in-place. Scoped to ``application/octet-stream`` so it
+    only touches binary uploads, not arbitrary content-typed strings.
+    """
+    if isinstance(node, dict):
+        if node.get("contentMediaType") == "application/octet-stream":
+            node.pop("contentMediaType", None)
+            node.pop("contentEncoding", None)
+            node["format"] = "binary"
+        for value in node.values():
+            _restore_binary_format(value)
+    elif isinstance(node, list):
+        for item in node:
+            _restore_binary_format(item)
+
+
 def generate_openapi_spec(output_path: str = None):
     """Generate OpenAPI spec and save to file."""
     # Default to hindsight-docs/static/openapi.json (single source of truth)
@@ -33,6 +59,9 @@ def generate_openapi_spec(output_path: str = None):
 
     # Get the OpenAPI schema from the app
     openapi_schema = app.openapi()
+
+    # Keep binary upload fields generator-compatible (see helper docstring).
+    _restore_binary_format(openapi_schema)
 
     # Write to file
     output_file = Path(output_path)

--- a/hindsight-dev/tests/test_generate_openapi.py
+++ b/hindsight-dev/tests/test_generate_openapi.py
@@ -1,0 +1,56 @@
+"""Regression tests for OpenAPI spec post-processing in generate_openapi."""
+
+from hindsight_dev.generate_openapi import _restore_binary_format
+
+
+def test_restores_format_binary_for_octet_stream_string():
+    """contentMediaType binary uploads are rewritten to the format:binary form.
+
+    Guards the Files / document-transfer file-upload regression: FastAPI 0.136 /
+    Pydantic 2.12 emit OpenAPI-3.1 contentMediaType, which openapi-generator
+    v7.10.0 generates as a plain string instead of a multipart file upload.
+    """
+    schema = {
+        "type": "string",
+        "title": "File",
+        "contentMediaType": "application/octet-stream",
+    }
+
+    _restore_binary_format(schema)
+
+    assert schema == {"type": "string", "title": "File", "format": "binary"}
+    assert "contentMediaType" not in schema
+
+
+def test_rewrites_nested_and_array_item_schemas():
+    """The walk reaches binary fields nested in properties and array items."""
+    schema = {
+        "components": {
+            "schemas": {
+                "Upload": {
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "type": "array",
+                            "items": {"type": "string", "contentMediaType": "application/octet-stream"},
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    _restore_binary_format(schema)
+
+    item = schema["components"]["schemas"]["Upload"]["properties"]["files"]["items"]
+    assert item == {"type": "string", "format": "binary"}
+
+
+def test_leaves_other_content_media_types_untouched():
+    """Only application/octet-stream is rewritten; other media types are preserved."""
+    schema = {"type": "string", "contentMediaType": "application/json"}
+
+    _restore_binary_format(schema)
+
+    assert schema == {"type": "string", "contentMediaType": "application/json"}
+    assert "format" not in schema

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -6862,9 +6862,9 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
             "title": "File",
-            "description": "Transfer ZIP archive"
+            "description": "Transfer ZIP archive",
+            "format": "binary"
           }
         },
         "type": "object",
@@ -11747,12 +11747,8 @@
             "title": "Input"
           },
           "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "url": {
-            "title": "URL",
-            "type": "string"
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -6862,9 +6862,9 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
             "title": "File",
-            "description": "Transfer ZIP archive"
+            "description": "Transfer ZIP archive",
+            "format": "binary"
           }
         },
         "type": "object",
@@ -11747,12 +11747,8 @@
             "title": "Input"
           },
           "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "url": {
-            "title": "URL",
-            "type": "string"
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",


### PR DESCRIPTION
## What

Fixes the two pre-existing CI failures on `main` — and corrects a **backward-incompatible regression** that a naive regeneration would have shipped.

### 1. `test-api` — `test_zeroentropy_embeddings.py` (2 failures)

`AttributeError: 'QueryAwareEmbeddings' object has no attribute 'dimension'`. PR #1670 added post-encode dimension validation to `generate_embeddings_batch` (reads `embeddings_backend.dimension`, a field the `EmbeddingsBackend` Protocol already requires); the pre-existing routing-test mocks (#1770) omit it. **Fix:** the mocks return 1-element vectors → declare `dimension = 1`. Pure test fix.

### 2. `verify-generated-files` — OpenAPI/client drift (with a regression trap)

The uv-group dep bump (#1982 → FastAPI 0.136 / Pydantic 2.12) changed how binary upload fields serialize: OpenAPI-3.1 `{"type":"string","contentMediaType":"application/octet-stream"}` instead of `format: binary`. Both are valid 3.1.0, **but openapi-generator v7.10.0 does not treat `contentMediaType` as a file upload** — so a plain regeneration rewrites the `files`/`file` upload params as strings, silently breaking multipart upload in all three SDKs:

| Client | Before | Naive regen (broken) |
|---|---|---|
| Go | `files []*os.File` | `files []string` (CSV form field) |
| Python | `List[Union[StrictBytes, StrictStr, ...]]` | `List[StrictStr]` |
| TypeScript | `Array<Blob \| File>` | `Array<string>` |

**Fix:** `generate_openapi.py` now post-processes the exported schema to restore the prior `format: binary` representation (still valid under 3.1.0, and what the generator understands), scoped to `application/octet-stream` only. Regenerated the spec + Go/Python/TS clients + docs-skill copy:
- **Upload signatures are identical to `main`** (file uploads preserved — verified).
- The only behavioral delta vs `main` is `ValidationError` dropping its `url` field — a real Pydantic 2.12 change (error-response metadata, harmless).

Added a unit test (`test_generate_openapi.py`) locking the binary-rewrite behavior.

## Verification

- `pytest tests/test_zeroentropy_embeddings.py` → 13 passed; `pytest tests/test_generate_openapi.py` → 3 passed.
- Generator is idempotent (re-running produces no diff) and all four generators + lint leave a clean tree — what `verify-generated-files` checks.
- Diffed every regenerated client vs `main`: upload params restored; remaining changes are only the `ValidationError.url` removal.

## Why not just commit the regenerated clients

That was the first instinct, but it would ship clients that can no longer upload files. Restoring `format: binary` at the spec boundary keeps the generated clients correct without reverting the dependency bump. The structural guard is self-reinforcing: drop the post-process and the regenerated string-typed params no longer match the committed file-upload clients, turning `verify-generated-files` red.