### PR TITLE
fix(migrations): catch CommandError-wrapped ResolutionError in rolling-deployment skip

### DIFF
--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from alembic.script.revision import ResolutionError
+from alembic.util.exc import CommandError
 from sqlalchemy import Connection, create_engine, text
 
 from ._pg_search import normalize_pg_search_tokenizer, pg_search_bm25_columns
@@ -131,7 +132,12 @@ def _run_migrations_internal(database_url: str, script_location: str, schema: st
     try:
         with _alembic_lock:
             command.upgrade(alembic_cfg, "heads")
-    except ResolutionError as e:
+    except (ResolutionError, CommandError) as e:
+        # command.upgrade() wraps ResolutionError in CommandError via
+        # ScriptDirectory._catch_revision_errors, so the wrapped form is what
+        # actually reaches us; re-raise CommandErrors with any other cause.
+        if isinstance(e, CommandError) and not isinstance(e.__cause__, ResolutionError):
+            raise
         # This happens during rolling deployments when a newer version of the code
         # has already run migrations, and this older replica doesn't have the new
         # migration files. The database is already at a newer revision than we know.

--- a/hindsight-api-slim/tests/test_migrations_newer_revision.py
+++ b/hindsight-api-slim/tests/test_migrations_newer_revision.py
@@ -1,0 +1,51 @@
+"""Newer-bank rolling-deployment handling in _run_migrations_internal.
+
+command.upgrade() does not raise ResolutionError directly: alembic's
+ScriptDirectory._catch_revision_errors wraps it in CommandError. The
+rolling-deployment skip must therefore handle the wrapped form too
+(github issue #2114).
+"""
+
+import logging
+
+import pytest
+from alembic.script.revision import ResolutionError
+from alembic.util.exc import CommandError
+
+from hindsight_api import migrations
+
+DB_URL = "postgresql://user:pass@localhost/db"
+
+
+def _raise_wrapped_resolution_error(_cfg, _revision):
+    # Mirrors alembic's _catch_revision_errors wrapping.
+    try:
+        raise ResolutionError("No such revision or branch 'c1d2e3f4a5b6'", "c1d2e3f4a5b6")
+    except ResolutionError as err:
+        raise CommandError("Can't locate revision identified by 'c1d2e3f4a5b6'") from err
+
+
+def test_wrapped_resolution_error_skips_migrations(monkeypatch, caplog):
+    monkeypatch.setattr(migrations.command, "upgrade", _raise_wrapped_resolution_error)
+    with caplog.at_level(logging.WARNING):
+        migrations._run_migrations_internal(DB_URL, "/tmp/alembic")
+    assert "newer migration revision" in caplog.text
+
+
+def test_bare_resolution_error_still_skips_migrations(monkeypatch, caplog):
+    def raise_resolution_error(_cfg, _revision):
+        raise ResolutionError("No such revision or branch 'c1d2e3f4a5b6'", "c1d2e3f4a5b6")
+
+    monkeypatch.setattr(migrations.command, "upgrade", raise_resolution_error)
+    with caplog.at_level(logging.WARNING):
+        migrations._run_migrations_internal(DB_URL, "/tmp/alembic")
+    assert "newer migration revision" in caplog.text
+
+
+def test_unrelated_command_error_propagates(monkeypatch):
+    def raise_command_error(_cfg, _revision):
+        raise CommandError("Path doesn't exist: '/tmp/alembic'")
+
+    monkeypatch.setattr(migrations.command, "upgrade", raise_command_error)
+    with pytest.raises(CommandError):
+        migrations._run_migrations_internal(DB_URL, "/tmp/alembic")


### PR DESCRIPTION
## What

The rolling-deployment "newer bank" guard in `_run_migrations_internal` catches `ResolutionError`, but `command.upgrade()` never raises that directly — alembic's `ScriptDirectory._catch_revision_errors` wraps it in `alembic.util.exc.CommandError`. So when an older replica starts against a database migrated by newer code, the designed warn-and-skip path never fires and startup dies with a raw traceback.

This PR catches the wrapped form too, cause-checked: `CommandError` is only swallowed when `isinstance(e.__cause__, ResolutionError)`; any other `CommandError` propagates unchanged.

Fixes #2114

## How it was hit

0.6.1 daemon starting against a bank migrated by 0.7.2 (head `c1d2e3f4a5b6`) — full traceback in #2114. The handler's log message ("Skipping migrations") never appeared; instead the daemon refused to start.

## Tests

New `tests/test_migrations_newer_revision.py` (modeled on `test_migrations_thread_safety.py` — monkeypatched `command.upgrade`, no DB needed):

- wrapped `CommandError(cause=ResolutionError)` → warn-and-skip (the regression)
- bare `ResolutionError` → warn-and-skip (existing behavior preserved)
- unrelated `CommandError` → still raises

## Verification

- `uv run pytest tests/test_migrations_newer_revision.py tests/test_migrations_thread_safety.py` → 4 passed
- `ruff check` / `ruff format --check` clean on both touched files
- Environment: macOS (Intel x86_64), Python 3.11.15
