### PR TITLE
docs(models): add Gemini Embedding 2 to Google models

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -444,8 +444,11 @@ Converts text into dense vector representations for semantic similarity search.
 | Model | Dimensions | Use Case |
 |-------|------------|----------|
 | `gemini-embedding-001` | 768 (configurable) | Default Google, general purpose |
+| `gemini-embedding-2-preview` | 768 (configurable) | Gemini Embedding 2 family; multimodal, one vector per input |
 
 Google's `gemini-embedding-001` supports configurable output dimensionality via truncation, google recommend using: 768, 1536, 3072, via `HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY`. Default is 768.
+
+The `gemini-embedding-2` family, including `gemini-embedding-2-preview`, is supported on both the Gemini API and Vertex AI. These models aggregate multi-input requests, so Hindsight automatically embeds one input per call to keep per-fact vectors aligned.
 
 ### Cohere Models
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -490,8 +490,11 @@ Converts text into dense vector representations for semantic similarity search.
 | Model | Dimensions | Use Case |
 |-------|------------|----------|
 | `gemini-embedding-001` | 768 (configurable) | Default Google, general purpose |
+| `gemini-embedding-2-preview` | 768 (configurable) | Gemini Embedding 2 family; multimodal, one vector per input |
 
 Google's `gemini-embedding-001` supports configurable output dimensionality via truncation, google recommend using: 768, 1536, 3072, via `HINDSIGHT_API_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY`. Default is 768.
+
+The `gemini-embedding-2` family, including `gemini-embedding-2-preview`, is supported on both the Gemini API and Vertex AI. These models aggregate multi-input requests, so Hindsight automatically embeds one input per call to keep per-fact vectors aligned.
 
 ### Cohere Models
 


### PR DESCRIPTION
## Summary

#2087 added support for the `gemini-embedding-2` family by embedding one input per call so multimodal aggregation does not collapse multiple facts into one vector. The canonical Models page still listed only `gemini-embedding-001`.

This adds `gemini-embedding-2-preview` to the Google embedding models table and notes the 1:1 input handling.

## Verification

- `./scripts/generate-docs-skill.sh`
  - regenerated `skills/hindsight-docs/references/developer/models.md`
  - generated skill link validation passed