### PR TITLE
docs: remove broken gitcgr code-graph badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![CI](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml/badge.svg)](https://github.com/vectorize-io/hindsight/actions/workflows/release.yml)
 [![Slack Community](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![gitcgr](https://gitcgr.com/badge/vectorize-io/hindsight.svg)](https://gitcgr.com/vectorize-io/hindsight)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/hindsight-api?label=PyPI)
 ![NPM Downloads](https://img.shields.io/npm/dm/%40vectorize-io%2Fhindsight-client?logoColor=orange&label=NPM&color=blue&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40vectorize-io%2Fhindsight-client)
 <br/>


### PR DESCRIPTION
## What

Removes the `gitcgr` code-graph badge from the README badge row.

## Why

The badge image at `https://gitcgr.com/badge/vectorize-io/hindsight.svg` no longer loads — the `gitcgr.com` SSL certificate has expired, so every request to the domain (badge SVG, link target, and root) fails TLS verification. The result is a broken-image icon sitting between the **License: MIT** and **PyPI** badges in the rendered README for all visitors.

It's a third-party service we don't control (added in #648) and appears defunct, so removing it rather than waiting on a cert renewal.

## Before

`Release · Slack · License · 🔲(broken) · PyPI · NPM`

## After

`Release · Slack · License · PyPI · NPM`