### PR TITLE
docs(superagent): add prerequisites to integration quick start

### DIFF
--- a/hindsight-docs/docs-integrations/superagent.md
+++ b/hindsight-docs/docs-integrations/superagent.md
@@ -17,13 +17,29 @@ Safety middleware for [Hindsight](https://vectorize.io/hindsight) memory operati
 pip install hindsight-superagent
 ```
 
+### Prerequisites
+
+Guard and Redact run on every `retain` by default, so the example below calls Superagent (and the LLM behind your guard/redact models) before anything is stored. Set both keys as environment variables first:
+
+| Variable             | Purpose                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SUPERAGENT_API_KEY` | Authenticates Superagent's guard/redact calls. [Get one at superagent.sh](https://www.superagent.sh).                                      |
+| `OPENAI_API_KEY`     | Backs the `guard_model` / `redact_model` (e.g. `openai/gpt-4.1-nano`). Any [supported LLM provider](https://docs.superagent.sh/sdk) works. |
+
+```bash
+export SUPERAGENT_API_KEY=sa-...
+export OPENAI_API_KEY=sk-...
+```
+
+You also need a reachable Hindsight endpoint for `hindsight_api_url`: a [self-hosted server](https://hindsight.vectorize.io/developer/installation) (`http://localhost:8888`), or your [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) URL together with its key (`HINDSIGHT_API_KEY`). The example uses a local server — point it at your Cloud URL to use Hindsight Cloud instead.
+
 ```python
 import asyncio
 from hindsight_superagent import SafeHindsight
 
 safe = SafeHindsight(
     bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",
+    hindsight_api_url="http://localhost:8888",  # or your Hindsight Cloud URL
     guard_model="openai/gpt-4.1-nano",
     redact_model="openai/gpt-4.1-nano",
 )
@@ -35,6 +51,10 @@ async def main():
 
 asyncio.run(main())
 ```
+
+:::note Hosted guard models
+Superagent's hosted endpoints for its guard models are currently unreliable. The guard models are open-weight (`superagent/guard-0.6b`, `guard-1.7b`, `guard-4b`) and can be [self-hosted](https://docs.superagent.sh/sdk/models) via Ollama or vLLM.
+:::
 
 ## Features
 

--- a/hindsight-docs/docs-integrations/superagent.md
+++ b/hindsight-docs/docs-integrations/superagent.md
@@ -19,27 +19,28 @@ pip install hindsight-superagent
 
 ### Prerequisites
 
-Guard and Redact run on every `retain` by default, so the example below calls Superagent (and the LLM behind your guard/redact models) before anything is stored. Set both keys as environment variables first:
+Guard and Redact run on every `retain` by default, so the example below calls Superagent (and the LLM behind your guard/redact models) before anything is stored. Set these keys as environment variables first:
 
 | Variable             | Purpose                                                                                                                                    |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HINDSIGHT_API_KEY`  | Authenticates your Hindsight Cloud workspace. [Sign up free](https://ui.hindsight.vectorize.io/signup) to grab one.                        |
 | `SUPERAGENT_API_KEY` | Authenticates Superagent's guard/redact calls. [Get one at superagent.sh](https://www.superagent.sh).                                      |
 | `OPENAI_API_KEY`     | Backs the `guard_model` / `redact_model` (e.g. `openai/gpt-4.1-nano`). Any [supported LLM provider](https://docs.superagent.sh/sdk) works. |
 
 ```bash
+export HINDSIGHT_API_KEY=hs-...
 export SUPERAGENT_API_KEY=sa-...
 export OPENAI_API_KEY=sk-...
 ```
 
-You also need a reachable Hindsight endpoint for `hindsight_api_url`: a [self-hosted server](https://hindsight.vectorize.io/developer/installation) (`http://localhost:8888`), or your [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) URL together with its key (`HINDSIGHT_API_KEY`). The example uses a local server — point it at your Cloud URL to use Hindsight Cloud instead.
+`SafeHindsight` connects to [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup) (`https://api.hindsight.vectorize.io`) by default, using `HINDSIGHT_API_KEY`. To target a [self-hosted server](https://hindsight.vectorize.io/developer/installation) instead, pass `hindsight_api_url="http://localhost:8888"`.
 
 ```python
 import asyncio
 from hindsight_superagent import SafeHindsight
 
 safe = SafeHindsight(
-    bank_id="user-123",
-    hindsight_api_url="http://localhost:8888",  # or your Hindsight Cloud URL
+    bank_id="user-123",  # connects to Hindsight Cloud by default
     guard_model="openai/gpt-4.1-nano",
     redact_model="openai/gpt-4.1-nano",
 )


### PR DESCRIPTION
## Problem

Copy-pasting the [Superagent integration quick start](https://hindsight.vectorize.io/sdks/integrations/superagent) fails on the first `retain()`. Guard/redact run on every `retain` by default, so the example calls Superagent before storing anything — but the page documents none of the prerequisites:

```
hindsight_superagent.errors.HindsightError: No Superagent API key configured.
Pass superagent_api_key=, set SUPERAGENT_API_KEY env var, or call configure(...) first.
```

I reproduced this by following the docs verbatim in a clean venv: `pip install` and import work fine, but the runnable example dies immediately because it needs a Superagent key, an LLM key for the guard/redact models, and a reachable Hindsight endpoint — all of which the integration README already documents but the docs page dropped.

## Changes

- **Prerequisites section** listing `SUPERAGENT_API_KEY` and `OPENAI_API_KEY` (for the `openai/gpt-4.1-nano` guard/redact models), with an `export` snippet.
- **Endpoint clarification** for `hindsight_api_url` — self-hosted (`localhost:8888`) vs Hindsight Cloud — resolving the contradiction between the "no self-hosting required" tip and the `localhost:8888` in the sample.
- **Caveat note** that Superagent's hosted guard-model endpoints are currently unreliable (open-weight guard models can be self-hosted), ported from the integration README.

Docs-only; prettier-clean.