### PR TITLE
docs(api): list all three supported webhook event types

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2670,7 +2670,7 @@ class CreateWebhookRequest(BaseModel):
     secret: str | None = Field(default=None, description="HMAC-SHA256 signing secret (optional)")
     event_types: list[str] = Field(
         default=["consolidation.completed"],
-        description="List of event types to deliver. Currently supported: 'consolidation.completed'",
+        description="List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.",
     )
     enabled: bool = Field(default=True, description="Whether this webhook is active")
     http_config: WebhookHttpConfig = Field(

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5103,7 +5103,8 @@ components:
         event_types:
           default:
           - consolidation.completed
-          description: "List of event types to deliver. Currently supported: 'consolidation.completed'"
+          description: "List of event types to deliver. Supported: 'retain.completed',\
+            \ 'consolidation.completed', 'memory_defense.triggered'."
           items:
             type: string
           type: array

--- a/hindsight-clients/go/model_create_webhook_request.go
+++ b/hindsight-clients/go/model_create_webhook_request.go
@@ -24,7 +24,7 @@ type CreateWebhookRequest struct {
 	// HTTP(S) endpoint URL to deliver events to
 	Url string `json:"url"`
 	Secret NullableString `json:"secret,omitempty"`
-	// List of event types to deliver. Currently supported: 'consolidation.completed'
+	// List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.
 	EventTypes []string `json:"event_types,omitempty"`
 	// Whether this webhook is active
 	Enabled *bool `json:"enabled,omitempty"`

--- a/hindsight-clients/python/hindsight_client_api/models/create_webhook_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/create_webhook_request.py
@@ -29,7 +29,7 @@ class CreateWebhookRequest(BaseModel):
     """ # noqa: E501
     url: StrictStr = Field(description="HTTP(S) endpoint URL to deliver events to")
     secret: Optional[StrictStr] = None
-    event_types: Optional[List[StrictStr]] = Field(default=None, description="List of event types to deliver. Currently supported: 'consolidation.completed'")
+    event_types: Optional[List[StrictStr]] = Field(default=None, description="List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.")
     enabled: Optional[StrictBool] = Field(default=True, description="Whether this webhook is active")
     http_config: Optional[WebhookHttpConfig] = Field(default=None, description="HTTP delivery configuration (method, timeout, headers, params)")
     __properties: ClassVar[List[str]] = ["url", "secret", "event_types", "enabled", "http_config"]

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1224,7 +1224,7 @@ export type CreateWebhookRequest = {
   /**
    * Event Types
    *
-   * List of event types to deliver. Currently supported: 'consolidation.completed'
+   * List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.
    */
   event_types?: Array<string>;
   /**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -7748,7 +7748,7 @@
             },
             "type": "array",
             "title": "Event Types",
-            "description": "List of event types to deliver. Currently supported: 'consolidation.completed'",
+            "description": "List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.",
             "default": [
               "consolidation.completed"
             ]

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -7748,7 +7748,7 @@
             },
             "type": "array",
             "title": "Event Types",
-            "description": "List of event types to deliver. Currently supported: 'consolidation.completed'",
+            "description": "List of event types to deliver. Supported: 'retain.completed', 'consolidation.completed', 'memory_defense.triggered'.",
             "default": [
               "consolidation.completed"
             ]


### PR DESCRIPTION
## What

The `CreateWebhookRequest.event_types` field description said only `Currently supported: 'consolidation.completed'`, but the API actually emits **and** accepts all three webhook events. Updated the description to list all three and propagated it through the regenerated OpenAPI spec + the embedded copies in the go/python/typescript clients.

## Why

All three are genuinely dispatched in the engine — verified:
- `retain.completed` → `memory_engine.py`
- `consolidation.completed` → `memory_engine.py`
- `memory_defense.triggered` → `retain/orchestrator.py`

So the doc was stale, not the behavior. (Surfaced while building the Zapier integration, whose triggers subscribe to all three.)

## Scope

Description-only change — no behavior change. 6 files, one line each (`http.py`, `openapi.json`, and the 4 generated client copies).

> Note: the client copies were updated by hand to match the spec because local SDK regen needs Docker (not available); `verify-generated-files` in CI (with Docker) is the backstop that confirms they match a real regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)