### PR TITLE
feat(api): add Gemini Batch API support for retain fact extraction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2392,7 +2392,7 @@ class MemoryEngine(MemoryEngineInterface):
                             f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "
                             f"but the retain LLM provider '{self._retain_llm_config.provider}' "
                             f"does not support the batch API. Either switch to a provider "
-                            f"that supports batch operations (e.g. 'openai', 'groq') or "
+                            f"that supports batch operations (e.g. 'openai', 'groq', 'gemini') or "
                             f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
                         )
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -8,6 +8,7 @@ This provider supports both:
 
 import asyncio
 import base64
+import io
 import json
 import logging
 import os
@@ -41,6 +42,14 @@ try:
     VERTEXAI_AVAILABLE = True
 except ImportError:
     VERTEXAI_AVAILABLE = False
+
+
+def _to_int(value: Any) -> int:
+    """Coerce Gemini's optional/string completion counts to int, defaulting to 0."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return 0
 
 
 class GeminiLLM(LLMInterface):
@@ -825,6 +834,282 @@ class GeminiLLM(LLMInterface):
             response_schema=response_schema,
             tools=tools,
         )
+
+    # ── Batch API (Gemini API only — not Vertex AI) ─────────────────────────
+    #
+    # Google's Gemini Batch API gives a flat 50% discount on input + output
+    # tokens with a 24h completion SLA (https://ai.google.dev/gemini-api/docs/batch-api).
+    # The retain orchestrator and ``fact_extraction`` consumer speak the
+    # OpenAI-batch interface contract, so these overrides translate that shape
+    # to/from Gemini's file-upload → ``batches.create`` → ``batches.get`` →
+    # download flow — nothing downstream changes (same pattern as FireworksLLM).
+    #
+    # Interface contract preserved (see fact_extraction.py result handling)::
+    #     result["response"]["body"]["choices"][0]["message"]["content"]
+
+    async def supports_batch_api(self) -> bool:
+        """True for the Gemini API; False for Vertex AI.
+
+        Only ``provider="gemini"`` is supported: it exposes the file-upload
+        Batch API used below. Vertex AI's batch path is GCS/BigQuery-backed (no
+        file-upload analogue), so it stays unsupported here — the startup
+        validation then surfaces a clear error instead of silently falling back
+        to synchronous, full-price calls.
+        """
+        return self.provider == "gemini"
+
+    async def submit_batch(
+        self,
+        requests: list[dict[str, Any]],
+        endpoint: str = "/v1/chat/completions",
+        completion_window: str = "24h",
+    ) -> dict[str, Any]:
+        """Submit a batch of (OpenAI-shaped) requests to the Gemini Batch API."""
+        if not await self.supports_batch_api():
+            raise NotImplementedError(f"Batch API not supported for provider: {self.provider}")
+
+        # endpoint/completion_window are part of the shared LLMInterface batch
+        # contract (used by the OpenAI path) but have no analogue on Gemini: the
+        # request shape is fixed (generateContent) and the SLA is server-side.
+        # Kept for signature compatibility with the shared retain driver.
+        logger.info(f"Submitting Gemini batch with {len(requests)} requests")
+
+        jsonl = self._translate_requests(requests)
+
+        # Upload the JSONL as a Gemini file (mime_type must be "jsonl"; a
+        # BytesIO has no path for the SDK to infer it from).
+        file_obj = io.BytesIO(jsonl.encode("utf-8"))
+        uploaded = await self._client.aio.files.upload(
+            file=file_obj,
+            config=genai_types.UploadFileConfig(mime_type="jsonl", display_name="hindsight-batch-input"),
+        )
+
+        batch = await self._client.aio.batches.create(
+            model=self.model,
+            src=uploaded.name,
+            config=genai_types.CreateBatchJobConfig(display_name="hindsight-batch"),
+        )
+
+        logger.info(f"Gemini batch submitted: {batch.name}, state={self._state_name(batch.state)}")
+
+        return {
+            "batch_id": batch.name,
+            "status": self._normalize_state(batch.state),
+            "input_file_id": uploaded.name,
+            "request_count": len(requests),
+        }
+
+    async def get_batch_status(self, batch_id: str) -> dict[str, Any]:
+        """Get the status of a Gemini batch job, in the shared status shape."""
+        if not await self.supports_batch_api():
+            raise NotImplementedError(f"Batch API not supported for provider: {self.provider}")
+
+        batch = await self._client.aio.batches.get(name=batch_id)
+
+        stats = batch.completion_stats
+        successful = _to_int(getattr(stats, "successful_count", None)) if stats else 0
+        failed = _to_int(getattr(stats, "failed_count", None)) if stats else 0
+        incomplete = _to_int(getattr(stats, "incomplete_count", None)) if stats else 0
+
+        result: dict[str, Any] = {
+            "batch_id": batch.name,
+            "status": self._normalize_state(batch.state),
+            "request_counts": {
+                "total": successful + failed + incomplete,
+                "completed": successful,
+                "failed": failed,
+            },
+        }
+
+        if batch.dest and getattr(batch.dest, "file_name", None):
+            result["output_file_id"] = batch.dest.file_name
+        if batch.error:
+            result["errors"] = self._error_to_dict(batch.error)
+
+        return result
+
+    async def retrieve_batch_results(self, batch_id: str) -> list[dict[str, Any]]:
+        """Download and normalize completed Gemini batch results."""
+        if not await self.supports_batch_api():
+            raise NotImplementedError(f"Batch API not supported for provider: {self.provider}")
+
+        batch = await self._client.aio.batches.get(name=batch_id)
+
+        status = self._normalize_state(batch.state)
+        if status != "completed":
+            raise ValueError(f"Gemini batch {batch_id} is not completed yet (state: {self._state_name(batch.state)})")
+
+        dest = batch.dest
+        if not dest or not getattr(dest, "file_name", None):
+            raise ValueError(
+                f"Gemini batch {batch_id} completed but reported no output file "
+                f"(submit_batch always uses file mode, so this is unexpected)"
+            )
+
+        content = await self._client.aio.files.download(file=dest.file_name)
+        text = content.decode("utf-8") if isinstance(content, (bytes, bytearray)) else str(content)
+
+        # The output is a JSONL error file plus results merged into one stream;
+        # error lines carry an `error` so partial failures surface per key
+        # instead of vanishing (JOB_STATE_PARTIALLY_SUCCEEDED maps to completed).
+        results: list[dict[str, Any]] = []
+        for line in text.strip().split("\n"):
+            if line.strip():
+                results.append(self._normalize_output_line(json.loads(line)))
+
+        logger.info(f"Retrieved {len(results)} results for Gemini batch {batch_id}")
+        return results
+
+    # ----- pure translation/normalization helpers (unit-tested) ----------
+
+    @staticmethod
+    def _translate_requests(requests: list[dict[str, Any]]) -> str:
+        """OpenAI batch requests -> Gemini batch input JSONL.
+
+        Each output line is ``{"key": <custom_id>, "request": <GenerateContentRequest>}``;
+        the model is supplied to ``batches.create`` so it is omitted per-line.
+        """
+        lines = []
+        for req in requests:
+            gemini_request = GeminiLLM._openai_body_to_gemini_request(req.get("body") or {})
+            lines.append(json.dumps({"key": req.get("custom_id"), "request": gemini_request}, ensure_ascii=False))
+        return "\n".join(lines)
+
+    @staticmethod
+    def _openai_body_to_gemini_request(body: dict[str, Any]) -> dict[str, Any]:
+        """OpenAI chat-completions body -> Gemini ``GenerateContentRequest`` JSON.
+
+        Mirrors the synchronous ``call`` path: system messages become
+        ``systemInstruction``; a ``response_format`` json_schema forces JSON
+        output (``responseMimeType``), appends the schema as a textual hint, and
+        grammar-enforces via ``responseJsonSchema`` when ``strict`` is set.
+        """
+        system_texts: list[str] = []
+        contents: list[dict[str, Any]] = []
+        for msg in body.get("messages") or []:
+            role = msg.get("role", "user")
+            text = msg.get("content", "") or ""
+            if role == "system":
+                system_texts.append(text)
+            elif role == "assistant":
+                contents.append({"role": "model", "parts": [{"text": text}]})
+            else:
+                contents.append({"role": "user", "parts": [{"text": text}]})
+
+        generation_config: dict[str, Any] = {}
+        if body.get("temperature") is not None:
+            generation_config["temperature"] = body["temperature"]
+        if body.get("max_completion_tokens") is not None:
+            generation_config["maxOutputTokens"] = body["max_completion_tokens"]
+
+        response_format = body.get("response_format")
+        if isinstance(response_format, dict) and response_format.get("type") == "json_schema":
+            json_schema = response_format.get("json_schema") or {}
+            schema = json_schema.get("schema")
+            generation_config["responseMimeType"] = "application/json"
+            if schema:
+                system_texts.append(
+                    "You must respond with valid JSON matching this schema:\n" + json.dumps(schema, ensure_ascii=False)
+                )
+                if json_schema.get("strict"):
+                    generation_config["responseJsonSchema"] = schema
+
+        request: dict[str, Any] = {"contents": contents}
+        if system_texts:
+            request["systemInstruction"] = {"parts": [{"text": "\n\n".join(system_texts)}]}
+        if generation_config:
+            request["generationConfig"] = generation_config
+        return request
+
+    @staticmethod
+    def _normalize_output_line(line: dict[str, Any]) -> dict[str, Any]:
+        """Gemini batch output line -> OpenAI-batch-output shape.
+
+        Target: ``{"custom_id", "response": {"body": {"choices": [...], "usage": {...}}}, "error"}``
+        so the consumer's ``result["response"]["body"]["choices"][0]...`` works and
+        it can read ``body["usage"]`` for token accounting (the consumer reports
+        zero usage otherwise).
+        """
+        custom_id = line.get("key") if line.get("key") is not None else line.get("custom_id")
+        error = line.get("error")
+        if error:
+            return {"custom_id": custom_id, "response": None, "error": error}
+
+        response = line.get("response") or {}
+        body: dict[str, Any] = {"choices": [{"message": {"content": GeminiLLM._extract_text_from_response(response)}}]}
+        usage = GeminiLLM._usage_from_response(response)
+        if usage is not None:
+            body["usage"] = usage
+        return {"custom_id": custom_id, "response": {"body": body}, "error": None}
+
+    @staticmethod
+    def _extract_text_from_response(response: dict[str, Any]) -> str:
+        """Concatenate the text parts of a (JSON) GenerateContentResponse."""
+        candidates = response.get("candidates") or []
+        if not candidates:
+            return ""
+        content = candidates[0].get("content") or {}
+        parts = content.get("parts") or []
+        return "".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text"))
+
+    @staticmethod
+    def _usage_from_response(response: dict[str, Any]) -> dict[str, Any] | None:
+        """Gemini ``usageMetadata`` -> OpenAI-shaped ``usage`` block, or None.
+
+        The batch consumer accumulates token usage from ``body["usage"]`` using
+        OpenAI key names, so translate here to keep the output contract uniform
+        across providers. Handles both the REST camelCase (downloaded JSONL) and
+        snake_case spellings defensively.
+        """
+        meta = response.get("usageMetadata") or response.get("usage_metadata")
+        if not isinstance(meta, dict):
+            return None
+        prompt = meta.get("promptTokenCount") or meta.get("prompt_token_count") or 0
+        completion = meta.get("candidatesTokenCount") or meta.get("candidates_token_count") or 0
+        total = meta.get("totalTokenCount") or meta.get("total_token_count") or 0
+        return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total}
+
+    @staticmethod
+    def _normalize_state(state: Any) -> str:
+        """Gemini ``JobState`` -> the retain driver's status strings.
+
+        Unknown / in-flight states map to ``in_progress`` so the driver keeps
+        polling; ``PARTIALLY_SUCCEEDED`` maps to ``completed`` (per-line errors
+        surface the partial failures during retrieval).
+        """
+        name = GeminiLLM._state_name(state).upper()
+        if name in ("JOB_STATE_SUCCEEDED", "JOB_STATE_PARTIALLY_SUCCEEDED"):
+            return "completed"
+        if name == "JOB_STATE_FAILED":
+            return "failed"
+        if name in ("JOB_STATE_CANCELLED", "JOB_STATE_CANCELLING"):
+            return "cancelled"
+        if name == "JOB_STATE_EXPIRED":
+            return "expired"
+        return "in_progress"
+
+    @staticmethod
+    def _state_name(state: Any) -> str:
+        """Extract the bare ``JOB_STATE_*`` name from a JobState enum or string."""
+        if state is None:
+            return ""
+        name = getattr(state, "name", None)
+        if name:
+            return str(name)
+        text = str(state)
+        if "." in text:
+            text = text.rsplit(".", 1)[-1]
+        return text
+
+    @staticmethod
+    def _error_to_dict(error: Any) -> dict[str, Any]:
+        """Coerce a Gemini JobError into a JSON-serializable dict for logging."""
+        if hasattr(error, "model_dump"):
+            try:
+                return error.model_dump(exclude_none=True)
+            except Exception:
+                pass
+        return {"message": str(error)}
 
     async def cleanup(self) -> None:
         """Clean up resources (close connections, etc.)."""

--- a/hindsight-api-slim/tests/test_batch_api_validation.py
+++ b/hindsight-api-slim/tests/test_batch_api_validation.py
@@ -23,7 +23,8 @@ async def test_startup_rejects_batch_enabled_with_non_batch_provider():
     mock_provider.supports_batch_api = AsyncMock(return_value=False)
 
     mock_llm_config = MagicMock()
-    mock_llm_config.provider = "gemini"
+    # anthropic has no batch API in the engine — a genuine non-batch provider.
+    mock_llm_config.provider = "anthropic"
     mock_llm_config._provider_impl = mock_provider
     mock_llm_config.verify_connection = AsyncMock()
 
@@ -40,7 +41,7 @@ async def test_startup_rejects_batch_enabled_with_non_batch_provider():
                     f"Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true "
                     f"but the retain LLM provider '{mock_llm_config.provider}' "
                     f"does not support the batch API. Either switch to a provider "
-                    f"that supports batch operations (e.g. 'openai', 'groq') or "
+                    f"that supports batch operations (e.g. 'openai', 'groq', 'gemini') or "
                     f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
                 )
 
@@ -97,7 +98,7 @@ async def test_runtime_raises_if_batch_unsupported():
     with pytest.raises(RuntimeError, match="does not support the batch API"):
         if not await mock_provider.supports_batch_api():
             raise RuntimeError(
-                "retain_batch_enabled=True but provider 'gemini' does not "
+                "retain_batch_enabled=True but provider 'anthropic' does not "
                 "support the batch API. This should have been caught at startup -- check "
                 "HINDSIGHT_API_RETAIN_BATCH_ENABLED and your LLM provider configuration."
             )

--- a/hindsight-api-slim/tests/test_gemini_batch.py
+++ b/hindsight-api-slim/tests/test_gemini_batch.py
@@ -1,0 +1,309 @@
+"""Tests for the Gemini Batch API provider path (``GeminiLLM`` batch overrides).
+
+Google's Gemini Batch API gives a flat 50% input+output discount with a 24h SLA
+(https://ai.google.dev/gemini-api/docs/batch-api). ``GeminiLLM`` extends
+``LLMInterface`` directly (not the OpenAI-compatible base), so it overrides the
+four batch members and translates Gemini's file-upload -> ``batches.create`` ->
+``batches.get`` -> download flow back onto the OpenAI-batch interface contract
+that the retain orchestrator + ``fact_extraction`` consumer depend on.
+
+The interface contract that MUST be preserved (see fact_extraction.py)::
+    result["response"]["body"]["choices"][0]["message"]["content"]
+
+The pure translation/normalization helpers are unit-tested directly; the async
+submit/status/retrieve flow is tested against a fake genai client. A live key is
+only needed for the (separate) end-to-end path.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("google.genai")
+
+from hindsight_api.engine.providers.gemini_llm import GeminiLLM
+
+
+def _make_gemini(model: str = "gemini-2.5-flash") -> GeminiLLM:
+    # Patch the genai client constructor so no real credentials/network are used;
+    # the batch tests swap in a fake aio client below.
+    with patch("hindsight_api.engine.providers.gemini_llm.genai.Client", MagicMock()):
+        return GeminiLLM(provider="gemini", api_key="test-key", base_url="", model=model)
+
+
+def _openai_request(custom_id: str, *, strict: bool = True) -> dict:
+    return {
+        "custom_id": custom_id,
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "system", "content": "Extract facts."},
+                {"role": "user", "content": "Paris is the capital of France."},
+            ],
+            "temperature": 0.1,
+            "max_completion_tokens": 2048,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "facts",
+                    "schema": {"type": "object", "properties": {"facts": {"type": "array"}}},
+                    "strict": strict,
+                },
+            },
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Structural: capability flag (gemini yes, vertexai no)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gemini_supports_batch_api_is_true():
+    llm = _make_gemini()
+    assert await llm.supports_batch_api() is True
+
+
+@pytest.mark.asyncio
+async def test_vertexai_does_not_support_batch_api():
+    # Vertex AI's batch path is GCS/BigQuery-backed (no file upload), so it stays
+    # unsupported — the startup validation then raises a clear error.
+    llm = _make_gemini()
+    llm.provider = "vertexai"
+    assert await llm.supports_batch_api() is False
+
+
+# --------------------------------------------------------------------------
+# Pure translation: OpenAI body -> Gemini GenerateContentRequest
+# --------------------------------------------------------------------------
+
+
+def test_translate_requests_builds_keyed_jsonl():
+    jsonl = GeminiLLM._translate_requests([_openai_request("chunk_0"), _openai_request("chunk_1")])
+    lines = jsonl.split("\n")
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["key"] == "chunk_0"
+    assert set(first["request"].keys()) == {"contents", "systemInstruction", "generationConfig"}
+
+
+def test_body_translation_maps_roles_and_generation_config():
+    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c")["body"])
+
+    # system -> systemInstruction; user -> contents(role=user)
+    assert req["contents"] == [{"role": "user", "parts": [{"text": "Paris is the capital of France."}]}]
+    assert req["systemInstruction"]["parts"][0]["text"].startswith("Extract facts.")
+
+    gc = req["generationConfig"]
+    assert gc["temperature"] == 0.1
+    assert gc["maxOutputTokens"] == 2048
+    assert gc["responseMimeType"] == "application/json"
+    # strict=True -> grammar-enforced via responseJsonSchema
+    assert gc["responseJsonSchema"] == {"type": "object", "properties": {"facts": {"type": "array"}}}
+    # schema is also appended as a textual hint (mirrors the sync call path)
+    assert "valid JSON matching this schema" in req["systemInstruction"]["parts"][0]["text"]
+
+
+def test_body_translation_omits_response_json_schema_when_not_strict():
+    req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c", strict=False)["body"])
+    gc = req["generationConfig"]
+    # Non-strict still forces JSON output, but does not grammar-enforce the schema
+    assert gc["responseMimeType"] == "application/json"
+    assert "responseJsonSchema" not in gc
+
+
+def test_assistant_role_maps_to_model():
+    body = {"messages": [{"role": "assistant", "content": "prior turn"}]}
+    req = GeminiLLM._openai_body_to_gemini_request(body)
+    assert req["contents"] == [{"role": "model", "parts": [{"text": "prior turn"}]}]
+    assert "systemInstruction" not in req
+
+
+# --------------------------------------------------------------------------
+# Pure normalization: Gemini output line -> OpenAI-batch-output shape
+# --------------------------------------------------------------------------
+
+
+def test_normalize_output_line_success_preserves_contract():
+    line = {
+        "key": "chunk_0",
+        "response": {"candidates": [{"content": {"parts": [{"text": '{"facts": []}'}]}}]},
+    }
+    out = GeminiLLM._normalize_output_line(line)
+    assert out["custom_id"] == "chunk_0"
+    assert out["error"] is None
+    # The exact path fact_extraction.py reads:
+    assert out["response"]["body"]["choices"][0]["message"]["content"] == '{"facts": []}'
+
+
+def test_normalize_output_line_concatenates_multiple_text_parts():
+    line = {
+        "key": "chunk_0",
+        "response": {"candidates": [{"content": {"parts": [{"text": "a"}, {"text": "b"}]}}]},
+    }
+    out = GeminiLLM._normalize_output_line(line)
+    assert out["response"]["body"]["choices"][0]["message"]["content"] == "ab"
+
+
+def test_normalize_output_line_includes_translated_usage():
+    line = {
+        "key": "chunk_0",
+        "response": {
+            "candidates": [{"content": {"parts": [{"text": "{}"}]}}],
+            "usageMetadata": {"promptTokenCount": 120, "candidatesTokenCount": 30, "totalTokenCount": 150},
+        },
+    }
+    out = GeminiLLM._normalize_output_line(line)
+    # OpenAI-shaped usage block the batch consumer accumulates (was missing -> usage=0).
+    assert out["response"]["body"]["usage"] == {
+        "prompt_tokens": 120,
+        "completion_tokens": 30,
+        "total_tokens": 150,
+    }
+
+
+def test_normalize_output_line_omits_usage_when_absent():
+    line = {"key": "chunk_0", "response": {"candidates": [{"content": {"parts": [{"text": "{}"}]}}]}}
+    out = GeminiLLM._normalize_output_line(line)
+    assert "usage" not in out["response"]["body"]
+
+
+def test_normalize_output_line_error_surfaces_per_key():
+    line = {"key": "chunk_1", "error": {"code": 400, "message": "bad request"}}
+    out = GeminiLLM._normalize_output_line(line)
+    assert out["custom_id"] == "chunk_1"
+    assert out["response"] is None
+    assert out["error"] == {"code": 400, "message": "bad request"}
+
+
+def test_extract_text_from_empty_response_is_empty_string():
+    assert GeminiLLM._extract_text_from_response({}) == ""
+    assert GeminiLLM._extract_text_from_response({"candidates": []}) == ""
+
+
+# --------------------------------------------------------------------------
+# Pure status mapping
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        ("JOB_STATE_SUCCEEDED", "completed"),
+        ("JOB_STATE_PARTIALLY_SUCCEEDED", "completed"),
+        ("JOB_STATE_FAILED", "failed"),
+        ("JOB_STATE_CANCELLED", "cancelled"),
+        ("JOB_STATE_CANCELLING", "cancelled"),
+        ("JOB_STATE_EXPIRED", "expired"),
+        ("JOB_STATE_RUNNING", "in_progress"),
+        ("JOB_STATE_PENDING", "in_progress"),
+        ("JOB_STATE_QUEUED", "in_progress"),
+        ("JOB_STATE_UNSPECIFIED", "in_progress"),
+    ],
+)
+def test_normalize_state(state, expected):
+    assert GeminiLLM._normalize_state(state) == expected
+
+
+def test_normalize_state_handles_enum_and_qualified_string():
+    assert GeminiLLM._normalize_state(SimpleNamespace(name="JOB_STATE_SUCCEEDED")) == "completed"
+    assert GeminiLLM._normalize_state("JobState.JOB_STATE_RUNNING") == "in_progress"
+    assert GeminiLLM._normalize_state(None) == "in_progress"
+
+
+# --------------------------------------------------------------------------
+# Async flow: submit -> status -> retrieve against a fake genai client
+# --------------------------------------------------------------------------
+
+
+def _fake_client(*, get_batch, download_text: bytes | None = None) -> MagicMock:
+    """Build a fake ``client.aio`` namespace covering the batch flow."""
+    aio = MagicMock()
+    aio.files.upload = AsyncMock(return_value=SimpleNamespace(name="files/uploaded-123"))
+    aio.batches.create = AsyncMock(return_value=SimpleNamespace(name="batches/abc", state="JOB_STATE_PENDING"))
+    aio.batches.get = AsyncMock(return_value=get_batch)
+    if download_text is not None:
+        aio.files.download = AsyncMock(return_value=download_text)
+    client = MagicMock()
+    client.aio = aio
+    return client
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_uploads_and_creates_job():
+    llm = _make_gemini()
+    llm._client = _fake_client(get_batch=None)
+
+    meta = await llm.submit_batch([_openai_request("chunk_0"), _openai_request("chunk_1")])
+
+    assert meta["batch_id"] == "batches/abc"
+    assert meta["status"] == "in_progress"  # JOB_STATE_PENDING
+    assert meta["request_count"] == 2
+
+    # Uploaded JSONL had one line per request, and the job used the model + file.
+    upload_kwargs = llm._client.aio.files.upload.call_args.kwargs
+    uploaded_bytes = upload_kwargs["file"].getvalue().decode("utf-8")
+    assert len(uploaded_bytes.strip().split("\n")) == 2
+    assert upload_kwargs["config"].mime_type == "jsonl"
+
+    create_kwargs = llm._client.aio.batches.create.call_args.kwargs
+    assert create_kwargs["model"] == "gemini-2.5-flash"
+    assert create_kwargs["src"] == "files/uploaded-123"
+
+
+@pytest.mark.asyncio
+async def test_get_batch_status_maps_counts_and_output_file():
+    batch = SimpleNamespace(
+        name="batches/abc",
+        state="JOB_STATE_SUCCEEDED",
+        completion_stats=SimpleNamespace(successful_count=3, failed_count=1, incomplete_count=0),
+        dest=SimpleNamespace(file_name="files/output-999"),
+        error=None,
+    )
+    llm = _make_gemini()
+    llm._client = _fake_client(get_batch=batch)
+
+    status = await llm.get_batch_status("batches/abc")
+    assert status["status"] == "completed"
+    assert status["request_counts"] == {"total": 4, "completed": 3, "failed": 1}
+    assert status["output_file_id"] == "files/output-999"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_batch_results_downloads_and_normalizes():
+    output_lines = [
+        {"key": "chunk_0", "response": {"candidates": [{"content": {"parts": [{"text": '{"facts": []}'}]}}]}},
+        {"key": "chunk_1", "error": {"code": 500, "message": "boom"}},
+    ]
+    download_text = ("\n".join(json.dumps(line) for line in output_lines)).encode("utf-8")
+    batch = SimpleNamespace(
+        name="batches/abc",
+        state="JOB_STATE_SUCCEEDED",
+        completion_stats=None,
+        dest=SimpleNamespace(file_name="files/output-999"),
+        error=None,
+    )
+    llm = _make_gemini()
+    llm._client = _fake_client(get_batch=batch, download_text=download_text)
+
+    results = await llm.retrieve_batch_results("batches/abc")
+    by_id = {r["custom_id"]: r for r in results}
+    assert by_id["chunk_0"]["response"]["body"]["choices"][0]["message"]["content"] == '{"facts": []}'
+    assert by_id["chunk_1"]["error"] == {"code": 500, "message": "boom"}
+
+    llm._client.aio.files.download.assert_awaited_once()
+    assert llm._client.aio.files.download.call_args.kwargs["file"] == "files/output-999"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_batch_results_raises_when_not_completed():
+    batch = SimpleNamespace(name="batches/abc", state="JOB_STATE_RUNNING", completion_stats=None, dest=None, error=None)
+    llm = _make_gemini()
+    llm._client = _fake_client(get_batch=batch)
+    with pytest.raises(ValueError, match="not completed"):
+        await llm.retrieve_batch_results("batches/abc")

--- a/hindsight-api-slim/tests/test_gemini_batch_integration.py
+++ b/hindsight-api-slim/tests/test_gemini_batch_integration.py
@@ -1,0 +1,122 @@
+"""Live integration test for the Gemini Batch API provider.
+
+This makes REAL calls to the Gemini Batch API and runs the full retain fact
+extraction pipeline end-to-end (translate -> upload JSONL -> batches.create ->
+poll -> download -> normalize -> parse facts). It is the only test that
+validates the one assumption the unit tests (which use a fake genai client)
+cannot: that Gemini's real batch output JSONL shape matches what
+``_normalize_output_line`` produces and what ``fact_extraction`` consumes. If
+the shape is wrong, this returns zero facts.
+
+Skipped automatically unless a Gemini API key is present. To run:
+
+    export GEMINI_API_KEY=...                          # or HINDSIGHT_API_GEMINI_API_KEY
+    # optional: override the model
+    export HINDSIGHT_API_GEMINI_TEST_MODEL=gemini-2.5-flash
+    uv run pytest tests/test_gemini_batch_integration.py -v -s
+
+It is slow (typically minutes, but the SLA is up to 24h) and costs money, so it
+does not run in CI (no key there). No database is required — it calls the
+extraction function directly with ``pool=None``.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+from dotenv import load_dotenv
+
+from hindsight_api.config import HindsightConfig, clear_config_cache
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.retain.fact_extraction import (
+    RetainContent,
+    extract_facts_from_contents_batch_api,
+)
+
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+_DEFAULT_TEST_MODEL = "gemini-2.5-flash"
+
+
+@dataclass
+class GeminiTestEnv:
+    api_key: str
+    model: str
+
+
+@pytest.fixture
+def gemini_env() -> GeminiTestEnv:
+    api_key = os.getenv("GEMINI_API_KEY") or os.getenv("HINDSIGHT_API_GEMINI_API_KEY")
+    if not api_key:
+        pytest.skip("Set GEMINI_API_KEY (or HINDSIGHT_API_GEMINI_API_KEY) to run the live Gemini batch test")
+
+    clear_config_cache()
+
+    return GeminiTestEnv(
+        api_key=api_key,
+        model=os.getenv("HINDSIGHT_API_GEMINI_TEST_MODEL", _DEFAULT_TEST_MODEL),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_real_gemini_batch_end_to_end(gemini_env):
+    config = HindsightConfig.from_env()
+    config.retain_batch_enabled = True
+    config.retain_batch_poll_interval_seconds = 30
+    config.retain_chunk_size = 4000
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = False
+
+    llm_config = LLMProvider(
+        provider="gemini",
+        api_key=gemini_env.api_key,
+        base_url="",
+        model=gemini_env.model,
+        reasoning_effort="low",
+    )
+    assert await llm_config._provider_impl.supports_batch_api() is True
+
+    contents = [
+        RetainContent(
+            content=(
+                "Alice is a senior software engineer at TechCorp. She specializes in "
+                "distributed systems and graduated from MIT in 2015."
+            ),
+            event_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            context="team member profile",
+        )
+    ]
+
+    logger.info("Submitting a real Gemini batch (this can take several minutes)...")
+    facts, chunks, usage = await extract_facts_from_contents_batch_api(
+        contents=contents,
+        llm_config=llm_config,
+        agent_name="test_agent",
+        config=config,
+        pool=None,
+        operation_id=None,
+        schema=None,
+    )
+
+    # The end-to-end proof: if the real output shape doesn't match the normalizer,
+    # the consumer extracts nothing and this is empty.
+    assert len(facts) > 0, (
+        "Gemini batch returned no facts. The live output JSONL shape likely "
+        "differs from what _normalize_output_line produces — inspect a raw output "
+        "line and adjust the normalizer."
+    )
+    assert any("Alice" in fact.fact_text for fact in facts)
+    # Token usage must be threaded from Gemini's usageMetadata into the batch
+    # result body — otherwise the consumer reports zero (the bug this guards).
+    assert usage.total_tokens > 0, "Gemini batch reported zero token usage — usageMetadata translation is broken"
+    assert usage.input_tokens > 0 and usage.output_tokens > 0
+    logger.info(
+        f"Extracted {len(facts)} facts; usage in={usage.input_tokens} out={usage.output_tokens} "
+        f"total={usage.total_tokens} tokens"
+    )

--- a/hindsight-api-slim/tests/test_gemini_batch_integration.py
+++ b/hindsight-api-slim/tests/test_gemini_batch_integration.py
@@ -8,16 +8,21 @@ cannot: that Gemini's real batch output JSONL shape matches what
 ``_normalize_output_line`` produces and what ``fact_extraction`` consumes. If
 the shape is wrong, this returns zero facts.
 
-Skipped automatically unless a Gemini API key is present. To run:
+This is an explicit opt-in test. It is gated on a dedicated flag rather than
+just "a Gemini API key exists" because CI always has a Gemini key (Gemini is the
+LLM-as-judge / core-LLM provider) — keying off the API key alone would let this
+slow batch job run in the standard CI shard and blow the 300s pytest timeout. To
+run it:
 
+    export HINDSIGHT_API_GEMINI_BATCH_LIVE_TEST=1
     export GEMINI_API_KEY=...                          # or HINDSIGHT_API_GEMINI_API_KEY
     # optional: override the model
     export HINDSIGHT_API_GEMINI_TEST_MODEL=gemini-2.5-flash
     uv run pytest tests/test_gemini_batch_integration.py -v -s
 
-It is slow (typically minutes, but the SLA is up to 24h) and costs money, so it
-does not run in CI (no key there). No database is required — it calls the
-extraction function directly with ``pool=None``.
+It is slow (typically minutes, but Gemini's batch queue can take far longer; the
+SLA is up to 24h) and costs money, so it never runs in CI. No database is
+required — it calls the extraction function directly with ``pool=None``.
 """
 
 import logging
@@ -50,6 +55,12 @@ class GeminiTestEnv:
 
 @pytest.fixture
 def gemini_env() -> GeminiTestEnv:
+    # Opt-in flag, NOT just key presence: CI always has GEMINI_API_KEY (judge /
+    # core-LLM provider), so gating on the key alone runs this slow batch job in
+    # the standard CI shard and times out. Require an explicit flag CI never sets.
+    if os.getenv("HINDSIGHT_API_GEMINI_BATCH_LIVE_TEST", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("Set HINDSIGHT_API_GEMINI_BATCH_LIVE_TEST=1 (and GEMINI_API_KEY) to run the live Gemini batch test")
+
     api_key = os.getenv("GEMINI_API_KEY") or os.getenv("HINDSIGHT_API_GEMINI_API_KEY")
     if not api_key:
         pytest.skip("Set GEMINI_API_KEY (or HINDSIGHT_API_GEMINI_API_KEY) to run the live Gemini batch test")

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -321,7 +321,7 @@ When `async: true`, the call returns immediately with an `operation_id`. Process
 
 ### Cut Costs 50% with Provider Batch APIs
 
-When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI and Groq both offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.
+When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI, Groq, and Gemini all offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.
 
 ```bash
 export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
@@ -330,5 +330,5 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 Hindsight submits fact extraction calls as a batch job to the provider, polls for completion, and processes results automatically. No changes to your API calls are needed.
 
 :::note
-Batch API cost savings require `async=true` in your retain request and a compatible provider (OpenAI or Groq).
+Batch API cost savings require `async=true` in your retain request and a compatible provider (OpenAI, Groq, or Gemini).
 :::

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1012,7 +1012,9 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 | `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` to skip storing it. Static, server-level. | `true` |
 
-> **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
+> **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, `gemini`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
+>
+> **Gemini** uses the [Gemini Batch API](https://ai.google.dev/gemini-api/docs/batch-api) (flat 50% input + output discount, 24h SLA — typically minutes). It needs no extra settings beyond `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` and an API-key `gemini` provider; Vertex AI (`vertexai`) is not batch-capable.
 
 #### Fireworks batch inference
 

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -1,7 +1,7 @@
 [
   {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini", "batchApi": true},
   {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5-20251001"},
-  {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-3.5-flash", "promptCaching": true},
+  {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-3.5-flash", "batchApi": true, "promptCaching": true},
   {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "google/gemini-3.1-flash-lite", "promptCaching": true},
   {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b", "batchApi": true},
   {"id": "ollama",        "label": "Ollama",            "iconKey": "ollama",             "defaultModel": "gemma3:12b"},

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -508,7 +508,7 @@ When `async: true`, the call returns immediately with an `operation_id`. Process
 
 ### Cut Costs 50% with Provider Batch APIs
 
-When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI and Groq both offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.
+When using async retain, enable the provider Batch API to reduce LLM fact-extraction costs by 50%. OpenAI, Groq, and Gemini all offer this discount in exchange for a processing window of up to 24 hours — a trade-off that's typically invisible when retain already runs in the background.
 
 ```bash
 export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
@@ -517,4 +517,4 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 Hindsight submits fact extraction calls as a batch job to the provider, polls for completion, and processes results automatically. No changes to your API calls are needed.
 
 :::note
-Batch API cost savings require `async=true` in your retain request and a compatible provider (OpenAI or Groq).
+Batch API cost savings require `async=true` in your retain request and a compatible provider (OpenAI, Groq, or Gemini).

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1012,7 +1012,9 @@ Controls the retain (memory ingestion) pipeline.
 | `HINDSIGHT_API_RETAIN_BATCH_POLL_INTERVAL_SECONDS` | Batch API polling interval in seconds | `60` |
 | `HINDSIGHT_API_STORE_DOCUMENT_TEXT` | Persist the raw source text alongside extracted memories. Set to `false` to skip storing it. Static, server-level. | `true` |
 
-> **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
+> **Batch-capable providers.** `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` only works with a retain LLM provider that implements a batch API: `openai`, `groq`, `gemini`, and `fireworks`. Batch always requires async retain (`async=true`); a sync retain with batch enabled errors. Other providers fail fast at startup.
+>
+> **Gemini** uses the [Gemini Batch API](https://ai.google.dev/gemini-api/docs/batch-api) (flat 50% input + output discount, 24h SLA — typically minutes). It needs no extra settings beyond `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` and an API-key `gemini` provider; Vertex AI (`vertexai`) is not batch-capable.
 
 #### Fireworks batch inference
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -78,7 +78,7 @@ Beyond basic generation, some providers support optional features that lower cos
 |----------|:---------:|:-----------------------:|
 | OpenAI (`openai`) | ✅ | — |
 | Anthropic (`anthropic`) | — | — |
-| Google Gemini (`gemini`) | — | ✅ |
+| Google Gemini (`gemini`) | ✅ | ✅ |
 | Vertex AI (`vertexai`) | — | ✅ |
 | Groq (`groq`) | ✅ | — |
 | Ollama (`ollama`) | — | — |


### PR DESCRIPTION
## Summary

Adds **Gemini Batch API** support for retain fact extraction, addressing the Gemini portion of #1144. This unlocks Google's flat **50% Gemini Batch API discount** (input + output tokens, 24h SLA — typically completes in minutes) for Hindsight deployments on Gemini. Previously only OpenAI/Groq/Fireworks could get a provider-side batch discount, so Gemini users had to switch providers to benefit.

No new config or API surface: it's enabled by the existing `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` flag on async retain, exactly like the other batch providers.

## How it works

`GeminiLLM` now overrides the four `LLMInterface` batch methods (`supports_batch_api`, `submit_batch`, `get_batch_status`, `retrieve_batch_results`), translating the OpenAI-batch request/result shapes the retain orchestrator and `fact_extraction` consumer already expect to/from Gemini's native flow:

> upload JSONL → `batches.create` → `batches.get` (poll) → download → normalize

This is the same adapter pattern `FireworksLLM` uses, so **nothing downstream changes** — the consumer's `result["response"]["body"]["choices"][0]["message"]["content"]` contract is preserved. Pure translation/normalization/state-mapping helpers are factored out and unit-tested.

Scope notes:
- **Gemini API only.** Vertex AI (`vertexai`) stays unsupported — its batch path is GCS/BigQuery-backed (no file-upload analogue), and the SDK's `files.upload` rejects Vertex clients. The existing startup validation surfaces a clear error rather than silently falling back to full-price sync calls.
- **Token usage:** Gemini's `usageMetadata` is now threaded into the normalized batch result body, so the consumer reports real token usage instead of zero (this gap affected only Gemini — the consumer already reads `body["usage"]` for the other providers).
- **Consolidation batch** (the second half of #1144) is intentionally left as a follow-up — it's a much larger restructuring of the consolidation worker into an async submit→poll→retrieve flow.

## Testing

**Unit tests** (`tests/test_gemini_batch.py`, 27 tests): capability flag, request translation, output normalization (incl. usage), status mapping, and the async submit→status→retrieve flow against a fake genai client.

**Live end-to-end** (`tests/test_gemini_batch_integration.py`, skipped without `GEMINI_API_KEY`, mirrors the Fireworks live test): ran against the **real Gemini Batch API** — full pipeline submit → poll → download → normalize → parse extracted 3 facts, with confirmed non-zero usage `{prompt: 2341, completion: 489, total: 2995}`. This validates the one thing mocks can't: that the real output JSONL + `usageMetadata` shapes match the normalizer.

Docs (`configuration.md`, `api/retain.mdx`, provider-capability matrix) updated to list Gemini as batch-capable.

Closes #1144 (Gemini portion).