### PR TITLE
fix: template bank-id path segment in HTTP metric endpoint label (follow-up to #850)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -88,7 +88,12 @@ from hindsight_api.engine.providers.none_llm import LLMNotAvailableError
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MemoryFact, TokenUsage
 from hindsight_api.engine.search.tags import TagGroup, TagsMatch
 from hindsight_api.extensions import HttpExtension, OperationValidationError, load_extension
-from hindsight_api.metrics import create_metrics_collector, get_metrics_collector, initialize_metrics
+from hindsight_api.metrics import (
+    create_metrics_collector,
+    get_metrics_collector,
+    initialize_metrics,
+    normalize_http_endpoint,
+)
 from hindsight_api.models import RequestContext
 
 logger = logging.getLogger(__name__)
@@ -3119,15 +3124,9 @@ def create_app(
     @app.middleware("http")
     async def http_metrics_middleware(request, call_next):
         """Record HTTP request metrics."""
-        # Normalize endpoint path to reduce cardinality
-        # Replace UUIDs and numeric IDs with placeholders
-        import re
-
-        path = request.url.path
-        # Replace UUIDs
-        path = re.sub(r"/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "/{id}", path)
-        # Replace numeric IDs
-        path = re.sub(r"/\d+(?=/|$)", "/{id}", path)
+        # Template id segments (bank ids, UUIDs, numeric ids) so the endpoint
+        # metric label stays bounded-cardinality.
+        path = normalize_http_endpoint(request.url.path)
 
         status_code = [500]  # Default to 500, will be updated
         metrics_collector = get_metrics_collector()

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -14,6 +14,7 @@ This module provides metrics for:
 import importlib
 import logging
 import os
+import re
 
 _resource_mod = importlib.import_module("resource") if importlib.util.find_spec("resource") else None
 import threading
@@ -85,6 +86,27 @@ def get_token_bucket(token_count: int) -> str:
         return "10k-50k"
     else:
         return "50k+"
+
+
+# Template unbounded id segments before a path is used as the low-cardinality
+# "endpoint" metric label. A raw per-bank path segment (e.g. user-123) would
+# otherwise create one never-evicted OTel series per bank.
+_METRIC_BANK_SEGMENT_RE = re.compile(r"(/banks/)[^/]+")
+_METRIC_UUID_RE = re.compile(r"/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_METRIC_NUMERIC_ID_RE = re.compile(r"/\d+(?=/|$)")
+
+
+def normalize_http_endpoint(path: str) -> str:
+    """Template high-cardinality id segments in an HTTP path for safe metric labeling.
+
+    Collapses the "/banks/<id>" segment (any bank id, including non-numeric ones like
+    "user-123"), UUIDs, and numeric ids to placeholders so the "endpoint" metric label
+    has bounded cardinality. Analogous to get_token_bucket for token counts.
+    """
+    path = _METRIC_BANK_SEGMENT_RE.sub(r"\g<1>{bank_id}", path)
+    path = _METRIC_UUID_RE.sub("/{id}", path)
+    path = _METRIC_NUMERIC_ID_RE.sub("/{id}", path)
+    return path
 
 
 logger = logging.getLogger(__name__)

--- a/hindsight-api-slim/tests/test_metrics.py
+++ b/hindsight-api-slim/tests/test_metrics.py
@@ -11,6 +11,7 @@ from hindsight_api.metrics import (
     get_token_bucket,
     create_metrics_collector,
     initialize_metrics,
+    normalize_http_endpoint,
 )
 
 
@@ -274,6 +275,24 @@ class TestGetTokenBucket:
         assert get_token_bucket(50000) == "50k+"
         assert get_token_bucket(100000) == "50k+"
         assert get_token_bucket(1000000) == "50k+"
+
+
+class TestNormalizeHttpEndpoint:
+    """Tests for normalize_http_endpoint (low-cardinality HTTP metric labels)."""
+
+    def test_templates_high_cardinality_segments(self):
+        """Bank ids (incl. non-numeric), UUIDs, and numeric ids collapse to placeholders."""
+        cases = [
+            ("/v1/default/banks/user-1680/memories/recall", "/v1/default/banks/{bank_id}/memories/recall"),
+            ("/v1/default/banks/tenant-acme/memories", "/v1/default/banks/{bank_id}/memories"),
+            ("/v1/default/banks/user-1680", "/v1/default/banks/{bank_id}"),
+            ("/v1/default/banks/3f8c1e2a-1111-2222-3333-444455556666/config", "/v1/default/banks/{bank_id}/config"),
+            ("/v1/default/banks/42/config", "/v1/default/banks/{bank_id}/config"),
+            ("/v1/default/banks", "/v1/default/banks"),
+            ("/health", "/health"),
+        ]
+        for raw, expected in cases:
+            assert normalize_http_endpoint(raw) == expected, raw
 
 
 class TestLLMMetrics:


### PR DESCRIPTION
## Summary

`http_metrics_middleware` (`hindsight_api/api/http.py`) labels each request with a normalized path, but only templates UUIDs and **pure-numeric** segments:

```python
path = re.sub(r"/[0-9a-f]{8}-...-[0-9a-f]{12}", "/{id}", path)  # UUIDs
path = re.sub(r"/\d+(?=/|$)", "/{id}", path)                    # numeric only
```

Bank-scoped routes are all `/v1/{tenant}/banks/{bank_id}/...`, so a bank id that is **not** a bare integer or UUID (e.g. `user-123`, `tenant-acme`, `org_42`, slug ids) survives in the `endpoint` label. Each distinct bank then creates a never-evicted OTel series — unbounded process-memory growth, on every per-bank request (it fires on every HTTP call, not only recorded operations).

This is the same unbounded-OTel-cardinality issue as #850 (fixed in #898 for the `record_operation` `bank_id` **attribute**), via a second code path #898 didn't touch: the HTTP request **path** label. Unlike the attribute, there is currently no config switch that bounds it.

## Change

- Extract endpoint normalization into a pure, unit-tested `normalize_http_endpoint()` in `metrics.py`, next to `get_token_bucket` (its low-cardinality-label sibling).
- Additionally template the `/banks/<id>` segment to `{bank_id}` for any bank id (the existing UUID/numeric templating moves into the helper unchanged).
- Call it from `http_metrics_middleware`.

## Test

`tests/test_metrics.py::TestNormalizeHttpEndpoint` covers non-numeric bank ids, UUIDs, numeric ids, list/non-bank paths, and unchanged-path cases.

## Alternatives to consider

Should the path label be always-templated (this PR), or gated behind the existing `HINDSIGHT_API_METRICS_INCLUDE_BANK_ID` flag for symmetry with #898?

A more thorough alternative is labeling by the matched route template (`route.matches(request.scope)`, as `unknown_params_middleware` already does), which would also bound other non-UUID/non-numeric id segments (document ids, etc.). Happy to adjust to whichever you prefer.