### PR TITLE
fix(docs): read observation history before curating facts in memories.py

### DIFF
--- a/hindsight-docs/examples/api/memories.py
+++ b/hindsight-docs/examples/api/memories.py
@@ -38,6 +38,20 @@ async def main():
     print(f"{len(invalidated.items)} invalidated fact(s)")
     # [/docs:list-memories]
 
+    # An observation (derived) exposes how it evolved as sources arrived. Read
+    # it here, before the edit/invalidate/restore below: any update_memory call
+    # re-consolidates and recreates observations with new ids, so an id captured
+    # before those steps is stale afterward (get_observation_history would 404).
+    observation = next((u for u in memories.items if u["fact_type"] == "observation"), None)
+    if observation is not None:
+        # [docs:observation-history]
+        # Get the refresh history of a derived observation.
+        history = await client.memory.get_observation_history(
+            bank_id=BANK_ID, memory_id=observation["id"]
+        )
+        print(f"Observation history entries: {len(history)}")
+        # [/docs:observation-history]
+
     # Grab a raw fact (world/experience) to curate in the examples below.
     fact = next((u for u in memories.items if u["fact_type"] in ("world", "experience")), None)
     if fact is None:
@@ -102,17 +116,6 @@ async def main():
         update_memory_request=UpdateMemoryRequest(state="valid"),
     )
     # [/docs:restore-memory]
-
-    # An observation (derived) exposes how it evolved as sources arrived.
-    observation = next((u for u in memories.items if u["fact_type"] == "observation"), None)
-    if observation is not None:
-        # [docs:observation-history]
-        # Get the refresh history of a derived observation.
-        history = await client.memory.get_observation_history(
-            bank_id=BANK_ID, memory_id=observation["id"]
-        )
-        print(f"Observation history entries: {len(history)}")
-        # [/docs:observation-history]
 
     # =========================================================================
     # Cleanup (not shown in docs)


### PR DESCRIPTION
## Problem

`test-doc-examples (python)` fails on `memories.py` across all open PRs:

```
File ".../hindsight-docs/examples/api/memories.py", in main
  ... get_observation_history ...
hindsight_client_api.exceptions.NotFoundException: (404)
```

## Root cause

The example lists memories once, then runs **edit → invalidate → restore** on a fact. Any `update_memory` call re-consolidates the bank and **recreates derived observations with new ids**. The example then selected an observation from the *earlier* listing and called `get_observation_history(observation["id"])` — but that id was dropped by the curate steps, so the engine correctly returns 404. Not an engine bug.

## Fix

Move the observation-history read to **immediately after `list_memories`, before** the edit/invalidate/restore — so it uses a live observation id. No re-consolidation timing dependency, and it actually exercises the endpoint against an observation that's present. The existing `if observation is not None` guard still covers the no-observation case.

(Earlier approach of re-listing *after* the restore was rejected — it relied on async re-consolidation rebuilding the observation within a sleep, which could silently skip the endpoint.)

Example-only change. Unblocks the python doc-examples check repo-wide (currently red on #2118, #1989, and any other open PR).