### PR TITLE
docs(models): register the nous provider so the Models page lists it

### DIFF
--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -18,6 +18,7 @@
   {"id": "claude-code",   "label": "Claude Code",       "iconKey": "anthropic",          "defaultModel": "claude-sonnet-4-5-20250929"},
   {"id": "bedrock",       "label": "AWS Bedrock",       "iconKey": "cloud",              "defaultModel": "us.amazon.nova-2-lite-v1:0"},
   {"id": "fireworks",     "label": "Fireworks AI",      "iconKey": "zap",                "defaultModel": "accounts/fireworks/models/llama-v3p1-8b-instruct", "batchApi": true},
+  {"id": "nous",          "label": "Nous Portal",       "iconKey": "openai-compatible",  "defaultModel": "deepseek/deepseek-v4-flash"},
   {"id": "",              "label": "OpenAI Compatible", "iconKey": "openai-compatible"},
   {"id": "litellm",       "label": "LiteLLM (100+)",    "iconKey": "layers",             "defaultModel": "gpt-4o-mini"}
 ]

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -38,6 +38,7 @@ Used for fact extraction, entity resolution, mental model consolidation, and ans
 - Claude Code
 - AWS Bedrock
 - Fireworks AI
+- Nous Portal
 - OpenAI Compatible
 - LiteLLM (100+)
 
@@ -95,6 +96,7 @@ Beyond basic generation, some providers support optional features that lower cos
 | Claude Code (`claude-code`) | — | — |
 | AWS Bedrock (`bedrock`) | — | — |
 | Fireworks AI (`fireworks`) | ✅ | — |
+| Nous Portal (`nous`) | — | — |
 | LiteLLM (100+) (`litellm`) | — | — |
 
 - **Batch API** — submits bulk retain extraction through the provider's asynchronous batch endpoint, typically at ~50% lower cost. Used automatically when available; otherwise calls run synchronously.
@@ -154,6 +156,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | `claude-code` | `claude-sonnet-4-5-20250929` |
 | `bedrock` | `us.amazon.nova-2-lite-v1:0` |
 | `fireworks` | `accounts/fireworks/models/llama-v3p1-8b-instruct` |
+| `nous` | `deepseek/deepseek-v4-flash` |
 | `litellm` | `gpt-4o-mini` |
 
 **Example:** Setting just the provider uses its default model:

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -85,6 +85,7 @@ Browse all supported integrations in the Integrations Hub.
 - Claude Code
 - AWS Bedrock
 - Fireworks AI
+- Nous Portal
 - OpenAI Compatible
 - LiteLLM (100+)
 


### PR DESCRIPTION
[#2102](https://github.com/vectorize-io/hindsight/pull/2102) added the native **Nous Portal** provider to `config.py` `PROVIDER_DEFAULT_MODELS` and the `models.mdx` prose, but not to `hindsight-docs/src/data/llmProviders.json` — the single source of truth that renders the Models page provider grid, default-models table, and capabilities table. So Nous is documented in prose yet absent from the canonical Models grid/tables.

This adds the `nous` entry (`Nous Portal`, `openai-compatible` icon, default `deepseek/deepseek-v4-flash` matching `config.py`) and regenerates the CI-enforced skill mirror with `scripts/generate-docs-skill.sh` (no capability flags — `NousLLM` is a bare `OpenAICompatibleLLM`, same as deepseek/opencode-go). Same pattern as #1911 (fireworks).