### PR TITLE
docs(configuration): document HINDSIGHT_API_DATABASE_BACKEND (postgresql|oracle)

### DIFF
--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -24,6 +24,7 @@ The API service handles all memory operations (retain, recall, reflect).
 | `HINDSIGHT_API_MIGRATION_DATABASE_URL` | Direct PostgreSQL URL for running migrations, bypassing connection poolers (e.g. PgBouncer). When set, advisory locks and Alembic migrations use this URL instead of `DATABASE_URL`. | Falls back to `DATABASE_URL` |
 | `HINDSIGHT_API_DATABASE_SCHEMA` | PostgreSQL schema name for tables | `public` |
 | `HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP` | Run database migrations on API startup | `true` |
+| `HINDSIGHT_API_DATABASE_BACKEND` | Database engine backend: `postgresql` or `oracle` (Oracle 23ai) | `postgresql` |
 
 If not provided, the server uses embedded `pg0` — convenient for development but not recommended for production.
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -24,6 +24,7 @@ The API service handles all memory operations (retain, recall, reflect).
 | `HINDSIGHT_API_MIGRATION_DATABASE_URL` | Direct PostgreSQL URL for running migrations, bypassing connection poolers (e.g. PgBouncer). When set, advisory locks and Alembic migrations use this URL instead of `DATABASE_URL`. | Falls back to `DATABASE_URL` |
 | `HINDSIGHT_API_DATABASE_SCHEMA` | PostgreSQL schema name for tables | `public` |
 | `HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP` | Run database migrations on API startup | `true` |
+| `HINDSIGHT_API_DATABASE_BACKEND` | Database engine backend: `postgresql` or `oracle` (Oracle 23ai) | `postgresql` |
 
 If not provided, the server uses embedded `pg0` — convenient for development but not recommended for production.
 


### PR DESCRIPTION
The `### Database` table in the configuration reference lists five `HINDSIGHT_API_DATABASE_*` variables but omits `HINDSIGHT_API_DATABASE_BACKEND` — the switch that selects the Oracle 23ai backend (`postgresql` default, `oracle` for Oracle 23ai).

The variable is source-grounded in `hindsight-api-slim/hindsight_api/config.py`:
- `ENV_DATABASE_BACKEND = "HINDSIGHT_API_DATABASE_BACKEND"` (L125)
- `DEFAULT_DATABASE_BACKEND = "postgresql"` (L561)
- `database_backend: Literal["postgresql", "oracle"]` (L1162)
- `os.getenv(ENV_DATABASE_BACKEND, DEFAULT_DATABASE_BACKEND).lower()` (L1816)

Oracle is a first-class, actively-hardened backend (#1307 origin + the #1952/#1980/#2000 parity wave, with `start-oracle.sh`, `e2e_oracle_smoke.py`, and a dedicated CI Oracle job), but an operator deploying on Oracle currently cannot discover the selector from any doc — only from source/CI/scripts. This adds the single missing row.

Mirrored into the generated `skills/hindsight-docs/references/developer/configuration.md` (link-free row, identical in both files) so `verify-generated-files` stays green.