### PR TITLE
fix(transfer): include mental_model_history count in import-bank CLI summary

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -463,7 +463,8 @@ def import_bank_command(
     typer.echo(
         f"Imported bank '{result.bank_id}': {result.documents_imported} doc(s), "
         f"{result.facts_imported} fact(s), {result.observations_imported} observation(s), "
-        f"{result.mental_models_imported} mental model(s), {result.directives_imported} directive(s), "
+        f"{result.mental_models_imported} mental model(s), "
+        f"{result.mental_model_history_imported} mm-history row(s), {result.directives_imported} directive(s), "
         f"{result.webhooks_imported} webhook(s), {result.history_rows_imported} history row(s)"
     )
 


### PR DESCRIPTION
The `import-bank` CLI summary line reports every restored entity count **except** `mental_model_history`, even though the importer tracks and logs it.

- `BankImportResult.mental_model_history_imported` is populated by the importer (`importer.py` field def L237, restored L405) and logged verbatim as `"%d mm-history row(s)"` (L416).
- But the user-facing `typer.echo` summary in `admin/cli.py` (the `import-bank` command) omits it — an operator running a cross-instance migration can't see how much mental-model version history was restored.

This inserts the missing `mm-history row(s)` segment between the `mental model(s)` and `directive(s)` counts, matching the importer's own log ordering/label. One-line addition; no behavior change.