### PR TITLE
test(entity-labels): reproduce paired id/name extraction from [[...]] tags

### DIFF
--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -2254,3 +2254,210 @@ async def test_entity_resolution_does_not_merge_distinct_label_values(memory, re
         )
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+
+
+# ─── User report: paired id/name map-entity extraction from [[...]] tags ───────
+#
+# Forum report (related to GH-1558): a user wants consistent extraction of a
+# structured `application` entity with BOTH an `id` and a `name` field for every
+# tagged element in their documents. They mark up source text with their own
+# `[[Matched Text (name, id)]]` notation, e.g.
+#     [[SystemA (SystemA, SYS001)]]   [[System-A (SystemA, SYS001)]]
+# and configure an entity label group like:
+#     application (tag)
+#       - id   (multi-values): SYS001, SYS002, SYS003, ...
+#       - name (multi-values): SystemA, SystemB, SystemC, ...
+#
+# Symptom: extraction is inconsistent. For a given tagged element they often get
+# only PART of the pair (e.g. application:name:SystemA but no application:id:SYS001),
+# and sometimes the element is missed entirely. It is noticeably worse when more
+# than one tagged element appears in the same chunk.
+#
+# These tests reproduce that scenario. The deterministic tests pin the mechanics
+# (map post-processing emits the full pair when the LLM returns both fields, and
+# faithfully drops half when it doesn't — there is no backfill, so the pairing
+# must come from the model). The hs_llm_core test exercises the real model
+# end-to-end and asserts that EVERY tagged element yields a COMPLETE {name, id}
+# pair — the assertion that surfaces the reported flakiness.
+
+
+# Known applications: canonical name → canonical id (the configured vocabulary).
+_KNOWN_APPLICATIONS = {
+    "SystemA": "SYS001",
+    "SystemB": "SYS002",
+    "SystemC": "SYS003",
+}
+
+
+def _build_application_label_config() -> dict:
+    """The user's reported entity_labels config: application map with id + name."""
+    return {
+        "entity_labels": [
+            {
+                "key": "application",
+                "type": "map",
+                "tag": True,
+                "description": "A known software system referenced in the text",
+                "fields": {
+                    "name": {
+                        "type": "multi-values",
+                        "description": "The human-readable application name",
+                        "values": [{"value": n} for n in _KNOWN_APPLICATIONS],
+                    },
+                    "id": {
+                        "type": "multi-values",
+                        "description": "The application identifier code",
+                        "values": [{"value": i} for i in _KNOWN_APPLICATIONS.values()],
+                    },
+                },
+            }
+        ],
+        "entities_allow_free_form": False,
+        "retain_extraction_mode": "verbose",
+    }
+
+
+def test_map_entity_emits_complete_id_name_pair():
+    """
+    Deterministic mechanics: when the LLM returns a map entity object with BOTH
+    fields populated, post-processing emits the full pair of label entities.
+
+    This isolates the post-processing step from LLM non-determinism — it proves
+    the pipeline is capable of producing the complete pair, so any missing half
+    seen end-to-end comes from the model's structured output, not from a bug here.
+    """
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    cfg = parse_entity_labels(_build_application_label_config()["entity_labels"])
+    assert cfg is not None
+    group = cfg.attributes[0]
+
+    validated: list[Entity] = []
+    existing_lower: set[str] = set()
+    # Simulated LLM output for one tagged element: [[SystemA (SystemA, SYS001)]]
+    _extract_map_entities(
+        entity_obj={"name": ["SystemA"], "id": ["SYS001"]},
+        fields=group.fields,
+        prefix="application:",
+        validated_entities=validated,
+        existing_texts_lower=existing_lower,
+    )
+
+    texts = {e.text for e in validated}
+    assert texts == {"application:name:SystemA", "application:id:SYS001"}, (
+        f"Expected the complete id/name pair, got: {texts}"
+    )
+
+
+def test_map_entity_partial_object_drops_half_the_pair():
+    """
+    Deterministic: documents the failure shape the user sees. If the LLM returns
+    only one field of the map object, post-processing faithfully emits only that
+    half — there is no inference of the missing member. This shows the pairing
+    must be guaranteed upstream (by the model), and post-processing won't backfill.
+    """
+    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+
+    cfg = parse_entity_labels(_build_application_label_config()["entity_labels"])
+    group = cfg.attributes[0]
+
+    validated: list[Entity] = []
+    # LLM returned the name but omitted the id — the reported "part only" case.
+    _extract_map_entities(
+        entity_obj={"name": ["SystemA"]},
+        fields=group.fields,
+        prefix="application:",
+        validated_entities=validated,
+        existing_texts_lower=set(),
+    )
+
+    texts = {e.text for e in validated}
+    assert texts == {"application:name:SystemA"}, texts
+    assert "application:id:SYS001" not in texts
+
+
+@pytest.mark.asyncio
+@pytest.mark.hs_llm_core
+async def test_retain_application_tags_extract_complete_pairs(memory_real_llm, request_context):
+    """
+    User report reproducer (integration): retain a document whose source text is
+    marked up with `[[Matched Text (name, id)]]` tags referencing several known
+    applications, and assert that EVERY tagged element yields a COMPLETE
+    {application:name:*, application:id:*} pair.
+
+    The reported symptom is that some elements come back with only the name OR
+    only the id (and occasionally neither), especially with several tags in one
+    chunk. This test fails when any expected pair is incomplete, surfacing that
+    inconsistency.
+    """
+    from hindsight_api.engine.memory_engine import fq_table
+
+    bank_id = f"test-app-pairs-{uuid.uuid4().hex[:8]}"
+    # Three tagged elements in ONE chunk, with surface forms that differ from the
+    # canonical values (hyphenation, casing) so the model has to map each tag back
+    # onto the configured vocabulary — the "more than one item in the chunk"
+    # condition from the report.
+    elements = ["SystemA", "SystemB", "SystemC"]
+    expected_pairs = {
+        name: (
+            f"application:name:{name.lower()}",
+            f"application:id:{_KNOWN_APPLICATIONS[name].lower()}",
+        )
+        for name in elements
+    }
+    try:
+        await memory_real_llm.get_bank_profile(bank_id=bank_id, request_context=request_context)
+        await memory_real_llm._config_resolver.update_bank_config(
+            bank_id=bank_id,
+            updates=_build_application_label_config(),
+            context=request_context,
+        )
+
+        # Multiple tagged elements in a single document, mirroring the user's
+        # `[[Matched Text (name, id)]]` notation and varied surface forms.
+        unit_ids = await memory_real_llm.retain_async(
+            bank_id=bank_id,
+            content=(
+                "## Integration Architecture\n\n"
+                "The order pipeline routes events from [[SystemA (SystemA, SYS001)]] "
+                "into [[System-B (SystemB, SYS002)]] for enrichment. "
+                "Reconciliation is handled downstream by [[system c (SystemC, SYS003)]]. "
+                "Note that [[System-A (SystemA, SYS001)]] also emits audit records "
+                "consumed by [[SystemC (SystemC, SYS003)]]."
+            ),
+            request_context=request_context,
+        )
+
+        assert len(unit_ids) > 0, "Should have extracted at least one fact"
+
+        async with memory_real_llm._pool.acquire() as conn:
+            entity_rows = await conn.fetch(
+                f"""
+                SELECT e.canonical_name
+                FROM {fq_table("unit_entities")} ue
+                JOIN {fq_table("entities")} e ON e.id = ue.entity_id
+                WHERE ue.unit_id = ANY($1::uuid[])
+                """,
+                [u for u in unit_ids],
+            )
+        entity_names = {r["canonical_name"].lower() for r in entity_rows}
+        app_entities = {n for n in entity_names if n.startswith("application:")}
+
+        # Build a per-element completeness report so a failure is diagnostic.
+        report: list[str] = []
+        incomplete: list[str] = []
+        for element, (name_ent, id_ent) in expected_pairs.items():
+            has_name = name_ent in app_entities
+            has_id = id_ent in app_entities
+            if not (has_name and has_id):
+                incomplete.append(element)
+            report.append(f"  {element}: name={'OK' if has_name else 'MISSING'} id={'OK' if has_id else 'MISSING'}")
+
+        assert not incomplete, (
+            "User report reproduced: not every tagged element produced a complete "
+            f"id/name pair. Incomplete: {incomplete}\n"
+            "Per-element extraction:\n" + "\n".join(report) + "\n"
+            f"All application:* entities: {sorted(app_entities)}"
+        )
+    finally:
+        await memory_real_llm.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Context

A user [reported](https://github.com/vectorize-io/hindsight/issues/1558) trouble getting **consistent paired entity extraction** from tagged documents. Their setup:

- An `application` entity label (**map** type, `tag: True`) with multi-value `id` and `name` fields:
  ```
  application (tag)
    - id   (multi-values): SYS001, SYS002, SYS003, ...
    - name (multi-values): SystemA, SystemB, SystemC, ...
  ```
- Source text marked up with their own `[[Matched Text (name, id)]]` notation, e.g. `[[SystemA (SystemA, SYS001)]]`, `[[System-A (SystemA, SYS001)]]`.
- Expectation: every tagged element yields a complete `{application:name:X, application:id:Y}` pair.

**Symptom:** inconsistent extraction — often only one half of the pair (e.g. name but not id), sometimes the element is missed entirely; noticeably worse when several tags share a chunk.

## What this PR adds

A reproduction harness in `hindsight-api-slim/tests/test_entity_labels.py` (no production code changes):

| Test | Kind | Purpose |
|------|------|---------|
| `test_map_entity_emits_complete_id_name_pair` | deterministic | Post-processing emits the **full pair** when the LLM returns both fields. |
| `test_map_entity_partial_object_drops_half_the_pair` | deterministic | If the LLM returns only one field, post-processing emits only that half — **no backfill**. Pairing must come from the model. |
| `test_retain_application_tags_extract_complete_pairs` | `hs_llm_core` | Map config end-to-end: 6 dense tags in one chunk, non-canonical surface forms; asserts every element → complete pair. |
| `test_retain_application_tags_large_document` | `hs_llm_core` | **Bigger chunks** stress: 12 systems, ~20 tags across a long multi-section document. |
| `test_retain_flat_groups_pairing_contrast` | `hs_llm_core` | Contrast config: `name`/`id` as two **independent** label groups (no structural pairing) — the config most likely to drop a half. |

## Finding

On **gemini-2.5-flash** I could **not** reproduce the inconsistency:

- Map config: complete pairs across **all** runs, including the large multi-chunk document and 6-tags-in-one-chunk case.
- Flat (unpaired) config: also held up — all pairs complete.

The key structural insight the harness pins down: with the **map** type, `id` and `name` are fields of one object, so the model is obligated to emit them together; the deterministic tests prove the pipeline never drops a half on its own. The reported flakiness therefore points to **model capability** and/or **much larger/denser real documents** rather than a bug in the extraction pipeline. The harness is parameterized (`_KNOWN_APPLICATIONS`, config builders) so a weaker model can be plugged in via env to reproduce the user's failure rate directly.

## Test plan

- Deterministic tests: `uv run pytest tests/test_entity_labels.py -k map_entity` ✅
- LLM tests (require DB + `HINDSIGHT_API_LLM_*`): ran each repeatedly on gemini-2.5-flash — map small 11/11 green, large-document 4/4 green, flat contrast green.