### PR TITLE
fix: prefer mental model abstraction in reflect to avoid unnecessary low-level retrieval

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -420,6 +420,10 @@ async def run_reflect_agent(
     available_mental_model_ids: set[str] = set()
     available_observation_ids: set[str] = set()
 
+    # Budget-aware short-circuit: when mental models are sufficient,
+    # skip forcing lower-level retrieval (search_observations, recall)
+    mental_models_sufficient = False
+
     def _get_llm_trace() -> list[LLMCall]:
         return [
             LLMCall(
@@ -592,8 +596,25 @@ async def run_reflect_agent(
         if include_recall:
             forced_sequence.append("recall")
 
-        if iteration < len(forced_sequence):
-            iter_tool_choice: str | dict = {"type": "function", "function": {"name": forced_sequence[iteration]}}
+        # Budget-aware short-circuit: for low/mid budgets, allow the agent to
+        # answer after search_mental_models returns sufficient fresh results,
+        # without forcing lower-level retrieval (search_observations, recall).
+        # High budget preserves the full forced hierarchical verification path.
+        effective_budget = budget or "low"
+        _skip_forcing = False
+        if has_mental_models and effective_budget == "low":
+            # Low budget: force only search_mental_models, then allow auto
+            if iteration >= 1:
+                _skip_forcing = True
+        elif has_mental_models and effective_budget == "mid" and mental_models_sufficient:
+            # Mid budget: skip lower retrieval when mental models are fresh and relevant
+            if iteration >= 1:
+                _skip_forcing = True
+
+        if _skip_forcing:
+            iter_tool_choice: str | dict = "auto"
+        elif iteration < len(forced_sequence):
+            iter_tool_choice = {"type": "function", "function": {"name": forced_sequence[iteration]}}
         else:
             iter_tool_choice = "auto"
 
@@ -956,6 +977,17 @@ async def run_reflect_agent(
                     for mm in output["mental_models"]:
                         if "id" in mm:
                             available_mental_model_ids.add(mm["id"])
+                    # Determine if mental models are fresh enough to short-circuit
+                    # lower-level retrieval (search_observations, recall).
+                    fresh_models = [
+                        mm for mm in output.get("mental_models", [])
+                        if not mm.get("is_stale", True) and mm.get("content")
+                    ]
+                    if fresh_models:
+                        # At least one mental model is non-empty and not stale.
+                        # Mark as sufficient so the forced-sequence logic can
+                        # skip to auto mode on the next iteration.
+                        mental_models_sufficient = True
 
                 if (
                     normalized_tool_name == "search_observations"


### PR DESCRIPTION
## Summary

The reflect operation was unconditionally forcing the full hierarchical retrieval chain (search_mental_models -> search_observations -> recall) before allowing the agent to answer, even when mental model abstraction would provide adequate context. This PR adds budget-aware short-circuit logic to prefer higher-level abstractions when appropriate.

## Problem

In `run_reflect_agent`, the `forced_sequence` always forced `search_mental_models`, then `search_observations`, then `recall` before allowing auto mode. Even when a fresh, relevant mental model could answer the query, the agent was forced to continue to lower-level retrieval, increasing latency, cost, and potentially duplicating already-synthesized knowledge.

## Changes

1. **Budget-aware short-circuit in forced sequence** (agent.py lines 599-618):
   - `low` budget: Force only `search_mental_models`, then allow auto mode
   - `mid` budget: Skip lower-level retrieval when mental models are fresh and non-empty
   - `high` budget: Preserve the full hierarchical verification path (existing behavior)

2. **Mental model freshness tracking** (agent.py line 425):
   - Added `mental_models_sufficient` flag to track when retrieved mental models are sufficient

3. **Freshness evaluation** (agent.py lines 982-990):
   - After `search_mental_models` returns, check for mental models with `is_stale=False` and non-empty content
   - Set `mental_models_sufficient = True` when at least one model meets these criteria

## Behavior

| Budget | Before | After |
|--------|--------|-------|
| `low` | Force all 3 retrieval layers | Force only `search_mental_models`, then auto |
| `mid` | Force all 3 retrieval layers | Force `search_mental_models`; skip lower layers if fresh results found |
| `high` | Force all 3 retrieval layers | Force all 3 retrieval layers (unchanged) |

The default budget (`low`) now completes in fewer iterations when mental models are available, reducing latency and cost while maintaining answer quality.

## Backward Compatibility

- `high` budget: Unchanged behavior (full verification chain)
- `mid` budget: Conditional short-circuit only when mental models are truly fresh
- `low` budget: Changed default to prefer speed, consistent with documented budget semantics ("Prioritize speed over completeness")

Fixes #1971