### PR TITLE
docs: flag Intel (x86_64) macOS as slim-only in supported-platforms grid (#2115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ main();
 pip install hindsight-all -U
 ```
 
+On Intel (x86_64) Macs, install `hindsight-all-slim` instead — see [Supported Platforms](#supported-platforms).
+
 ```python
 import os
 from hindsight import HindsightServer, HindsightClient
@@ -157,6 +159,19 @@ with HindsightServer(
     results = client.recall(bank_id="my-bank", query="Where does Alice work?")
 ```
 
+
+---
+
+## Supported Platforms
+
+| Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
+|----------|--------|------------------|--------------------|-------|
+| **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
+| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
+| **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported |
+
+See the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -162,19 +162,6 @@ with HindsightServer(
 
 ---
 
-## Supported Platforms
-
-| Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
-|----------|--------|------------------|--------------------|-------|
-| **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
-| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
-| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
-| **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported |
-
-See the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation) for details.
-
----
-
 ## Use Cases
 
 
@@ -313,6 +300,19 @@ client.reflect(bank_id="my-bank", query="What should I know about Alice?")
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=vectorize-io/hindsight&type=date&legend=top-left)](https://www.star-history.com/#vectorize-io/hindsight&type=date&legend=top-left)
+---
+
+## Supported Platforms
+
+| Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
+|----------|--------|------------------|--------------------|-------|
+| **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
+| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
+| **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported |
+
+See the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation) for details.
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -304,14 +304,14 @@ client.reflect(bank_id="my-bank", query="What should I know about Alice?")
 
 ## Supported Platforms
 
-| Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
-|----------|--------|------------------|--------------------|-------|
-| **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
-| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
-| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
-| **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported |
+| Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) |
+|----------|--------|------------------|--------------------|
+| **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ |
+| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ |
+| **macOS** (Intel / x86_64) | ✅ | ⚠️ | ✅ |
+| **Windows** (x86_64) | ✅ | ✅ | ✅ |
 
-See the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation) for details.
+⚠️ Intel Macs: use `hindsight-all-slim` — see the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation#supported-platforms) for details.
 
 ---
 

--- a/hindsight-docs/docs/developer/installation.md
+++ b/hindsight-docs/docs/developer/installation.md
@@ -13,7 +13,8 @@ Hindsight runs on **Linux**, **macOS**, and **Windows**:
 | Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
 |----------|--------|------------------|--------------------|-------|
 | **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
-| **macOS** (Apple Silicon, Intel) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
 | **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported — see [Windows setup](#windows) for external PostgreSQL option |
 
 All platforms support the embedded database (pg0) for development. On Windows, you can also use an external PostgreSQL installation — see the [Windows](#windows) section for a step-by-step guide.
@@ -364,9 +365,11 @@ The `HF_ENDPOINT` variable is used by Hugging Face tooling (`huggingface_hub`), 
 **Best for**: Using Hindsight programmatically from Python without running a separate server process.
 
 ```bash
-pip install hindsight-all        # Full — works out of the box
+pip install hindsight-all        # Full — works out of the box (Linux, Windows, Apple Silicon Macs)
 pip install hindsight-all-slim   # Slim — requires external services for embeddings, reranking, and the database
 ```
+
+On Intel (x86_64) Macs, install `hindsight-all-slim` — see [Supported Platforms](#supported-platforms).
 
 `hindsight-all` supports two modes of embedding:
 

--- a/hindsight-docs/docs/sdks/hindsight-all.md
+++ b/hindsight-docs/docs/sdks/hindsight-all.md
@@ -27,6 +27,8 @@ pip install hindsight-all
 
 The `hindsight-all` wheel bundles `hindsight-api-slim`, `hindsight-client`, and `hindsight-embed` as dependencies, so one `pip install` gets you everything.
 
+On Intel (x86_64) Macs, install `hindsight-all-slim` instead — the full bundle's local ML models have no Intel-Mac wheels. See [Supported Platforms](../developer/installation#supported-platforms).
+
 ## `HindsightServer` — explicit lifecycle
 
 Use `HindsightServer` as a context manager when you want the server to start immediately, run for the duration of a block, and shut down cleanly afterwards. Ideal for tests and short-lived scripts.

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -13,7 +13,8 @@ Hindsight runs on **Linux**, **macOS**, and **Windows**:
 | Platform | Docker | Bare Metal (pip) | Embedded DB (pg0) | Notes |
 |----------|--------|------------------|--------------------|-------|
 | **Linux** (x86_64, ARM64) | ✅ | ✅ | ✅ | Fully supported, recommended for production |
-| **macOS** (Apple Silicon, Intel) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Apple Silicon / arm64) | ✅ | ✅ | ✅ | Fully supported |
+| **macOS** (Intel / x86_64) | ✅ | ⚠️ slim only | ✅ | Use `hindsight-all-slim` / `hindsight-api-slim`. The full bundle's local ML models (PyTorch, MLX) publish no Intel-Mac wheels, so `pip install hindsight-all` silently backtracks to a months-old release. Pair the slim bundle with a hosted embeddings/reranker provider or the in-process ONNX backend (`hindsight-api-slim[local-onnx]`). |
 | **Windows** (x86_64) | ✅ | ✅ | ✅ | Fully supported — see [Windows setup](#windows) for external PostgreSQL option |
 
 All platforms support the embedded database (pg0) for development. On Windows, you can also use an external PostgreSQL installation — see the [Windows](#windows) section for a step-by-step guide.
@@ -364,9 +365,11 @@ The `HF_ENDPOINT` variable is used by Hugging Face tooling (`huggingface_hub`), 
 **Best for**: Using Hindsight programmatically from Python without running a separate server process.
 
 ```bash
-pip install hindsight-all        # Full — works out of the box
+pip install hindsight-all        # Full — works out of the box (Linux, Windows, Apple Silicon Macs)
 pip install hindsight-all-slim   # Slim — requires external services for embeddings, reranking, and the database
 ```
+
+On Intel (x86_64) Macs, install `hindsight-all-slim` — see [Supported Platforms](#supported-platforms).
 
 `hindsight-all` supports two modes of embedding:
 

--- a/skills/hindsight-docs/references/sdks/hindsight-all.md
+++ b/skills/hindsight-docs/references/sdks/hindsight-all.md
@@ -27,6 +27,8 @@ pip install hindsight-all
 
 The `hindsight-all` wheel bundles `hindsight-api-slim`, `hindsight-client`, and `hindsight-embed` as dependencies, so one `pip install` gets you everything.
 
+On Intel (x86_64) Macs, install `hindsight-all-slim` instead — the full bundle's local ML models have no Intel-Mac wheels. See [Supported Platforms](../developer/installation#supported-platforms).
+
 ## `HindsightServer` — explicit lifecycle
 
 Use `HindsightServer` as a context manager when you want the server to start immediately, run for the duration of a block, and shut down cleanly afterwards. Ideal for tests and short-lived scripts.


### PR DESCRIPTION
## Problem

Fixes #2115. On Intel (x86_64) macOS, the README quickstart `pip install hindsight-all -U` succeeds but **silently** resolves to a months-old release (0.4.17) instead of the current one.

**Root cause:** every release since 0.4.18 depends on `hindsight-api-slim[all]`, whose `local-ml` extra requires:
- `torch>=2.6.0` (CVE floor) — PyTorch's last x86_64-macOS wheel is **2.2.2** (Intel dropped after 2.2.x)
- `mlx` — Apple-Silicon-only

Neither is installable on Intel Macs, so `pip` backtracks through ~15 releases with no error and lands on the last resolvable one. The docs' supported-platforms grid compounded this by listing Intel macOS bare-metal pip as **"Fully supported"**, which is false.

## Why docs-only

A packaging marker/sentinel can't fix the reported command: `pip install hindsight-all -U` is unpinned, so pip always backtracks to an old release that predates any marker. (A non-existent sentinel also breaks `uv lock`.) The honest, effective fix is to stop steering Intel-Mac users at the heavy bundle.

The slim path **does** work on Intel Macs — verified: `hindsight-api-slim` base is pure-Python/universal2, `pg0-embedded` ships an x86_64-mac wheel, and `local-onnx` is torch-free (`onnxruntime` ships x86_64-mac wheels).

## Changes

- Split the **Supported Platforms** grid row in `installation.md` into Apple Silicon (✅ all) and Intel/x86_64 (Docker ✅, bare-metal pip ⚠️ **slim only**, pg0 ✅), with the rationale and the slim + hosted/ONNX path.
- Mirror the same grid into `README.md`.
- Replace the ad-hoc warnings with one-line pointers to the grid; regenerate the `skills/hindsight-docs` mirror.

No code or packaging changes; no per-platform default changes.