### PR TITLE
fix(deps): cap tokenizers<=0.23.0 for local-ML extras (#2055)

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -81,6 +81,10 @@ local-ml = [
     # Local ML models for embeddings/reranking
     "sentence-transformers>=3.3.0",
     "transformers>=4.53.0", # Security fixes for ReDoS vulnerabilities
+    # transformers (incl. latest 5.x) hard-requires tokenizers<=0.23.0 via a
+    # runtime check; without this cap an in-place upgrade can pull tokenizers
+    # 0.23.1 and break local embeddings/reranker startup. See issue #2055.
+    "tokenizers>=0.22.0,<=0.23.0",
     "torch>=2.6.0", # CVE fix for remote code execution
     "einops>=0.8.2",
     "flashrank>=0.2.0",
@@ -100,6 +104,7 @@ local-onnx = [
     # In-process ONNX Runtime embeddings without an Ollama/TEI sidecar
     "onnxruntime>=1.17.0",
     "transformers>=4.53.0",
+    "tokenizers>=0.22.0,<=0.23.0", # See issue #2055 (transformers caps tokenizers<=0.23.0)
     "huggingface-hub>=0.20.0",
     "numpy>=1.26.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1730,6 +1730,7 @@ all = [
     { name = "pg0-embedded" },
     { name = "safetensors" },
     { name = "sentence-transformers" },
+    { name = "tokenizers" },
     { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "transformers" },
@@ -1748,6 +1749,7 @@ local-ml = [
     { name = "mlx-lm", marker = "sys_platform != 'win32'" },
     { name = "safetensors" },
     { name = "sentence-transformers" },
+    { name = "tokenizers" },
     { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "transformers" },
@@ -1756,6 +1758,7 @@ local-onnx = [
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "onnxruntime" },
+    { name = "tokenizers" },
     { name = "transformers" },
 ]
 oracle = [
@@ -1852,6 +1855,8 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.44,<2.1" },
     { name = "testcontainers", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "tiktoken", specifier = ">=0.12.0" },
+    { name = "tokenizers", marker = "extra == 'local-ml'", specifier = ">=0.22.0,<=0.23.0" },
+    { name = "tokenizers", marker = "extra == 'local-onnx'", specifier = ">=0.22.0,<=0.23.0" },
     { name = "torch", marker = "extra == 'local-ml'", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "transformers", marker = "extra == 'local-ml'", specifier = ">=4.53.0" },


### PR DESCRIPTION
## Summary

Fixes #2055.

`hindsight-api-slim` ships no lockfile, so `tokenizers` is only constrained transitively via `transformers`. Every current `transformers` (latest 5.10.2, and our floor `>=4.53.0`) declares `tokenizers>=0.22.0,<=0.23.0` **and** enforces that range with a hard runtime check at import. But `tokenizers==0.23.1` is the newest release on PyPI, so an in-place `pip install -U hindsight-api-slim==0.8.0` into an existing env can resolve/keep `0.23.1`. transformers then aborts during local model init:

```
ImportError: tokenizers>=0.22.0,<=0.23.0 is required ... but found tokenizers==0.23.1
```

This breaks startup on the local embeddings/reranker path (`local-ml` / `local-onnx`), exactly as reported.

## Fix

Add an explicit `tokenizers>=0.22.0,<=0.23.0` constraint to both extras that pull in `transformers` (`local-ml`, `local-onnx`). This mirrors what transformers itself requires and forces any resolver away from `0.23.1`.

## Verification

Fresh resolution of each extra now lands inside the compatible range:

- `local-ml`  → `tokenizers==0.22.2`, `transformers==5.10.2`
- `local-onnx` → `tokenizers==0.22.2`, `transformers==5.10.2`

## Note

This cap will need to be raised whenever transformers later lifts its own `tokenizers` ceiling — the tradeoff of pinning without a lockfile, and what the issue's "tighten constraints" suggestion asks for.
