### PR TITLE
fix(consolidation): honor an observation scope limit of 0 (no new observations)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1489,8 +1489,14 @@ async def _process_memory_batch(
     # the bank-wide max_observations_per_scope for scopes matching its tag pattern.
     max_obs = _effective_scope_limit(config, fact_tags)
     remaining_observation_slots: int | None = None
-    if max_obs > 0 and fact_tags:
-        current_count = await _count_observations_for_scope(conn, bank_id, fact_tags)
+    if max_obs >= 0 and fact_tags:
+        # max_obs == 0 means "no new observations": there are no slots regardless
+        # of the current count, so skip the count query for that case.
+        current_count = (
+            await _count_observations_for_scope(conn, bank_id, fact_tags)
+            if max_obs > 0
+            else 0
+        )
         remaining_observation_slots = max(max_obs - current_count, 0)
         if remaining_observation_slots == 0:
             logger.info(
@@ -2128,7 +2134,7 @@ async def _consolidate_batch_with_llm(
 
     # Build capacity note for the prompt when observation limit is configured
     observation_capacity_note: str | None = None
-    if remaining_observation_slots is not None and max_observations_per_scope > 0:
+    if remaining_observation_slots is not None and max_observations_per_scope >= 0:
         if remaining_observation_slots == 0:
             observation_capacity_note = (
                 f"OBSERVATION LIMIT REACHED ({max_observations_per_scope}/{max_observations_per_scope}). "

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -3115,6 +3115,59 @@ async def test_max_observations_per_scope_limits_creates(memory: MemoryEngine, r
 
 
 @pytest.mark.asyncio
+async def test_max_observations_per_scope_zero_forbids_all_creates(memory: MemoryEngine, request_context):
+    """limit=0 means "no new observations": consolidation must create none.
+
+    Regression for the ``> 0`` call-site guards that excluded 0, leaving
+    ``remaining_observation_slots=None`` (unconstrained) so a limit of 0 behaved
+    like unlimited — the inverse of the documented ``0 = no new observations``.
+    """
+    bank_id = f"test-max-obs-zero-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    raw = _get_raw_config()
+    fake_config = type(raw)(
+        **{
+            **{f: getattr(raw, f) for f in raw.__dataclass_fields__},
+            "max_observations_per_scope": 0,
+        }
+    )
+
+    try:
+        original_global_config = memory._config_resolver._global_config
+        memory._config_resolver._global_config = fake_config
+        wrapper, mock_llm = _make_mock_llm_one_obs_per_fact()
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+
+        try:
+            # Insert tagged memories; the mock LLM will try to create 1 obs per
+            # fact, but limit=0 must block every create.
+            async with memory._pool.acquire() as conn:
+                await _insert_memories_with_tags(
+                    conn,
+                    bank_id,
+                    ["Alice loves hiking.", "Bob swims daily.", "Charlie does yoga."],
+                    tags=["scope:test"],
+                )
+
+            for _ in range(3):
+                await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+            async with memory._pool.acquire() as conn:
+                count = await _count_observations_for_scope(conn, bank_id, ["scope:test"])
+                assert count == 0, f"Expected 0 observations (limit=0), got {count}"
+
+                consolidation_calls = [c for c in mock_llm.get_mock_calls() if c["scope"] == "consolidation"]
+                assert len(consolidation_calls) >= 1, "LLM should have been called at least once"
+        finally:
+            memory._config_resolver._global_config = original_global_config
+            memory._consolidation_llm_config = original_llm
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_max_observations_per_scope_allows_updates_at_capacity(memory: MemoryEngine, request_context):
     """At capacity, the LLM can still update existing observations."""
     from hindsight_api.engine.consolidation.consolidator import (


### PR DESCRIPTION
### What

`observation_scope_limits` / `max_observations_per_scope` document the limit as:

> `-1 = unlimited, 0 = no new observations, >0 = hard cap`

…but a configured limit of **0** currently behaves like **unlimited**.

### Why

In `_process_memory_batch` the slot computation gates on `> 0`:

```python
max_obs = _effective_scope_limit(config, fact_tags)
remaining_observation_slots: int | None = None
if max_obs > 0 and fact_tags:          # 0 is excluded -> stays None
    ...
```

So for `max_obs == 0`, `remaining_observation_slots` stays `None`, and
`_build_response_model(None)` builds the *unconstrained* response model — the
scope is free to create unlimited new observations, the inverse of the
documented "no new observations". The capacity-note guard in
`_consolidate_batch_with_llm` had the same `> 0` defect, so the LLM was never
even told the scope was frozen.

The enforcement machinery already handles 0 correctly: `_build_response_model(0)`
forbids all creates (covered by `test_zero_limit_forbids_creates`) and the
create-truncation guard already uses `>= 0`. Only the two call-site guards were
blocking 0 from reaching it.

### Change

- `> 0` → `>= 0` at both call-site guards, matching the existing `>= 0`
  truncation guard.
- Short-circuit the `_count_observations_for_scope` query when the limit is 0
  (there are no slots regardless of the current count).
- Add `test_max_observations_per_scope_zero_forbids_all_creates`: with a scope
  cap of 0 and a mock LLM that tries to create one observation per fact,
  consolidation must create **zero** observations (this fails before the fix).

Caught while reading #2140.
