### PR TITLE
Chore (opencode): drop utility re-exports from plugin entry

### DIFF
--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -84,12 +84,13 @@ const HindsightPlugin: Plugin = async (input, options) => {
 // Named export for direct import
 export { HindsightPlugin };
 
-// Default export is the Plugin function itself — OpenCode's loader calls the
-// default export directly.
+// Default export is the Plugin function itself — OpenCode's legacy loader
+// iterates Object.values(mod) and calls every function export as a Plugin
+// factory. Keep the entry surface free of utility re-exports (loadConfig,
+// deriveBankId) so they are not invoked as plugins. The plugin itself imports
+// those utilities directly from their modules.
 export default HindsightPlugin;
 
 // Re-export types for consumers
 export type { HindsightConfig } from "./config.js";
 export type { PluginState } from "./hooks.js";
-export { loadConfig } from "./config.js";
-export { deriveBankId } from "./bank.js";

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -158,4 +158,28 @@ describe("plugin default export", () => {
       expect(typeof value, `export "${name}" must be a function`).toBe("function");
     }
   });
+
+  it("does not expose other callable utilities from the plugin entry (legacy-loader invariant)", async () => {
+    // OpenCode's legacy plugin loader (getLegacyPlugins) iterates Object.values(mod)
+    // and calls every function export as a Plugin factory. It deduplicates by
+    // reference, so default and HindsightPlugin (same fn) are fine. But any
+    // other callable utility re-exported from the entry (e.g. loadConfig,
+    // deriveBankId) would be incorrectly invoked as a plugin — likely producing
+    // a hooks object with the wrong shape (a string, a config object, etc.) and
+    // silently breaking session behavior.
+    //
+    // The fix is to NOT re-export utilities from the entry; consumers that
+    // need them import from "@vectorize-io/opencode-hindsight/dist/config.js"
+    // or rely on the plugin itself using them internally.
+    const mod = await import("./index.js");
+    const functionValues = Object.values(mod).filter(
+      (v) => typeof v === "function"
+    );
+    // Exactly two function exports remain: the default export and the
+    // HindsightPlugin named export, both pointing at the same function.
+    expect(functionValues.length).toBe(2);
+    expect(functionValues[0]).toBe(functionValues[1]);
+    // And the only callable symbol in the entry is the plugin itself.
+    expect(new Set(functionValues).size).toBe(1);
+  });
 });


### PR DESCRIPTION
This PR removes two unused exports from `src/index.ts`:

```diff
-export { loadConfig } from "./config.js";
-export { deriveBankId } from "./bank.js";
```

These were undocumented convenience re-exports. The plugin itself imports both utilities directly from their submodules; no internal or documented consumer is affected.

## Why

OpenCode's legacy plugin loader calls **every** function export as a Plugin factory. Post-#2038 (which removed the `DEFAULT_HINDSIGHT_API_URL` string export), the entry still re-exports `loadConfig` and `deriveBankId`. The loader invokes them with the plugin input, pushes the returns (a config object and a string) into the hooks array, and downstream consumption silently ignores them. No crash, no user-visible symptom, but 2 unnecessary calls per session and a hooks array with garbage entries. The #2028 test (`typeof === "function"` for each export) doesn't catch this because both are functions.

After this change, `dist/index.js` exports exactly `{ default, HindsightPlugin }`, same reference, deduped by the loader.

A new regression test in `src/plugin.test.ts` asserts exactly 2 function exports, both the same reference. Verified to fail on unfixed source.

This is smoke-tested against real opencode 1.17.5, v0.2.5 dist: silent, 0 errors. Fixed dist: identical behavior