### PR TITLE
docs(models): sync gemini + vertexai default models to 3.x matching config.py

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -166,7 +166,7 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
-export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash
+export HINDSIGHT_API_LLM_MODEL=gemini-3.5-flash
 
 # Anthropic
 export HINDSIGHT_API_LLM_PROVIDER=anthropic
@@ -210,7 +210,7 @@ export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
-export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
 export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-gcp-project-id
 # Optional: region (default: us-central1)
 # export HINDSIGHT_API_LLM_VERTEXAI_REGION=us-central1
@@ -374,7 +374,7 @@ Google Cloud's Vertex AI provides access to Gemini models via the native Google 
 
    # Configure Hindsight
    export HINDSIGHT_API_LLM_PROVIDER=vertexai
-   export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+   export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
    export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-project-id
    ```
 
@@ -390,13 +390,13 @@ Google Cloud's Vertex AI provides access to Gemini models via the native Google 
 
    # Configure Hindsight
    export HINDSIGHT_API_LLM_PROVIDER=vertexai
-   export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+   export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
    export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-project-id
    export HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY=/path/to/key.json
    ```
 
 **Notes:**
-- Model names can optionally include the `google/` prefix (e.g., `google/gemini-2.0-flash-001`) — it will be stripped automatically
+- Model names can optionally include the `google/` prefix (e.g., `google/gemini-3.1-flash-lite`) — it will be stripped automatically
 - The native SDK handles token refresh automatically
 - Uses service account credentials if provided, otherwise falls back to ADC
 

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -1,8 +1,8 @@
 [
   {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini", "batchApi": true},
   {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5-20251001"},
-  {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-2.5-flash", "promptCaching": true},
-  {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "gemini-2.5-flash-lite", "promptCaching": true},
+  {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-3.5-flash", "promptCaching": true},
+  {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "google/gemini-3.1-flash-lite", "promptCaching": true},
   {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b", "batchApi": true},
   {"id": "ollama",        "label": "Ollama",            "iconKey": "ollama",             "defaultModel": "gemma3:12b"},
   {"id": "ollama-cloud",  "label": "Ollama Cloud",      "iconKey": "ollama",             "defaultModel": "gemma3:12b"},

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -216,7 +216,7 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 # Gemini
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
-export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash
+export HINDSIGHT_API_LLM_MODEL=gemini-3.5-flash
 
 # Anthropic
 export HINDSIGHT_API_LLM_PROVIDER=anthropic
@@ -260,7 +260,7 @@ export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
-export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
 export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-gcp-project-id
 # Optional: region (default: us-central1)
 # export HINDSIGHT_API_LLM_VERTEXAI_REGION=us-central1
@@ -420,7 +420,7 @@ Google Cloud's Vertex AI provides access to Gemini models via the native Google 
 
    # Configure Hindsight
    export HINDSIGHT_API_LLM_PROVIDER=vertexai
-   export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+   export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
    export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-project-id
    ```
 
@@ -436,13 +436,13 @@ Google Cloud's Vertex AI provides access to Gemini models via the native Google 
 
    # Configure Hindsight
    export HINDSIGHT_API_LLM_PROVIDER=vertexai
-   export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash-001
+   export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
    export HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=your-project-id
    export HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY=/path/to/key.json
    ```
 
 **Notes:**
-- Model names can optionally include the `google/` prefix (e.g., `google/gemini-2.0-flash-001`) — it will be stripped automatically
+- Model names can optionally include the `google/` prefix (e.g., `google/gemini-3.1-flash-lite`) — it will be stripped automatically
 - The native SDK handles token refresh automatically
 - Uses service account credentials if provided, otherwise falls back to ADC
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -137,8 +137,8 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 |----------|--------------|
 | `openai` | `gpt-4o-mini` |
 | `anthropic` | `claude-haiku-4-5-20251001` |
-| `gemini` | `gemini-2.5-flash` |
-| `vertexai` | `gemini-2.5-flash-lite` |
+| `gemini` | `gemini-3.5-flash` |
+| `vertexai` | `google/gemini-3.1-flash-lite` |
 | `groq` | `openai/gpt-oss-120b` |
 | `ollama` | `gemma3:12b` |
 | `ollama-cloud` | `gemma3:12b` |


### PR DESCRIPTION
The canonical provider-defaults data source still lists the retired Gemini 2.5 defaults, while `config.py` `PROVIDER_DEFAULT_MODELS` was moved to the 3.x series in #1787 — so the **Provider Default Models** table users consult shows models that diverge from what the runtime actually selects.

**Drift (source-grounded):**

| Provider | `config.py` (`PROVIDER_DEFAULT_MODELS`, main) | `llmProviders.json` (table data, main) |
|---|---|---|
| `gemini` | `gemini-3.5-flash` (L570) | `gemini-2.5-flash` |
| `vertexai` | `google/gemini-3.1-flash-lite` (L580) | `gemini-2.5-flash-lite` |

`#2001` corrected vertexai's prior `2.0-flash-001` → `2.5-flash-lite`; `#1787` then re-bumped `config.py` (and the models.mdx *recommendations* + skills mirror) to 3.x but left the defaults-table data behind. This syncs the two stale rows. All other 18 providers already match.

**Change:** `llmProviders.json` two `defaultModel` values + the regenerated skills-mirror default-model table rows. `models.mdx` renders `<LLMProvidersTable />` from the JSON at build, so no manual edit there. Verbatim from `config.py` (the `google/` prefix matches how `groq`/`openrouter`/`fireworks`/`litellm` already store litellm-prefixed defaults in the JSON).

---

**Update — also synced the prose surface (`models.mdx`):** the env-var examples + Vertex AI setup walkthrough still handed users the **retired** `gemini-2.0-flash-001` (a hard 404 on Vertex AI, per #2001) and the stale `gemini-2.0-flash` Gemini example. Synced them to the same 3.x defaults this PR establishes (`gemini-3.1-flash-lite` for Vertex AI, `gemini-3.5-flash` for Gemini) + regenerated the skills mirror, so the whole gemini/vertexai 3.x sync lands in one PR.