### PR TITLE
fix(reranker): make litellm-sdk reranker api_key optional for Bedrock IAM auth

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -46,7 +46,6 @@ from ..config import (
     ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA,
     ENV_RERANKER_FLASHRANK_MODEL,
     ENV_RERANKER_GOOGLE_PROJECT_ID,
-    ENV_RERANKER_LITELLM_SDK_API_KEY,
     ENV_RERANKER_LOCAL_FORCE_CPU,
     ENV_RERANKER_LOCAL_MAX_CONCURRENT,
     ENV_RERANKER_LOCAL_MODEL,
@@ -1199,7 +1198,7 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         model: str = DEFAULT_RERANKER_LITELLM_SDK_MODEL,
         api_base: str | None = None,
         timeout: float = 60.0,
@@ -1209,7 +1208,8 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
         Initialize LiteLLM SDK cross-encoder client.
 
         Args:
-            api_key: API key for the reranking provider
+            api_key: API key for the reranking provider (optional — omit for
+                     providers that use ambient credentials, e.g. AWS Bedrock with IAM)
             model: Model name with provider prefix (e.g., "deepinfra/Qwen3-reranker-8B")
             api_base: Custom base URL for API (optional)
             timeout: Request timeout in seconds (default: 60.0)
@@ -1284,8 +1284,9 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
                 "model": self.model,
                 "query": query,
                 "documents": texts,
-                "api_key": self.api_key,
             }
+            if self.api_key:
+                rerank_kwargs["api_key"] = self.api_key
             if self.api_base:
                 rerank_kwargs["api_base"] = self.api_base
 
@@ -1697,13 +1698,8 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             timeout=config.reranker_litellm_timeout,
         )
     elif provider == "litellm-sdk":
-        api_key = config.reranker_litellm_sdk_api_key
-        if not api_key:
-            raise ValueError(
-                f"{ENV_RERANKER_LITELLM_SDK_API_KEY} is required when {ENV_RERANKER_PROVIDER} is 'litellm-sdk'"
-            )
         return LiteLLMSDKCrossEncoder(
-            api_key=api_key,
+            api_key=config.reranker_litellm_sdk_api_key or None,
             model=config.reranker_litellm_sdk_model,
             api_base=config.reranker_litellm_sdk_api_base,
             max_tokens_per_doc=config.reranker_litellm_max_tokens_per_doc,

--- a/hindsight-api-slim/tests/test_litellm_sdk_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_cross_encoder.py
@@ -104,6 +104,35 @@ class TestLiteLLMSDKCrossEncoder:
             assert len(call_args.kwargs["documents"]) == 3
             assert call_args.kwargs["api_key"] == "test_key"
 
+    def test_constructor_without_api_key(self):
+        """api_key is optional (e.g. AWS Bedrock reranker with ambient IAM creds)."""
+        encoder = LiteLLMSDKCrossEncoder(model="bedrock/cohere.rerank-v3-5:0")
+        assert encoder.api_key is None
+
+    @pytest.mark.asyncio
+    async def test_predict_omits_api_key_for_ambient_credentials(self):
+        """When no api_key is set, it must not be injected into the rerank call.
+
+        litellm maps an explicit ``api_key`` to ``aws_access_key_id`` for Bedrock,
+        which overrides ambient IAM/task-role credentials; omitting it lets litellm
+        resolve credentials from the environment (regression test for IAM auth).
+        """
+        encoder = LiteLLMSDKCrossEncoder(model="bedrock/cohere.rerank-v3-5:0")
+
+        mock_response = MagicMock()
+        mock_response.results = [{"index": 0, "relevance_score": 0.9}]
+
+        mock_litellm = MagicMock()
+        mock_litellm.arerank = AsyncMock(return_value=mock_response)
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            await encoder.initialize()
+            await encoder.predict([("query", "document")])
+
+            mock_litellm.arerank.assert_called_once()
+            call_kwargs = mock_litellm.arerank.call_args.kwargs
+            assert "api_key" not in call_kwargs
+
     @pytest.mark.asyncio
     async def test_predict_multiple_queries(self):
         """Test prediction with multiple different queries (grouped efficiently)."""
@@ -278,11 +307,11 @@ class TestFactoryFunction:
                 assert encoder.model == "deepinfra/Qwen3-reranker-8B"
 
     @pytest.mark.asyncio
-    async def test_create_litellm_sdk_missing_api_key(self):
-        """Test that factory raises error when API key is missing."""
+    async def test_create_litellm_sdk_without_api_key(self):
+        """Test that litellm-sdk works without an API key (e.g. AWS Bedrock with IAM)."""
         env_vars = {
             "HINDSIGHT_API_RERANKER_PROVIDER": "litellm-sdk",
-            "HINDSIGHT_API_RERANKER_LITELLM_SDK_MODEL": "deepinfra/Qwen3-reranker-8B",
+            "HINDSIGHT_API_RERANKER_LITELLM_SDK_MODEL": "bedrock/cohere.rerank-v3-5:0",
         }
 
         with patch.dict(os.environ, env_vars, clear=False):
@@ -295,8 +324,11 @@ class TestFactoryFunction:
             config = HindsightConfig.from_env()
 
             with patch("hindsight_api.config.get_config", return_value=config):
-                with pytest.raises(ValueError, match="HINDSIGHT_API_RERANKER_LITELLM_SDK_API_KEY is required"):
-                    create_cross_encoder_from_env()
+                encoder = create_cross_encoder_from_env()
+
+                assert isinstance(encoder, LiteLLMSDKCrossEncoder)
+                assert encoder.api_key is None
+                assert encoder.model == "bedrock/cohere.rerank-v3-5:0"
 
     @pytest.mark.asyncio
     async def test_create_litellm_sdk_with_custom_api_base(self):


### PR DESCRIPTION
Mirrors the embeddings fix in #1744 for the **litellm-sdk reranker**.

`LiteLLMSDKCrossEncoder` advertises AWS Bedrock support, but the reranker path still requires an `api_key` and unconditionally injects it into the `litellm.arerank()` call. litellm maps an explicit `api_key` to `aws_access_key_id` for Bedrock, which **overrides ambient IAM/task-role credentials** — so a Bedrock reranker (e.g. `bedrock/cohere.rerank-*`) on IAM auth can't start (`create_cross_encoder_from_env` raises `ValueError`), and supplying a dummy key makes litellm reject the request.

The embeddings side already handles this (#1744). This applies the identical pattern to the reranker:
- `LiteLLMSDKCrossEncoder.__init__` — `api_key` is now `str | None = None`
- `predict()` — only injects `api_key` into the rerank kwargs when set (otherwise lets litellm resolve ambient credentials)
- `create_cross_encoder_from_env()` — drops the `api_key`-required `ValueError`, passing `config.reranker_litellm_sdk_api_key or None`

Tests: added IAM/no-key construction + predict-omits-key cases and updated the factory test to assert successful construction without a key (mirrors #1744's `test_create_from_env_without_api_key`). `uv run pytest tests/test_litellm_sdk_cross_encoder.py` → 15 passed; `ruff check` clean.