### PR TITLE
chore(cursor): fix ruff-format drift in cursor integration tests

### DIFF
--- a/hindsight-integrations/cursor/tests/test_cli.py
+++ b/hindsight-integrations/cursor/tests/test_cli.py
@@ -45,7 +45,9 @@ class TestInit:
         project.mkdir()
 
         with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
-            cmd_init(_Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False))
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
 
         dest = project / ".cursor-plugin" / "hindsight-memory"
         assert dest.exists()
@@ -61,7 +63,9 @@ class TestInit:
         dest.mkdir(parents=True)
 
         with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
-            cmd_init(_Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False))
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
 
         out = capsys.readouterr().out
         assert "already installed" in out
@@ -74,7 +78,9 @@ class TestInit:
         (dest / "old-file.txt").write_text("old")
 
         with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
-            cmd_init(_Args(project=str(project), force=True, api_url=None, api_token=None, bank_id="cursor", no_mcp=False))
+            cmd_init(
+                _Args(project=str(project), force=True, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
 
         assert (dest / "hooks" / "hooks.json").exists()
 
@@ -119,7 +125,16 @@ class TestInit:
             patch("hindsight_cursor.cli._USER_CONFIG_DIR", config_dir),
             patch("hindsight_cursor.cli._USER_CONFIG_FILE", config_file),
         ):
-            cmd_init(_Args(project=str(project), force=False, api_url="http://x", api_token=None, bank_id="cursor", no_mcp=False))
+            cmd_init(
+                _Args(
+                    project=str(project),
+                    force=False,
+                    api_url="http://x",
+                    api_token=None,
+                    bank_id="cursor",
+                    no_mcp=False,
+                )
+            )
 
         # Original config should be untouched
         cfg = json.loads(config_file.read_text())
@@ -162,7 +177,9 @@ class TestInit:
         project.mkdir()
 
         with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
-            cmd_init(_Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False))
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
 
         mcp_file = project / ".cursor" / "mcp.json"
         assert not mcp_file.exists()
@@ -191,9 +208,7 @@ class TestInit:
         project.mkdir()
         mcp_dir = project / ".cursor"
         mcp_dir.mkdir()
-        (mcp_dir / "mcp.json").write_text(json.dumps({
-            "mcpServers": {"other-server": {"url": "http://other"}}
-        }))
+        (mcp_dir / "mcp.json").write_text(json.dumps({"mcpServers": {"other-server": {"url": "http://other"}}}))
 
         with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
             cmd_init(
@@ -239,12 +254,16 @@ class TestUninstall:
 
         mcp_dir = project / ".cursor"
         mcp_dir.mkdir()
-        (mcp_dir / "mcp.json").write_text(json.dumps({
-            "mcpServers": {
-                "hindsight": {"url": "http://localhost:8888/mcp/cursor/"},
-                "other": {"url": "http://other"},
-            }
-        }))
+        (mcp_dir / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "hindsight": {"url": "http://localhost:8888/mcp/cursor/"},
+                        "other": {"url": "http://other"},
+                    }
+                }
+            )
+        )
 
         cmd_uninstall(_Args(project=str(project)))
 

--- a/hindsight-integrations/cursor/tests/test_daemon.py
+++ b/hindsight-integrations/cursor/tests/test_daemon.py
@@ -42,9 +42,12 @@ class TestGetApiUrlResolution:
         """If the opt-in daemon start fails, fall back to the hosted backend
         rather than hard-erroring — the plugin should keep working."""
         config = {"hindsightApiUrl": "", "apiPort": 65535, "useLocalDaemon": True}
-        with patch("lib.daemon._check_health", return_value=False), patch(
-            "lib.daemon._ensure_daemon_running",
-            side_effect=RuntimeError("hindsight-embed not found"),
+        with (
+            patch("lib.daemon._check_health", return_value=False),
+            patch(
+                "lib.daemon._ensure_daemon_running",
+                side_effect=RuntimeError("hindsight-embed not found"),
+            ),
         ):
             assert get_api_url(config, allow_daemon_start=True) == DEFAULT_HINDSIGHT_API_URL
 

--- a/hindsight-integrations/cursor/tests/test_e2e.py
+++ b/hindsight-integrations/cursor/tests/test_e2e.py
@@ -100,8 +100,7 @@ def hook_env(tmp_path):
             # boilerplate; that's correct for production but too diffuse to
             # surface targeted test fixtures within a 15s wait.
             "HINDSIGHT_BANK_MISSION": (
-                "Track project canary markers and user coding preferences "
-                "for the development assistant."
+                "Track project canary markers and user coding preferences for the development assistant."
             ),
             # retain.py batches retains every N turns (default 10). For a
             # single-shot E2E that drives one stop event, force every-turn
@@ -154,9 +153,7 @@ def _wait_for_recall_to_surface(client, bank_id: str, query: str, attempts: int 
 
 
 class TestE2ESessionStart:
-    def test_writes_rules_file_with_recalled_content_and_appends_gitignore(
-        self, live, hook_env, tmp_path
-    ):
+    def test_writes_rules_file_with_recalled_content_and_appends_gitignore(self, live, hook_env, tmp_path):
         client, bank_id = live
         # The fact is phrased to overlap with the bank-mission query the hook
         # builds, so it actually surfaces in the session-start recall (otherwise
@@ -184,8 +181,7 @@ class TestE2ESessionStart:
             hook_env,
         )
         assert result.returncode == 0, (
-            f"session_start exited {result.returncode}\n"
-            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+            f"session_start exited {result.returncode}\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
         # Rules-file workaround content
@@ -194,9 +190,7 @@ class TestE2ESessionStart:
         content = rule_path.read_text()
         assert "alwaysApply: true" in content, "rules file missing alwaysApply: true"
         assert "<hindsight_memories>" in content, "rules file missing memory wrapper"
-        assert "FROBNICATE_QUUX_42" in content, (
-            f"canary not surfaced in rules file:\n{content}"
-        )
+        assert "FROBNICATE_QUUX_42" in content, f"canary not surfaced in rules file:\n{content}"
         # In-file comment links to the upstream Cursor bug for future readers
         assert "forum.cursor.com" in content
         assert "158452" in content
@@ -213,9 +207,7 @@ class TestE2ESessionStart:
         assert "additionalContext" in stdout_json
         assert "FROBNICATE_QUUX_42" in stdout_json["additionalContext"]
 
-    def test_empty_bank_writes_no_rules_file_but_still_succeeds(
-        self, live, hook_env, tmp_path
-    ):
+    def test_empty_bank_writes_no_rules_file_but_still_succeeds(self, live, hook_env, tmp_path):
         _, bank_id = live  # bank exists but is empty
         workspace = _make_workspace(tmp_path)
         hook_env["HINDSIGHT_BANK_ID"] = bank_id
@@ -237,9 +229,7 @@ class TestE2ESessionStart:
         rule_path = workspace / ".cursor" / "rules" / "hindsight-session.mdc"
         assert not rule_path.exists()
 
-    def test_useRulesFileFallback_false_disables_workaround(
-        self, live, hook_env, tmp_path
-    ):
+    def test_useRulesFileFallback_false_disables_workaround(self, live, hook_env, tmp_path):
         client, bank_id = live
         # Use the same on-topic fixture as the first test so the hook's
         # session-recall reliably surfaces content. The point of *this* test
@@ -270,18 +260,12 @@ class TestE2ESessionStart:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         # Workaround disabled → no rules-dir, no .gitignore touch. This is the
         # only assertion that matters for the opt-out contract.
-        assert not (workspace / ".cursor").exists(), (
-            ".cursor was created despite useRulesFileFallback=false"
-        )
-        assert not (workspace / ".gitignore").exists(), (
-            ".gitignore was created despite useRulesFileFallback=false"
-        )
+        assert not (workspace / ".cursor").exists(), ".cursor was created despite useRulesFileFallback=false"
+        assert not (workspace / ".gitignore").exists(), ".gitignore was created despite useRulesFileFallback=false"
 
 
 class TestE2ERetain:
-    def test_retain_persists_transcript_so_recall_surfaces_it(
-        self, live, hook_env, tmp_path
-    ):
+    def test_retain_persists_transcript_so_recall_surfaces_it(self, live, hook_env, tmp_path):
         client, bank_id = live
         hook_env["HINDSIGHT_BANK_ID"] = bank_id
 
@@ -291,14 +275,24 @@ class TestE2ERetain:
         # under test.
         transcript_path = tmp_path / "transcript.jsonl"
         with open(transcript_path, "w") as f:
-            f.write(json.dumps({
-                "role": "user",
-                "content": "We picked Postgres 16 in us-east-1 for the new analytics service.",
-            }) + "\n")
-            f.write(json.dumps({
-                "role": "assistant",
-                "content": "Confirmed — Postgres 16 in us-east-1 for analytics.",
-            }) + "\n")
+            f.write(
+                json.dumps(
+                    {
+                        "role": "user",
+                        "content": "We picked Postgres 16 in us-east-1 for the new analytics service.",
+                    }
+                )
+                + "\n"
+            )
+            f.write(
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "content": "Confirmed — Postgres 16 in us-east-1 for analytics.",
+                    }
+                )
+                + "\n"
+            )
 
         result = _run_hook(
             RETAIN_SCRIPT,
@@ -316,12 +310,8 @@ class TestE2ERetain:
         # output shape. What matters is that the bank ends up holding the
         # fact, verified via direct recall (not the hook's session query,
         # which is bank-mission-shaped for auto-inject).
-        assert result.returncode == 0, (
-            f"retain exited {result.returncode}\nstderr: {result.stderr!r}"
-        )
-        results = _wait_for_recall_to_surface(
-            client, bank_id, "Postgres deployment region"
-        )
+        assert result.returncode == 0, f"retain exited {result.returncode}\nstderr: {result.stderr!r}"
+        results = _wait_for_recall_to_surface(client, bank_id, "Postgres deployment region")
         joined = " | ".join(r.text for r in results).lower()
         assert "postgres" in joined or "us-east" in joined, (
             f"recall surfaced results but none referenced the retained content: {joined[:400]}"

--- a/hindsight-integrations/cursor/tests/test_hooks.py
+++ b/hindsight-integrations/cursor/tests/test_hooks.py
@@ -21,6 +21,7 @@ class TestSessionStartHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"workspace_roots": ["/tmp/test"]})))
 
         import session_start
+
         importlib.reload(session_start)
         session_start.main()
 
@@ -39,12 +40,15 @@ class TestSessionStartHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
 
         import session_start
+
         importlib.reload(session_start)
 
-        with patch.object(session_start, "get_api_url", return_value="http://localhost:8888"), \
-             patch.object(session_start, "HindsightClient", return_value=mock_client), \
-             patch.object(session_start, "ensure_bank_mission"), \
-             patch.object(session_start, "write_state"):
+        with (
+            patch.object(session_start, "get_api_url", return_value="http://localhost:8888"),
+            patch.object(session_start, "HindsightClient", return_value=mock_client),
+            patch.object(session_start, "ensure_bank_mission"),
+            patch.object(session_start, "write_state"),
+        ):
             session_start.main()
 
         output = capsys.readouterr()
@@ -63,11 +67,14 @@ class TestSessionStartHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
 
         import session_start
+
         importlib.reload(session_start)
 
-        with patch.object(session_start, "get_api_url", return_value="http://localhost:8888"), \
-             patch.object(session_start, "HindsightClient", return_value=mock_client), \
-             patch.object(session_start, "ensure_bank_mission"):
+        with (
+            patch.object(session_start, "get_api_url", return_value="http://localhost:8888"),
+            patch.object(session_start, "HindsightClient", return_value=mock_client),
+            patch.object(session_start, "ensure_bank_mission"),
+        ):
             session_start.main()
 
         output = capsys.readouterr()
@@ -77,20 +84,21 @@ class TestSessionStartHook:
         monkeypatch.setenv("CURSOR_PLUGIN_ROOT", "/nonexistent")
 
         mock_client = MagicMock()
-        mock_client.recall.return_value = {
-            "results": [{"text": "Uses FastAPI", "type": "world"}]
-        }
+        mock_client.recall.return_value = {"results": [{"text": "Uses FastAPI", "type": "world"}]}
 
         hook_input = {"workspace_roots": ["/home/user/projects/my-app"]}
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
 
         import session_start
+
         importlib.reload(session_start)
 
-        with patch.object(session_start, "get_api_url", return_value="http://localhost:8888"), \
-             patch.object(session_start, "HindsightClient", return_value=mock_client), \
-             patch.object(session_start, "ensure_bank_mission"), \
-             patch.object(session_start, "write_state"):
+        with (
+            patch.object(session_start, "get_api_url", return_value="http://localhost:8888"),
+            patch.object(session_start, "HindsightClient", return_value=mock_client),
+            patch.object(session_start, "ensure_bank_mission"),
+            patch.object(session_start, "write_state"),
+        ):
             session_start.main()
 
         # Verify the query included the project name
@@ -108,12 +116,15 @@ class TestSessionStartHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
 
         import session_start
+
         importlib.reload(session_start)
 
         mock_get_url = MagicMock(return_value="http://localhost:9077")
-        with patch.object(session_start, "get_api_url", mock_get_url), \
-             patch.object(session_start, "HindsightClient", return_value=mock_client), \
-             patch.object(session_start, "ensure_bank_mission"):
+        with (
+            patch.object(session_start, "get_api_url", mock_get_url),
+            patch.object(session_start, "HindsightClient", return_value=mock_client),
+            patch.object(session_start, "ensure_bank_mission"),
+        ):
             session_start.main()
 
         # Verify allow_daemon_start=True was passed
@@ -129,6 +140,7 @@ class TestRetainHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"conversation_id": "c1"})))
 
         import retain
+
         importlib.reload(retain)
         retain.main()
 
@@ -143,6 +155,7 @@ class TestRetainHook:
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
 
         import retain
+
         importlib.reload(retain)
         retain.main()
 
@@ -150,11 +163,9 @@ class TestRetainHook:
         """Sanity: flat shape {role, content} still works after the parser
         rewrite."""
         import retain
+
         transcript = tmp_path / "flat.jsonl"
-        transcript.write_text(
-            '{"role": "user", "content": "Hello"}\n'
-            '{"role": "assistant", "content": "Hi back"}\n'
-        )
+        transcript.write_text('{"role": "user", "content": "Hello"}\n{"role": "assistant", "content": "Hi back"}\n')
         msgs = retain.read_transcript(str(transcript))
         assert len(msgs) == 2
         assert msgs[0] == {"role": "user", "content": "Hello"}
@@ -163,6 +174,7 @@ class TestRetainHook:
     def test_read_transcript_parses_type_nested_format(self, tmp_path):
         """Sanity: type-nested shape {type: "user", message: {...}}."""
         import retain
+
         transcript = tmp_path / "typenested.jsonl"
         transcript.write_text(
             '{"type": "user", "message": {"role": "user", "content": "Hello"}}\n'
@@ -184,6 +196,7 @@ class TestRetainHook:
         transcript file existed and had real content.
         """
         import retain
+
         transcript = tmp_path / "cursor3.jsonl"
         transcript.write_text(
             '{"role":"user","message":{"content":[{"type":"text","text":"Remember Vim over Emacs"}]}}\n'
@@ -225,11 +238,14 @@ class TestRetainHook:
         monkeypatch.setenv("CURSOR_PLUGIN_DATA", str(tmp_path / "data"))
 
         import retain
+
         importlib.reload(retain)
 
-        with patch.object(retain, "get_api_url", return_value="http://localhost:8888"), \
-             patch.object(retain, "HindsightClient", return_value=mock_client), \
-             patch.object(retain, "ensure_bank_mission"):
+        with (
+            patch.object(retain, "get_api_url", return_value="http://localhost:8888"),
+            patch.object(retain, "HindsightClient", return_value=mock_client),
+            patch.object(retain, "ensure_bank_mission"),
+        ):
             retain.main()
 
         mock_client.retain.assert_called_once()
@@ -240,9 +256,7 @@ class TestRetainHook:
 
 class TestManifest:
     def test_plugin_json_valid(self):
-        plugin_path = os.path.join(
-            os.path.dirname(__file__), "..", ".cursor-plugin", "plugin.json"
-        )
+        plugin_path = os.path.join(os.path.dirname(__file__), "..", ".cursor-plugin", "plugin.json")
         with open(plugin_path) as f:
             manifest = json.load(f)
 
@@ -252,9 +266,7 @@ class TestManifest:
         assert manifest["license"] == "MIT"
 
     def test_hooks_json_valid(self):
-        hooks_path = os.path.join(
-            os.path.dirname(__file__), "..", "hooks", "hooks.json"
-        )
+        hooks_path = os.path.join(os.path.dirname(__file__), "..", "hooks", "hooks.json")
         with open(hooks_path) as f:
             hooks = json.load(f)
 
@@ -265,9 +277,7 @@ class TestManifest:
         assert "beforeSubmitPrompt" not in hooks["hooks"]
 
     def test_settings_json_valid(self):
-        settings_path = os.path.join(
-            os.path.dirname(__file__), "..", "settings.json"
-        )
+        settings_path = os.path.join(os.path.dirname(__file__), "..", "settings.json")
         with open(settings_path) as f:
             settings = json.load(f)
 


### PR DESCRIPTION
## What

Run `ruff format` on `hindsight-integrations/cursor/tests/*.py` — formatting-only, no logic changes.

## Why

These four test files were committed without ruff formatting, so the **`verify-generated-files`** CI job (which runs `./scripts/hooks/lint.sh` and fails on any diff) is **red on every PR branched off current `main`**, e.g. observed on #2094:

```
 M hindsight-integrations/cursor/tests/test_cli.py
 M hindsight-integrations/cursor/tests/test_daemon.py
 M hindsight-integrations/cursor/tests/test_e2e.py
 M hindsight-integrations/cursor/tests/test_hooks.py
```

This unblocks `verify-generated-files` for all open PRs. After this merges, rebasing other branches on `main` clears the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)