### PR TITLE
fix(api): make recall/reflect disconnect cancellation actually work (behind BaseHTTPMiddleware)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/disconnect.py
+++ b/hindsight-api-slim/hindsight_api/api/disconnect.py
@@ -1,0 +1,97 @@
+"""Client-disconnect detection that works behind ``BaseHTTPMiddleware``.
+
+``Request.is_disconnected()`` is the obvious way to notice an abandoned HTTP
+request, but it is silently broken once any ``@app.middleware("http")``
+(Starlette ``BaseHTTPMiddleware``) is installed: that middleware runs the route
+in a child task behind anyio memory streams, so the ``http.disconnect`` ASGI
+event never reaches the route's ``Request``. This app has such middlewares, so
+the recall/reflect cancellation in #2122/#2127 never actually fired in
+production — the disconnect was never observed.
+
+This pure-ASGI middleware sits *outside* the ``BaseHTTPMiddleware`` layer, where
+it still owns the real ``receive`` channel. For the recall and reflect routes it
+drains ``receive`` in a background task and trips a :class:`CancellationToken`
+the moment ``http.disconnect`` arrives, stashing the token on the ASGI ``scope``.
+The route copies that token onto its ``RequestContext`` and the engine checks it
+at stage boundaries — so abandoned work stops instead of running to completion.
+
+It only wraps recall/reflect (small JSON bodies); every other request — uploads,
+MCP streams, etc. — passes straight through untouched, so there is no buffering
+or latency cost elsewhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+
+from ..cancellation import CancellationToken
+
+# Key under which the per-request CancellationToken is stored on the ASGI scope.
+# A dedicated top-level scope key (not scope["state"]) avoids any interaction
+# with Starlette's per-request state copying.
+SCOPE_CANCELLATION_TOKEN = "hindsight.cancellation_token"
+
+_CLIENT_DISCONNECTED_REASON = "client disconnected"
+
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+
+
+def _should_monitor(path: str) -> bool:
+    """Only the two long-running, abandon-prone read endpoints need monitoring."""
+    return path.endswith("/memories/recall") or path.endswith("/reflect")
+
+
+class ClientDisconnectCancellationMiddleware:
+    """Trip a scope-level CancellationToken when the client disconnects.
+
+    Must be installed *outside* any ``BaseHTTPMiddleware`` so it owns the real
+    ASGI ``receive`` channel.
+    """
+
+    def __init__(self, app: Callable) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not _should_monitor(scope.get("path", "")):
+            await self.app(scope, receive, send)
+            return
+
+        token = CancellationToken()
+        scope[SCOPE_CANCELLATION_TOKEN] = token
+
+        # The downstream app still needs to read the request body, so we cannot
+        # simply consume `receive` ourselves. Instead a single pump task drains
+        # the real channel, forwards every message to a queue the app reads from,
+        # and trips the token the instant `http.disconnect` shows up — which the
+        # app would otherwise never pull once it has finished reading the body.
+        queue: asyncio.Queue = asyncio.Queue()
+
+        async def pump() -> None:
+            while True:
+                message = await receive()
+                if message["type"] == "http.disconnect":
+                    token.cancel(_CLIENT_DISCONNECTED_REASON)
+                    await queue.put(message)
+                    return
+                await queue.put(message)
+
+        async def proxied_receive() -> MutableMapping[str, Any]:
+            return await queue.get()
+
+        pump_task = asyncio.create_task(pump())
+        try:
+            await self.app(scope, proxied_receive, send)
+        finally:
+            pump_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pump_task
+
+
+def get_scope_cancellation_token(scope: Scope) -> CancellationToken | None:
+    """Return the CancellationToken the middleware attached, if any."""
+    return scope.get(SCOPE_CANCELLATION_TOKEN)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -6,12 +6,11 @@ the FastAPI application with all API endpoints.
 """
 
 import asyncio
-import contextlib
 import json
 import logging
 import re
 import uuid
-from collections.abc import AsyncIterator, Awaitable
+from collections.abc import Awaitable
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Literal, TypeVar
@@ -19,7 +18,8 @@ from typing import Any, Literal, TypeVar
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
 
-from hindsight_api.cancellation import CancellationToken, OperationCancelledError
+from hindsight_api.api.disconnect import ClientDisconnectCancellationMiddleware, get_scope_cancellation_token
+from hindsight_api.cancellation import OperationCancelledError
 from hindsight_api.engine.audit import (
     AuditEntry,
     AuditLogger,
@@ -93,49 +93,8 @@ from hindsight_api.models import RequestContext
 
 logger = logging.getLogger(__name__)
 
-# Starlette surfaces client disconnects through an async receive check. A
-# one-second poll stops abandoned long-running recalls without busy-waiting.
-_CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS = 1.0
 # 499 is the de facto reverse-proxy status for "client closed request".
 _CLIENT_CLOSED_REQUEST_STATUS_CODE = 499
-_CLIENT_DISCONNECTED_REASON = "client disconnected"
-
-
-@asynccontextmanager
-async def _cancel_on_client_disconnect(
-    http_request: Request,
-    request_context: RequestContext,
-    *,
-    poll_interval: float = _CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS,
-) -> AsyncIterator[CancellationToken]:
-    """Attach a cancellation token that fires when the HTTP client disconnects.
-
-    The engine checks ``request_context`` at each pipeline stage boundary and
-    raises ``OperationCancelledError`` once this token fires, so an abandoned
-    request stops consuming CPU/DB resources instead of running to completion
-    (issue #2122). A background task polls ``request.is_disconnected()``; the
-    token is restored to its previous value on exit so nested scopes compose.
-    """
-    token = CancellationToken()
-    previous_token = request_context.cancellation
-    request_context.cancellation = token
-
-    async def _watch() -> None:
-        while True:
-            if await http_request.is_disconnected():
-                token.cancel(_CLIENT_DISCONNECTED_REASON)
-                return
-            await asyncio.sleep(poll_interval)
-
-    watcher = asyncio.create_task(_watch())
-    try:
-        yield token
-    finally:
-        watcher.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await watcher
-        request_context.cancellation = previous_token
-
 
 _T = TypeVar("_T")
 
@@ -147,22 +106,30 @@ async def run_cancellable_on_disconnect(
     *,
     operation: str,
     bank_id: str,
-    poll_interval: float = _CLIENT_DISCONNECT_POLL_INTERVAL_SECONDS,
 ) -> _T:
     """Run an engine coroutine, aborting it with 499 if the client disconnects.
 
-    Shared by the recall and reflect handlers: it attaches the disconnect-driven
-    cancellation token (which the engine checks at its stage/iteration
-    boundaries) and translates the resulting ``OperationCancelledError`` into the
-    de facto 499 status so abandoned work stops instead of running to completion
-    (issue #2122).
+    Shared by the recall and reflect handlers. The actual disconnect detection
+    lives in ``ClientDisconnectCancellationMiddleware`` (a pure-ASGI middleware
+    installed outside the ``BaseHTTPMiddleware`` layer), which attaches a
+    :class:`CancellationToken` to the ASGI scope and trips it on
+    ``http.disconnect``. Here we simply hand that token to the engine via
+    ``RequestContext`` — the engine checks it at stage/iteration boundaries — and
+    translate the resulting ``OperationCancelledError`` into 499 so abandoned
+    work stops instead of running to completion (issue #2122).
+
+    Note: ``Request.is_disconnected()`` is deliberately NOT used — it silently
+    never fires behind ``BaseHTTPMiddleware``, which is why the original #2127
+    implementation did not actually cancel anything in this app.
     """
-    async with _cancel_on_client_disconnect(http_request, request_context, poll_interval=poll_interval):
-        try:
-            return await coro
-        except OperationCancelledError as e:
-            logger.info(f"[{operation.upper()} CANCELLED] bank={bank_id} reason={e.reason}")
-            raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason) from e
+    token = get_scope_cancellation_token(http_request.scope)
+    if token is not None:
+        request_context.cancellation = token
+    try:
+        return await coro
+    except OperationCancelledError as e:
+        logger.info(f"[{operation.upper()} CANCELLED] bank={bank_id} reason={e.reason}")
+        raise HTTPException(status_code=_CLIENT_CLOSED_REQUEST_STATUS_CODE, detail=e.reason) from e
 
 
 class EntityIncludeOptions(BaseModel):
@@ -3144,6 +3111,13 @@ def create_app(
         if root_router:
             app.include_router(root_router)
             logging.info("HTTP extension root router mounted")
+
+    # Client-disconnect cancellation for recall/reflect. Added LAST so it sits
+    # OUTSIDE the @app.middleware("http") (BaseHTTPMiddleware) layers above —
+    # that placement is mandatory: BaseHTTPMiddleware breaks
+    # Request.is_disconnected(), so the only way to observe an abandoned request
+    # is to own the raw ASGI receive channel from outside it (issue #2122).
+    app.add_middleware(ClientDisconnectCancellationMiddleware)
 
     return app
 

--- a/hindsight-api-slim/hindsight_api/cancellation.py
+++ b/hindsight-api-slim/hindsight_api/cancellation.py
@@ -28,6 +28,15 @@ class OperationCancelledError(Exception):
     Carries the ``reason`` set by whoever cancelled (e.g. "client disconnected")
     so the HTTP layer can translate it into the appropriate status code instead
     of a generic 500.
+
+    NOTE: this is a plain ``Exception`` on purpose, NOT ``BaseException``. The
+    recall/reflect pipelines have broad ``except Exception`` handlers that would
+    otherwise swallow it — those handlers re-raise ``OperationCancelledError``
+    explicitly (see ``_search_with_retries``) so cancellation propagates to the
+    HTTP layer. A ``BaseException`` would dodge those handlers but also slip past
+    legitimate ``isinstance(result, Exception)`` checks (e.g. the reflect agent's
+    ``asyncio.gather(..., return_exceptions=True)`` tool-result handling), which
+    expect every non-tuple result to be an ``Exception``.
     """
 
     def __init__(self, reason: str = "operation cancelled") -> None:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -26,6 +26,7 @@ import asyncpg
 import httpx
 
 from .._vector_index import ann_search_tuning_settings, configured_vector_extension
+from ..cancellation import OperationCancelledError
 from ..config import (
     DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
     DEFAULT_RECALL_INCLUDE_CHUNKS,
@@ -3947,6 +3948,10 @@ class MemoryEngine(MemoryEngineInterface):
                             reranking=reranking,
                         )
                         break  # Success - exit retry loop
+                    except OperationCancelledError:
+                        # Client disconnected — propagate to the HTTP layer (499);
+                        # not a failure to retry or report via the post-op hook.
+                        raise
                     except Exception as e:
                         # Check if it's a connection error (PG or Oracle)
                         is_connection_error = (
@@ -4969,6 +4974,11 @@ class MemoryEngine(MemoryEngineInterface):
                 source_facts=source_facts_dict,
             )
 
+        except OperationCancelledError:
+            # Client disconnected mid-recall — propagate the cancellation so the
+            # HTTP layer can return 499. Must precede the broad handler below,
+            # which would otherwise bury it inside a RuntimeError (issue #2122).
+            raise
         except Exception as e:
             # Use repr(e) so exceptions with empty __str__ (e.g. raise SomeError())
             # still emit a discriminating class+args string into operations.error_message.

--- a/hindsight-api-slim/tests/test_recall_cancellation.py
+++ b/hindsight-api-slim/tests/test_recall_cancellation.py
@@ -1,11 +1,13 @@
-"""Tests for cooperative recall cancellation on client disconnect (issue #2122).
+"""Tests for cooperative recall/reflect cancellation on client disconnect (#2122).
 
-Covers three layers:
+Layers covered:
 - the ``CancellationToken`` primitive,
-- ``RequestContext`` integration (the carrier the engine checks at stage
-  boundaries),
-- the HTTP ``_cancel_on_client_disconnect`` driver, including an ASGI-level
-  end-to-end that proves a disconnect aborts staged work and surfaces 499.
+- ``RequestContext`` integration (the carrier the engine checks at boundaries),
+- ``run_cancellable_on_disconnect`` (reads the scope token, maps cancel -> 499),
+- ``ClientDisconnectCancellationMiddleware``, including the critical regression
+  test that it still fires **behind a BaseHTTPMiddleware** — the exact condition
+  under which ``Request.is_disconnected()`` silently never fires and the original
+  #2127 implementation did nothing.
 """
 
 import asyncio
@@ -13,25 +15,17 @@ import asyncio
 import pytest
 from fastapi import FastAPI, HTTPException, Request
 
-from hindsight_api.api.http import (
-    _CLIENT_CLOSED_REQUEST_STATUS_CODE,
-    _cancel_on_client_disconnect,
-    run_cancellable_on_disconnect,
+from hindsight_api.api.disconnect import (
+    SCOPE_CANCELLATION_TOKEN,
+    ClientDisconnectCancellationMiddleware,
+    _should_monitor,
+    get_scope_cancellation_token,
 )
+from hindsight_api.api.http import _CLIENT_CLOSED_REQUEST_STATUS_CODE, run_cancellable_on_disconnect
 from hindsight_api.cancellation import CancellationToken, OperationCancelledError
 from hindsight_api.models import RequestContext
 
 _TEST_TIMEOUT_SECONDS = 3.0
-
-
-class _FakeRequest:
-    """Minimal Request stand-in whose disconnect state is driven by an Event."""
-
-    def __init__(self, disconnected: asyncio.Event) -> None:
-        self._disconnected = disconnected
-
-    async def is_disconnected(self) -> bool:
-        return self._disconnected.is_set()
 
 
 # --- CancellationToken primitive ------------------------------------------------
@@ -46,7 +40,6 @@ def test_token_starts_uncancelled():
 def test_token_raises_after_cancel():
     token = CancellationToken()
     token.cancel("client disconnected")
-
     assert token.cancelled is True
     assert token.reason == "client disconnected"
     with pytest.raises(OperationCancelledError) as exc:
@@ -86,158 +79,123 @@ def test_request_context_raises_when_token_fired():
     token = CancellationToken()
     token.cancel("client disconnected")
     ctx = RequestContext(cancellation=token)
-
     with pytest.raises(OperationCancelledError):
         ctx.raise_if_cancelled()
 
 
-# --- HTTP disconnect driver -----------------------------------------------------
+# --- _should_monitor path gating ------------------------------------------------
 
 
-async def test_driver_attaches_and_restores_token():
+def test_should_monitor_only_recall_and_reflect():
+    assert _should_monitor("/v1/default/banks/b/memories/recall") is True
+    assert _should_monitor("/v1/default/banks/b/reflect") is True
+    assert _should_monitor("/v1/default/banks/b/memories") is False
+    assert _should_monitor("/health") is False
+    assert _should_monitor("/v1/default/banks/b/memories/recall/extra") is False
+
+
+# --- run_cancellable_on_disconnect ----------------------------------------------
+
+
+class _ScopeRequest:
+    """Minimal Request stand-in exposing a .scope dict."""
+
+    def __init__(self, scope: dict) -> None:
+        self.scope = scope
+
+
+async def test_run_cancellable_returns_result_when_no_token():
     ctx = RequestContext()
-    disconnected = asyncio.Event()
-
-    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0) as token:
-        assert ctx.cancellation is token
-
-    # Restored to the previous (None) token once the scope exits.
-    assert ctx.cancellation is None
-
-
-async def test_driver_restores_previous_token_when_nested():
-    outer = CancellationToken()
-    ctx = RequestContext(cancellation=outer)
-    disconnected = asyncio.Event()
-
-    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
-        assert ctx.cancellation is not outer
-
-    assert ctx.cancellation is outer
-
-
-async def test_driver_cancels_staged_work_on_disconnect():
-    """A worker that checks the token between stages aborts once the client leaves."""
-    ctx = RequestContext()
-    disconnected = asyncio.Event()
-
-    async def staged_work() -> str:
-        # Stand-in for the recall pipeline: checkpoint, do a slice of work, repeat.
-        for _ in range(1000):
-            ctx.raise_if_cancelled()
-            await asyncio.sleep(0.005)
-        return "done"
-
-    async def run() -> None:
-        async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
-            work = asyncio.create_task(staged_work())
-            await asyncio.sleep(0.02)
-            disconnected.set()
-            await work
-
-    with pytest.raises(OperationCancelledError) as exc:
-        await asyncio.wait_for(run(), timeout=_TEST_TIMEOUT_SECONDS)
-    assert exc.value.reason == "client disconnected"
-    assert ctx.cancellation is None
-
-
-async def test_driver_returns_work_result_when_client_stays():
-    ctx = RequestContext()
-    disconnected = asyncio.Event()  # never set
-
-    async def staged_work() -> str:
-        for _ in range(3):
-            ctx.raise_if_cancelled()
-            await asyncio.sleep(0)
-        return "done"
-
-    async with _cancel_on_client_disconnect(_FakeRequest(disconnected), ctx, poll_interval=0):
-        result = await staged_work()
-
-    assert result == "done"
-
-
-# --- Shared HTTP helper (used by both the recall and reflect handlers) ----------
-
-
-async def test_run_cancellable_returns_result_when_connected():
-    ctx = RequestContext()
-    disconnected = asyncio.Event()  # never set
+    req = _ScopeRequest({})  # middleware didn't attach a token
 
     async def work() -> str:
         ctx.raise_if_cancelled()
         return "ok"
 
-    result = await run_cancellable_on_disconnect(
-        _FakeRequest(disconnected), ctx, work(), operation="reflect", bank_id="b1", poll_interval=0
-    )
+    result = await run_cancellable_on_disconnect(req, ctx, work(), operation="recall", bank_id="b1")
     assert result == "ok"
-    assert ctx.cancellation is None  # restored
 
 
-async def test_run_cancellable_maps_disconnect_to_499():
+async def test_run_cancellable_wires_scope_token_and_maps_to_499():
+    token = CancellationToken()
     ctx = RequestContext()
-    disconnected = asyncio.Event()
+    req = _ScopeRequest({SCOPE_CANCELLATION_TOKEN: token})
 
-    async def staged_work() -> str:
-        for _ in range(1000):  # stand-in for the reflect agent loop / recall stages
+    async def work() -> str:
+        # token fires mid-flight; engine checkpoint raises
+        for _ in range(1000):
             ctx.raise_if_cancelled()
             await asyncio.sleep(0.005)
         return "done"
 
-    async def disconnect_soon() -> None:
+    async def fire_soon():
         await asyncio.sleep(0.02)
-        disconnected.set()
+        token.cancel("client disconnected")
 
-    asyncio.create_task(disconnect_soon())
+    asyncio.create_task(fire_soon())
     with pytest.raises(HTTPException) as exc:
         await asyncio.wait_for(
-            run_cancellable_on_disconnect(
-                _FakeRequest(disconnected), ctx, staged_work(), operation="reflect", bank_id="b1", poll_interval=0
-            ),
+            run_cancellable_on_disconnect(req, ctx, work(), operation="reflect", bank_id="b1"),
             timeout=_TEST_TIMEOUT_SECONDS,
         )
     assert exc.value.status_code == _CLIENT_CLOSED_REQUEST_STATUS_CODE
     assert exc.value.detail == "client disconnected"
-    assert ctx.cancellation is None
+    # the engine's carrier was wired to the scope token
+    assert ctx.cancellation is token
 
 
-# --- ASGI end-to-end: disconnect -> aborted work -> 499 -------------------------
+# --- Middleware ASGI integration (the regression that matters) ------------------
 
 
-async def test_asgi_disconnect_aborts_work_and_returns_499():
-    """Exercises the real shared helper through the ASGI stack (both endpoints'
-    path), proving disconnect -> aborted staged work -> 499."""
+def _build_app(*, with_base_http_middleware: bool) -> tuple[FastAPI, asyncio.Event]:
+    """Reflect-like app guarded by the disconnect middleware.
+
+    with_base_http_middleware reproduces the production setup where a
+    @app.middleware("http") (BaseHTTPMiddleware) sits between uvicorn and the
+    route and breaks Request.is_disconnected().
+    """
     app = FastAPI()
-    started = asyncio.Event()
     cancelled = asyncio.Event()
 
-    @app.post("/recall")
-    async def recall(http_request: Request):
+    @app.post("/v1/default/banks/{bank_id}/reflect")
+    async def reflect(bank_id: str, http_request: Request):
         ctx = RequestContext()
 
-        async def staged_work() -> dict:
-            started.set()
+        async def work():
             try:
-                while True:  # staged pipeline: checkpoint then a slice of work
+                while True:
                     ctx.raise_if_cancelled()
                     await asyncio.sleep(0.005)
             except OperationCancelledError:
                 cancelled.set()
                 raise
 
-        return await run_cancellable_on_disconnect(
-            http_request, ctx, staged_work(), operation="recall", bank_id="b1", poll_interval=0
-        )
+        return await run_cancellable_on_disconnect(http_request, ctx, work(), operation="reflect", bank_id=bank_id)
 
+    if with_base_http_middleware:
+
+        @app.middleware("http")
+        async def noop(request, call_next):
+            return await call_next(request)
+
+    # Installed last -> outermost -> owns the raw receive (as in create_app).
+    app.add_middleware(ClientDisconnectCancellationMiddleware)
+    return app, cancelled
+
+
+async def _drive_disconnect(app: FastAPI) -> list:
+    """Send a request, then http.disconnect once the handler is running."""
+    started = asyncio.Event()
     body_sent = False
 
     async def receive():
         nonlocal body_sent
         if not body_sent:
             body_sent = True
-            return {"type": "http.request", "body": b"", "more_body": False}
+            started.set()
+            return {"type": "http.request", "body": b"{}", "more_body": False}
         await started.wait()
+        await asyncio.sleep(0.05)
         return {"type": "http.disconnect"}
 
     messages = []
@@ -248,13 +206,80 @@ async def test_asgi_disconnect_aborts_work_and_returns_499():
     scope = {
         "type": "http",
         "method": "POST",
-        "path": "/recall",
+        "path": "/v1/default/banks/b1/reflect",
+        "raw_path": b"/v1/default/banks/b1/reflect",
         "query_string": b"",
-        "headers": [],
+        "headers": [(b"content-type", b"application/json")],
     }
-
     await asyncio.wait_for(app(scope, receive, send), timeout=_TEST_TIMEOUT_SECONDS)
+    return messages
 
+
+async def test_middleware_cancels_behind_base_http_middleware():
+    """THE regression test: disconnect cancellation must fire even with a
+    BaseHTTPMiddleware in the stack (where is_disconnected() is broken)."""
+    app, cancelled = _build_app(with_base_http_middleware=True)
+    messages = await _drive_disconnect(app)
+    assert cancelled.is_set(), "work was not cancelled behind BaseHTTPMiddleware"
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    assert start["status"] == _CLIENT_CLOSED_REQUEST_STATUS_CODE
+
+
+async def test_middleware_cancels_without_base_http_middleware():
+    app, cancelled = _build_app(with_base_http_middleware=False)
+    messages = await _drive_disconnect(app)
     assert cancelled.is_set()
-    response_start = next(m for m in messages if m["type"] == "http.response.start")
-    assert response_start["status"] == _CLIENT_CLOSED_REQUEST_STATUS_CODE
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    assert start["status"] == _CLIENT_CLOSED_REQUEST_STATUS_CODE
+
+
+async def test_middleware_passes_through_unmonitored_paths():
+    """Non-recall/reflect paths get no token and no receive proxying."""
+    seen_scope = {}
+
+    async def app(scope, receive, send):
+        seen_scope.update(scope)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = ClientDisconnectCancellationMiddleware(app)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(m):
+        sent.append(m)
+
+    await mw({"type": "http", "path": "/health"}, receive, send)
+    assert SCOPE_CANCELLATION_TOKEN not in seen_scope
+    assert any(m["type"] == "http.response.start" for m in sent)
+
+
+async def test_middleware_completes_normally_when_no_disconnect():
+    app, cancelled = _build_app(with_base_http_middleware=True)
+    # never disconnects; the route would loop forever, so give it a token and
+    # trip it via a normal completion path instead: hit an unmonitored no-op.
+    token_seen = {}
+
+    async def inner(scope, receive, send):
+        token_seen["t"] = get_scope_cancellation_token(scope)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    mw = ClientDisconnectCancellationMiddleware(inner)
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    sent = []
+
+    async def send(m):
+        sent.append(m)
+
+    scope = {"type": "http", "path": "/v1/default/banks/b1/reflect"}
+    await asyncio.wait_for(mw(scope, receive, send), timeout=_TEST_TIMEOUT_SECONDS)
+    # monitored path => token attached, request completed 200
+    assert isinstance(token_seen["t"], CancellationToken)
+    assert any(m.get("status") == 200 for m in sent if m["type"] == "http.response.start")


### PR DESCRIPTION
### Summary

Follow-up to #2127. That PR added recall/reflect cancellation on client disconnect — but **it never actually fired in production.** Serious black-box testing against a running server (curl `--max-time`, which closes the socket like a real abandoned client) showed abandoned recall/reflect requests still ran to completion, with **0 cancellations across a 4,000-request storm.**

This PR makes it actually work.

### Root cause 1 — `Request.is_disconnected()` is broken behind `BaseHTTPMiddleware`

The app installs two `@app.middleware("http")` handlers (Starlette `BaseHTTPMiddleware`). `BaseHTTPMiddleware` runs the route in a child task behind anyio memory streams, so the `http.disconnect` ASGI event never reaches the route's `Request` — `is_disconnected()` returns `False` for the entire handler. The #2127 disconnect watcher polled it every second and never saw a disconnect.

Reproduced in isolation with the same uvicorn/starlette/uvloop versions: a server with `is_disconnected()` polling detects a curl disconnect at ~2s; adding a **single no-op `@app.middleware("http")`** flips it to never detecting. Isolation probes are in the PR discussion.

**Fix:** `ClientDisconnectCancellationMiddleware` — a pure-ASGI middleware installed *outside* the `BaseHTTPMiddleware` layer, where it owns the real `receive` channel. It drains `receive` in a background pump, trips a `CancellationToken` the instant `http.disconnect` arrives, and stashes the token on the ASGI `scope`. It only wraps the recall/reflect paths (small JSON bodies); every other request — uploads, MCP streams — passes straight through, so there's no buffering or latency cost elsewhere.

### Root cause 2 — recall swallowed the cancellation anyway

Even once the token tripped, recall didn't cancel: `_search_with_retries` wraps its whole body in `except Exception` and re-raises as `RuntimeError("Failed to search memories")`, burying `OperationCancelledError` (→ 500, not 499, and the work had already finished). **Fix:** re-raise `OperationCancelledError` ahead of the broad handlers (search body + connection-retry loop).

`OperationCancelledError` stays a plain `Exception` (not `BaseException`) on purpose: `BaseException` dodges the broad handlers but also slips past the reflect agent's `isinstance(result, Exception)` check in its `asyncio.gather(..., return_exceptions=True)` tool handling and crashes it with `cannot unpack non-iterable OperationCancelledError`.

### Other changes

- `run_cancellable_on_disconnect` now just reads the scope token onto `RequestContext`; the polling `is_disconnected()` watcher (`_cancel_on_client_disconnect`) is removed.
- Engine stage-boundary checkpoints from #2127 are unchanged — they were correct, they just never got a tripped token.

### Verification (live, real server + real corpus)

A 30-second storm of socket-closing aborts (recall + reflect) with a dedicated canary client:

| Metric | Result |
|---|---|
| `RECALL CANCELLED` (abandoned work aborted server-side) | **397** |
| `REFLECT CANCELLED` | **80** |
| Canary normal recalls succeeded | **40 / 40** (no starvation) |
| `/health` during storm | **all 200** |
| Server 5xx / tracebacks | **0** |
| Recovery (health + normal recall) | **200, 0.55s** |

Single-shot: `curl --max-time 2.5` on a reflect and a queued recall both log `[REFLECT CANCELLED]` / `[RECALL CANCELLED] reason=client disconnected` and stop instead of running to completion.

### Known limit (unchanged from #2127)

Reflect cancellation is best-effort *between* agent iterations — a disconnect during the final-answer LLM call isn't interruptible (one long await), the same class of limit as the in-thread cross-encoder rerank. The disconnect is still detected immediately; it just takes effect at the next checkpoint.

### Tests

`tests/test_recall_cancellation.py` rewritten around the middleware, including the key regression test `test_middleware_cancels_behind_base_http_middleware` — disconnect cancellation must fire *with* a `BaseHTTPMiddleware` in the stack (the exact condition #2127 missed). 13 tests, all green; `ruff` + `ty` clean.
