### PR TITLE
feat(api): expose retrieval scores in recall API via include_scores

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -182,6 +182,10 @@ class RecallRequest(BaseModel):
         description="Compound tag filter using boolean groups. Groups in the list are AND-ed. "
         "Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.",
     )
+    include_scores: bool = Field(
+        default=False,
+        description="If true, include the relevance score for each result.",
+    )
 
     @field_validator("query")
     @classmethod
@@ -234,6 +238,7 @@ class RecallResult(BaseModel):
     metadata: dict[str, str] | None = None  # User-defined metadata
     chunk_id: str | None = None  # Chunk this fact was extracted from
     tags: list[str] | None = None  # Visibility scope tags
+    score: float | None = None  # Relevance score (only set when include_scores is enabled)
     source_fact_ids: list[str] | None = (
         None  # IDs of source facts (observation type only, when source_facts is enabled)
     )
@@ -3376,6 +3381,7 @@ def _register_routes(app: FastAPI):
                     metadata=fact.metadata,
                     chunk_id=fact.chunk_id,
                     tags=fact.tags,
+                    score=fact.score if request.include_scores else None,
                     source_fact_ids=fact.source_fact_ids,
                 )
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4709,6 +4709,7 @@ class MemoryEngine(MemoryEngineInterface):
                         metadata=result_dict.get("metadata"),
                         chunk_id=result_dict.get("chunk_id"),
                         tags=result_dict.get("tags"),
+                        score=result_dict.get("combined_score"),
                         source_fact_ids=source_fact_ids_by_obs.get(result_id) if include_source_facts else None,
                     )
                 )

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -177,6 +177,10 @@ class MemoryFact(BaseModel):
         None, description="ID of the chunk this fact was extracted from (format: bank_id_document_id_chunk_index)"
     )
     tags: list[str] | None = Field(None, description="Visibility scope tags associated with this fact")
+    score: float | None = Field(
+        None,
+        description="Relevance score of this memory fact to the query. Only present when include_scores is enabled.",
+    )
     source_fact_ids: list[str] | None = Field(
         None,
         description="IDs of source facts this observation was derived from (observation type only, when source_facts is enabled)",


### PR DESCRIPTION
## Summary

Add an optional `include_scores` parameter to the recall endpoint. When enabled, each result includes a `score` field with the final combined relevance score (0.0–1.0). Default is `false` — no breaking change.

Closes #1624

## Changes

| File | Change |
|------|--------|
| `hindsight-api-slim/hindsight_api/api/http.py` | Add `include_scores` to `RecallRequest`, `score` to `RecallResult`, pipe through in `_fact_to_result` |
| `hindsight-api-slim/hindsight_api/engine/response_models.py` | Add optional `score` field to `MemoryFact` |
| `hindsight-api-slim/hindsight_api/engine/memory_engine.py` | Pass `combined_score` from `ScoredResult.to_dict()` into `MemoryFact` |

## Design

- Scores are already computed internally in the reranking pipeline (`ScoredResult.combined_score`) and exposed via `trace: true` — this just surfaces the final value without requiring full trace mode.
- The combined score is the output of Hindsight's existing scoring pipeline (cross-encoder score → normalization → recency/temporal boosts → weighted combination), already normalized to 0.0–1.0.
- Non-breaking: `include_scores` defaults to `false`, preserving existing API behavior.

## Testing

- When `include_scores: false` (default): `score` field is omitted from response — existing behavior unchanged.
- When `include_scores: true`: each result object includes `score: 0.87` with the final combined relevance score.