### PR TITLE
claude-code: case-insensitive directoryBankMap matching on Windows

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -88,10 +88,16 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
     cwd = hook_input.get("cwd", "")
     dir_map = config.get("directoryBankMap") or {}
     if cwd and dir_map:
-        # Normalize cwd for matching (resolve symlinks, trailing slashes)
-        normalized_cwd = os.path.normpath(cwd)
+        # Normalize cwd for matching (trailing slashes, separators, and —
+        # via normcase — drive-letter/path case on Windows, where launchers
+        # disagree: PowerShell and git-bash hand children an UPPERCASE drive
+        # while the VS Code extension spawn reports lowercase, so a
+        # case-sensitive compare silently misses the map and falls through
+        # to the default bank. normcase is a no-op on POSIX, preserving
+        # case-sensitive matching there.
+        normalized_cwd = os.path.normcase(os.path.normpath(cwd))
         for dir_path, bank_id in dir_map.items():
-            if os.path.normpath(dir_path) == normalized_cwd:
+            if os.path.normcase(os.path.normpath(dir_path)) == normalized_cwd:
                 return f"{prefix}-{bank_id}" if prefix else bank_id
 
     if not config.get("dynamicBankId", False):

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -177,6 +177,29 @@ class TestDirectoryBankMap:
         result = derive_bank_id(_hook(cwd="/home/user/myproject"), cfg)
         assert result == "custom-bank"
 
+    def test_windows_drive_letter_case_insensitive_match(self):
+        # On Windows, the cwd's drive-letter (and path) case depends on the
+        # launcher: PowerShell and git-bash hand children an UPPERCASE drive
+        # while the VS Code extension spawn reports lowercase. The map match
+        # must not depend on which launcher started the session. normcase is
+        # a no-op on POSIX, so this test only exercises the Windows behavior
+        # when run there; the POSIX-case-sensitivity test below pins the
+        # complementary guarantee.
+        import os as _os
+
+        if _os.path.normcase("A") == _os.path.normcase("a"):  # case-insensitive FS semantics
+            cfg = _cfg(directoryBankMap={r"c:\Users\dev\proj": "custom-bank"})
+            result = derive_bank_id(_hook(cwd=r"C:\Users\dev\proj"), cfg)
+            assert result == "custom-bank"
+
+    def test_posix_paths_stay_case_sensitive(self):
+        import os as _os
+
+        if _os.path.normcase("A") != _os.path.normcase("a"):  # POSIX semantics
+            cfg = _cfg(directoryBankMap={"/home/User/myproject": "custom-bank"}, bankId="default-bank")
+            result = derive_bank_id(_hook(cwd="/home/user/myproject"), cfg)
+            assert result == "default-bank"
+
     def test_no_match_falls_through_to_static(self):
         cfg = _cfg(directoryBankMap={"/home/user/other": "other-bank"}, bankId="default-bank")
         result = derive_bank_id(_hook(cwd="/home/user/myproject"), cfg)


### PR DESCRIPTION
## Problem

`derive_bank_id` matches `directoryBankMap` keys against the session cwd with `os.path.normpath(...) ==`, which is case-sensitive. On Windows the **drive-letter case of the cwd a Claude Code session reports depends on the launcher**:

| Launcher | cwd drive case |
|---|---|
| PowerShell (incl. VS Code integrated pwsh terminal) | `C:` (canonicalizes even at startup) |
| git-bash (`/c/...` translation) | `C:` |
| cmd.exe | as typed |
| VS Code extension spawn | `c:` |

So a map entry written one way silently misses for sessions started the other way — no error, the session just falls through to the default bank and memories land in the wrong bank. We hit this in production: an entry matched only extension-spawned sessions; every terminal-launched session silently sank. (Verified by the `~/.claude/projects/` namespace casing per launcher and the server-side bank routing.)

The comment above the existing code says "Normalize cwd for matching" — this PR makes the normalization complete on Windows.

## Fix

Wrap both sides of the comparison in `os.path.normcase`, which lowercases and normalizes separators on Windows and is a **documented no-op on POSIX** — Linux/macOS matching stays case-sensitive.

## Tests

- `test_windows_drive_letter_case_insensitive_match` — fails without the fix on Windows (mutant-verified), no-ops on POSIX.
- `test_posix_paths_stay_case_sensitive` — pins the complementary POSIX guarantee, no-ops on Windows.
- Full `tests/test_bank.py`: 39/39 pass on Windows with the fix; 38 pass + the new Windows test FAILS without it.

Note: `mcp_server.py` builds its hook input from `os.getcwd()` and routes through the same `derive_bank_id`, so this fix covers the MCP path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)