### PR TITLE
fix(control-plane): stop double-fetching graph data on bank view

### DIFF
--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -443,6 +443,7 @@ export function DataView({
   // scope reset never triggers a second fetch.
   const contextKeyRef = useRef<string | null>(null);
   const skipScopeResetReload = useRef(false);
+  const lastAutoLoadSig = useRef<string | null>(null);
   useEffect(() => {
     if (!currentBank) return;
     // The previous run already issued the reload with scope=null; this run is
@@ -462,6 +463,14 @@ export function DataView({
       setSelectedScope(null);
     }
     const { tags, match } = resolveTagQuery(scope);
+    // Collapse identical consecutive auto-loads into a single request. This makes
+    // the effect idempotent, so React's mount-effect double-invoke (dev
+    // StrictMode, and any redundant re-render) can't re-issue the same /api/graph
+    // query. Manual reloads (search, load-more, consolidation poll) call loadData
+    // directly and intentionally bypass this guard.
+    const sig = JSON.stringify([contextKey, tags ?? null, match ?? null]);
+    if (sig === lastAutoLoadSig.current) return;
+    lastAutoLoadSig.current = sig;
     loadData(undefined, searchQuery || undefined, tags, match);
   }, [factType, currentBank, documentId, chunkId, tagFilters, selectedScope]);
 

--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -415,12 +415,16 @@ export function DataView({
   // A selected observation scope takes precedence and uses exact set-equality
   // matching (so scope [a] excludes [a, b]); otherwise the free-form tag filter
   // uses the default contains semantics. `null` scope means "no scope filter".
-  const resolveTagQuery = useCallback((): { tags?: string[]; match?: string } => {
-    if (selectedScope !== null) {
-      return { tags: selectedScope, match: "exact" };
-    }
-    return { tags: tagFilters.length > 0 ? tagFilters : undefined };
-  }, [selectedScope, tagFilters]);
+  const resolveTagQuery = useCallback(
+    (scopeOverride?: string[] | null): { tags?: string[]; match?: string } => {
+      const scope = scopeOverride === undefined ? selectedScope : scopeOverride;
+      if (scope !== null) {
+        return { tags: scope, match: "exact" };
+      }
+      return { tags: tagFilters.length > 0 ? tagFilters : undefined };
+    },
+    [selectedScope, tagFilters]
+  );
 
   // Trigger text search on Enter key
   const executeSearch = () => {
@@ -431,22 +435,35 @@ export function DataView({
     }
   };
 
-  // Trigger server-side reload immediately when the tag filter or scope changes
+  // Single auto-loader for the graph data. This deliberately replaces what used
+  // to be two effects (mount/context + filter change) that BOTH fired on mount,
+  // doubling the initial /api/graph request (see issue #2158). When the context
+  // (factType/bank/document/chunk) changes we drop the now-meaningless scope
+  // filter and feed the cleared value straight into the same reload, so the
+  // scope reset never triggers a second fetch.
+  const contextKeyRef = useRef<string | null>(null);
+  const skipScopeResetReload = useRef(false);
   useEffect(() => {
-    if (currentBank) {
-      const { tags, match } = resolveTagQuery();
-      loadData(undefined, searchQuery || undefined, tags, match);
+    if (!currentBank) return;
+    // The previous run already issued the reload with scope=null; this run is
+    // only the echo of our own setSelectedScope(null), so skip it.
+    if (skipScopeResetReload.current) {
+      skipScopeResetReload.current = false;
+      return;
     }
-  }, [tagFilters, selectedScope]);
+    const contextKey = `${factType} ${currentBank} ${documentId ?? ""} ${chunkId ?? ""}`;
+    const contextChanged = contextKeyRef.current !== contextKey;
+    contextKeyRef.current = contextKey;
 
-  // Auto-load data when component mounts or factType/currentBank changes.
-  // Clearing the scope here resets it before the filter effect above re-runs.
-  useEffect(() => {
-    setSelectedScope(null);
-    if (currentBank) {
-      loadData();
+    let scope = selectedScope;
+    if (contextChanged && selectedScope !== null) {
+      scope = null;
+      skipScopeResetReload.current = true;
+      setSelectedScope(null);
     }
-  }, [factType, currentBank, documentId, chunkId]);
+    const { tags, match } = resolveTagQuery(scope);
+    loadData(undefined, searchQuery || undefined, tags, match);
+  }, [factType, currentBank, documentId, chunkId, tagFilters, selectedScope]);
 
   // Load the available observation scopes for the scope filter dropdown.
   const loadScopes = useCallback(async () => {


### PR DESCRIPTION
## Problem

Fixes #2158 (the duplicate-fetch part).

Opening a bank in the Control Plane and clicking through the fact-type tabs fired `GET /api/graph` repeatedly per view. On a large bank that multiplies an already heavy (~14MB) payload.

`DataView` had **two effects that both call `loadData`** — one keyed on `[factType, currentBank, documentId, chunkId]`, one on `[tagFilters, selectedScope]`. When the component mounts with `currentBank` already populated (i.e. clicking a fact-type tab / any in-app navigation), both fire, so each view loaded the graph twice. The effect was also not idempotent, so any extra re-render re-issued the same query.

> Note: the issue also claims the graph loads "without any limit" and that the Control Plane "doesn't use the `limit` parameter". That's inaccurate — the frontend already sends `limit` (default `1000`), which is exactly why the reporter saw 1,000 nodes for a 3,346-memory bank. This PR keeps the 1000 default and only removes the duplicate requests.

## Fix

- **Collapse the two effects into one auto-loader.** When the context (factType/bank/document/chunk) changes we drop the now-meaningless observation scope and feed the cleared value straight into the same `loadData` call, guarding the `setSelectedScope(null)` echo render with a ref so the reset never triggers a second fetch. `resolveTagQuery` now takes an optional scope override so the cleared scope flows into the single fetch.
- **Make the auto-load idempotent** with a fetch-signature ref: identical consecutive auto-loads collapse to one request. Manual reloads (search, load-more, consolidation poll) call `loadData` directly and intentionally bypass the guard.

## Verification (Playwright, live CP + dataplane, DevTools network)

Measured `/api/graph` count per interaction, before (main HEAD) vs after (this branch), in the same dev server:

| Interaction | Before | After |
|---|---|---|
| Switch to Experience tab | 4 | **1** |
| Switch to Observations tab | 4 | **1** |
| Select an observation scope | 1 | **1** (`tags=eng&tags_match=exact`) |

The "4" is two effects x React's dev-StrictMode mount double-invoke. In a **production** build (no StrictMode double-invoke — what the reporter runs on Docker) the two effects produce **2** per tab; this fix brings every path to exactly **1**, in both dev and prod. All responses 200.

Type-check (`tsc --noEmit`) clean; `eslint` on the changed file reports 0 errors.

No component test added — the control-plane suite runs vitest in a `node` env over `tests/**/*.test.ts` with no `@testing-library`/jsdom, so there is no component-render harness; this is effect-orchestration logic that can't be unit-tested without adding that infra.
