### PR TITLE
fix(control-plane): match bank ID from URL regardless of locale prefix

### DIFF
--- a/hindsight-control-plane/src/lib/bank-context.tsx
+++ b/hindsight-control-plane/src/lib/bank-context.tsx
@@ -58,7 +58,7 @@ export function BankProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize bank from URL on mount
   useEffect(() => {
-    const bankMatch = pathname?.match(/^\/banks\/([^/?]+)/);
+    const bankMatch = pathname?.match(/\/banks\/([^/?]+)/);
     if (bankMatch) {
       setCurrentBank(decodeURIComponent(bankMatch[1]));
     }


### PR DESCRIPTION
## What does this PR do?

Control Plane loses the selected bank on page refresh.

Root cause: `bank-context.tsx` parses the bank ID from the URL using a regex with a `^/banks/` anchor. However, Next.js i18n routing produces paths like `/{locale}/banks/{bankId}` (e.g. `/en/banks/hermes`). The `^` anchor prevents a match, so `currentBank` stays `null` on page load.

Fix: remove the `^` anchor to match `/banks/` at any path position.

## Related Issue

Fixes #2069

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hindsight-control-plane/src/lib/bank-context.tsx`: remove `^` from URL regex anchor (1 line)

## How to Test

1. Open Control Plane
2. Select a bank
3. Refresh the page
4. The bank should remain selected

## Test Results

- All 65 existing vitest tests passed (5 files, 0 failures, 1.03s)
