### PR TITLE
fix(opencode): drop non-function export from plugin entry so it loads under OpenCode 1.16 (#2028)

### DIFF
--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -75,5 +75,5 @@ export default HindsightPlugin;
 // Re-export types for consumers
 export type { HindsightConfig } from "./config.js";
 export type { PluginState } from "./hooks.js";
-export { loadConfig, DEFAULT_HINDSIGHT_API_URL } from "./config.js";
+export { loadConfig } from "./config.js";
 export { deriveBankId } from "./bank.js";

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -11,7 +11,8 @@ vi.mock("@vectorize-io/hindsight-client", () => {
   return { HindsightClient: MockHindsightClient };
 });
 
-import { HindsightPlugin, DEFAULT_HINDSIGHT_API_URL } from "./index.js";
+import { HindsightPlugin } from "./index.js";
+import { DEFAULT_HINDSIGHT_API_URL } from "./config.js";
 import { HindsightClient } from "@vectorize-io/hindsight-client";
 
 const mockPluginInput = {
@@ -145,5 +146,18 @@ describe("plugin default export", () => {
     // the same reference as the named HindsightPlugin export to avoid
     // running the factory twice.
     expect(mod.default).toBe(mod.HindsightPlugin);
+  });
+
+  it("does not expose non-function exports from the plugin entry (#2028)", async () => {
+    // OpenCode >=1.16 iterates EVERY export of the plugin entry and treats it
+    // as a Plugin factory, throwing "Plugin export is not a function" on any
+    // non-function value — a single re-exported constant (e.g. a string URL)
+    // bricks the whole plugin load. Keep the entry surface function-only.
+    const mod = await import("./index.js");
+    for (const [name, value] of Object.entries(mod)) {
+      expect(typeof value, `export "${name}" must be a function`).toBe(
+        "function"
+      );
+    }
   });
 });


### PR DESCRIPTION
Fixes #2028.

`@vectorize-io/opencode-hindsight@0.2.1` fails to load on OpenCode >=1.16.2 with `Plugin export is not a function`. OpenCode's loader iterates **every** export of the plugin entry and treats each as a Plugin factory, throwing on any non-function value. The entry's `export { loadConfig, DEFAULT_HINDSIGHT_API_URL } from "./config.js"` re-exports `DEFAULT_HINDSIGHT_API_URL` (a string constant), which trips the loader and aborts plugin load (0 tools registered).

Introduced in #1915, which created `DEFAULT_HINDSIGHT_API_URL` and added it to the entry re-export. 0.2.0 (functions only) loads fine on 1.16.2; the string export is the only breaking delta.

Fix:
- Drop `DEFAULT_HINDSIGHT_API_URL` from the **plugin entry** re-export. It stays exported from `./config` and is still used internally by `loadConfig`, so default-URL behavior is unchanged — only the entry surface becomes function-only as the loader requires.
- Repoint the test's `DEFAULT_HINDSIGHT_API_URL` import to `./config`.
- Add a regression test asserting every entry export is a function (mirrors OpenCode's `typeof v === "function"` predicate): fails on current `main`, passes after the fix, and locks out the whole class of entry-bricking non-function exports.

Source-only change (`dist` is built on publish, not committed).