### PR TITLE
fix(api): apply bank-config disposition + mission overlay in list_banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -8,6 +8,7 @@ Config values are resolved on every request to ensure consistency across
 multiple API servers.
 """
 
+import asyncio
 import json
 import logging
 from dataclasses import asdict, replace
@@ -161,26 +162,83 @@ class ConfigResolver:
         resolved_config = await self.resolve_full_config(bank_id, context)
         config_dict = asdict(resolved_config)
 
-        # SECURITY: Filter to only configurable fields (exclude static/infrastructure)
-        filtered = {k: v for k, v in config_dict.items() if k in self._configurable_fields}
+        # SECURITY: drop static/infrastructure + credential fields, then permission-filter.
+        filtered = self._strip_static_and_credential_fields(config_dict)
+        return await self._apply_permission_filter(filtered, bank_id, context)
 
-        # SECURITY: Remove ALL credential fields (API keys, base URLs, etc.)
-        filtered = {k: v for k, v in filtered.items() if k not in self._credential_fields}
+    def _strip_static_and_credential_fields(self, config_dict: dict[str, Any]) -> dict[str, Any]:
+        """Keep only configurable, non-credential fields.
 
-        # PERMISSIONS: Further filter based on tenant/bank permissions
+        SECURITY: excludes static/infrastructure fields and ALL credential fields
+        (API keys, base URLs, etc.) so a resolved config is safe to return over the API.
+        """
+        return {
+            k: v for k, v in config_dict.items() if k in self._configurable_fields and k not in self._credential_fields
+        }
+
+    async def _apply_permission_filter(
+        self, filtered: dict[str, Any], bank_id: str, context: RequestContext | None
+    ) -> dict[str, Any]:
+        """Further restrict already-stripped config to the tenant/bank permission allow-list.
+
+        On extension error, leaves ``filtered`` unchanged (parity with the historical
+        single-bank path: a permissions lookup failure must not leak or drop fields).
+        """
+        if not (self.tenant_extension and context):
+            return filtered
+        try:
+            allowed_fields = await self.tenant_extension.get_allowed_config_fields(context, bank_id)
+            if allowed_fields is not None:  # None means "allow all"
+                filtered = {k: v for k, v in filtered.items() if k in allowed_fields}
+                logger.debug(
+                    f"Applied permission filter for bank {bank_id}: allowed={len(allowed_fields)} fields, "
+                    f"returned={len(filtered)} fields"
+                )
+        except Exception as e:
+            logger.warning(f"Failed to load permissions for bank {bank_id}: {e}")
+        return filtered
+
+    async def get_bank_configs(
+        self, bank_ids: list[str], context: RequestContext | None = None
+    ) -> dict[str, dict[str, Any]]:
+        """Batch variant of :meth:`get_bank_config` for many banks.
+
+        Equivalent to calling ``get_bank_config`` per bank, but resolves the
+        global + tenant base once and loads every bank's ``banks.config`` JSONB
+        in a single query, instead of one config round-trip per bank. Used by
+        ``list_banks`` to overlay disposition + mission without an N+1.
+
+        Returns a mapping of bank_id -> filtered configurable-field dict. A bank
+        with no config row still appears, mapped to the global+tenant base.
+        """
+        if not bank_ids:
+            return {}
+
+        # Global + tenant base, resolved once (tenant override is per-request, not per-bank).
+        base_dict = asdict(self._global_config)
         if self.tenant_extension and context:
             try:
-                allowed_fields = await self.tenant_extension.get_allowed_config_fields(context, bank_id)
-                if allowed_fields is not None:  # None means "allow all"
-                    filtered = {k: v for k, v in filtered.items() if k in allowed_fields}
-                    logger.debug(
-                        f"Applied permission filter for bank {bank_id}: allowed={len(allowed_fields)} fields, "
-                        f"returned={len(filtered)} fields"
-                    )
+                tenant_overrides = await self.tenant_extension.get_tenant_config(context)
+                if tenant_overrides:
+                    normalized_tenant = normalize_config_dict(tenant_overrides)
+                    base_dict.update({k: v for k, v in normalized_tenant.items() if k in self._configurable_fields})
             except Exception as e:
-                logger.warning(f"Failed to load permissions for bank {bank_id}: {e}")
+                logger.warning(f"Failed to load tenant config for bulk resolve: {e}")
 
-        return filtered
+        # All bank overrides in one query, then merge + strip per bank.
+        bank_overrides = await self._load_bank_configs(bank_ids)
+        stripped = {
+            bank_id: self._strip_static_and_credential_fields({**base_dict, **bank_overrides.get(bank_id, {})})
+            for bank_id in bank_ids
+        }
+
+        # Permission filter is per-bank; resolve concurrently when an extension is present.
+        if not (self.tenant_extension and context):
+            return stripped
+        permission_filtered = await asyncio.gather(
+            *(self._apply_permission_filter(stripped[bank_id], bank_id, context) for bank_id in bank_ids)
+        )
+        return dict(zip(bank_ids, permission_filtered, strict=True))
 
     async def _load_bank_config(self, bank_id: str) -> dict[str, Any]:
         """
@@ -218,6 +276,45 @@ class ConfigResolver:
             logger.error(f"Failed to load bank config for {bank_id}: {e}")
 
         return {}
+
+    async def _load_bank_configs(self, bank_ids: list[str]) -> dict[str, dict[str, Any]]:
+        """Bulk variant of :meth:`_load_bank_config`: load many banks' overrides in one query.
+
+        Returns a mapping of bank_id -> normalized active overrides. Banks with no row
+        (or an empty/all-tombstone config) are simply absent from the mapping.
+        """
+        result: dict[str, dict[str, Any]] = {}
+        if not bank_ids:
+            return result
+        try:
+            async with self._backend.acquire() as conn:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT bank_id, config FROM {fq_table("banks")} WHERE bank_id = ANY($1)
+                    """,
+                    bank_ids,
+                )
+                for row in rows:
+                    config_data = row["config"]
+                    if not config_data:
+                        continue
+                    # Handle case where JSONB is returned as JSON string
+                    if isinstance(config_data, str):
+                        config_data = json.loads(config_data)
+
+                    # Normalize keys (handle both env var format and Python field format)
+                    normalized = normalize_config_dict(config_data)
+
+                    # Only active overrides for configurable fields. JSON null is a tombstone
+                    # for "Server Default" in the bank-config UI and must not override defaults.
+                    overrides = {
+                        k: v for k, v in normalized.items() if k in self._configurable_fields and v is not None
+                    }
+                    if overrides:
+                        result[row["bank_id"]] = overrides
+        except Exception as e:
+            logger.error(f"Failed to bulk-load bank configs: {e}")
+        return result
 
     async def update_bank_config(
         self, bank_id: str, updates: dict[str, Any], context: RequestContext | None = None

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -745,9 +745,17 @@ def _resolve_refresh_tag_filtering(
     return RefreshTagFiltering(tags=model_tags, tags_match=tags_match, tag_groups=None)
 
 
+@dataclass
+class ResolvedDispositionMission:
+    """Disposition + mission after overlaying resolved bank config on the legacy columns."""
+
+    disposition: dict[str, int]
+    mission: str
+
+
 def _overlay_bank_config_disposition_mission(
     disposition: dict[str, int], mission: str, config_dict: dict[str, Any]
-) -> tuple[dict[str, int], str]:
+) -> ResolvedDispositionMission:
     """Overlay resolved bank config on top of the legacy banks.disposition /
     banks.mission column values.
 
@@ -765,7 +773,7 @@ def _overlay_bank_config_disposition_mission(
         "literalism": cfg_lit if cfg_lit is not None else disposition["literalism"],
         "empathy": cfg_emp if cfg_emp is not None else disposition["empathy"],
     }
-    return resolved_disposition, resolved_mission
+    return ResolvedDispositionMission(disposition=resolved_disposition, mission=resolved_mission)
 
 
 class MemoryEngine(MemoryEngineInterface):
@@ -8149,13 +8157,13 @@ class MemoryEngine(MemoryEngineInterface):
         config_dict = await self._config_resolver.get_bank_config(bank_id, request_context)
         db_disp = profile["disposition"]
         db_disp_dict = db_disp.model_dump() if hasattr(db_disp, "model_dump") else dict(db_disp)
-        disposition, mission = _overlay_bank_config_disposition_mission(db_disp_dict, profile["mission"], config_dict)
+        resolved = _overlay_bank_config_disposition_mission(db_disp_dict, profile["mission"], config_dict)
 
         return {
             "bank_id": bank_id,
             "name": profile["name"],
-            "disposition": disposition,
-            "mission": mission,
+            "disposition": resolved.disposition,
+            "mission": resolved.mission,
         }
 
     async def _ensure_bank_exists(
@@ -8373,11 +8381,14 @@ class MemoryEngine(MemoryEngineInterface):
         # Overlay resolved bank config (reflect_mission + disposition_*) on top of the
         # legacy banks.disposition / banks.mission columns, mirroring get_bank_profile so
         # the list and get paths return identical disposition + mission for a bank.
+        # Resolve every bank's config in one batch (single config-column query + a single
+        # tenant-config resolve) rather than one round-trip per bank.
+        configs = await self._config_resolver.get_bank_configs([bank["bank_id"] for bank in banks], request_context)
         for bank in banks:
-            config_dict = await self._config_resolver.get_bank_config(bank["bank_id"], request_context)
-            bank["disposition"], bank["mission"] = _overlay_bank_config_disposition_mission(
-                bank["disposition"], bank["mission"], config_dict
+            resolved = _overlay_bank_config_disposition_mission(
+                bank["disposition"], bank["mission"], configs.get(bank["bank_id"], {})
             )
+            bank["disposition"], bank["mission"] = resolved.disposition, resolved.mission
         return banks
 
     # ==================== Reflect Methods ====================

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -745,6 +745,29 @@ def _resolve_refresh_tag_filtering(
     return RefreshTagFiltering(tags=model_tags, tags_match=tags_match, tag_groups=None)
 
 
+def _overlay_bank_config_disposition_mission(
+    disposition: dict[str, int], mission: str, config_dict: dict[str, Any]
+) -> tuple[dict[str, int], str]:
+    """Overlay resolved bank config on top of the legacy banks.disposition /
+    banks.mission column values.
+
+    ``reflect_mission`` and ``disposition_*`` in the resolved bank config take
+    precedence over the legacy DB columns. Shared by ``get_bank_profile`` and
+    ``list_banks`` so the single-bank and list paths return identical
+    disposition + mission for the same bank.
+    """
+    resolved_mission = config_dict.get("reflect_mission") or mission
+    cfg_skep = config_dict.get("disposition_skepticism")
+    cfg_lit = config_dict.get("disposition_literalism")
+    cfg_emp = config_dict.get("disposition_empathy")
+    resolved_disposition = {
+        "skepticism": cfg_skep if cfg_skep is not None else disposition["skepticism"],
+        "literalism": cfg_lit if cfg_lit is not None else disposition["literalism"],
+        "empathy": cfg_emp if cfg_emp is not None else disposition["empathy"],
+    }
+    return resolved_disposition, resolved_mission
+
+
 class MemoryEngine(MemoryEngineInterface):
     """
     Advanced memory system using temporal and semantic linking with PostgreSQL.
@@ -8124,19 +8147,9 @@ class MemoryEngine(MemoryEngineInterface):
 
         # reflect_mission and disposition in config take precedence over the legacy DB columns
         config_dict = await self._config_resolver.get_bank_config(bank_id, request_context)
-        mission = config_dict.get("reflect_mission") or profile["mission"]
-
-        # Overlay disposition from config if explicitly set; fall back to DB values
         db_disp = profile["disposition"]
         db_disp_dict = db_disp.model_dump() if hasattr(db_disp, "model_dump") else dict(db_disp)
-        cfg_skep = config_dict.get("disposition_skepticism")
-        cfg_lit = config_dict.get("disposition_literalism")
-        cfg_emp = config_dict.get("disposition_empathy")
-        disposition = {
-            "skepticism": cfg_skep if cfg_skep is not None else db_disp_dict["skepticism"],
-            "literalism": cfg_lit if cfg_lit is not None else db_disp_dict["literalism"],
-            "empathy": cfg_emp if cfg_emp is not None else db_disp_dict["empathy"],
-        }
+        disposition, mission = _overlay_bank_config_disposition_mission(db_disp_dict, profile["mission"], config_dict)
 
         return {
             "bank_id": bank_id,
@@ -8357,6 +8370,14 @@ class MemoryEngine(MemoryEngineInterface):
                 BankListContext(banks=banks, request_context=request_context)
             )
             banks = result.banks
+        # Overlay resolved bank config (reflect_mission + disposition_*) on top of the
+        # legacy banks.disposition / banks.mission columns, mirroring get_bank_profile so
+        # the list and get paths return identical disposition + mission for a bank.
+        for bank in banks:
+            config_dict = await self._config_resolver.get_bank_config(bank["bank_id"], request_context)
+            bank["disposition"], bank["mission"] = _overlay_bank_config_disposition_mission(
+                bank["disposition"], bank["mission"], config_dict
+            )
         return banks
 
     # ==================== Reflect Methods ====================

--- a/hindsight-api-slim/tests/test_list_banks_config_overlay.py
+++ b/hindsight-api-slim/tests/test_list_banks_config_overlay.py
@@ -1,0 +1,71 @@
+"""Regression test: list_banks must apply the same disposition + mission
+config overlay that get_bank_profile applies.
+
+Bug (reproduced live against 0.8.1): for a bank whose disposition and
+mission were evolved/overridden via bank *config* (the banks.config JSONB:
+reflect_mission, disposition_skepticism/literalism/empathy), the single-bank
+get path returns the real values while the list path returns the stale legacy
+DB-column defaults ({skepticism:3, literalism:3, empathy:3} and "").
+
+Root cause: MemoryEngine.get_bank_profile overlays the resolved bank config
+on top of the legacy banks.disposition/banks.mission columns, but
+MemoryEngine.list_banks returned bank_utils.list_banks rows straight from
+those columns with no overlay. The two endpoints disagreed for the same bank.
+
+This test sets disposition + mission through the config path (so the legacy
+columns keep their defaults) and asserts list_banks agrees with
+get_bank_profile for that bank.
+
+Runs via: uv run pytest tests/test_list_banks_config_overlay.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_api.models import RequestContext
+
+
+@pytest.mark.asyncio
+async def test_list_banks_overlays_config_disposition_and_mission(memory):
+    bank_id = "list_banks_config_overlay_bank"
+    request_context = RequestContext(api_key=None, api_key_id=None, tenant_id=None, internal=False)
+
+    # Values that differ from the 3/3/3 defaults on every trait, and a
+    # clearly non-empty mission, so a stale-default regression is unmissable.
+    overrides = {
+        "reflect_mission": "I am the shared long-term memory for this regression test.",
+        "disposition_skepticism": 4,
+        "disposition_literalism": 5,
+        "disposition_empathy": 2,
+    }
+
+    try:
+        # Create the bank. Its legacy banks.disposition/banks.mission columns
+        # keep their defaults (3/3/3 and "") — the real values live in config.
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        # Set disposition + mission via the *config* path (banks.config JSONB),
+        # exactly the path that triggered the live bug.
+        await memory._config_resolver.update_bank_config(bank_id, overrides, request_context)
+
+        # Source of truth: the single-bank get path already overlays config.
+        profile = await memory.get_bank_profile(bank_id, request_context=request_context)
+        assert profile["mission"] == overrides["reflect_mission"]
+        assert profile["disposition"] == {"skepticism": 4, "literalism": 5, "empathy": 2}
+
+        # The list path must agree with the get path for this bank.
+        banks = await memory.list_banks(request_context=request_context)
+        entry = next((b for b in banks if b["bank_id"] == bank_id), None)
+        assert entry is not None, f"bank {bank_id!r} not present in list_banks output"
+
+        assert entry["mission"] == profile["mission"], (
+            "list_banks returned a different mission than get_bank_profile: "
+            f"list={entry['mission']!r} get={profile['mission']!r}"
+        )
+        assert entry["disposition"] == profile["disposition"], (
+            "list_banks returned a different disposition than get_bank_profile: "
+            f"list={entry['disposition']!r} get={profile['disposition']!r}"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

`list_banks` returns a bank's `disposition` and `mission` straight from the legacy `banks.disposition` / `banks.mission` columns, while `get_bank_profile` overlays the resolved bank config (`reflect_mission`, `disposition_skepticism/literalism/empathy`) on top of those columns. For a bank whose disposition/mission were set via bank config, the two endpoints disagree for the same bank.

The config overlay in `get_bank_profile` has been the source of truth since the slim package was introduced (its own comment notes config "take[s] precedence over the legacy DB columns"); `list_banks` (via `bank_utils.list_banks`) simply never applied it.

## Reproduction

Against `ghcr.io/vectorize-io/hindsight:0.8.1`, for a bank configured through bank config:

* `list_banks` returns `disposition = {empathy: 3, literalism: 3, skepticism: 3}` (the 3/3/3 defaults) and `mission = ""`.
* `get_bank` on the same bank returns the real `disposition = {skepticism: 4, literalism: 3, empathy: 4}` and the full evolved mission.
* `fact_count` and the `created_at` / `updated_at` / `last_document_at` timestamps are correct in both, only `disposition` + `mission` differ.

## Fix

* Extract the overlay into a shared helper `_overlay_bank_config_disposition_mission(...)`.
* `get_bank_profile` is refactored to call it (behavior-preserving).
* `list_banks` now applies the same overlay per bank, so the list and get paths return identical `disposition` + `mission` for a bank.

## Test

Adds `tests/test_list_banks_config_overlay.py`, a regression test that sets `disposition` + `mission` through the config path (so the legacy columns keep their defaults) and asserts `list_banks` agrees with `get_bank_profile`. It fails before the fix (list mission `''` vs get `'I am ...'`) and passes after.

`ruff check`, `ruff format`, and `ty check hindsight_api` are clean.

## Note / open question

`list_banks` now resolves bank config once per bank (one extra DB round-trip each), mirroring `get_bank_profile`. This keeps the two paths consistent; for workspaces with many banks a batched config resolve could optimize it. Happy to switch to a batch approach if you'd prefer.