### PR TITLE
blog: add truncate markers to oh-my-pi and 10k-stars posts

### DIFF
--- a/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
+++ b/hindsight-docs/blog/2026-04-21-hindsight-10k-stars.md
@@ -17,6 +17,8 @@ That vote of confidence came from real deployments. Moreover, it came from teams
 
 Today, we're celebrating that community and sharing what the numbers reveal about Hindsight's impact. Here's the story behind 10,000 stars, what surprised us most, and where agent memory systems are headed.
 
+<!-- truncate -->
+
 ---
 
 ## By the Numbers

--- a/hindsight-docs/blog/2026-06-08-oh-my-pi-hindsight-memory.md
+++ b/hindsight-docs/blog/2026-06-08-oh-my-pi-hindsight-memory.md
@@ -15,6 +15,8 @@ hide_table_of_contents: true
 
 It's not a thin integration either: it features a complete memory subsystem built on top of Hindsight's API — bank scoping, mental-model seeding, debounced retain queues, auto-recall on the first turn. This post is a tour of how they built it, with code pulled straight from the public repo. If you're considering Hindsight for a coding agent of your own, this is a useful reference for the shape of a deep integration.
 
+<!-- truncate -->
+
 ## TL;DR
 
 - oh-my-pi exposes `retain` / `recall` / `reflect` as model-facing tools backed by Hindsight, plus an auto-retain / auto-recall lifecycle the model doesn't have to think about.


### PR DESCRIPTION
## Summary

- Adds `<!-- truncate -->` to the two blog posts that were triggering this warning on production build:
  - `blog/2026-06-08-oh-my-pi-hindsight-memory.md`
  - `blog/2026-04-21-hindsight-10k-stars.md`
- Placed after the lead paragraphs so the blog index gets a clean preview instead of the full body.

## Why

Docusaurus production build logs:

\`\`\`
Warning:  Docusaurus found blog posts without truncation markers:
- "blog/2026-06-08-oh-my-pi-hindsight-memory.md"
- "blog/2026-04-21-hindsight-10k-stars.md"
\`\`\`

Every other blog post in the repo follows the same lead-paragraphs-then-marker pattern — see `2026-05-25-hermes-coding-assistant-codebase-memory.md` for a recent example.

## Test plan

- [ ] \`cd hindsight-docs && npm run build\` no longer warns about untruncated posts
- [ ] Blog index page (\`/blog\`) shows the lead paragraphs only for both posts; "Read more" link present

🤖 Generated with [Claude Code](https://claude.com/claude-code)