### PR TITLE
fix(opencode): call OpenCode app.log as a method so logging actually works

### DIFF
--- a/hindsight-integrations/opencode/package-lock.json
+++ b/hindsight-integrations/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/opencode-hindsight",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/opencode-hindsight",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@vectorize-io/hindsight-client": "^0.4.19"

--- a/hindsight-integrations/opencode/src/hooks.test.ts
+++ b/hindsight-integrations/opencode/src/hooks.test.ts
@@ -162,39 +162,40 @@ describe("event hook — session.idle", () => {
   });
 });
 
-describe("event hook — session.created", () => {
-  it("tracks session for recall injection", async () => {
+describe("autoRecall is independent of session.created ordering (#1758)", () => {
+  it("injects recall on the first system.transform even if session.created never fired", async () => {
     const state = makeState();
-    const hooks = createHooks(makeClient(), "bank", makeConfig(), state, makeOpencodeClient());
+    const client = makeClient();
+    client.recall.mockResolvedValue({ results: [{ text: "User is a developer", type: "world" }] });
+    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
-    await hooks.event({
-      event: {
-        type: "session.created",
-        properties: { info: { id: "sess-1", title: "Test" } },
-      },
-    });
+    // No session.created beforehand — this is the #1758 reproduction.
+    const output: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
 
+    expect(output.system.length).toBeGreaterThan(0);
+    expect(output.system[0]).toContain("hindsight_memories");
+    // Marked as recalled so it won't repeat on the next message.
     expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
-  it("does not track when autoRecall is false", async () => {
+  it("injects recall even when system.transform fires BEFORE session.created", async () => {
     const state = makeState();
-    const hooks = createHooks(
-      makeClient(),
-      "bank",
-      makeConfig({ autoRecall: false }),
-      state,
-      makeOpencodeClient()
-    );
+    const client = makeClient();
+    client.recall.mockResolvedValue({ results: [{ text: "User is a developer", type: "world" }] });
+    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
+    const out1: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, out1);
+    expect(out1.system.length).toBeGreaterThan(0); // recall happened on turn 1
+
+    // session.created arriving late is a no-op and must not re-trigger recall.
     await hooks.event({
-      event: {
-        type: "session.created",
-        properties: { info: { id: "sess-1" } },
-      },
+      event: { type: "session.created", properties: { info: { id: "sess-1" } } },
     });
-
-    expect(state.recalledSessions.has("sess-1")).toBe(false);
+    const out2: { system: string[] } = { system: [] };
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, out2);
+    expect(out2.system.length).toBe(0); // already recalled — deduped
   });
 });
 
@@ -307,13 +308,12 @@ describe("compacting hook", () => {
 });
 
 describe("system transform hook", () => {
-  it("injects memories for tracked sessions", async () => {
+  it("injects memories on the first transform for a session", async () => {
     const client = makeClient();
     client.recall.mockResolvedValue({
       results: [{ text: "User is a developer", type: "world" }],
     });
     const state = makeState();
-    state.recalledSessions.add("sess-1");
     const output = { system: [] as string[] };
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
@@ -321,39 +321,36 @@ describe("system transform hook", () => {
 
     expect(output.system.length).toBeGreaterThan(0);
     expect(output.system[0]).toContain("hindsight_memories");
-    // Session should be removed after first injection
-    expect(state.recalledSessions.has("sess-1")).toBe(false);
+    // Marked as recalled so it won't repeat.
+    expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
-  it("skips untracked sessions", async () => {
+  it("deduplicates: does not recall again for an already-recalled session", async () => {
     const client = makeClient();
     const state = makeState();
-    const output = { system: [] as string[] };
-    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
-
-    await hooks["experimental.chat.system.transform"](
-      { sessionID: "sess-unknown", model: {} },
-      output
-    );
-
-    expect(output.system.length).toBe(0);
-    expect(client.recall).not.toHaveBeenCalled();
-  });
-
-  it("consumes session on empty recall (no repeated queries for empty banks)", async () => {
-    const client = makeClient();
-    // No results — empty bank
-    client.recall.mockResolvedValue({ results: [] });
-    const state = makeState();
-    state.recalledSessions.add("sess-1");
+    state.recalledSessions.add("sess-1"); // already recalled
     const output = { system: [] as string[] };
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
     await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
 
-    // No injection, but session consumed — won't re-query on next transform
     expect(output.system.length).toBe(0);
-    expect(state.recalledSessions.has("sess-1")).toBe(false);
+    expect(client.recall).not.toHaveBeenCalled();
+  });
+
+  it("marks session recalled on empty recall (no repeated queries for empty banks)", async () => {
+    const client = makeClient();
+    // No results — empty bank
+    client.recall.mockResolvedValue({ results: [] });
+    const state = makeState();
+    const output = { system: [] as string[] };
+    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    // No injection, but session marked — won't re-query on next transform
+    expect(output.system.length).toBe(0);
+    expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
   it("retries recall on next transform after transient API failure", async () => {
@@ -365,26 +362,24 @@ describe("system transform hook", () => {
       results: [{ text: "Found it", type: "world" }],
     });
     const state = makeState();
-    state.recalledSessions.add("sess-1");
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
-    // First attempt — API error, session preserved for retry
+    // First attempt — API error, NOT marked, so it retries next time
     const output1 = { system: [] as string[] };
     await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output1);
     expect(output1.system.length).toBe(0);
-    expect(state.recalledSessions.has("sess-1")).toBe(true);
+    expect(state.recalledSessions.has("sess-1")).toBe(false);
 
-    // Second attempt — succeeds, session consumed
+    // Second attempt — succeeds, injected and marked
     const output2 = { system: [] as string[] };
     await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output2);
     expect(output2.system.length).toBeGreaterThan(0);
-    expect(state.recalledSessions.has("sess-1")).toBe(false);
+    expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
   it("skips when autoRecall is false", async () => {
     const client = makeClient();
     const state = makeState();
-    state.recalledSessions.add("sess-1");
     const output = { system: [] as string[] };
     const hooks = createHooks(
       client,
@@ -397,5 +392,6 @@ describe("system transform hook", () => {
     await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
 
     expect(output.system.length).toBe(0);
+    expect(client.recall).not.toHaveBeenCalled();
   });
 });

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -2,7 +2,8 @@
  * Hook implementations for the Hindsight OpenCode plugin.
  *
  * Hooks:
- *   - event (session.created) → recall memories and inject into system prompt
+ *   - experimental.chat.system.transform → recall memories once per session and
+ *     inject them into the system prompt (order-independent; see #1758)
  *   - event (session.idle) → auto-retain conversation transcript
  *   - experimental.session.compacting → inject memories into compaction context
  */
@@ -232,19 +233,11 @@ export function createHooks(
           await handleSessionIdle(sessionId);
         }
       }
-
-      if (evt.type === "session.created") {
-        const session = evt.properties.info as { id?: string; title?: string } | undefined;
-        const sessionId = session?.id;
-        if (sessionId && config.autoRecall && !state.recalledSessions.has(sessionId)) {
-          state.recalledSessions.add(sessionId);
-          // Cap tracked sessions
-          if (state.recalledSessions.size > 1000) {
-            const first = state.recalledSessions.values().next().value;
-            if (first) state.recalledSessions.delete(first);
-          }
-        }
-      }
+      // NOTE: autoRecall is driven entirely by `experimental.chat.system.transform`
+      // (see below). We deliberately do NOT key it off `session.created` — the
+      // relative firing order of `session.created` vs `system.transform` is an
+      // undocumented OpenCode implementation detail that has differed between
+      // versions, and relying on it silently disabled recall (see #1758).
     } catch (e) {
       logger.error("Event hook error", e);
     }
@@ -300,8 +293,11 @@ export function createHooks(
       const sessionId = input.sessionID;
       if (!sessionId) return;
 
-      // Only inject on first message of a session (tracked by recalledSessions)
-      if (!state.recalledSessions.has(sessionId)) return;
+      // Recall once per session, on the first system.transform we see for it.
+      // `recalledSessions` is a dedup marker for sessions we've ALREADY recalled
+      // into — not an event-ordering gate. This makes autoRecall independent of
+      // whether session.created fired first (see #1758).
+      if (state.recalledSessions.has(sessionId)) return;
 
       await ensureBankMission(hindsightClient, bankId, config, state.missionsSet, logger);
 
@@ -309,10 +305,15 @@ export function createHooks(
       const query = `project context and recent work`;
       const { context, ok } = await recallForContext(query);
 
-      // Consume after a successful API round-trip (even with 0 results).
-      // Only preserve retry for transient API failures (ok=false).
+      // Mark as recalled only after a successful API round-trip (even with 0
+      // results), so transient failures retry on the next message.
       if (ok) {
-        state.recalledSessions.delete(sessionId);
+        state.recalledSessions.add(sessionId);
+        // Cap tracked sessions
+        if (state.recalledSessions.size > 1000) {
+          const first = state.recalledSessions.values().next().value;
+          if (first) state.recalledSessions.delete(first);
+        }
       }
 
       if (context) {

--- a/hindsight-integrations/opencode/src/logger.test.ts
+++ b/hindsight-integrations/opencode/src/logger.test.ts
@@ -67,6 +67,29 @@ describe("Logger", () => {
     expect(String(spy.mock.calls[0][0])).toContain("no client here");
   });
 
+  it("calls app.log with `this` bound to app (regression for detached-method crash)", () => {
+    // Mirrors OpenCode's real client: app.log is a method that uses `this`.
+    // A detached call (`const log = app.log; log(...)`) would throw on
+    // `this._client` and silently log nothing.
+    const calls: Captured[] = [];
+    const app = {
+      _client: { ok: true },
+      log(opts: { body: Captured }) {
+        // Throws if `this` is lost (i.e. called detached).
+        if (!this || !this._client) throw new TypeError("this._client is undefined");
+        calls.push(opts.body);
+        return Promise.resolve();
+      },
+    };
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    new Logger({ client: { app } }).info("init", { api: "http://localhost:8888" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ service: "hindsight", level: "info", message: "init" });
+    // It went through app.log, not the console fallback.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it("never throws when app.log throws", () => {
     const logger = new Logger({
       client: {

--- a/hindsight-integrations/opencode/src/logger.ts
+++ b/hindsight-integrations/opencode/src/logger.ts
@@ -54,22 +54,28 @@ export class Logger {
   private emit(level: LogLevel, message: string, extra?: Record<string, unknown>): void {
     if (this.silent) return;
 
-    const log = this.client?.app?.log;
-    if (log) {
+    const app = this.client?.app;
+    if (app && typeof app.log === "function") {
       try {
-        const result = log({ body: { service: SERVICE, level, message, extra } });
+        // IMPORTANT: call as a method on `app` so `this` is preserved.
+        // OpenCode's `app.log` is a class method that uses `this` internally;
+        // calling a detached reference (`const log = app.log; log(...)`) throws
+        // `this._client is undefined`, which would otherwise be swallowed below
+        // and produce no log at all.
+        const result = app.log({ body: { service: SERVICE, level, message, extra } });
         // Fire-and-forget: a logging failure must never surface to OpenCode.
         if (result && typeof (result as Promise<unknown>).then === "function") {
           (result as Promise<unknown>).then(undefined, () => {});
         }
+        return;
       } catch {
-        // ignore — logging must never break the plugin
+        // Fall through to the console fallback if app.log throws synchronously.
       }
-      return;
     }
 
-    // Fallback when no OpenCode client is available. OpenCode captures plugin
-    // console output into its logs, so this stays visible and TUI-safe.
+    // Fallback when no OpenCode client is available (or app.log failed).
+    // OpenCode captures plugin console output into its logs, so this stays
+    // visible and TUI-safe.
     const line = extra
       ? `[Hindsight] ${message} ${JSON.stringify(extra)}`
       : `[Hindsight] ${message}`;


### PR DESCRIPTION
## Why

0.2.3 added logging via OpenCode's `client.app.log`, but it **logged nothing in real OpenCode**. `Logger.emit` extracted a detached reference:

```js
const log = this.client?.app?.log;
log({ body: { ... } });   // `this` is lost
```

OpenCode's `app.log` is a class method that uses `this` internally, so the detached call throws `TypeError: undefined is not an object (evaluating 'this._client')`. That throw was swallowed by the surrounding `try/catch`, and the `console.error` fallback was skipped because `log` was truthy → **no resolved-endpoint line, no surfaced errors**. (Verified live: see below.)

## Fix

- Call `app.log({...})` as a **method on `app`** so `this` is preserved.
- On synchronous failure, **fall through to the `console.error` fallback** instead of swallowing.
- Regression test using a `this`-dependent `app.log` that mirrors OpenCode's real client (fails on the old detached call, passes now).

## Verification

Live against OpenCode 1.16.2 (loading the built plugin), the log stream now shows:

```
INFO  service=hindsight api=http://localhost:61831 bank=opencode authenticated=false autoRecall=true autoRetain=true Hindsight plugin initialized
DEBUG service=hindsight Injected recall context for session ses_...
```

(Before this fix: zero `service=hindsight` lines.) `tsc --noEmit` clean, prettier clean, 110 tests pass.

## Notes

- This is the actual delivery of the 0.2.3 observability goal — recommend a patch release (0.2.4) once merged.
- No version bump/changelog (handled by `release-integration.sh`).