### PR TITLE
fix(docs): credit Cursor CLI integration to its community author (@Korayem)

### DIFF
--- a/hindsight-docs/src/data/integrations.json
+++ b/hindsight-docs/src/data/integrations.json
@@ -164,8 +164,8 @@
       "id": "cursor-cli",
       "name": "Cursor CLI",
       "description": "Automatic long-term memory for Cursor CLI via Hindsight hooks. Recalls relevant context before each prompt and retains conversations after each turn.",
-      "type": "official",
-      "by": "hindsight",
+      "type": "community",
+      "by": "Korayem",
       "category": "tool",
       "link": "/sdks/integrations/cursor-cli",
       "icon": "/img/icons/cursor-cli.svg"


### PR DESCRIPTION
## What

The **Cursor CLI** integration was a community contribution by **Salem Korayem ([@Korayem](https://github.com/Korayem))** in #1975, but the integrations gallery (`integrations.json`) listed it as `official` / "Hindsight Team". This flips it to a `community` entry attributed to the author.

```diff
-      "type": "official",
-      "by": "hindsight",
+      "type": "community",
+      "by": "Korayem",
```

## Effect

In the integrations hub the entry now renders with the **Community** badge, the author's GitHub avatar (`github.com/Korayem.png`), and **@Korayem** instead of "Hindsight Team" — matching how other community integrations (outsystems, hindclaw, context-forge) are credited.

## Notes

- Single source of truth: `hindsight-docs/src/data/integrations.json`. No other place attributed it to the Hindsight team.
- `check-integrations.mjs` passes (doc page + entry intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)