### PR TITLE
fix(control-plane): add missing /observations/scopes endpoint

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1330,6 +1330,41 @@ class ListTagsResponse(BaseModel):
     offset: int
 
 
+class ObservationScopeItem(BaseModel):
+    """A single observation scope, represented by the tag list that defines it.
+
+    An empty ``tags`` list corresponds to the "global" scope — observations
+    with no tags. Otherwise the scope is the set of tags used on the
+    observation's memory.
+    """
+
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The list of tags that define this scope. An empty list represents "
+            "the global (no-tag) scope."
+        ),
+    )
+
+
+class ListObservationScopesResponse(BaseModel):
+    """Response model for the list observation scopes endpoint."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "scopes": [
+                    {"tags": []},
+                    {"tags": ["user:alice"]},
+                    {"tags": ["user:alice", "team:engineering"]},
+                ],
+            }
+        }
+    )
+
+    scopes: list[ObservationScopeItem]
+
+
 class DocumentResponse(BaseModel):
     """Response model for get document endpoint."""
 
@@ -5456,6 +5491,52 @@ def _register_routes(app: FastAPI):
     async def api_get_bank_template_schema():
         """Return the JSON Schema for the bank template manifest."""
         return BankTemplateManifest.model_json_schema()
+
+    @app.get(
+        "/v1/default/banks/{bank_id}/observations/scopes",
+        response_model=ListObservationScopesResponse,
+        summary="List observation scopes",
+        description=(
+            "List the distinct observation scopes for a bank. A scope is the "
+            "effective tag set of an observation memory; the empty scope is "
+            "included for observations with no tags. Use this endpoint to "
+            "populate the scope filter in the observations view of the "
+            "Control Plane UI."
+        ),
+        operation_id="list_observation_scopes",
+        tags=["Banks"],
+    )
+    async def api_list_observation_scopes(
+        bank_id: str,
+        limit: int = Query(
+            default=500,
+            description="Maximum number of distinct scopes to return (default 500).",
+        ),
+        request_context: RequestContext = Depends(get_request_context),
+    ):
+        """List the distinct observation scopes for a bank.
+
+        Args:
+            bank_id: Memory Bank ID (from path).
+            limit: Maximum number of distinct scopes to return.
+        """
+        try:
+            data = await app.state.memory.list_observation_scopes(
+                bank_id=bank_id,
+                limit=limit,
+                request_context=request_context,
+            )
+            return data
+        except OperationValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except (AuthenticationError, HTTPException):
+            raise
+        except Exception as e:
+            import traceback
+
+            error_detail = f"{str(e)}\n\nTraceback:\n{traceback.format_exc()}"
+            logger.error(f"Error in /v1/default/banks/{bank_id}/observations/scopes: {error_detail}")
+            raise HTTPException(status_code=500, detail=str(e))
 
     @app.delete(
         "/v1/default/banks/{bank_id}/observations",

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8316,6 +8316,78 @@ class MemoryEngine(MemoryEngineInterface):
             offset=offset,
         )
 
+    async def list_observation_scopes(
+        self,
+        bank_id: str,
+        *,
+        limit: int = 500,
+        request_context: "RequestContext",
+    ) -> dict[str, Any]:
+        """List the distinct observation scopes for a bank.
+
+        An observation scope is the effective tag set used when an observation
+        memory was created. The "global" scope (observations with no tags) is
+        represented as an empty ``tags`` list.
+
+        The scopes are derived from the ``tags`` column of observation memories
+        (``fact_type = 'observation'``). This is intentionally simpler than
+        re-deriving the scope spec from ``observation_scopes`` and resolving it
+        against the memory's tags — the effective scope for a memory is the
+        memory's own tag list, so a ``SELECT DISTINCT tags`` covers all three
+        supported scope modes (``per_tag``, ``all_combinations``, ``combined``).
+
+        Args:
+            bank_id: Bank identifier.
+            limit: Cap on the number of distinct scopes returned. Defaults to 500.
+            request_context: Request context for authentication.
+
+        Returns:
+            Dict with a ``scopes`` list of ``{"tags": [...]}`` items, sorted
+            first by tag count descending and then by tag list for stability.
+        """
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankReadContext
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation="list_observation_scopes",
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            # Select distinct (tags, count) pairs from observation memories.
+            # ORDER BY count DESC, tags ASC for stable, useful ordering in the UI
+            # (most-used scopes first). tags is a varchar[] so we sort by its
+            # array-to-string representation for a deterministic order.
+            rows = await conn.fetch(
+                f"""
+                SELECT tags, COUNT(*) AS count
+                FROM {fq_table("memory_units")}
+                WHERE bank_id = $1
+                  AND fact_type = 'observation'
+                GROUP BY tags
+                ORDER BY count DESC, ARRAY_TO_STRING(tags, chr(1)) ASC
+                LIMIT $2
+                """,
+                bank_id,
+                limit,
+            )
+
+        scopes = []
+        for row in rows:
+            tags_value = row["tags"]
+            if isinstance(tags_value, str):
+                # asyncpg may serialise the array as a string in some configurations
+                import json
+
+                tags_value = json.loads(tags_value) if tags_value else []
+            scopes.append({"tags": list(tags_value or [])})
+
+        return {"scopes": scopes}
+
     async def _list_tags_from_table(
         self,
         *,

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+
+export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
+  try {
+    const { bankId } = await params;
+    if (!bankId) {
+      return NextResponse.json(
+        localizeApiErrorPayload(request, {
+          error: "bank_id is required",
+          errorKey: "api.errors.validation.bankIdRequired",
+        }),
+        { status: 400 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.get("limit");
+
+    const queryParams = new URLSearchParams();
+    if (limit) queryParams.append("limit", limit);
+
+    const url = dataplaneBankUrl(
+      bankId,
+      `/observations/scopes${queryParams.toString() ? `?${queryParams}` : ""}`
+    );
+    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("API error listing observation scopes:", errorText);
+      return NextResponse.json(
+        localizeApiErrorPayload(request, {
+          error: "Failed to list observation scopes",
+          errorKey: "api.errors.observations.scopes",
+        }),
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error("Error listing observation scopes:", error);
+    return NextResponse.json(
+      localizeApiErrorPayload(request, {
+        error: "Failed to list observation scopes",
+        errorKey: "api.errors.observations.scopes",
+      }),
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

The Control Plane UI polls `GET /api/banks/{bank_id}/observations/scopes` every ~5 seconds to populate the scope filter on the Observations view. The route was never implemented in either the Next.js control plane or the underlying Hindsight dataplane, producing a 404 loop in the browser console and clogging server logs.

This PR implements the endpoint end-to-end in two layers.

## Changes

### Dataplane (`hindsight-api-slim`)
- **New `MemoryEngine.list_observation_scopes()`** — returns the distinct tag sets used on observation memories (the effective scope in all three supported modes: `per_tag`, `all_combinations`, `combined`). The empty `[]` scope is included for observations with no tags.
- **New route** `GET /v1/default/banks/{bank_id}/observations/scopes` with a matching `ListObservationScopesResponse` model in the OpenAPI spec.
- Auth/authz/rate-limit/error handling follow the existing `/tags` endpoint pattern.

### Control plane (`hindsight-control-plane`)
- **New Next.js proxy** at `/api/banks/[bankId]/observations/scopes/route.ts` that forwards the optional `limit` query param to the dataplane and localises any errors.

## Verification

Tested end-to-end with the local Hindsight instance (banks `main`, `lapo73`, `claude_code`):

```bash
$ curl http://localhost:9999/api/banks/main/observations/scopes
{"scopes":[{"tags":[]}]}

$ curl http://localhost:9999/api/banks/claude_code/observations/scopes
{"scopes":[
  {"tags":["5b8bd321-4087-4a51-9dca-8dc82ee01463"]},
  {"tags":["bbecfa20-d8e4-4404-ba42-fed2ddbd4268"]},
  ...
]}
```

Negative test (`?limit=foo`) returns 422 with localised error. Non-existent banks return 200 with empty scopes (consistent with `/observations` and `/tags` behavior).

## Fixes

Closes #2176