### PR TITLE
fix(docs): correct Grok Build icon path in integrations banner

### DIFF
--- a/hindsight-docs/src/components/IntegrationsBanner.tsx
+++ b/hindsight-docs/src/components/IntegrationsBanner.tsx
@@ -33,7 +33,7 @@ const ITEMS: BannerItem[] = [
   {label: 'MCP Server',    imgSrc: '/img/icons/mcp.png',       href: '/sdks/integrations/local-mcp'},
   {label: 'LiteLLM',      imgSrc: '/img/icons/litellm.png',    href: '/sdks/integrations/litellm'},
   {label: 'Claude Code',  imgSrc: '/img/icons/claudecode.svg', href: '/sdks/integrations/claude-code'},
-  {label: 'Grok Build',   imgSrc: '/img/icons/grok-build.png', href: '/sdks/integrations/grok-build'},
+  {label: 'Grok Build',   imgSrc: '/img/icons/grok-build.svg', href: '/sdks/integrations/grok-build'},
   {label: 'OpenClaw',     imgSrc: '/img/icons/openclaw.png',   href: '/sdks/integrations/openclaw'},
   {label: 'Vercel AI',    icon: SiVercel,                      href: '/sdks/integrations/ai-sdk'},
   {label: 'Vercel Chat',  icon: SiVercel,                      href: '/sdks/integrations/chat'},


### PR DESCRIPTION
## Problem

In the **Integrations Hub**, the Grok Build entry shows a **broken-image placeholder** in the rotating banner/marquee at the top of the page. Every other integration renders its icon fine, and the gallery card below renders the Grok Build icon correctly — the bug is isolated to the marquee.

## Root cause

`IntegrationsBanner.tsx` hardcodes its own icon list, and the Grok Build row pointed at `/img/icons/grok-build.png`:

```ts
{label: 'Grok Build', imgSrc: '/img/icons/grok-build.png', ...}
```

…but the asset that actually exists is **`grok-build.svg`** (there is no `.png`). The gallery works because it reads the icon path from `integrations.json`, which correctly uses `.svg`. The marquee's hardcoded `.png` 404s and renders as a broken image.

## Fix

Point the banner at the existing `.svg` — a one-line change:

```diff
-  {label: 'Grok Build',   imgSrc: '/img/icons/grok-build.png', ...}
+  {label: 'Grok Build',   imgSrc: '/img/icons/grok-build.svg', ...}
```

## Verification

- Confirmed `hindsight-docs/static/img/icons/grok-build.svg` exists and `grok-build.png` does not.
- Audited **all** `imgSrc` paths in `IntegrationsBanner.tsx` against the icons directory — every one resolves to a real file after this change; Grok Build was the only broken reference.
