### PR TITLE
fix(docs): deflake memories.py doc example (async-consolidation race)

### DIFF
--- a/hindsight-docs/examples/api/memories.py
+++ b/hindsight-docs/examples/api/memories.py
@@ -13,6 +13,29 @@ HINDSIGHT_URL = os.getenv("HINDSIGHT_API_URL", "http://localhost:8888")
 BANK_ID = "memories-demo-bank"
 
 
+async def wait_for_idle(client, bank_id, *, attempts=120, interval=0.5):
+    """Block until the bank has no pending/processing async operations.
+
+    Retain and every update_memory edit re-embed and re-consolidate in the
+    background. Draining that queue between curation steps keeps the example
+    deterministic — otherwise a later step can race the prior step's
+    re-consolidation and 404 on a unit that is mid-rewrite.
+    """
+    await asyncio.sleep(interval)  # let the just-submitted operation register
+    for _ in range(attempts):
+        busy = False
+        for state in ("pending", "processing"):
+            res = await client.operations.list_operations(
+                bank_id=bank_id, status=state, limit=1
+            )
+            if res.operations:
+                busy = True
+                break
+        if not busy:
+            return
+        await asyncio.sleep(interval)
+
+
 async def main():
     # =========================================================================
     # Setup (not shown in docs)
@@ -21,7 +44,7 @@ async def main():
     await client.acreate_bank(bank_id=BANK_ID, name="Memories Demo")
     await client.aretain(bank_id=BANK_ID, content="The assistant visited Paris in 2023.")
     await client.aretain(bank_id=BANK_ID, content="The deploy server srv-04 runs PostgreSQL 14.")
-    await asyncio.sleep(3)  # let extraction finish
+    await wait_for_idle(client, BANK_ID)  # let extraction + consolidation finish
 
     # =========================================================================
     # Doc Examples
@@ -81,6 +104,10 @@ async def main():
     )
     # [/docs:edit-memory]
 
+    # The text edit re-consolidates in the background; let it settle before the
+    # next edit so the unit isn't mid-rewrite when we touch it again.
+    await wait_for_idle(client, BANK_ID)
+
     # [docs:edit-memory-fields]
     # Correct dates, fact type, and entities in one call. "" clears a field;
     # entities replaces the set ([] detaches all); omit to leave unchanged.
@@ -95,6 +122,8 @@ async def main():
     )
     # [/docs:edit-memory-fields]
 
+    await wait_for_idle(client, BANK_ID)
+
     # [docs:invalidate-memory]
     # Soft-retire a fact: removed from recall/consolidation/graph, links pruned,
     # derived observations recomputed without it — but kept for audit.
@@ -107,6 +136,10 @@ async def main():
         ),
     )
     # [/docs:invalidate-memory]
+
+    # Invalidation also re-derives observations in the background; drain it so the
+    # restore below doesn't race a unit that is being moved between tables.
+    await wait_for_idle(client, BANK_ID)
 
     # [docs:restore-memory]
     # Restore a previously invalidated fact.


### PR DESCRIPTION
## Problem

The `test-doc-examples (python)` CI job has been intermittently red on the `memories.py` API example, failing with:

```
hindsight-docs/examples/api/memories.py, line ~111, in main
  raise NotFoundException ... (404)
  "Memory unit '<uuid>' not found"
```

This is a **pre-existing main-side flake** (the example was introduced in #1976) that surfaces on any PR touching `.github/**`, since the example is main-owned and re-runs there.

## Root cause

The example curates one unit with four back-to-back calls: edit text → edit fields → invalidate → restore. Each `update_memory` **edit** re-embeds and **re-consolidates in the background** (a tracked `consolidation` operation, plus graph maintenance / mental-model refreshes). The next step fired immediately, racing that background work — so a later call (most often the **restore**) could hit the unit while it was mid-rewrite and 404. The fixed `await asyncio.sleep(3)` after the seed retains was also unreliable under CI load with a live LLM.

## Fix

Add a small `wait_for_idle()` helper that polls `list_operations` until the bank has no `pending`/`processing` operations, and drain between each curation step (and after the seed retains, replacing the `sleep(3)`).

- Deterministic: waits for the actual async work to finish instead of guessing with a sleep.
- Best-effort & bounded: caps at ~60s per wait, then falls through (never hangs the example).
- **Documentation snippets are unchanged** — every `wait_for_idle()` call sits *outside* the `# [docs:...]` blocks that get rendered into the docs site.

## Verification

- `python -m py_compile` passes.
- Confirmed `update_memory` → `submit_async_consolidation` creates a tracked operation visible to `list_operations` (so the poll actually drains the racing work).
- Doc-block purity checked: no `wait_for_idle` inside any `[docs:...]` marker.
- Final validation is the `test-doc-examples (python)` job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)