### PR TITLE
feat(obsidian): grounded-note citations, collapsed-by-default, persisted layout, inline depth

### DIFF
--- a/hindsight-integrations/obsidian/src/chat-view.ts
+++ b/hindsight-integrations/obsidian/src/chat-view.ts
@@ -8,11 +8,15 @@ import { ItemView, MarkdownRenderer, Notice, type WorkspaceLeaf, setIcon } from 
 import { HINDSIGHT_ICON_ID, HINDSIGHT_MARK_DATA_URI } from "./branding";
 import { runChatTurn } from "./chat";
 import type HindsightPlugin from "./main";
-import { collectDocIds, retrievedNotesDetailed } from "./reflect-util";
+import { collectDocIds, groundedNotes, type RetrievedNote } from "./reflect-util";
 import { renderSyncStatus } from "./status-bar";
-import type { ReflectResponse, ReflectToolCall, TagGroup, TagLeaf } from "./types";
+import type { Budget, ReflectResponse, ReflectToolCall, TagGroup, TagLeaf } from "./types";
 
 const SNIPPET_MAX = 160;
+
+// Grounded notes shown before the "show all" toggle — keeps a long retrieval
+// list from burying the answer (the rest are one click away).
+const NOTES_VISIBLE = 3;
 
 // px — the composer grows with the message up to this height, then scrolls.
 const INPUT_MAX_HEIGHT = 240;
@@ -163,6 +167,23 @@ export class ChatView extends ItemView {
     folderSel.addEventListener("change", () => {
       this.folderFilter = folderSel.value;
     });
+
+    // Chat depth (reflect budget) — settable inline, and written back to the
+    // persisted default so the chat-window choice sticks across turns/sessions.
+    const depthSel = bar.createEl("select", { cls: "hindsight-chat__filter" });
+    const depths: Record<Budget, string> = {
+      low: "Depth: Low",
+      mid: "Depth: Medium",
+      high: "Depth: High",
+    };
+    for (const [value, label] of Object.entries(depths)) {
+      depthSel.createEl("option", { text: label, value });
+    }
+    depthSel.value = this.plugin.settings.defaultBudget;
+    depthSel.addEventListener("change", () => {
+      this.plugin.settings.defaultBudget = depthSel.value as Budget;
+      void this.plugin.saveSettings();
+    });
   }
 
   /** Distinct folder paths in the current vault (mirrors the folder: tags we emit). */
@@ -218,34 +239,62 @@ export class ChatView extends ItemView {
     });
   }
 
-  /** The actual notes pulled in by the reflect agent's tool calls, with snippets. */
+  /** Render one grounded note (citation link + snippet); returns the row element. */
+  private renderNoteItem(parent: HTMLElement, note: RetrievedNote): HTMLElement {
+    const item = parent.createDiv({ cls: "hindsight-chat__note" });
+    const link = item.createEl("a", {
+      cls: "hindsight-chat__citation",
+      text: this.plugin.stripDocPrefix(note.docId),
+      href: "#",
+    });
+    link.addEventListener("click", (evt) => {
+      evt.preventDefault();
+      this.openNote(note.docId);
+    });
+    const snippet = note.snippets[0];
+    if (snippet) {
+      item.createDiv({
+        cls: "hindsight-chat__snippet",
+        text: snippet.length > SNIPPET_MAX ? `${snippet.slice(0, SNIPPET_MAX)}…` : snippet,
+      });
+    }
+    return item;
+  }
+
+  /** The notes the answer is grounded on (citations), capped with a "show all". */
   private renderRetrievedNotes(container: HTMLElement, response: ReflectResponse): void {
-    const notes = retrievedNotesDetailed(response);
+    const notes = groundedNotes(response);
     const models = response.based_on?.mental_models ?? [];
     if (notes.length === 0 && models.length === 0) return;
 
     const details = container.createEl("details", { cls: "hindsight-chat__disclosure" });
-    details.open = true; // notes are the most useful evidence — show by default
+    // Collapsed by default; thereafter remembers the user's last choice (persisted).
+    details.open = this.plugin.settings.notesExpanded;
+    this.persistDisclosure(details, "notesExpanded");
     details.createEl("summary", { text: `Notes retrieved (${notes.length})` });
-    for (const note of notes) {
-      const item = details.createDiv({ cls: "hindsight-chat__note" });
-      const link = item.createEl("a", {
-        cls: "hindsight-chat__citation",
-        text: this.plugin.stripDocPrefix(note.docId),
+
+    // Render all rows but hide the overflow; "show all" reveals them in place.
+    const overflow: HTMLElement[] = [];
+    notes.forEach((note, i) => {
+      const item = this.renderNoteItem(details, note);
+      if (i >= NOTES_VISIBLE) {
+        item.hidden = true;
+        overflow.push(item);
+      }
+    });
+    if (overflow.length > 0) {
+      const more = details.createEl("a", {
+        cls: "hindsight-chat__show-all",
+        text: `Show all (${overflow.length} more)`,
         href: "#",
       });
-      link.addEventListener("click", (evt) => {
+      more.addEventListener("click", (evt) => {
         evt.preventDefault();
-        this.openNote(note.docId);
+        more.remove();
+        for (const el of overflow) el.hidden = false;
       });
-      const snippet = note.snippets[0];
-      if (snippet) {
-        item.createDiv({
-          cls: "hindsight-chat__snippet",
-          text: snippet.length > SNIPPET_MAX ? `${snippet.slice(0, SNIPPET_MAX)}…` : snippet,
-        });
-      }
     }
+
     for (const model of models) {
       details.createEl("span", {
         cls: "hindsight-chat__citation",
@@ -254,10 +303,23 @@ export class ChatView extends ItemView {
     }
   }
 
+  /** Persist a disclosure's open/closed state to settings (last value wins). */
+  private persistDisclosure(
+    details: HTMLDetailsElement,
+    key: "notesExpanded" | "reasoningExpanded"
+  ): void {
+    details.addEventListener("toggle", () => {
+      this.plugin.settings[key] = details.open;
+      void this.plugin.saveSettings();
+    });
+  }
+
   private renderReasoning(container: HTMLElement, response: ReflectResponse): void {
     const calls = response.trace?.tool_calls ?? [];
     if (calls.length === 0) return;
     const details = container.createEl("details", { cls: "hindsight-chat__disclosure" });
+    details.open = this.plugin.settings.reasoningExpanded;
+    this.persistDisclosure(details, "reasoningExpanded");
     details.createEl("summary", { text: `Reasoning (${calls.length} steps)` });
     for (const call of calls) {
       const ids = new Set<string>();

--- a/hindsight-integrations/obsidian/src/reflect-util.ts
+++ b/hindsight-integrations/obsidian/src/reflect-util.ts
@@ -68,3 +68,61 @@ export function retrievedNotesDetailed(response: ReflectResponse): RetrievedNote
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([docId, snippets]) => ({ docId, snippets: [...snippets] }));
 }
+
+/**
+ * The notes the answer is actually *grounded on* — not every note the agent
+ * glanced at. `based_on.memories` lists the cited facts (with `id` + `text` but
+ * no `document_id`); the trace's recall results carry both `id` and
+ * `document_id`. We join the two by fact `id` to recover which note each cited
+ * fact came from, deduped by note and kept in citation order.
+ *
+ * This is a much tighter, more relevant list than `retrievedNotesDetailed` (the
+ * agent's whole scratchpad). Falls back to the scratchpad only when the answer
+ * cited nothing resolvable, so the panel never goes empty while notes exist.
+ */
+export function groundedNotes(response: ReflectResponse): RetrievedNote[] {
+  // fact id → {docId, text} harvested from the trace (recall/expand/source_facts
+  // results all carry both id and document_id).
+  const factToDoc = new Map<string, { docId: string; text: string }>();
+  const indexTrace = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const v of value) indexTrace(v);
+      return;
+    }
+    if (value && typeof value === "object") {
+      const obj = value as Record<string, unknown>;
+      const id = obj.id;
+      const docId = obj.document_id;
+      if (
+        typeof id === "string" &&
+        id &&
+        typeof docId === "string" &&
+        docId &&
+        !factToDoc.has(id)
+      ) {
+        factToDoc.set(id, { docId, text: typeof obj.text === "string" ? obj.text.trim() : "" });
+      }
+      for (const v of Object.values(obj)) indexTrace(v);
+    }
+  };
+  for (const call of response.trace?.tool_calls ?? []) indexTrace(call.output);
+
+  const byDoc = new Map<string, Set<string>>();
+  const order: string[] = [];
+  for (const mem of response.based_on?.memories ?? []) {
+    // Prefer a document_id on the cited fact itself; otherwise resolve via the trace.
+    const resolved = mem.document_id ? { docId: mem.document_id, text: "" } : factToDoc.get(mem.id);
+    if (!resolved) continue;
+    let snippets = byDoc.get(resolved.docId);
+    if (!snippets) {
+      snippets = new Set<string>();
+      byDoc.set(resolved.docId, snippets);
+      order.push(resolved.docId);
+    }
+    const snippet = (mem.text || resolved.text || "").trim();
+    if (snippet) snippets.add(snippet);
+  }
+
+  if (order.length === 0) return retrievedNotesDetailed(response);
+  return order.map((docId) => ({ docId, snippets: [...(byDoc.get(docId) ?? [])] }));
+}

--- a/hindsight-integrations/obsidian/src/settings.ts
+++ b/hindsight-integrations/obsidian/src/settings.ts
@@ -16,6 +16,9 @@ export interface HindsightSettings {
   prefixDocId: boolean;
   /** Log reflect requests/responses to the console (open devtools to view). */
   debugLogging: boolean;
+  /** Chat disclosure open/closed state — remembered across sessions (last value wins). */
+  notesExpanded: boolean;
+  reasoningExpanded: boolean;
 }
 
 export const DEFAULT_SETTINGS: HindsightSettings = {
@@ -31,6 +34,10 @@ export const DEFAULT_SETTINGS: HindsightSettings = {
   // to avoid cross-vault collisions (e.g. two vaults both having Notes/todo.md).
   prefixDocId: true,
   debugLogging: false,
+  // Notes default to collapsed (the panel was previously always-open and noisy);
+  // thereafter both disclosures remember the user's last open/closed choice.
+  notesExpanded: false,
+  reasoningExpanded: false,
 };
 
 function parseFolders(value: string): string[] {

--- a/hindsight-integrations/obsidian/styles.css
+++ b/hindsight-integrations/obsidian/styles.css
@@ -161,6 +161,14 @@
   margin: 1px 0 4px;
 }
 
+.hindsight-chat__show-all {
+  display: block;
+  padding: 2px 0;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
 .hindsight-chat__actions {
   display: flex;
   gap: var(--size-4-2);

--- a/hindsight-integrations/obsidian/tests/reflect-util.spec.ts
+++ b/hindsight-integrations/obsidian/tests/reflect-util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { retrievedNotes, retrievedNotesDetailed } from "../src/reflect-util";
+import { groundedNotes, retrievedNotes, retrievedNotesDetailed } from "../src/reflect-util";
 import type { ReflectResponse } from "../src/types";
 
 describe("retrievedNotes", () => {
@@ -67,5 +67,87 @@ describe("retrievedNotesDetailed", () => {
       { docId: "Personal/journal.md", snippets: ["felt scattered"] },
       { docId: "Work/acme.md", snippets: ["Acme cares about SOC2"] },
     ]);
+  });
+});
+
+describe("groundedNotes", () => {
+  it("returns only the notes the answer cited, joined to the trace by fact id", () => {
+    const response: ReflectResponse = {
+      text: "Jon's favorite band is Tool.",
+      // The answer is grounded on just one fact...
+      based_on: { memories: [{ id: "f-tool", text: "Jon's favorite band is Tool" }] },
+      trace: {
+        tool_calls: [
+          {
+            tool: "recall",
+            input: { query: "Jon band" },
+            // ...even though the agent's scratchpad retrieved several notes.
+            output: {
+              results: [
+                { id: "f-tool", text: "Jon's favorite band is Tool", document_id: "Music/Jon.md" },
+                { id: "f-x", text: "Jon likes hiking", document_id: "People/Jon-misc.md" },
+                { id: "f-y", text: "unrelated", document_id: "Random/notes.md" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    // Only the cited note appears — not the full scratchpad.
+    expect(groundedNotes(response)).toEqual([
+      { docId: "Music/Jon.md", snippets: ["Jon's favorite band is Tool"] },
+    ]);
+  });
+
+  it("dedupes by note and preserves citation order", () => {
+    const response: ReflectResponse = {
+      text: "answer",
+      based_on: {
+        memories: [
+          { id: "b1", text: "from acme" },
+          { id: "a1", text: "from journal" },
+          { id: "b2", text: "also acme" },
+        ],
+      },
+      trace: {
+        tool_calls: [
+          {
+            tool: "recall",
+            input: { query: "q" },
+            output: {
+              results: [
+                { id: "b1", text: "from acme", document_id: "Work/acme.md" },
+                { id: "a1", text: "from journal", document_id: "Personal/journal.md" },
+                { id: "b2", text: "also acme", document_id: "Work/acme.md" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(groundedNotes(response)).toEqual([
+      { docId: "Work/acme.md", snippets: ["from acme", "also acme"] },
+      { docId: "Personal/journal.md", snippets: ["from journal"] },
+    ]);
+  });
+
+  it("falls back to the full retrieved list when nothing was cited", () => {
+    const response: ReflectResponse = {
+      text: "answer",
+      // No based_on (some responses omit it) — don't show an empty panel.
+      trace: {
+        tool_calls: [
+          {
+            tool: "recall",
+            input: { query: "q" },
+            output: { results: [{ id: "a", text: "x", document_id: "Work/acme.md" }] },
+          },
+        ],
+      },
+    };
+
+    expect(groundedNotes(response)).toEqual([{ docId: "Work/acme.md", snippets: ["x"] }]);
   });
 });


### PR DESCRIPTION
Addresses chat-UX feedback on the Obsidian plugin: the retrieved-notes panel was overwhelming (≈10 notes for a one-fact answer), always expanded, forgot its state, and depth wasn't reachable from the chat window.

## Changes

### 1. "Notes retrieved" → grounded citations (the big one)
The panel previously walked the **entire reflect trace** and unioned **every** `document_id` any tool call touched — i.e. the agent's scratchpad, not the answer's basis. A simple "Jon's favorite band is Tool" came back with ~10 notes.

Now it shows only the notes the answer is **grounded on**. `based_on.memories` lists the cited facts (with `id` + `text` but no `document_id`); the trace's recall results carry both `id` and `document_id`. New `groundedNotes()` **joins the two by fact `id`** to recover which note each cited fact came from, deduped by note in citation order. Capped at **3 visible** with a **"Show all (N more)"** toggle. Falls back to the full retrieved list only when nothing resolvable was cited, so the panel never goes empty.

### 2. Notes default to collapsed
Was hard-coded `details.open = true`. Now seeded from settings, default collapsed.

### 3. Both disclosures remember their last state
Two new persisted settings (`notesExpanded`, `reasoningExpanded`). Notes and Reasoning each write their open/closed state on toggle — last value wins across sessions.

### 4. Chat depth settable inline
Added a **Depth: Low/Medium/High** dropdown to the chat filter bar, seeded from and **written back to** the persisted default (`defaultBudget`), so the in-window choice sticks.

## Deliberately out of scope: match %
Showing a relevance/match % would need a dataplane API change — the engine computes `activation = rrf_score` internally but **drops it** when serializing (`MemoryFact` exposes no score; the `activation: 0.95` in the OpenAPI is a stale example). Deferred by design; the citations approach already fixes the "overkill" problem without it.

## Tests
- New `groundedNotes` unit tests: cites-only filtering, dedupe + order preservation, empty-`based_on` fallback.
- `tsc` clean, **46 tests pass**, build clean, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)