### PR TITLE
chore(embed): drop unused HINDSIGHT_EMBED_BANK_ID + fix HINDSIGHT_EMBED_LLM_* docs

### DIFF
--- a/hindsight-docs/docs/sdks/embed.md
+++ b/hindsight-docs/docs/sdks/embed.md
@@ -60,7 +60,6 @@ Configuration is saved to `~/.hindsight/embed`:
 ```bash
 HINDSIGHT_EMBED_LLM_PROVIDER=openai
 HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
-HINDSIGHT_EMBED_BANK_ID=default
 HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
 
 # Daemon settings (macOS: force CPU to avoid MPS/XPC issues)
@@ -90,7 +89,6 @@ The daemon starts automatically on first use!
 | `HINDSIGHT_EMBED_LLM_API_KEY` | **Required**. API key for LLM provider | - |
 | `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
 | `HINDSIGHT_EMBED_LLM_MODEL` | Model name | `gpt-4o-mini` |
-| `HINDSIGHT_EMBED_BANK_ID` | Default memory bank ID | `default` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
 
 **Provider Examples:**

--- a/hindsight-docs/docs/sdks/embed.md
+++ b/hindsight-docs/docs/sdks/embed.md
@@ -49,18 +49,18 @@ pipx install hindsight-embed
 hindsight-embed configure
 
 # Or non-interactive via environment variables
-export HINDSIGHT_EMBED_LLM_PROVIDER=openai
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 hindsight-embed configure
 ```
 
 Configuration is saved to `~/.hindsight/embed`:
 
 ```bash
-HINDSIGHT_EMBED_LLM_PROVIDER=openai
-HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
-HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
+HINDSIGHT_API_LLM_PROVIDER=openai
+HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
+HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
 
 # Daemon settings (macOS: force CPU to avoid MPS/XPC issues)
 HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=1
@@ -86,28 +86,28 @@ The daemon starts automatically on first use!
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_EMBED_LLM_API_KEY` | **Required**. API key for LLM provider | - |
-| `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
-| `HINDSIGHT_EMBED_LLM_MODEL` | Model name | `gpt-4o-mini` |
+| `HINDSIGHT_API_LLM_API_KEY` | **Required**. API key for LLM provider | - |
+| `HINDSIGHT_API_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
+| `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
 
 **Provider Examples:**
 
 ```bash
 # OpenAI
-export HINDSIGHT_EMBED_LLM_PROVIDER=openai
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=gpt-4o
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-4o
 
 # Groq (fast inference)
-export HINDSIGHT_EMBED_LLM_PROVIDER=groq
-export HINDSIGHT_EMBED_LLM_API_KEY=gsk_xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=llama-3.3-70b-versatile
+export HINDSIGHT_API_LLM_PROVIDER=groq
+export HINDSIGHT_API_LLM_API_KEY=gsk_xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=llama-3.3-70b-versatile
 
 # Anthropic
-export HINDSIGHT_EMBED_LLM_PROVIDER=anthropic
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=claude-sonnet-4-20250514
+export HINDSIGHT_API_LLM_PROVIDER=anthropic
+export HINDSIGHT_API_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-20250514
 ```
 
 ## Daemon Management
@@ -206,7 +206,7 @@ hindsight-embed daemon logs -f
 ```
 
 Common issues:
-- **Missing API key**: Set `HINDSIGHT_EMBED_LLM_API_KEY`
+- **Missing API key**: Set `HINDSIGHT_API_LLM_API_KEY`
 - **Port conflict**: Another service using port 8888
 - **Permissions**: Check `~/.hindsight/` directory permissions
 

--- a/hindsight-embed/README.md
+++ b/hindsight-embed/README.md
@@ -52,8 +52,8 @@ hindsight-embed configure
 
 # Create/update named profile with single command
 hindsight-embed configure --profile my-app \
-  --env HINDSIGHT_EMBED_LLM_PROVIDER=openai \
-  --env HINDSIGHT_EMBED_LLM_API_KEY=sk-xxx
+  --env HINDSIGHT_API_LLM_PROVIDER=openai \
+  --env HINDSIGHT_API_LLM_API_KEY=sk-xxx
 
 # Create/update named profile interactively
 hindsight-embed configure --profile staging
@@ -62,7 +62,7 @@ hindsight-embed configure --profile staging
 This will:
 - Let you choose an LLM provider (OpenAI, Groq, Google, Ollama)
 - Configure your API key
-- Set the model and memory bank ID
+- Set the model
 - Start the daemon with your configuration
 
 ### memory retain
@@ -150,9 +150,9 @@ Run `hindsight-embed configure` for a guided setup that saves to `~/.hindsight/e
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_EMBED_PROFILE` | Profile name to use (overrides active profile) | None (uses default profile) |
-| `HINDSIGHT_EMBED_LLM_API_KEY` | LLM API key (or use `OPENAI_API_KEY`) | Required |
-| `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider (`openai`, `groq`, `google`, `ollama`) | `openai` |
-| `HINDSIGHT_EMBED_LLM_MODEL` | LLM model | `gpt-4o-mini` |
+| `HINDSIGHT_API_LLM_API_KEY` | LLM API key (or use `OPENAI_API_KEY`) | Required |
+| `HINDSIGHT_API_LLM_PROVIDER` | LLM provider (`openai`, `groq`, `google`, `ollama`) | `openai` |
+| `HINDSIGHT_API_LLM_MODEL` | LLM model | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_API_URL` | Use external API server instead of starting local daemon | None (starts local daemon) |
 | `HINDSIGHT_EMBED_API_TOKEN` | Authentication token for external API (sent as Bearer token) | None |
 | `HINDSIGHT_EMBED_API_DATABASE_URL` | Database URL for daemon | `pg0://hindsight-embed` |
@@ -192,9 +192,9 @@ When you run `hindsight-embed configure` without specifying a profile, it config
 ```bash
 # Create a profile with single command
 hindsight-embed configure --profile my-app \
-  --env HINDSIGHT_EMBED_LLM_PROVIDER=openai \
-  --env HINDSIGHT_EMBED_LLM_API_KEY=sk-xxx \
-  --env HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
+  --env HINDSIGHT_API_LLM_PROVIDER=openai \
+  --env HINDSIGHT_API_LLM_API_KEY=sk-xxx \
+  --env HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 
 # Create a profile interactively
 hindsight-embed configure --profile staging

--- a/hindsight-embed/README.md
+++ b/hindsight-embed/README.md
@@ -153,7 +153,6 @@ Run `hindsight-embed configure` for a guided setup that saves to `~/.hindsight/e
 | `HINDSIGHT_EMBED_LLM_API_KEY` | LLM API key (or use `OPENAI_API_KEY`) | Required |
 | `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider (`openai`, `groq`, `google`, `ollama`) | `openai` |
 | `HINDSIGHT_EMBED_LLM_MODEL` | LLM model | `gpt-4o-mini` |
-| `HINDSIGHT_EMBED_BANK_ID` | Default memory bank ID (optional, used when not specified in CLI) | `default` |
 | `HINDSIGHT_EMBED_API_URL` | Use external API server instead of starting local daemon | None (starts local daemon) |
 | `HINDSIGHT_EMBED_API_TOKEN` | Authentication token for external API (sent as Bearer token) | None |
 | `HINDSIGHT_EMBED_API_DATABASE_URL` | Database URL for daemon | `pg0://hindsight-embed` |

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -14,7 +14,6 @@ Environment variables:
     HINDSIGHT_API_LLM_API_KEY: Required. API key for LLM provider.
     HINDSIGHT_API_LLM_PROVIDER: Optional. LLM provider (default: "openai").
     HINDSIGHT_API_LLM_MODEL: Optional. LLM model (default: provider-specific, resolved by hindsight-api).
-    HINDSIGHT_EMBED_BANK_ID: Optional. Memory bank ID (default: "default").
     HINDSIGHT_EMBED_API_URL: Optional. Use external API server instead of starting local daemon.
     HINDSIGHT_EMBED_API_TOKEN: Optional. Authentication token for external API (sent as Bearer token).
     HINDSIGHT_EMBED_API_DATABASE_URL: Optional. Database URL for daemon (default: "pg0://hindsight-embed").
@@ -130,7 +129,6 @@ def get_config():
         "llm_api_key": os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY"),
         "llm_provider": os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai"),
         "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL"),
-        "bank_id": os.environ.get("HINDSIGHT_EMBED_BANK_ID", "default"),
     }
 
 
@@ -229,14 +227,12 @@ def _do_configure_from_env():
         return 1
 
     model = os.environ.get("HINDSIGHT_API_LLM_MODEL")
-    bank_id = os.environ.get("HINDSIGHT_EMBED_BANK_ID", "default")
 
     print()
     print("\033[1m\033[36m  Hindsight Embed - Non-interactive Configuration\033[0m")
     print()
     print(f"  \033[2mProvider:\033[0m {provider}")
     print(f"  \033[2mModel:\033[0m {model or '(provider default)'}")
-    print(f"  \033[2mBank ID:\033[0m {bank_id}")
 
     # Save configuration
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -244,7 +240,6 @@ def _do_configure_from_env():
     config_values = {"HINDSIGHT_API_LLM_PROVIDER": provider}
     if model:
         config_values["HINDSIGHT_API_LLM_MODEL"] = model
-    config_values["HINDSIGHT_EMBED_BANK_ID"] = bank_id
     if api_key:
         config_values["HINDSIGHT_API_LLM_API_KEY"] = api_key
 
@@ -411,17 +406,11 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         return 1
     print()
 
-    # Bank ID
-    bank_id = _prompt_text("Memory bank ID", default="default")
-    if bank_id is None:
-        return 1
-
     # Save configuration
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
     config_dict = {
         "HINDSIGHT_API_LLM_PROVIDER": provider,
-        "HINDSIGHT_EMBED_BANK_ID": bank_id,
     }
     if model:
         config_dict["HINDSIGHT_API_LLM_MODEL"] = model
@@ -458,7 +447,6 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         "llm_api_key": api_key,
         "llm_provider": provider,
         "llm_model": model,
-        "bank_id": bank_id,
     }
     if daemon_client.ensure_daemon_running(new_config, daemon_profile):
         print("  \033[32m✓ Daemon started\033[0m")

--- a/hindsight-embed/tests/test_env_template.py
+++ b/hindsight-embed/tests/test_env_template.py
@@ -22,13 +22,13 @@ def test_user_values_are_active():
         {
             "HINDSIGHT_API_LLM_PROVIDER": "anthropic",
             "HINDSIGHT_API_LLM_API_KEY": "sk-secret",
-            "HINDSIGHT_EMBED_BANK_ID": "default",
+            "HINDSIGHT_API_LLM_MODEL": "gpt-4o-mini",
         }
     )
     active = _active_keys(text)
     assert active["HINDSIGHT_API_LLM_PROVIDER"] == "anthropic"
     assert active["HINDSIGHT_API_LLM_API_KEY"] == "sk-secret"
-    assert active["HINDSIGHT_EMBED_BANK_ID"] == "default"
+    assert active["HINDSIGHT_API_LLM_MODEL"] == "gpt-4o-mini"
 
 
 def test_only_user_values_are_active():
@@ -40,7 +40,7 @@ def test_only_user_values_are_active():
     values = {
         "HINDSIGHT_API_LLM_PROVIDER": "anthropic",
         "HINDSIGHT_API_LLM_API_KEY": "sk-secret",
-        "HINDSIGHT_EMBED_BANK_ID": "default",
+        "HINDSIGHT_API_LLM_MODEL": "gpt-4o-mini",
     }
     assert _active_keys(render_config(values)) == values
 

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -179,7 +179,6 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
         "HINDSIGHT_API_LLM_PROVIDER=openai\n"
         "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
         "HINDSIGHT_API_LLM_API_KEY=sk-default-key\n"
-        "HINDSIGHT_EMBED_BANK_ID=default-bank\n"
     )
 
     # Create named profile
@@ -192,7 +191,6 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
         "HINDSIGHT_API_LLM_PROVIDER=anthropic\n"
         "HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-20250514\n"
         "HINDSIGHT_API_LLM_API_KEY=sk-ant-production\n"
-        "HINDSIGHT_EMBED_BANK_ID=production-bank\n"
     )
 
     # Create metadata
@@ -215,7 +213,6 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
     monkeypatch.delenv("HINDSIGHT_API_LLM_PROVIDER", raising=False)
     monkeypatch.delenv("HINDSIGHT_API_LLM_MODEL", raising=False)
     monkeypatch.delenv("HINDSIGHT_API_LLM_API_KEY", raising=False)
-    monkeypatch.delenv("HINDSIGHT_EMBED_BANK_ID", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     # Test with named profile
@@ -226,7 +223,6 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
     assert config["llm_provider"] == "anthropic", "Should use profile's provider"
     assert config["llm_model"] == "claude-sonnet-4-20250514", "Should use profile's model"
     assert config["llm_api_key"] == "sk-ant-production", "Should use profile's API key"
-    assert config["bank_id"] == "production-bank", "Should use profile's bank_id"
 
 
 def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, monkeypatch):

--- a/hindsight-embed/tests/test_profile_integration.py
+++ b/hindsight-embed/tests/test_profile_integration.py
@@ -45,11 +45,11 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini",
+                "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini",
             ],
             capture_output=True,
             text=True,
@@ -64,8 +64,8 @@ class TestProfileIntegration:
         assert profile_path.exists()
 
         config_content = profile_path.read_text()
-        assert "HINDSIGHT_EMBED_LLM_PROVIDER=openai" in config_content
-        assert "HINDSIGHT_EMBED_LLM_API_KEY=sk-test" in config_content
+        assert "HINDSIGHT_API_LLM_PROVIDER=openai" in config_content
+        assert "HINDSIGHT_API_LLM_API_KEY=sk-test" in config_content
 
         # List profiles
         result = subprocess.run(
@@ -109,9 +109,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
             env={**os.environ, "HOME": str(temp_home)},
@@ -136,9 +136,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
             env={**os.environ, "HOME": str(temp_home)},
@@ -183,9 +183,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
         )
@@ -214,9 +214,9 @@ class TestProfileIntegration:
                 "--profile",
                 "app1",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
         )
@@ -229,9 +229,9 @@ class TestProfileIntegration:
                 "--profile",
                 "app2",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
         )
@@ -264,9 +264,9 @@ class TestProfileIntegration:
         config_dir = temp_home / ".hindsight"
         config_dir.mkdir(parents=True, exist_ok=True)
         (config_dir / "embed").write_text(
-            "HINDSIGHT_EMBED_LLM_PROVIDER=openai\n"
-            "HINDSIGHT_EMBED_LLM_API_KEY=sk-test\n"
-            "HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini\n"
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+            "HINDSIGHT_API_LLM_API_KEY=sk-test\n"
+            "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
         )
 
         # Show profile should work
@@ -289,9 +289,9 @@ class TestProfileIntegration:
         env = {
             **os.environ,
             "HOME": str(temp_home),
-            "HINDSIGHT_EMBED_LLM_PROVIDER": "openai",
-            "HINDSIGHT_EMBED_LLM_API_KEY": "sk-test",
-            "HINDSIGHT_EMBED_LLM_MODEL": "gpt-4o-mini",
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+            "HINDSIGHT_API_LLM_API_KEY": "sk-test",
+            "HINDSIGHT_API_LLM_MODEL": "gpt-4o-mini",
         }
 
         result = subprocess.run(hindsight_embed_cmd + ["configure"], capture_output=True, text=True, env=env)
@@ -313,9 +313,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
         )
@@ -349,9 +349,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=openai",
+                "HINDSIGHT_API_LLM_PROVIDER=openai",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=sk-test",
+                "HINDSIGHT_API_LLM_API_KEY=sk-test",
             ],
             capture_output=True,
         )
@@ -369,9 +369,9 @@ class TestProfileIntegration:
                 "--profile",
                 "test-app",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_PROVIDER=groq",
+                "HINDSIGHT_API_LLM_PROVIDER=groq",
                 "--env",
-                "HINDSIGHT_EMBED_LLM_API_KEY=gsk-test",
+                "HINDSIGHT_API_LLM_API_KEY=gsk-test",
             ],
             capture_output=True,
         )

--- a/hindsight-embed/tests/test_profile_manager.py
+++ b/hindsight-embed/tests/test_profile_manager.py
@@ -55,9 +55,9 @@ class TestProfileManager:
     def test_create_profile_success(self, profile_manager, temp_hindsight_dir):
         """Test creating a new profile."""
         config = {
-            "HINDSIGHT_EMBED_LLM_PROVIDER": "openai",
-            "HINDSIGHT_EMBED_LLM_API_KEY": "sk-test",
-            "HINDSIGHT_EMBED_LLM_MODEL": "gpt-4o-mini",
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+            "HINDSIGHT_API_LLM_API_KEY": "sk-test",
+            "HINDSIGHT_API_LLM_MODEL": "gpt-4o-mini",
         }
 
         profile_manager.create_profile("test-profile", config)
@@ -68,9 +68,9 @@ class TestProfileManager:
 
         # Verify config contents
         config_content = config_path.read_text()
-        assert "HINDSIGHT_EMBED_LLM_PROVIDER=openai" in config_content
-        assert "HINDSIGHT_EMBED_LLM_API_KEY=sk-test" in config_content
-        assert "HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini" in config_content
+        assert "HINDSIGHT_API_LLM_PROVIDER=openai" in config_content
+        assert "HINDSIGHT_API_LLM_API_KEY=sk-test" in config_content
+        assert "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini" in config_content
 
         # Verify metadata was created
         metadata_path = temp_hindsight_dir / "profiles" / "metadata.json"

--- a/skills/hindsight-docs/references/sdks/embed.md
+++ b/skills/hindsight-docs/references/sdks/embed.md
@@ -60,7 +60,6 @@ Configuration is saved to `~/.hindsight/embed`:
 ```bash
 HINDSIGHT_EMBED_LLM_PROVIDER=openai
 HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
-HINDSIGHT_EMBED_BANK_ID=default
 HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
 
 # Daemon settings (macOS: force CPU to avoid MPS/XPC issues)
@@ -90,7 +89,6 @@ The daemon starts automatically on first use!
 | `HINDSIGHT_EMBED_LLM_API_KEY` | **Required**. API key for LLM provider | - |
 | `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
 | `HINDSIGHT_EMBED_LLM_MODEL` | Model name | `gpt-4o-mini` |
-| `HINDSIGHT_EMBED_BANK_ID` | Default memory bank ID | `default` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
 
 **Provider Examples:**

--- a/skills/hindsight-docs/references/sdks/embed.md
+++ b/skills/hindsight-docs/references/sdks/embed.md
@@ -49,18 +49,18 @@ pipx install hindsight-embed
 hindsight-embed configure
 
 # Or non-interactive via environment variables
-export HINDSIGHT_EMBED_LLM_PROVIDER=openai
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 hindsight-embed configure
 ```
 
 Configuration is saved to `~/.hindsight/embed`:
 
 ```bash
-HINDSIGHT_EMBED_LLM_PROVIDER=openai
-HINDSIGHT_EMBED_LLM_MODEL=gpt-4o-mini
-HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
+HINDSIGHT_API_LLM_PROVIDER=openai
+HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
+HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
 
 # Daemon settings (macOS: force CPU to avoid MPS/XPC issues)
 HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=1
@@ -86,28 +86,28 @@ The daemon starts automatically on first use!
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_EMBED_LLM_API_KEY` | **Required**. API key for LLM provider | - |
-| `HINDSIGHT_EMBED_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
-| `HINDSIGHT_EMBED_LLM_MODEL` | Model name | `gpt-4o-mini` |
+| `HINDSIGHT_API_LLM_API_KEY` | **Required**. API key for LLM provider | - |
+| `HINDSIGHT_API_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `gemini`, `groq`, `minimax`, `ollama` | `openai` |
+| `HINDSIGHT_API_LLM_MODEL` | Model name | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` | Seconds before daemon auto-exits when idle (0 = never) | `0` |
 
 **Provider Examples:**
 
 ```bash
 # OpenAI
-export HINDSIGHT_EMBED_LLM_PROVIDER=openai
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=gpt-4o
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=gpt-4o
 
 # Groq (fast inference)
-export HINDSIGHT_EMBED_LLM_PROVIDER=groq
-export HINDSIGHT_EMBED_LLM_API_KEY=gsk_xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=llama-3.3-70b-versatile
+export HINDSIGHT_API_LLM_PROVIDER=groq
+export HINDSIGHT_API_LLM_API_KEY=gsk_xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=llama-3.3-70b-versatile
 
 # Anthropic
-export HINDSIGHT_EMBED_LLM_PROVIDER=anthropic
-export HINDSIGHT_EMBED_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
-export HINDSIGHT_EMBED_LLM_MODEL=claude-sonnet-4-20250514
+export HINDSIGHT_API_LLM_PROVIDER=anthropic
+export HINDSIGHT_API_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
+export HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-20250514
 ```
 
 ## Daemon Management
@@ -206,7 +206,7 @@ hindsight-embed daemon logs -f
 ```
 
 Common issues:
-- **Missing API key**: Set `HINDSIGHT_EMBED_LLM_API_KEY`
+- **Missing API key**: Set `HINDSIGHT_API_LLM_API_KEY`
 - **Port conflict**: Another service using port 8888
 - **Permissions**: Check `~/.hindsight/` directory permissions
 


### PR DESCRIPTION
Cleans up two `HINDSIGHT_EMBED_*` env vars that don't work as written. Both share the same root cause: the embed layer reads/forwards `HINDSIGHT_API_*` (and `OPENAI_API_KEY`), and the daemon env-builder forwards `HINDSIGHT_*` keys to the `hindsight-api` subprocess **verbatim — no `EMBED→API` prefix rewrite** — so `HINDSIGHT_EMBED_*` names the daemon doesn't recognize are inert.

## 1. Remove `HINDSIGHT_EMBED_BANK_ID` (dead)
Collected, persisted, printed, round-tripped through config dicts — but never consumed. `run_cli`/the daemon env-builder ignore `bank_id`; the `memory retain|recall|reflect <bank> …` commands take the bank as a **required positional arg**. Only reader was a test assertion.

## 2. Fix `HINDSIGHT_EMBED_LLM_*` → `HINDSIGHT_API_LLM_*` (documented but inert)
`sdks/embed.md` + the embed README documented `HINDSIGHT_EMBED_LLM_API_KEY` (marked **Required**), `_PROVIDER`, `_MODEL` as the user-facing LLM config — but **no code reads those names**. The CLI honors `HINDSIGHT_API_LLM_*`/`OPENAI_API_KEY` and `configure` writes the `HINDSIGHT_API_` prefix, so a user following the docs literally got "LLM API key is required". Renames every occurrence to the working `HINDSIGHT_API_LLM_*` (config that's genuinely needed is corrected, not deleted).

Regenerated the `skills/hindsight-docs` mirror. All `hindsight-embed` tests pass (88); lint clean.