### PR TITLE
fix(api): stop forcing vchordrq.probes on listless vchord indexes

### DIFF
--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -54,23 +54,20 @@ _INDEX_TYPE_KEYWORDS = {
 #   pre-dispatcher code (internal benchmarks tuned around our embedding count
 #   and recall floor; see the link_utils / pool init call sites for the
 #   latency-vs-recall framing).
-# - vchord exposes vchordrq.probes (no default; see VectorChord issue #392)
-#   and vchordrq.epsilon (default 1.9). probes = 10 / 30 are starting
-#   defaults pending a workload-specific sweep — vchordrq's recall curve
-#   shape differs from HNSW's, so the pgvector numbers don't translate
-#   directly. Revisit with a per-cluster benchmark once we have production
-#   recall data; until then these are deliberately conservative on the
-#   high-recall path. We leave epsilon at its default; tightening it is a
-#   separate trade-off.
+# - vchord exposes vchordrq.probes, but its shape must match the index's
+#   build.internal.lists hierarchy. VectorChord 1.1 added per-index fallback
+#   parameters for this reason: a session GUC overrides every vchordrq index,
+#   and a single value can be invalid for listless or mixed-layout indexes.
+#   Hindsight's built-in vchord clause does not set lists, so the safe default
+#   is no session-level probe override; deployments that partition vchordrq
+#   indexes should attach probes to the index storage parameters instead.
 # - pgvectorscale / pg_diskann / scann do not expose an equivalent per-statement
 #   knob in the engine today, so the dispatcher returns no statements for them.
 _ANN_TUNING_LOW_LATENCY: dict[str, tuple[tuple[str, str], ...]] = {
     "pgvector": (("hnsw.ef_search", "60"),),
-    "vchord": (("vchordrq.probes", "10"),),
 }
 _ANN_TUNING_HIGH_RECALL: dict[str, tuple[tuple[str, str], ...]] = {
     "pgvector": (("hnsw.ef_search", "200"),),
-    "vchord": (("vchordrq.probes", "30"),),
 }
 
 _EXTENSION_INSTALL_SQL = {

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2513,11 +2513,9 @@ class MemoryEngine(MemoryEngineInterface):
                 await conn.execute('SET search_path TO "$user", public, bm25_catalog, tokenizer_catalog')
 
             # SET (not SET LOCAL) so per-backend ANN tuning persists for the
-            # connection lifetime. Each backend exposes its own GUC: pgvector
-            # uses hnsw.ef_search, vchord uses vchordrq.probes. The dispatcher
-            # returns the right one for the configured extension, tuned for
-            # the higher recall the per-fact_type semantic queries in
-            # retrieve_semantic_bm25_combined() need.
+            # connection lifetime. The dispatcher returns only safe, portable
+            # knobs for the configured extension; VectorChord probe tuning is
+            # index-shaped and should be stored on vchordrq indexes instead.
             for guc, value in ann_search_tuning_settings(configured_vector_extension(), kind="high_recall"):
                 try:
                     await conn.execute(f"SET {guc} = {value}")

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -574,12 +574,10 @@ async def compute_semantic_links_ann(
     # the transaction end handles both.
     rows: list = []
     async with conn.transaction():
-        # Transaction-local ANN tuning. Each supported backend exposes its own
-        # GUC (hnsw.ef_search on pgvector, vchordrq.probes on vchord); the
-        # dispatcher returns the right knob for the configured backend with a
-        # value tuned for top-50 semantic link creation (lower recall but much
-        # lower latency than the recall-side default). SET LOCAL auto-reverts
-        # at commit, so we don't pollute the pool for subsequent queries.
+        # Transaction-local ANN tuning. The dispatcher only returns GUCs that
+        # are safe to apply at session/transaction scope for the configured
+        # backend. VectorChord probe values are index-shaped, so vchordrq uses
+        # index storage fallback parameters instead of a blanket SET LOCAL.
         for guc, value in ann_search_tuning_settings(configured_vector_extension(), kind="low_latency"):
             await conn.execute(f"SET LOCAL {guc} = {value}")
 
@@ -636,7 +634,7 @@ async def compute_semantic_links_ann(
             logger.debug(f"[ANN] fact_type={fact_type}: {len(ft_rows)} rows in {time_mod.time() - t_query:.3f}s")
             rows.extend(ft_rows)
     # Transaction commits here. _ann_seeds is dropped (ON COMMIT DROP).
-    # hnsw.ef_search reverts (SET LOCAL).
+    # Transaction-local ANN tuning reverts (SET LOCAL).
 
     for row in rows:
         sim = float(min(1.0, max(0.0, row["similarity"])))

--- a/hindsight-api-slim/tests/test_link_utils.py
+++ b/hindsight-api-slim/tests/test_link_utils.py
@@ -511,16 +511,13 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("ext", "guc"),
-        [("pgvector", "hnsw.ef_search"), ("vchord", "vchordrq.probes")],
-    )
-    async def test_uses_set_local_for_ann_tuning(self, mock_conn, monkeypatch, ext, guc):
+    async def test_uses_set_local_for_pgvector_ann_tuning(self, mock_conn, monkeypatch):
         """The per-backend ANN tuning GUC must be set with SET LOCAL so the
         change is scoped to the transaction. Without SET LOCAL, the setting
         would leak onto the pooled backend and affect subsequent recall
         queries that land on the same backend."""
-        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", ext)
+        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector")
+        guc = "hnsw.ef_search"
         emb = [0.1] * 384
         await compute_semantic_links_ann(
             conn=mock_conn,
@@ -532,8 +529,29 @@ class TestComputeSemanticLinksAnnPgBouncerSafety:
 
         executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
         tuning_statements = [s for s in executed_sql if guc in s]
-        assert tuning_statements, f"{guc} must be tuned for retain ANN under ext={ext}"
+        assert tuning_statements, f"{guc} must be tuned for retain ANN under pgvector"
         for stmt in tuning_statements:
             assert stmt.strip().startswith("SET LOCAL"), f"{guc} must use SET LOCAL, got: {stmt}"
         # And there must not be a RESET — SET LOCAL handles it at commit.
         assert not any(f"RESET {guc}" in s for s in executed_sql)
+
+    @pytest.mark.asyncio
+    async def test_vchord_ann_does_not_set_fixed_probe_count(self, mock_conn, monkeypatch):
+        """VectorChord probe counts must come from index/default config.
+
+        VectorChord requires vchordrq.probes to match the index's
+        build.internal.lists shape. Hindsight must not apply one fixed session
+        GUC across listless and partitioned vchordrq indexes.
+        """
+        monkeypatch.setenv("HINDSIGHT_API_VECTOR_EXTENSION", "vchord")
+        emb = [0.1] * 384
+        await compute_semantic_links_ann(
+            conn=mock_conn,
+            bank_id="bank-1",
+            unit_ids=["u1"],
+            embeddings=[emb],
+            fact_types=["world"],
+        )
+
+        executed_sql = [call.args[0] for call in mock_conn.execute.call_args_list]
+        assert not any("vchordrq.probes" in s for s in executed_sql)

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -81,15 +81,17 @@ def test_ann_search_tuning_settings_pgvector_dispatches_hnsw_ef_search():
     assert ann_search_tuning_settings("pgvector", kind="high_recall") == (("hnsw.ef_search", "200"),)
 
 
-def test_ann_search_tuning_settings_vchord_dispatches_vchordrq_probes():
-    # vchord doesn't recognize hnsw.ef_search; the dispatcher must route to
-    # the vchordrq equivalent (probes), otherwise the GUC silently does nothing.
-    assert ann_search_tuning_settings("vchord", kind="low_latency") == (("vchordrq.probes", "10"),)
-    assert ann_search_tuning_settings("vchord", kind="high_recall") == (("vchordrq.probes", "30"),)
+def test_ann_search_tuning_settings_vchord_leaves_probes_to_index_defaults():
+    # vchordrq.probes must match the index's build.internal.lists shape.
+    # VectorChord 1.1 supports per-index fallback parameters for this; a
+    # session GUC would override every index and can be invalid for listless or
+    # mixed-layout indexes.
+    assert ann_search_tuning_settings("vchord", kind="low_latency") == ()
+    assert ann_search_tuning_settings("vchord", kind="high_recall") == ()
 
 
 def test_ann_search_tuning_settings_returns_empty_for_backends_without_knob():
-    for ext in ("pgvectorscale", "pg_diskann", "scann"):
+    for ext in ("vchord", "pgvectorscale", "pg_diskann", "scann"):
         assert ann_search_tuning_settings(ext, kind="low_latency") == ()
         assert ann_search_tuning_settings(ext, kind="high_recall") == ()
 


### PR DESCRIPTION
## Summary

Stop applying the blanket session-level `vchordrq.probes` GUC for the **vchord** vector backend. The dispatcher now returns no ANN-tuning statements for vchord; pgvector `hnsw.ef_search` tuning is unchanged.

## The bug (vchord deployments only)

Hindsight set a session-level `vchordrq.probes` override (`10` on the retain link path via `SET LOCAL`, `30` on pooled connections via `SET`). But VectorChord requires the `probes` value to match each index's `build.internal.lists` hierarchy. Hindsight's built-in vchordrq index clause does **not** set `lists`, so the index is *listless* and expects **0 probes** — supplying any value makes the query fail with:

```
need 0 probes, but 1 probes provided
```

Concretely, on a vchord backend this rejects the worker's retain completion **after** LLM extraction has already succeeded (`output_tokens: 1104, time: 230s` in the worker log), so the retain op retries forever, the worker queue fills with stuck retain ops, and **consolidation is blocked**. A hard, full-stop break for vchord users.

This was introduced by #1668 (which correctly moved vchord to `vector_cosine_ops` but also added the blanket probe GUCs). Reported in #1667.

## Fix

Remove the `vchord` entries from `_ANN_TUNING_LOW_LATENCY` / `_ANN_TUNING_HIGH_RECALL`, so `ann_search_tuning_settings("vchord", …)` returns `()` and no session-level probe override is applied. Deployments that *do* create partitioned vchordrq indexes should attach probes via VectorChord 1.1 index storage fallback parameters instead — the safe place for index-shaped tuning.

## Verification

- `uv run pytest tests/test_vector_index.py tests/test_link_utils.py::TestComputeSemanticLinksAnnPgBouncerSafety -q` — 23 passed
- Tests assert pgvector still uses `SET LOCAL hnsw.ef_search` and that vchord emits no `vchordrq.probes`.

## Scope

This is the isolated regression fix split out of #1954; the structured-output / `strict_schema` hardening in that PR is a separate concern and is intentionally **not** included here.