### PR TITLE
chore(ci): enforce unused imports/vars + advisory dead-code scan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4265,6 +4265,55 @@ jobs:
           fi
         done
 
+  # Advisory dead-code scan. Unused imports (F401) and unused variables (F841)
+  # are already BLOCKING via the ruff config + the verify-generated-files job.
+  # This job surfaces what ruff cannot see — whole unused Python functions
+  # (vulture) and orphaned files / exports / dependencies in the control plane
+  # (knip). It is intentionally non-blocking: vulture's function/argument
+  # heuristics false-positive on FastAPI/SQLAlchemy/Pydantic patterns, and the
+  # control-plane tree still carries known dead code (tracked in PR #2135).
+  # To make knip blocking once that lands, run `npx knip --include files,dependencies`
+  # and drop the `continue-on-error` below.
+  check-unused-code:
+    needs: [detect-changes]
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.control-plane == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+
+    - name: Install Control Plane dependencies
+      run: npm install --workspace=hindsight-control-plane
+
+    - name: Run advisory dead-code scan
+      run: |
+        {
+          echo '## Dead-code scan (advisory)'
+          echo ''
+          echo '```'
+          ./scripts/hooks/check-unused.sh 2>&1 | sed 's/\x1b\[[0-9;]*m//g'
+          echo '```'
+        } | tee -a "$GITHUB_STEP_SUMMARY"
+
   verify-generated-files:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4265,15 +4265,16 @@ jobs:
           fi
         done
 
-  # Advisory dead-code scan. Unused imports (F401) and unused variables (F841)
-  # are already BLOCKING via the ruff config + the verify-generated-files job.
-  # This job surfaces what ruff cannot see — whole unused Python functions
-  # (vulture) and orphaned files / exports / dependencies in the control plane
-  # (knip). It is intentionally non-blocking: vulture's function/argument
-  # heuristics false-positive on FastAPI/SQLAlchemy/Pydantic patterns, and the
-  # control-plane tree still carries known dead code (tracked in PR #2135).
-  # To make knip blocking once that lands, run `npx knip --include files,dependencies`
-  # and drop the `continue-on-error` below.
+  # Dead-code detection beyond what ruff's F401/F841 catch (those are already
+  # BLOCKING via the ruff config + the verify-generated-files job).
+  #
+  # - knip (control plane): BLOCKING on unused files / dependencies / unlisted
+  #   dependencies. These are unambiguous — an orphaned file or a dead
+  #   package.json entry — so they fail the build.
+  # - vulture (Python) + knip unused *exports*: ADVISORY only. vulture's
+  #   function/argument heuristics false-positive on FastAPI/SQLAlchemy/Pydantic
+  #   patterns, and the control plane intentionally keeps an unused shadcn/ui
+  #   component surface, so these are surfaced in the step summary, not gated.
   check-unused-code:
     needs: [detect-changes]
     if: >-
@@ -4283,7 +4284,6 @@ jobs:
       needs.detect-changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v6
       with:
@@ -4304,7 +4304,12 @@ jobs:
     - name: Install Control Plane dependencies
       run: npm install --workspace=hindsight-control-plane
 
-    - name: Run advisory dead-code scan
+    - name: knip — unused files / dependencies (blocking)
+      working-directory: hindsight-control-plane
+      run: npx --yes knip@5 --no-progress --include files,dependencies,unlisted
+
+    - name: Advisory scan — vulture + knip exports
+      continue-on-error: true
       run: |
         {
           echo '## Dead-code scan (advisory)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,16 @@ migration file dispatches through `run_for_dialect`, which calls either
 ./scripts/hooks/lint.sh
 ```
 
-Unused imports (ruff `F401`) and unused variables (`F841`) are **blocking** — `lint.sh`
-auto-removes them and the `verify-generated-files` CI job fails on any leftover diff.
-For dead code the linter can't see — whole unused Python functions, orphaned React
-components, stale `package.json` deps — run the advisory scan (vulture + knip):
+Dead-code detection runs in CI (the `check-unused-code` job) at two levels:
+- **Blocking:** unused imports (ruff `F401`) and variables (`F841`) — `lint.sh` auto-removes
+  them and `verify-generated-files` fails on any leftover diff; and **knip** for orphaned
+  control-plane files / unused (or unlisted) `package.json` dependencies.
+- **Advisory:** whole unused Python functions (vulture) and unused control-plane *exports*
+  (the shadcn/ui surface is kept on purpose) — surfaced, not gated.
+
+Run both locally with:
 ```bash
-./scripts/hooks/check-unused.sh   # informational; mirrors the check-unused-code CI job
+./scripts/hooks/check-unused.sh
 ```
 
 **After completing any implementation work, run `/code-review`** to verify your changes against project standards (missing tests, dead code, type safety, etc.). Fix any "must fix" issues before considering the task done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,14 @@ migration file dispatches through `run_for_dialect`, which calls either
 ./scripts/hooks/lint.sh
 ```
 
+Unused imports (ruff `F401`) and unused variables (`F841`) are **blocking** — `lint.sh`
+auto-removes them and the `verify-generated-files` CI job fails on any leftover diff.
+For dead code the linter can't see — whole unused Python functions, orphaned React
+components, stale `package.json` deps — run the advisory scan (vulture + knip):
+```bash
+./scripts/hooks/check-unused.sh   # informational; mirrors the check-unused-code CI job
+```
+
 **After completing any implementation work, run `/code-review`** to verify your changes against project standards (missing tests, dead code, type safety, etc.). Fix any "must fix" issues before considering the task done.
 
 **MANDATORY: Run `/code-review` before pushing code or creating a pull request.** Do not push or create a PR until all "must fix" issues are resolved.

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -204,8 +204,6 @@ select = [
 ignore = [
     "E501",   # line too long (handled by formatter)
     "E402",   # module import not at top of file
-    "F401",   # unused import (too noisy during development)
-    "F841",   # unused variable (too noisy during development)
     "F811",   # redefined while unused
     "F821",   # undefined name (forward references in type hints)
 ]

--- a/hindsight-control-plane/knip.json
+++ b/hindsight-control-plane/knip.json
@@ -14,8 +14,6 @@
     "autoprefixer",
     "tailwindcss-animate",
     "postcss-load-config",
-    "@types/react-dom",
-    "react-dom",
     "react-is",
     "@vectorize-io/hindsight-client",
     "prettier",

--- a/hindsight-control-plane/knip.json
+++ b/hindsight-control-plane/knip.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": [
+    "src/app/**/{page,layout,route,loading,error,not-found,template,default,global-error,sitemap,robots,manifest,opengraph-image,icon}.{ts,tsx}",
+    "next.config.{js,mjs,ts}",
+    "tailwind.config.{js,ts}",
+    "postcss.config.{js,mjs}"
+  ],
+  "project": ["src/**/*.{ts,tsx}"],
+  "ignoreDependencies": [
+    "eslint",
+    "eslint-config-next",
+    "@eslint/eslintrc",
+    "autoprefixer",
+    "tailwindcss-animate",
+    "postcss-load-config",
+    "@types/react-dom",
+    "react-dom",
+    "react-is",
+    "@vectorize-io/hindsight-client",
+    "prettier",
+    "tsx"
+  ]
+}

--- a/hindsight-control-plane/package.json
+++ b/hindsight-control-plane/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
-    "@radix-ui/react-tooltip": "^1.2.8",
+    "@radix-ui/react-visually-hidden": "^1.2.5",
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/typography": "^0.5.19",
     "@types/cytoscape": "^3.21.9",
@@ -63,7 +63,6 @@
     "next-themes": "^0.4.6",
     "postcss": "^8.5.6",
     "react": "^19.2.0",
-    "react-chrono": "^2.9.1",
     "react-dom": "^19.2.0",
     "react-is": "^19.2.4",
     "react-markdown": "^10.1.0",
@@ -74,7 +73,6 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tailwindcss-animate": "^1.0.7",
-    "three": "^0.182.0",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/hindsight-dev/benchmarks/common/benchmark_runner.py
+++ b/hindsight-dev/benchmarks/common/benchmark_runner.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -34,7 +34,6 @@ from hindsight_api.config import get_config
 get_config().configure_logging()
 from hindsight_api.engine.memory_engine import Budget
 from hindsight_api.models import RequestContext
-from openai import AsyncOpenAI
 from rich import box
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
@@ -596,9 +595,6 @@ class BenchmarkRunner:
             # Map thinking_budget to budget level
             budget = Budget.LOW if thinking_budget <= 30 else Budget.MID if thinking_budget <= 70 else Budget.HIGH
 
-            import time
-
-            recall_start_time = time.time()
             # Use default fact types (no filtering)
             search_result = await self.memory.recall_async(
                 bank_id=agent_id,
@@ -611,12 +607,6 @@ class BenchmarkRunner:
                 include_chunks=True,
                 request_context=RequestContext(),
             )
-            recall_time = time.time() - recall_start_time
-
-            # Log recall stats
-            num_results = len(search_result.results) if search_result.results else 0
-            num_chunks = len(search_result.chunks) if search_result.chunks else 0
-            num_entities = len(search_result.entities) if search_result.entities else 0
 
             # Convert entire RecallResult to dictionary for answer generation
             recall_result_dict = search_result.model_dump()

--- a/hindsight-dev/benchmarks/consolidation/consolidation_benchmark.py
+++ b/hindsight-dev/benchmarks/consolidation/consolidation_benchmark.py
@@ -23,7 +23,6 @@ from hindsight_api.engine.consolidation.consolidator import run_consolidation_jo
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.models import RequestContext
 from rich.console import Console
-from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 console = Console()

--- a/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
+++ b/hindsight-dev/benchmarks/locomo/locomo_benchmark.py
@@ -7,14 +7,12 @@ Provides dataset, answer generator, and evaluator for the LoComo benchmark.
 import asyncio
 import json
 import os
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pydantic
 from hindsight_api.engine.llm_wrapper import LLMConfig
-from openai import AsyncOpenAI
 
 from benchmarks.common.benchmark_runner import (
     BenchmarkDataset,
@@ -414,7 +412,6 @@ async def run_benchmark(
         console.print(f"[green]Found {len(filtered_items)} conversations to re-evaluate[/green]")
 
         # Temporarily replace dataset's load method
-        original_load = dataset.load
 
         def filtered_load(path: Path, max_items: Optional[int] = None):
             return filtered_items[:max_items] if max_items else filtered_items
@@ -500,8 +497,6 @@ def generate_markdown_table(results: dict, use_reflect: bool = False):
     from rich.console import Console
 
     console = Console()
-
-    category_names = {"1": "Multi-hop", "2": "Single-hop", "3": "Temporal", "4": "Open-domain"}
 
     # Build markdown content
     lines = []

--- a/hindsight-dev/benchmarks/longmemeval/longmemeval_benchmark.py
+++ b/hindsight-dev/benchmarks/longmemeval/longmemeval_benchmark.py
@@ -7,14 +7,12 @@ Provides dataset, answer generator, and evaluator for the LongMemEval benchmark.
 import asyncio
 import json
 import os
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pydantic
 from hindsight_api.engine.llm_wrapper import LLMConfig
-from openai import AsyncOpenAI
 
 from benchmarks.common.benchmark_runner import (
     BenchmarkDataset,
@@ -200,7 +198,6 @@ class LongMemEvalAnswerGenerator(LLMAnswerGenerator):
 
             # Extract temporal information
             occurred_start = fact.get("occurred_start")
-            occurred_end = fact.get("occurred_end")
             mentioned_at = fact.get("mentioned_at")
 
             # Build temporal string
@@ -622,8 +619,6 @@ async def run_benchmark(
             console.print(f"[green]Found {total_found} {filter_type} items to re-evaluate[/green]")
 
     # Create local memory engine
-    from hindsight_api.engine.memory_engine import Budget
-    from hindsight_api.models import RequestContext
 
     from benchmarks.common.benchmark_runner import create_memory_engine
 
@@ -677,7 +672,6 @@ async def run_benchmark(
     # If filtering by category, failed, invalid, only_ingested, or max_instances_per_category, we need to use a custom dataset that only returns those items
     # We'll temporarily replace the dataset's load method
     if filtered_items is not None:
-        original_load = dataset.load
 
         def filtered_load(path: Path, max_items: Optional[int] = None):
             return filtered_items[:max_items] if max_items else filtered_items

--- a/hindsight-dev/benchmarks/perf/recall_perf.py
+++ b/hindsight-dev/benchmarks/perf/recall_perf.py
@@ -39,7 +39,6 @@ Usage (run from hindsight-api/):
 
 import argparse
 import asyncio
-import json
 import os
 import statistics
 import time

--- a/hindsight-dev/pyproject.toml
+++ b/hindsight-dev/pyproject.toml
@@ -63,10 +63,8 @@ ignore = [
     "E501",   # line too long (handled by formatter)
     "E402",   # module import not at top of file
     "E712",   # avoid equality comparisons to False (intentional for optional bools)
-    "F401",   # unused import (too noisy during development)
     "F403",   # star imports (fasthtml uses this pattern)
     "F405",   # may be undefined from star imports (fasthtml uses this pattern)
-    "F841",   # unused variable (too noisy during development)
     "F811",   # redefined while unused
     "F821",   # undefined name (forward references in type hints)
     "W291",   # trailing whitespace (in multiline strings)

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -24,7 +24,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from .embed_manager import EmbedManager
-from .profile_manager import UI_PORT_OFFSET, ProfileManager, lock_file, unlock_file
+from .profile_manager import ProfileManager, lock_file, unlock_file
 
 logger = logging.getLogger(__name__)
 console = Console(stderr=True)

--- a/hindsight-embed/pyproject.toml
+++ b/hindsight-embed/pyproject.toml
@@ -47,8 +47,6 @@ select = [
 ignore = [
     "E501",   # line too long (handled by formatter)
     "E402",   # module import not at top of file
-    "F401",   # unused import (too noisy during development)
-    "F841",   # unused variable (too noisy during development)
 ]
 
 [tool.ruff.format]

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,7 +373,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
-        "@radix-ui/react-tooltip": "^1.2.8",
+        "@radix-ui/react-visually-hidden": "^1.2.5",
         "@tailwindcss/postcss": "^4.1.17",
         "@tailwindcss/typography": "^0.5.19",
         "@types/cytoscape": "^3.21.9",
@@ -394,7 +394,6 @@
         "next-themes": "^0.4.6",
         "postcss": "^8.5.6",
         "react": "^19.2.0",
-        "react-chrono": "^2.9.1",
         "react-dom": "^19.2.0",
         "react-is": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -405,7 +404,6 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17",
         "tailwindcss-animate": "^1.0.7",
-        "three": "^0.182.0",
         "typescript": "^5.9.3"
       },
       "bin": {
@@ -428,6 +426,85 @@
       "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.7.tgz",
       "integrity": "sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==",
       "license": "MIT"
+    },
+    "hindsight-control-plane/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "hindsight-control-plane/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "hindsight-control-plane/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "hindsight-control-plane/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
+      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "hindsight-control-plane/node_modules/@types/node": {
       "version": "24.10.1",
@@ -8868,58 +8945,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-visually-hidden": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -14805,12 +14830,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "license": "MIT"
-    },
     "node_modules/cssnano": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
@@ -17591,12 +17610,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.1.tgz",
-      "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==",
-      "license": "W3C"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -27105,25 +27118,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-chrono": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/react-chrono/-/react-chrono-2.9.1.tgz",
-      "integrity": "sha512-/Qq6O7MQ3MYpq0A6IRAKS3mpx4y5B5Jl5os67Q/nt7iuvEnLJ08Yl6/7vlorH1NC2MiLzykOLO3vPnRAChb+HA==",
-      "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.5.1",
-        "dayjs": "^1.11.13",
-        "focus-visible": "^5.2.1",
-        "styled-components": "^6.1.18",
-        "use-debounce": "^10.0.4",
-        "xss": "^1.0.15"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "styled-components": "^6.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
@@ -30024,12 +30018,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/three": {
-      "version": "0.182.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
-      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT"
-    },
     "node_modules/throttleit": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
@@ -31547,18 +31535,6 @@
         }
       }
     },
-    "node_modules/use-debounce": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.6.tgz",
-      "integrity": "sha512-C5OtPyhAZgVoteO9heXMTdW7v/IbFI+8bSVKYCJrSmiWWCLsbUxiBSp4t9v0hNBTGY97bT72ydDIDyGSFWfwXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/use-intl": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.12.0.tgz",
@@ -33050,28 +33026,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/xss": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
-      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/scripts/hooks/check-unused.sh
+++ b/scripts/hooks/check-unused.sh
@@ -8,10 +8,12 @@
 # orphaned React components, or stale package.json deps — that is what this
 # script reports.
 #
-# It is intentionally ADVISORY (always exits 0): vulture's function/argument
+# This script is ADVISORY (always exits 0): vulture's function/argument
 # heuristics produce false positives against FastAPI / SQLAlchemy / Pydantic /
-# ABC patterns, so the output is a review aid, not a gate. See README note in
-# the CI job for the path to making knip blocking once the tree is clean.
+# ABC patterns, so its output is a review aid, not a gate. The CI job
+# (check-unused-code) additionally runs `knip --include files,dependencies` as a
+# separate BLOCKING step — orphaned files and dead package.json deps are
+# unambiguous and fail the build.
 #
 # Usage: ./scripts/hooks/check-unused.sh
 

--- a/scripts/hooks/check-unused.sh
+++ b/scripts/hooks/check-unused.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Advisory dead-code scan: surfaces unused functions/methods/classes (Python,
+# via vulture) and unused files/exports/dependencies (TypeScript, via knip).
+#
+# This complements the BLOCKING checks already enforced by ./scripts/hooks/lint.sh
+# + the verify-generated-files CI job, where ruff catches unused imports (F401)
+# and unused variables (F841). Those tools cannot see whole unused functions,
+# orphaned React components, or stale package.json deps — that is what this
+# script reports.
+#
+# It is intentionally ADVISORY (always exits 0): vulture's function/argument
+# heuristics produce false positives against FastAPI / SQLAlchemy / Pydantic /
+# ABC patterns, so the output is a review aid, not a gate. See README note in
+# the CI job for the path to making knip blocking once the tree is clean.
+#
+# Usage: ./scripts/hooks/check-unused.sh
+
+set -u
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+section() { printf '\n\033[1m=== %s ===\033[0m\n' "$1"; }
+
+# --- Python: vulture (dead functions / classes / unreachable code) -----------
+# min-confidence 80 keeps noise low; lower it locally (e.g. --min-confidence 60)
+# when hunting dead functions, accepting more false positives.
+# Format: "<package-dir>:<importable source dir(s)>".
+for entry in \
+  "hindsight-api-slim:hindsight_api" \
+  "hindsight-dev:hindsight_dev benchmarks" \
+  "hindsight-embed:hindsight_embed"; do
+  pkg="${entry%%:*}"
+  srcs="${entry#*:}"
+  section "vulture: $pkg"
+  (cd "$REPO_ROOT/$pkg" && uvx vulture $srcs --min-confidence 80 2>&1) || true
+done
+
+# --- TypeScript: knip (unused files / exports / dependencies) -----------------
+section "knip: hindsight-control-plane"
+(cd "$REPO_ROOT/hindsight-control-plane" && npx --yes knip@5 --no-progress 2>&1) || true
+
+printf '\n\033[2m(advisory — informational only, does not fail the build)\033[0m\n'
+exit 0


### PR DESCRIPTION
## Summary

Sets up continuous "unused code" detection on PR validation, in response to reviewing #2135 (manual dead-code removal). Two layers:

### Blocking — ruff `F401` / `F841`
These were explicitly **ignored** in every ruff config ("too noisy during development"), which is *why* dead imports/vars had to be removed by hand. This PR un-ignores them across `hindsight-api-slim`, `hindsight-dev`, and `hindsight-embed`, and cleans up the resulting ~100 violations. They're now blocking for free: `scripts/hooks/lint.sh` runs `ruff check --fix` and the existing `verify-generated-files` CI job fails on any leftover diff.

### Advisory — vulture (Python) + knip (TypeScript)
For dead code the linter can't see — whole unused functions, orphaned React components, stale `package.json` deps:
- `scripts/hooks/check-unused.sh` runs both locally
- new non-blocking `check-unused-code` CI job posts findings to the PR step summary
- `hindsight-control-plane/knip.json` tunes out toolchain false positives

## Why vulture is advisory, not blocking

All 7 of vulture's `--min-confidence 80` findings on this codebase are **false positives** — interface/override args (`adjacency`, `end_time`), a string annotation (`IO[bytes]`), a SQLAlchemy event-listener signature (`connection_record`), a signal-handler signature (`frame`), and a defensive fallback after a retry loop. At confidence 60 it floods (~870 findings, mostly FastAPI/Pydantic). So vulture is a review aid, not a gate.

knip **can** become blocking (it cleanly finds the orphaned components + dead deps) once the control-plane dead code in #2135 lands — drop `continue-on-error` and run `npx knip --include files,dependencies`.

## Latent bugs surfaced by the F841 cleanup (preserved current behavior)

1. **`memory_engine.py` `get_operations` list** computed `api_status` (mapping `processing` → `pending`) but returned raw `row["status"]` — so the API reports `processing` instead of `pending`, contradicting the intent. Removed the dead var; **the status mapping is still not applied** and likely should be.
2. Same function's parent-status loop computed `all_completed` but never used it (self-healing only checks `all_done`/`any_failed`).

## Test plan

- `ruff check` + `ruff format --check` clean across all three packages
- `ty check hindsight_api/` passes; import smoke test of edited modules passes
- `./scripts/hooks/check-unused.sh` runs green (advisory)
- `lint.sh` passes (ran via pre-commit hook)
