### PR TITLE
docs(models): flag Fireworks AI Batch API support in the provider capabilities table

### DIFF
--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -17,7 +17,7 @@
   {"id": "openai-codex",  "label": "OpenAI Codex",      "iconKey": "openai",             "defaultModel": "gpt-5.4-mini"},
   {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
   {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
-  {"id": "fireworks",     "label": "Fireworks AI",      "iconKey": "zap",                "defaultModel": "accounts/fireworks/models/llama-v3p1-8b-instruct"},
+  {"id": "fireworks",     "label": "Fireworks AI",      "iconKey": "zap",                "defaultModel": "accounts/fireworks/models/llama-v3p1-8b-instruct", "batchApi": true},
   {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},
   {"id": "litellm",       "label": "LiteLLM (100+)",    "iconKey": "layers",             "defaultModel": "gpt-4o-mini"}
 ]

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -94,7 +94,7 @@ Beyond basic generation, some providers support optional features that lower cos
 | OpenAI Codex (`openai-codex`) | — | — |
 | Claude Code (`claude-code`) | — | — |
 | AWS Bedrock (`bedrock`) | — | — |
-| Fireworks AI (`fireworks`) | — | — |
+| Fireworks AI (`fireworks`) | ✅ | — |
 | LiteLLM (100+) (`litellm`) | — | — |
 
 - **Batch API** — submits bulk retain extraction through the provider's asynchronous batch endpoint, typically at ~50% lower cost. Used automatically when available; otherwise calls run synchronously.


### PR DESCRIPTION
The provider capabilities table renders Fireworks' Batch API column as `—` (not supported), but it *is* supported:

- `provider == "fireworks"` dispatches to `FireworksLLM` (`llm_wrapper.py:424`)
- `FireworksLLM.supports_batch_api()` overrides to `True` (`fireworks_llm.py:106`)
- the base `OpenAICompatibleLLM` only grants batch to openai/groq (`openai_compatible_llm.py:1236`), so the override is load-bearing

Added `"batchApi": true` to the fireworks entry in the canonical `llmProviders.json` and regenerated the CI-enforced skills mirror (`models.md`). The async Batch API path (cheaper retain extraction) is opt-in — gated behind `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` with async retain (`DEFAULT_RETAIN_BATCH_ENABLED = False`) — but the capabilities table previously implied Fireworks couldn't use it at all, which is wrong: it's fully supported, users just have to enable it.
