### PR TITLE
fix(opencode): observable logging — config-only debug, resolved-endpoint log, surfaced errors

### DIFF
--- a/hindsight-docs/docs-integrations/opencode.md
+++ b/hindsight-docs/docs-integrations/opencode.md
@@ -133,9 +133,20 @@ Create `~/.hindsight/opencode.json` for persistent configuration that applies ac
 | `HINDSIGHT_RECALL_TAGS_MATCH` | Tag match mode: `any`, `all`, `any_strict`, `all_strict` | `any` |
 | `HINDSIGHT_DYNAMIC_BANK_ID` | Enable dynamic bank ID derivation | `false` |
 | `HINDSIGHT_BANK_MISSION` | Bank mission/context for reflect | |
-| `HINDSIGHT_DEBUG` | Enable debug logging to stderr | `false` |
 
 Configuration priority (later wins): defaults < `~/.hindsight/opencode.json` < plugin options < env vars.
+
+### Logging & debugging
+
+The plugin logs through OpenCode's own log stream (`service=hindsight`), visible with `opencode --print-logs` or in the OpenCode log files. Errors (failed retain/recall, unreachable API, auth problems) and the resolved API URL + bank are logged **by default** — so if memories aren't saving, the reason is visible without any opt-in.
+
+Verbose tracing is controlled by the `debug` option, which is **config-only** (set `"debug": true` in `opencode.json` plugin options or `~/.hindsight/opencode.json`). There is intentionally no `HINDSIGHT_DEBUG` environment variable: env vars are unreliable to set for OpenCode's plugin runtime (notably on Windows, where a persistent OpenCode server may never see them).
+
+```json
+{
+  "plugin": [["@vectorize-io/opencode-hindsight", { "debug": true }]]
+}
+```
 
 ## Dynamic Bank IDs
 

--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -115,7 +115,14 @@ Create `~/.hindsight/opencode.json` for persistent configuration:
 | `HINDSIGHT_RECALL_MAX_TOKENS` | Max tokens for recall results       | `1024`                                |
 | `HINDSIGHT_DYNAMIC_BANK_ID`   | Enable dynamic bank ID derivation   | `false`                               |
 | `HINDSIGHT_BANK_MISSION`      | Bank mission/context                | (none)                                |
-| `HINDSIGHT_DEBUG`             | Enable debug logging                | `false`                               |
+
+> **Debug logging** is a config-only option (`"debug": true` in `opencode.json`
+> plugin options or `~/.hindsight/opencode.json`) — there is intentionally no
+> `HINDSIGHT_DEBUG` env var, because environment variables are unreliable to set
+> for OpenCode's plugin runtime (notably on Windows). Errors and the resolved
+> API URL/bank are logged regardless of this setting; `debug` only adds verbose
+> tracing. All plugin logs go to OpenCode's log stream (`service=hindsight`),
+> visible with `--print-logs` or in the OpenCode log files.
 
 ### Configuration Priority
 

--- a/hindsight-integrations/opencode/package-lock.json
+++ b/hindsight-integrations/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/opencode-hindsight",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/opencode-hindsight",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@vectorize-io/hindsight-client": "^0.4.19"

--- a/hindsight-integrations/opencode/src/bank.ts
+++ b/hindsight-integrations/opencode/src/bank.ts
@@ -16,7 +16,7 @@
 import { basename, dirname } from "node:path";
 import { execFileSync } from "node:child_process";
 import type { HindsightConfig } from "./config.js";
-import { debugLog } from "./config.js";
+import { Logger } from "./logger.js";
 import type { HindsightClient } from "@vectorize-io/hindsight-client";
 
 const DEFAULT_BANK_NAME = "opencode";
@@ -121,7 +121,8 @@ export async function ensureBankMission(
   client: HindsightClient,
   bankId: string,
   config: HindsightConfig,
-  missionsSet: Set<string>
+  missionsSet: Set<string>,
+  logger: Logger = new Logger({ silent: true })
 ): Promise<void> {
   const mission = config.bankMission;
   if (!mission?.trim()) return;
@@ -140,9 +141,9 @@ export async function ensureBankMission(
         missionsSet.delete(k);
       }
     }
-    debugLog(config, `Set mission for bank: ${bankId}`);
+    logger.debug(`Set mission for bank: ${bankId}`);
   } catch (e) {
     // Don't fail if mission set fails — bank may not exist yet
-    debugLog(config, `Could not set bank mission for ${bankId}: ${e}`);
+    logger.debug(`Could not set bank mission for ${bankId}`, { error: String(e) });
   }
 }

--- a/hindsight-integrations/opencode/src/config.test.ts
+++ b/hindsight-integrations/opencode/src/config.test.ts
@@ -39,7 +39,6 @@ describe("loadConfig", () => {
     process.env.HINDSIGHT_AUTO_RECALL = "false";
     process.env.HINDSIGHT_AUTO_RETAIN = "0";
     process.env.HINDSIGHT_RECALL_MAX_TOKENS = "2048";
-    process.env.HINDSIGHT_DEBUG = "true";
 
     const config = loadConfig();
     expect(config.hindsightApiUrl).toBe("https://example.com");
@@ -48,7 +47,15 @@ describe("loadConfig", () => {
     expect(config.autoRecall).toBe(false);
     expect(config.autoRetain).toBe(false);
     expect(config.recallMaxTokens).toBe(2048);
-    expect(config.debug).toBe(true);
+  });
+
+  it("does not read debug from the environment (config-only)", () => {
+    // `debug` is intentionally NOT an env override — env vars are unreliable to
+    // set for OpenCode's plugin runtime (notably on Windows). It must come from
+    // plugin options or ~/.hindsight/opencode.json.
+    process.env.HINDSIGHT_DEBUG = "true";
+    expect(loadConfig().debug).toBe(false);
+    expect(loadConfig({ debug: true }).debug).toBe(true);
   });
 
   it("plugin options override defaults", () => {
@@ -56,10 +63,12 @@ describe("loadConfig", () => {
       bankId: "plugin-bank",
       autoRecall: false,
       recallBudget: "high",
+      debug: true,
     });
     expect(config.bankId).toBe("plugin-bank");
     expect(config.autoRecall).toBe(false);
     expect(config.recallBudget).toBe("high");
+    expect(config.debug).toBe(true);
   });
 
   it("env vars override plugin options", () => {

--- a/hindsight-integrations/opencode/src/config.ts
+++ b/hindsight-integrations/opencode/src/config.ts
@@ -109,7 +109,10 @@ const ENV_OVERRIDES: Record<string, [keyof HindsightConfig, "string" | "bool" | 
   HINDSIGHT_RECALL_CONTEXT_TURNS: ["recallContextTurns", "int"],
   HINDSIGHT_DYNAMIC_BANK_ID: ["dynamicBankId", "bool"],
   HINDSIGHT_BANK_MISSION: ["bankMission", "string"],
-  HINDSIGHT_DEBUG: ["debug", "bool"],
+  // NOTE: `debug` is intentionally NOT an env override. It is a proper config
+  // option set via opencode.json plugin options or ~/.hindsight/opencode.json,
+  // because env vars are unreliable to set for OpenCode's plugin runtime
+  // (notably on Windows).
 };
 
 function castEnv(value: string, typ: "string" | "bool" | "int"): string | boolean | number | null {
@@ -207,10 +210,4 @@ export function loadConfig(pluginOptions?: Record<string, unknown>): HindsightCo
   }
 
   return result;
-}
-
-export function debugLog(config: HindsightConfig, ...args: unknown[]): void {
-  if (config.debug) {
-    console.error("[Hindsight]", ...args);
-  }
 }

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -9,7 +9,7 @@
 
 import type { HindsightClient } from "@vectorize-io/hindsight-client";
 import type { HindsightConfig } from "./config.js";
-import { debugLog } from "./config.js";
+import { Logger } from "./logger.js";
 import {
   formatMemories,
   formatCurrentTime,
@@ -87,7 +87,8 @@ export function createHooks(
   bankId: string,
   config: HindsightConfig,
   state: PluginState,
-  opencodeClient: OpencodeClient
+  opencodeClient: OpencodeClient,
+  logger: Logger = new Logger({ silent: true })
 ): HindsightHooks {
   interface RecallOutcome {
     /** formatted context string, or null if no results */
@@ -119,7 +120,7 @@ export function createHooks(
         `</hindsight_memories>`;
       return { context, ok: true };
     } catch (e) {
-      debugLog(config, "Recall failed:", e);
+      logger.error("Recall failed", e);
       return { context: null, ok: false };
     }
   }
@@ -127,15 +128,14 @@ export function createHooks(
   /** Extract plain-text messages from an OpenCode session */
   async function getSessionMessages(sessionId: string): Promise<Message[]> {
     try {
-      debugLog(config, `getSessionMessages: fetching messages for session ${sessionId}`);
+      logger.debug(`getSessionMessages: fetching messages for session ${sessionId}`);
       const response = await opencodeClient.session.messages({
         path: { id: sessionId },
       });
       if (response.error) {
-        debugLog(
-          config,
-          `getSessionMessages: error=${JSON.stringify(response.error)?.substring(0, 500)}`
-        );
+        logger.warn("getSessionMessages: OpenCode returned an error", {
+          error: JSON.stringify(response.error)?.substring(0, 500),
+        });
       }
       const rawMessages = response.data || [];
       const messages: Message[] = [];
@@ -147,10 +147,10 @@ export function createHooks(
           messages.push({ role, content: textParts.join("\n") });
         }
       }
-      debugLog(config, `getSessionMessages: raw=${rawMessages.length}, parsed=${messages.length}`);
+      logger.debug(`getSessionMessages: raw=${rawMessages.length}, parsed=${messages.length}`);
       return messages;
     } catch (e) {
-      debugLog(config, "Failed to get session messages:", e);
+      logger.error("Failed to get session messages", e);
       return [];
     }
   }
@@ -179,7 +179,7 @@ export function createHooks(
     const { transcript } = prepareRetentionTranscript(targetMessages, true);
     if (!transcript) return;
 
-    await ensureBankMission(hindsightClient, bankId, config, state.missionsSet);
+    await ensureBankMission(hindsightClient, bankId, config, state.missionsSet, logger);
     await hindsightClient.retain(bankId, transcript, {
       documentId,
       context: config.retainContext,
@@ -193,7 +193,7 @@ export function createHooks(
 
   /** Auto-retain conversation transcript */
   async function handleSessionIdle(sessionId: string): Promise<void> {
-    debugLog(config, `handleSessionIdle called for session ${sessionId}`);
+    logger.debug(`handleSessionIdle called for session ${sessionId}`);
     if (!config.autoRetain) return;
 
     const messages = await getSessionMessages(sessionId);
@@ -202,8 +202,7 @@ export function createHooks(
     // Count user turns
     const userTurns = messages.filter((m) => m.role === "user").length;
     const lastRetained = state.lastRetainedTurn.get(sessionId) || 0;
-    debugLog(
-      config,
+    logger.debug(
       `handleSessionIdle: userTurns=${userTurns}, lastRetained=${lastRetained}, retainEveryNTurns=${config.retainEveryNTurns}`
     );
 
@@ -213,16 +212,19 @@ export function createHooks(
     try {
       await retainSession(sessionId, messages);
       state.lastRetainedTurn.set(sessionId, userTurns);
-      debugLog(config, `Auto-retained ${messages.length} messages for session ${sessionId}`);
+      logger.info(`Auto-retained ${messages.length} messages`, {
+        session: sessionId,
+        bank: bankId,
+      });
     } catch (e) {
-      debugLog(config, "Auto-retain failed:", e);
+      logger.error("Auto-retain failed", e);
     }
   }
 
   const event = async (input: EventInput): Promise<void> => {
     try {
       const { event: evt } = input;
-      debugLog(config, `event hook fired: type=${evt.type}`);
+      logger.debug(`event hook fired: type=${evt.type}`);
 
       if (evt.type === "session.idle") {
         const sessionId = (evt.properties as { sessionID?: string }).sessionID;
@@ -244,7 +246,7 @@ export function createHooks(
         }
       }
     } catch (e) {
-      debugLog(config, "Event hook error:", e);
+      logger.error("Event hook error", e);
     }
   };
 
@@ -258,9 +260,9 @@ export function createHooks(
           // Reset turn tracking — after compaction the message list shrinks,
           // so the old lastRetainedTurn value would block future idle retains.
           state.lastRetainedTurn.delete(input.sessionID);
-          debugLog(config, "Pre-compaction retain completed");
+          logger.debug("Pre-compaction retain completed");
         } catch (e) {
-          debugLog(config, "Pre-compaction retain failed:", e);
+          logger.error("Pre-compaction retain failed", e);
         }
       }
 
@@ -285,7 +287,7 @@ export function createHooks(
         }
       }
     } catch (e) {
-      debugLog(config, "Compaction hook error:", e);
+      logger.error("Compaction hook error", e);
     }
   };
 
@@ -301,7 +303,7 @@ export function createHooks(
       // Only inject on first message of a session (tracked by recalledSessions)
       if (!state.recalledSessions.has(sessionId)) return;
 
-      await ensureBankMission(hindsightClient, bankId, config, state.missionsSet);
+      await ensureBankMission(hindsightClient, bankId, config, state.missionsSet, logger);
 
       // Use a generic project-context query for session start
       const query = `project context and recent work`;
@@ -315,10 +317,10 @@ export function createHooks(
 
       if (context) {
         output.system.push(context);
-        debugLog(config, `Injected recall context for session ${sessionId}`);
+        logger.debug(`Injected recall context for session ${sessionId}`);
       }
     } catch (e) {
-      debugLog(config, "System transform hook error:", e);
+      logger.error("System transform hook error", e);
     }
   };
 

--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -23,7 +23,7 @@ import { loadConfig } from "./config.js";
 import { deriveBankId } from "./bank.js";
 import { createTools } from "./tools.js";
 import { createHooks, type PluginState } from "./hooks.js";
-import { debugLog } from "./config.js";
+import { Logger, type OpencodeLogClient } from "./logger.js";
 
 // Module-level state persists across sessions (plugin is instantiated per session,
 // but the module is loaded once per OpenCode server process).
@@ -37,6 +37,13 @@ const state: PluginState = {
 const HindsightPlugin: Plugin = async (input, options) => {
   const config = loadConfig(options);
 
+  // Route logs through OpenCode's server log stream (TUI-safe). error/warn/info
+  // are always emitted; debug is gated on config.debug.
+  const logger = new Logger({
+    client: input.client as unknown as OpencodeLogClient,
+    debug: config.debug,
+  });
+
   // hindsightApiUrl always resolves to a value (DEFAULT_HINDSIGHT_API_URL by default),
   // so plugin instantiation never fails just because the URL is unset.
   // Requests fail at call time if no API key is configured for a Cloud URL —
@@ -48,15 +55,24 @@ const HindsightPlugin: Plugin = async (input, options) => {
   });
 
   const bankId = deriveBankId(config, input.directory);
-  debugLog(config, `Initialized with bank: ${bankId}, API: ${config.hindsightApiUrl}`);
+  // Always log the resolved endpoint + bank so users can see which instance the
+  // plugin is talking to (a common source of "memories aren't saving" confusion).
+  logger.info("Hindsight plugin initialized", {
+    api: config.hindsightApiUrl,
+    bank: bankId,
+    authenticated: Boolean(config.hindsightApiToken),
+    autoRecall: config.autoRecall,
+    autoRetain: config.autoRetain,
+  });
 
-  const tools = createTools(client, bankId, config, state.missionsSet);
+  const tools = createTools(client, bankId, config, state.missionsSet, logger);
   const hooks = createHooks(
     client,
     bankId,
     config,
     state,
-    input.client as unknown as Parameters<typeof createHooks>[4]
+    input.client as unknown as Parameters<typeof createHooks>[4],
+    logger
   );
 
   return {

--- a/hindsight-integrations/opencode/src/logger.test.ts
+++ b/hindsight-integrations/opencode/src/logger.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Logger, type LogLevel } from "./logger.js";
+
+interface Captured {
+  service: string;
+  level: LogLevel;
+  message: string;
+  extra?: Record<string, unknown>;
+}
+
+function makeClient(): { log: ReturnType<typeof vi.fn>; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const log = vi.fn((opts: { body: Captured }) => {
+    calls.push(opts.body);
+    return Promise.resolve();
+  });
+  return { log, calls };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Logger", () => {
+  it("routes error/warn/info to OpenCode's app.log with the hindsight service", () => {
+    const { log, calls } = makeClient();
+    const logger = new Logger({ client: { app: { log } } });
+
+    logger.info("init", { api: "http://localhost:8888" });
+    logger.warn("watch out");
+    logger.error("boom", new Error("network down"));
+
+    expect(calls).toHaveLength(3);
+    expect(calls.every((c) => c.service === "hindsight")).toBe(true);
+    expect(calls[0]).toMatchObject({ level: "info", message: "init" });
+    expect(calls[0].extra).toEqual({ api: "http://localhost:8888" });
+    expect(calls[1]).toMatchObject({ level: "warn", message: "watch out" });
+    expect(calls[2].level).toBe("error");
+    expect(String(calls[2].extra?.error)).toContain("network down");
+  });
+
+  it("suppresses debug unless debug is enabled", () => {
+    const off = makeClient();
+    new Logger({ client: { app: { log: off.log } }, debug: false }).debug("verbose");
+    expect(off.calls).toHaveLength(0);
+
+    const on = makeClient();
+    new Logger({ client: { app: { log: on.log } }, debug: true }).debug("verbose");
+    expect(on.calls).toHaveLength(1);
+    expect(on.calls[0]).toMatchObject({ level: "debug", message: "verbose" });
+  });
+
+  it("emits nothing when silent (used as the default in tests)", () => {
+    const { log, calls } = makeClient();
+    const logger = new Logger({ client: { app: { log } }, debug: true, silent: true });
+    logger.info("x");
+    logger.error("y");
+    logger.debug("z");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("falls back to console.error when no OpenCode client is available", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    new Logger().error("no client here");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(String(spy.mock.calls[0][0])).toContain("[Hindsight]");
+    expect(String(spy.mock.calls[0][0])).toContain("no client here");
+  });
+
+  it("never throws when app.log throws", () => {
+    const logger = new Logger({
+      client: {
+        app: {
+          log: () => {
+            throw new Error("log endpoint exploded");
+          },
+        },
+      },
+    });
+    expect(() => logger.error("still fine")).not.toThrow();
+  });
+
+  it("swallows rejected app.log promises (no unhandled rejection)", async () => {
+    const logger = new Logger({
+      client: { app: { log: () => Promise.reject(new Error("server 500")) } },
+    });
+    expect(() => logger.info("fire and forget")).not.toThrow();
+    // Give the rejected promise a tick to settle; it must be caught internally.
+    await Promise.resolve();
+  });
+});

--- a/hindsight-integrations/opencode/src/logger.ts
+++ b/hindsight-integrations/opencode/src/logger.ts
@@ -1,0 +1,99 @@
+/**
+ * Lightweight logger for the Hindsight OpenCode plugin.
+ *
+ * Routes through OpenCode's server log API (`client.app.log`) when available so
+ * messages land in OpenCode's own log stream — visible via `--print-logs` and
+ * the OpenCode log files — without writing to stdout/stderr and corrupting the
+ * TUI. Falls back to `console.error` when the OpenCode client is unavailable
+ * (e.g. degraded load); unit tests use a silent logger.
+ *
+ * Levels:
+ *   - error / warn / info → always emitted, so failures and the resolved
+ *     endpoint are visible WITHOUT any debug opt-in.
+ *   - debug               → emitted only when `debug` is enabled in config.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/** Minimal shape of OpenCode's `client.app.log` that we depend on. */
+export interface OpencodeLogClient {
+  app?: {
+    log?: (options: {
+      body: {
+        service: string;
+        level: LogLevel;
+        message: string;
+        extra?: Record<string, unknown>;
+      };
+    }) => unknown;
+  };
+}
+
+export interface LoggerOptions {
+  /** OpenCode client used to write into the server log stream. */
+  client?: OpencodeLogClient;
+  /** When true, `debug()` messages are emitted. */
+  debug?: boolean;
+  /** When true, the logger emits nothing (used as a safe default in tests). */
+  silent?: boolean;
+}
+
+const SERVICE = "hindsight";
+
+export class Logger {
+  private readonly client?: OpencodeLogClient;
+  private readonly debugEnabled: boolean;
+  private readonly silent: boolean;
+
+  constructor(options: LoggerOptions = {}) {
+    this.client = options.client;
+    this.debugEnabled = options.debug ?? false;
+    this.silent = options.silent ?? false;
+  }
+
+  private emit(level: LogLevel, message: string, extra?: Record<string, unknown>): void {
+    if (this.silent) return;
+
+    const log = this.client?.app?.log;
+    if (log) {
+      try {
+        const result = log({ body: { service: SERVICE, level, message, extra } });
+        // Fire-and-forget: a logging failure must never surface to OpenCode.
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          (result as Promise<unknown>).then(undefined, () => {});
+        }
+      } catch {
+        // ignore — logging must never break the plugin
+      }
+      return;
+    }
+
+    // Fallback when no OpenCode client is available. OpenCode captures plugin
+    // console output into its logs, so this stays visible and TUI-safe.
+    const line = extra
+      ? `[Hindsight] ${message} ${JSON.stringify(extra)}`
+      : `[Hindsight] ${message}`;
+    console.error(line);
+  }
+
+  error(message: string, error?: unknown): void {
+    this.emit("error", message, error === undefined ? undefined : { error: errorToString(error) });
+  }
+
+  warn(message: string, extra?: Record<string, unknown>): void {
+    this.emit("warn", message, extra);
+  }
+
+  info(message: string, extra?: Record<string, unknown>): void {
+    this.emit("info", message, extra);
+  }
+
+  debug(message: string, extra?: Record<string, unknown>): void {
+    if (this.debugEnabled) this.emit("debug", message, extra);
+  }
+}
+
+function errorToString(error: unknown): string {
+  if (error instanceof Error) return error.stack || `${error.name}: ${error.message}`;
+  return String(error);
+}

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -155,9 +155,7 @@ describe("plugin default export", () => {
     // bricks the whole plugin load. Keep the entry surface function-only.
     const mod = await import("./index.js");
     for (const [name, value] of Object.entries(mod)) {
-      expect(typeof value, `export "${name}" must be a function`).toBe(
-        "function"
-      );
+      expect(typeof value, `export "${name}" must be a function`).toBe("function");
     }
   });
 });

--- a/hindsight-integrations/opencode/src/tools.ts
+++ b/hindsight-integrations/opencode/src/tools.ts
@@ -11,6 +11,7 @@ import type { HindsightClient } from "@vectorize-io/hindsight-client";
 import type { HindsightConfig } from "./config.js";
 import { formatMemories, formatCurrentTime } from "./content.js";
 import { ensureBankMission } from "./bank.js";
+import { Logger } from "./logger.js";
 
 export interface HindsightTools {
   hindsight_retain: ToolDefinition;
@@ -25,7 +26,8 @@ export function createTools(
   client: HindsightClient,
   bankId: string,
   config: HindsightConfig,
-  missionsSet?: Set<string>
+  missionsSet?: Set<string>,
+  logger: Logger = new Logger({ silent: true })
 ): HindsightTools {
   const hindsight_retain = tool({
     description:
@@ -43,7 +45,7 @@ export function createTools(
     },
     async execute(args) {
       if (missionsSet) {
-        await ensureBankMission(client, bankId, config, missionsSet);
+        await ensureBankMission(client, bankId, config, missionsSet, logger);
       }
       await client.retain(bankId, args.content, {
         context: args.context || config.retainContext,
@@ -95,7 +97,7 @@ export function createTools(
     },
     async execute(args) {
       if (missionsSet) {
-        await ensureBankMission(client, bankId, config, missionsSet);
+        await ensureBankMission(client, bankId, config, missionsSet, logger);
       }
       const response = await client.reflect(bankId, args.query, {
         context: args.context,


### PR DESCRIPTION
## Why

An OpenCode user (on Windows) reported the plugin "running but not writing" — tool calls register, but the DB stays empty and there's **no signal** as to why. Investigating, three things make this class of problem invisible:

1. **Failures are swallowed.** Every retain/recall/hook error went to `debugLog` (suppressed unless debug is on). A connection-refused to a local server, an HTTP 500, an auth failure → zero output.
2. **The resolved endpoint is never shown by default.** The init line (which API URL + bank) was also `debugLog`-gated, so you can't tell it silently defaulted to Hindsight Cloud while you inspect a local DB.
3. **`HINDSIGHT_DEBUG` is unreliable** to set for OpenCode's plugin runtime (notably on Windows: `set` only affects the launching cmd session; a persistent/stale OpenCode server never sees it), so "turn on debug" often yields nothing.

## What

- **New `Logger`** (`src/logger.ts`) that routes through OpenCode's own log stream via `client.app.log` (`service=hindsight`) — TUI-safe, visible with `--print-logs` and in the OpenCode log files (the same stream that emits `service=tool.registry …`). Falls back to `console.error` when no client (degraded load / unit tests).
  - `error` / `warn` / `info` are **always** emitted; `debug` is gated on `config.debug`.
- **Always log the resolved endpoint + bank at init** (`Hindsight plugin initialized {api, bank, authenticated, autoRecall, autoRetain}`).
- **Surface failures**: retain/recall/session-message/hook errors now log at `error`. Hooks still catch and never throw, so OpenCode is unaffected; tools keep their existing throw-to-surface contract.
- **Drop the `HINDSIGHT_DEBUG` env override.** `debug` is now a config-only option (opencode.json plugin options or `~/.hindsight/opencode.json`).
- Tests for the logger; updated config tests; README updated.

## Verification

- `tsc --noEmit` clean, prettier clean, 109 tests pass (clean `HOME`).
- Integration check: drove the **built** plugin with a fake OpenCode client pointed at an unreachable URL →
  - `hindsight | info | Hindsight plugin initialized {"api":"http://127.0.0.1:1","bank":"opencode",...}`
  - `hindsight | error | Auto-retain failed {"error":"...fetch failed..."}`
  - hook did not throw.

## Notes

- This is scoped to **observability**. The separate autoRecall hook-ordering bug (#1758 item 2) is **not** addressed here — happy to do it in a follow-up.
- No version bump / changelog entry (handled at release time by `release-integration.sh`).

Refs #1758