### PR TITLE
fix(trace): preserve RRF source ranks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/tracer.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/tracer.py
@@ -358,12 +358,15 @@ class SearchTracer:
         """
         self.rrf_merged = []
         for rank, (doc_id, data, rrf_meta) in enumerate(merged_results, start=1):
+            source_ranks = rrf_meta.get("source_ranks")
+            if source_ranks is None:
+                source_ranks = {key: value for key, value in rrf_meta.items() if key.endswith("_rank")}
             self.rrf_merged.append(
                 RRFMergeResult(
                     node_id=doc_id,
                     text=data.get("text", ""),
                     rrf_score=rrf_meta.get("rrf_score", 0.0),
-                    source_ranks=rrf_meta.get("source_ranks", {}),
+                    source_ranks=source_ranks,
                     final_rrf_rank=rank,
                 )
             )

--- a/hindsight-api-slim/tests/test_search_trace.py
+++ b/hindsight-api-slim/tests/test_search_trace.py
@@ -1,10 +1,29 @@
 """
 Test search tracing functionality.
 """
-import pytest
-from hindsight_api.engine.memory_engine import Budget
-from hindsight_api import SearchTrace, RequestContext
 from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.engine.search.tracer import SearchTracer
+
+
+def test_rrf_trace_preserves_flattened_source_ranks():
+    """Source ranks flattened by the recall pipeline remain visible in traces."""
+    tracer = SearchTracer(query="test", budget=10, max_tokens=100)
+
+    tracer.add_rrf_merged(
+        [
+            (
+                "memory-1",
+                {"text": "alpha"},
+                {"rrf_score": 0.1, "semantic_rank": 1, "bm25_rank": 2},
+            )
+        ]
+    )
+
+    assert tracer.rrf_merged[0].source_ranks == {"semantic_rank": 1, "bm25_rank": 2}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve `semantic_rank`, `bm25_rank`, `graph_rank`, and `temporal_rank` in recall traces
- accept both the flattened metadata currently emitted by the recall pipeline and the existing nested `source_ranks` shape
- add a regression test for the flattened metadata path

`SearchTracer.add_rrf_merged()` currently reads `rrf_meta["source_ranks"]`, while the recall pipeline expands `MergedCandidate.source_ranks` into the metadata top level. The trace therefore reports an empty source-rank map even though fusion computed the ranks correctly.

This change only fixes trace serialization; it does not change fusion, reranking, strategy boosts, or result ordering.

## Validation

- `uv run ruff check hindsight-api-slim/hindsight_api/engine/search/tracer.py hindsight-api-slim/tests/test_search_trace.py`
- `uv run pytest hindsight-api-slim/tests/test_search_trace.py::test_rrf_trace_preserves_flattened_source_ranks -q`
- `uv run pytest hindsight-api-slim/tests/test_interleave_fusion.py hindsight-api-slim/tests/test_fusion_cap.py hindsight-api-slim/tests/test_recall_boost.py -q` (29 passed)
- pre-commit hooks: docs generation and lint passed