### PR TITLE
config: add consolidation_dedup_tag_match for cross-scope dedup

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -442,6 +442,7 @@ ENV_CONSOLIDATION_BATCH_SIZE = "HINDSIGHT_API_CONSOLIDATION_BATCH_SIZE"
 ENV_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = "HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND"
 ENV_CONSOLIDATION_LLM_BATCH_SIZE = "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"
 ENV_CONSOLIDATION_DEDUP_THRESHOLD = "HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD"
+ENV_CONSOLIDATION_DEDUP_TAG_MATCH = "HINDSIGHT_API_CONSOLIDATION_DEDUP_TAG_MATCH"
 ENV_CONSOLIDATION_LLM_PARALLELISM = "HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM"
 ENV_CONSOLIDATION_MAX_TOKENS = "HINDSIGHT_API_CONSOLIDATION_MAX_TOKENS"
 ENV_CONSOLIDATION_MAX_COMPLETION_TOKENS = "HINDSIGHT_API_CONSOLIDATION_MAX_COMPLETION_TOKENS"
@@ -876,6 +877,17 @@ DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 8  # Facts per LLM call (1 = no batching;
 # entities are respected). Enabled by default; set to 1.0 to disable. Postgres only — the merge
 # path uses Postgres-only SQL, so consolidation skips it on Oracle regardless of this value.
 DEFAULT_CONSOLIDATION_DEDUP_THRESHOLD = 0.97
+# Tag matching mode for the dedup probe (the pre-CREATE check that asks "does a
+# near-identical observation already exist?"). Default all_strict preserves
+# multi-tenant isolation. Single-user deployments where tags are used for
+# provenance/session tracking instead of tenant separation can set this to "any"
+# so the dedup probe can find near-duplicates across different tag scopes.
+# Note: the consolidation recall scope (showing existing observations to the LLM
+# for CREATE vs UPDATE) always uses all_strict regardless of this setting.
+DEFAULT_CONSOLIDATION_DEDUP_TAG_MATCH = "all_strict"
+# Valid values for consolidation_dedup_tag_match (mirrors TagsMatch in engine/search/tags.py).
+# "any" is intentionally included — single-user deployments may need cross-scope dedup.
+_CONSOLIDATION_DEDUP_TAG_MATCH_VALID = {"any", "all", "any_strict", "all_strict", "exact"}
 DEFAULT_CONSOLIDATION_LLM_PARALLELISM = (
     4  # Max tag groups consolidated concurrently per op. Locks on overlapping write
     # scopes degrade to sequential automatically; matches retain_max_concurrent.
@@ -1110,6 +1122,19 @@ def _validate_recall_budget_function(function: str) -> str:
         )
         return DEFAULT_RECALL_BUDGET_FUNCTION
     return function_lower
+
+
+def _validate_consolidation_dedup_tag_match(match: str) -> str:
+    """Validate and normalize consolidation dedup tag match mode."""
+    match_lower = match.lower()
+    if match_lower not in _CONSOLIDATION_DEDUP_TAG_MATCH_VALID:
+        logger.warning(
+            f"Invalid consolidation dedup tag match '{match}', must be one of "
+            f"{_CONSOLIDATION_DEDUP_TAG_MATCH_VALID}. "
+            f"Defaulting to '{DEFAULT_CONSOLIDATION_DEDUP_TAG_MATCH}'."
+        )
+        return DEFAULT_CONSOLIDATION_DEDUP_TAG_MATCH
+    return match_lower
 
 
 def _parse_bank_priority(raw: str) -> dict[str, int]:
@@ -1477,6 +1502,7 @@ class HindsightConfig:
     mental_model_history_max_entries: int
     consolidation_batch_size: int
     consolidation_dedup_threshold: float
+    consolidation_dedup_tag_match: str
     consolidation_max_memories_per_round: int
     consolidation_llm_batch_size: int
     consolidation_llm_parallelism: int
@@ -2404,6 +2430,9 @@ class HindsightConfig:
             ),
             consolidation_dedup_threshold=float(
                 os.getenv(ENV_CONSOLIDATION_DEDUP_THRESHOLD, str(DEFAULT_CONSOLIDATION_DEDUP_THRESHOLD))
+            ),
+            consolidation_dedup_tag_match=_validate_consolidation_dedup_tag_match(
+                os.getenv(ENV_CONSOLIDATION_DEDUP_TAG_MATCH, DEFAULT_CONSOLIDATION_DEDUP_TAG_MATCH)
             ),
             consolidation_llm_batch_size=int(
                 os.getenv(ENV_CONSOLIDATION_LLM_BATCH_SIZE, str(DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE))

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -170,7 +170,7 @@ async def _dedup_adjudicate(
         if not embs:
             return _DedupOutcome(best_id=None, merged_text="", should_merge=False)
         anchor_emb_str = str(embs[0])
-    tags_match = "all_strict" if tags else "any"
+    tags_match = config.consolidation_dedup_tag_match if tags else "any"
     grouped = await retrieve_semantic_bm25_combined(
         conn, anchor_emb_str, anchor_text, bank_id, ["observation"], _DEDUP_TOP_K, tags=tags, tags_match=tags_match
     )


### PR DESCRIPTION
Closes #2188

Adds HINDSIGHT_API_CONSOLIDATION_DEDUP_TAG_MATCH env var to make the dedup probe's tag matching mode independently configurable.

**What changed:**
- config.py: new env var constant, default all_strict, validation function, config field
- consolidator.py line 173: dedup probe uses config value instead of hardcoded all_strict
- Consolidation recall (line 1981) stays hardcoded all_strict — security boundary intact

**Validation:**
- Invalid values log a warning and fall back to all_strict
- Valid: any, all, any_strict, all_strict, exact

**Default behavior unchanged.** Single-user deployments set HINDSIGHT_API_CONSOLIDATION_DEDUP_TAG_MATCH=any to enable cross-scope dedup.