### PR TITLE
feat(providers): add native Nous Portal provider (Codex-style OAuth, no hermes_cli dep)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -596,6 +596,7 @@ PROVIDER_DEFAULT_MODELS = {
     "volcano": "doubao-pro-32k",
     "openrouter": "qwen/qwen3.5-9b",
     "fireworks": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+    "nous": "deepseek/deepseek-v4-flash",
 }
 DEFAULT_LLM_MODEL = "gpt-4o-mini"  # Fallback if provider not in table
 # Built-in llama.cpp defaults

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -232,6 +232,7 @@ _PROVIDERS_WITHOUT_API_KEY = frozenset(
         "litellm",
         "litellmrouter",
         "bedrock",
+        "nous",
     }
 )
 
@@ -437,6 +438,21 @@ def create_llm_provider(
             extra_body=extra_body,
         )
 
+    elif provider_lower == "nous":
+        # Nous Portal is OpenAI-compatible on the wire; NousLLM adds rotating
+        # inference:invoke JWT auth read natively from ~/.hermes/auth.json
+        # (no static api_key, no hermes_cli dependency — same shape as Codex).
+        from hindsight_api.engine.providers.nous_llm import NousLLM
+
+        return NousLLM(
+            provider=provider,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            extra_body=extra_body,
+        )
+
     elif provider_lower in (
         "openai",
         "groq",
@@ -569,6 +585,7 @@ class LLMProvider:
             "zai",
             "opencode-go",
             "fireworks",
+            "nous",
         ]
         if self.provider not in valid_providers:
             raise ValueError(f"Invalid LLM provider: {self.provider}. Must be one of: {', '.join(valid_providers)}")
@@ -593,6 +610,8 @@ class LLMProvider:
                 self.base_url = "https://api.z.ai/api/coding/paas/v4"
             elif self.provider == "opencode-go":
                 self.base_url = "https://opencode.ai/zen/go/v1"
+            elif self.provider == "nous":
+                self.base_url = "https://inference-api.nousresearch.com/v1"
 
         # Prepare Vertex AI config (if applicable)
         vertexai_project_id = None

--- a/hindsight-api-slim/hindsight_api/engine/providers/nous_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/nous_auth.py
@@ -1,0 +1,463 @@
+"""
+Native Nous Portal OAuth authentication manager.
+
+The Nous Portal inference endpoint (https://inference-api.nousresearch.com/v1)
+speaks the OpenAI-compatible wire format but authenticates with a short-lived,
+inference-scoped JWT rather than a static API key. Hermes obtains that JWT once
+via an interactive browser login (``hermes portal``) and persists the resulting
+OAuth state — ``access_token`` + ``refresh_token`` — under ``providers.nous`` in
+``~/.hermes/auth.json``.
+
+This manager reads that file *directly* and refreshes the access token itself,
+exactly mirroring ``codex_auth.py`` (read ``~/.codex/auth.json`` + native
+refresh). It deliberately does **not** import the Hermes ``hermes_cli`` package:
+that package is the interactive CLI, not a library Hindsight can depend on. The
+refresh request shape is mirrored from Hermes' own resolver
+(``POST {portal}/api/oauth/token`` with an ``x-nous-refresh-token`` header and a
+``grant_type=refresh_token`` form body), so server-side changes affect both
+clients identically. The inference bearer is the access token itself — in
+Hermes' state the ``agent_key`` field is literally ``= access_token``.
+
+Single-use refresh tokens
+-------------------------
+Nous refresh tokens are single-use with server-side reuse-detection: if two
+processes refresh with the same ``refresh_token``, or a rotated token is not
+persisted back, the Portal revokes the whole session as a theft signal. Because
+Hindsight shares ``~/.hermes/auth.json`` with a possibly-running Hermes agent,
+every refresh here is performed while holding the **same cross-process advisory
+lock Hermes uses** (``~/.hermes/auth.lock`` via ``fcntl.flock``) and re-reads the
+latest ``refresh_token`` from disk under that lock before exchanging it. That is
+the protocol Hermes follows too, so the two coordinate safely through the file.
+
+Usage
+-----
+    mgr = NousAuthManager.from_file()
+    token = mgr.ensure_fresh_token()        # proactive; refreshes if near expiry
+    ...                                       # use token as Bearer
+    mgr.refresh_tokens(force=True)           # reactive, on a 401
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants — mirrored from Hermes' canonical Nous resolver
+# (hermes_cli/auth.py: DEFAULT_NOUS_* and _refresh_access_token). Endpoints and
+# client id are overridable via the same env vars Hermes honours, so a staging
+# Portal or a future change can be pointed at without a code change.
+# ---------------------------------------------------------------------------
+
+_NOUS_PORTAL_BASE_URL = (
+    os.environ.get("HERMES_PORTAL_BASE_URL")
+    or os.environ.get("NOUS_PORTAL_BASE_URL")
+    or "https://portal.nousresearch.com"
+)
+_NOUS_INFERENCE_BASE_URL = os.environ.get("NOUS_INFERENCE_BASE_URL") or "https://inference-api.nousresearch.com/v1"
+_NOUS_CLIENT_ID = "hermes-cli"
+
+# Proactively refresh this many seconds before the JWT ``exp`` claim — matches
+# the 120s skew Hermes' own runtime resolver uses for Nous.
+_NOUS_TOKEN_REFRESH_SKEW_SECONDS = 120
+
+# OAuth error codes the Portal returns when the refresh_token itself is no
+# longer usable. These are terminal — retrying will not succeed; the user must
+# re-run ``hermes portal``.
+_NOUS_TERMINAL_REFRESH_ERROR_CODES = frozenset(
+    {"invalid_grant", "invalid_token", "refresh_token_reused", "refresh_token_expired"}
+)
+
+_AUTH_LOCK_TIMEOUT_SECONDS = 20.0
+
+
+def _default_auth_file() -> Path:
+    return Path.home() / ".hermes" / "auth.json"
+
+
+class NousNotLoggedInError(RuntimeError):
+    """Raised when ``~/.hermes/auth.json`` has no usable Nous OAuth state.
+
+    Remediation: run ``hermes portal`` to log in to Nous Portal.
+    """
+
+
+class NousRefreshExpiredError(RuntimeError):
+    """Raised when the Nous refresh_token itself is permanently invalid.
+
+    The user must re-run ``hermes portal`` to obtain new credentials. Callers
+    should surface a clear remediation message and stop retrying.
+    """
+
+
+@contextlib.contextmanager
+def _hermes_auth_lock(auth_file: Path, timeout_seconds: float = _AUTH_LOCK_TIMEOUT_SECONDS) -> Iterator[None]:
+    """Cross-process advisory lock on the Hermes auth store.
+
+    Uses ``<auth_file>.lock`` (i.e. ``~/.hermes/auth.lock``) with
+    ``fcntl.flock(LOCK_EX)`` — the exact same lock file and primitive Hermes'
+    ``_auth_store_lock`` takes — so a refresh here is mutually exclusive with a
+    concurrently-running Hermes agent. Degrades to a no-op (with a debug log)
+    where ``fcntl`` is unavailable (Windows); the single-process in-memory lock
+    still serialises this process's own refreshes.
+    """
+    if fcntl is None:  # pragma: no cover - Windows
+        logger.debug("fcntl unavailable; Nous refresh proceeds without a cross-process lock.")
+        yield
+        return
+
+    lock_path = auth_file.with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+") as lock_file:
+        deadline = time.monotonic() + max(1.0, timeout_seconds)
+        while True:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("Timed out waiting for the Hermes auth store lock") from None
+                time.sleep(0.05)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+class NousAuthManager:
+    """Sync Nous Portal OAuth credential manager.
+
+    Holds the access_token + refresh_token in memory and handles
+    proactive/reactive refresh. A ``threading.Lock`` gives single-flight
+    semantics within the process; the cross-process ``fcntl`` lock guards
+    against a concurrent Hermes agent (see module docstring).
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        refresh_token: str | None,
+        auth_file: Path,
+        *,
+        portal_base_url: str = _NOUS_PORTAL_BASE_URL,
+        inference_base_url: str = _NOUS_INFERENCE_BASE_URL,
+        client_id: str = _NOUS_CLIENT_ID,
+    ) -> None:
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self._auth_file = auth_file
+        self._portal_base_url = portal_base_url.rstrip("/")
+        self._inference_base_url = inference_base_url.rstrip("/")
+        self._client_id = client_id
+        self._lock = threading.Lock()
+        self._http_client = httpx.Client(timeout=30.0)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_file(cls, auth_file: Path | None = None) -> "NousAuthManager":
+        """Build a manager from ``providers.nous`` in the Hermes auth store.
+
+        Raises
+        ------
+        NousNotLoggedInError:
+            If the file is missing, unreadable, or has no Nous OAuth state with
+            an ``access_token``.
+        """
+        if auth_file is None:
+            auth_file = _default_auth_file()
+
+        if not auth_file.exists():
+            raise NousNotLoggedInError(
+                f"Hermes auth file not found: {auth_file}. Run 'hermes portal' to log in to Nous Portal."
+            )
+
+        try:
+            with open(auth_file) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise NousNotLoggedInError(f"Could not read Hermes auth file {auth_file}: {type(e).__name__}") from e
+
+        state = cls._nous_state(data)
+        if not state:
+            raise NousNotLoggedInError(
+                "Hermes is not logged into Nous Portal (no providers.nous OAuth state). Run 'hermes portal'."
+            )
+
+        access_token = state.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise NousNotLoggedInError("Nous OAuth state has no access_token. Re-authenticate with 'hermes portal'.")
+
+        return cls(
+            access_token=access_token,
+            refresh_token=state.get("refresh_token"),
+            auth_file=auth_file,
+            portal_base_url=cls._optional_url(state.get("portal_base_url")) or _NOUS_PORTAL_BASE_URL,
+            inference_base_url=cls._optional_url(state.get("inference_base_url")) or _NOUS_INFERENCE_BASE_URL,
+            client_id=str(state.get("client_id") or _NOUS_CLIENT_ID),
+        )
+
+    @staticmethod
+    def _nous_state(data: dict[str, Any]) -> dict[str, Any]:
+        """Pull the ``providers.nous`` state dict out of a loaded auth store."""
+        providers = data.get("providers")
+        if not isinstance(providers, dict):
+            return {}
+        state = providers.get("nous")
+        return state if isinstance(state, dict) else {}
+
+    @staticmethod
+    def _optional_url(value: Any) -> str | None:
+        return value.rstrip("/") if isinstance(value, str) and value.strip() else None
+
+    @property
+    def base_url(self) -> str:
+        return self._inference_base_url
+
+    # ------------------------------------------------------------------
+    # Token state
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def load_refresh_token_from_file(auth_file: Path) -> str | None:
+        """Read ``providers.nous.refresh_token`` from ``auth_file``.
+
+        Returns ``None`` when the file is unreadable or omits the field. Does
+        not raise — the caller degrades to using the in-memory token.
+        """
+        try:
+            with open(auth_file) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        return NousAuthManager._nous_state(data).get("refresh_token")
+
+    @staticmethod
+    def _decode_jwt_exp_unixtime(token: str) -> int | None:
+        """Return the JWT ``exp`` claim as a unix timestamp, or None on failure.
+
+        The signature is not verified — the server is the source of truth on
+        acceptance. This only schedules proactive refresh.
+        """
+        try:
+            parts = token.split(".")
+            if len(parts) < 2:
+                return None
+            payload_b64 = parts[1]
+            padding = "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64 + padding).decode("utf-8"))
+            exp = payload.get("exp")
+            return int(exp) if exp is not None else None
+        except (ValueError, TypeError, json.JSONDecodeError, binascii.Error):
+            return None
+
+    def _token_is_stale(self, skew_seconds: int = _NOUS_TOKEN_REFRESH_SKEW_SECONDS) -> bool:
+        """True when the cached access_token is past expiry (with skew).
+
+        Returns False when expiry cannot be determined — we'd rather use a
+        possibly-expired token and recover via the reactive 401 path than
+        refresh aggressively on every request when ``exp`` is unparseable.
+        """
+        exp = self._decode_jwt_exp_unixtime(self.access_token)
+        if exp is None:
+            return False
+        return exp <= int(time.time()) + skew_seconds
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _persist_state_atomic(self, updated: dict[str, Any]) -> None:
+        """Patch ``providers.nous`` in ``_auth_file`` and write atomically.
+
+        Re-reads the on-disk store first so fields written by Hermes (other
+        providers, the credential pool, rotated tokens) are never clobbered,
+        then patches only the Nous OAuth fields and ``os.replace``s into place
+        (atomic on POSIX within the same filesystem). Must be called while
+        holding :func:`_hermes_auth_lock`.
+        """
+        try:
+            with open(self._auth_file) as f:
+                loaded = json.load(f)
+            current: dict[str, Any] = loaded if isinstance(loaded, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            current = {}
+
+        providers = current.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+            current["providers"] = providers
+        state = providers.get("nous")
+        if not isinstance(state, dict):
+            state = {}
+            providers["nous"] = state
+
+        state.update(updated)
+        # The inference bearer is the access token itself; keep agent_key in
+        # sync so Hermes' own resolver/status sees the rotation too.
+        state["agent_key"] = updated.get("access_token", state.get("access_token"))
+        current["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        parent = self._auth_file.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".auth.", suffix=".json.tmp", dir=str(parent))
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(current, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            with contextlib.suppress(OSError):
+                os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, self._auth_file)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+
+    # ------------------------------------------------------------------
+    # Refresh
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_oauth_error_code(response: httpx.Response) -> str | None:
+        """Pull the OAuth error code out of a 4xx refresh response, if present."""
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(body, dict):
+            return None
+        err = body.get("error")
+        if isinstance(err, str):
+            return err
+        if isinstance(err, dict) and isinstance(err.get("code"), str):
+            return err["code"]
+        code = body.get("error_code")
+        return code if isinstance(code, str) else None
+
+    def refresh_tokens(self, reason: str = "", *, force: bool = False) -> None:
+        """Single-flight Nous OAuth token refresh.
+
+        Serialised through ``self._lock`` (in-process single-flight) and
+        :func:`_hermes_auth_lock` (cross-process, vs a running Hermes agent).
+        The latest ``refresh_token`` is re-read from disk under the lock before
+        the exchange — single-use tokens make using a stale in-memory RT a
+        session-revoking mistake.
+
+        Raises
+        ------
+        NousRefreshExpiredError:
+            On a terminal refresh error (expired/reused/invalid grant).
+        RuntimeError:
+            For other refresh failures (network, 5xx, missing refresh_token).
+        """
+        token_before_lock = self.access_token
+        with self._lock:
+            if force:
+                if self.access_token != token_before_lock:
+                    return  # another caller already refreshed while we waited
+            elif not self._token_is_stale():
+                return
+
+            with _hermes_auth_lock(self._auth_file):
+                # Re-read the freshest refresh_token persisted by whoever rotated
+                # last (this process or Hermes). Using a stale RT is exactly what
+                # trips the Portal's single-use reuse-detection.
+                disk_rt = self.load_refresh_token_from_file(self._auth_file)
+                if disk_rt:
+                    self.refresh_token = disk_rt
+
+                if not self.refresh_token:
+                    raise RuntimeError(
+                        "Nous access_token is expired but no refresh_token is available. "
+                        "Run 'hermes portal' to re-authenticate."
+                    )
+
+                log_reason = f" ({reason})" if reason else ""
+                logger.info(f"Refreshing Nous Portal access_token{log_reason}")
+
+                try:
+                    response = self._http_client.post(
+                        f"{self._portal_base_url}/api/oauth/token",
+                        headers={"x-nous-refresh-token": self.refresh_token},
+                        data={"grant_type": "refresh_token", "client_id": self._client_id},
+                        timeout=30.0,
+                    )
+                except httpx.RequestError as e:
+                    raise RuntimeError(f"Nous OAuth refresh network error: {type(e).__name__}") from e
+
+                if response.status_code != 200:
+                    code = self._extract_oauth_error_code(response)
+                    if code in _NOUS_TERMINAL_REFRESH_ERROR_CODES or response.status_code in (400, 401):
+                        raise NousRefreshExpiredError(
+                            f"Nous refresh_token is no longer valid (status={response.status_code}, "
+                            f"error={code or 'none'}). Run 'hermes portal' to re-authenticate."
+                        )
+                    raise RuntimeError(f"Nous OAuth refresh failed with HTTP {response.status_code}")
+
+                try:
+                    body = response.json()
+                except (json.JSONDecodeError, ValueError) as e:
+                    raise RuntimeError(f"Nous OAuth refresh returned non-JSON body: {e}") from e
+
+                new_access = body.get("access_token")
+                if not new_access:
+                    raise RuntimeError("Nous OAuth refresh returned no access_token")
+                new_refresh = body.get("refresh_token") or self.refresh_token
+
+                # Update in-memory state first so waiters see fresh credentials
+                # even if the disk write fails.
+                self.access_token = new_access
+                self.refresh_token = new_refresh
+
+                persisted: dict[str, Any] = {"access_token": new_access, "refresh_token": new_refresh}
+                expires_in = body.get("expires_in")
+                if isinstance(expires_in, (int, float)):
+                    persisted["expires_at"] = datetime.fromtimestamp(
+                        time.time() + float(expires_in), tz=timezone.utc
+                    ).isoformat()
+                try:
+                    self._persist_state_atomic(persisted)
+                except OSError as e:
+                    logger.warning(
+                        f"Nous refresh succeeded but persisting auth.json failed: {type(e).__name__}. "
+                        "In-memory credentials are current; the on-disk rotated token was not saved."
+                    )
+                logger.info("Nous Portal access_token refreshed successfully")
+
+    def ensure_fresh_token(self) -> str:
+        """Refresh proactively if near/at expiry, then return the bearer token.
+
+        Cheap when fresh (a JWT exp decode + comparison).
+        """
+        if self._token_is_stale():
+            self.refresh_tokens(reason="proactive (token near expiry)")
+        return self.access_token
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._http_client.close()

--- a/hindsight-api-slim/hindsight_api/engine/providers/nous_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/nous_llm.py
@@ -1,0 +1,167 @@
+"""
+Nous Portal LLM provider for Hindsight.
+
+Thin wrapper over :class:`OpenAICompatibleLLM`. The Nous Portal speaks the
+OpenAI chat-completions wire format, so all request/response handling is
+inherited unchanged. The only thing Nous needs on top is a rotating,
+inference-scoped JWT (there is no static API key in the Hermes login flow),
+which :class:`NousAuthManager` reads from ``~/.hermes/auth.json`` and refreshes
+natively — the same pattern as the Codex provider, with no dependency on the
+``hermes_cli`` package. See ``nous_auth.py`` for the auth mechanics.
+
+Configure with::
+
+    llm_provider = "nous"
+    llm_base_url = "https://inference-api.nousresearch.com/v1"   # or omit
+    llm_model    = "deepseek/deepseek-v4-flash"                  # any Nous slug
+
+No API key is set in config; the token comes from the shared Hermes auth store
+after a one-time ``hermes portal`` login.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from openai import APIStatusError, AsyncOpenAI
+
+from hindsight_api.engine.providers.nous_auth import (
+    NousAuthManager,
+    NousNotLoggedInError,
+    NousRefreshExpiredError,
+)
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["NousLLM", "NousAuthManager", "NousNotLoggedInError", "NousRefreshExpiredError"]
+
+
+class NousLLM(OpenAICompatibleLLM):
+    """OpenAI-compatible provider for the Nous Portal with rotating-JWT auth."""
+
+    def __init__(
+        self,
+        provider: str,
+        api_key: str,  # Ignored — the token is read from ~/.hermes/auth.json
+        base_url: str,
+        model: str,
+        reasoning_effort: str = "low",
+        **kwargs: Any,
+    ):
+        try:
+            self._auth = NousAuthManager.from_file()
+        except NousNotLoggedInError as e:
+            raise RuntimeError(
+                f"Failed to load Nous Portal credentials: {e}\n\n"
+                "To set up Nous authentication:\n"
+                "1. Install Hermes: https://hermes-agent.nousresearch.com\n"
+                "2. Log in to Nous Portal: hermes portal\n"
+                "3. Verify: hermes portal status\n\n"
+                "Or use a different provider (openai, anthropic, gemini) with an API key."
+            ) from e
+
+        # Single-flight async refresh lock — concurrent coroutines racing toward
+        # an expired token produce one network refresh.
+        self._auth_lock = asyncio.Lock()
+
+        token = self._auth.access_token
+        resolved_base = base_url or self._auth.base_url
+        # Parent validates provider against a fixed list; present as "openai"
+        # (identical wire format) while retaining the true identity for logs.
+        super().__init__(
+            provider="openai",
+            api_key=token,
+            base_url=resolved_base,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            **kwargs,
+        )
+        self._nous_provider_name = provider
+        logger.info(
+            "Nous LLM initialized: model=%s base_url=%s (rotating inference:invoke JWT)",
+            self.model,
+            self.base_url,
+        )
+
+    # ------------------------------------------------------------------
+    # Token lifecycle
+    # ------------------------------------------------------------------
+
+    def _rebuild_client(self) -> None:
+        """Rebuild the OpenAI SDK client against the current token."""
+        self.api_key = self._auth.access_token
+        self._client = AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            max_retries=0,
+            timeout=self.timeout,
+        )
+
+    async def _ensure_fresh_token(self) -> None:
+        """Proactively refresh if the JWT is near expiry; rebuild on change.
+
+        Cheap when fresh (a JWT exp decode). The blocking refresh (network +
+        cross-process file lock) is offloaded to a thread so the event loop is
+        never stalled.
+        """
+        if not self._auth._token_is_stale():
+            return
+        await self._refresh(reason="proactive (token near expiry)", force=False)
+
+    async def _refresh(self, *, reason: str, force: bool) -> None:
+        token_before = self.api_key
+        async with self._auth_lock:
+            if force:
+                if self.api_key != token_before:
+                    return  # another coroutine already refreshed
+            elif not self._auth._token_is_stale():
+                return
+            await asyncio.to_thread(lambda: self._auth.refresh_tokens(reason, force=force))
+            if self._auth.access_token != self.api_key:
+                self._rebuild_client()
+
+    async def _with_auth_retry(self, fn: Any, label: str, *args: Any, **kwargs: Any) -> Any:
+        """Run an OpenAI-compatible call, refreshing once on a 401.
+
+        The proactive refresh covers most expiries; a token can still be
+        rejected mid-flight if Hermes rotated it out from under us or the exp
+        claim was unparseable. One reactive refresh + retry is the safety net.
+        """
+        await self._ensure_fresh_token()
+        try:
+            return await fn(*args, **kwargs)
+        except APIStatusError as e:
+            if getattr(e, "status_code", None) != 401:
+                raise
+            logger.warning("Nous 401 (%s) — forcing token refresh and retrying once.", label)
+            try:
+                await self._refresh(reason=f"reactive (HTTP 401 on {label})", force=True)
+            except NousRefreshExpiredError as refresh_err:
+                raise RuntimeError(
+                    "Nous authentication failed and the refresh_token is no longer valid.\n"
+                    "Run 'hermes portal' to re-authenticate."
+                ) from refresh_err
+            return await fn(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+
+    async def verify_connection(self) -> None:
+        await self._ensure_fresh_token()
+        return await super().verify_connection()
+
+    async def call(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._with_auth_retry(super().call, "call", *args, **kwargs)
+
+    async def call_with_tools(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._with_auth_retry(super().call_with_tools, "call_with_tools", *args, **kwargs)
+
+    async def cleanup(self) -> None:
+        self._auth.close()
+        parent_cleanup = getattr(super(), "cleanup", None)
+        if parent_cleanup is not None:
+            await parent_cleanup()

--- a/hindsight-api-slim/tests/test_nous_auth_refresh.py
+++ b/hindsight-api-slim/tests/test_nous_auth_refresh.py
@@ -1,0 +1,234 @@
+"""Tests for the native Nous Portal OAuth provider.
+
+The Nous provider mirrors the Codex provider: it reads OAuth state from the
+Hermes auth store (``~/.hermes/auth.json``, ``providers.nous``) and refreshes
+the inference JWT itself, with no dependency on the ``hermes_cli`` package.
+
+These tests pin that behaviour against a fake auth store on disk and a stubbed
+refresh endpoint — no network, no Hermes install required:
+
+- ``from_file`` loads access/refresh tokens (and raises a clear "logged out"
+  error when ``providers.nous`` is absent / has no access_token).
+- A loaded static-shaped store still surfaces the access_token as the bearer.
+- Proactive refresh fires when the JWT ``exp`` claim is near/past expiry.
+- The refresh request matches Hermes' shape: POST {portal}/api/oauth/token with
+  an ``x-nous-refresh-token`` header and a ``grant_type=refresh_token`` body.
+- The rotated refresh_token is persisted atomically back into
+  ``providers.nous`` (mode 0600) without clobbering sibling fields.
+- Terminal refresh errors raise ``NousRefreshExpiredError`` and do not loop.
+- Single-use safety: refresh re-reads the latest refresh_token from disk under
+  the lock before exchanging.
+- The provider registers in ``create_llm_provider`` and needs no api_key.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from hindsight_api.engine.providers.nous_auth import (
+    _NOUS_TOKEN_REFRESH_SKEW_SECONDS,
+    NousAuthManager,
+    NousNotLoggedInError,
+    NousRefreshExpiredError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _jwt_with_exp(exp_unixtime: int) -> str:
+    """Build an unsigned JWT whose payload carries the given ``exp`` claim."""
+
+    def b64(obj: dict) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+    return f"{b64({'alg': 'none'})}.{b64({'exp': exp_unixtime})}.sig"
+
+
+def _write_store(path: Path, state: dict | None, *, extra: dict | None = None) -> None:
+    store: dict = {"version": 1, "providers": {}, "credential_pool": {"openai-codex": {"keep": "me"}}}
+    if extra:
+        store.update(extra)
+    if state is not None:
+        store["providers"]["nous"] = state
+    path.write_text(json.dumps(store, indent=2))
+
+
+def _fresh_state(**overrides) -> dict:
+    state = {
+        "access_token": _jwt_with_exp(int(time.time()) + 3600),
+        "refresh_token": "rt-original",
+        "portal_base_url": "https://portal.nousresearch.com",
+        "inference_base_url": "https://inference-api.nousresearch.com/v1",
+        "client_id": "hermes-cli",
+    }
+    state.update(overrides)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# from_file
+# ---------------------------------------------------------------------------
+
+
+def test_from_file_loads_nous_oauth_state(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    _write_store(auth, _fresh_state())
+
+    mgr = NousAuthManager.from_file(auth)
+
+    assert mgr.refresh_token == "rt-original"
+    assert mgr.base_url == "https://inference-api.nousresearch.com/v1"
+    assert mgr.ensure_fresh_token() == mgr.access_token  # fresh JWT → no refresh
+
+
+def test_from_file_missing_file_raises_not_logged_in(tmp_path: Path) -> None:
+    with pytest.raises(NousNotLoggedInError, match="hermes portal"):
+        NousAuthManager.from_file(tmp_path / "nope.json")
+
+
+def test_from_file_without_nous_provider_raises_not_logged_in(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    _write_store(auth, None)  # has other providers/pool, but no providers.nous
+    with pytest.raises(NousNotLoggedInError, match="not logged into Nous Portal"):
+        NousAuthManager.from_file(auth)
+
+
+def test_from_file_without_access_token_raises(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    _write_store(auth, {"refresh_token": "rt"})
+    with pytest.raises(NousNotLoggedInError, match="no access_token"):
+        NousAuthManager.from_file(auth)
+
+
+# ---------------------------------------------------------------------------
+# Proactive refresh + request shape + persistence
+# ---------------------------------------------------------------------------
+
+
+def test_stale_token_triggers_refresh_with_hermes_request_shape(tmp_path: Path, monkeypatch) -> None:
+    auth = tmp_path / "auth.json"
+    near_exp = int(time.time()) + (_NOUS_TOKEN_REFRESH_SKEW_SECONDS - 5)  # within skew → stale
+    _write_store(auth, _fresh_state(access_token=_jwt_with_exp(near_exp)))
+    mgr = NousAuthManager.from_file(auth)
+
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    captured: dict = {}
+
+    def fake_post(url, *, headers=None, data=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["data"] = data
+        return httpx.Response(
+            200,
+            json={"access_token": new_access, "refresh_token": "rt-rotated", "expires_in": 3600},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(mgr._http_client, "post", fake_post)
+
+    token = mgr.ensure_fresh_token()
+
+    assert token == new_access
+    assert captured["url"] == "https://portal.nousresearch.com/api/oauth/token"
+    assert captured["headers"]["x-nous-refresh-token"] == "rt-original"
+    assert captured["data"] == {"grant_type": "refresh_token", "client_id": "hermes-cli"}
+
+    # Rotated tokens persisted back into providers.nous, pool preserved.
+    on_disk = json.loads(auth.read_text())
+    assert on_disk["providers"]["nous"]["access_token"] == new_access
+    assert on_disk["providers"]["nous"]["refresh_token"] == "rt-rotated"
+    assert on_disk["providers"]["nous"]["agent_key"] == new_access  # bearer == access_token
+    assert on_disk["credential_pool"]["openai-codex"] == {"keep": "me"}  # not clobbered
+    assert stat.S_IMODE(auth.stat().st_mode) == 0o600
+
+
+def test_refresh_rereads_latest_refresh_token_from_disk(tmp_path: Path, monkeypatch) -> None:
+    """Single-use safety: a token Hermes rotated on disk is used, not the stale
+    in-memory one the manager loaded at startup."""
+    auth = tmp_path / "auth.json"
+    near_exp = int(time.time()) + 10
+    _write_store(auth, _fresh_state(access_token=_jwt_with_exp(near_exp)))
+    mgr = NousAuthManager.from_file(auth)
+    assert mgr.refresh_token == "rt-original"
+
+    # Simulate a concurrent Hermes refresh that rotated the RT on disk.
+    rotated = _fresh_state(access_token=_jwt_with_exp(near_exp), refresh_token="rt-from-hermes")
+    _write_store(auth, rotated)
+
+    sent_rt: dict = {}
+
+    def fake_post(url, *, headers=None, data=None, timeout=None):
+        sent_rt["value"] = headers["x-nous-refresh-token"]
+        return httpx.Response(
+            200,
+            json={"access_token": _jwt_with_exp(int(time.time()) + 3600), "expires_in": 3600},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(mgr._http_client, "post", fake_post)
+    mgr.refresh_tokens(force=True)
+
+    assert sent_rt["value"] == "rt-from-hermes"  # disk value, not the stale in-memory "rt-original"
+
+
+# ---------------------------------------------------------------------------
+# Terminal errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status,body", [(400, {"error": "invalid_grant"}), (401, {"error": "refresh_token_reused"})])
+def test_terminal_refresh_error_raises_and_does_not_loop(tmp_path: Path, monkeypatch, status, body) -> None:
+    auth = tmp_path / "auth.json"
+    _write_store(auth, _fresh_state(access_token=_jwt_with_exp(int(time.time()) - 10)))
+    mgr = NousAuthManager.from_file(auth)
+
+    calls = {"n": 0}
+
+    def fake_post(url, *, headers=None, data=None, timeout=None):
+        calls["n"] += 1
+        return httpx.Response(status, json=body, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(mgr._http_client, "post", fake_post)
+
+    with pytest.raises(NousRefreshExpiredError, match="hermes portal"):
+        mgr.refresh_tokens(force=True)
+    assert calls["n"] == 1  # one attempt, no retry loop
+
+
+def test_missing_refresh_token_raises_runtime_error(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    state = _fresh_state(access_token=_jwt_with_exp(int(time.time()) - 10))
+    del state["refresh_token"]
+    _write_store(auth, state)
+    mgr = NousAuthManager.from_file(auth)
+
+    with pytest.raises(RuntimeError, match="no refresh_token"):
+        mgr.refresh_tokens(force=True)
+
+
+# ---------------------------------------------------------------------------
+# JWT exp decoding
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_exp_is_not_treated_as_stale(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    _write_store(auth, _fresh_state(access_token="not-a-jwt"))
+    mgr = NousAuthManager.from_file(auth)
+    # exp can't be determined → prefer reactive 401 recovery over aggressive refresh.
+    assert mgr._token_is_stale() is False
+
+
+def test_load_refresh_token_from_file_missing_returns_none(tmp_path: Path) -> None:
+    assert NousAuthManager.load_refresh_token_from_file(tmp_path / "absent.json") is None

--- a/hindsight-api-slim/tests/test_nous_provider.py
+++ b/hindsight-api-slim/tests/test_nous_provider.py
@@ -1,0 +1,125 @@
+"""Tests for Nous provider wiring into the LLM factory and the NousLLM subclass.
+
+These exercise the integration surface without a Hermes install: the auth
+manager is stubbed so we can assert base-url handling, the no-api-key contract,
+provider validation, and the proactive/reactive token-refresh plumbing on
+``NousLLM`` (rebuild client on rotation; one reactive refresh on a 401).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from openai import APIStatusError
+
+from hindsight_api.engine.llm_wrapper import requires_api_key
+from hindsight_api.engine.providers.nous_auth import NousAuthManager
+from hindsight_api.engine.providers.nous_llm import NousLLM
+
+
+class _FakeAuth:
+    """Stand-in for NousAuthManager with a controllable token + refresh."""
+
+    def __init__(self, token: str = "tok-1") -> None:
+        self.access_token = token
+        self.base_url = "https://inference-api.nousresearch.com/v1"
+        self.stale = False
+        self.refresh_calls: list[tuple[str, bool]] = []
+        self.next_token = token
+
+    def _token_is_stale(self) -> bool:
+        return self.stale
+
+    def refresh_tokens(self, reason: str = "", *, force: bool = False) -> None:
+        self.refresh_calls.append((reason, force))
+        self.access_token = self.next_token
+        self.stale = False
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _make(base_url: str = "", auth: _FakeAuth | None = None) -> NousLLM:
+    fake = auth or _FakeAuth()
+    with patch.object(NousAuthManager, "from_file", return_value=fake):
+        return NousLLM(provider="nous", api_key="ignored", base_url=base_url, model="deepseek/deepseek-v4-flash")
+
+
+# ---------------------------------------------------------------------------
+# Factory contract
+# ---------------------------------------------------------------------------
+
+
+def test_nous_does_not_require_api_key() -> None:
+    assert requires_api_key("nous") is False
+
+
+def test_nous_default_base_url_when_empty() -> None:
+    assert _make("").base_url == "https://inference-api.nousresearch.com/v1"
+
+
+def test_nous_respects_explicit_base_url() -> None:
+    llm = _make("https://staging-inference.example.com/v1")
+    assert llm.base_url == "https://staging-inference.example.com/v1"
+
+
+def test_nous_uses_loaded_token_as_api_key() -> None:
+    llm = _make(auth=_FakeAuth(token="tok-loaded"))
+    assert llm.api_key == "tok-loaded"
+
+
+# ---------------------------------------------------------------------------
+# Token refresh plumbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_token_rebuilds_client_on_rotation() -> None:
+    auth = _FakeAuth(token="tok-1")
+    llm = _make(auth=auth)
+    original_client = llm._client
+
+    auth.stale = True
+    auth.next_token = "tok-2"
+    await llm._ensure_fresh_token()
+
+    assert auth.refresh_calls == [("proactive (token near expiry)", False)]
+    assert llm.api_key == "tok-2"
+    assert llm._client is not original_client  # client rebuilt with the new token
+
+
+@pytest.mark.asyncio
+async def test_fresh_token_skips_refresh() -> None:
+    auth = _FakeAuth(token="tok-1")
+    llm = _make(auth=auth)
+    await llm._ensure_fresh_token()
+    assert auth.refresh_calls == []
+
+
+@pytest.mark.asyncio
+async def test_call_refreshes_once_on_401_then_retries() -> None:
+    auth = _FakeAuth(token="tok-1")
+    llm = _make(auth=auth)
+    auth.next_token = "tok-2"
+
+    calls = {"n": 0}
+
+    async def fake_super_call(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise APIStatusError(
+                "unauthorized",
+                response=httpx.Response(401, request=httpx.Request("POST", "http://x")),
+                body=None,
+            )
+        return "ok"
+
+    with patch.object(NousLLM.__bases__[0], "call", side_effect=fake_super_call, autospec=False):
+        result = await llm.call(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "ok"
+    assert calls["n"] == 2  # original + one retry
+    assert auth.refresh_calls[-1][1] is True  # forced refresh on the 401 path
+    assert llm.api_key == "tok-2"

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -163,7 +163,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -288,6 +288,13 @@ export HINDSIGHT_API_LLM_PROVIDER=opencode-go
 export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
 export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 # Default base_url: https://opencode.ai/zen/go/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+
+# Nous Portal (OpenAI-compatible; no API key — uses your `hermes portal` login)
+export HINDSIGHT_API_LLM_PROVIDER=nous
+export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash
+# No API key needed — reads a rotating JWT from ~/.hermes/auth.json (run `hermes portal` first).
+# Default base_url: https://inference-api.nousresearch.com/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+# See the "Nous Portal Setup" section in the Models guide for the login flow.
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -208,6 +208,11 @@ export HINDSIGHT_API_LLM_PROVIDER=opencode-go
 export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
 export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 
+# Nous Portal (OpenAI-compatible; no API key — uses your `hermes portal` login)
+export HINDSIGHT_API_LLM_PROVIDER=nous
+export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash  # any Nous-hosted slug
+# No API key needed — reads a rotating JWT from ~/.hermes/auth.json (see "Nous Portal Setup" below)
+
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
 export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
@@ -267,6 +272,49 @@ You can use any model supported by OpenAI Codex CLI
 - Tokens refresh automatically when needed
 - Usage is billed to your ChatGPT subscription (not separate API costs)
 - For personal development use only (see ChatGPT Terms of Service)
+
+---
+
+### Nous Portal Setup (Hermes)
+
+Use your [Nous Portal](https://portal.nousresearch.com) subscription for Hindsight via the Hermes CLI login — no static API key required.
+
+**Prerequisites:**
+- A Nous Portal account
+- The [Hermes](https://hermes-agent.nousresearch.com) CLI installed
+
+**Setup Steps:**
+
+1. **Log in to Nous Portal:**
+   ```bash
+   hermes portal
+   ```
+   This opens a browser to authenticate with Nous Portal and saves OAuth credentials to `~/.hermes/auth.json`.
+
+2. **Verify authentication:**
+   ```bash
+   hermes portal status  # should show "Auth: ✓ logged in"
+   ```
+
+3. **Configure Hindsight:**
+   ```bash
+   export HINDSIGHT_API_LLM_PROVIDER=nous
+   # export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash  # defaults to deepseek/deepseek-v4-flash
+   # No API key needed — reads from ~/.hermes/auth.json automatically
+   ```
+
+4. **Start Hindsight:**
+   ```bash
+   hindsight-api
+   ```
+
+You can use any model hosted on the Nous Portal inference API.
+
+**Important Notes:**
+- Credentials are read from `~/.hermes/auth.json` (the same store the Hermes agent uses) — no static API key in Hindsight's config.
+- The short-lived inference JWT is refreshed automatically, before expiry and reactively on a 401.
+- Refreshes coordinate with a running Hermes agent through the shared auth store, so the two never disrupt each other's session.
+- Default base URL: `https://inference-api.nousresearch.com/v1` (override with `HINDSIGHT_API_LLM_BASE_URL`).
 
 ---
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -163,7 +163,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
+| `HINDSIGHT_API_LLM_PROVIDER` | Provider: `openai`, `openai-codex`, `claude-code`, `anthropic`, `gemini`, `groq`, `minimax`, `deepseek`, `zai`, `opencode-go`, `nous`, `fireworks`, `ollama`, `ollama-cloud`, `lmstudio`, `llamacpp`, `vertexai`, `bedrock`, `litellm`, `litellmrouter`, `volcano`, `openrouter`, `none` | `openai` |
 | `HINDSIGHT_API_LLM_API_KEY` | API key for LLM provider | - |
 | `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-5-mini` |
 | `HINDSIGHT_API_LLM_BASE_URL` | Custom LLM endpoint | Provider default |
@@ -288,6 +288,13 @@ export HINDSIGHT_API_LLM_PROVIDER=opencode-go
 export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
 export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 # Default base_url: https://opencode.ai/zen/go/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+
+# Nous Portal (OpenAI-compatible; no API key — uses your `hermes portal` login)
+export HINDSIGHT_API_LLM_PROVIDER=nous
+export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash
+# No API key needed — reads a rotating JWT from ~/.hermes/auth.json (run `hermes portal` first).
+# Default base_url: https://inference-api.nousresearch.com/v1 (override with HINDSIGHT_API_LLM_BASE_URL if needed)
+# See the "Nous Portal Setup" section in the Models guide for the login flow.
 
 # AWS Bedrock (native support - no API key needed, uses AWS credentials)
 export HINDSIGHT_API_LLM_PROVIDER=bedrock

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -258,6 +258,11 @@ export HINDSIGHT_API_LLM_PROVIDER=opencode-go
 export HINDSIGHT_API_LLM_API_KEY=your-opencode-go-api-key
 export HINDSIGHT_API_LLM_MODEL=deepseek-v4-flash
 
+# Nous Portal (OpenAI-compatible; no API key — uses your `hermes portal` login)
+export HINDSIGHT_API_LLM_PROVIDER=nous
+export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash  # any Nous-hosted slug
+# No API key needed — reads a rotating JWT from ~/.hermes/auth.json (see "Nous Portal Setup" below)
+
 # Vertex AI (Google Cloud)
 export HINDSIGHT_API_LLM_PROVIDER=vertexai
 export HINDSIGHT_API_LLM_MODEL=gemini-3.1-flash-lite
@@ -317,6 +322,49 @@ You can use any model supported by OpenAI Codex CLI
 - Tokens refresh automatically when needed
 - Usage is billed to your ChatGPT subscription (not separate API costs)
 - For personal development use only (see ChatGPT Terms of Service)
+
+---
+
+### Nous Portal Setup (Hermes)
+
+Use your [Nous Portal](https://portal.nousresearch.com) subscription for Hindsight via the Hermes CLI login — no static API key required.
+
+**Prerequisites:**
+- A Nous Portal account
+- The [Hermes](https://hermes-agent.nousresearch.com) CLI installed
+
+**Setup Steps:**
+
+1. **Log in to Nous Portal:**
+   ```bash
+   hermes portal
+   ```
+   This opens a browser to authenticate with Nous Portal and saves OAuth credentials to `~/.hermes/auth.json`.
+
+2. **Verify authentication:**
+   ```bash
+   hermes portal status  # should show "Auth: ✓ logged in"
+   ```
+
+3. **Configure Hindsight:**
+   ```bash
+   export HINDSIGHT_API_LLM_PROVIDER=nous
+   # export HINDSIGHT_API_LLM_MODEL=deepseek/deepseek-v4-flash  # defaults to deepseek/deepseek-v4-flash
+   # No API key needed — reads from ~/.hermes/auth.json automatically
+   ```
+
+4. **Start Hindsight:**
+   ```bash
+   hindsight-api
+   ```
+
+You can use any model hosted on the Nous Portal inference API.
+
+**Important Notes:**
+- Credentials are read from `~/.hermes/auth.json` (the same store the Hermes agent uses) — no static API key in Hindsight's config.
+- The short-lived inference JWT is refreshed automatically, before expiry and reactively on a 401.
+- Refreshes coordinate with a running Hermes agent through the shared auth store, so the two never disrupt each other's session.
+- Default base URL: `https://inference-api.nousresearch.com/v1` (override with `HINDSIGHT_API_LLM_BASE_URL`).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a `nous` LLM provider that speaks the OpenAI-compatible wire format and authenticates with the rotating, inference-scoped JWT from a `hermes portal` login — read **natively** from `~/.hermes/auth.json`, exactly mirroring the existing Codex provider (`codex_auth.py`). **No dependency on the `hermes_cli` package.**

This is an alternative to #2097, which imported `hermes_cli.auth.resolve_nous_runtime_credentials`. That package is the interactive Hermes CLI, not a library Hindsight can depend on — it isn't declared in `pyproject.toml` and isn't importable in the API venv, so the provider in #2097 `ImportError`s at construction in any real deployment (`ty` flags it as an unresolved import). This PR follows the house pattern instead: read the local auth store + refresh the OAuth token ourselves.

## How it works

The Nous inference bearer **is** the OAuth access token (in Hermes' state, `agent_key == access_token`). So the flow is the same as Codex:

- **`nous_auth.py`** — `NousAuthManager.from_file()` loads `providers.nous` (`access_token` + `refresh_token`) from `~/.hermes/auth.json`, decodes the JWT `exp` for proactive refresh, and refreshes via `POST {portal}/api/oauth/token` with the `x-nous-refresh-token` header (shape mirrored from Hermes' own resolver, endpoints/client-id overridable via the same env vars). Rotated tokens are written back atomically (tempfile + `os.replace`, mode `0600`).
- **`nous_llm.py`** — thin `OpenAICompatibleLLM` subclass; the blocking refresh is offloaded via `asyncio.to_thread` so the event loop never stalls; one reactive refresh + retry on a 401.
- **`llm_wrapper.py`** — register `nous` in dispatch, validator, the no-api-key set, and the base-URL default.

### Single-use refresh token safety

Nous refresh tokens are single-use with server-side reuse-detection, and Hindsight shares `~/.hermes/auth.json` with a possibly-running Hermes agent. Every refresh here:
1. takes the **same `~/.hermes/auth.lock` `fcntl.flock`** Hermes' `_auth_store_lock` uses (mutual exclusion vs a live Hermes agent), and
2. **re-reads the latest `refresh_token` from disk under that lock** before exchanging it.

That's the protocol Hermes follows too, so the two coordinate safely through the file rather than revoking each other's session.

## Testing

**18 unit tests** (no Hermes install or network needed):
- `test_nous_auth_refresh.py` — load / missing-file / logged-out / no-access-token; proactive refresh + exact request shape; atomic write-back without clobbering the credential pool (mode 0600); terminal-error → `NousRefreshExpiredError` with no retry loop; single-use safety (refresh re-reads the latest RT from disk); JWT-exp decoding.
- `test_nous_provider.py` — factory dispatch, no-api-key contract, base-URL handling, client rebuild on rotation, one reactive refresh on a 401.

**Full live verification** against the real Nous endpoint after a `hermes portal` login:
- factory → `NousLLM` → real inference call ✅
- forced OAuth refresh: access_token changed, RT rotated + persisted ✅
- second consecutive refresh succeeds (no reuse-detection revocation — proves the rotated single-use RT was persisted correctly) ✅
- inference with the freshly-rotated token ✅
- after our rotations, Hermes' own `portal status` and resolver still report a healthy session ✅

`ty` clean on all source files; `ruff` + project lint hook pass.