### PR TITLE
fix(docs): add cursor-cli to integrations gallery (unblock build-docs)

### DIFF
--- a/hindsight-docs/docs-integrations/cursor-cli.md
+++ b/hindsight-docs/docs-integrations/cursor-cli.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 7
+title: "Cursor CLI Persistent Memory with Hindsight | Integration Guide"
+description: "Add persistent memory to Cursor CLI with Hindsight. Python hook scripts automatically recall context before each prompt and retain conversations — no workflow changes required."
+---
+
+# Cursor CLI
+
+[View Changelog →](/changelog/integrations/cursor-cli)
+
+Persistent memory for [Cursor CLI](https://docs.cursor.com/en/cli/overview) using [Hindsight](https://vectorize.io/hindsight). Python hook scripts automatically recall relevant context before each prompt and retain conversations after each turn — no changes to your Cursor workflow required.
+
+## Quick Start
+
+:::tip Recommended: Hindsight Cloud
+[Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key — no self-hosting, no local daemon to manage.
+:::
+
+```bash
+export HINDSIGHT_API_URL=https://api.hindsight.vectorize.io
+export HINDSIGHT_API_TOKEN=your-api-key
+
+git clone https://github.com/vectorize-io/hindsight.git
+cd hindsight/hindsight-integrations/cursor-cli
+./scripts/install.sh
+```
+
+The installer copies the hook scripts to `~/.cursor/hooks/cursor-cli/`, writes `~/.cursor/hooks.json` (merged with any existing entries), and creates `~/.hindsight/cursor-cli.json` for your personal config. Restart Cursor CLI — memory is live.
+
+To uninstall:
+
+```bash
+./scripts/uninstall.sh
+```
+
+## Features
+
+- **Auto-recall** — before each prompt, queries Hindsight for relevant memories and injects them as additional context (visible to the model, not the transcript)
+- **Auto-retain** — after each response, and again on session end, stores the conversation to Hindsight for future recall
+- **Dynamic bank IDs** — supports per-project memory isolation based on the working directory
+- **Session-level upsert** — uses the session ID as the document ID so re-running the same session updates rather than duplicates stored content
+- **Zero dependencies** — pure Python stdlib, no pip install required
+
+## Architecture
+
+The plugin uses four Cursor CLI hook events:
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `session_start.py` | `sessionStart` | Warm up — verify Hindsight is reachable |
+| `recall.py` | `beforeSubmitPrompt` | **Auto-recall** — query memories, inject as additional context |
+| `retain.py` | `stop` | **Auto-retain** — extract transcript, POST to Hindsight (async) |
+| `session_end.py` | `sessionEnd` | **Final flush** — force a retain so the last turns aren't lost |
+
+On `beforeSubmitPrompt`, the hook reads the prompt, queries Hindsight for the most relevant memories, and injects a context block. Cursor prepends this to the conversation before sending it to the model:
+
+```
+<hindsight_memories>
+Relevant memories from past conversations...
+Current time - 2026-03-27 09:14
+
+- Project uses FastAPI with asyncpg — not SQLAlchemy [world] (2026-03-26)
+- Preferred testing framework: pytest with pytest-asyncio [experience] (2026-03-26)
+</hindsight_memories>
+```
+
+On `stop` (and again on `sessionEnd`), the hook reads the session transcript, strips previously injected memory tags (to prevent feedback loops), and POSTs the conversation to Hindsight asynchronously.
+
+## Connection Modes
+
+### 1. External API (recommended)
+
+Connect to a running Hindsight server (cloud or self-hosted) via `~/.hindsight/cursor-cli.json`:
+
+```json
+{
+  "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+  "hindsightApiToken": "hsk_your_token"
+}
+```
+
+### 2. Local Daemon
+
+Run `hindsight-embed` locally. The `session_start.py` hook detects it on `apiPort` (default `9077`). The daemon is not auto-started by the plugin — start it separately:
+
+```bash
+uvx hindsight-embed
+```
+
+Then leave `hindsightApiUrl` empty in your config and the plugin connects to `http://localhost:9077`.
+
+## Configuration
+
+Default config ships in `~/.cursor/hooks/cursor-cli/settings.json`. For personal overrides that survive updates, create `~/.hindsight/cursor-cli.json`. Most settings can also be overridden via environment variable.
+
+**Loading order** (later entries win):
+
+1. Built-in defaults
+2. Plugin `settings.json` (at `~/.cursor/hooks/cursor-cli/settings.json`)
+3. User config (`~/.hindsight/cursor-cli.json`)
+4. Environment variables
+
+---
+
+### Connection
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `hindsightApiUrl` | `HINDSIGHT_API_URL` | `""` | URL of the Hindsight API server. Empty = local daemon. |
+| `hindsightApiToken` | `HINDSIGHT_API_TOKEN` | `null` | API token for authentication. Required for Hindsight Cloud. |
+| `apiPort` | `HINDSIGHT_API_PORT` | `9077` | Port for the local `hindsight-embed` daemon. |
+
+---
+
+### Memory Bank
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `bankId` | `HINDSIGHT_BANK_ID` | `"cursor-cli"` | The bank to read from and write to. All sessions share this bank unless `dynamicBankId` is enabled. |
+| `bankMission` | `HINDSIGHT_BANK_MISSION` | coding assistant prompt | Describes the agent's purpose. Sent when creating or updating the bank. |
+| `retainMission` | — | extraction prompt | Instructions for Hindsight's fact extraction — what to extract from coding conversations. |
+| `dynamicBankId` | `HINDSIGHT_DYNAMIC_BANK_ID` | `false` | When `true`, derives a unique bank ID from `dynamicBankGranularity` fields — useful for per-project isolation. |
+| `dynamicBankGranularity` | — | `["agent", "project"]` | Which fields to combine for dynamic bank IDs. `"project"` = working directory, `"agent"` = agent name. |
+| `agentName` | `HINDSIGHT_AGENT_NAME` | `"cursor-cli"` | Agent name used in dynamic bank ID derivation. |
+
+---
+
+### Auto-Recall
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `autoRecall` | `HINDSIGHT_AUTO_RECALL` | `true` | Master switch for auto-recall. |
+| `recallBudget` | `HINDSIGHT_RECALL_BUDGET` | `"mid"` | Search depth: `"low"` (fast), `"mid"` (balanced), `"high"` (thorough). |
+| `recallMaxTokens` | `HINDSIGHT_RECALL_MAX_TOKENS` | `1024` | Max tokens in the recalled memory block. |
+| `recallTypes` | — | `["world", "experience"]` | Memory types to retrieve. |
+| `recallContextTurns` | `HINDSIGHT_RECALL_CONTEXT_TURNS` | `1` | Prior turns to include when building the recall query. `1` = latest prompt only. |
+
+---
+
+### Auto-Retain
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `autoRetain` | `HINDSIGHT_AUTO_RETAIN` | `true` | Master switch for auto-retain. |
+| `retainMode` | `HINDSIGHT_RETAIN_MODE` | `"full-session"` | `"full-session"` sends the full transcript per session (upserted by session ID). `"chunked"` sends sliding windows every N turns. |
+| `retainEveryNTurns` | — | `10` | Retain fires every N turns. `1` = every turn. Higher values reduce API calls. |
+| `retainContext` | — | `"cursor-cli"` | Label identifying the source integration. Useful when multiple integrations write to the same bank. |
+
+---
+
+### Debug
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `debug` | `HINDSIGHT_DEBUG` | `false` | Enable verbose logging to stderr. All log lines are prefixed with `[Hindsight]`. |
+
+## Per-Project Memory
+
+To give each project its own isolated memory bank, enable dynamic bank IDs:
+
+```json
+{
+  "dynamicBankId": true,
+  "dynamicBankGranularity": ["agent", "project"]
+}
+```
+
+With this config, running Cursor in `~/projects/api` and `~/projects/frontend` stores and recalls memories separately. Bank IDs are derived from the working directory path.
+
+## Troubleshooting
+
+**Hooks not firing**: Confirm `~/.cursor/hooks.json` exists and that `python3` is on your shell's `$PATH`. Re-run `./scripts/install.sh` to rewrite the hook entries.
+
+**No memories recalled**: Recall returns results only after something has been retained. Complete one Cursor session first, then start a new one.
+
+**Memory not being stored**: `retainEveryNTurns` defaults to `10` — the `stop` hook only fires a retain every 10 turns. While testing, add `"retainEveryNTurns": 1` to `~/.hindsight/cursor-cli.json`. The `sessionEnd` hook also forces a final retain when you close the session.
+
+**Debug mode**: Add `"debug": true` to `~/.hindsight/cursor-cli.json` to see what Hindsight is doing on each turn.

--- a/hindsight-docs/src/data/integrations.json
+++ b/hindsight-docs/src/data/integrations.json
@@ -141,6 +141,16 @@
       "icon": "/img/icons/codex.svg"
     },
     {
+      "id": "cursor-cli",
+      "name": "Cursor CLI",
+      "description": "Automatic long-term memory for Cursor CLI via Hindsight hooks. Recalls relevant context before each prompt and retains conversations after each turn.",
+      "type": "official",
+      "by": "hindsight",
+      "category": "tool",
+      "link": "/sdks/integrations/cursor-cli",
+      "icon": "/img/icons/cursor-cli.svg"
+    },
+    {
       "id": "openclaw",
       "name": "OpenClaw",
       "description": "Integrate Hindsight with OpenClaw to add memory capabilities to Claude-based agent workflows.",

--- a/hindsight-docs/static/img/icons/cursor-cli.svg
+++ b/hindsight-docs/static/img/icons/cursor-cli.svg
@@ -1,0 +1,19 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cursorA" x1="32" y1="6" x2="32" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E4E4E4"/>
+      <stop offset="1" stop-color="#9B9B9B"/>
+    </linearGradient>
+    <linearGradient id="cursorB" x1="10" y1="19" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#BDBDBD"/>
+      <stop offset="1" stop-color="#6E6E6E"/>
+    </linearGradient>
+    <linearGradient id="cursorC" x1="54" y1="19" x2="32" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7A7A7A"/>
+      <stop offset="1" stop-color="#3A3A3A"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 6 54 19 32 32 10 19Z" fill="url(#cursorA)"/>
+  <path d="M10 19 32 32 32 58 10 45Z" fill="url(#cursorB)"/>
+  <path d="M54 19 32 32 32 58 54 45Z" fill="url(#cursorC)"/>
+</svg>


### PR DESCRIPTION
## Problem

`build-docs` is failing on `main` (and therefore on every open PR, e.g. [#866](https://github.com/vectorize-io/hindsight/pull/866)) at the **Check integrations (single source of truth)** step:

```
[integrations] ❌ Released integrations missing from integrations.json:
  cursor-cli — released as integrations/cursor-cli/vX.Y.Z but no entry in integrations.json
```

This is **not** caused by the PRs it surfaces on. The Cursor CLI integration (#1975) was released as tag `integrations/cursor-cli/v0.1.0`, but the PR never added it to the docs single source of truth. `check-integrations.mjs` enforces that every released integration tag has an entry in `src/data/integrations.json` *and* a matching `docs-integrations/<slug>.{md,mdx}` page — so the reverse check has been red since the release.

## Fix

- Add the `cursor-cli` gallery entry to `hindsight-docs/src/data/integrations.json` (modeled on its sibling `codex`).
- Add the `docs-integrations/cursor-cli.md` page (install via git-clone + `./scripts/install.sh`, accurate hook wiring: `sessionStart` / `beforeSubmitPrompt` / `stop` / `sessionEnd`).
- Add a `cursor-cli.svg` icon for the gallery.

## Verification

```
$ node hindsight-docs/scripts/check-integrations.mjs
[integrations] ✅ All 38 integration entries have a doc page.
[integrations] ✅ All 30 released integrations are present in integrations.json.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)