### PR TITLE
feat(retain): chunk JSONL at line boundaries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -445,7 +445,7 @@ def _split_contents_into_sub_batches(
 
     Any single item that already exceeds the budget is chunked via
     ``fact_extraction.chunk_text`` (paragraph/sentence aware, or
-    conversation-turn aware for JSON arrays) and each chunk becomes its
+    conversation-turn aware for JSON arrays and JSONL) and each chunk becomes its
     own single-item sub-batch. Without this, an oversized single item
     would pass through as a ``1/1`` sub-batch holding the entire
     payload — which contradicts the splitter's log and lets the

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -406,22 +406,63 @@ class VerbatimFactExtractionResponse(BaseModel):
     facts: list[VerbatimExtractedFact] = Field(description="List of metadata entries (one per chunk)")
 
 
+# Separators for sentence-aware recursive text splitting, ordered most- to
+# least-preferred. The final "" lets the splitter break mid-word as a last
+# resort so a chunk can never exceed the size budget.
+_RECURSIVE_TEXT_SEPARATORS = [
+    "\n\n",  # Paragraph breaks
+    "\n",  # Line breaks
+    ". ",  # Sentence endings
+    "! ",  # Exclamations
+    "? ",  # Questions
+    "; ",  # Semicolons
+    ", ",  # Commas
+    " ",  # Words
+    "",  # Characters (last resort)
+]
+
+# A single structured unit (a JSONL line or a conversation turn) is kept whole
+# even when it overflows the budget — but only up to this multiple. Beyond it,
+# the unit is split as text rather than handed to the LLM wildly over budget
+# (the extractor has no second re-chunk pass; an oversized chunk just errors).
+_CHUNK_OVERFLOW_FACTOR = 1.5
+
+
+def _split_oversized_unit(text: str, max_chars: int) -> list[str]:
+    """Sentence-aware split of a single unit that overflowed the budget.
+
+    Used when one JSONL line / conversation turn is so large it can't be kept
+    whole within ``_CHUNK_OVERFLOW_FACTOR``. The resulting fragments are no
+    longer valid JSON, but the fact extractor treats every chunk as plain text.
+    """
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=max_chars,
+        chunk_overlap=0,
+        length_function=len,
+        is_separator_regex=False,
+        separators=_RECURSIVE_TEXT_SEPARATORS,
+    )
+    return splitter.split_text(text)
+
+
 def chunk_text(text: str, max_chars: int) -> list[str]:
     """
     Split text into chunks, preserving conversation structure when possible.
 
-    For JSON conversation arrays (user/assistant turns), splits at turn boundaries
-    while preserving speaker context. For plain text, uses sentence-aware splitting.
+    For JSON conversation arrays (user/assistant turns) and JSONL (newline-delimited
+    JSON objects), splits at turn/line boundaries so no object is split across chunks.
+    A single turn/line that overflows is kept whole up to ``_CHUNK_OVERFLOW_FACTOR``×
+    the budget, then split as text. For plain text, uses sentence-aware splitting.
 
     Args:
-        text: Input text to chunk (plain text or JSON conversation)
+        text: Input text to chunk (plain text, JSON conversation, or JSONL)
         max_chars: Maximum characters per chunk (default 120k ≈ 30k tokens)
 
     Returns:
         List of text chunks, roughly under max_chars
     """
-    from langchain_text_splitters import RecursiveCharacterTextSplitter
-
     # If text is small enough, return as-is
     if len(text) <= max_chars:
         return [text]
@@ -435,26 +476,13 @@ def chunk_text(text: str, max_chars: int) -> list[str]:
     except (json.JSONDecodeError, ValueError):
         pass
 
-    # Fall back to sentence-aware text splitting
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=max_chars,
-        chunk_overlap=0,
-        length_function=len,
-        is_separator_regex=False,
-        separators=[
-            "\n\n",  # Paragraph breaks
-            "\n",  # Line breaks
-            ". ",  # Sentence endings
-            "! ",  # Exclamations
-            "? ",  # Questions
-            "; ",  # Semicolons
-            ", ",  # Commas
-            " ",  # Words
-            "",  # Characters (last resort)
-        ],
-    )
+    # Try to parse as JSONL (newline-delimited JSON objects, e.g. session logs)
+    jsonl_chunks = _chunk_jsonl(text, max_chars)
+    if jsonl_chunks is not None:
+        return jsonl_chunks
 
-    return splitter.split_text(text)
+    # Fall back to sentence-aware text splitting
+    return _split_oversized_unit(text, max_chars)
 
 
 def _chunk_conversation(turns: list[dict], max_chars: int) -> list[str]:
@@ -469,30 +497,107 @@ def _chunk_conversation(turns: list[dict], max_chars: int) -> list[str]:
         List of JSON-serialized chunks, each containing complete turns
     """
 
+    overflow_limit = int(max_chars * _CHUNK_OVERFLOW_FACTOR)
+
     chunks = []
     current_chunk = []
     current_size = 2  # Account for "[]"
+
+    def _flush() -> None:
+        nonlocal current_chunk, current_size
+        if current_chunk:
+            chunks.append(json.dumps(current_chunk, ensure_ascii=False))
+            current_chunk = []
+            current_size = 2  # Reset to "[]"
 
     for turn in turns:
         # Estimate size of this turn when serialized (with comma separator)
         turn_json = json.dumps(turn, ensure_ascii=False)
         turn_size = len(turn_json) + 1  # +1 for comma
 
+        # A turn too large to keep whole even alone: flush, then split it as
+        # text so no chunk runs far over budget (the extractor won't re-chunk).
+        if turn_size > overflow_limit:
+            _flush()
+            chunks.extend(_split_oversized_unit(turn_json, max_chars))
+            continue
+
         # If adding this turn would exceed limit and we have turns, save current chunk
         if current_size + turn_size > max_chars and current_chunk:
-            chunks.append(json.dumps(current_chunk, ensure_ascii=False))
-            current_chunk = []
-            current_size = 2  # Reset to "[]"
+            _flush()
 
         # Add turn to current chunk
         current_chunk.append(turn)
         current_size += turn_size
 
     # Add final chunk if non-empty
-    if current_chunk:
-        chunks.append(json.dumps(current_chunk, ensure_ascii=False))
+    _flush()
 
     return chunks if chunks else [json.dumps(turns, ensure_ascii=False)]
+
+
+def _chunk_jsonl(text: str, max_chars: int) -> list[str] | None:
+    """Chunk newline-delimited JSON (JSONL) at line boundaries.
+
+    Detects JSONL — two or more non-empty lines, each a complete JSON object —
+    and packs whole lines into chunks so no line is split across chunks (multiple
+    short lines may share a chunk). A line that overflows is kept whole up to
+    ``_CHUNK_OVERFLOW_FACTOR``× the budget, then split as text. Returns ``None``
+    if the input is not JSONL, so the caller falls back to plain-text splitting.
+
+    Args:
+        text: Input text to inspect/chunk.
+        max_chars: Maximum characters per chunk.
+
+    Returns:
+        List of JSONL chunks (lines joined by newline), or ``None`` if not JSONL.
+    """
+    lines = [line for line in text.splitlines() if line.strip()]
+    if len(lines) < 2:
+        return None
+
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+
+    overflow_limit = int(max_chars * _CHUNK_OVERFLOW_FACTOR)
+
+    chunks: list[str] = []
+    current_chunk: list[str] = []
+    current_size = 0
+
+    def _flush() -> None:
+        nonlocal current_chunk, current_size
+        if current_chunk:
+            chunks.append("\n".join(current_chunk))
+            current_chunk = []
+            current_size = 0
+
+    for line in lines:
+        line_size = len(line) + 1  # +1 for the joining newline
+
+        # A line too large to keep whole even alone: flush, then split it as
+        # text so no chunk runs far over budget (the extractor won't re-chunk).
+        if line_size > overflow_limit:
+            _flush()
+            chunks.extend(_split_oversized_unit(line, max_chars))
+            continue
+
+        # If adding this line would exceed the limit and we have lines, flush.
+        # A line up to overflow_limit is kept whole (a small, bounded overflow).
+        if current_size + line_size > max_chars and current_chunk:
+            _flush()
+
+        current_chunk.append(line)
+        current_size += line_size
+
+    _flush()
+
+    return chunks
 
 
 # =============================================================================

--- a/hindsight-api-slim/tests/test_chunking.py
+++ b/hindsight-api-slim/tests/test_chunking.py
@@ -1,5 +1,9 @@
 """
 Test chunking functionality for large documents.
+
+These assert the EXACT chunk output for small, controlled inputs (so a change
+in splitting behavior is caught precisely), plus a few property/scale tests for
+large inputs where spelling out every chunk would be unwieldy.
 """
 
 import json
@@ -8,14 +12,35 @@ import pytest
 
 from hindsight_api.engine.retain.fact_extraction import chunk_text
 
+# Mirror of fact_extraction._CHUNK_OVERFLOW_FACTOR — a unit is kept whole only
+# up to this multiple of the budget before being split as text.
+OVERFLOW_FACTOR = 1.5
+
+
+# ---------------------------------------------------------------------------
+# Plain text
+# ---------------------------------------------------------------------------
+
 
 def test_chunk_text_small():
-    """Test that small text is not chunked."""
+    """Text within the budget is returned unchanged, as a single chunk."""
     text = "This is a short text. It should not be chunked."
-    chunks = chunk_text(text, max_chars=1000)
+    assert chunk_text(text, max_chars=1000) == [text]
 
-    assert len(chunks) == 1, "Small text should not be chunked"
-    assert chunks[0] == text
+
+def test_chunk_text_exact_split():
+    """Plain text splits at sentence boundaries — exact chunks."""
+    text = "Alpha sentence one. Beta sentence two. Gamma sentence three. Delta sentence four."
+
+    chunks = chunk_text(text, max_chars=40)
+
+    assert chunks == [
+        "Alpha sentence one. Beta sentence two",
+        ". Gamma sentence three",
+        ". Delta sentence four.",
+    ]
+    # Sentence-boundary splitting here is lossless: concatenation rebuilds the input.
+    assert "".join(chunks) == text
 
 
 def test_chunk_text_large():
@@ -59,14 +84,40 @@ def test_chunk_text_64k():
     assert combined_length >= len(text) * 0.95, "Lost too much content during chunking"
 
 
+# ---------------------------------------------------------------------------
+# JSONL (newline-delimited JSON objects)
+# ---------------------------------------------------------------------------
+
+
 def test_chunk_jsonl_small():
     """JSONL that fits in one chunk is returned unchanged."""
     lines = [json.dumps({"role": "user", "content": f"message {i}"}) for i in range(3)]
     text = "\n".join(lines)
 
-    chunks = chunk_text(text, max_chars=10000)
+    assert chunk_text(text, max_chars=10000) == [text]
 
-    assert chunks == [text]
+
+def test_chunk_jsonl_packs_multiple_short_lines():
+    """Short JSONL lines are packed together — exact chunk boundaries."""
+    lines = [json.dumps({"i": i}) for i in range(6)]  # each '{"i": N}' is 8 chars
+    text = "\n".join(lines)
+
+    chunks = chunk_text(text, max_chars=40)
+
+    # Four lines (8 chars + newline = 9 each -> 36) fit; the fifth would hit 45 > 40.
+    assert chunks == [
+        '{"i": 0}\n{"i": 1}\n{"i": 2}\n{"i": 3}',
+        '{"i": 4}\n{"i": 5}',
+    ]
+
+
+def test_chunk_jsonl_one_line_per_chunk():
+    """When two lines don't fit together, each lands in its own chunk."""
+    lines = [json.dumps({"k": "a" * 10}) for _ in range(3)]  # 19 chars each
+    text = "\n".join(lines)
+
+    # Budget 25: one line (20 w/ newline) fits, two (40) don't.
+    assert chunk_text(text, max_chars=25) == lines
 
 
 def test_chunk_jsonl_splits_at_line_boundaries():
@@ -86,63 +137,73 @@ def test_chunk_jsonl_splits_at_line_boundaries():
     assert seen == [json.loads(line) for line in lines], "Lines must be preserved in order"
 
 
-def test_chunk_jsonl_packs_multiple_short_lines():
-    """Several short JSONL lines that fit together share a chunk."""
-    lines = [json.dumps({"i": i}) for i in range(6)]
-    text = "\n".join(lines)
-
-    # Budget large enough for a few lines but not all of them.
-    chunks = chunk_text(text, max_chars=40)
-
-    assert len(chunks) > 1
-    # At least one chunk should contain more than a single line.
-    assert any(len(chunk.split("\n")) > 1 for chunk in chunks)
-
-
 def test_chunk_jsonl_small_overflow_kept_whole():
     """A JSONL line that overflows by less than 1.5x is kept whole, not split."""
-    # max_chars=100, overflow cap=150 -> a ~130-char line stays whole.
-    big = json.dumps({"role": "user", "content": "y" * 100})  # ~130 chars
-    small = json.dumps({"role": "assistant", "content": "ok"})
+    big = json.dumps({"c": "y" * 20})  # 29 chars; budget 25, cap 37 -> kept whole
+    small = json.dumps({"c": "ok"})
     text = "\n".join([big, small])
-    assert 100 < len(big) <= int(100 * 1.5)
+    assert 25 < len(big) <= int(25 * OVERFLOW_FACTOR)
 
-    chunks = chunk_text(text, max_chars=100)
+    chunks = chunk_text(text, max_chars=25)
 
-    # The line overflows the budget but stays a single intact JSON object.
-    assert any(json.loads(chunk.split("\n")[0]) == json.loads(big) for chunk in chunks)
-    for chunk in chunks:
-        for line in chunk.split("\n"):
-            json.loads(line)
+    # The line overflows the budget but stays a single intact chunk of its own.
+    assert chunks == [big, small]
 
 
 def test_chunk_jsonl_huge_line_is_split():
-    """A JSONL line past the 1.5x overflow cap is split as text, bounding chunk size."""
-    huge = json.dumps({"role": "user", "content": "y" * 1000})
-    small = json.dumps({"role": "assistant", "content": "ok"})
+    """A JSONL line past the 1.5x overflow cap is split as text — exact fragments."""
+    huge = json.dumps({"c": "y" * 40})  # 50 chars; budget 20, cap 30 -> must split
+    small = json.dumps({"c": "ok"})
     text = "\n".join([huge, small])
 
-    chunks = chunk_text(text, max_chars=100)
+    chunks = chunk_text(text, max_chars=20)
 
-    # The huge line can't be kept whole, so it is split into multiple chunks.
-    assert len(chunks) > 2
-    # No chunk exceeds the overflow cap (1.5x). Split fragments are <= max_chars;
-    # the only whole-kept line here ("ok") is tiny.
+    # The huge line is split into text fragments; the small line survives intact.
+    assert chunks == [
+        '{"c":',
+        '"yyyyyyyyyyyyyyyyyy',
+        "yyyyyyyyyyyyyyyyyyyy",
+        'yy"}',
+        '{"c": "ok"}',
+    ]
+    # No fragment exceeds the overflow cap.
     for chunk in chunks:
-        assert len(chunk) <= int(100 * 1.5)
-    # The small line survives intact as its own parseable object.
-    assert any(chunk == small for chunk in chunks)
+        assert len(chunk) <= int(20 * OVERFLOW_FACTOR)
+
+
+# ---------------------------------------------------------------------------
+# JSON conversation array
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_conversation_packs_turns():
+    """A conversation array packs whole turns per chunk — exact JSON-array chunks."""
+    turns = [
+        {"r": "u", "c": "hi"},
+        {"r": "a", "c": "yo"},
+        {"r": "u", "c": "bye"},
+        {"r": "a", "c": "ok"},
+    ]
+    text = json.dumps(turns)
+
+    chunks = chunk_text(text, max_chars=50)
+
+    assert chunks == [
+        '[{"r": "u", "c": "hi"}, {"r": "a", "c": "yo"}]',
+        '[{"r": "u", "c": "bye"}, {"r": "a", "c": "ok"}]',
+    ]
+    # Each chunk is itself a valid JSON array of complete turns.
+    assert [json.loads(c) for c in chunks] == [turns[:2], turns[2:]]
 
 
 def test_chunk_conversation_splits_at_turn_boundaries():
-    """A JSON conversation array chunks at turn boundaries, keeping turns whole."""
+    """A large conversation array chunks at turn boundaries, keeping turns whole."""
     turns = [{"role": "user", "content": f"message {i} " + "x" * 80} for i in range(10)]
     text = json.dumps(turns)
 
     chunks = chunk_text(text, max_chars=300)
 
     assert len(chunks) > 1
-    # Every chunk is a JSON array of complete turn objects.
     seen = []
     for chunk in chunks:
         parsed = json.loads(chunk)
@@ -152,29 +213,37 @@ def test_chunk_conversation_splits_at_turn_boundaries():
 
 
 def test_chunk_conversation_huge_turn_is_split():
-    """A single conversation turn past the 1.5x overflow cap is split as text."""
-    turns = [
-        {"role": "user", "content": "y" * 1000},
-        {"role": "assistant", "content": "ok"},
-    ]
+    """A single turn past the 1.5x overflow cap is split as text — exact fragments."""
+    turns = [{"c": "y" * 40}, {"c": "ok"}]
     text = json.dumps(turns)
 
-    chunks = chunk_text(text, max_chars=100)
+    chunks = chunk_text(text, max_chars=20)
 
-    # The huge turn can't be kept whole, so it is split into multiple chunks
-    # and no chunk runs past the overflow cap.
-    assert len(chunks) > 2
+    # The huge turn is split into text fragments; the small turn stays a JSON array.
+    assert chunks == [
+        '{"c":',
+        '"yyyyyyyyyyyyyyyyyy',
+        "yyyyyyyyyyyyyyyyyyyy",
+        'yy"}',
+        '[{"c": "ok"}]',
+    ]
     for chunk in chunks:
-        assert len(chunk) <= int(100 * 1.5)
+        assert len(chunk) <= int(20 * OVERFLOW_FACTOR)
+
+
+# ---------------------------------------------------------------------------
+# Detection guard
+# ---------------------------------------------------------------------------
 
 
 def test_plain_text_lines_not_treated_as_jsonl():
-    """Plain numeric/text lines are not misdetected as JSONL."""
-    text = "\n".join([f"This is line number {i}. " + "z" * 60 for i in range(10)])
+    """Plain (non-JSON) lines fall back to text splitting, not JSONL chunking."""
+    text = "\n".join(["Line one here.", "Line two here.", "Line three now."])
 
-    chunks = chunk_text(text, max_chars=200)
+    chunks = chunk_text(text, max_chars=20)
 
-    assert len(chunks) > 1
-    # Falls back to text splitting — chunks are not JSON objects per line.
+    # Each line fits the budget, so text splitting emits one line per chunk.
+    assert chunks == ["Line one here.", "Line two here.", "Line three now."]
+    # Sanity: these are not JSON objects (so the JSONL path correctly declined).
     with pytest.raises(json.JSONDecodeError):
-        json.loads(chunks[0].split("\n")[0])
+        json.loads(chunks[0])

--- a/hindsight-api-slim/tests/test_chunking.py
+++ b/hindsight-api-slim/tests/test_chunking.py
@@ -2,7 +2,10 @@
 Test chunking functionality for large documents.
 """
 
+import json
+
 import pytest
+
 from hindsight_api.engine.retain.fact_extraction import chunk_text
 
 
@@ -54,3 +57,124 @@ def test_chunk_text_64k():
     # Verify we didn't lose content
     combined_length = sum(len(chunk) for chunk in chunks)
     assert combined_length >= len(text) * 0.95, "Lost too much content during chunking"
+
+
+def test_chunk_jsonl_small():
+    """JSONL that fits in one chunk is returned unchanged."""
+    lines = [json.dumps({"role": "user", "content": f"message {i}"}) for i in range(3)]
+    text = "\n".join(lines)
+
+    chunks = chunk_text(text, max_chars=10000)
+
+    assert chunks == [text]
+
+
+def test_chunk_jsonl_splits_at_line_boundaries():
+    """Large JSONL is chunked at line boundaries without splitting any line."""
+    lines = [json.dumps({"role": "user", "content": f"message {i} " + "x" * 80}) for i in range(10)]
+    text = "\n".join(lines)
+
+    chunks = chunk_text(text, max_chars=300)
+
+    assert len(chunks) > 1, "Large JSONL should be chunked"
+
+    # Every line across all chunks must remain a complete, parseable JSON object.
+    seen = []
+    for chunk in chunks:
+        for line in chunk.split("\n"):
+            seen.append(json.loads(line))  # raises if a line was split mid-object
+    assert seen == [json.loads(line) for line in lines], "Lines must be preserved in order"
+
+
+def test_chunk_jsonl_packs_multiple_short_lines():
+    """Several short JSONL lines that fit together share a chunk."""
+    lines = [json.dumps({"i": i}) for i in range(6)]
+    text = "\n".join(lines)
+
+    # Budget large enough for a few lines but not all of them.
+    chunks = chunk_text(text, max_chars=40)
+
+    assert len(chunks) > 1
+    # At least one chunk should contain more than a single line.
+    assert any(len(chunk.split("\n")) > 1 for chunk in chunks)
+
+
+def test_chunk_jsonl_small_overflow_kept_whole():
+    """A JSONL line that overflows by less than 1.5x is kept whole, not split."""
+    # max_chars=100, overflow cap=150 -> a ~130-char line stays whole.
+    big = json.dumps({"role": "user", "content": "y" * 100})  # ~130 chars
+    small = json.dumps({"role": "assistant", "content": "ok"})
+    text = "\n".join([big, small])
+    assert 100 < len(big) <= int(100 * 1.5)
+
+    chunks = chunk_text(text, max_chars=100)
+
+    # The line overflows the budget but stays a single intact JSON object.
+    assert any(json.loads(chunk.split("\n")[0]) == json.loads(big) for chunk in chunks)
+    for chunk in chunks:
+        for line in chunk.split("\n"):
+            json.loads(line)
+
+
+def test_chunk_jsonl_huge_line_is_split():
+    """A JSONL line past the 1.5x overflow cap is split as text, bounding chunk size."""
+    huge = json.dumps({"role": "user", "content": "y" * 1000})
+    small = json.dumps({"role": "assistant", "content": "ok"})
+    text = "\n".join([huge, small])
+
+    chunks = chunk_text(text, max_chars=100)
+
+    # The huge line can't be kept whole, so it is split into multiple chunks.
+    assert len(chunks) > 2
+    # No chunk exceeds the overflow cap (1.5x). Split fragments are <= max_chars;
+    # the only whole-kept line here ("ok") is tiny.
+    for chunk in chunks:
+        assert len(chunk) <= int(100 * 1.5)
+    # The small line survives intact as its own parseable object.
+    assert any(chunk == small for chunk in chunks)
+
+
+def test_chunk_conversation_splits_at_turn_boundaries():
+    """A JSON conversation array chunks at turn boundaries, keeping turns whole."""
+    turns = [{"role": "user", "content": f"message {i} " + "x" * 80} for i in range(10)]
+    text = json.dumps(turns)
+
+    chunks = chunk_text(text, max_chars=300)
+
+    assert len(chunks) > 1
+    # Every chunk is a JSON array of complete turn objects.
+    seen = []
+    for chunk in chunks:
+        parsed = json.loads(chunk)
+        assert isinstance(parsed, list)
+        seen.extend(parsed)
+    assert seen == turns
+
+
+def test_chunk_conversation_huge_turn_is_split():
+    """A single conversation turn past the 1.5x overflow cap is split as text."""
+    turns = [
+        {"role": "user", "content": "y" * 1000},
+        {"role": "assistant", "content": "ok"},
+    ]
+    text = json.dumps(turns)
+
+    chunks = chunk_text(text, max_chars=100)
+
+    # The huge turn can't be kept whole, so it is split into multiple chunks
+    # and no chunk runs past the overflow cap.
+    assert len(chunks) > 2
+    for chunk in chunks:
+        assert len(chunk) <= int(100 * 1.5)
+
+
+def test_plain_text_lines_not_treated_as_jsonl():
+    """Plain numeric/text lines are not misdetected as JSONL."""
+    text = "\n".join([f"This is line number {i}. " + "z" * 60 for i in range(10)])
+
+    chunks = chunk_text(text, max_chars=200)
+
+    assert len(chunks) > 1
+    # Falls back to text splitting — chunks are not JSON objects per line.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(chunks[0].split("\n")[0])


### PR DESCRIPTION
## Summary

Adds JSONL (newline-delimited JSON) support to `chunk_text`, so JSONL session data chunks the same way JSON conversation arrays already do: whole lines are packed into chunks and lines are not split mid-object. This lets JSONL be ingested with mode `append` (instead of coercing to a JSON array + `replace`).

Closes #2113

## Behavior

`chunk_text` detection order:
1. **JSON conversation array** (list of dicts) → chunk at turn boundaries
2. **JSONL** (≥2 non-empty lines, each a complete JSON object) → chunk at line boundaries *(new)*
3. **Plain text** → sentence-aware recursive splitting

## Overflow cap (both structured paths)

A single line/turn that overflows the budget is kept whole **only up to `_CHUNK_OVERFLOW_FACTOR` (1.5×)**. Beyond that it is split as text.

This matters because the oversized-item path in `retain_batch_async` (`memory_engine.py:502`) emits each `chunk_text` chunk directly to fact extraction — there is **no second token-based re-chunk**. A chunk that exceeds the model's limits just errors at the LLM (`openai_compatible_llm.py:741`). Previously both the JSONL and the existing conversation-array paths kept an oversized unit whole regardless of size, so e.g. one 10k-token line/turn would be sent wildly over budget. The cap fixes that for both paths.

## Tests

`tests/test_chunking.py` (11 pass):
- JSONL: fits-in-one-chunk, line-boundary splitting, short-line packing, ≤1.5× overflow kept whole, >1.5× split, plain-text-not-misdetected
- Conversation array: turn-boundary splitting, >1.5× turn split

Lint / format / `ty` type-check clean.