### PR TITLE
fix(metrics): don't count a client-disconnect cancellation as a failed recall/reflect operation

### DIFF
--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -39,6 +39,32 @@ def _get_tenant() -> str:
     return get_current_schema()
 
 
+def _is_client_cancellation(exc: BaseException) -> bool:
+    """Whether *exc* is a client-disconnect cancellation rather than a failure.
+
+    An abandoned recall/reflect raises OperationCancelledError (issue #2122);
+    the HTTP layer re-raises it as ``HTTPException(499) from exc`` (see
+    api/http.py run_cancellable_on_disconnect). The exception itself, or any
+    link in its ``__cause__`` chain, being an OperationCancelledError marks it
+    as a cancellation. Matching on the cause chain rather than a bare status
+    code avoids misclassifying an unrelated 499 as a cancellation. Per the
+    engine contract a cancellation is "not a failure to retry or report"
+    (cancellation.OperationCancelledError), so it must not be counted against
+    ``hindsight.operation.total``.
+    """
+    # Imported lazily to avoid import-time coupling (cf. _get_tenant above).
+    from hindsight_api.cancellation import OperationCancelledError
+
+    cause: BaseException | None = exc
+    seen: set[int] = set()  # guard against a cyclic __cause__ chain
+    while cause is not None and id(cause) not in seen:
+        if isinstance(cause, OperationCancelledError):
+            return True
+        seen.add(id(cause))
+        cause = cause.__cause__
+    return False
+
+
 # Custom bucket boundaries for operation duration (in seconds)
 # Fine granularity in 0-30s range where most operations complete
 DURATION_BUCKETS = (0.1, 0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 5.0, 7.5, 10.0, 15.0, 20.0, 30.0, 60.0, 120.0)
@@ -373,20 +399,31 @@ class MetricsCollector(MetricsCollectorBase):
             attributes["max_tokens"] = str(max_tokens)
 
         success = True
+        cancelled = False
         try:
             yield
-        except Exception:
-            success = False
+        except Exception as exc:
+            # A client disconnect cancels the operation cooperatively (#2122),
+            # raised as OperationCancelledError and re-raised by the HTTP layer
+            # as HTTPException(499) from it. An abandoned request is neither a
+            # success nor a failure, so it is excluded from the metric entirely
+            # rather than inflating either the failure or the success rate on
+            # hindsight.operation.total.
+            if _is_client_cancellation(exc):
+                cancelled = True
+            else:
+                success = False
             raise
         finally:
-            duration = time.time() - start_time
-            attributes["success"] = str(success).lower()
+            if not cancelled:
+                duration = time.time() - start_time
+                attributes["success"] = str(success).lower()
 
-            # Record duration
-            self.operation_duration.record(duration, attributes)
+                # Record duration
+                self.operation_duration.record(duration, attributes)
 
-            # Record operation count
-            self.operation_total.add(1, attributes)
+                # Record operation count
+                self.operation_total.add(1, attributes)
 
     def record_llm_call(
         self,

--- a/hindsight-api-slim/tests/test_metrics.py
+++ b/hindsight-api-slim/tests/test_metrics.py
@@ -117,6 +117,54 @@ class TestMetricsCollector:
         attributes = call_args[0][1]
         assert attributes["success"] == "false"
 
+    def test_record_operation_cancellation_excluded_from_metric(self, collector):
+        """A client-disconnect cancellation is neither a success nor a failure.
+
+        Recall/reflect run the engine call inside record_operation; when the
+        client disconnects the engine raises OperationCancelledError (issue
+        #2122). That abandoned request must not be recorded on
+        hindsight.operation.total at all -- inflating neither the failure nor
+        the success rate -- even though the exception still propagates.
+        """
+        from hindsight_api.cancellation import OperationCancelledError
+
+        with pytest.raises(OperationCancelledError):
+            with collector.record_operation("recall", bank_id="test_bank", source="api"):
+                raise OperationCancelledError("client disconnected")
+
+        collector.operation_total.add.assert_not_called()
+        collector.operation_duration.record.assert_not_called()
+
+    def test_record_operation_http_499_from_cancellation_excluded(self, collector):
+        """run_cancellable_on_disconnect re-raises the cancellation as
+        ``HTTPException(499) from exc``; the cause chain marks it as a
+        cancellation, so it is excluded from the metric too."""
+        from fastapi import HTTPException
+
+        from hindsight_api.cancellation import OperationCancelledError
+
+        with pytest.raises(HTTPException):
+            with collector.record_operation("reflect", bank_id="test_bank", source="api"):
+                try:
+                    raise OperationCancelledError("client disconnected")
+                except OperationCancelledError as cancel:
+                    raise HTTPException(status_code=499, detail="client disconnected") from cancel
+
+        collector.operation_total.add.assert_not_called()
+        collector.operation_duration.record.assert_not_called()
+
+    def test_record_operation_unrelated_499_still_recorded_as_failure(self, collector):
+        """A 499 that is NOT caused by a cancellation (no OperationCancelledError
+        in the cause chain) is a real failure and must still be recorded."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            with collector.record_operation("recall", bank_id="test_bank", source="api"):
+                raise HTTPException(status_code=499, detail="unrelated downstream error")
+
+        attributes = collector.operation_duration.record.call_args[0][1]
+        assert attributes["success"] == "false"
+
     def test_record_operation_with_budget(self, collector):
         """Test that budget is included in attributes when provided."""
         with collector.record_operation("recall", bank_id="test_bank", source="api", budget="mid"):


### PR DESCRIPTION
The client-disconnect cancellation added in #2127/#2131 (issue #2122) left a metrics-accuracy gap.

In `api_recall`/`api_reflect` the engine call runs inside `with metrics.record_operation(...)`, and `run_cancellable_on_disconnect` converts the engine's `OperationCancelledError` into `HTTPException(499)`. That 499 propagates out through `record_operation`'s blanket `except Exception: success = False`, so **every abandoned/cancelled recall and reflect is counted as a failed operation** on the documented `hindsight.operation.total` `success` label — inflating the recall/reflect failure rate (and any alerts built on it) the moment a client disconnects. The engine already treats cancellation as "not a failure to retry or report" (`OperationCancelledError`); `record_operation` was the one place still violating that.

**Fix:** recognise a client cancellation in `record_operation` and exclude it from `hindsight.operation.total` entirely — it's neither a success nor a failure, so it inflates neither rate, and its partial duration isn't recorded. Cancellation is detected via the exception's `__cause__` chain (the HTTP layer raises `HTTPException(499) from OperationCancelledError`), not a bare status code, so an unrelated 499 is still recorded as a failure.

I kept the binary `success` label unchanged, so there's no docs/generated-file change. If you'd prefer explicit observability I'm happy to switch to a distinct `cancelled` outcome instead (that would also update `monitoring.md` + regenerate the skills docs mirror) — let me know which you'd rather have.

Regression tests cover: a direct `OperationCancelledError` and the `HTTPException(499) from cancel` path are excluded from the counter/histogram, while a bare 499 (no cancellation cause) is still recorded as a failure.