### PR TITLE
fix(ci): authenticate the obsidian mirror push with OBSIDIAN_DIST_TOKEN

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -144,6 +144,12 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+        # actions/checkout injects an auth header for the default GITHUB_TOKEN
+        # (github-actions[bot]) that overrides URL-embedded credentials — so the
+        # push below would use the bot, which has no access to the dedicated repo.
+        # Drop it so the OBSIDIAN_DIST_TOKEN in the push URL is used instead.
+        git config --local --unset-all http.https://github.com/.extraheader || true
+
         # Mirror the subdir to the dedicated repo's root (one-way; the dedicated
         # repo is only ever written here, so the split fast-forwards each time).
         git subtree push --prefix="$OBS_DIR" \


### PR DESCRIPTION
## Problem

The obsidian mirror step (added in #2078) failed on its first run:

```
remote: Permission to vectorize-io/hindsight-obsidian.git denied to github-actions[bot].
fatal: ... 403
```

The push used **`github-actions[bot]`**, not `OBSIDIAN_DIST_TOKEN`. `actions/checkout` configures git with an `http.https://github.com/.extraheader` carrying the default `GITHUB_TOKEN`, and that header **overrides** the `x-access-token:${DIST_TOKEN}@…` credentials embedded in the `git subtree push` URL. So the push authenticated as the bot, which has no access to the dedicated repo.

## Fix

Unset that header right before the subtree push so the URL-embedded `OBSIDIAN_DIST_TOKEN` is used:

```bash
git config --local --unset-all http.https://github.com/.extraheader || true
```

One line, scoped to the obsidian mirror step. No effect on other integrations (the header is only relevant to git pushes, and the subsequent npm publish uses `NODE_AUTH_TOKEN`).

## Verification
- `release-integration.yml` is valid YAML.
- Once merged, re-pointing the `integrations/obsidian/v0.1.0` tag to the merge commit re-runs the mirror — this time authenticating with the dist token — to backfill the dedicated repo + cut the BRAT release.
