### PR TITLE
fix(llm): downgrade tool_choice="required" for servers that silently drop it (vLLM/LM Studio/Ollama)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -44,6 +44,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_LLM_SEED = 4242
 JSON_MODE_USER_HINT = "Return valid json only."
 
+# Self-hosted OpenAI-compatible servers that advertise tool_choice="required"
+# but silently ignore it: instead of forcing a tool call they return
+# finish_reason "stop"/"tool_calls" with an EMPTY tool_calls array and no error.
+# Reflect's agent loop then sees no tool call, runs synthesis with no retrieval,
+# and answers "I don't have information" even when the bank holds the answer.
+# See issues #1563 (LM Studio), #1179 (LM Studio + Qwen), #1877 (vLLM with
+# --enable-auto-tool-choice). llama-server (the "llamacpp" provider) honors
+# "required" correctly and is intentionally excluded (#1179).
+_TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS = frozenset({"lmstudio", "ollama"})
+
 
 class ProviderResponseError(RuntimeError):
     """Raised when a provider returns a success response without usable content."""
@@ -359,6 +369,21 @@ class OpenAICompatibleLLM(LLMInterface):
             f"OpenAI-compatible client initialized: provider={self.provider}, model={self.model}, "
             f"base_url={self.base_url or 'default'}"
         )
+
+    def _drops_tool_choice_required(self) -> bool:
+        """Whether this endpoint silently ignores ``tool_choice="required"``.
+
+        True for self-hosted OpenAI-compatible servers known to return an empty
+        tool_calls array for "required" instead of forcing a call (#1563/#1179/
+        #1877). Covers LM Studio / Ollama directly, plus any server reached via
+        the generic "openai" provider with a custom ``base_url`` (e.g. a local
+        vLLM endpoint). The real OpenAI API (no base_url override) honors
+        "required", and cloud providers keep their own default base_urls, so both
+        are left untouched.
+        """
+        if self.provider in _TOOL_CHOICE_REQUIRED_UNSUPPORTED_PROVIDERS:
+            return True
+        return self.provider == "openai" and bool(self.base_url)
 
     async def verify_connection(self) -> None:
         """
@@ -869,6 +894,16 @@ class OpenAICompatibleLLM(LLMInterface):
         # only when the caller asks for a non-default behaviour avoids those 400s
         # without changing semantics for compliant providers.
         if request_tool_choice == "auto":
+            request_tool_choice = None
+
+        # vLLM (--enable-auto-tool-choice), LM Studio, Ollama and similar
+        # self-hosted servers silently drop tool_choice="required", returning an
+        # empty tool_calls array instead of forcing a call (#1563/#1179/#1877).
+        # Downgrade to auto (None) so the model still gets to call a tool. Named
+        # tool_choice dicts were already normalized to "required" + a single
+        # filtered tool above, so the call stays practically forced even under
+        # auto. The real OpenAI API honors "required" and is left untouched.
+        if request_tool_choice == "required" and self._drops_tool_choice_required():
             request_tool_choice = None
 
         # DeepSeek tool-call replies can carry provider-specific reasoning_content.

--- a/hindsight-api-slim/tests/test_lmstudio_tool_choice.py
+++ b/hindsight-api-slim/tests/test_lmstudio_tool_choice.py
@@ -81,7 +81,9 @@ def _make_lmstudio_llm() -> OpenAICompatibleLLM:
     )
 
 
-def _lmstudio_400_error(msg: str = "Tool choice of type 'function' is not supported. Use 'auto', 'none', or 'required'.") -> APIStatusError:
+def _lmstudio_400_error(
+    msg: str = "Tool choice of type 'function' is not supported. Use 'auto', 'none', or 'required'.",
+) -> APIStatusError:
     """Simulate the HTTP 400 LM Studio returns for unsupported tool_choice format."""
     mock_response = MagicMock()
     mock_response.status_code = 400
@@ -151,7 +153,11 @@ class TestLMStudioNamedToolChoiceBug:
         assert result.tool_calls[0].name == "search_mental_models"
 
         sent_kwargs = mock_create.call_args.kwargs
-        assert sent_kwargs["tool_choice"] == "required"
+        # The named dict is normalized to "required" + a single filtered tool,
+        # then "required" is downgraded to auto (omitted) because LM Studio
+        # silently drops it (#1563/#1179/#1877). The single filtered tool keeps
+        # the call forced in practice. See test_tool_choice_required_downgrade.py.
+        assert "tool_choice" not in sent_kwargs
         assert len(sent_kwargs["tools"]) == 1
         assert sent_kwargs["tools"][0]["function"]["name"] == "search_mental_models"
 
@@ -182,11 +188,12 @@ class TestLMStudioNamedToolChoiceBug:
             assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_lmstudio_string_tool_choice_works_fine(self):
+    async def test_lmstudio_string_required_is_downgraded(self):
         """
-        String tool_choice values ("auto", "none", "required") ARE supported by LM Studio.
-        Only the dict format {"type": "function", "function": {"name": "..."}} fails.
-        This test confirms the control case works.
+        LM Studio does not honour the string ``tool_choice="required"`` either:
+        it silently returns an empty tool_calls array (#1563/#1179/#1877). So
+        "required" is downgraded to auto (omitted) for LM Studio. See the
+        dedicated suite in test_tool_choice_required_downgrade.py.
         """
         llm = _make_lmstudio_llm()
         success_response = _make_tool_call_response("search_mental_models", {"query": "user name"})
@@ -197,16 +204,16 @@ class TestLMStudioNamedToolChoiceBug:
             result = await llm.call_with_tools(
                 messages=[{"role": "user", "content": "What is the user's name?"}],
                 tools=REFLECT_TOOLS,
-                tool_choice="required",  # string form — LM Studio accepts this
+                tool_choice="required",
                 max_retries=0,
             )
 
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0].name == "search_mental_models"
 
-        # Confirm "required" was sent, not a dict
+        # "required" is omitted (downgraded to auto) rather than sent verbatim.
         sent_kwargs = mock_create.call_args.kwargs
-        assert sent_kwargs["tool_choice"] == "required"
+        assert "tool_choice" not in sent_kwargs
 
 
 class TestExpectedFixBehavior:
@@ -225,10 +232,11 @@ class TestExpectedFixBehavior:
     """
 
     @pytest.mark.asyncio
-    async def test_fix_converts_named_tool_choice_to_required(self):
+    async def test_fix_converts_named_tool_choice_and_downgrades(self):
         """
-        After fix: named tool_choice dict is converted to "required" for lmstudio.
-        The API receives tool_choice="required" instead of the unsupported dict.
+        Named tool_choice dict → normalized to "required" + a single filtered
+        tool → "required" downgraded to auto (omitted) for lmstudio. The API
+        never sees the unsupported dict nor the silently-dropped "required".
         """
         llm = _make_lmstudio_llm()
         named_tool_choice = {"type": "function", "function": {"name": "search_mental_models"}}
@@ -248,11 +256,9 @@ class TestExpectedFixBehavior:
         assert result.tool_calls[0].name == "search_mental_models"
 
         sent_kwargs = mock_create.call_args.kwargs
-        # Fix: dict was converted to "required"
-        assert sent_kwargs["tool_choice"] == "required", (
-            f"Expected tool_choice='required', got {sent_kwargs['tool_choice']!r}"
-        )
-        # Fix: tools filtered to just the requested one
+        # Fix: dict was normalized then "required" downgraded to auto (omitted)
+        assert "tool_choice" not in sent_kwargs
+        # Fix: tools filtered to just the requested one (keeps the call forced)
         assert len(sent_kwargs["tools"]) == 1
         assert sent_kwargs["tools"][0]["function"]["name"] == "search_mental_models"
 
@@ -281,7 +287,9 @@ class TestExpectedFixBehavior:
             )
 
         sent_kwargs = mock_create.call_args.kwargs
-        assert sent_kwargs["tool_choice"] == "required"
+        # "required" is downgraded to auto (omitted) for lmstudio; the single
+        # filtered tool keeps the call forced.
+        assert "tool_choice" not in sent_kwargs
         assert len(sent_kwargs["tools"]) == 1
         assert sent_kwargs["tools"][0]["function"]["name"] == forced_tool_name
 
@@ -290,7 +298,9 @@ class TestExpectedFixBehavior:
         """
         The fix is generalized: all providers convert named tool_choice to
         "required" + filtered tools.  OpenAI natively supports the dict format
-        too, so the behaviour is semantically identical either way.
+        too, so the behaviour is semantically identical either way. The real
+        OpenAI API (no base_url override) honours "required", so unlike the
+        self-hosted providers it is NOT downgraded.
         """
         from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
 

--- a/hindsight-api-slim/tests/test_tool_choice_required_downgrade.py
+++ b/hindsight-api-slim/tests/test_tool_choice_required_downgrade.py
@@ -1,0 +1,171 @@
+"""Regression tests for the silent-drop of ``tool_choice="required"``.
+
+Reproduces issues #1563 (LM Studio), #1179 (LM Studio + Qwen) and #1877 (vLLM
+with ``--enable-auto-tool-choice``). These self-hosted OpenAI-compatible servers
+advertise ``tool_choice="required"`` but silently ignore it — returning a
+``finish_reason`` of ``"stop"``/``"tool_calls"`` with an EMPTY ``tool_calls``
+array and no HTTP error. Reflect's agent loop then sees no tool call, runs
+synthesis with no retrieval, and answers "I don't have information" even when the
+bank holds the answer.
+
+The fix downgrades ``"required"`` to auto (omitted) for these endpoints so the
+model still gets to call a tool. Named ``tool_choice`` dicts are normalized to
+``"required"`` + a single filtered tool first, so forced calls stay practically
+forced even under auto. The real OpenAI API and cloud providers honor
+``"required"`` and must be left untouched.
+
+These are fast, deterministic unit tests: the OpenAI client's ``create`` is
+mocked and we assert on the exact kwargs sent over the wire.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "recall",
+            "description": "Recall semantic memories",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "done",
+            "description": "Finish and return the answer",
+            "parameters": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+        },
+    },
+]
+
+
+def _make_llm(provider: str, base_url: str) -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider=provider,
+        api_key="local" if provider in ("ollama", "lmstudio") else "sk-test",
+        base_url=base_url,
+        model="qwen3",
+    )
+
+
+def _tool_call_response() -> MagicMock:
+    """A populated tool call — what these servers return under auto (not required)."""
+    tc = MagicMock()
+    tc.id = "call_abc123"
+    tc.function.name = "recall"
+    tc.function.arguments = json.dumps({"query": "test"})
+
+    resp = MagicMock()
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 5
+    resp.usage.total_tokens = 15
+    resp.choices[0].finish_reason = "tool_calls"
+    resp.choices[0].message.content = None
+    resp.choices[0].message.tool_calls = [tc]
+    return resp
+
+
+async def _capture_call(llm: OpenAICompatibleLLM, tool_choice) -> dict:
+    """Invoke call_with_tools and return the kwargs sent to the OpenAI client."""
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _tool_call_response()
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "What did claude say?"}],
+            tools=TOOLS,
+            tool_choice=tool_choice,
+            max_retries=0,
+        )
+    return mock_create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider,base_url",
+    [
+        ("lmstudio", "http://localhost:1234/v1"),  # #1563 / #1179
+        ("ollama", "http://localhost:11434/v1"),  # #1563
+        ("openai", "http://vllm:8000/v1"),  # #1877 — self-hosted vLLM via openai provider
+    ],
+)
+async def test_required_is_downgraded_for_self_hosted(provider: str, base_url: str):
+    """``required`` is omitted (downgraded to auto) for servers that drop it."""
+    sent = await _capture_call(_make_llm(provider, base_url), "required")
+    assert "tool_choice" not in sent, (
+        f"{provider} should not receive tool_choice='required' (it silently drops it); got {sent.get('tool_choice')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_preserved_for_real_openai():
+    """The real OpenAI API honors ``required`` — no base_url override, so leave it."""
+    sent = await _capture_call(_make_llm("openai", ""), "required")
+    assert sent["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_required_preserved_for_llama_server():
+    """llama-server (llamacpp) honors ``required`` and is excluded (#1179)."""
+    sent = await _capture_call(_make_llm("llamacpp", "http://localhost:8080/v1"), "required")
+    assert sent["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_required_preserved_for_cloud_provider():
+    """Cloud providers (e.g. groq) honor ``required`` and keep it."""
+    sent = await _capture_call(_make_llm("groq", ""), "required")
+    assert sent["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_named_tool_choice_forced_call_survives_downgrade():
+    """Reflect forces a tool via a named dict; it must still effectively force.
+
+    The dict is normalized to ``required`` + a single filtered tool, then the
+    downgrade drops ``required`` to auto. With only one tool available the call
+    stays practically forced, so the model still emits the tool call instead of
+    the empty-tool_calls failure mode.
+    """
+    llm = _make_llm("lmstudio", "http://localhost:1234/v1")
+    named = {"type": "function", "function": {"name": "recall"}}
+    with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _tool_call_response()
+        result = await llm.call_with_tools(
+            messages=[{"role": "user", "content": "What did claude say?"}],
+            tools=TOOLS,
+            tool_choice=named,
+            max_retries=0,
+        )
+
+    sent = mock_create.call_args.kwargs
+    # required was dropped (the silent-drop trigger is gone) ...
+    assert "tool_choice" not in sent
+    # ... but tools were narrowed to just the forced one, keeping the call forced.
+    assert len(sent["tools"]) == 1
+    assert sent["tools"][0]["function"]["name"] == "recall"
+    # and the model returns the tool call rather than an empty array.
+    assert [tc.name for tc in result.tool_calls] == ["recall"]
+
+
+def test_drops_tool_choice_required_classification():
+    """Direct unit check of the endpoint classifier."""
+    assert _make_llm("lmstudio", "http://localhost:1234/v1")._drops_tool_choice_required()
+    assert _make_llm("ollama", "http://localhost:11434/v1")._drops_tool_choice_required()
+    assert _make_llm("openai", "http://vllm:8000/v1")._drops_tool_choice_required()
+    # Real OpenAI, llama-server, and cloud providers are not affected.
+    assert not _make_llm("openai", "")._drops_tool_choice_required()
+    assert not _make_llm("llamacpp", "http://localhost:8080/v1")._drops_tool_choice_required()
+    assert not _make_llm("groq", "")._drops_tool_choice_required()


### PR DESCRIPTION
## Summary

Fixes #1877. Also resolves #1563 (LM Studio) and #1179 (LM Studio + Qwen) — same bug class.

**vLLM (`--enable-auto-tool-choice`), LM Studio and Ollama advertise `tool_choice="required"` but silently ignore it.** Instead of forcing a tool call they return `finish_reason` `"stop"`/`"tool_calls"` with an **empty `tool_calls` array** and no HTTP error.

Reflect's agent loop forces its retrieval tools on the first iterations via named `tool_choice` dicts (`agent.py:596`), which `OpenAICompatibleLLM.call_with_tools` normalizes to `tool_choice="required"` + a single filtered tool. On these endpoints the model returns zero tool calls → synthesis runs with no retrieval → reflect answers **"I don't have information"** even though `recall()` against the same bank returns the memories.

## Fix

In `openai_compatible_llm.py`, after the existing `"auto" → None` conversion, downgrade `"required" → None` (auto) for endpoints known to drop it:

```python
if request_tool_choice == "required" and self._drops_tool_choice_required():
    request_tool_choice = None
```

`_drops_tool_choice_required()` returns true for:
- providers `lmstudio` / `ollama` (issues #1563, #1179), and
- the generic `openai` provider with a **custom `base_url`** (a self-hosted vLLM endpoint — issue #1877).

Named tool_choice dicts already narrow the tools list to one entry, so forced calls stay practically forced under auto. **Left untouched:** the real OpenAI API (no `base_url` override), **llama-server** (`llamacpp` — it honors `"required"`, per #1179's own workaround), and cloud providers (groq/minimax/deepseek/openrouter/…), which keep their default base_urls and honor `"required"`.

This is the narrowly-scoped, defensive shim proposed in #1877: corrective behavior only for the custom-endpoint case, zero change for compliant providers.

## How it was reproduced

Verified locally through the **real** provider code path (`OpenAICompatibleLLM.call_with_tools`) against a faithful mock of vLLM's broken response, and confirmed the toolchain end-to-end by building **vLLM 0.22.0 on Apple Silicon via [vllm-metal](https://github.com/vllm-project/vllm-metal)** serving Qwen3:

| `tool_choice` | `tool_calls` returned | reflect outcome |
|---|---|---|
| `"required"` (pre-fix) | `[]` | agent calls zero tools → "I don't have information" |
| `"auto"` (control) | `["search_memory"]` | model is fully capable |
| `"required"` (post-fix → downgraded) | `["search_memory"]` | tool called, retrieval runs |

## Tests

- **New** `tests/test_tool_choice_required_downgrade.py` — fast deterministic unit tests asserting the exact kwargs sent over the wire: `required` omitted for lmstudio/ollama/`openai`+custom-base_url; preserved for real OpenAI, llama-server, and cloud providers; and that a named-dict forced call still emits the tool after the downgrade.
- **Updated** `tests/test_lmstudio_tool_choice.py` — the prior #520 regression asserted LM Studio *receives* `tool_choice="required"`; corrected to assert it is now downgraded (omitted) while tools stay filtered to the forced one.

The change is deterministic wire-level mechanics (which param value is sent), not model-interpretation, so no LLM-judge test is needed.

## Note / tradeoff

`provider == "openai"` + a custom `base_url` also matches **Azure OpenAI**, which does honor `"required"`. The downgrade is safe there (auto + a single filtered tool still calls it) and matches the issue's "treat custom endpoints as potentially non-compliant" intent, so Azure is not special-cased.

Closes #1877.