### PR TITLE
fix(test): bump hierarchical-config count for observation_scope_limits (unblocks test-api)

### DIFF
--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -131,6 +131,7 @@ async def test_hierarchical_fields_categorization():
     assert "retain_default_strategy" in configurable
     assert "retain_strategies" in configurable
     assert "max_observations_per_scope" in configurable
+    assert "observation_scope_limits" in configurable
     assert "reflect_source_facts_max_tokens" in configurable
     assert "llm_gemini_safety_settings" in configurable
     assert "mcp_enabled_tools" in configurable
@@ -139,7 +140,7 @@ async def test_hierarchical_fields_categorization():
     assert "consolidation_llm_parallelism" in configurable
 
     # Verify count is correct
-    assert len(configurable) == 38
+    assert len(configurable) == 39
 
     # Verify credential fields (NEVER exposed)
     assert "llm_api_key" in credentials


### PR DESCRIPTION
## Problem

`tests/test_hierarchical_config.py::test_hierarchical_fields_categorization` fails **deterministically on every open PR**:

```
AssertionError: assert 39 == 38
```

It isn't a flake — `len(HindsightConfig.get_configurable_fields())` is genuinely 39, but the test still asserts 38.

## Cause

[#2140 (per-scope observation limits)](https://github.com/vectorize-io/hindsight/pull/2140) added `observation_scope_limits` to `_CONFIGURABLE_FIELDS` (a legitimate per-bank behavioral override) but didn't update this test's count tripwire (38 → 39). Confirmed: that PR touched `config.py` but not `test_hierarchical_config.py`.

## Fix

The field categorization is correct, so the tripwire just needs updating — exactly what #2140 should have included:
- bump `assert len(configurable) == 38` → `39`
- add `assert "observation_scope_limits" in configurable` (matching the test's documented-subset pattern, so the new field is explicitly guarded)

Unblocks `test-api (2/3)` across all open PRs (#2153, #1989, …).