### PR TITLE
fix(retain): preserve client timezone context

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -13,6 +13,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
@@ -446,6 +447,7 @@ class MemoryItem(BaseModel):
             "example": {
                 "content": "Alice mentioned she's working on a new ML model",
                 "timestamp": "2024-01-15T10:30:00Z",
+                "client_timezone": "America/Los_Angeles",
                 "context": "team meeting",
                 "metadata": {"source": "slack", "channel": "engineering"},
                 "document_id": "meeting_notes_2024_01_15",
@@ -468,6 +470,14 @@ class MemoryItem(BaseModel):
     context: str | None = None
     metadata: dict[str, str] | None = None
     document_id: str | None = Field(default=None, description="Optional document ID for this memory item.")
+    client_timezone: str | None = Field(
+        default=None,
+        description=(
+            "Optional IANA timezone name for the client/user (e.g. 'Asia/Shanghai'). "
+            "When present, fact extraction renders natural-language time references in this local timezone while "
+            "stored timestamps remain normalized to UTC."
+        ),
+    )
     entities: list[EntityInput] | None = Field(
         default=None,
         description="Optional entities to combine with auto-extracted entities.",
@@ -544,6 +554,22 @@ class MemoryItem(BaseModel):
                     f"Invalid timestamp/event_date format: '{v}'. Expected ISO format like '2024-01-15T10:30:00' or '2024-01-15T10:30:00Z', or the special value 'unset' to store without a timestamp."
                 ) from e
         raise ValueError(f"timestamp must be a string or datetime, got {type(v).__name__}")
+
+    @field_validator("client_timezone", mode="before")
+    @classmethod
+    def validate_client_timezone(cls, v):
+        if v is None or v == "":
+            return None
+        if not isinstance(v, str):
+            raise ValueError(f"client_timezone must be a string, got {type(v).__name__}")
+        timezone_name = v.strip()
+        if not timezone_name:
+            return None
+        try:
+            ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError as e:
+            raise ValueError(f"Invalid client_timezone: '{v}'. Expected an IANA timezone like 'Asia/Shanghai'.") from e
+        return timezone_name
 
 
 class RetainRequest(BaseModel):
@@ -6060,6 +6086,8 @@ def _register_routes(app: FastAPI):
                     content_dict["event_date"] = None
                 elif item.timestamp:
                     content_dict["event_date"] = item.timestamp
+                if item.client_timezone:
+                    content_dict["client_timezone"] = item.client_timezone
                 if item.context:
                     content_dict["context"] = item.context
                 if item.metadata:

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -9,8 +9,9 @@ import asyncio
 import json
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, cast
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
@@ -111,6 +112,22 @@ def _infer_temporal_date(fact_text: str, event_date: datetime | None) -> str | N
 
 def _sanitize_text(text: str | None) -> str | None:
     return sanitize_llm_output(text)
+
+
+def _timezone_offset_label(timezone_name: str, reference: datetime | None) -> str:
+    """Return a compact UTC offset label for a timezone at the event instant."""
+    reference_dt = reference or datetime.now(UTC)
+    if reference_dt.tzinfo is None:
+        reference_dt = reference_dt.replace(tzinfo=UTC)
+    local_dt = reference_dt.astimezone(ZoneInfo(timezone_name))
+    offset = local_dt.utcoffset()
+    if offset is None:
+        return "UTC offset unavailable"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"UTC{sign}{hours:02d}:{minutes:02d}"
 
 
 class Entity(BaseModel):
@@ -1021,6 +1038,7 @@ def _build_user_message(
     metadata: dict[str, str] | None = None,
     agent_name: str | None = None,
     mission_preamble: str = "",
+    client_timezone: str | None = None,
 ) -> str:
     """Build user message for fact extraction.
 
@@ -1035,9 +1053,24 @@ def _build_user_message(
 
     if event_date is not None:
         event_date = parse_datetime_flexible(event_date)
-        event_date_str = f"{event_date.strftime('%A, %B %d, %Y')} ({event_date.isoformat()})"
+        if client_timezone:
+            local_event_date = event_date.astimezone(ZoneInfo(client_timezone))
+            event_date_str = (
+                f"{local_event_date.strftime('%A, %B %d, %Y')} "
+                f"({local_event_date.isoformat()}, UTC instant {event_date.isoformat()})"
+            )
+        else:
+            event_date_str = f"{event_date.strftime('%A, %B %d, %Y')} ({event_date.isoformat()})"
     else:
         event_date_str = "Unknown"
+
+    timezone_section = ""
+    if client_timezone:
+        offset_label = _timezone_offset_label(client_timezone, event_date)
+        timezone_section = (
+            f"\nClient Timezone: {client_timezone} ({offset_label}). When generating date/time references in "
+            "extracted memory text, use this local timezone. Keep UTC only as the storage/reference instant."
+        )
 
     metadata_section = ""
     if metadata:
@@ -1064,7 +1097,7 @@ def _build_user_message(
 
 Chunk: {chunk_index + 1}/{total_chunks}
 Event Date: {event_date_str}
-Context: {sanitized_context}{metadata_section}{narrator_section}
+Context: {sanitized_context}{timezone_section}{metadata_section}{narrator_section}
 
 Text:
 {sanitized_chunk}"""
@@ -1110,6 +1143,7 @@ async def _extract_facts_from_chunk(
     config,
     agent_name: str = None,
     metadata: dict[str, str] | None = None,
+    client_timezone: str | None = None,
 ) -> tuple[list[dict[str, str]], TokenUsage]:
     """
     Extract facts from a single chunk (internal helper for parallel processing).
@@ -1140,6 +1174,7 @@ async def _extract_facts_from_chunk(
         metadata,
         agent_name,
         mission_preamble=_retain_mission_preamble(config),
+        client_timezone=client_timezone,
     )
 
     # Opt into context caching when the provider supports it. The prompt and
@@ -1489,6 +1524,7 @@ async def _extract_facts_with_auto_split(
     config,
     agent_name: str = None,
     metadata: dict[str, str] | None = None,
+    client_timezone: str | None = None,
 ) -> tuple[list[dict[str, str]], TokenUsage]:
     """
     Extract facts from a chunk with automatic splitting if output exceeds token limits.
@@ -1506,6 +1542,7 @@ async def _extract_facts_with_auto_split(
         config: Resolved HindsightConfig for this bank
         agent_name: Optional agent name (memory owner)
         metadata: Optional document metadata key-value pairs
+        client_timezone: Optional IANA timezone for local-time extraction context
 
     Returns:
         Tuple of (facts list, token usage) extracted from the chunk (possibly from sub-chunks)
@@ -1526,6 +1563,7 @@ async def _extract_facts_with_auto_split(
             config=config,
             agent_name=agent_name,
             metadata=metadata,
+            client_timezone=client_timezone,
         )
     except OutputTooLongError:
         # Output exceeded token limits - split the chunk in half and retry
@@ -1572,6 +1610,7 @@ async def _extract_facts_with_auto_split(
                 config=config,
                 agent_name=agent_name,
                 metadata=metadata,
+                client_timezone=client_timezone,
             ),
             _extract_facts_with_auto_split(
                 chunk=second_half,
@@ -1583,6 +1622,7 @@ async def _extract_facts_with_auto_split(
                 config=config,
                 agent_name=agent_name,
                 metadata=metadata,
+                client_timezone=client_timezone,
             ),
         ]
 
@@ -1608,6 +1648,7 @@ async def extract_facts_from_text(
     config,
     context: str = "",
     metadata: dict[str, str] | None = None,
+    client_timezone: str | None = None,
 ) -> tuple[list[Fact], list[tuple[str, int]], TokenUsage]:
     """
     Extract semantic facts from conversational or narrative text using LLM.
@@ -1626,6 +1667,7 @@ async def extract_facts_from_text(
         config: Resolved HindsightConfig for this bank
         context: Context about the conversation/document
         metadata: Optional document metadata key-value pairs
+        client_timezone: Optional IANA timezone for local-time extraction context
 
     Returns:
         Tuple of (facts, chunks, usage) where:
@@ -1659,6 +1701,7 @@ async def extract_facts_from_text(
             config=config,
             agent_name=agent_name,
             metadata=metadata,
+            client_timezone=client_timezone,
         )
         for i, chunk in enumerate(chunks)
     ]
@@ -1777,7 +1820,8 @@ async def extract_facts_from_contents_batch_api(
                 logger.info(f"Resuming existing batch: batch_id={batch_id} (crash recovery)")
 
     # Step 1: Chunk all contents and build batch requests (skip if resuming)
-    all_chunks_info = []  # List of (chunk_text, content_index, chunk_index_in_content, event_date, context)
+    # List of (chunk_text, content_index, chunk_index_in_content, event_date, context)
+    all_chunks_info = []
     batch_requests = []
 
     # Build prompt and schema once (same for all chunks)
@@ -1802,6 +1846,7 @@ async def extract_facts_from_contents_batch_api(
                 item.metadata or None,
                 agent_name,
                 mission_preamble=_retain_mission_preamble(config),
+                client_timezone=item.client_timezone,
             )
 
             # Build request body using helper function
@@ -2281,6 +2326,7 @@ async def extract_facts_from_contents(
             agent_name=agent_name,
             config=config,
             metadata=item.metadata or None,
+            client_timezone=item.client_timezone,
         )
         fact_extraction_tasks.append(task)
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...worker.stage import set_stage
 from ..db.base import DatabaseBackend
@@ -74,16 +75,30 @@ def parse_datetime_flexible(value: Any) -> datetime:
         # Ensure timezone-aware
         if value.tzinfo is None:
             return value.replace(tzinfo=UTC)
-        return value
+        return value.astimezone(UTC)
     elif isinstance(value, str):
         # Parse ISO format string (handles both 'Z' and '+00:00' timezone formats)
         dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
         # Ensure timezone-aware
         if dt.tzinfo is None:
             return dt.replace(tzinfo=UTC)
-        return dt
+        return dt.astimezone(UTC)
     else:
         raise TypeError(f"Expected datetime or string, got {type(value).__name__}")
+
+
+def _validate_client_timezone(value: str | None) -> str | None:
+    """Validate a caller-supplied IANA timezone name."""
+    if value is None:
+        return None
+    timezone_name = value.strip()
+    if not timezone_name:
+        return None
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as e:
+        raise ValueError(f"Invalid client_timezone '{value}'. Expected an IANA timezone like 'Asia/Shanghai'.") from e
+    return timezone_name
 
 
 import asyncpg
@@ -975,6 +990,7 @@ async def _streaming_retain_batch(
                 metadata=source.metadata,
                 entities=source.entities,
                 tags=source.tags,
+                client_timezone=source.client_timezone,
                 observation_scopes=source.observation_scopes,
             )
             # Attribute this chunk's extraction LLM call to its document, so the
@@ -2025,6 +2041,7 @@ def _build_contents(contents_dicts: list[RetainContentDict], document_tags: list
             metadata=item.get("metadata", {}),
             entities=item.get("entities", []),
             tags=merged_tags,
+            client_timezone=_validate_client_timezone(item.get("client_timezone")),
             observation_scopes=item.get("observation_scopes"),
         )
         contents.append(content)
@@ -2081,6 +2098,7 @@ def _build_delta_contents(
             metadata=template_content.metadata,
             entities=template_content.entities,
             tags=template_content.tags,
+            client_timezone=template_content.client_timezone,
             observation_scopes=template_content.observation_scopes,
         )
         delta_contents.append(delta_content)

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -22,6 +22,7 @@ class RetainContentDict(TypedDict, total=False):
         document_id: Document ID for this content item (optional)
         entities: User-provided entities to merge with extracted entities (optional)
         tags: Visibility scope tags for this content item (optional)
+        client_timezone: IANA timezone name for rendering local time in extraction prompts (optional)
         observation_scopes: How to scope observations for consolidation (optional).
             "per_tag" runs one pass per individual tag; "combined" (default) runs a
             single pass with all tags; a list[list[str]] specifies exact passes.
@@ -37,6 +38,7 @@ class RetainContentDict(TypedDict, total=False):
     document_id: str
     entities: list[dict[str, str]]  # [{"text": "...", "type": "..."}]
     tags: list[str]  # Visibility scope tags
+    client_timezone: str
     observation_scopes: (
         Literal["per_tag", "combined", "all_combinations"] | list[list[str]]
     )  # Observation scopes for consolidation
@@ -57,6 +59,7 @@ class RetainContent:
     metadata: dict[str, str] = field(default_factory=dict)
     entities: list[dict[str, str]] = field(default_factory=list)  # User-provided entities
     tags: list[str] = field(default_factory=list)  # Visibility scope tags
+    client_timezone: str | None = None  # IANA timezone for local-time prompt context
     observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = (
         None  # Observation scopes
     )

--- a/hindsight-api-slim/tests/test_retain_timezone.py
+++ b/hindsight-api-slim/tests/test_retain_timezone.py
@@ -1,0 +1,113 @@
+"""Regression tests for retain timezone handling."""
+
+import os
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+
+from hindsight_api import LLMConfig
+from hindsight_api.api.http import RetainRequest
+from hindsight_api.config import DEFAULT_LLM_PROVIDER, ENV_LLM_API_KEY, ENV_LLM_PROVIDER, _get_raw_config
+from hindsight_api.engine.llm_wrapper import requires_api_key
+from hindsight_api.engine.retain.fact_extraction import _build_user_message, extract_facts_from_text
+from hindsight_api.engine.retain.orchestrator import _build_contents, parse_datetime_flexible
+from tests.llm_judge import assert_meets_criteria
+
+
+def test_parse_datetime_flexible_converts_aware_values_to_utc() -> None:
+    """Offset-aware retain timestamps must be converted, not relabelled, as UTC."""
+    expected = datetime(2026, 6, 5, 12, 36, tzinfo=UTC)
+
+    assert parse_datetime_flexible("2026-06-05T20:36:00+08:00") == expected
+    assert parse_datetime_flexible(datetime(2026, 6, 5, 20, 36, tzinfo=ZoneInfo("Asia/Shanghai"))) == expected
+
+
+def test_retain_request_accepts_and_validates_client_timezone() -> None:
+    request = RetainRequest.model_validate(
+        {"items": [{"content": "Alice joined the call at 8:36 PM.", "client_timezone": " Asia/Shanghai "}]}
+    )
+
+    assert request.items[0].client_timezone == "Asia/Shanghai"
+
+    with pytest.raises(ValidationError, match="Invalid client_timezone"):
+        RetainRequest.model_validate(
+            {"items": [{"content": "Alice joined the call at 8:36 PM.", "client_timezone": "Mars/Phobos"}]}
+        )
+
+
+def test_build_contents_carries_client_timezone_and_normalizes_event_date() -> None:
+    contents = _build_contents(
+        [
+            {
+                "content": "Alice joined the call at 8:36 PM.",
+                "event_date": "2026-06-05T20:36:00+08:00",
+                "client_timezone": "Asia/Shanghai",
+            }
+        ],
+        document_tags=None,
+    )
+
+    assert contents[0].event_date == datetime(2026, 6, 5, 12, 36, tzinfo=UTC)
+    assert contents[0].client_timezone == "Asia/Shanghai"
+
+    with pytest.raises(ValueError, match="Invalid client_timezone"):
+        _build_contents([{"content": "Alice joined the call.", "client_timezone": "Mars/Phobos"}], None)
+
+
+def test_build_user_message_uses_client_timezone_for_event_date() -> None:
+    msg = _build_user_message(
+        chunk="Alice joined the call at 8:36 PM.",
+        chunk_index=0,
+        total_chunks=1,
+        event_date=datetime(2026, 6, 5, 12, 36, tzinfo=UTC),
+        context="support chat",
+        client_timezone="Asia/Shanghai",
+    )
+
+    assert "Event Date: Friday, June 05, 2026 (2026-06-05T20:36:00+08:00" in msg
+    assert "UTC instant 2026-06-05T12:36:00+00:00" in msg
+    assert "Client Timezone: Asia/Shanghai (UTC+08:00)" in msg
+    assert "use this local timezone" in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.hs_llm_core
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
+async def test_extract_facts_uses_client_timezone_for_relative_dates() -> None:
+    """Real extraction should resolve relative dates against the client's local day."""
+    provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER)
+    if not os.getenv(ENV_LLM_API_KEY) and requires_api_key(provider):
+        pytest.skip(f"{ENV_LLM_API_KEY} is required for real LLM extraction")
+
+    facts, _, _ = await extract_facts_from_text(
+        text="Today I paid the January rent after breakfast.",
+        event_date=datetime(2025, 12, 31, 16, 30, tzinfo=UTC),
+        context="personal journal entry written just after midnight in Shanghai",
+        llm_config=LLMConfig.from_env(),
+        agent_name="TestUser",
+        config=_get_raw_config(),
+        client_timezone="Asia/Shanghai",
+    )
+
+    assert facts, "Should extract at least one fact"
+    extracted = "\n".join(
+        f"fact={fact.fact}; occurred_start={fact.occurred_start}; occurred_end={fact.occurred_end}"
+        for fact in facts
+    )
+
+    await assert_meets_criteria(
+        response=extracted,
+        criteria=(
+            "The extraction treats 'today' as January 1, 2026 in Asia/Shanghai for the rent payment. "
+            "It must not resolve the event as December 31, 2025 just because the storage/reference "
+            "instant is in UTC."
+        ),
+        context=(
+            "The event instant is 2025-12-31T16:30:00+00:00, which is "
+            "2026-01-01T00:30:00+08:00 in Asia/Shanghai. The input says: "
+            "'Today I paid the January rent after breakfast.'"
+        ),
+        msg=f"Client timezone should drive relative-date extraction. Facts: {extracted}",
+    )

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -6026,6 +6026,7 @@ components:
     MemoryItem:
       description: Single memory item for retain.
       example:
+        client_timezone: America/Los_Angeles
         content: Alice mentioned she's working on a new ML model
         context: team meeting
         document_id: meeting_notes_2024_01_15
@@ -6054,6 +6055,9 @@ components:
             type: string
           nullable: true
         document_id:
+          nullable: true
+          type: string
+        client_timezone:
           nullable: true
           type: string
         entities:

--- a/hindsight-clients/go/model_memory_item.go
+++ b/hindsight-clients/go/model_memory_item.go
@@ -26,6 +26,7 @@ type MemoryItem struct {
 	Context NullableString `json:"context,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 	DocumentId NullableString `json:"document_id,omitempty"`
+	ClientTimezone NullableString `json:"client_timezone,omitempty"`
 	Entities []EntityInput `json:"entities,omitempty"`
 	Tags []string `json:"tags,omitempty"`
 	ObservationScopes NullableObservationScopes `json:"observation_scopes,omitempty"`
@@ -234,6 +235,48 @@ func (o *MemoryItem) SetDocumentIdNil() {
 // UnsetDocumentId ensures that no value is present for DocumentId, not even an explicit nil
 func (o *MemoryItem) UnsetDocumentId() {
 	o.DocumentId.Unset()
+}
+
+// GetClientTimezone returns the ClientTimezone field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MemoryItem) GetClientTimezone() string {
+	if o == nil || IsNil(o.ClientTimezone.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.ClientTimezone.Get()
+}
+
+// GetClientTimezoneOk returns a tuple with the ClientTimezone field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MemoryItem) GetClientTimezoneOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ClientTimezone.Get(), o.ClientTimezone.IsSet()
+}
+
+// HasClientTimezone returns a boolean if a field has been set.
+func (o *MemoryItem) HasClientTimezone() bool {
+	if o != nil && o.ClientTimezone.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetClientTimezone gets a reference to the given NullableString and assigns it to the ClientTimezone field.
+func (o *MemoryItem) SetClientTimezone(v string) {
+	o.ClientTimezone.Set(&v)
+}
+// SetClientTimezoneNil sets the value for ClientTimezone to be an explicit nil
+func (o *MemoryItem) SetClientTimezoneNil() {
+	o.ClientTimezone.Set(nil)
+}
+
+// UnsetClientTimezone ensures that no value is present for ClientTimezone, not even an explicit nil
+func (o *MemoryItem) UnsetClientTimezone() {
+	o.ClientTimezone.Unset()
 }
 
 // GetEntities returns the Entities field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -450,6 +493,9 @@ func (o MemoryItem) ToMap() (map[string]interface{}, error) {
 	}
 	if o.DocumentId.IsSet() {
 		toSerialize["document_id"] = o.DocumentId.Get()
+	}
+	if o.ClientTimezone.IsSet() {
+		toSerialize["client_timezone"] = o.ClientTimezone.Get()
 	}
 	if o.Entities != nil {
 		toSerialize["entities"] = o.Entities

--- a/hindsight-clients/python/hindsight_client_api/models/memory_item.py
+++ b/hindsight-clients/python/hindsight_client_api/models/memory_item.py
@@ -34,12 +34,13 @@ class MemoryItem(BaseModel):
     context: Optional[StrictStr] = None
     metadata: Optional[Dict[str, StrictStr]] = None
     document_id: Optional[StrictStr] = None
+    client_timezone: Optional[StrictStr] = None
     entities: Optional[List[EntityInput]] = None
     tags: Optional[List[StrictStr]] = None
     observation_scopes: Optional[ObservationScopes] = None
     strategy: Optional[StrictStr] = None
     update_mode: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["content", "timestamp", "context", "metadata", "document_id", "entities", "tags", "observation_scopes", "strategy", "update_mode"]
+    __properties: ClassVar[List[str]] = ["content", "timestamp", "context", "metadata", "document_id", "client_timezone", "entities", "tags", "observation_scopes", "strategy", "update_mode"]
 
     @field_validator('update_mode')
     def update_mode_validate_enum(cls, value):
@@ -123,6 +124,11 @@ class MemoryItem(BaseModel):
         if self.document_id is None and "document_id" in self.model_fields_set:
             _dict['document_id'] = None
 
+        # set to None if client_timezone (nullable) is None
+        # and model_fields_set contains the field
+        if self.client_timezone is None and "client_timezone" in self.model_fields_set:
+            _dict['client_timezone'] = None
+
         # set to None if entities (nullable) is None
         # and model_fields_set contains the field
         if self.entities is None and "entities" in self.model_fields_set:
@@ -165,6 +171,7 @@ class MemoryItem(BaseModel):
             "context": obj.get("context"),
             "metadata": obj.get("metadata"),
             "document_id": obj.get("document_id"),
+            "client_timezone": obj.get("client_timezone"),
             "entities": [EntityInput.from_dict(_item) for _item in obj["entities"]] if obj.get("entities") is not None else None,
             "tags": obj.get("tags"),
             "observation_scopes": ObservationScopes.from_dict(obj["observation_scopes"]) if obj.get("observation_scopes") is not None else None,

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2140,6 +2140,12 @@ export type MemoryItem = {
    */
   document_id?: string | null;
   /**
+   * Client Timezone
+   *
+   * Optional IANA timezone name for the client/user (e.g. 'Asia/Shanghai'). When present, fact extraction renders natural-language time references in this local timezone while stored timestamps remain normalized to UTC.
+   */
+  client_timezone?: string | null;
+  /**
    * Entities
    *
    * Optional entities to combine with auto-extracted entities.

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -86,6 +86,22 @@ When the event described in the content actually occurred. Three forms are accep
 
 The timestamp is injected into the LLM fact-extraction prompt so the model can resolve relative temporal references in the content — for example, if the content says "last Monday", the model uses the provided timestamp as the anchor to pin down the actual date. When `"unset"` is passed the prompt shows `Event Date: Unknown`, allowing the model to correctly return `N/A` for the `when` field of every extracted fact. Providing a real timestamp also enables temporal recall queries like "What happened last spring?" to work correctly.
 
+Offset-aware timestamps are normalized to UTC before storage. For example, `"2026-06-05T20:36:00+08:00"` is stored as the same instant as `"2026-06-05T12:36:00Z"`, not relabeled as `20:36Z`.
+
+### client_timezone
+
+Optional IANA timezone name for the user's local time, such as `"Asia/Shanghai"` or `"America/Los_Angeles"`. When present, Hindsight includes it in the fact-extraction prompt so natural-language time references in stored memory text use the user's local time, while database timestamps remain normalized to UTC.
+
+Use this when `timestamp` is a UTC instant but the source conversation happened in a user's local timezone:
+
+```json
+{
+  "content": "User said the outage started at 8:36 PM.",
+  "timestamp": "2026-06-05T12:36:00Z",
+  "client_timezone": "Asia/Shanghai"
+}
+```
+
 ### context
 
 A short label describing the source or situation — for example `"team meeting"`, `"slack"`, or `"support ticket"`. It is injected directly into the LLM prompt, so it actively shapes how facts are extracted. The same sentence can mean something very different depending on context: "the project was terminated" in a `"performance review"` context versus a `"product roadmap"` context produces different memories.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9062,6 +9062,18 @@
             "title": "Document Id",
             "description": "Optional document ID for this memory item."
           },
+          "client_timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Timezone",
+            "description": "Optional IANA timezone name for the client/user (e.g. 'Asia/Shanghai'). When present, fact extraction renders natural-language time references in this local timezone while stored timestamps remain normalized to UTC."
+          },
           "entities": {
             "anyOf": [
               {
@@ -9154,6 +9166,7 @@
         "title": "MemoryItem",
         "description": "Single memory item for retain.",
         "example": {
+          "client_timezone": "America/Los_Angeles",
           "content": "Alice mentioned she's working on a new ML model",
           "context": "team meeting",
           "document_id": "meeting_notes_2024_01_15",

--- a/hindsight-docs/versioned_docs/version-0.7/developer/api/retain.mdx
+++ b/hindsight-docs/versioned_docs/version-0.7/developer/api/retain.mdx
@@ -86,6 +86,22 @@ When the event described in the content actually occurred. Three forms are accep
 
 The timestamp is injected into the LLM fact-extraction prompt so the model can resolve relative temporal references in the content — for example, if the content says "last Monday", the model uses the provided timestamp as the anchor to pin down the actual date. When `"unset"` is passed the prompt shows `Event Date: Unknown`, allowing the model to correctly return `N/A` for the `when` field of every extracted fact. Providing a real timestamp also enables temporal recall queries like "What happened last spring?" to work correctly.
 
+Offset-aware timestamps are normalized to UTC before storage. For example, `"2026-06-05T20:36:00+08:00"` is stored as the same instant as `"2026-06-05T12:36:00Z"`, not relabeled as `20:36Z`.
+
+### client_timezone
+
+Optional IANA timezone name for the user's local time, such as `"Asia/Shanghai"` or `"America/Los_Angeles"`. When present, Hindsight includes it in the fact-extraction prompt so natural-language time references in stored memory text use the user's local time, while database timestamps remain normalized to UTC.
+
+Use this when `timestamp` is a UTC instant but the source conversation happened in a user's local timezone:
+
+```json
+{
+  "content": "User said the outage started at 8:36 PM.",
+  "timestamp": "2026-06-05T12:36:00Z",
+  "client_timezone": "Asia/Shanghai"
+}
+```
+
 ### context
 
 A short label describing the source or situation — for example `"team meeting"`, `"slack"`, or `"support ticket"`. It is injected directly into the LLM prompt, so it actively shapes how facts are extracted. The same sentence can mean something very different depending on context: "the project was terminated" in a `"performance review"` context versus a `"product roadmap"` context produces different memories.

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -134,6 +134,22 @@ When the event described in the content actually occurred. Three forms are accep
 
 The timestamp is injected into the LLM fact-extraction prompt so the model can resolve relative temporal references in the content — for example, if the content says "last Monday", the model uses the provided timestamp as the anchor to pin down the actual date. When `"unset"` is passed the prompt shows `Event Date: Unknown`, allowing the model to correctly return `N/A` for the `when` field of every extracted fact. Providing a real timestamp also enables temporal recall queries like "What happened last spring?" to work correctly.
 
+Offset-aware timestamps are normalized to UTC before storage. For example, `"2026-06-05T20:36:00+08:00"` is stored as the same instant as `"2026-06-05T12:36:00Z"`, not relabeled as `20:36Z`.
+
+### client_timezone
+
+Optional IANA timezone name for the user's local time, such as `"Asia/Shanghai"` or `"America/Los_Angeles"`. When present, Hindsight includes it in the fact-extraction prompt so natural-language time references in stored memory text use the user's local time, while database timestamps remain normalized to UTC.
+
+Use this when `timestamp` is a UTC instant but the source conversation happened in a user's local timezone:
+
+```json
+{
+  "content": "User said the outage started at 8:36 PM.",
+  "timestamp": "2026-06-05T12:36:00Z",
+  "client_timezone": "Asia/Shanghai"
+}
+```
+
 ### context
 
 A short label describing the source or situation — for example `"team meeting"`, `"slack"`, or `"support ticket"`. It is injected directly into the LLM prompt, so it actively shapes how facts are extracted. The same sentence can mean something very different depending on context: "the project was terminated" in a `"performance review"` context versus a `"product roadmap"` context produces different memories.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9062,6 +9062,18 @@
             "title": "Document Id",
             "description": "Optional document ID for this memory item."
           },
+          "client_timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Timezone",
+            "description": "Optional IANA timezone name for the client/user (e.g. 'Asia/Shanghai'). When present, fact extraction renders natural-language time references in this local timezone while stored timestamps remain normalized to UTC."
+          },
           "entities": {
             "anyOf": [
               {
@@ -9154,6 +9166,7 @@
         "title": "MemoryItem",
         "description": "Single memory item for retain.",
         "example": {
+          "client_timezone": "America/Los_Angeles",
           "content": "Alice mentioned she's working on a new ML model",
           "context": "team meeting",
           "document_id": "meeting_notes_2024_01_15",


### PR DESCRIPTION
Summary
- add optional `client_timezone` on retain items and validate it as an IANA timezone
- normalize offset-aware retain timestamps to UTC instead of relabeling the wall-clock time
- pass client timezone through normal retain, Batch API retain, streaming retain, and delta retain paths
- render the extraction Event Date in the client timezone while keeping the UTC instant visible for storage/reference
- regenerate OpenAPI, clients, and the docs skill references

Closes #2033

Tests
- `uv run --project hindsight-api-slim pytest -n 0 hindsight-api-slim/tests/test_retain_timezone.py hindsight-api-slim/tests/test_fact_extraction_metadata.py -q`
- `uv run --project hindsight-api-slim ruff check hindsight-api-slim/hindsight_api/api/http.py hindsight-api-slim/hindsight_api/engine/retain/types.py hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py hindsight-api-slim/tests/test_retain_timezone.py`
- `./scripts/generate-openapi.sh`
- `./scripts/generate-clients.sh`
- `./scripts/generate-docs-skill.sh`
- `./scripts/hooks/lint.sh`

Note: the new `hs_llm_core` regression test is present but skipped in my local run because `HINDSIGHT_API_LLM_API_KEY` is not configured locally.
