### PR TITLE
fix(opencode): fold recall into the first system section, not a new one

### DIFF
--- a/hindsight-integrations/opencode/package-lock.json
+++ b/hindsight-integrations/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/opencode-hindsight",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/opencode-hindsight",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@vectorize-io/hindsight-client": "^0.4.19"

--- a/hindsight-integrations/opencode/src/hooks.test.ts
+++ b/hindsight-integrations/opencode/src/hooks.test.ts
@@ -325,6 +325,26 @@ describe("system transform hook", () => {
     expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
+  it("appends recall into the existing first system section, not a new one", async () => {
+    // OpenCode emits each system[] entry as a separate system message and some
+    // providers only honor the first; recall must fold into system[0].
+    const client = makeClient();
+    client.recall.mockResolvedValue({
+      results: [{ text: "User is a developer", type: "world" }],
+    });
+    const state = makeState();
+    const output = { system: ["You are a helpful coding assistant."] as string[] };
+    const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    // Still a single system section — appended, not pushed.
+    expect(output.system.length).toBe(1);
+    expect(output.system[0]).toContain("You are a helpful coding assistant.");
+    expect(output.system[0]).toContain("hindsight_memories");
+    expect(output.system[0]).toContain("User is a developer");
+  });
+
   it("deduplicates: does not recall again for an already-recalled session", async () => {
     const client = makeClient();
     const state = makeState();

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -317,7 +317,12 @@ export function createHooks(
       }
 
       if (context) {
-        output.system.push(context);
+        // Fold recall into the FIRST system section rather than pushing a new
+        // one. OpenCode emits each system[] entry as a separate system message,
+        // and some providers/LLMs only honor the first — a pushed section can be
+        // silently dropped. Appending to system[0] guarantees recall is seen.
+        // (Original approach from #1988 by @sdrobov.)
+        output.system[0] = output.system[0] ? `${output.system[0]}\n\n${context}` : context;
         logger.debug(`Injected recall context for session ${sessionId}`);
       }
     } catch (e) {


### PR DESCRIPTION
Ports and verifies the approach from #1988 (@sdrobov), rebased onto current main.

## Problem

`system.transform` injected recall via `output.system.push(context)` — a **new** system section. OpenCode emits each `system[]` entry as a **separate** system message, and some providers/LLMs only honor the first, so the pushed recall can be **silently dropped**.

Confirmed in opencode 1.16.2 (binary): after `experimental.chat.system.transform`, the `system[]` array is mapped to individual `{role:"system"}` messages (provider-dependent), and only collapsed when `length > 2`.

## Fix

Fold recall into `system[0]`:

```ts
output.system[0] = output.system[0] ? `${output.system[0]}\n\n${context}` : context;
```

So recall is always part of the primary system message, regardless of provider.

## Why a new PR instead of #1988

#1988 is based on pre-0.2.4 code and conflicts with main: it uses the removed `debugLog`, the old `recalledSessions` (event-ordering) semantics, and a test that fails against the current `system.transform`; it also carried unrelated `package-lock.json` churn. This is the same idea applied to the current order-independent recall path + OpenCode-routed logger. Credit to @sdrobov (`Co-authored-by`).

## Verification

- 111 tests pass (added: existing `system[0]` is appended to, not pushed alongside), tsc + prettier clean.
- Live: real recall folds into a single system entry containing both the agent prompt and the memories block.

Supersedes #1988.