### PR TITLE
docs: add Memory Defense to the 0.8.2 blog post

### DIFF
--- a/hindsight-docs/blog/2026-06-12-version-0-8-2.md
+++ b/hindsight-docs/blog/2026-06-12-version-0-8-2.md
@@ -1,21 +1,46 @@
 ---
 title: "What's new in Hindsight 0.8.2"
-description: Reversible memory curation, observation scopes, a local Control Center for embedded deployments, new providers and embedding models, plus operational and data-integrity fixes in Hindsight 0.8.2
+description: Memory Defense secret and PII scrubbing, reversible memory curation, observation scopes, a local Control Center for embedded deployments, new providers and embedding models, plus operational and data-integrity fixes in Hindsight 0.8.2
 authors: [nicoloboschi]
 date: 2026-06-12
 hide_table_of_contents: true
 tags: [release]
 ---
 
-Hindsight 0.8.2 builds on [0.8.1](/blog/2026/06/09/version-0-8-1) with a much bigger release: you can now **edit, invalidate, and revert individual memories**, organize and cap memories with **observation scopes**, and run a **local Control Center** alongside an embedded deployment. It also adds new LLM providers and embedding models, and ships several operational and data-integrity fixes. **Anyone self-managing Hindsight should upgrade** — this release includes concurrency and data-storage fixes that affect long-running deployments.
+Hindsight 0.8.2 builds on [0.8.1](/blog/2026/06/09/version-0-8-1) with a much bigger release: you can now keep secrets and PII out of memory with **Memory Defense**, **edit, invalidate, and revert individual memories**, organize and cap memories with **observation scopes**, and run a **local Control Center** alongside an embedded deployment. It also adds new LLM providers and embedding models, and ships several operational and data-integrity fixes. **Anyone self-managing Hindsight should upgrade** — this release includes concurrency and data-storage fixes that affect long-running deployments.
 
 <!-- truncate -->
 
+- [**Memory Defense**](#memory-defense): Scrub secrets and PII out of retained memory, per bank.
 - [**Reversible Memory Curation**](#reversible-memory-curation): Edit, invalidate, and revert memory units without losing history.
 - [**Observation Scopes**](#observation-scopes): List, filter, visualize, and cap memories per scope.
 - [**Local Control Center**](#local-control-center): A built-in web app for embedded deployments.
 - [**More Providers and Models**](#more-providers-and-models): Native Nous Portal, Gemini Batch retain, Gemini embedding-2, per-bank cost attribution, and a connectivity probe.
 - [**Operational and Data-Integrity Fixes**](#operational-and-data-integrity-fixes): Why you should upgrade.
+
+## Memory Defense
+
+Agents routinely see API keys, tokens, and personal data — and without guardrails, any of it can get written straight into long-term memory. **Memory Defense** is a new, open-source layer that scrubs sensitive data out of retained content before it's ever stored.
+
+When enabled on a bank, every memory the agent writes is scanned against a **44-pattern set** covering provider API keys (Anthropic, OpenAI, Google, and more), generic secrets, database connection strings, and common PII. Each match is replaced with a `[REDACTED:type]` marker before the content reaches memory units or the document body, so recall, exports, and reflect never see the original secret. You choose the action per rule:
+
+- **`redact`** — replace each match with a `[REDACTED:type]` marker and store the scrubbed memory.
+- **`block`** — drop any item that contains a match; if every item in a retain request is blocked, the call returns `422`.
+
+Memory Defense is **per bank and off by default**. Turn it on with a policy on the bank's config:
+
+```json
+{
+  "memory_defense": {
+    "enabled": true,
+    "rules": [{ "on": "sensitive_data", "action": "redact" }]
+  }
+}
+```
+
+A policy only affects future retain calls on that bank — existing memories aren't retroactively scanned.
+
+Every redact or block decision can also notify your security tooling: when a bank has a webhook subscribed to `memory_defense.triggered`, Hindsight fires an event reporting the action, the document ID, and which patterns matched. These payloads now carry **SIEM-friendly enrichment fields**, so alerts route cleanly into a SIEM or Slack without extra glue. See the [Memory Defense guide](/developer/memory-defense) for the full pattern list and policy options.
 
 ## Reversible Memory Curation
 
@@ -62,3 +87,10 @@ Several fixes make self-managed and long-running deployments more robust — the
 - **Reflect synthesis fidelity.** Final reflect output now respects directives and language rules more consistently.
 - **JSONL retain chunking.** JSONL files are chunked on line boundaries so records are never split mid-line during ingestion.
 - **Control Plane graph view.** The bank graph view no longer double-loads its data, cutting redundant requests.
+- **Rolling-deployment migrations.** Already-applied migrations are skipped more reliably during rolling deploys, including when the resolution error is wrapped in a `CommandError`.
+- **Webhook payloads.** Event payloads now include fields that were previously missing.
+- **CLI `get-memory`.** The CLI parses `get-memory` responses correctly.
+
+## And More
+
+- **Export a constellation as a poster.** The Control Plane can now export a bank's memory constellation as a shareable SVG poster.


### PR DESCRIPTION
Follow-up to #2172. The 0.8.2 blog post missed **Memory Defense**, the headline new OSS feature in this release, plus a few smaller items.

## Added
- **Memory Defense section (lead):** per-bank secret/PII scrubbing with the 44-pattern set, `redact`/`block` actions, opt-in policy example, and the `memory_defense.triggered` webhook with new SIEM enrichment fields. Verified new in 0.8.2 (no docs/config at v0.8.1; landed via #2077, #2149 webhook fields via #f304ce7e0).
- **Operational fixes:** rolling-deployment migration skip (#2117), webhook payload missing fields, CLI `get-memory` parse (#2111).
- **And More:** constellation SVG poster export (#2099).

## Notes
- Did **not** list integrations in the blog, per the release-blog convention (they keep their own changelogs).
- Docs link uses `/developer/memory-defense` (docs `routeBasePath` is `/`).
- Prettier-clean.