### PR TITLE
fix(reflect): carry directives + language rule into final synthesis prompt

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -505,7 +505,9 @@ async def run_reflect_agent(
                 messages=[
                     {
                         "role": "system",
-                        "content": build_final_system_prompt(bank_profile.get("mission"), llm_output_language),
+                        "content": build_final_system_prompt(
+                            bank_profile.get("mission"), llm_output_language, directives
+                        ),
                     },
                     {"role": "user", "content": prompt},
                 ],
@@ -565,7 +567,9 @@ async def run_reflect_agent(
                 messages=[
                     {
                         "role": "system",
-                        "content": build_final_system_prompt(bank_profile.get("mission"), llm_output_language),
+                        "content": build_final_system_prompt(
+                            bank_profile.get("mission"), llm_output_language, directives
+                        ),
                     },
                     {"role": "user", "content": prompt},
                 ],
@@ -684,7 +688,9 @@ async def run_reflect_agent(
                 messages=[
                     {
                         "role": "system",
-                        "content": build_final_system_prompt(bank_profile.get("mission"), llm_output_language),
+                        "content": build_final_system_prompt(
+                            bank_profile.get("mission"), llm_output_language, directives
+                        ),
                     },
                     {"role": "user", "content": prompt},
                 ],
@@ -808,7 +814,9 @@ async def run_reflect_agent(
                 messages=[
                     {
                         "role": "system",
-                        "content": build_final_system_prompt(bank_profile.get("mission"), llm_output_language),
+                        "content": build_final_system_prompt(
+                            bank_profile.get("mission"), llm_output_language, directives
+                        ),
                     },
                     {"role": "user", "content": prompt},
                 ],

--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -604,16 +604,44 @@ Just provide the direct answer with proper markdown formatting.
 CRITICAL: This is a NON-CONVERSATIONAL system. NEVER ask follow-up questions, offer to search again, suggest alternatives, or end with anything like "Would you like me to..." or "Let me know if...". The user cannot reply. Your answer must be complete and self-contained."""
 
 
-def build_final_system_prompt(mission: str | None = None, llm_output_language: str | None = None) -> str:
+# The final synthesis is a SEPARATE LLM call with its own system prompt — the
+# agent/reasoning system prompt (which carries directives and the language rule)
+# is NOT in scope here. So this default language rule, and the directives, must
+# be repeated for the answer-writing model. Without it, weaker models drift to
+# English even when the question/facts are in another language or a directive
+# demands a specific one (the cause of flaky multilingual reflect tests).
+_FINAL_LANGUAGE_RULE = (
+    "## LANGUAGE\n"
+    "- Respond in the SAME language as the user's question "
+    "(e.g. a question in Chinese gets a Chinese answer; Japanese → Japanese).\n"
+    "- If a directive above specifies a response language, follow the directive — "
+    "it takes precedence over this default."
+)
+
+
+def build_final_system_prompt(
+    mission: str | None = None,
+    llm_output_language: str | None = None,
+    directives: list[dict[str, Any]] | None = None,
+) -> str:
     """Build the final synthesis system prompt, using mission as role when set.
 
-    When ``llm_output_language`` is set, the response is forced into that
-    language regardless of the query/source language.
+    ``directives`` are re-injected here (they live in the agent/reasoning prompt,
+    but the final answer is a separate call) so output-constraining rules — most
+    visibly response language — are honoured by the model that actually writes
+    the answer. When ``llm_output_language`` is set it forces that language
+    regardless of the query/source/directive language (config override wins).
     """
     from hindsight_api.engine.prompt_utils import escape_for_prompt, output_language_directive
 
     role_section = escape_for_prompt(mission.strip()) if mission else _DEFAULT_FINAL_ROLE
-    return _FINAL_SYSTEM_PROMPT_BASE.format(role_section=role_section) + output_language_directive(llm_output_language)
+
+    parts = [build_directives_section(directives) if directives else ""]
+    parts.append(_FINAL_SYSTEM_PROMPT_BASE.format(role_section=role_section))
+    parts.append(_FINAL_LANGUAGE_RULE)
+    parts.append(build_directives_reminder(directives) if directives else "")
+
+    return "\n\n".join(p.strip() for p in parts if p.strip()) + output_language_directive(llm_output_language)
 
 
 # Backward-compatible constant for non-identity missions

--- a/hindsight-api-slim/tests/test_reflect_prompt_builder.py
+++ b/hindsight-api-slim/tests/test_reflect_prompt_builder.py
@@ -19,7 +19,7 @@ without hiding what each one produces — the ``_assemble`` helper is a
 mechanical join, not a re-implementation of the builder.
 """
 
-from hindsight_api.engine.reflect.prompts import build_system_prompt_for_tools
+from hindsight_api.engine.reflect.prompts import build_final_system_prompt, build_system_prompt_for_tools
 
 BANK = {"name": "TestBank", "mission": ""}
 
@@ -540,3 +540,51 @@ def test_include_observations_defaults_to_true():
     paths that don't gate the flag aren't silently changed."""
     actual = build_system_prompt_for_tools(bank_profile=BANK, has_mental_models=False)
     assert actual == _assemble(_RETRIEVAL_OBS_ONLY, _WORKFLOW_OBS_ONLY)
+
+
+# =========================================================================
+# build_final_system_prompt: language rule + directives
+#
+# The final synthesis is a SEPARATE LLM call from the agent loop, so its
+# system prompt must independently carry the language rule and any directives
+# — otherwise the answer-writing model has no instruction to stay in the
+# query's language / obey a language directive and weaker models drift to
+# English (flaky multilingual reflect tests).
+# =========================================================================
+
+_FRENCH_DIRECTIVE = {
+    "name": "Language Policy",
+    "content": "ALWAYS respond in French language. Never respond in English.",
+}
+
+
+def test_final_prompt_always_includes_language_rule():
+    prompt = build_final_system_prompt()
+    assert "## LANGUAGE" in prompt
+    assert "SAME language as the user's question" in prompt
+
+
+def test_final_prompt_without_directives_omits_directives_section():
+    prompt = build_final_system_prompt()
+    assert "## DIRECTIVES (MANDATORY)" not in prompt
+    assert "REMINDER: MANDATORY DIRECTIVES" not in prompt
+
+
+def test_final_prompt_injects_directives_so_answer_obeys_them():
+    """The answer-writing model — not just the reasoning loop — must see the
+    directive, else a 'respond in French' rule is silently dropped at synthesis."""
+    prompt = build_final_system_prompt(directives=[_FRENCH_DIRECTIVE])
+    assert "## DIRECTIVES (MANDATORY)" in prompt
+    assert "respond in French" in prompt
+    # End-of-prompt reminder reinforces compliance, mirroring the reasoning prompt.
+    assert "REMINDER: MANDATORY DIRECTIVES" in prompt
+    # The default language rule still defers to the directive.
+    assert "takes precedence over this default" in prompt
+
+
+def test_final_prompt_output_language_override_is_appended_last():
+    """HINDSIGHT_API_LLM_OUTPUT_LANGUAGE forces a language regardless of query/directive."""
+    prompt = build_final_system_prompt(llm_output_language="Spanish")
+    assert "Respond exclusively in Spanish" in prompt
+    # The config override is appended after the default LANGUAGE rule so it wins.
+    assert prompt.index("Respond exclusively in Spanish") > prompt.index("## LANGUAGE")


### PR DESCRIPTION
## What I found

CI's "Core LLM tests" job was failing on multilingual reflect tests — a **different** test each run (`test_reflect_follows_language_directive` → French, then `test_reflect_chinese_content` → Chinese), where reflect returned **English** instead of the expected language. That "different test each run" pattern is the signature of intermittent LLM non-determinism, not a deterministic break.

Investigating the cause, I found a real underlying weakness rather than pure test flakiness:

**The reflect final answer is a separate LLM call.** Its system prompt comes from `build_final_system_prompt`, which only received `mission` + an optional `llm_output_language` override. The agent/reasoning prompt's **language rule** and the bank's **directives** were *not* in scope for the model that actually writes the answer. So at synthesis time the model had no instruction to stay in the query's language or obey a `"respond in French"` directive — it relied entirely on inferring the language from the (often English) context. Stronger models infer it; weaker models (CI uses the `vertexai` `gemini-3.1-flash-lite` tier) intermittently drift to English.

## The fix

`build_final_system_prompt` now re-injects:
- the **directives** section + end-of-prompt reminder (when present), and
- a default **`## LANGUAGE`** rule ("respond in the same language as the question; a directive language takes precedence").

`HINDSIGHT_API_LLM_OUTPUT_LANGUAGE` remains the hard override, appended last. This also closes a broader latent gap: *any* output-constraining directive (tone, forbidden content, language) was previously dropped at the final-answer step — directives only shaped the agent's reasoning, not the synthesized answer.

## Validation

- **Deterministic unit tests** (`test_reflect_prompt_builder.py`) pin the new assembly: the final prompt always carries the language rule; a French directive now appears in the final prompt (it didn't before); the config override is appended last. These guard the regression without depending on a live model.
- **Real-LLM tests** `test_reflect_chinese_content` and `test_reflect_follows_language_directive` pass locally on both `gemini-2.5-flash` and the CI-tier `gemini-3.1-flash-lite`.
- The intermittent drift can't be cheaply reproduced in a single run (it's the rare tail), but the fix removes the *mechanism* that allowed it — the answer-writing model now always has the language/directive instruction in front of it.

Spun out of the Gemini Batch API PR (#2089) CI run, where this flaky job was the only non-batch failure.