### PR TITLE
docs(api): document the operation progress snapshot + include_payload on the status endpoint

### DIFF
--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -150,6 +150,30 @@ Query parameters:
 </TabItem>
 </Tabs>
 
+Query parameters:
+
+| Param | Description |
+|-------|-------------|
+| `include_payload` | Include the raw task payload (the submission params) in the response as `task_payload`. Default `false`; may be large. |
+
+A few response fields are worth calling out:
+
+| Field | Description |
+|-------|-------------|
+| `updated_at` | When the operation's row last changed — claim, progress heartbeat, or completion. |
+| `progress` | Last-known progress snapshot for a running operation, or `null` if none was recorded (completed-instantly or pre-feature rows). |
+| `task_payload` | The raw submission params; only populated when `include_payload=true`. |
+
+`progress` is written at coarse phase/batch boundaries (consolidation, batch retain) and lets you tell a healthy long-running job from a frozen one: if `processed` keeps advancing across polls the job is alive; identical numbers with no movement in `at` mean it's stuck. Its shape:
+
+| Field | Description |
+|-------|-------------|
+| `stage` | Coarse phase the operation last reported (e.g. `processing_batch`). |
+| `at` | ISO-8601 timestamp when this snapshot was written. |
+| `processed` | Units of work finished so far (sub-batches, memories), when known. |
+| `total` | Total units of work for the operation, when known. |
+| `detail` | Operation-specific counters (e.g. `observations_created`, `round`, `items_in_sub_batch`). |
+
 ### Cancel a pending operation
 
 Returns `409` if the operation is already in `processing`, `completed`, or `failed` state.

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -188,6 +188,30 @@ hindsight operation get my-bank "$OPERATION_ID"
 # Section 'operations-get' not found in api/operations.go
 ```
 
+Query parameters:
+
+| Param | Description |
+|-------|-------------|
+| `include_payload` | Include the raw task payload (the submission params) in the response as `task_payload`. Default `false`; may be large. |
+
+A few response fields are worth calling out:
+
+| Field | Description |
+|-------|-------------|
+| `updated_at` | When the operation's row last changed — claim, progress heartbeat, or completion. |
+| `progress` | Last-known progress snapshot for a running operation, or `null` if none was recorded (completed-instantly or pre-feature rows). |
+| `task_payload` | The raw submission params; only populated when `include_payload=true`. |
+
+`progress` is written at coarse phase/batch boundaries (consolidation, batch retain) and lets you tell a healthy long-running job from a frozen one: if `processed` keeps advancing across polls the job is alive; identical numbers with no movement in `at` mean it's stuck. Its shape:
+
+| Field | Description |
+|-------|-------------|
+| `stage` | Coarse phase the operation last reported (e.g. `processing_batch`). |
+| `at` | ISO-8601 timestamp when this snapshot was written. |
+| `processed` | Units of work finished so far (sub-batches, memories), when known. |
+| `total` | Total units of work for the operation, when known. |
+| `detail` | Operation-specific counters (e.g. `observations_created`, `round`, `items_in_sub_batch`). |
+
 ### Cancel a pending operation
 
 Returns `409` if the operation is already in `processing`, `completed`, or `failed` state.


### PR DESCRIPTION
`GET .../operations/{operation_id}` gained a durable progress snapshot in #2013 (`OperationProgress`: `stage`/`at`/`processed`/`total`/`detail`), an `updated_at` heartbeat, and an `include_payload` query param that returns `task_payload` — but "Get operation status" documented none of them (the example passes `include_payload` without explaining what it does).

Added a response-fields subsection: the `include_payload` query param, the `updated_at`/`progress`/`task_payload` response fields, and the `progress` object's shape. Field descriptions are taken verbatim from `http.py` (`OperationProgress` / `OperationStatusResponse`). The snapshot's own stated purpose — telling a healthy long-running job from a frozen one — is now discoverable. Regenerated the CI-enforced skills mirror.