### PR TITLE
fix(ci): npm provenance 409 guard + add Obsidian MIT LICENSE

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -177,7 +177,12 @@ jobs:
         EXIT_CODE=$?
         echo "$OUTPUT"
         if [ $EXIT_CODE -ne 0 ]; then
-          if echo "$OUTPUT" | grep -q "cannot publish over"; then
+          # Treat "already published" as success so re-pointed-tag re-runs stay green.
+          # "cannot publish over" = the version exists. TLOG_CREATE_ENTRY_ERROR / 409
+          # "equivalent entry already exists in the transparency log" = the identical
+          # --provenance artifact was already logged on a prior run (Sigstore tlog is
+          # idempotent); the package is published, so this is benign.
+          if echo "$OUTPUT" | grep -qE "cannot publish over|TLOG_CREATE_ENTRY_ERROR|already exists in the transparency log"; then
             echo "Package version already published, skipping..."
             exit 0
           fi

--- a/hindsight-integrations/obsidian/LICENSE
+++ b/hindsight-integrations/obsidian/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vectorize
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What

Widen the "already published" guard in the npm-publish step of `release-integration.yml` so it also swallows the Sigstore transparency-log idempotency error.

```diff
-          if echo "$OUTPUT" | grep -q "cannot publish over"; then
+          if echo "$OUTPUT" | grep -qE "cannot publish over|TLOG_CREATE_ENTRY_ERROR|already exists in the transparency log"; then
```

## Why

When a release tag is re-pointed (e.g. moving `integrations/obsidian/v0.1.0` to a clean merge commit after a CI fix lands) the release workflow re-runs. `npm publish --access public --provenance` then fails with:

```
npm error code TLOG_CREATE_ENTRY_ERROR
npm error error creating tlog entry - (409) an equivalent entry already exists in the transparency log with UUID …
```

This is **benign**: the package version is already published, and the 409 is just Sigstore's transparency log being idempotent about the identical `--provenance` artifact. But the step's guard only matched the literal string `"cannot publish over"`, so the re-run went red despite nothing being wrong (observed on the obsidian v0.1.0 re-run after #2093 merged).

Treating it as already-published keeps re-pointed-tag re-runs green.

## Risk

Minimal — this only changes which already-published error strings are treated as success; a genuine publish failure (auth, build, a different version) still exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)