### PR TITLE
fix(retain): expose retain outcome metadata

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -57,7 +57,10 @@ from .operation_metadata import (
     BatchRetainParentMetadata,
     ConsolidationMetadata,
     RefreshMentalModelMetadata,
+    RetainExtractionErrors,
     RetainMetadata,
+    RetainOutcomeAggregate,
+    RetainOutcomeMetadata,
 )
 from .sql import SQLDialect, create_sql_dialect
 
@@ -2036,6 +2039,44 @@ class MemoryEngine(MemoryEngineInterface):
         except Exception as e:
             logger.error(f"Failed to mark operation as completed {operation_id}: {e}")
 
+    async def _write_retain_outcome_metadata(self, operation_id: str | None, unit_ids: list[list[str]]) -> None:
+        """Persist completed retain outcome fields before the operation is marked completed."""
+        if not operation_id:
+            return
+
+        unit_ids_count = sum(len(group) for group in unit_ids)
+        try:
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                row = await conn.fetchrow(
+                    f"SELECT result_metadata FROM {fq_table('async_operations')} WHERE operation_id = $1",
+                    uuid.UUID(operation_id),
+                )
+                if not row:
+                    return
+
+                metadata = conn.parse_json(row["result_metadata"]) or {}
+                extraction_errors = RetainExtractionErrors()
+                extraction_errors.merge_metadata(metadata)
+                outcome = RetainOutcomeMetadata(
+                    unit_ids_count=unit_ids_count,
+                    extraction_errors_count=extraction_errors.count,
+                    extraction_errors_sample=extraction_errors.sample,
+                )
+
+                await conn.execute(
+                    f"""
+                    UPDATE {fq_table("async_operations")}
+                    SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb,
+                        updated_at = now()
+                    WHERE operation_id = $1
+                    """,
+                    uuid.UUID(operation_id),
+                    json.dumps(outcome.to_dict()),
+                )
+        except Exception as e:
+            logger.debug(f"Failed to write retain outcome metadata for {operation_id}: {e}")
+
     async def _mark_operation_completed_and_fire_webhook(
         self,
         operation_id: str,
@@ -2147,14 +2188,16 @@ class MemoryEngine(MemoryEngineInterface):
 
             # Get all sibling operations (including this one).
             # This query runs in the same transaction, so it sees the current
-            # child's updated status. Pull error_message too so a parent that
+            # child's updated status. Pull result_metadata for completed
+            # children so the parent exposes the same outcome counters as the
+            # individual retain operations. Pull error_message too so a parent that
             # fails can inherit a representative child reason -- otherwise
             # downstream consumers (dashboards, alert filters) lose the actual
             # cause once a batch has children. See the worker poller's
             # _summarise_child_error_messages for the propagation rationale.
             siblings = await conn.fetch(
                 f"""
-                SELECT status, error_message
+                SELECT status, error_message, result_metadata
                 FROM {fq_table("async_operations")}
                 WHERE bank_id = $1
                 AND result_metadata::jsonb @> $2::jsonb
@@ -2196,14 +2239,22 @@ class MemoryEngine(MemoryEngineInterface):
                 )
             elif all_completed:
                 new_status = "completed"
+                outcome_aggregate = RetainOutcomeAggregate()
+                for sibling in siblings:
+                    sibling_metadata = conn.parse_json(sibling["result_metadata"]) or {}
+                    outcome_aggregate.add_metadata(sibling_metadata)
                 await conn.execute(
                     f"""
                     UPDATE {fq_table("async_operations")}
-                    SET status = $2, updated_at = NOW(), completed_at = NOW()
+                    SET status = $2,
+                        result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $3::jsonb,
+                        updated_at = NOW(),
+                        completed_at = NOW()
                     WHERE operation_id = $1
                     """,
                     uuid.UUID(parent_operation_id),
                     new_status,
+                    json.dumps(outcome_aggregate.to_outcome_metadata().to_dict()),
                 )
 
             logger.info(f"Updated parent operation {parent_operation_id} to status '{new_status}' (all children done)")
@@ -3120,6 +3171,8 @@ class MemoryEngine(MemoryEngineInterface):
             )
             # Progress for this path is emitted by the streaming pipeline as
             # "storing N/total chunks" via progress_callback (see _retain_batch_async_internal).
+
+        await self._write_retain_outcome_metadata(operation_id, result)
 
         # Call post-operation hook if validator is configured
         if self._operation_validator:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2075,7 +2075,10 @@ class MemoryEngine(MemoryEngineInterface):
                     json.dumps(outcome.to_dict()),
                 )
         except Exception as e:
-            logger.debug(f"Failed to write retain outcome metadata for {operation_id}: {e}")
+            # Best-effort, but log loudly: the whole point of this metadata is to
+            # give clients a reliable success/silent-failure signal, so a missing
+            # write silently regresses them to the ambiguous pre-fix behaviour.
+            logger.warning(f"Failed to write retain outcome metadata for {operation_id}: {e}")
 
     async def _mark_operation_completed_and_fire_webhook(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -5,8 +5,10 @@ These dataclasses define the structure of result_metadata for different operatio
 The metadata is exposed in the API for debugging purposes and may change without notice.
 """
 
-from dataclasses import asdict, dataclass
-from typing import Any
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+MAX_EXTRACTION_ERROR_SAMPLES = 5
 
 
 @dataclass
@@ -46,6 +48,86 @@ class RetainMetadata:
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for JSON serialization."""
         return asdict(self)
+
+
+@dataclass
+class RetainExtractionErrors:
+    """Non-fatal fact extraction failures observed inside one retain operation."""
+
+    count: int = 0
+    sample: list[str] = field(default_factory=list)
+
+    def add(self, message: str) -> None:
+        """Record one extraction error while keeping the stored sample bounded."""
+        self.count += 1
+        if len(self.sample) < MAX_EXTRACTION_ERROR_SAMPLES:
+            self.sample.append(message[:500])
+
+    def merge_metadata(self, metadata: Mapping[str, Any]) -> None:
+        """Merge errors already present on an operation result_metadata object."""
+        self.count += int(metadata.get("extraction_errors_count") or 0)
+
+        sample = metadata.get("extraction_errors_sample") or []
+        if isinstance(sample, str):
+            sample = [sample]
+        if isinstance(sample, list):
+            for entry in sample:
+                if isinstance(entry, str) and len(self.sample) < MAX_EXTRACTION_ERROR_SAMPLES:
+                    self.sample.append(entry[:500])
+
+    def merge_errors(self, other: "RetainExtractionErrors") -> None:
+        """Merge another bounded extraction-error summary."""
+        self.count += other.count
+        for entry in other.sample:
+            if len(self.sample) < MAX_EXTRACTION_ERROR_SAMPLES:
+                self.sample.append(entry[:500])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the public result_metadata field shape."""
+        data: dict[str, Any] = {"extraction_errors_count": self.count}
+        if self.sample:
+            data["extraction_errors_sample"] = self.sample
+        return data
+
+
+@dataclass
+class RetainOutcomeMetadata:
+    """Machine-readable outcome metadata for a completed retain operation."""
+
+    unit_ids_count: int
+    extraction_errors_count: int = 0
+    extraction_errors_sample: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict for JSON serialization, omitting empty optional samples."""
+        data: dict[str, Any] = {
+            "unit_ids_count": self.unit_ids_count,
+            "extraction_errors_count": self.extraction_errors_count,
+        }
+        if self.extraction_errors_sample:
+            data["extraction_errors_sample"] = self.extraction_errors_sample[:MAX_EXTRACTION_ERROR_SAMPLES]
+        return data
+
+
+@dataclass
+class RetainOutcomeAggregate:
+    """Aggregate retain outcome metadata from child retain operations."""
+
+    unit_ids_count: int = 0
+    extraction_errors: RetainExtractionErrors = field(default_factory=RetainExtractionErrors)
+
+    def add_metadata(self, metadata: Mapping[str, Any]) -> None:
+        """Fold one child operation's result_metadata into the aggregate."""
+        self.unit_ids_count += int(metadata.get("unit_ids_count") or 0)
+        self.extraction_errors.merge_metadata(metadata)
+
+    def to_outcome_metadata(self) -> RetainOutcomeMetadata:
+        """Return the aggregate in the public result_metadata field shape."""
+        return RetainOutcomeMetadata(
+            unit_ids_count=self.unit_ids_count,
+            extraction_errors_count=self.extraction_errors.count,
+            extraction_errors_sample=self.extraction_errors.sample,
+        )
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -75,13 +75,6 @@ class RetainExtractionErrors:
                 if isinstance(entry, str) and len(self.sample) < MAX_EXTRACTION_ERROR_SAMPLES:
                     self.sample.append(entry[:500])
 
-    def merge_errors(self, other: "RetainExtractionErrors") -> None:
-        """Merge another bounded extraction-error summary."""
-        self.count += other.count
-        for entry in other.sample:
-            if len(self.sample) < MAX_EXTRACTION_ERROR_SAMPLES:
-                self.sample.append(entry[:500])
-
     def to_dict(self) -> dict[str, Any]:
         """Convert to the public result_metadata field shape."""
         data: dict[str, Any] = {"extraction_errors_count": self.count}

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
 from ...config import get_config
 from ..llm_wrapper import LLMConfig, OutputTooLongError, sanitize_llm_output
+from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
 from .entity_labels import (
     EntityLabelsConfig,
@@ -111,6 +112,17 @@ def _infer_temporal_date(fact_text: str, event_date: datetime | None) -> str | N
 
 def _sanitize_text(text: str | None) -> str | None:
     return sanitize_llm_output(text)
+
+
+def _parse_result_metadata(raw_metadata: Any) -> dict[str, Any]:
+    """Parse async_operations.result_metadata from raw asyncpg or DatabaseBackend rows."""
+    if not raw_metadata:
+        return {}
+    if isinstance(raw_metadata, str):
+        return json.loads(raw_metadata)
+    if isinstance(raw_metadata, dict):
+        return raw_metadata
+    return dict(raw_metadata)
 
 
 class Entity(BaseModel):
@@ -1710,6 +1722,42 @@ logger = logging.getLogger(__name__)
 SECONDS_PER_FACT = 0.01
 
 
+async def _write_batch_extraction_errors(
+    pool: Any,
+    operation_id: str | None,
+    schema: str | None,
+    errors: RetainExtractionErrors,
+) -> None:
+    """Persist non-fatal Batch API extraction errors into operation result_metadata."""
+    if not pool or not operation_id or errors.count == 0:
+        return
+
+    from ..db_utils import acquire_with_retry
+    from ..task_backend import fq_table
+
+    table = fq_table("async_operations", schema)
+    async with acquire_with_retry(pool) as conn:
+        row = await conn.fetchrow(
+            f"SELECT result_metadata FROM {table} WHERE operation_id = $1",
+            operation_id,
+        )
+        existing_errors = RetainExtractionErrors()
+        if row:
+            existing_metadata = _parse_result_metadata(row["result_metadata"])
+            existing_errors.merge_metadata(existing_metadata)
+        existing_errors.merge_errors(errors)
+        await conn.execute(
+            f"""
+            UPDATE {table}
+            SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb,
+                updated_at = now()
+            WHERE operation_id = $1
+            """,
+            operation_id,
+            json.dumps(existing_errors.to_dict()),
+        )
+
+
 async def extract_facts_from_contents_batch_api(
     contents: list[RetainContent],
     llm_config,
@@ -1887,6 +1935,7 @@ async def extract_facts_from_contents_batch_api(
     all_facts_from_llm = []
     chunks_metadata = []
     total_usage = TokenUsage()
+    extraction_errors = RetainExtractionErrors()
 
     for chunk_idx, (chunk_content, content_index, chunk_index_in_content, event_date, context) in enumerate(
         all_chunks_info
@@ -1895,7 +1944,9 @@ async def extract_facts_from_contents_batch_api(
         result = results_by_id.get(custom_id)
 
         if not result:
-            logger.warning(f"Missing result for {custom_id}, skipping")
+            message = f"{custom_id}: missing batch result"
+            logger.warning(message)
+            extraction_errors.add(message)
             chunks_metadata.append(
                 ChunkMetadata(
                     chunk_text=chunk_content, fact_count=0, content_index=content_index, chunk_index=chunk_idx
@@ -1905,7 +1956,9 @@ async def extract_facts_from_contents_batch_api(
 
         # Check for errors
         if result.get("error"):
-            logger.error(f"Error in {custom_id}: {result['error']}")
+            message = f"{custom_id}: {result['error']}"
+            logger.error(f"Error in {message}")
+            extraction_errors.add(message)
             chunks_metadata.append(
                 ChunkMetadata(
                     chunk_text=chunk_content, fact_count=0, content_index=content_index, chunk_index=chunk_idx
@@ -1918,7 +1971,9 @@ async def extract_facts_from_contents_batch_api(
         choices = response_body.get("choices", [])
 
         if not choices:
-            logger.warning(f"No choices in response for {custom_id}")
+            message = f"{custom_id}: no choices in response"
+            logger.warning(message)
+            extraction_errors.add(message)
             chunks_metadata.append(
                 ChunkMetadata(
                     chunk_text=chunk_content, fact_count=0, content_index=content_index, chunk_index=chunk_idx
@@ -1933,7 +1988,9 @@ async def extract_facts_from_contents_batch_api(
         try:
             extraction_response_json = json.loads(content_str)
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON for {custom_id}: {e}")
+            message = f"{custom_id}: failed to parse JSON: {e}"
+            logger.error(message)
+            extraction_errors.add(message)
             chunks_metadata.append(
                 ChunkMetadata(
                     chunk_text=chunk_content, fact_count=0, content_index=content_index, chunk_index=chunk_idx
@@ -2106,7 +2163,9 @@ async def extract_facts_from_contents_batch_api(
                 fact = Fact(fact=combined_text, fact_type=fact_type, **fact_data)
                 chunk_facts.append(fact)
             except Exception as e:
-                logger.error(f"Failed to create Fact model for fact {i}: {e}")
+                message = f"{custom_id}: failed to create Fact model for fact {i}: {e}"
+                logger.error(message)
+                extraction_errors.add(message)
                 continue
 
         all_facts_from_llm.extend(chunk_facts)
@@ -2170,6 +2229,8 @@ async def extract_facts_from_contents_batch_api(
 
     # Step 8: Auto-tag facts from label groups with tag=True
     _inject_label_tags(extracted_facts, config)
+
+    await _write_batch_extraction_errors(pool, operation_id, schema, extraction_errors)
 
     logger.info(f"Batch API extracted {len(extracted_facts)} facts from {len(all_chunks_info)} chunks")
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -114,17 +114,6 @@ def _sanitize_text(text: str | None) -> str | None:
     return sanitize_llm_output(text)
 
 
-def _parse_result_metadata(raw_metadata: Any) -> dict[str, Any]:
-    """Parse async_operations.result_metadata from raw asyncpg or DatabaseBackend rows."""
-    if not raw_metadata:
-        return {}
-    if isinstance(raw_metadata, str):
-        return json.loads(raw_metadata)
-    if isinstance(raw_metadata, dict):
-        return raw_metadata
-    return dict(raw_metadata)
-
-
 class Entity(BaseModel):
     """An entity extracted from text."""
 
@@ -1735,17 +1724,14 @@ async def _write_batch_extraction_errors(
     from ..db_utils import acquire_with_retry
     from ..task_backend import fq_table
 
+    # `errors` is the complete set for this extraction run, so overwrite the
+    # extraction_errors_* keys rather than folding in what's already stored. On
+    # batch crash recovery the resumed batch reprocesses every result and
+    # recomputes `errors` from scratch; reading + merging the prior run's
+    # counters here would double-count them. The SQL `||` merge still preserves
+    # unrelated keys (e.g. batch_id) already on result_metadata.
     table = fq_table("async_operations", schema)
     async with acquire_with_retry(pool) as conn:
-        row = await conn.fetchrow(
-            f"SELECT result_metadata FROM {table} WHERE operation_id = $1",
-            operation_id,
-        )
-        existing_errors = RetainExtractionErrors()
-        if row:
-            existing_metadata = _parse_result_metadata(row["result_metadata"])
-            existing_errors.merge_metadata(existing_metadata)
-        existing_errors.merge_errors(errors)
         await conn.execute(
             f"""
             UPDATE {table}
@@ -1754,7 +1740,7 @@ async def _write_batch_extraction_errors(
             WHERE operation_id = $1
             """,
             operation_id,
-            json.dumps(existing_errors.to_dict()),
+            json.dumps(errors.to_dict()),
         )
 
 

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -103,6 +103,11 @@ async def test_small_async_batch_no_splitting(memory, request_context):
     assert status["result_metadata"]["num_sub_batches"] == 1  # Single sub-batch
     assert len(status["child_operations"]) == 1
     assert status["child_operations"][0]["status"] == "completed"
+    child_meta = await _child_metadata(memory, bank_id, operation_id, request_context)
+    assert child_meta["unit_ids_count"] > 0
+    assert child_meta["extraction_errors_count"] == 0
+    assert status["result_metadata"]["unit_ids_count"] == child_meta["unit_ids_count"]
+    assert status["result_metadata"]["extraction_errors_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -166,6 +171,19 @@ async def test_large_async_batch_auto_splits(memory, request_context):
 
     # Parent status should be aggregated as "completed"
     assert parent_status["status"] == "completed"
+    child_unit_counts = []
+    for child in child_ops:
+        child_status = await memory.get_operation_status(
+            bank_id=bank_id,
+            operation_id=child["operation_id"],
+            request_context=request_context,
+        )
+        child_meta = child_status["result_metadata"]
+        assert child_meta["unit_ids_count"] > 0
+        assert child_meta["extraction_errors_count"] == 0
+        child_unit_counts.append(child_meta["unit_ids_count"])
+    assert parent_status["result_metadata"]["unit_ids_count"] == sum(child_unit_counts)
+    assert parent_status["result_metadata"]["extraction_errors_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -459,6 +477,42 @@ async def _child_metadata(memory, bank_id: str, parent_operation_id: str, reques
         request_context=request_context,
     )
     return child["result_metadata"]
+
+
+@pytest.mark.asyncio
+async def test_retain_outcome_metadata_records_zero_counts(memory, request_context, monkeypatch):
+    """Completed retain operations expose explicit zero outcome counters."""
+    from hindsight_api.engine.response_models import TokenUsage
+    from hindsight_api.engine.retain import fact_extraction
+
+    async def empty_extract_facts_from_contents(
+        *args: object, **kwargs: object
+    ) -> tuple[list[object], list[object], TokenUsage]:
+        return [], [], TokenUsage()
+
+    monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", empty_extract_facts_from_contents)
+
+    bank_id = "test_retain_outcome_zero_counts"
+    result = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[{"content": "No extracted facts for this item."}],
+        request_context=request_context,
+    )
+    await asyncio.sleep(0.2)
+
+    parent = await memory.get_operation_status(
+        bank_id=bank_id,
+        operation_id=result["operation_id"],
+        request_context=request_context,
+    )
+    child_meta = await _child_metadata(memory, bank_id, result["operation_id"], request_context)
+
+    assert child_meta["unit_ids_count"] == 0
+    assert child_meta["extraction_errors_count"] == 0
+    assert "extraction_errors_sample" not in child_meta
+    assert parent["result_metadata"]["unit_ids_count"] == 0
+    assert parent["result_metadata"]["extraction_errors_count"] == 0
+    assert "extraction_errors_sample" not in parent["result_metadata"]
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -7,21 +7,23 @@ Tests cover:
 - Hard error when provider doesn't support the batch API (no silent fallback)
 - Worker recovery on restart
 """
-import pytest
 import asyncio
-import logging
 import json
+import logging
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from hindsight_api import RequestContext
-from hindsight_api.engine.retain.fact_extraction import (
-    extract_facts_from_contents_batch_api,
-    extract_facts_from_contents,
-    RetainContent,
-)
 from hindsight_api.config import HindsightConfig
 from hindsight_api.engine.llm_wrapper import create_llm_provider
+from hindsight_api.engine.retain.fact_extraction import (
+    RetainContent,
+    extract_facts_from_contents,
+    extract_facts_from_contents_batch_api,
+)
 from hindsight_api.worker.poller import WorkerPoller
 
 logger = logging.getLogger(__name__)
@@ -325,6 +327,101 @@ async def test_batch_api_crash_recovery(mock_llm_config, test_contents, hindsigh
 
     finally:
         # Cleanup
+        try:
+            await memory.delete_bank(bank_id, request_context=request_context)
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_batch_api_records_non_fatal_extraction_errors(
+    mock_llm_config, test_contents, hindsight_config, memory, request_context
+):
+    """Batch API skipped chunks are surfaced in operation result_metadata."""
+    bank_id = f"test_batch_errors_{datetime.now(timezone.utc).timestamp()}"
+    operation_id = str(uuid.uuid4())
+
+    try:
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        pool = memory._pool
+        schema = request_context.tenant_id
+
+        from hindsight_api.engine.task_backend import fq_table
+
+        table = fq_table("async_operations", schema)
+        await pool.execute(
+            f"""
+            INSERT INTO {table} (operation_id, operation_type, bank_id, status, result_metadata)
+            VALUES ($1, 'retain', $2, 'processing', $3::jsonb)
+            """,
+            operation_id,
+            bank_id,
+            json.dumps({}),
+        )
+
+        batch_id = "batch_partial_errors"
+        mock_llm_config._provider_impl.supports_batch_api = AsyncMock(return_value=True)
+        mock_llm_config._provider_impl.submit_batch = AsyncMock(return_value={"batch_id": batch_id})
+        mock_llm_config._provider_impl.get_batch_status = AsyncMock(
+            return_value={
+                "status": "completed",
+                "request_counts": {"total": 2, "completed": 2, "failed": 0},
+            }
+        )
+        mock_llm_config._provider_impl.retrieve_batch_results = AsyncMock(
+            return_value=[
+                {
+                    "custom_id": "chunk_0",
+                    "response": {
+                        "body": {
+                            "choices": [
+                                {
+                                    "message": {
+                                        "content": json.dumps({
+                                            "facts": [
+                                                {
+                                                    "what": "Alice is a senior software engineer",
+                                                    "when": "present",
+                                                    "where": "TechCorp",
+                                                    "who": "Alice",
+                                                    "why": "Background",
+                                                    "fact_type": "world",
+                                                    "fact_kind": "conversation",
+                                                }
+                                            ]
+                                        })
+                                    }
+                                }
+                            ],
+                            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+                        }
+                    },
+                }
+            ]
+        )
+
+        facts, chunks, usage = await extract_facts_from_contents_batch_api(
+            contents=test_contents,
+            llm_config=mock_llm_config,
+            agent_name="test_agent",
+            config=hindsight_config,
+            pool=pool,
+            operation_id=operation_id,
+            schema=schema,
+        )
+
+        assert len(facts) == 1
+        assert len(chunks) == 2
+        assert chunks[1].fact_count == 0
+        assert usage.total_tokens == 150
+
+        row = await pool.fetchrow(f"SELECT result_metadata FROM {table} WHERE operation_id = $1", operation_id)
+        metadata = json.loads(row["result_metadata"]) if isinstance(row["result_metadata"], str) else row["result_metadata"]
+        assert metadata["batch_id"] == batch_id
+        assert metadata["extraction_errors_count"] == 1
+        assert metadata["extraction_errors_sample"] == ["chunk_1: missing batch result"]
+
+    finally:
         try:
             await memory.delete_bank(bank_id, request_context=request_context)
         except Exception:


### PR DESCRIPTION
Summary
- add completed retain outcome counters to async operation result_metadata
- aggregate child retain outcome counters onto parent batch_retain operations
- record non-fatal Batch API extraction skips in extraction_errors_count/sample

Closes #1579.

Tests
- HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 uv run --project hindsight-api-slim pytest -n 0 hindsight-api-slim/tests/test_async_batch_retain.py::test_small_async_batch_no_splitting hindsight-api-slim/tests/test_async_batch_retain.py::test_large_async_batch_auto_splits hindsight-api-slim/tests/test_async_batch_retain.py::test_retain_outcome_metadata_records_zero_counts hindsight-api-slim/tests/test_batch_api.py::test_batch_api_records_non_fatal_extraction_errors -q
- ./scripts/hooks/lint.sh
