### PR TITLE
feat(api): config flag to skip storing raw document text (#2061)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1352,7 +1352,8 @@ class DocumentResponse(BaseModel):
 
     id: str
     bank_id: str
-    original_text: str
+    # None when document text storage is disabled (HINDSIGHT_API_STORE_DOCUMENT_TEXT=false).
+    original_text: str | None
     content_hash: str | None
     created_at: str
     updated_at: str
@@ -6155,6 +6156,11 @@ def _register_routes(app: FastAPI):
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
             raise
+        except ValueError as e:
+            # Invalid request parameters (e.g. duplicate document_ids, or
+            # update_mode='append' when document text storage is disabled) are
+            # client errors, not server faults.
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             import traceback
 

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2419,6 +2419,9 @@ class FeaturesInfo(BaseModel):
     document_import_api: bool = Field(description="Whether the document import endpoint is enabled")
     audit_log: bool = Field(description="Whether audit logging is enabled")
     llm_trace: bool = Field(description="Whether per-bank LLM request tracing is enabled")
+    store_document_text: bool = Field(
+        description="Whether raw source text is persisted. When false, document/chunk source text is not stored."
+    )
 
 
 class VersionResponse(BaseModel):
@@ -3086,6 +3089,7 @@ def _register_routes(app: FastAPI):
                 document_import_api=config.enable_document_import_api,
                 audit_log=config.audit_log_enabled,
                 llm_trace=config.llm_trace_enabled,
+                store_document_text=config.store_document_text,
             ),
         )
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1441,7 +1441,7 @@ class HindsightConfig:
     file_conversion_max_batch_size: int  # Max files per request
     enable_file_upload_api: bool
     file_delete_after_retain: bool
-    store_document_text: bool  # When False, store NULL original_text / empty chunk_text (privacy mode)
+    store_document_text: bool  # When False, store NULL original_text / empty chunk_text
     enable_document_export_api: bool
     enable_document_import_api: bool
 

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -424,6 +424,7 @@ ENV_FILE_CONVERSION_MAX_BATCH_SIZE_MB = "HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH
 ENV_FILE_CONVERSION_MAX_BATCH_SIZE = "HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE"
 ENV_ENABLE_FILE_UPLOAD_API = "HINDSIGHT_API_ENABLE_FILE_UPLOAD_API"
 ENV_FILE_DELETE_AFTER_RETAIN = "HINDSIGHT_API_FILE_DELETE_AFTER_RETAIN"
+ENV_STORE_DOCUMENT_TEXT = "HINDSIGHT_API_STORE_DOCUMENT_TEXT"
 
 # Document transfer (export/import documents between banks without re-running the LLM)
 ENV_ENABLE_DOCUMENT_EXPORT_API = "HINDSIGHT_API_ENABLE_DOCUMENT_EXPORT_API"
@@ -831,6 +832,7 @@ DEFAULT_FILE_CONVERSION_MAX_BATCH_SIZE_MB = 100  # Max total batch size in MB (a
 DEFAULT_FILE_CONVERSION_MAX_BATCH_SIZE = 10  # Max files per batch upload
 DEFAULT_ENABLE_FILE_UPLOAD_API = True  # Enable file upload endpoint
 DEFAULT_FILE_DELETE_AFTER_RETAIN = True  # Delete file bytes after retain (saves storage)
+DEFAULT_STORE_DOCUMENT_TEXT = True  # Persist raw source text in documents.original_text / chunks.chunk_text
 
 # Document transfer defaults (export/import enabled by default; gated independently)
 DEFAULT_ENABLE_DOCUMENT_EXPORT_API = True
@@ -1439,6 +1441,7 @@ class HindsightConfig:
     file_conversion_max_batch_size: int  # Max files per request
     enable_file_upload_api: bool
     file_delete_after_retain: bool
+    store_document_text: bool  # When False, store NULL original_text / empty chunk_text (privacy mode)
     enable_document_export_api: bool
     enable_document_import_api: bool
 
@@ -2302,6 +2305,7 @@ class HindsightConfig:
                 ENV_FILE_DELETE_AFTER_RETAIN, str(DEFAULT_FILE_DELETE_AFTER_RETAIN)
             ).lower()
             == "true",
+            store_document_text=os.getenv(ENV_STORE_DOCUMENT_TEXT, str(DEFAULT_STORE_DOCUMENT_TEXT)).lower() == "true",
             enable_document_export_api=os.getenv(
                 ENV_ENABLE_DOCUMENT_EXPORT_API, str(DEFAULT_ENABLE_DOCUMENT_EXPORT_API)
             ).lower()

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7738,9 +7738,9 @@ class MemoryEngine(MemoryEngineInterface):
             if recall_include_chunks is not None
             else config_dict.get("recall_include_chunks", DEFAULT_RECALL_INCLUDE_CHUNKS)
         )
-        # Privacy mode stores no raw chunk text, so fetching chunks would only
-        # attach empty strings to every recall result. Force it off (this also
-        # pairs with the expand tool being excluded from the reflect toolset).
+        # With document text storage disabled there is no raw chunk text, so
+        # fetching chunks would only attach empty strings to every recall
+        # result. Force it off (pairs with excluding the expand tool below).
         if not get_config().store_document_text:
             effective_recall_include_chunks = False
         effective_recall_max_tokens = (

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3002,6 +3002,19 @@ class MemoryEngine(MemoryEngineInterface):
             if item.get("update_mode") == "append" and not item.get("document_id"):
                 raise ValueError("update_mode='append' requires a document_id")
 
+        # Append mode rebuilds the full document by reading back the previously
+        # stored original_text and prepending it. With store_document_text
+        # disabled there is no stored text to read, so the append would silently
+        # drop all prior content — reject it explicitly instead.
+        if not get_config().store_document_text:
+            for item in contents:
+                if item.get("update_mode") == "append":
+                    raise ValueError(
+                        "update_mode='append' is not supported when HINDSIGHT_API_STORE_DOCUMENT_TEXT "
+                        "is disabled: the prior document text is not stored and cannot be appended to. "
+                        "Use update_mode='replace' instead."
+                    )
+
         # Auto-chunk large batches by token count to avoid timeouts and memory issues
         # Calculate total token count
         total_tokens = sum(count_tokens(item.get("content", "")) for item in contents)
@@ -7725,6 +7738,11 @@ class MemoryEngine(MemoryEngineInterface):
             if recall_include_chunks is not None
             else config_dict.get("recall_include_chunks", DEFAULT_RECALL_INCLUDE_CHUNKS)
         )
+        # Privacy mode stores no raw chunk text, so fetching chunks would only
+        # attach empty strings to every recall result. Force it off (this also
+        # pairs with the expand tool being excluded from the reflect toolset).
+        if not get_config().store_document_text:
+            effective_recall_include_chunks = False
         effective_recall_max_tokens = (
             recall_max_tokens_override
             if recall_max_tokens_override is not None

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -379,7 +379,7 @@ async def run_reflect_agent(
 
     # Get tools for this agent (with directive compliance field if directives exist).
     # The expand tool only reads back raw source text (chunks/documents), so it is
-    # useless and excluded when document text storage is disabled (privacy mode).
+    # useless and excluded when document text storage is disabled.
     include_expand = get_config().store_document_text
     tools = get_reflect_tools(
         directive_rules=directive_rules,
@@ -914,7 +914,7 @@ async def run_reflect_agent(
             for tc in other_tools:
                 norm = _normalize_tool_name(tc.name)
                 # "done" is always available. "expand" is governed by enabled_tools
-                # (it is excluded in privacy mode), so it is not hardcoded here.
+                # (it is excluded when text storage is disabled), so it is not hardcoded here.
                 if enabled_tools is not None and norm not in enabled_tools and norm != "done":
                     hallucinated_tools.append(tc)
                 else:
@@ -1245,7 +1245,7 @@ async def _execute_tool(
 
     # Guard against LLMs hallucinating calls to tools that were not provided.
     # "done" is always available; "expand" is governed by enabled_tools (excluded
-    # in privacy mode), so it is not hardcoded as always-allowed here.
+    # when text storage is disabled), so it is not hardcoded as always-allowed here.
     if enabled_tools is not None and tool_name not in enabled_tools and tool_name != "done":
         return {"error": f"Tool '{tool_name}' is not available. Use only the tools provided to you."}
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -14,6 +14,7 @@ import re
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from ...config import get_config
 from .models import DirectiveInfo, LLMCall, ReflectAgentResult, TokenUsageSummary, ToolCall
 from .prompts import (
     _extract_directive_rules,
@@ -376,12 +377,16 @@ async def run_reflect_agent(
     # Extract directive rules for tool schema (if any)
     directive_rules = _extract_directive_rules(directives) if directives else None
 
-    # Get tools for this agent (with directive compliance field if directives exist)
+    # Get tools for this agent (with directive compliance field if directives exist).
+    # The expand tool only reads back raw source text (chunks/documents), so it is
+    # useless and excluded when document text storage is disabled (privacy mode).
+    include_expand = get_config().store_document_text
     tools = get_reflect_tools(
         directive_rules=directive_rules,
         include_mental_models=has_mental_models,
         include_observations=include_observations,
         include_recall=include_recall,
+        include_expand=include_expand,
     )
     # Build set of enabled tool names to guard against LLM hallucinating disabled tool calls
     enabled_tools: frozenset[str] = frozenset(t["function"]["name"] for t in tools if t.get("type") == "function")
@@ -908,7 +913,9 @@ async def run_reflect_agent(
             hallucinated_tools = []
             for tc in other_tools:
                 norm = _normalize_tool_name(tc.name)
-                if enabled_tools is not None and norm not in enabled_tools and norm not in ("done", "expand"):
+                # "done" is always available. "expand" is governed by enabled_tools
+                # (it is excluded in privacy mode), so it is not hardcoded here.
+                if enabled_tools is not None and norm not in enabled_tools and norm != "done":
                     hallucinated_tools.append(tc)
                 else:
                     allowed_tools.append(tc)
@@ -1236,8 +1243,10 @@ async def _execute_tool(
     # Normalize tool name for various LLM output formats
     tool_name = _normalize_tool_name(tool_name)
 
-    # Guard against LLMs hallucinating calls to tools that were not provided
-    if enabled_tools is not None and tool_name not in enabled_tools and tool_name not in ("done", "expand"):
+    # Guard against LLMs hallucinating calls to tools that were not provided.
+    # "done" is always available; "expand" is governed by enabled_tools (excluded
+    # in privacy mode), so it is not hardcoded as always-allowed here.
+    if enabled_tools is not None and tool_name not in enabled_tools and tool_name != "done":
         return {"error": f"Tool '{tool_name}' is not available. Use only the tools provided to you."}
 
     if tool_name == "search_mental_models":

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
@@ -232,6 +232,7 @@ def get_reflect_tools(
     include_mental_models: bool = True,
     include_observations: bool = True,
     include_recall: bool = True,
+    include_expand: bool = True,
 ) -> list[dict]:
     """
     Get the list of tools for the reflect agent.
@@ -247,6 +248,9 @@ def get_reflect_tools(
         include_mental_models: Whether to include the search_mental_models tool.
         include_observations: Whether to include the search_observations tool.
         include_recall: Whether to include the recall tool.
+        include_expand: Whether to include the expand tool. Disabled when raw
+            document/chunk text is not stored (privacy mode), since expand only
+            reads back source text and would return empty results.
 
     Returns:
         List of tool definitions in OpenAI format
@@ -260,7 +264,8 @@ def get_reflect_tools(
     if include_recall:
         tools.append(TOOL_RECALL)
 
-    tools.append(TOOL_EXPAND)
+    if include_expand:
+        tools.append(TOOL_EXPAND)
 
     # Use directive-aware done tool if directives are present
     if directive_rules:

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
@@ -249,8 +249,8 @@ def get_reflect_tools(
         include_observations: Whether to include the search_observations tool.
         include_recall: Whether to include the recall tool.
         include_expand: Whether to include the expand tool. Disabled when raw
-            document/chunk text is not stored (privacy mode), since expand only
-            reads back source text and would return empty results.
+            document/chunk text is not stored, since expand only reads back
+            source text and would return empty results.
 
     Returns:
         List of tool definitions in OpenAI format

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -89,9 +89,9 @@ async def store_chunks_batch(
     if not chunks:
         return {}
 
-    # Privacy mode: when document text storage is disabled, persist empty
-    # chunk_text (the column is NOT NULL) while still computing content_hash from
-    # the real text so delta-retain dedup is unaffected.
+    # When document text storage is disabled, persist empty chunk_text (the
+    # column is NOT NULL) while still computing content_hash from the real text
+    # so delta-retain dedup is unaffected.
     store_text = get_config().store_document_text
 
     # Prepare chunk data for batch insert

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -8,6 +8,7 @@ import hashlib
 import logging
 from dataclasses import dataclass
 
+from ...config import get_config
 from ..memory_engine import fq_table
 from .types import ChunkMetadata
 
@@ -88,6 +89,11 @@ async def store_chunks_batch(
     if not chunks:
         return {}
 
+    # Privacy mode: when document text storage is disabled, persist empty
+    # chunk_text (the column is NOT NULL) while still computing content_hash from
+    # the real text so delta-retain dedup is unaffected.
+    store_text = get_config().store_document_text
+
     # Prepare chunk data for batch insert
     chunk_ids = []
     chunk_texts = []
@@ -98,7 +104,7 @@ async def store_chunks_batch(
     for chunk in chunks:
         chunk_id = f"{bank_id}_{document_id}_{chunk.chunk_index}"
         chunk_ids.append(chunk_id)
-        chunk_texts.append(chunk.chunk_text)
+        chunk_texts.append(chunk.chunk_text if store_text else "")
         chunk_indices.append(chunk.chunk_index)
         content_hashes.append(compute_chunk_hash(chunk.chunk_text))
         chunk_id_map[chunk.chunk_index] = chunk_id

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -400,7 +400,7 @@ async def _upsert_document_row(
     keeps the original creation timestamp. ``updated_at`` is always set to
     ``NOW()`` on both INSERT and the ON CONFLICT UPDATE branch.
 
-    When ``store_document_text`` is disabled (privacy mode), the raw source text
+    When ``store_document_text`` is disabled, the raw source text
     is dropped and ``original_text`` is stored as NULL. The ``content_hash`` is
     still computed from the real content so delta-retain dedup is unaffected.
     """

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -399,7 +399,12 @@ async def _upsert_document_row(
     INSERT so that re-ingesting a document (which deletes + inserts the row)
     keeps the original creation timestamp. ``updated_at`` is always set to
     ``NOW()`` on both INSERT and the ON CONFLICT UPDATE branch.
+
+    When ``store_document_text`` is disabled (privacy mode), the raw source text
+    is dropped and ``original_text`` is stored as NULL. The ``content_hash`` is
+    still computed from the real content so delta-retain dedup is unaffected.
     """
+    original_text = combined_content if get_config().store_document_text else None
     await conn.execute(
         f"""
         INSERT INTO {fq_table("documents")} (id, bank_id, original_text, content_hash, retain_params, tags, created_at, updated_at)
@@ -413,7 +418,7 @@ async def _upsert_document_row(
         """,
         document_id,
         bank_id,
-        combined_content,
+        original_text,
         content_hash,
         json.dumps(retain_params) if retain_params else None,
         document_tags or [],

--- a/hindsight-api-slim/tests/test_store_document_text.py
+++ b/hindsight-api-slim/tests/test_store_document_text.py
@@ -191,6 +191,14 @@ async def test_get_document_endpoint_returns_null_text(
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
+@pytest.mark.asyncio
+async def test_version_endpoint_reports_store_document_text(api_client, store_document_text_disabled):
+    """The /version feature flags expose store_document_text so the UI can warn."""
+    resp = await api_client.get("/version")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["features"]["store_document_text"] is False
+
+
 def test_reflect_excludes_expand_tool_when_text_disabled():
     """The reflect 'expand' tool (get chunk/document source text) is dropped in privacy mode."""
     with_text = {t["function"]["name"] for t in get_reflect_tools(include_expand=True)}

--- a/hindsight-api-slim/tests/test_store_document_text.py
+++ b/hindsight-api-slim/tests/test_store_document_text.py
@@ -1,5 +1,5 @@
 """
-Tests for the HINDSIGHT_API_STORE_DOCUMENT_TEXT privacy flag.
+Tests for the HINDSIGHT_API_STORE_DOCUMENT_TEXT flag.
 
 When disabled, the retain pipeline still extracts facts/entities and embeds
 them, but the raw source text is dropped: documents.original_text is stored as
@@ -58,10 +58,12 @@ def store_document_text_disabled():
 
 
 @pytest.mark.asyncio
-async def test_privacy_mode_nulls_text_but_keeps_memories(memory, request_context, store_document_text_disabled):
+async def test_text_storage_disabled_nulls_text_but_keeps_memories(
+    memory, request_context, store_document_text_disabled
+):
     """With the flag off, raw text is dropped but facts/recall still work."""
-    bank_id = f"test_privacy_off_{datetime.now(timezone.utc).timestamp()}"
-    document_id = "doc-privacy-001"
+    bank_id = f"test_text_off_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-text-001"
 
     try:
         unit_ids = await memory.retain_async(
@@ -73,7 +75,7 @@ async def test_privacy_mode_nulls_text_but_keeps_memories(memory, request_contex
         )
 
         # Pipeline still ran: facts were extracted and stored.
-        assert len(unit_ids) > 0, "Facts should still be extracted in privacy mode"
+        assert len(unit_ids) > 0, "Facts should still be extracted when text storage is disabled"
 
         # documents.original_text is dropped (NULL).
         doc = await memory.get_document(document_id, bank_id, request_context=request_context)
@@ -97,7 +99,7 @@ async def test_privacy_mode_nulls_text_but_keeps_memories(memory, request_contex
             max_tokens=500,
             request_context=request_context,
         )
-        assert len(result.results) > 0, "Recall must still return facts in privacy mode"
+        assert len(result.results) > 0, "Recall must still return facts when text storage is disabled"
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
 
@@ -105,8 +107,8 @@ async def test_privacy_mode_nulls_text_but_keeps_memories(memory, request_contex
 @pytest.mark.asyncio
 async def test_default_mode_stores_text(memory, request_context):
     """By default (flag on) raw document and chunk text are persisted."""
-    bank_id = f"test_privacy_on_{datetime.now(timezone.utc).timestamp()}"
-    document_id = "doc-privacy-002"
+    bank_id = f"test_text_on_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-text-002"
 
     try:
         await memory.retain_async(
@@ -132,14 +134,14 @@ async def test_default_mode_stores_text(memory, request_context):
 
 
 @pytest.mark.asyncio
-async def test_append_mode_rejected_in_privacy_mode(memory, request_context, store_document_text_disabled):
+async def test_append_mode_rejected_when_text_disabled(memory, request_context, store_document_text_disabled):
     """update_mode='append' must be rejected when document text storage is disabled.
 
     Append rebuilds the document by reading back the stored original_text; with
     storage off there is nothing to read, so appending would silently drop the
     prior content. The pipeline rejects it instead of losing data.
     """
-    bank_id = f"test_append_privacy_{datetime.now(timezone.utc).timestamp()}"
+    bank_id = f"test_append_text_off_{datetime.now(timezone.utc).timestamp()}"
 
     with pytest.raises(ValueError, match="update_mode='append' is not supported"):
         await memory.retain_batch_async(
@@ -147,7 +149,7 @@ async def test_append_mode_rejected_in_privacy_mode(memory, request_context, sto
             contents=[
                 {
                     "content": "Some content",
-                    "document_id": "doc-append-privacy",
+                    "document_id": "doc-append-text-off",
                     "update_mode": "append",
                 }
             ],
@@ -164,8 +166,8 @@ async def test_get_document_endpoint_returns_null_text(
     The DocumentResponse model declares original_text as optional; a non-optional
     str would raise ResponseValidationError -> HTTP 500 when the text is NULL.
     """
-    bank_id = f"test_get_doc_privacy_{datetime.now(timezone.utc).timestamp()}"
-    document_id = "doc-http-privacy"
+    bank_id = f"test_get_doc_text_off_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-http-text-off"
 
     try:
         retain = await api_client.post(
@@ -177,7 +179,7 @@ async def test_get_document_endpoint_returns_null_text(
         resp = await api_client.get(f"/v1/default/banks/{bank_id}/documents/{document_id}")
         assert resp.status_code == 200, resp.text
         body = resp.json()
-        assert body["original_text"] is None, "Raw text must be null in privacy mode"
+        assert body["original_text"] is None, "Raw text must be null when text storage is disabled"
         assert body["memory_unit_count"] > 0
 
         # Append to the same document is rejected as a client error (400), not a 500.
@@ -200,7 +202,7 @@ async def test_version_endpoint_reports_store_document_text(api_client, store_do
 
 
 def test_reflect_excludes_expand_tool_when_text_disabled():
-    """The reflect 'expand' tool (get chunk/document source text) is dropped in privacy mode."""
+    """The reflect 'expand' tool (get chunk/document source text) is dropped when text storage is disabled."""
     with_text = {t["function"]["name"] for t in get_reflect_tools(include_expand=True)}
     without_text = {t["function"]["name"] for t in get_reflect_tools(include_expand=False)}
 

--- a/hindsight-api-slim/tests/test_store_document_text.py
+++ b/hindsight-api-slim/tests/test_store_document_text.py
@@ -10,11 +10,24 @@ unaffected because it reads from memory_units, not original_text.
 import os
 from datetime import datetime, timezone
 
+import httpx
 import pytest
+import pytest_asyncio
 
 from hindsight_api import config as config_module
+from hindsight_api.api import create_app
 from hindsight_api.engine.memory_engine import Budget
 from hindsight_api.engine.reflect.tools_schema import get_reflect_tools
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    """Async HTTP client against the FastAPI app (exercises response-model validation)."""
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
 
 LONG_CONTENT = """
 Alice Johnson is a senior software engineer at Acme Corp. She specializes in
@@ -140,6 +153,42 @@ async def test_append_mode_rejected_in_privacy_mode(memory, request_context, sto
             ],
             request_context=request_context,
         )
+
+
+@pytest.mark.asyncio
+async def test_get_document_endpoint_returns_null_text(
+    api_client, memory, request_context, store_document_text_disabled
+):
+    """GET document must return 200 with null original_text (not fail response validation).
+
+    The DocumentResponse model declares original_text as optional; a non-optional
+    str would raise ResponseValidationError -> HTTP 500 when the text is NULL.
+    """
+    bank_id = f"test_get_doc_privacy_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-http-privacy"
+
+    try:
+        retain = await api_client.post(
+            f"/v1/default/banks/{bank_id}/memories",
+            json={"items": [{"content": "Alice works at Acme Corp.", "document_id": document_id}]},
+        )
+        assert retain.status_code == 200, retain.text
+
+        resp = await api_client.get(f"/v1/default/banks/{bank_id}/documents/{document_id}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["original_text"] is None, "Raw text must be null in privacy mode"
+        assert body["memory_unit_count"] > 0
+
+        # Append to the same document is rejected as a client error (400), not a 500.
+        append = await api_client.post(
+            f"/v1/default/banks/{bank_id}/memories",
+            json={"items": [{"content": "More text.", "document_id": document_id, "update_mode": "append"}]},
+        )
+        assert append.status_code == 400, append.text
+        assert "append" in append.json()["detail"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
 
 
 def test_reflect_excludes_expand_tool_when_text_disabled():

--- a/hindsight-api-slim/tests/test_store_document_text.py
+++ b/hindsight-api-slim/tests/test_store_document_text.py
@@ -14,6 +14,7 @@ import pytest
 
 from hindsight_api import config as config_module
 from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.engine.reflect.tools_schema import get_reflect_tools
 
 LONG_CONTENT = """
 Alice Johnson is a senior software engineer at Acme Corp. She specializes in
@@ -115,3 +116,39 @@ async def test_default_mode_stores_text(memory, request_context):
         assert any(chunk["chunk_text"] for chunk in chunks["items"]), "Chunk text should be stored by default"
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_append_mode_rejected_in_privacy_mode(memory, request_context, store_document_text_disabled):
+    """update_mode='append' must be rejected when document text storage is disabled.
+
+    Append rebuilds the document by reading back the stored original_text; with
+    storage off there is nothing to read, so appending would silently drop the
+    prior content. The pipeline rejects it instead of losing data.
+    """
+    bank_id = f"test_append_privacy_{datetime.now(timezone.utc).timestamp()}"
+
+    with pytest.raises(ValueError, match="update_mode='append' is not supported"):
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Some content",
+                    "document_id": "doc-append-privacy",
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+
+
+def test_reflect_excludes_expand_tool_when_text_disabled():
+    """The reflect 'expand' tool (get chunk/document source text) is dropped in privacy mode."""
+    with_text = {t["function"]["name"] for t in get_reflect_tools(include_expand=True)}
+    without_text = {t["function"]["name"] for t in get_reflect_tools(include_expand=False)}
+
+    assert "expand" in with_text, "expand should be available by default"
+    assert "expand" not in without_text, "expand must be excluded when document text is not stored"
+    # Other reflect tools are unaffected.
+    assert "recall" in without_text
+    assert "done" in without_text

--- a/hindsight-api-slim/tests/test_store_document_text.py
+++ b/hindsight-api-slim/tests/test_store_document_text.py
@@ -1,0 +1,117 @@
+"""
+Tests for the HINDSIGHT_API_STORE_DOCUMENT_TEXT privacy flag.
+
+When disabled, the retain pipeline still extracts facts/entities and embeds
+them, but the raw source text is dropped: documents.original_text is stored as
+NULL and chunks.chunk_text is stored as an empty string. Recall must be
+unaffected because it reads from memory_units, not original_text.
+"""
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api import config as config_module
+from hindsight_api.engine.memory_engine import Budget
+
+LONG_CONTENT = """
+Alice Johnson is a senior software engineer at Acme Corp. She specializes in
+distributed systems and leads the platform team. Bob Smith works in marketing
+and reports to Carol. The team uses Kubernetes and deploys to AWS. Code reviews
+are mandatory before merging.
+"""
+
+
+@pytest.fixture
+def store_document_text_disabled():
+    """Disable raw document/chunk text storage for the duration of a test.
+
+    Restores the environment and clears the config cache afterwards so other
+    tests in the same worker see the default behaviour again.
+    """
+    original = os.environ.get("HINDSIGHT_API_STORE_DOCUMENT_TEXT")
+    os.environ["HINDSIGHT_API_STORE_DOCUMENT_TEXT"] = "false"
+    config_module.clear_config_cache()
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("HINDSIGHT_API_STORE_DOCUMENT_TEXT", None)
+        else:
+            os.environ["HINDSIGHT_API_STORE_DOCUMENT_TEXT"] = original
+        config_module.clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_privacy_mode_nulls_text_but_keeps_memories(memory, request_context, store_document_text_disabled):
+    """With the flag off, raw text is dropped but facts/recall still work."""
+    bank_id = f"test_privacy_off_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-privacy-001"
+
+    try:
+        unit_ids = await memory.retain_async(
+            bank_id=bank_id,
+            content=LONG_CONTENT,
+            context="team overview",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        # Pipeline still ran: facts were extracted and stored.
+        assert len(unit_ids) > 0, "Facts should still be extracted in privacy mode"
+
+        # documents.original_text is dropped (NULL).
+        doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["original_text"] is None, "Raw document text must not be stored"
+        assert doc["memory_unit_count"] > 0, "Memory units should still be created"
+
+        # chunks.chunk_text is blanked.
+        chunks = await memory.list_document_chunks(
+            bank_id=bank_id, document_id=document_id, request_context=request_context
+        )
+        assert chunks["total"] > 0, "Chunks should still be stored (for graph/structure)"
+        for chunk in chunks["items"]:
+            assert chunk["chunk_text"] == "", "Raw chunk text must not be stored"
+
+        # Recall is unaffected — it reads from memory_units, not original_text.
+        result = await memory.recall_async(
+            bank_id=bank_id,
+            query="Where does Alice work?",
+            budget=Budget.LOW,
+            max_tokens=500,
+            request_context=request_context,
+        )
+        assert len(result.results) > 0, "Recall must still return facts in privacy mode"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_default_mode_stores_text(memory, request_context):
+    """By default (flag on) raw document and chunk text are persisted."""
+    bank_id = f"test_privacy_on_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-privacy-002"
+
+    try:
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=LONG_CONTENT,
+            context="team overview",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        doc = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["original_text"] is not None
+        assert "Alice Johnson" in doc["original_text"]
+
+        chunks = await memory.list_document_chunks(
+            bank_id=bank_id, document_id=document_id, request_context=request_context
+        )
+        assert chunks["total"] > 0
+        assert any(chunk["chunk_text"] for chunk in chunks["items"]), "Chunk text should be stored by default"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-cli/src/commands/document.rs
+++ b/hindsight-cli/src/commands/document.rs
@@ -237,7 +237,10 @@ pub fn get(
                 println!("  Created: {}", doc.created_at);
                 println!("  Updated: {}", doc.updated_at);
                 println!("  Memory Units: {}", doc.memory_unit_count);
-                println!("\n  Text:\n{}", doc.original_text);
+                println!(
+                    "\n  Text:\n{}",
+                    doc.original_text.as_deref().unwrap_or("(not stored)")
+                );
             } else {
                 output::print_output(&doc, output_format)?;
             }

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5135,7 +5135,7 @@ components:
           title: Bank Id
           type: string
         original_text:
-          title: Original Text
+          nullable: true
           type: string
         content_hash:
           nullable: true
@@ -5426,6 +5426,11 @@ components:
           description: Whether per-bank LLM request tracing is enabled
           title: Llm Trace
           type: boolean
+        store_document_text:
+          description: "Whether raw source text is persisted. When false, document/chunk\
+            \ source text is not stored."
+          title: Store Document Text
+          type: boolean
       required:
       - audit_log
       - bank_config_api
@@ -5435,6 +5440,7 @@ components:
       - llm_trace
       - mcp
       - observations
+      - store_document_text
       - worker
       title: FeaturesInfo
     FileRetainResponse:

--- a/hindsight-clients/go/model_document_response.go
+++ b/hindsight-clients/go/model_document_response.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &DocumentResponse{}
 type DocumentResponse struct {
 	Id string `json:"id"`
 	BankId string `json:"bank_id"`
-	OriginalText string `json:"original_text"`
+	OriginalText NullableString `json:"original_text"`
 	ContentHash NullableString `json:"content_hash"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
@@ -41,7 +41,7 @@ type _DocumentResponse DocumentResponse
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDocumentResponse(id string, bankId string, originalText string, contentHash NullableString, createdAt string, updatedAt string, memoryUnitCount int32) *DocumentResponse {
+func NewDocumentResponse(id string, bankId string, originalText NullableString, contentHash NullableString, createdAt string, updatedAt string, memoryUnitCount int32) *DocumentResponse {
 	this := DocumentResponse{}
 	this.Id = id
 	this.BankId = bankId
@@ -110,27 +110,29 @@ func (o *DocumentResponse) SetBankId(v string) {
 }
 
 // GetOriginalText returns the OriginalText field value
+// If the value is explicit nil, the zero value for string will be returned
 func (o *DocumentResponse) GetOriginalText() string {
-	if o == nil {
+	if o == nil || o.OriginalText.Get() == nil {
 		var ret string
 		return ret
 	}
 
-	return o.OriginalText
+	return *o.OriginalText.Get()
 }
 
 // GetOriginalTextOk returns a tuple with the OriginalText field value
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *DocumentResponse) GetOriginalTextOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.OriginalText, true
+	return o.OriginalText.Get(), o.OriginalText.IsSet()
 }
 
 // SetOriginalText sets field value
 func (o *DocumentResponse) SetOriginalText(v string) {
-	o.OriginalText = v
+	o.OriginalText.Set(&v)
 }
 
 // GetContentHash returns the ContentHash field value
@@ -374,7 +376,7 @@ func (o DocumentResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
 	toSerialize["bank_id"] = o.BankId
-	toSerialize["original_text"] = o.OriginalText
+	toSerialize["original_text"] = o.OriginalText.Get()
 	toSerialize["content_hash"] = o.ContentHash.Get()
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["updated_at"] = o.UpdatedAt

--- a/hindsight-clients/go/model_features_info.go
+++ b/hindsight-clients/go/model_features_info.go
@@ -39,6 +39,8 @@ type FeaturesInfo struct {
 	AuditLog bool `json:"audit_log"`
 	// Whether per-bank LLM request tracing is enabled
 	LlmTrace bool `json:"llm_trace"`
+	// Whether raw source text is persisted. When false, document/chunk source text is not stored.
+	StoreDocumentText bool `json:"store_document_text"`
 }
 
 type _FeaturesInfo FeaturesInfo
@@ -47,7 +49,7 @@ type _FeaturesInfo FeaturesInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, fileUploadApi bool, documentExportApi bool, documentImportApi bool, auditLog bool, llmTrace bool) *FeaturesInfo {
+func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, fileUploadApi bool, documentExportApi bool, documentImportApi bool, auditLog bool, llmTrace bool, storeDocumentText bool) *FeaturesInfo {
 	this := FeaturesInfo{}
 	this.Observations = observations
 	this.Mcp = mcp
@@ -58,6 +60,7 @@ func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi boo
 	this.DocumentImportApi = documentImportApi
 	this.AuditLog = auditLog
 	this.LlmTrace = llmTrace
+	this.StoreDocumentText = storeDocumentText
 	return &this
 }
 
@@ -285,6 +288,30 @@ func (o *FeaturesInfo) SetLlmTrace(v bool) {
 	o.LlmTrace = v
 }
 
+// GetStoreDocumentText returns the StoreDocumentText field value
+func (o *FeaturesInfo) GetStoreDocumentText() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.StoreDocumentText
+}
+
+// GetStoreDocumentTextOk returns a tuple with the StoreDocumentText field value
+// and a boolean to check if the value has been set.
+func (o *FeaturesInfo) GetStoreDocumentTextOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.StoreDocumentText, true
+}
+
+// SetStoreDocumentText sets field value
+func (o *FeaturesInfo) SetStoreDocumentText(v bool) {
+	o.StoreDocumentText = v
+}
+
 func (o FeaturesInfo) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -304,6 +331,7 @@ func (o FeaturesInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["document_import_api"] = o.DocumentImportApi
 	toSerialize["audit_log"] = o.AuditLog
 	toSerialize["llm_trace"] = o.LlmTrace
+	toSerialize["store_document_text"] = o.StoreDocumentText
 	return toSerialize, nil
 }
 
@@ -321,6 +349,7 @@ func (o *FeaturesInfo) UnmarshalJSON(data []byte) (err error) {
 		"document_import_api",
 		"audit_log",
 		"llm_trace",
+		"store_document_text",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/hindsight-clients/python/hindsight_client_api/models/document_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/document_response.py
@@ -28,7 +28,7 @@ class DocumentResponse(BaseModel):
     """ # noqa: E501
     id: StrictStr
     bank_id: StrictStr
-    original_text: StrictStr
+    original_text: Optional[StrictStr]
     content_hash: Optional[StrictStr]
     created_at: StrictStr
     updated_at: StrictStr
@@ -78,6 +78,11 @@ class DocumentResponse(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # set to None if original_text (nullable) is None
+        # and model_fields_set contains the field
+        if self.original_text is None and "original_text" in self.model_fields_set:
+            _dict['original_text'] = None
+
         # set to None if content_hash (nullable) is None
         # and model_fields_set contains the field
         if self.content_hash is None and "content_hash" in self.model_fields_set:

--- a/hindsight-clients/python/hindsight_client_api/models/features_info.py
+++ b/hindsight-clients/python/hindsight_client_api/models/features_info.py
@@ -35,7 +35,8 @@ class FeaturesInfo(BaseModel):
     document_import_api: StrictBool = Field(description="Whether the document import endpoint is enabled")
     audit_log: StrictBool = Field(description="Whether audit logging is enabled")
     llm_trace: StrictBool = Field(description="Whether per-bank LLM request tracing is enabled")
-    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "file_upload_api", "document_export_api", "document_import_api", "audit_log", "llm_trace"]
+    store_document_text: StrictBool = Field(description="Whether raw source text is persisted. When false, document/chunk source text is not stored.")
+    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "file_upload_api", "document_export_api", "document_import_api", "audit_log", "llm_trace", "store_document_text"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,7 +97,8 @@ class FeaturesInfo(BaseModel):
             "document_export_api": obj.get("document_export_api"),
             "document_import_api": obj.get("document_import_api"),
             "audit_log": obj.get("audit_log"),
-            "llm_trace": obj.get("llm_trace")
+            "llm_trace": obj.get("llm_trace"),
+            "store_document_text": obj.get("store_document_text")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1372,7 +1372,7 @@ export type DocumentResponse = {
   /**
    * Original Text
    */
-  original_text: string;
+  original_text: string | null;
   /**
    * Content Hash
    */
@@ -1688,6 +1688,12 @@ export type FeaturesInfo = {
    * Whether per-bank LLM request tracing is enabled
    */
   llm_trace: boolean;
+  /**
+   * Store Document Text
+   *
+   * Whether raw source text is persisted. When false, document/chunk source text is not stored.
+   */
+  store_document_text: boolean;
 };
 
 /**

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -748,12 +748,6 @@ function BankSelectorInner() {
             </DialogHeader>
 
             <div className="space-y-4 overflow-y-auto flex-1 px-1 -mx-1">
-              {features?.store_document_text === false && (
-                <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
-                  <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                  <span>{tAddDocument("textNotStoredWarning")}</span>
-                </div>
-              )}
               {/* Content — tab-switched input only */}
               <Tabs value={docTab} onValueChange={(v) => setDocTab(v as "text" | "upload")}>
                 <TabsList className="grid w-full grid-cols-2">
@@ -1281,6 +1275,13 @@ function BankSelectorInner() {
                 </div>
               )}
             </div>
+
+            {features?.store_document_text === false && (
+              <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>{tAddDocument("textNotStoredWarning")}</span>
+              </div>
+            )}
 
             <DialogFooter>
               <Button

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -748,6 +748,12 @@ function BankSelectorInner() {
             </DialogHeader>
 
             <div className="space-y-4 overflow-y-auto flex-1 px-1 -mx-1">
+              {features?.store_document_text === false && (
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                  <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <span>{tAddDocument("textNotStoredWarning")}</span>
+                </div>
+              )}
               {/* Content — tab-switched input only */}
               <Tabs value={docTab} onValueChange={(v) => setDocTab(v as "text" | "upload")}>
                 <TabsList className="grid w-full grid-cols-2">

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -73,6 +73,7 @@ import {
   Activity,
   Download,
   Upload,
+  Lock,
 } from "lucide-react";
 
 const ITEMS_PER_PAGE = 50;
@@ -1204,8 +1205,13 @@ export function DocumentsView() {
               <div className="flex-1 overflow-y-auto mt-4">
                 {/* Content Tab */}
                 <TabsContent value="content" className="mt-0">
-                  {selectedDocument.original_text !== undefined &&
-                    (editingContent ? (
+                  {!features?.store_document_text && !selectedDocument.original_text ? (
+                    <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-700 dark:text-amber-400">
+                      <Lock className="h-4 w-4 mt-0.5 shrink-0" />
+                      <span>{t("textNotStoredWarning")}</span>
+                    </div>
+                  ) : selectedDocument.original_text !== undefined ? (
+                    editingContent ? (
                       <div className="space-y-2">
                         <div className="flex items-center justify-end mb-2">
                           <div className="flex gap-2">
@@ -1269,7 +1275,8 @@ export function DocumentsView() {
                           {selectedDocument.original_text}
                         </pre>
                       </div>
-                    ))}
+                    )
+                  ) : null}
                 </TabsContent>
 
                 {/* General Tab */}

--- a/hindsight-control-plane/src/components/documents-view.tsx
+++ b/hindsight-control-plane/src/components/documents-view.tsx
@@ -1443,6 +1443,12 @@ export function DocumentsView() {
 
                 {/* Chunks Tab */}
                 <TabsContent value="chunks" className="mt-0">
+                  {!features?.store_document_text && (
+                    <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 mb-3 text-xs text-amber-700 dark:text-amber-400">
+                      <Lock className="h-4 w-4 mt-0.5 shrink-0" />
+                      <span>{t("textNotStoredWarning")}</span>
+                    </div>
+                  )}
                   {loadingChunks ? (
                     <div className="flex items-center justify-center py-20">
                       <div className="text-center">

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1307,6 +1307,7 @@ export class ControlPlaneClient {
         document_import_api: boolean;
         audit_log: boolean;
         llm_trace: boolean;
+        store_document_text: boolean;
       };
     }>("/api/version");
   }

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -33,7 +33,7 @@ const defaultFeatures: Features = {
   audit_log: false,
   llm_trace: false,
   // Default to true so the "text not stored" warning only appears when the
-  // server explicitly reports the privacy flag is on (and not on fetch errors).
+  // server explicitly reports text storage is disabled (and not on fetch errors).
   store_document_text: true,
 };
 

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -13,6 +13,7 @@ interface Features {
   document_import_api: boolean;
   audit_log: boolean;
   llm_trace: boolean;
+  store_document_text: boolean;
 }
 
 interface FeaturesContextType {
@@ -31,6 +32,9 @@ const defaultFeatures: Features = {
   document_import_api: false,
   audit_log: false,
   llm_trace: false,
+  // Default to true so the "text not stored" warning only appears when the
+  // server explicitly reports the privacy flag is on (and not on fetch errors).
+  store_document_text: true,
 };
 
 const FeaturesContext = createContext<FeaturesContextType | undefined>(undefined);

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "Überspringen — vorhandenes Dokument behalten",
     "importConflictReplace": "Ersetzen — durch das importierte überschreiben",
     "importConflictNewId": "Beide behalten — unter neuer id importieren",
-    "textNotStoredWarning": "Der Quelltext wird auf diesem Server nicht gespeichert (Datenschutzmodus) – nur die extrahierten Erinnerungen werden behalten."
+    "textNotStoredWarning": "Der Quelltext wird auf diesem Server nicht gespeichert – nur die extrahierten Erinnerungen werden behalten."
   },
   "entitiesView": {
     "viewRelations": "Beziehungen",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "Fügen Sie oben Tags hinzu, um Beobachtungsbereiche vorzuschauen",
     "metadataHelpText": "Ein <code>key: value</code> pro Zeile",
     "entitiesHelpText": "Kommagetrennte Hinweise, die mit automatisch extrahierten Entitäten zusammengeführt werden",
-    "textNotStoredWarning": "Der Rohtext des Dokuments wird auf diesem Server nicht gespeichert (Datenschutzmodus) – nur die extrahierten Erinnerungen werden behalten."
+    "textNotStoredWarning": "Der Rohtext des Dokuments wird auf diesem Server nicht gespeichert – nur die extrahierten Erinnerungen werden behalten."
   },
   "dashboard": {
     "welcome": "Willkommen bei Hindsight",

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "Wenn ein Dokument bereits existiert",
     "importConflictSkip": "Überspringen — vorhandenes Dokument behalten",
     "importConflictReplace": "Ersetzen — durch das importierte überschreiben",
-    "importConflictNewId": "Beide behalten — unter neuer id importieren"
+    "importConflictNewId": "Beide behalten — unter neuer id importieren",
+    "textNotStoredWarning": "Der Quelltext wird auf diesem Server nicht gespeichert (Datenschutzmodus) – nur die extrahierten Erinnerungen werden behalten."
   },
   "entitiesView": {
     "viewRelations": "Beziehungen",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "Alle Kombinationen",
     "observationScopesEmpty": "Fügen Sie oben Tags hinzu, um Beobachtungsbereiche vorzuschauen",
     "metadataHelpText": "Ein <code>key: value</code> pro Zeile",
-    "entitiesHelpText": "Kommagetrennte Hinweise, die mit automatisch extrahierten Entitäten zusammengeführt werden"
+    "entitiesHelpText": "Kommagetrennte Hinweise, die mit automatisch extrahierten Entitäten zusammengeführt werden",
+    "textNotStoredWarning": "Der Rohtext des Dokuments wird auf diesem Server nicht gespeichert (Datenschutzmodus) – nur die extrahierten Erinnerungen werden behalten."
   },
   "dashboard": {
     "welcome": "Willkommen bei Hindsight",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "Skip — keep the existing document",
     "importConflictReplace": "Replace — overwrite with the imported one",
     "importConflictNewId": "Keep both — import under a new id",
-    "textNotStoredWarning": "Source text isn't stored on this server (privacy mode) — only the extracted memories are kept."
+    "textNotStoredWarning": "Source text isn't stored on this server — only the extracted memories are kept."
   },
   "entitiesView": {
     "viewRelations": "Relations",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "Add tags above to preview observation scopes",
     "metadataHelpText": "One <code>key: value</code> per line",
     "entitiesHelpText": "Comma-separated hints merged with auto-extracted entities",
-    "textNotStoredWarning": "Raw document text won't be stored on this server (privacy mode) — only the extracted memories are kept."
+    "textNotStoredWarning": "Raw document text won't be stored on this server — only the extracted memories are kept."
   },
   "dashboard": {
     "welcome": "Welcome to Hindsight",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "If a document already exists",
     "importConflictSkip": "Skip — keep the existing document",
     "importConflictReplace": "Replace — overwrite with the imported one",
-    "importConflictNewId": "Keep both — import under a new id"
+    "importConflictNewId": "Keep both — import under a new id",
+    "textNotStoredWarning": "Source text isn't stored on this server (privacy mode) — only the extracted memories are kept."
   },
   "entitiesView": {
     "viewRelations": "Relations",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "All combinations",
     "observationScopesEmpty": "Add tags above to preview observation scopes",
     "metadataHelpText": "One <code>key: value</code> per line",
-    "entitiesHelpText": "Comma-separated hints merged with auto-extracted entities"
+    "entitiesHelpText": "Comma-separated hints merged with auto-extracted entities",
+    "textNotStoredWarning": "Raw document text won't be stored on this server (privacy mode) — only the extracted memories are kept."
   },
   "dashboard": {
     "welcome": "Welcome to Hindsight",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "Si un documento ya existe",
     "importConflictSkip": "Omitir — conservar el documento existente",
     "importConflictReplace": "Reemplazar — sobrescribir con el importado",
-    "importConflictNewId": "Conservar ambos — importar con un nuevo id"
+    "importConflictNewId": "Conservar ambos — importar con un nuevo id",
+    "textNotStoredWarning": "El texto original no se almacena en este servidor (modo de privacidad): solo se conservan las memorias extraídas."
   },
   "entitiesView": {
     "viewRelations": "Relaciones",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "Todas las combinaciones",
     "observationScopesEmpty": "Añade etiquetas arriba para previsualizar los ámbitos de observación",
     "metadataHelpText": "Un <code>key: value</code> por línea",
-    "entitiesHelpText": "Sugerencias separadas por comas que se combinan con las entidades extraídas automáticamente"
+    "entitiesHelpText": "Sugerencias separadas por comas que se combinan con las entidades extraídas automáticamente",
+    "textNotStoredWarning": "El texto original del documento no se almacenará en este servidor (modo de privacidad): solo se conservan las memorias extraídas."
   },
   "dashboard": {
     "welcome": "Bienvenido a Hindsight",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "Omitir — conservar el documento existente",
     "importConflictReplace": "Reemplazar — sobrescribir con el importado",
     "importConflictNewId": "Conservar ambos — importar con un nuevo id",
-    "textNotStoredWarning": "El texto original no se almacena en este servidor (modo de privacidad): solo se conservan las memorias extraídas."
+    "textNotStoredWarning": "El texto original no se almacena en este servidor: solo se conservan las memorias extraídas."
   },
   "entitiesView": {
     "viewRelations": "Relaciones",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "Añade etiquetas arriba para previsualizar los ámbitos de observación",
     "metadataHelpText": "Un <code>key: value</code> por línea",
     "entitiesHelpText": "Sugerencias separadas por comas que se combinan con las entidades extraídas automáticamente",
-    "textNotStoredWarning": "El texto original del documento no se almacenará en este servidor (modo de privacidad): solo se conservan las memorias extraídas."
+    "textNotStoredWarning": "El texto original del documento no se almacenará en este servidor: solo se conservan las memorias extraídas."
   },
   "dashboard": {
     "welcome": "Bienvenido a Hindsight",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "Ignorer — conserver le document existant",
     "importConflictReplace": "Remplacer — écraser par celui importé",
     "importConflictNewId": "Conserver les deux — importer sous un nouvel id",
-    "textNotStoredWarning": "Le texte source n'est pas conservé sur ce serveur (mode confidentialité) — seules les mémoires extraites sont conservées."
+    "textNotStoredWarning": "Le texte source n'est pas conservé sur ce serveur — seules les mémoires extraites sont conservées."
   },
   "entitiesView": {
     "viewRelations": "Relations",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "Ajoutez des tags ci-dessus pour prévisualiser les portées d'observation",
     "metadataHelpText": "Un <code>key: value</code> par ligne",
     "entitiesHelpText": "Indications séparées par des virgules fusionnées avec les entités extraites automatiquement",
-    "textNotStoredWarning": "Le texte brut du document ne sera pas conservé sur ce serveur (mode confidentialité) — seules les mémoires extraites sont conservées."
+    "textNotStoredWarning": "Le texte brut du document ne sera pas conservé sur ce serveur — seules les mémoires extraites sont conservées."
   },
   "dashboard": {
     "welcome": "Bienvenue sur Hindsight",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "Si un document existe déjà",
     "importConflictSkip": "Ignorer — conserver le document existant",
     "importConflictReplace": "Remplacer — écraser par celui importé",
-    "importConflictNewId": "Conserver les deux — importer sous un nouvel id"
+    "importConflictNewId": "Conserver les deux — importer sous un nouvel id",
+    "textNotStoredWarning": "Le texte source n'est pas conservé sur ce serveur (mode confidentialité) — seules les mémoires extraites sont conservées."
   },
   "entitiesView": {
     "viewRelations": "Relations",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "Toutes les combinaisons",
     "observationScopesEmpty": "Ajoutez des tags ci-dessus pour prévisualiser les portées d'observation",
     "metadataHelpText": "Un <code>key: value</code> par ligne",
-    "entitiesHelpText": "Indications séparées par des virgules fusionnées avec les entités extraites automatiquement"
+    "entitiesHelpText": "Indications séparées par des virgules fusionnées avec les entités extraites automatiquement",
+    "textNotStoredWarning": "Le texte brut du document ne sera pas conservé sur ce serveur (mode confidentialité) — seules les mémoires extraites sont conservées."
   },
   "dashboard": {
     "welcome": "Bienvenue sur Hindsight",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "スキップ — 既存のドキュメントを保持",
     "importConflictReplace": "置換 — インポート版で上書き",
     "importConflictNewId": "両方保持 — 新しい id でインポート",
-    "textNotStoredWarning": "このサーバーでは元のテキストは保存されません（プライバシーモード）。抽出されたメモリのみが保持されます。"
+    "textNotStoredWarning": "このサーバーでは元のテキストは保存されません。抽出されたメモリのみが保持されます。"
   },
   "entitiesView": {
     "viewRelations": "関係",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "観察スコープをプレビューするには、上にタグを追加してください",
     "metadataHelpText": "1行に1つの <code>key: value</code>",
     "entitiesHelpText": "自動抽出されたエンティティとマージされるカンマ区切りのヒント",
-    "textNotStoredWarning": "このサーバーでは文書の元テキストは保存されません（プライバシーモード）。抽出されたメモリのみが保持されます。"
+    "textNotStoredWarning": "このサーバーでは文書の元テキストは保存されません。抽出されたメモリのみが保持されます。"
   },
   "dashboard": {
     "welcome": "Hindsightへようこそ",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "ドキュメントが既に存在する場合",
     "importConflictSkip": "スキップ — 既存のドキュメントを保持",
     "importConflictReplace": "置換 — インポート版で上書き",
-    "importConflictNewId": "両方保持 — 新しい id でインポート"
+    "importConflictNewId": "両方保持 — 新しい id でインポート",
+    "textNotStoredWarning": "このサーバーでは元のテキストは保存されません（プライバシーモード）。抽出されたメモリのみが保持されます。"
   },
   "entitiesView": {
     "viewRelations": "関係",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "すべての組み合わせ",
     "observationScopesEmpty": "観察スコープをプレビューするには、上にタグを追加してください",
     "metadataHelpText": "1行に1つの <code>key: value</code>",
-    "entitiesHelpText": "自動抽出されたエンティティとマージされるカンマ区切りのヒント"
+    "entitiesHelpText": "自動抽出されたエンティティとマージされるカンマ区切りのヒント",
+    "textNotStoredWarning": "このサーバーでは文書の元テキストは保存されません（プライバシーモード）。抽出されたメモリのみが保持されます。"
   },
   "dashboard": {
     "welcome": "Hindsightへようこそ",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "문서가 이미 있는 경우",
     "importConflictSkip": "건너뛰기 — 기존 문서 유지",
     "importConflictReplace": "교체 — 가져온 것으로 덮어쓰기",
-    "importConflictNewId": "둘 다 유지 — 새 id로 가져오기"
+    "importConflictNewId": "둘 다 유지 — 새 id로 가져오기",
+    "textNotStoredWarning": "이 서버에는 원본 텍스트가 저장되지 않습니다(개인정보 보호 모드). 추출된 메모리만 보관됩니다."
   },
   "entitiesView": {
     "viewRelations": "관계",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "모든 조합",
     "observationScopesEmpty": "관찰 범위를 미리 보려면 위에 태그를 추가하세요",
     "metadataHelpText": "한 줄에 하나의 <code>key: value</code>",
-    "entitiesHelpText": "자동 추출된 엔터티와 병합되는 쉼표로 구분된 힌트"
+    "entitiesHelpText": "자동 추출된 엔터티와 병합되는 쉼표로 구분된 힌트",
+    "textNotStoredWarning": "이 서버에는 문서 원본 텍스트가 저장되지 않습니다(개인정보 보호 모드). 추출된 메모리만 보관됩니다."
   },
   "dashboard": {
     "welcome": "Hindsight에 오신 것을 환영합니다",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "건너뛰기 — 기존 문서 유지",
     "importConflictReplace": "교체 — 가져온 것으로 덮어쓰기",
     "importConflictNewId": "둘 다 유지 — 새 id로 가져오기",
-    "textNotStoredWarning": "이 서버에는 원본 텍스트가 저장되지 않습니다(개인정보 보호 모드). 추출된 메모리만 보관됩니다."
+    "textNotStoredWarning": "이 서버에는 원본 텍스트가 저장되지 않습니다. 추출된 메모리만 보관됩니다."
   },
   "entitiesView": {
     "viewRelations": "관계",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "관찰 범위를 미리 보려면 위에 태그를 추가하세요",
     "metadataHelpText": "한 줄에 하나의 <code>key: value</code>",
     "entitiesHelpText": "자동 추출된 엔터티와 병합되는 쉼표로 구분된 힌트",
-    "textNotStoredWarning": "이 서버에는 문서 원본 텍스트가 저장되지 않습니다(개인정보 보호 모드). 추출된 메모리만 보관됩니다."
+    "textNotStoredWarning": "이 서버에는 문서 원본 텍스트가 저장되지 않습니다. 추출된 메모리만 보관됩니다."
   },
   "dashboard": {
     "welcome": "Hindsight에 오신 것을 환영합니다",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "Se um documento já existir",
     "importConflictSkip": "Ignorar — manter o documento existente",
     "importConflictReplace": "Substituir — sobrescrever pelo importado",
-    "importConflictNewId": "Manter ambos — importar com novo id"
+    "importConflictNewId": "Manter ambos — importar com novo id",
+    "textNotStoredWarning": "O texto de origem não é armazenado neste servidor (modo de privacidade) — apenas as memórias extraídas são mantidas."
   },
   "entitiesView": {
     "viewRelations": "Relações",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "Todas as combinações",
     "observationScopesEmpty": "Adicione tags acima para visualizar os escopos de observação",
     "metadataHelpText": "Um <code>key: value</code> por linha",
-    "entitiesHelpText": "Sugestões separadas por vírgula mescladas com entidades extraídas automaticamente"
+    "entitiesHelpText": "Sugestões separadas por vírgula mescladas com entidades extraídas automaticamente",
+    "textNotStoredWarning": "O texto bruto do documento não será armazenado neste servidor (modo de privacidade) — apenas as memórias extraídas são mantidas."
   },
   "dashboard": {
     "welcome": "Bem-vindo ao Hindsight",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "Ignorar — manter o documento existente",
     "importConflictReplace": "Substituir — sobrescrever pelo importado",
     "importConflictNewId": "Manter ambos — importar com novo id",
-    "textNotStoredWarning": "O texto de origem não é armazenado neste servidor (modo de privacidade) — apenas as memórias extraídas são mantidas."
+    "textNotStoredWarning": "O texto de origem não é armazenado neste servidor — apenas as memórias extraídas são mantidas."
   },
   "entitiesView": {
     "viewRelations": "Relações",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "Adicione tags acima para visualizar os escopos de observação",
     "metadataHelpText": "Um <code>key: value</code> por linha",
     "entitiesHelpText": "Sugestões separadas por vírgula mescladas com entidades extraídas automaticamente",
-    "textNotStoredWarning": "O texto bruto do documento não será armazenado neste servidor (modo de privacidade) — apenas as memórias extraídas são mantidas."
+    "textNotStoredWarning": "O texto bruto do documento não será armazenado neste servidor — apenas as memórias extraídas são mantidas."
   },
   "dashboard": {
     "welcome": "Bem-vindo ao Hindsight",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "略過 — 保留現有文件",
     "importConflictReplace": "取代 — 以匯入嘅覆寫",
     "importConflictNewId": "兩者都保留 — 以新 id 匯入",
-    "textNotStoredWarning": "呢個伺服器唔會儲存原始文字（私隱模式），淨係保留擷取到嘅記憶。"
+    "textNotStoredWarning": "呢個伺服器唔會儲存原始文字，淨係保留擷取到嘅記憶。"
   },
   "entitiesView": {
     "viewRelations": "關係",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "在上方新增標籤以預覽觀察範圍",
     "metadataHelpText": "每行一個 <code>key: value</code>",
     "entitiesHelpText": "以逗號分隔的提示，會與自動擷取的實體合併",
-    "textNotStoredWarning": "呢個伺服器唔會儲存文件原始文字（私隱模式），淨係保留擷取到嘅記憶。"
+    "textNotStoredWarning": "呢個伺服器唔會儲存文件原始文字，淨係保留擷取到嘅記憶。"
   },
   "dashboard": {
     "welcome": "歡迎使用 Hindsight",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "當文件已存在時",
     "importConflictSkip": "略過 — 保留現有文件",
     "importConflictReplace": "取代 — 以匯入嘅覆寫",
-    "importConflictNewId": "兩者都保留 — 以新 id 匯入"
+    "importConflictNewId": "兩者都保留 — 以新 id 匯入",
+    "textNotStoredWarning": "呢個伺服器唔會儲存原始文字（私隱模式），淨係保留擷取到嘅記憶。"
   },
   "entitiesView": {
     "viewRelations": "關係",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "所有組合",
     "observationScopesEmpty": "在上方新增標籤以預覽觀察範圍",
     "metadataHelpText": "每行一個 <code>key: value</code>",
-    "entitiesHelpText": "以逗號分隔的提示，會與自動擷取的實體合併"
+    "entitiesHelpText": "以逗號分隔的提示，會與自動擷取的實體合併",
+    "textNotStoredWarning": "呢個伺服器唔會儲存文件原始文字（私隱模式），淨係保留擷取到嘅記憶。"
   },
   "dashboard": {
     "welcome": "歡迎使用 Hindsight",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "跳过 — 保留现有文档",
     "importConflictReplace": "替换 — 用导入的覆盖",
     "importConflictNewId": "两者都保留 — 以新 id 导入",
-    "textNotStoredWarning": "此服务器不存储原始文本（隐私模式），仅保留提取的记忆。"
+    "textNotStoredWarning": "此服务器不存储原始文本，仅保留提取的记忆。"
   },
   "entitiesView": {
     "viewRelations": "关系",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "在上方添加标签以预览观察范围",
     "metadataHelpText": "每行一个 <code>key: value</code>",
     "entitiesHelpText": "逗号分隔的提示，与自动提取的实体合并",
-    "textNotStoredWarning": "此服务器不会存储文档原始文本（隐私模式），仅保留提取的记忆。"
+    "textNotStoredWarning": "此服务器不会存储文档原始文本，仅保留提取的记忆。"
   },
   "dashboard": {
     "welcome": "欢迎使用 Hindsight",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "当文档已存在时",
     "importConflictSkip": "跳过 — 保留现有文档",
     "importConflictReplace": "替换 — 用导入的覆盖",
-    "importConflictNewId": "两者都保留 — 以新 id 导入"
+    "importConflictNewId": "两者都保留 — 以新 id 导入",
+    "textNotStoredWarning": "此服务器不存储原始文本（隐私模式），仅保留提取的记忆。"
   },
   "entitiesView": {
     "viewRelations": "关系",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "所有组合",
     "observationScopesEmpty": "在上方添加标签以预览观察范围",
     "metadataHelpText": "每行一个 <code>key: value</code>",
-    "entitiesHelpText": "逗号分隔的提示，与自动提取的实体合并"
+    "entitiesHelpText": "逗号分隔的提示，与自动提取的实体合并",
+    "textNotStoredWarning": "此服务器不会存储文档原始文本（隐私模式），仅保留提取的记忆。"
   },
   "dashboard": {
     "welcome": "欢迎使用 Hindsight",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -641,7 +641,7 @@
     "importConflictSkip": "略過 — 保留現有文件",
     "importConflictReplace": "取代 — 以匯入的覆寫",
     "importConflictNewId": "兩者都保留 — 以新 id 匯入",
-    "textNotStoredWarning": "此伺服器不會儲存原始文字（隱私模式），僅保留擷取的記憶。"
+    "textNotStoredWarning": "此伺服器不會儲存原始文字，僅保留擷取的記憶。"
   },
   "entitiesView": {
     "viewRelations": "關係",
@@ -1446,7 +1446,7 @@
     "observationScopesEmpty": "在上方新增標籤以預覽觀察範圍",
     "metadataHelpText": "每行一個 <code>key: value</code>",
     "entitiesHelpText": "逗號分隔的提示，與自動擷取的實體合併",
-    "textNotStoredWarning": "此伺服器不會儲存文件原始文字（隱私模式），僅保留擷取的記憶。"
+    "textNotStoredWarning": "此伺服器不會儲存文件原始文字，僅保留擷取的記憶。"
   },
   "dashboard": {
     "welcome": "歡迎使用 Hindsight",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -640,7 +640,8 @@
     "importConflictLabel": "當文件已存在時",
     "importConflictSkip": "略過 — 保留現有文件",
     "importConflictReplace": "取代 — 以匯入的覆寫",
-    "importConflictNewId": "兩者都保留 — 以新 id 匯入"
+    "importConflictNewId": "兩者都保留 — 以新 id 匯入",
+    "textNotStoredWarning": "此伺服器不會儲存原始文字（隱私模式），僅保留擷取的記憶。"
   },
   "entitiesView": {
     "viewRelations": "關係",
@@ -1444,7 +1445,8 @@
     "observationScopeAllCombinations": "所有組合",
     "observationScopesEmpty": "在上方新增標籤以預覽觀察範圍",
     "metadataHelpText": "每行一個 <code>key: value</code>",
-    "entitiesHelpText": "逗號分隔的提示，與自動擷取的實體合併"
+    "entitiesHelpText": "逗號分隔的提示，與自動擷取的實體合併",
+    "textNotStoredWarning": "此伺服器不會儲存文件原始文字（隱私模式），僅保留擷取的記憶。"
   },
   "dashboard": {
     "welcome": "歡迎使用 Hindsight",

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1048,10 +1048,14 @@ When disabled, the full retain pipeline still runs — chunking, fact extraction
 - `documents.original_text` is stored as `NULL` instead of the raw payload.
 - The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
 
+**`update_mode="append"` is rejected in this mode.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
+
 **Features that degrade in this mode** (because they read the source text back):
 
 - **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
-- **Reading a document's source** (the get-document and list-chunks endpoints) and **reflect tools that quote source text** return empty content.
+- **Reading a document's source** (the get-document, list-chunks, and get-chunk endpoints, including their MCP equivalents) returns empty content.
+- **Recall with `include_chunks=true`** returns empty `chunk_text` — the facts themselves are unaffected, but the surrounding source-chunk context is no longer available.
+- **Reflect** no longer offers the `expand` tool (which fetches a memory's source chunk/document), and its `recall` step stops attaching source chunks, since there is no stored text to return. Reflection over the extracted memories is otherwise unaffected.
 - **Reprocessing a document** from its stored text is a no-op (there is nothing to reprocess).
 
 This is a static, server-level setting and cannot be overridden per bank.

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1010,6 +1010,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
+| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` for privacy-sensitive deployments to drop it. Static, server-level. | `true` |
 
 > **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
 
@@ -1033,6 +1034,27 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 ```
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
+
+#### Privacy mode: skip storing raw document text
+
+By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For privacy-sensitive deployments that only want to keep the extracted, anonymised memories (facts, entities, mental models), set:
+
+```bash
+export HINDSIGHT_API_STORE_DOCUMENT_TEXT=false
+```
+
+When disabled, the full retain pipeline still runs — chunking, fact extraction, embedding, and entity linking are unchanged, so **memory quality and recall are not affected** (recall reads from the extracted memories, never from the raw text). The difference is purely what gets persisted:
+
+- `documents.original_text` is stored as `NULL` instead of the raw payload.
+- The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
+
+**Features that degrade in this mode** (because they read the source text back):
+
+- **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
+- **Reading a document's source** (the get-document and list-chunks endpoints) and **reflect tools that quote source text** return empty content.
+- **Reprocessing a document** from its stored text is a no-op (there is nothing to reprocess).
+
+This is a static, server-level setting and cannot be overridden per bank.
 
 #### Customizing retain: when to use what
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1010,7 +1010,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
-| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` for privacy-sensitive deployments to drop it. Static, server-level. | `true` |
+| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` to skip storing it. Static, server-level. | `true` |
 
 > **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
 
@@ -1035,9 +1035,9 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](/developer/api/memory-banks#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](/developer/retain#entity-labels) for details.
 
-#### Privacy mode: skip storing raw document text
+#### Skip storing raw document text
 
-By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For privacy-sensitive deployments that only want to keep the extracted, anonymised memories (facts, entities, mental models), set:
+By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For deployments that only want to keep the extracted memories (facts, entities, mental models) and not the source text, set:
 
 ```bash
 export HINDSIGHT_API_STORE_DOCUMENT_TEXT=false
@@ -1048,9 +1048,9 @@ When disabled, the full retain pipeline still runs — chunking, fact extraction
 - `documents.original_text` is stored as `NULL` instead of the raw payload.
 - The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
 
-**`update_mode="append"` is rejected in this mode.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
+**`update_mode="append"` is rejected when text storage is disabled.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
 
-**Features that degrade in this mode** (because they read the source text back):
+**Features that degrade when text storage is disabled** (because they read the source text back):
 
 - **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
 - **Reading a document's source** (the get-document, list-chunks, and get-chunk endpoints, including their MCP equivalents) returns empty content.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7715,7 +7715,14 @@
             "title": "Bank Id"
           },
           "original_text": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Original Text"
           },
           "content_hash": {
@@ -8239,6 +8246,11 @@
             "type": "boolean",
             "title": "Llm Trace",
             "description": "Whether per-bank LLM request tracing is enabled"
+          },
+          "store_document_text": {
+            "type": "boolean",
+            "title": "Store Document Text",
+            "description": "Whether raw source text is persisted. When false, document/chunk source text is not stored."
           }
         },
         "type": "object",
@@ -8251,7 +8263,8 @@
           "document_export_api",
           "document_import_api",
           "audit_log",
-          "llm_trace"
+          "llm_trace",
+          "store_document_text"
         ],
         "title": "FeaturesInfo",
         "description": "Feature flags indicating which capabilities are enabled."

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1010,6 +1010,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
+| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` for privacy-sensitive deployments to drop it. Static, server-level. | `true` |
 
 > **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
 
@@ -1033,6 +1034,27 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 ```
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](api/memory-banks.md#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](retain.md#entity-labels) for details.
+
+#### Privacy mode: skip storing raw document text
+
+By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For privacy-sensitive deployments that only want to keep the extracted, anonymised memories (facts, entities, mental models), set:
+
+```bash
+export HINDSIGHT_API_STORE_DOCUMENT_TEXT=false
+```
+
+When disabled, the full retain pipeline still runs — chunking, fact extraction, embedding, and entity linking are unchanged, so **memory quality and recall are not affected** (recall reads from the extracted memories, never from the raw text). The difference is purely what gets persisted:
+
+- `documents.original_text` is stored as `NULL` instead of the raw payload.
+- The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
+
+**Features that degrade in this mode** (because they read the source text back):
+
+- **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
+- **Reading a document's source** (the get-document and list-chunks endpoints) and **reflect tools that quote source text** return empty content.
+- **Reprocessing a document** from its stored text is a no-op (there is nothing to reprocess).
+
+This is a static, server-level setting and cannot be overridden per bank.
 
 #### Customizing retain: when to use what
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1010,7 +1010,7 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_ENTITY_RESOLUTION_BATCH_SIZE` | Max unique entity names per fuzzy candidate lookup query (`trigram` on PG, `oracle_fuzzy` on Oracle). Bounds query size so very wide retain batches don't time out a single `unnest(...)` join on banks with many entities. | `100` |
 | `HINDSIGHT_API_RETAIN_DEFAULT_STRATEGY` | Default retain strategy name. When set, all retain calls without an explicit `strategy` parameter use this strategy. | - |
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
-| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` for privacy-sensitive deployments to drop it. Static, server-level. | `true` |
+| `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` to skip storing it. Static, server-level. | `true` |
 
 > **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
 
@@ -1035,9 +1035,9 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 
 > **Entity labels** (`entity_labels`) and **free-form entity extraction** (`entities_allow_free_form`) are configured per bank via the [bank config API](api/memory-banks.md#retain-configuration), not as global environment variables — each bank can have its own controlled vocabulary. See [Entity Labels](retain.md#entity-labels) for details.
 
-#### Privacy mode: skip storing raw document text
+#### Skip storing raw document text
 
-By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For privacy-sensitive deployments that only want to keep the extracted, anonymised memories (facts, entities, mental models), set:
+By default Hindsight keeps a verbatim copy of everything you retain so you can later read the source, re-process a document, or export it. For deployments that only want to keep the extracted memories (facts, entities, mental models) and not the source text, set:
 
 ```bash
 export HINDSIGHT_API_STORE_DOCUMENT_TEXT=false
@@ -1048,9 +1048,9 @@ When disabled, the full retain pipeline still runs — chunking, fact extraction
 - `documents.original_text` is stored as `NULL` instead of the raw payload.
 - The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
 
-**`update_mode="append"` is rejected in this mode.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
+**`update_mode="append"` is rejected when text storage is disabled.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
 
-**Features that degrade in this mode** (because they read the source text back):
+**Features that degrade when text storage is disabled** (because they read the source text back):
 
 - **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
 - **Reading a document's source** (the get-document, list-chunks, and get-chunk endpoints, including their MCP equivalents) returns empty content.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1048,10 +1048,14 @@ When disabled, the full retain pipeline still runs — chunking, fact extraction
 - `documents.original_text` is stored as `NULL` instead of the raw payload.
 - The raw chunk text is dropped (stored as empty), while the chunk's content hash is still kept so incremental re-retain of the same document continues to deduplicate correctly.
 
+**`update_mode="append"` is rejected in this mode.** Append rebuilds a document by reading back its previously stored text and adding to it. With nothing stored, appending would silently drop the prior content, so an append retain returns an error instead. Use `update_mode="replace"` (the default).
+
 **Features that degrade in this mode** (because they read the source text back):
 
 - **Document export** carries no source text; re-importing such a bank cannot re-run extraction from the original payload.
-- **Reading a document's source** (the get-document and list-chunks endpoints) and **reflect tools that quote source text** return empty content.
+- **Reading a document's source** (the get-document, list-chunks, and get-chunk endpoints, including their MCP equivalents) returns empty content.
+- **Recall with `include_chunks=true`** returns empty `chunk_text` — the facts themselves are unaffected, but the surrounding source-chunk context is no longer available.
+- **Reflect** no longer offers the `expand` tool (which fetches a memory's source chunk/document), and its `recall` step stops attaching source chunks, since there is no stored text to return. Reflection over the extracted memories is otherwise unaffected.
 - **Reprocessing a document** from its stored text is a no-op (there is nothing to reprocess).
 
 This is a static, server-level setting and cannot be overridden per bank.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7715,7 +7715,14 @@
             "title": "Bank Id"
           },
           "original_text": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Original Text"
           },
           "content_hash": {
@@ -8239,6 +8246,11 @@
             "type": "boolean",
             "title": "Llm Trace",
             "description": "Whether per-bank LLM request tracing is enabled"
+          },
+          "store_document_text": {
+            "type": "boolean",
+            "title": "Store Document Text",
+            "description": "Whether raw source text is persisted. When false, document/chunk source text is not stored."
           }
         },
         "type": "object",
@@ -8251,7 +8263,8 @@
           "document_export_api",
           "document_import_api",
           "audit_log",
-          "llm_trace"
+          "llm_trace",
+          "store_document_text"
         ],
         "title": "FeaturesInfo",
         "description": "Feature flags indicating which capabilities are enabled."


### PR DESCRIPTION
Closes #2061

## What

Adds a static, server-level config flag `HINDSIGHT_API_STORE_DOCUMENT_TEXT` (default `true`). When set to `false`, privacy-sensitive deployments keep only the extracted, anonymised memories (facts, entities, mental models) and Hindsight stops persisting the verbatim source text.

## How it works

The full retain pipeline runs unchanged — chunking, fact extraction, embedding, and entity linking are unaffected, so **memory quality and recall do not change** (recall reads from `memory_units`, never from `original_text`). The only difference is what gets persisted:

- `documents.original_text` is stored as `NULL` instead of the raw payload.
- Raw chunk text is dropped (stored as empty string — the `chunks.chunk_text` column is `NOT NULL`).
- `content_hash` is still computed from the **real** text, so incremental/delta re-retain dedup continues to work.

Both the normal and delta/recovery write paths funnel through a single chokepoint (`_upsert_document_row`), so one gate covers all real text writes. The pre-existing placeholder inserts only ever write `''`/`__pending__`, never raw text.

## Degraded features (documented)

When the flag is off, features that read the source text back degrade gracefully (they already tolerate NULL/empty, so no read-path code changes were needed):
- Document export carries no source text; re-import can't re-run extraction from the original payload.
- Get-document / list-chunks endpoints and reflect tools that quote source text return empty content.
- Reprocessing a document from its stored text is a no-op.

## Tests

`tests/test_store_document_text.py`:
- `test_privacy_mode_nulls_text_but_keeps_memories` — flag off: `original_text` is NULL, `chunk_text` is empty, but facts are still extracted and recall still returns results.
- `test_default_mode_stores_text` — default: raw document and chunk text are persisted.

Also ran the delta-retain / document-tracking / chunk-upsert suites (33 tests) to confirm the default path is unchanged. Lint passes.

## Docs

Added a "Privacy mode" section and a config-table row in `hindsight-docs/docs/developer/configuration.md`.