### PR TITLE
fix(webhook) missing fields in payload

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -126,6 +126,16 @@ async def _fire_memory_defense_webhook(
                 matched_types=decision.matched_types or None,
                 message=decision.message or None,
                 hits=hits,
+                # Optional SIEM-enrichment fields populated by downstream
+                # extensions (e.g. hindsight-cloud's _CloudDefenseDecision
+                # subclass). Read via getattr so OSS doesn't need to know
+                # about extension subclasses. Combined with the manager's
+                # exclude_none serialization, missing values stay absent
+                # from the wire entirely rather than appearing as null.
+                severity=getattr(decision, "severity", None),
+                api_key_name=getattr(decision, "api_key_name", None),
+                memory_unit_id=getattr(decision, "memory_unit_id", None),
+                receipt_uri=getattr(decision, "receipt_uri", None),
             ),
         )
         await webhook_manager.fire_event_with_conn(event, conn, schema=schema)

--- a/hindsight-api-slim/hindsight_api/webhooks/manager.py
+++ b/hindsight-api-slim/hindsight_api/webhooks/manager.py
@@ -70,7 +70,10 @@ class WebhookManager:
         webhook_table = _fq_table("webhooks", schema)
         ops_table = _fq_table("async_operations", schema)
         now = datetime.now(timezone.utc)
-        payload_str = event.model_dump_json()
+        # Drop null fields so receivers don't see promised-but-unfilled keys.
+        # OSS leaves SIEM-enrichment fields (severity, api_key_name, etc.) None
+        # because it doesn't have the data; cloud populates them when it does.
+        payload_str = event.model_dump_json(exclude_none=True)
 
         try:
             async with self._backend.acquire() as conn:
@@ -150,7 +153,10 @@ class WebhookManager:
         webhook_table = _fq_table("webhooks", schema)
         ops_table = _fq_table("async_operations", schema)
         now = datetime.now(timezone.utc)
-        payload_str = event.model_dump_json()
+        # Drop null fields so receivers don't see promised-but-unfilled keys.
+        # OSS leaves SIEM-enrichment fields (severity, api_key_name, etc.) None
+        # because it doesn't have the data; cloud populates them when it does.
+        payload_str = event.model_dump_json(exclude_none=True)
 
         try:
             rows = await self._backend.ops.get_webhooks_for_dispatch(


### PR DESCRIPTION
## Summary

  Two small fixes that close gaps left after the SIEM-enrichment schema add in #2157:

  1. **`webhooks/manager.py`**: serialize the queued payload with `model_dump_json(exclude_none=True)` at both fire sites (`fire_event` and `fire_event_with_conn`).
  Null fields drop from the wire, so receivers don't see promised-but-unfilled keys like `severity: null` / `api_key_name: null` / `memory_unit_id: null` /
  `receipt_uri: null` on every OSS delivery. OSS payloads now contain only what OSS actually populates; cloud payloads contain only what cloud actually populates.

  2. **`engine/retain/orchestrator.py:_fire_memory_defense_webhook`**: read the four optional SIEM-enrichment fields off the decision via `getattr` (`severity`,
  `api_key_name`, `memory_unit_id`, `receipt_uri`) and forward them to `MemoryDefenseEventData`. OSS's `DefenseDecision` dataclass doesn't carry these fields and OSS
  leaves them `None` — but downstream extensions (e.g. hindsight-cloud's `_CloudDefenseDecision` subclass) populate them on the decision they return from `screen()`,
  and without this passthrough they were silently dropped at the orchestrator boundary. Reading via `getattr` keeps OSS agnostic to extension subclasses while still
  routing the data through.

  Combined with #1, this means a cloud user subscribing to a per-bank webhook now sees the same SIEM-actionable enrichment they used to see on the deprecated
  `memory_defense.violation` event, and an OSS-only user sees a strictly smaller payload (no noisy nulls) than before.

  ## Backward compatibility

  - `exclude_none` removes keys from the JSON, not from the schema. Receivers that decode the payload into the published Pydantic models still get `None` defaults for
   absent fields. Receivers that key by string presence already had to handle the previous-null case anyway.
  - `getattr(decision, "...", None)` returns the same default the model had — no behavior change for OSS's regex defense (whose `DefenseDecision` has no extra
  attributes).

  ## Test plan

  - [x] Existing webhook flow tests still green: `test_retain_fires_webhook_on_redact`, `test_retain_fires_webhook_on_block`.
  - [x] `ruff check` + `ty check` clean.
  - [x] Verified end-to-end with the cloud extension: cloud's `_CloudDefenseDecision` now populates `severity` and `api_key_name`, and both fields arrive on the n8n
  receiver instead of being null.