### PR TITLE
fix(control-plane): drop locale slug from URLs (localePrefix never)

### DIFF
--- a/hindsight-control-plane/src/i18n/routing.ts
+++ b/hindsight-control-plane/src/i18n/routing.ts
@@ -4,7 +4,9 @@ import { locales, defaultLocale } from "./config";
 export const routing = defineRouting({
   locales,
   defaultLocale,
-  // Don't add locale prefix for the default locale (English)
-  // /dashboard instead of /en/dashboard
-  localePrefix: "as-needed",
+  // Never expose the locale in the URL. The active locale is resolved from the
+  // NEXT_LOCALE cookie (Accept-Language as fallback) and next-intl rewrites
+  // internally to the [locale] segment, so paths stay clean (/banks/x, never
+  // /es/banks/x). Keeps the control plane locale-agnostic in the address bar.
+  localePrefix: "never",
 });

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -22,17 +22,6 @@ const PUBLIC_PATTERNS = [
 
 const intlMiddleware = createIntlMiddleware(routing);
 
-function stripLocalePrefix(pathname: string): string {
-  // Strip a leading /<locale> segment when present so auth rules can match
-  // against the canonical path (e.g. /es/login → /login).
-  const segments = pathname.split("/");
-  if (segments.length >= 2 && (routing.locales as readonly string[]).includes(segments[1])) {
-    const rest = "/" + segments.slice(2).join("/");
-    return rest === "/" ? "/" : rest;
-  }
-  return pathname;
-}
-
 export async function middleware(request: NextRequest) {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
   const { pathname } = request.nextUrl;
@@ -65,11 +54,11 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Page routes: enforce auth first (using locale-stripped path), then delegate
-  // to the i18n middleware for locale negotiation and rewriting.
+  // Page routes: enforce auth first, then delegate to the i18n middleware for
+  // locale negotiation and rewriting. With localePrefix "never" the locale is
+  // never in the path, so appPathname is already the canonical route.
   if (accessKey) {
-    const canonicalPath = stripLocalePrefix(appPathname);
-    const isPublic = PUBLIC_PATTERNS.some((pattern) => canonicalPath.startsWith(pattern));
+    const isPublic = PUBLIC_PATTERNS.some((pattern) => appPathname.startsWith(pattern));
 
     if (!isPublic) {
       const sessionCookie = request.cookies.get(ACCESS_KEY_COOKIE)?.value;


### PR DESCRIPTION
## What does this PR do?

Control Plane loses the selected bank on page refresh **for non-default locales**.

Root cause: routing used `localePrefix: "as-needed"`, so non-English locales carry a locale prefix in the URL (e.g. `/es/banks/hermes`). `bank-context.tsx` reads `usePathname()` from `next/navigation` (which includes the prefix) and parses the bank id with a `^/banks/` anchored regex, so the match fails and `currentBank` stays `null` on load. English (the default locale) had no prefix, so the bug only affected the other 9 locales.

Fix: switch next-intl to `localePrefix: "never"`. The active locale is resolved from the `NEXT_LOCALE` cookie (Accept-Language fallback) and next-intl rewrites internally to the `[locale]` segment, so the locale **never** appears in the URL. Every path stays clean (`/banks/x`), and the existing `^/banks/` parsing works for all languages.

Also removes the now-dead `stripLocalePrefix()` helper in `middleware.ts` (there is no prefix to strip anymore).

## Supersedes #2070

#2070 patched the same symptom by un-anchoring the regex. This addresses it at the routing layer instead: the locale slug was unintentional for an authenticated admin UI, and removing it keeps the address bar locale-agnostic. With this change #2070 is no longer needed.

## Related Issue

Fixes #2069

## Trade-offs

- Language is now a per-user cookie preference, not URL-addressable (no shareable `/es/...` deep links). Irrelevant for an authed control plane with no SEO surface.
- `[locale]` route folders are unchanged; next-intl rewrites to them internally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Open Control Plane, select a bank, refresh → bank stays selected.
2. Switch language via the picker → UI translates, URL stays `/banks/x` (no `/es/` prefix), locale persists across refresh via cookie.

## Test Results

- `tsc --noEmit`: clean
- `eslint` (changed files): clean
- `vitest`: 65/65 pass
