### PR TITLE
fix(api): cancel abandoned recall & reflect via cooperative cancellation token

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -6,10 +6,12 @@ the FastAPI application with all API endpoints.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import re
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Literal
@@ -17,6 +19,7 @@ from typing import Any, Literal
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
 
+from hindsight_api.cancellation import CancellationToken, OperationCancelledError
 from hindsight_api.engine.audit import (
     AuditEntry,
     AuditLogger,
@@ -89,6 +92,49 @@ from hindsight_api.metrics import create_metrics_collector, get_metrics_collecto
 from hindsight_api.models import RequestContext
 
 logger = logging.getLogger(__name__)
+
+# Starlette surfaces client disconnects through an async receive check. A
+# one-second poll stops abandoned long-running recalls without busy-waiting.
+_CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS = 1.0
+# 499 is the de facto reverse-proxy status for "client closed request".
+_CLIENT_CLOSED_REQUEST_STATUS_CODE = 499
+_CLIENT_DISCONNECTED_REASON = "client disconnected"
+
+
+@asynccontextmanager
+async def _cancel_on_client_disconnect(
+    http_request: Request,
+    request_context: RequestContext,
+    *,
+    poll_interval: float = _CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS,
+) -> AsyncIterator[CancellationToken]:
+    """Attach a cancellation token that fires when the HTTP client disconnects.
+
+    The engine checks ``request_context`` at each pipeline stage boundary and
+    raises ``OperationCancelledError`` once this token fires, so an abandoned
+    request stops consuming CPU/DB resources instead of running to completion
+    (issue #2122). A background task polls ``request.is_disconnected()``; the
+    token is restored to its previous value on exit so nested scopes compose.
+    """
+    token = CancellationToken()
+    previous_token = request_context.cancellation
+    request_context.cancellation = token
+
+    async def _watch() -> None:
+        while True:
+            if await http_request.is_disconnected():
+                token.cancel(_CLIENT_DISCONNECTED_REASON)
+                return
+            await asyncio.sleep(poll_interval)
+
+    watcher = asyncio.create_task(_watch())
+    try:
+        yield token
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+        request_context.cancellation = previous_token
 
 
 class EntityIncludeOptions(BaseModel):
@@ -3465,6 +3511,7 @@ def _register_routes(app: FastAPI):
     async def api_recall(
         bank_id: str,
         request: RecallRequest,
+        http_request: Request,
         request_context: RequestContext = Depends(get_request_context),
         _precheck: None = Depends(precheck_for("recall")),
     ):
@@ -3520,26 +3567,30 @@ def _register_routes(app: FastAPI):
                 "recall", bank_id=bank_id, source="api", budget=request.budget.value, max_tokens=request.max_tokens
             ):
                 recall_start = time.time()
-                core_result = await app.state.memory.recall_async(
-                    bank_id=bank_id,
-                    query=request.query,
-                    budget=request.budget,
-                    max_tokens=request.max_tokens,
-                    enable_trace=request.trace,
-                    fact_type=fact_types,
-                    question_date=question_date,
-                    include_entities=include_entities,
-                    max_entity_tokens=max_entity_tokens,
-                    include_chunks=include_chunks,
-                    max_chunk_tokens=max_chunk_tokens,
-                    include_source_facts=include_source_facts,
-                    max_source_facts_tokens=max_source_facts_tokens,
-                    max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,
-                    request_context=request_context,
-                    tags=request.tags,
-                    tags_match=request.tags_match,
-                    tag_groups=request.tag_groups,
-                )
+                # Cancel the recall if the client disconnects: the engine checks
+                # request_context at each stage boundary and aborts abandoned
+                # work rather than running it to completion (issue #2122).
+                async with _cancel_on_client_disconnect(http_request, request_context):
+                    core_result = await app.state.memory.recall_async(
+                        bank_id=bank_id,
+                        query=request.query,
+                        budget=request.budget,
+                        max_tokens=request.max_tokens,
+                        enable_trace=request.trace,
+                        fact_type=fact_types,
+                        question_date=question_date,
+                        include_entities=include_entities,
+                        max_entity_tokens=max_entity_tokens,
+                        include_chunks=include_chunks,
+                        max_chunk_tokens=max_chunk_tokens,
+                        include_source_facts=include_source_facts,
+                        max_source_facts_tokens=max_source_facts_tokens,
+                        max_source_facts_tokens_per_observation=max_source_facts_tokens_per_observation,
+                        request_context=request_context,
+                        tags=request.tags,
+                        tags_match=request.tags_match,
+                        tag_groups=request.tag_groups,
+                    )
 
             # Convert core MemoryFact objects to API RecallResult objects (excluding internal metrics)
             def _fact_to_result(fact: "MemoryFact") -> RecallResult:
@@ -3615,6 +3666,11 @@ def _register_routes(app: FastAPI):
             return response
         except HTTPException:
             raise
+        except OperationCancelledError as e:
+            # Client went away mid-recall; the engine aborted at a stage boundary.
+            handler_duration = time.time() - handler_start
+            logger.info(f"[RECALL CANCELLED] bank={bank_id} handler_duration={handler_duration:.3f}s reason={e.reason}")
+            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -11,10 +11,10 @@ import json
 import logging
 import re
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
@@ -135,6 +135,34 @@ async def _cancel_on_client_disconnect(
         with contextlib.suppress(asyncio.CancelledError):
             await watcher
         request_context.cancellation = previous_token
+
+
+_T = TypeVar("_T")
+
+
+async def run_cancellable_on_disconnect(
+    http_request: Request,
+    request_context: RequestContext,
+    coro: Awaitable[_T],
+    *,
+    operation: str,
+    bank_id: str,
+    poll_interval: float = _CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS,
+) -> _T:
+    """Run an engine coroutine, aborting it with 499 if the client disconnects.
+
+    Shared by the recall and reflect handlers: it attaches the disconnect-driven
+    cancellation token (which the engine checks at its stage/iteration
+    boundaries) and translates the resulting ``OperationCancelledError`` into the
+    de facto 499 status so abandoned work stops instead of running to completion
+    (issue #2122).
+    """
+    async with _cancel_on_client_disconnect(http_request, request_context, poll_interval=poll_interval):
+        try:
+            return await coro
+        except OperationCancelledError as e:
+            logger.info(f"[{operation.upper()} CANCELLED] bank={bank_id} reason={e.reason}")
+            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason) from e
 
 
 class EntityIncludeOptions(BaseModel):
@@ -3570,8 +3598,10 @@ def _register_routes(app: FastAPI):
                 # Cancel the recall if the client disconnects: the engine checks
                 # request_context at each stage boundary and aborts abandoned
                 # work rather than running it to completion (issue #2122).
-                async with _cancel_on_client_disconnect(http_request, request_context):
-                    core_result = await app.state.memory.recall_async(
+                core_result = await run_cancellable_on_disconnect(
+                    http_request,
+                    request_context,
+                    app.state.memory.recall_async(
                         bank_id=bank_id,
                         query=request.query,
                         budget=request.budget,
@@ -3590,7 +3620,10 @@ def _register_routes(app: FastAPI):
                         tags=request.tags,
                         tags_match=request.tags_match,
                         tag_groups=request.tag_groups,
-                    )
+                    ),
+                    operation="recall",
+                    bank_id=bank_id,
+                )
 
             # Convert core MemoryFact objects to API RecallResult objects (excluding internal metrics)
             def _fact_to_result(fact: "MemoryFact") -> RecallResult:
@@ -3666,11 +3699,6 @@ def _register_routes(app: FastAPI):
             return response
         except HTTPException:
             raise
-        except OperationCancelledError as e:
-            # Client went away mid-recall; the engine aborted at a stage boundary.
-            handler_duration = time.time() - handler_start
-            logger.info(f"[RECALL CANCELLED] bank={bank_id} handler_duration={handler_duration:.3f}s reason={e.reason}")
-            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
@@ -3712,6 +3740,7 @@ def _register_routes(app: FastAPI):
     async def api_reflect(
         bank_id: str,
         request: ReflectRequest,
+        http_request: Request,
         request_context: RequestContext = Depends(get_request_context),
         _precheck: None = Depends(precheck_for("reflect")),
     ):
@@ -3725,20 +3754,30 @@ def _register_routes(app: FastAPI):
 
             # Use the memory system's reflect_async method (record metrics)
             with metrics.record_operation("reflect", bank_id=bank_id, source="api", budget=request.budget.value):
-                core_result = await app.state.memory.reflect_async(
+                # Cancel the reflect if the client disconnects: the agent loop
+                # checks request_context between iterations and the nested recall
+                # checks at its stage boundaries, so abandoned work stops instead
+                # of running to completion (issue #2122).
+                core_result = await run_cancellable_on_disconnect(
+                    http_request,
+                    request_context,
+                    app.state.memory.reflect_async(
+                        bank_id=bank_id,
+                        query=query,
+                        budget=request.budget,
+                        context=None,  # Deprecated, now concatenated with query
+                        max_tokens=request.max_tokens,
+                        response_schema=request.response_schema,
+                        request_context=request_context,
+                        tags=request.tags,
+                        tags_match=request.tags_match,
+                        tag_groups=request.tag_groups,
+                        fact_types=request.fact_types,
+                        exclude_mental_models=request.exclude_mental_models,
+                        exclude_mental_model_ids=request.exclude_mental_model_ids,
+                    ),
+                    operation="reflect",
                     bank_id=bank_id,
-                    query=query,
-                    budget=request.budget,
-                    context=None,  # Deprecated, now concatenated with query
-                    max_tokens=request.max_tokens,
-                    response_schema=request.response_schema,
-                    request_context=request_context,
-                    tags=request.tags,
-                    tags_match=request.tags_match,
-                    tag_groups=request.tag_groups,
-                    fact_types=request.fact_types,
-                    exclude_mental_models=request.exclude_mental_models,
-                    exclude_mental_model_ids=request.exclude_mental_model_ids,
                 )
 
             # Build based_on (memories + mental_models + directives) if facts are requested

--- a/hindsight-api-slim/hindsight_api/cancellation.py
+++ b/hindsight-api-slim/hindsight_api/cancellation.py
@@ -1,0 +1,76 @@
+"""Cooperative cancellation for long-running engine operations.
+
+Recall runs as a staged pipeline whose heavy stages — graph expansion and
+cross-encoder reranking — execute in worker threads (``run_in_executor``) that
+asyncio task cancellation cannot interrupt once they have started. Cancelling
+the awaiting task only unblocks the ``await``; the thread keeps burning CPU to
+completion. So rather than rely on task cancellation, callers thread a
+``CancellationToken`` through ``RequestContext`` and the engine checks it at
+stage boundaries (``raise_if_cancelled``), bailing out *before* dispatching the
+next expensive stage.
+
+This is cooperative by design: it cannot stop a computation already inside a
+worker thread, but it does stop an abandoned recall from progressing into — or
+past — that work, which is what starves the instance in issue #2122. The token
+lives on ``RequestContext``, so any operation that receives one (recall today;
+reflect/consolidation/MCP later) can adopt the same checkpoints, and any driver
+(client disconnect today; a deadline tomorrow) can fire it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class OperationCancelledError(Exception):
+    """Raised at a checkpoint when the operation has been cancelled.
+
+    Carries the ``reason`` set by whoever cancelled (e.g. "client disconnected")
+    so the HTTP layer can translate it into the appropriate status code instead
+    of a generic 500.
+    """
+
+    def __init__(self, reason: str = "operation cancelled") -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class CancellationToken:
+    """A one-shot, cooperative cancellation signal.
+
+    Cheap to poll (``raise_if_cancelled``) at stage boundaries and awaitable
+    (``wait``) so a driver task can block until cancellation. Safe to share
+    across an engine call tree; polling is a no-op until something cancels, and
+    cancellation is idempotent (the first reason wins).
+    """
+
+    __slots__ = ("_event", "_reason")
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+        self._reason = "operation cancelled"
+
+    def cancel(self, reason: str = "operation cancelled") -> None:
+        """Signal cancellation. Idempotent; the first reason recorded wins."""
+        if not self._event.is_set():
+            self._reason = reason
+            self._event.set()
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether cancellation has been signalled."""
+        return self._event.is_set()
+
+    @property
+    def reason(self) -> str:
+        """The reason recorded by the first ``cancel`` call."""
+        return self._reason
+
+    def raise_if_cancelled(self) -> None:
+        """Raise ``OperationCancelledError`` if cancellation has been signalled."""
+        if self._event.is_set():
+            raise OperationCancelledError(self._reason)
+
+    async def wait(self) -> None:
+        """Block until cancellation is signalled."""
+        await self._event.wait()

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8234,6 +8234,12 @@ class MemoryEngine(MemoryEngineInterface):
         # Authenticate tenant and set schema in context (for fq_table())
         await self._authenticate_tenant(request_context)
 
+        # Cooperative cancellation checkpoint: if the client already disconnected
+        # while this request waited to be scheduled, abort before doing any work
+        # (issue #2122). The agentic loop re-checks between iterations, and the
+        # nested recall tool checks at its own stage boundaries.
+        request_context.raise_if_cancelled()
+
         # Validate operation if validator is configured
         if self._operation_validator:
             from hindsight_api.extensions import ReflectContext
@@ -8446,6 +8452,7 @@ class MemoryEngine(MemoryEngineInterface):
                         budget=effective_budget,
                         max_context_tokens=max_context_tokens,
                         llm_output_language=getattr(resolved_reflect_config, "llm_output_language", None),
+                        cancel_check=request_context.raise_if_cancelled,
                     ),
                     timeout=wall_timeout,
                 )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3826,6 +3826,12 @@ class MemoryEngine(MemoryEngineInterface):
         # Authenticate tenant and set schema in context (for fq_table())
         await self._authenticate_tenant(request_context)
 
+        # Cooperative cancellation checkpoint: if the client already disconnected
+        # while this request waited to be scheduled, abort before doing any work
+        # (issue #2122). Further checkpoints sit at each pipeline stage boundary
+        # inside _search_with_retries.
+        request_context.raise_if_cancelled()
+
         # Sanitize the query at ingress: a client may serialize a half-emoji as a
         # lone UTF-16 surrogate, which crashes downstream logging, the embedder, and
         # the cross-encoder tokenizer with an HTTP 500 (see issue #1875). Cleaning it
@@ -4149,6 +4155,11 @@ class MemoryEngine(MemoryEngineInterface):
             if tracer:
                 tracer.record_query_embedding(query_embedding)
                 tracer.add_phase_metric("generate_query_embedding", step_duration)
+
+            # Cancellation checkpoint: bail before the DB-heavy retrieval stage
+            # if the client has gone away (issue #2122).
+            if request_context is not None:
+                request_context.raise_if_cancelled()
 
             # Step 2: Optimized parallel retrieval using batched queries
             # - Semantic + BM25 combined in 1 CTE query for ALL fact types
@@ -4477,6 +4488,15 @@ class MemoryEngine(MemoryEngineInterface):
                     merged_candidates = merged_candidates[:reranker_max_candidates]
 
                 if reranking == "cross_encoder":
+                    # Cancellation checkpoint: the cross-encoder rerank is the
+                    # single most CPU-expensive stage and runs in a worker thread
+                    # that cannot be interrupted once dispatched (issue #2122).
+                    # Skip it entirely if the client already disconnected during
+                    # retrieval, rather than burning ~2 CPUs producing a result
+                    # nobody will read.
+                    if request_context is not None:
+                        request_context.raise_if_cancelled()
+
                     # Ensure reranker is initialized (for lazy initialization mode)
                     await reranker_instance.ensure_initialized()
                     scored_results = await reranker_instance.rerank(query, merged_candidates)
@@ -4557,6 +4577,12 @@ class MemoryEngine(MemoryEngineInterface):
                     step_duration,
                     {"reranker_type": rerank_kind, "candidates_reranked": len(scored_results)},
                 )
+
+            # Cancellation checkpoint: reranking is done; skip the remaining
+            # enrichment (chunk/entity/source-fact fetches, each its own DB work)
+            # if the client disconnected while we were reranking (issue #2122).
+            if request_context is not None:
+                request_context.raise_if_cancelled()
 
             # Step 5: Truncate to thinking_budget * 2 for token filtering
             rerank_limit = thinking_budget * 2

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -341,6 +341,7 @@ async def run_reflect_agent(
     budget: str | None = None,
     max_context_tokens: int = 100_000,
     llm_output_language: str | None = None,
+    cancel_check: Callable[[], None] | None = None,
 ) -> ReflectAgentResult:
     """
     Execute the reflect agent loop using native tool calling.
@@ -493,6 +494,13 @@ async def run_reflect_agent(
     # under ``auto`` tool choice. None means the full forced path still applies.
     stop_forcing_from_iteration: int | None = None
     for iteration in range(max_iterations):
+        # Cooperative cancellation checkpoint: abort the agent loop between
+        # iterations if the caller (e.g. an HTTP client) has gone away, rather
+        # than spending another LLM round-trip on a result nobody will read
+        # (issue #2122). Raises OperationCancelledError when fired.
+        if cancel_check is not None:
+            cancel_check()
+
         is_last = iteration == max_iterations - 1
 
         if is_last:

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -4,7 +4,11 @@ SQLAlchemy models for the memory system.
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID as PyUUID
+
+if TYPE_CHECKING:
+    from .cancellation import CancellationToken
 
 
 @dataclass
@@ -30,6 +34,21 @@ class RequestContext:
     # validators that want exponential backoff on repeated failures (e.g.
     # "defer for 2^retry_count minutes") without querying the DB themselves.
     retry_count: int = 0
+    # Cooperative cancellation signal for long-running operations. The HTTP
+    # layer sets this to a token that fires when the client disconnects; the
+    # engine checks it at stage boundaries and aborts abandoned work so it stops
+    # consuming CPU/DB resources (issue #2122). None means "never cancelled" —
+    # every checkpoint is a no-op.
+    cancellation: "CancellationToken | None" = None
+
+    def raise_if_cancelled(self) -> None:
+        """Abort the current operation if its cancellation token has fired.
+
+        A no-op when no token is attached, so engine code can call it at every
+        stage boundary without caring whether the caller opted into cancellation.
+        """
+        if self.cancellation is not None:
+            self.cancellation.raise_if_cancelled()
 
 
 from pgvector.sqlalchemy import Vector

--- a/hindsight-api-slim/tests/test_recall_cancellation.py
+++ b/hindsight-api-slim/tests/test_recall_cancellation.py
@@ -1,0 +1,208 @@
+"""Tests for cooperative recall cancellation on client disconnect (issue #2122).
+
+Covers three layers:
+- the ``CancellationToken`` primitive,
+- ``RequestContext`` integration (the carrier the engine checks at stage
+  boundaries),
+- the HTTP ``_cancel_on_client_disconnect`` driver, including an ASGI-level
+  end-to-end that proves a disconnect aborts staged work and surfaces 499.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+
+from hindsight_api.api.http import (
+    _CLIENT_CLOSED_REQUEST_STATUS_CODE,
+    _cancel_on_client_disconnect,
+)
+from hindsight_api.cancellation import CancellationToken, OperationCancelledError
+from hindsight_api.models import RequestContext
+
+_TEST_TIMEOUT_SECONDS = 3.0
+
+
+class _FakeRequest:
+    """Minimal Request stand-in whose disconnect state is driven by an Event."""
+
+    def __init__(self, disconnected: asyncio.Event) -> None:
+        self._disconnected = disconnected
+
+    async def is_disconnected(self) -> bool:
+        return self._disconnected.is_set()
+
+
+# --- CancellationToken primitive ------------------------------------------------
+
+
+def test_token_starts_uncancelled():
+    token = CancellationToken()
+    assert token.cancelled is False
+    token.raise_if_cancelled()  # no-op
+
+
+def test_token_raises_after_cancel():
+    token = CancellationToken()
+    token.cancel("client disconnected")
+
+    assert token.cancelled is True
+    assert token.reason == "client disconnected"
+    with pytest.raises(OperationCancelledError) as exc:
+        token.raise_if_cancelled()
+    assert exc.value.reason == "client disconnected"
+
+
+def test_token_cancel_is_idempotent_first_reason_wins():
+    token = CancellationToken()
+    token.cancel("first")
+    token.cancel("second")
+    assert token.reason == "first"
+
+
+async def test_token_wait_unblocks_on_cancel():
+    token = CancellationToken()
+
+    async def cancel_soon():
+        await asyncio.sleep(0)
+        token.cancel("done")
+
+    asyncio.create_task(cancel_soon())
+    await asyncio.wait_for(token.wait(), timeout=_TEST_TIMEOUT_SECONDS)
+    assert token.cancelled is True
+
+
+# --- RequestContext integration -------------------------------------------------
+
+
+def test_request_context_check_is_noop_without_token():
+    ctx = RequestContext()
+    assert ctx.cancellation is None
+    ctx.raise_if_cancelled()  # must not raise
+
+
+def test_request_context_raises_when_token_fired():
+    token = CancellationToken()
+    token.cancel("client disconnected")
+    ctx = RequestContext(cancellation=token)
+
+    with pytest.raises(OperationCancelledError):
+        ctx.raise_if_cancelled()
+
+
+# --- HTTP disconnect driver -----------------------------------------------------
+
+
+async def test_driver_attaches_and_restores_token():
+    ctx = RequestContext()
+    disconnected = asyncio.Event()
+
+    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0) as token:
+        assert ctx.cancellation is token
+
+    # Restored to the previous (None) token once the scope exits.
+    assert ctx.cancellation is None
+
+
+async def test_driver_restores_previous_token_when_nested():
+    outer = CancellationToken()
+    ctx = RequestContext(cancellation=outer)
+    disconnected = asyncio.Event()
+
+    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
+        assert ctx.cancellation is not outer
+
+    assert ctx.cancellation is outer
+
+
+async def test_driver_cancels_staged_work_on_disconnect():
+    """A worker that checks the token between stages aborts once the client leaves."""
+    ctx = RequestContext()
+    disconnected = asyncio.Event()
+
+    async def staged_work() -> str:
+        # Stand-in for the recall pipeline: checkpoint, do a slice of work, repeat.
+        for _ in range(1000):
+            ctx.raise_if_cancelled()
+            await asyncio.sleep(0.005)
+        return "done"
+
+    async def run() -> None:
+        async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
+            work = asyncio.create_task(staged_work())
+            await asyncio.sleep(0.02)
+            disconnected.set()
+            await work
+
+    with pytest.raises(OperationCancelledError) as exc:
+        await asyncio.wait_for(run(), timeout=_TEST_TIMEOUT_SECONDS)
+    assert exc.value.reason == "client disconnected"
+    assert ctx.cancellation is None
+
+
+async def test_driver_returns_work_result_when_client_stays():
+    ctx = RequestContext()
+    disconnected = asyncio.Event()  # never set
+
+    async def staged_work() -> str:
+        for _ in range(3):
+            ctx.raise_if_cancelled()
+            await asyncio.sleep(0)
+        return "done"
+
+    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
+        result = await staged_work()
+
+    assert result == "done"
+
+
+# --- ASGI end-to-end: disconnect -> aborted work -> 499 -------------------------
+
+
+async def test_asgi_disconnect_aborts_work_and_returns_499():
+    app = FastAPI()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    @app.post("/recall")
+    async def recall(http_request: Request):
+        ctx = RequestContext()
+        try:
+            async with _cancel_on_client_disconnect(http_request, ctx, poll_interval=0):
+                started.set()
+                while True:  # staged pipeline: checkpoint then a slice of work
+                    ctx.raise_if_cancelled()
+                    await asyncio.sleep(0.005)
+        except OperationCancelledError as e:
+            cancelled.set()
+            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason)
+        return {"ok": True}
+
+    body_sent = False
+
+    async def receive():
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await started.wait()
+        return {"type": "http.disconnect"}
+
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/recall",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    await asyncio.wait_for(app(scope, receive, send), timeout=_TEST_TIMEOUT_SECONDS)
+
+    assert cancelled.is_set()
+    response_start = next(m for m in messages if m["type"] == "http.response.start")
+    assert response_start["status"] == _CLIENT_CLOSED_REQUEST_STATUS_CODE

--- a/hindsight-api-slim/tests/test_recall_cancellation.py
+++ b/hindsight-api-slim/tests/test_recall_cancellation.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, HTTPException, Request
 from hindsight_api.api.http import (
     _CLIENT_CLOSED_REQUEST_STATUS_CODE,
     _cancel_on_client_disconnect,
+    run_cancellable_on_disconnect,
 )
 from hindsight_api.cancellation import CancellationToken, OperationCancelledError
 from hindsight_api.models import RequestContext
@@ -156,10 +157,57 @@ async def test_driver_returns_work_result_when_client_stays():
     assert result == "done"
 
 
+# --- Shared HTTP helper (used by both the recall and reflect handlers) ----------
+
+
+async def test_run_cancellable_returns_result_when_connected():
+    ctx = RequestContext()
+    disconnected = asyncio.Event()  # never set
+
+    async def work() -> str:
+        ctx.raise_if_cancelled()
+        return "ok"
+
+    result = await run_cancellable_on_disconnect(
+        _FakeRequest(disconnected), ctx, work(), operation="reflect", bank_id="b1", poll_interval=0
+    )
+    assert result == "ok"
+    assert ctx.cancellation is None  # restored
+
+
+async def test_run_cancellable_maps_disconnect_to_499():
+    ctx = RequestContext()
+    disconnected = asyncio.Event()
+
+    async def staged_work() -> str:
+        for _ in range(1000):  # stand-in for the reflect agent loop / recall stages
+            ctx.raise_if_cancelled()
+            await asyncio.sleep(0.005)
+        return "done"
+
+    async def disconnect_soon() -> None:
+        await asyncio.sleep(0.02)
+        disconnected.set()
+
+    asyncio.create_task(disconnect_soon())
+    with pytest.raises(HTTPException) as exc:
+        await asyncio.wait_for(
+            run_cancellable_on_disconnect(
+                _FakeRequest(disconnected), ctx, staged_work(), operation="reflect", bank_id="b1", poll_interval=0
+            ),
+            timeout=_TEST_TIMEOUT_SECONDS,
+        )
+    assert exc.value.status_code == _CLIENT_CLOSED_REQUEST_STATUS_CODE
+    assert exc.value.detail == "client disconnected"
+    assert ctx.cancellation is None
+
+
 # --- ASGI end-to-end: disconnect -> aborted work -> 499 -------------------------
 
 
 async def test_asgi_disconnect_aborts_work_and_returns_499():
+    """Exercises the real shared helper through the ASGI stack (both endpoints'
+    path), proving disconnect -> aborted staged work -> 499."""
     app = FastAPI()
     started = asyncio.Event()
     cancelled = asyncio.Event()
@@ -167,16 +215,20 @@ async def test_asgi_disconnect_aborts_work_and_returns_499():
     @app.post("/recall")
     async def recall(http_request: Request):
         ctx = RequestContext()
-        try:
-            async with _cancel_on_client_disconnect(http_request, ctx, poll_interval=0):
-                started.set()
+
+        async def staged_work() -> dict:
+            started.set()
+            try:
                 while True:  # staged pipeline: checkpoint then a slice of work
                     ctx.raise_if_cancelled()
                     await asyncio.sleep(0.005)
-        except OperationCancelledError as e:
-            cancelled.set()
-            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason)
-        return {"ok": True}
+            except OperationCancelledError:
+                cancelled.set()
+                raise
+
+        return await run_cancellable_on_disconnect(
+            http_request, ctx, staged_work(), operation="recall", bank_id="b1", poll_interval=0
+        )
 
     body_sent = False
 


### PR DESCRIPTION
### Summary

Cancel abandoned HTTP **recall and reflect** work via a cooperative cancellation token carried on `RequestContext`, instead of relying on asyncio task cancellation. Alternative to #2125 with an architecture that stops the most expensive stage and generalizes across endpoints.

Fixes #2122.

### Problem

A `/memories/recall` (or `/reflect`) that outlives its client kept running server-side — ~2 CPUs for 60–95 s per abandoned recall on an 11.6K-unit bank — and abandoned requests accumulated toward `RECALL_MAX_CONCURRENT` until the instance starved (RSS 7.2 GB, CPU pinned at the container cap for hours, from a single retry-looping client). See #2122.

### Why a token, not asyncio task cancellation

The recall pipeline's heaviest stage — cross-encoder reranking (flashrank) — runs in a `ThreadPoolExecutor` via `run_in_executor`. Cancelling the awaiting asyncio task only unblocks the `await`; **the worker thread keeps burning CPU to completion**. So task cancellation (the approach in #2125) returns `499` and frees the recall semaphore while an uncancellable thread still pins a CPU — `RECALL_MAX_CONCURRENT` stops bounding actual CPU.

Instead, a `CancellationToken` is threaded through `RequestContext` (already passed into every engine operation) and checked at **stage / iteration boundaries**, bailing out *before* dispatching the next expensive stage.

### Changes

- New `hindsight_api/cancellation.py`: `CancellationToken` (one-shot, awaitable, idempotent) + `OperationCancelledError`.
- `RequestContext` gains a `cancellation` field and a `raise_if_cancelled()` helper (no-op when no token attached).
- **Recall** checkpoints in `recall_async` / `_search_with_retries`: pre-retrieval, **pre-rerank**, and pre-enrichment (chunk/entity/source-fact fetches).
- **Reflect** checkpoints: an early check in `reflect_async`, plus a `cancel_check` hook in `run_reflect_agent` invoked between agent iterations (and the nested recall tool already checks at its own boundaries since it shares the `RequestContext`).
- **Shared HTTP wiring**: `run_cancellable_on_disconnect()` attaches the disconnect-driven token (1 s poll, restores the prior token on exit) and maps `OperationCancelledError` → **499**. Both the recall and reflect handlers call it — no duplicated try/except.
- Scoped to HTTP recall + reflect: internal callers (consolidation, MCP, mental-model triggers) pass no token, so every checkpoint is a no-op and behavior is unchanged.

### Honest limitation

Cooperative: it cannot interrupt a computation **already inside** a worker thread. If the client disconnects mid-rerank, we finish that one rerank then abort at the next checkpoint. The win is that an abandoned request never *starts* rerank (if the client left during retrieval), never runs post-rerank enrichment, and a reflect loop stops between iterations instead of spending every remaining LLM round-trip — and `RECALL_MAX_CONCURRENT` keeps bounding real work. Truly bounding mid-rerank would need chunked token checks inside the predict loop or a killable subprocess (out of scope). A deadline-based driver (for the consolidation-contention half of #2122) is a trivial extension since the token lives on `RequestContext`.

### Relationship to #2125

Alternative implementation of the same fix. #2125 wraps recall in a disconnect watcher and cancels the asyncio task; this PR uses a checkpoint token. The token approach stops the threadpool rerank stage from starting (which task cancellation can't reach), avoids early-releasing the concurrency slot while a thread runs on, reuses a carrier every engine operation already receives, and **covers reflect** with the same mechanism. Pick one.

### Tests

```bash
uv run pytest tests/test_recall_cancellation.py -q   # 13 tests, all green
uv run ruff check hindsight_api/ && uv run ty check hindsight_api/api/http.py
```

Covers the token primitive, `RequestContext` integration, the disconnect driver (attach/restore/abort), the shared `run_cancellable_on_disconnect` helper (result-on-connected, 499-on-disconnect), and an ASGI end-to-end (disconnect → aborted staged work → 499). Existing reflect suites (`test_reflect_agent`, `test_per_operation_llm_config`, etc.) remain green — `cancel_check` defaults to `None`.
