### PR TITLE
fix: remove Markdown bold formatting from fact extraction prompt

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -510,11 +510,11 @@ LANGUAGE: MANDATORY — Detect the language of the input text and produce ALL ou
 FACT FORMAT - BE CONCISE
 ══════════════════════════════════════════════════════════════════════════
 
-1. **what**: Core fact - concise but complete (1-2 sentences max)
-2. **when**: Temporal info if mentioned. "N/A" if none. Use day name when known.
-3. **where**: Location if relevant. "N/A" if none.
-4. **who**: People involved with relationships. "N/A" if just general info.
-5. **why**: Context/significance ONLY if important. "N/A" if obvious.
+1. "what": Core fact - concise but complete (1-2 sentences max)
+2. "when": Temporal info if mentioned. "N/A" if none. Use day name when known.
+3. "where": Location if relevant. "N/A" if none.
+4. "who": People involved with relationships. "N/A" if just general info.
+5. "why": Context/significance ONLY if important. "N/A" if obvious.
 
 CONCISENESS: Capture the essence, not every word. One good sentence beats three mediocre ones.
 


### PR DESCRIPTION
## What
Fixes #1138 — The fact extraction prompt uses `**what**`, `**when**` etc. as field labels. This Markdown bold syntax leaks into LLM outputs, causing non-JSON parsing errors.

## Fix
Replaced `**field**` with `"field"` — same visual emphasis, no Markdown ambiguity.

## Confirmed affected models
The issue was observed across ALL tested models:
- GPT-4
- Ollama: gemma4, kimi-k2, llama3.2, qwen3.5, glm-5.1

## Before
```
1. **what**: Core fact...
2. **when**: Temporal info...
```

## After
```
1. "what": Core fact...
2. "when": Temporal info...
```