### PR TITLE
docs(memory-defense): clarify detector policy names

### DIFF
--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -333,7 +333,7 @@ Per-bank Memory Defense policy. Defaults to absent (Memory Defense disabled on t
 |---|---|---|---|
 | `enabled` | bool | `false` | Master switch. |
 | `default_action` | `allow`\|`redact`\|`quarantine`\|`block` | `allow` | Fallback action when no rule matches. |
-| `protected_tag_namespaces` | `list[str]` | `[]` | Writes with tags in these namespaces (`ns:*`) are subject to the `protected_key` detector. |
+| `protected_tag_namespaces` | `list[str]` | `[]` | Extension policy metadata for tags in these namespaces (`ns:*`). The OSS regex extension ignores this unless a downstream extension handles the corresponding detector. |
 | `immutable_tag_namespaces` | `list[str]` | `[]` | Writes to these namespaces are blocked. |
 | `rules` | `list[Rule]` | `[]` | Detector-to-action mappings (see below). |
 | `detector_overrides` | `dict` | `{}` | Per-detector tuning (e.g. `size_anomaly.max_size`). |
@@ -342,7 +342,7 @@ Per-bank Memory Defense policy. Defaults to absent (Memory Defense disabled on t
 
 | Field | Required | Description |
 |---|---|---|
-| `on` | yes | Detector name (`prompt_injection`, `sensitive_data`, `protected_key`, `immutable_key`, `size_anomaly`) or `*` for any. |
+| `on` | yes | Any non-empty detector name. The OSS extension implements `sensitive_data`; other names are accepted and persisted for cloud/downstream extensions (for example `prompt_injection`, `size_anomaly`, `protected_keys`, `detect_secrets`, `base64_decode`, `llm_screen`, or `*` if that extension treats it as a wildcard). |
 | `action` | yes | One of `allow`, `redact`, `quarantine`, `block`. |
 | `min_severity` | no | Minimum severity (`low`, `medium`, `high`, `critical`) for the rule to fire. Defaults to `low`. |
 

--- a/hindsight-docs/docs/developer/memory-defense/index.md
+++ b/hindsight-docs/docs/developer/memory-defense/index.md
@@ -18,7 +18,7 @@ A policy only affects future retain calls on the bank where it is set. Existing 
 
 Memory Defense is configured per bank via the bank's `memory_defense` config field. You can set the policy at bank creation time or update it later via `PATCH /v1/{tenant}/banks/{bank_id}/config`.
 
-The open-source version implements the `sensitive_data` rule with two possible actions:
+The open-source version implements the `sensitive_data` detector with two possible actions:
 
 - **`redact`** — replace each matched secret with a `[REDACTED:type]` marker and store the scrubbed memory.
 - **`block`** — drop any item that contains a match. If every item in a retain request is blocked, the call returns `422`.
@@ -37,6 +37,8 @@ A minimal policy:
 ```
 
 Once that policy is on a bank, every retain to that bank is screened with the 44 redaction patterns documented below.
+
+The policy parser accepts any non-empty `rules[].on` detector name so cloud or downstream extensions can store their own policy vocabulary without breaking OSS PATCH validation. In the default OSS runtime, only `sensitive_data` is executed; other detector names are persisted but do not screen content unless another loaded extension handles them.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -351,7 +351,7 @@ Per-bank Memory Defense policy. Defaults to absent (Memory Defense disabled on t
 |---|---|---|---|
 | `enabled` | bool | `false` | Master switch. |
 | `default_action` | `allow`\|`redact`\|`quarantine`\|`block` | `allow` | Fallback action when no rule matches. |
-| `protected_tag_namespaces` | `list[str]` | `[]` | Writes with tags in these namespaces (`ns:*`) are subject to the `protected_key` detector. |
+| `protected_tag_namespaces` | `list[str]` | `[]` | Extension policy metadata for tags in these namespaces (`ns:*`). The OSS regex extension ignores this unless a downstream extension handles the corresponding detector. |
 | `immutable_tag_namespaces` | `list[str]` | `[]` | Writes to these namespaces are blocked. |
 | `rules` | `list[Rule]` | `[]` | Detector-to-action mappings (see below). |
 | `detector_overrides` | `dict` | `{}` | Per-detector tuning (e.g. `size_anomaly.max_size`). |
@@ -360,7 +360,7 @@ Per-bank Memory Defense policy. Defaults to absent (Memory Defense disabled on t
 
 | Field | Required | Description |
 |---|---|---|
-| `on` | yes | Detector name (`prompt_injection`, `sensitive_data`, `protected_key`, `immutable_key`, `size_anomaly`) or `*` for any. |
+| `on` | yes | Any non-empty detector name. The OSS extension implements `sensitive_data`; other names are accepted and persisted for cloud/downstream extensions (for example `prompt_injection`, `size_anomaly`, `protected_keys`, `detect_secrets`, `base64_decode`, `llm_screen`, or `*` if that extension treats it as a wildcard). |
 | `action` | yes | One of `allow`, `redact`, `quarantine`, `block`. |
 | `min_severity` | no | Minimum severity (`low`, `medium`, `high`, `critical`) for the rule to fire. Defaults to `low`. |
 

--- a/skills/hindsight-docs/references/developer/memory-defense/index.md
+++ b/skills/hindsight-docs/references/developer/memory-defense/index.md
@@ -18,7 +18,7 @@ A policy only affects future retain calls on the bank where it is set. Existing 
 
 Memory Defense is configured per bank via the bank's `memory_defense` config field. You can set the policy at bank creation time or update it later via `PATCH /v1/{tenant}/banks/{bank_id}/config`.
 
-The open-source version implements the `sensitive_data` rule with two possible actions:
+The open-source version implements the `sensitive_data` detector with two possible actions:
 
 - **`redact`** — replace each matched secret with a `[REDACTED:type]` marker and store the scrubbed memory.
 - **`block`** — drop any item that contains a match. If every item in a retain request is blocked, the call returns `422`.
@@ -37,6 +37,8 @@ A minimal policy:
 ```
 
 Once that policy is on a bank, every retain to that bank is screened with the 44 redaction patterns documented below.
+
+The policy parser accepts any non-empty `rules[].on` detector name so cloud or downstream extensions can store their own policy vocabulary without breaking OSS PATCH validation. In the default OSS runtime, only `sensitive_data` is executed; other detector names are persisted but do not screen content unless another loaded extension handles them.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.


### PR DESCRIPTION
## Summary
- clarify that `memory_defense.rules[].on` accepts any non-empty detector name
- state that the default OSS runtime only executes `sensitive_data`; other detector names are persisted for cloud/downstream extensions
- update the generated `skills/hindsight-docs` mirror with the docs generator

## Source
This follows #2142, which changed the policy parser to stop validating detector names against a fixed roster while keeping the OSS regex extension scoped to `sensitive_data`.

## Checks
- `./scripts/generate-docs-skill.sh`
- `git diff --check`

## Dual KPI
Real value: operators copying the Memory Defense policy docs no longer use stale detector names or assume unknown cloud/downstream detectors are rejected by the OSS PATCH layer.

Farming risk: low; this is source-grounded API contract documentation plus the generated mirror, not typo or formatting churn.
