### PR TITLE
docs(claude-code): correct enableKnowledgeTools default (false→true) and disabled-behavior after #1999

### DIFF
--- a/hindsight-docs/docs-integrations/claude-code.md
+++ b/hindsight-docs/docs-integrations/claude-code.md
@@ -228,7 +228,7 @@ The plugin runs an MCP server that exposes `agent_knowledge_*` tools, letting Cl
 
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
-| `enableKnowledgeTools` | `HINDSIGHT_ENABLE_KNOWLEDGE_TOOLS` | `false` | Master switch for the MCP knowledge tools. When `false`, the MCP server exits at startup and none of the `agent_knowledge_*` tools are exposed. |
+| `enableKnowledgeTools` | `HINDSIGHT_ENABLE_KNOWLEDGE_TOOLS` | `true` | Master switch for the MCP knowledge tools. When `false`, the MCP server stays alive as an empty server exposing no `agent_knowledge_*` tools (it does not exit — exiting would trigger a `-32000` reconnect error in Claude Code). |
 
 ---
 


### PR DESCRIPTION
The Knowledge Tools settings table lists a wrong default and describes the exact crash that #1999 fixed.

`docs-integrations/claude-code.md` row for `enableKnowledgeTools` currently says:

> Default `false` — "When `false`, the MCP server **exits at startup** and none of the `agent_knowledge_*` tools are exposed."

Both halves are stale after #1999 (*"default enableKnowledgeTools to true; keep MCP server alive when disabled"*):

1. **Default is now `true`** — `hindsight-integrations/claude-code/scripts/lib/config.py:59` (`"enableKnowledgeTools": True`) and `settings.json:36` (`true`).
2. **Disabled no longer exits** — #1999's whole point was that exiting triggered the `-32000` reconnect crash. The sibling `README.md:281` already documents the correct behavior: *"the MCP server stays alive as an empty server (it does not exit, which would otherwise trigger a `-32000` reconnect error)."*

This doc's own Troubleshooting entry (further down) warns about the `-32000` error, so the table currently contradicts the rest of the page. This aligns the row with `README.md` and the shipped source. Single-file edit (`docs-integrations/` is not generated/mirrored, so no `verify-generated-files` impact).
