### PR TITLE
fix(api): defer provider quota reset retries

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_interface.py
@@ -6,6 +6,7 @@ enabling support for multiple LLM backends (OpenAI, Anthropic, Gemini, Codex, et
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any
 
 from .response_models import LLMToolCallResult
@@ -252,3 +253,11 @@ class OutputTooLongError(Exception):
     """
 
     pass
+
+
+class ProviderRateLimitResetError(Exception):
+    """Raised when an upstream provider says quota will reopen at a known time."""
+
+    def __init__(self, retry_at: datetime, message: str = "") -> None:
+        self.retry_at = retry_at
+        super().__init__(message)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -45,6 +45,7 @@ from .audit import AuditLogger, audit_context
 from .bank_stats_cache import BankStatsCache
 from .db import DatabaseBackend, create_database_backend
 from .db_budget import budgeted_operation
+from .llm_interface import ProviderRateLimitResetError
 from .llm_trace import (
     LLMRequestEntry,
     LLMRequestListResponse,
@@ -1745,6 +1746,9 @@ class MemoryEngine(MemoryEngineInterface):
 
                 audit_entry.response = {"status": "completed", "operation_id": operation_id}
 
+            except ProviderRateLimitResetError as e:
+                logger.warning(f"Task deferred until provider quota resets at {e.retry_at}: {e}")
+                raise DeferOperation(exec_date=e.retry_at, reason=str(e)) from e
             except RetryTaskAt:
                 # Task-owned retry: let the poller handle scheduling
                 raise

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -26,6 +26,8 @@ import logging
 import os
 import re
 import time
+from datetime import UTC, datetime, timedelta
+from email.utils import parsedate_to_datetime
 from typing import Any
 from urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -34,7 +36,7 @@ from openai import APIConnectionError, APIStatusError, AsyncOpenAI, LengthFinish
 
 from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.bank_attribution import apply_bank_attribution
-from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
+from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError, ProviderRateLimitResetError
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
@@ -232,6 +234,122 @@ def _summarize_status_error(e: APIStatusError, body_max: int = 400) -> str:
     if len(body_str) > body_max:
         body_str = body_str[:body_max] + "...TRUNCATED"
     return f"HTTP {e.status_code}: {body_str or '<no body>'}"
+
+
+_RATE_LIMIT_RESET_AT_RE = re.compile(
+    r"\breset at\s+"
+    r"(?P<reset_at>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\s*(?:Z|[+-]\d{2}:?\d{2}))?)",
+    re.IGNORECASE,
+)
+_RATE_LIMIT_WINDOW_RE = re.compile(
+    r"\b(?:for|in)\s+(?P<amount>\d+)\s*(?P<unit>second|minute|hour|day)s?\b",
+    re.IGNORECASE,
+)
+
+
+def _status_error_body_text(e: APIStatusError) -> str:
+    body: Any = getattr(e, "body", None)
+    if body is None:
+        try:
+            body = e.response.text
+        except Exception:
+            body = None
+    if isinstance(body, (dict, list)):
+        try:
+            return json.dumps(body, default=str, ensure_ascii=False)
+        except Exception:
+            return str(body)
+    return str(body or "").strip()
+
+
+def _parse_retry_after_header(value: str | None, now: datetime) -> datetime | None:
+    if not value:
+        return None
+    raw = value.strip()
+    try:
+        seconds = float(raw)
+    except ValueError:
+        seconds = -1.0
+    if seconds >= 0:
+        return now + timedelta(seconds=seconds)
+
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _parse_reset_at_datetime(value: str) -> datetime | None:
+    raw = value.strip().replace(" ", "T")
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    elif re.search(r"[+-]\d{4}$", raw):
+        raw = f"{raw[:-2]}:{raw[-2:]}"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        # Some providers (z.ai included) return a wall-clock reset timestamp
+        # without a zone. Interpret it in the host's local zone so logs, status
+        # pages, and the queued next_retry_at describe the same operator-facing
+        # clock instead of silently shifting by UTC offset.
+        parsed = parsed.astimezone()
+    return parsed.astimezone(UTC)
+
+
+def _rate_limit_retry_at(e: APIStatusError) -> datetime | None:
+    now = datetime.now(UTC)
+    response = getattr(e, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        retry_at = _parse_retry_after_header(headers.get("retry-after") or headers.get("Retry-After"), now)
+        if retry_at is not None and retry_at > now:
+            return retry_at
+
+    body_text = _status_error_body_text(e)
+    reset_match = _RATE_LIMIT_RESET_AT_RE.search(body_text)
+    if reset_match:
+        retry_at = _parse_reset_at_datetime(reset_match.group("reset_at"))
+        if retry_at is not None and retry_at > now:
+            return retry_at
+
+    window_match = _RATE_LIMIT_WINDOW_RE.search(body_text)
+    if not window_match:
+        return None
+    amount = int(window_match.group("amount"))
+    unit = window_match.group("unit").lower()
+    if unit == "second":
+        seconds = amount
+    elif unit == "minute":
+        seconds = amount * 60
+    elif unit == "hour":
+        seconds = amount * 3600
+    else:
+        seconds = amount * 86400
+    return now + timedelta(seconds=seconds)
+
+
+def _raise_provider_quota_defer(
+    e: APIStatusError, *, provider: str, model: str, scope: str, max_backoff: float
+) -> None:
+    if e.status_code != 429:
+        return
+    retry_at = _rate_limit_retry_at(e)
+    if retry_at is None:
+        return
+    if (retry_at - datetime.now(UTC)).total_seconds() <= max_backoff:
+        return
+    summary = _summarize_status_error(e)
+    raise ProviderRateLimitResetError(
+        retry_at=retry_at,
+        message=(
+            f"Provider quota exhausted ({provider}/{model}, scope={scope}); retry at {retry_at.isoformat()}: {summary}"
+        ),
+    ) from e
 
 
 class OpenAICompatibleLLM(LLMInterface):
@@ -761,6 +879,10 @@ class OpenAICompatibleLLM(LLMInterface):
                     logger.error(f"Auth error (HTTP {e.status_code}), not retrying: {str(e)}")
                     raise
 
+                _raise_provider_quota_defer(
+                    e, provider=self.provider, model=self.model, scope=scope, max_backoff=max_backoff
+                )
+
                 # Handle tool_use_failed error - model outputted in tool call format
                 if e.status_code == 400 and response_format is not None:
                     try:
@@ -814,7 +936,6 @@ class OpenAICompatibleLLM(LLMInterface):
                         f"scope={scope}): {_summarize_status_error(e)}"
                     )
                     raise
-
             except ProviderResponseError as e:
                 last_exception = e
                 if e.retryable and attempt < max_retries:
@@ -1047,6 +1168,10 @@ class OpenAICompatibleLLM(LLMInterface):
                         f"not retrying: {_summarize_status_error(e)}"
                     )
                     raise
+                _raise_provider_quota_defer(
+                    e, provider=self.provider, model=self.model, scope=scope, max_backoff=max_backoff
+                )
+
                 last_exception = e
                 if attempt < max_retries:
                     logger.warning(
@@ -1060,7 +1185,6 @@ class OpenAICompatibleLLM(LLMInterface):
                     f"({self.provider}/{self.model}, scope={scope}): {_summarize_status_error(e)}"
                 )
                 raise
-
             except Exception:
                 raise
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
+from ..llm_interface import ProviderRateLimitResetError
 from ..llm_wrapper import LLMConfig, OutputTooLongError, sanitize_llm_output
 from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
@@ -1787,10 +1788,21 @@ async def extract_facts_from_text(
         total_usage = total_usage + chunk_usage
 
     if failed_chunks:
+        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}" for idx, err in failed_chunks[:5])
+        quota_errors = [err for _, err in failed_chunks if isinstance(err, ProviderRateLimitResetError)]
+        if quota_errors and len(quota_errors) == len(failed_chunks):
+            retry_at = max(err.retry_at for err in quota_errors)
+            raise ProviderRateLimitResetError(
+                retry_at=retry_at,
+                message=(
+                    f"Fact extraction deferred by provider quota: {len(failed_chunks)}/{len(chunks)} chunks failed. "
+                    f"First failures: {failed_summary}. Provider detail: {quota_errors[0]}"
+                ),
+            ) from quota_errors[0]
+
         # Fail the entire retain — partial extraction is not acceptable.
         # All successfully extracted facts are discarded because the transaction
         # hasn't committed yet. The worker poller will retry the entire task.
-        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}" for idx, err in failed_chunks[:5])
         raise RuntimeError(
             f"Fact extraction failed: {len(failed_chunks)}/{len(chunks)} chunks failed. "
             f"First failures: {failed_summary}"

--- a/hindsight-api-slim/tests/test_provider_quota_reset_defer.py
+++ b/hindsight-api-slim/tests/test_provider_quota_reset_defer.py
@@ -1,0 +1,110 @@
+"""Provider quota reset windows defer worker retries instead of failing retains."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from openai import APIStatusError
+
+from hindsight_api.engine.llm_interface import ProviderRateLimitResetError
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+def _llm() -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="zai",
+        model="glm-5-turbo",
+        api_key="test",
+        base_url="https://example.com/v1",
+    )
+
+
+def _usage_limit_error(reset_at: str) -> APIStatusError:
+    body = {
+        "code": "1308",
+        "message": f"Usage limit reached for 5 hour. Your limit will reset at {reset_at}",
+    }
+    response = MagicMock()
+    response.status_code = 429
+    response.text = '{"code": "1308", "message": "usage limit"}'
+    response.headers = {}
+    return APIStatusError("rate limited", response=response, body=body)
+
+
+def _short_retry_after_error() -> APIStatusError:
+    response = MagicMock()
+    response.status_code = 429
+    response.text = '{"code": "rate_limit", "message": "retry shortly"}'
+    response.headers = {"retry-after": "1"}
+    return APIStatusError("rate limited", response=response, body={"message": "retry shortly"})
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_429_with_reset_defers_without_inner_retry() -> None:
+    llm = _llm()
+    reset_at = (datetime.now(UTC) + timedelta(hours=5)).replace(microsecond=0)
+    create = AsyncMock(side_effect=_usage_limit_error(reset_at.isoformat().replace("+00:00", "Z")))
+    llm._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with patch(
+        "hindsight_api.engine.providers.openai_compatible_llm.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as sleep:
+        with pytest.raises(ProviderRateLimitResetError) as exc_info:
+            await llm.call(
+                messages=[{"role": "user", "content": "x"}],
+                scope="retain_extract_facts",
+                max_retries=2,
+            )
+
+    assert create.await_count == 1
+    sleep.assert_not_awaited()
+    assert abs((exc_info.value.retry_at - reset_at).total_seconds()) < 1
+    assert "Provider quota exhausted" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_short_retry_after_429_uses_normal_retry_loop() -> None:
+    llm = _llm()
+    create = AsyncMock(side_effect=_short_retry_after_error())
+    llm._client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+    with patch(
+        "hindsight_api.engine.providers.openai_compatible_llm.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as sleep:
+        with pytest.raises(APIStatusError):
+            await llm.call(
+                messages=[{"role": "user", "content": "x"}],
+                scope="retain_extract_facts",
+                max_retries=2,
+                max_backoff=60,
+            )
+
+    assert create.await_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_from_text_preserves_provider_quota_reset(monkeypatch) -> None:
+    from hindsight_api.engine.retain import fact_extraction
+
+    retry_at = (datetime.now(UTC) + timedelta(hours=2)).replace(microsecond=0)
+
+    async def quota_limited_chunk(**_: object) -> None:
+        raise ProviderRateLimitResetError(retry_at=retry_at, message="quota resets later")
+
+    monkeypatch.setattr(fact_extraction, "_extract_facts_with_auto_split", quota_limited_chunk)
+
+    with pytest.raises(ProviderRateLimitResetError) as exc_info:
+        await fact_extraction.extract_facts_from_text(
+            text="Alice moved to Berlin.",
+            event_date=None,
+            llm_config=object(),
+            agent_name="TestAgent",
+            config=SimpleNamespace(retain_chunk_size=1000),
+        )
+
+    assert exc_info.value.retry_at == retry_at
+    assert "Fact extraction deferred by provider quota" in str(exc_info.value)

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -833,6 +833,34 @@ class TestWorkerPoller:
         assert not isinstance(exc_info.value, RetryTaskAt)
 
     @pytest.mark.asyncio
+    async def test_memory_engine_provider_quota_reset_becomes_defer_operation(self, memory, monkeypatch):
+        """Provider quota windows should park worker tasks until the reset time."""
+        from datetime import UTC, datetime, timedelta
+
+        from hindsight_api.engine.llm_interface import ProviderRateLimitResetError
+        from hindsight_api.worker.exceptions import DeferOperation, RetryTaskAt
+
+        retry_at = (datetime.now(UTC) + timedelta(hours=5)).replace(microsecond=0)
+
+        async def quota_limited_retain(_task_dict: object) -> None:
+            raise ProviderRateLimitResetError(retry_at=retry_at, message="quota resets later")
+
+        monkeypatch.setattr(memory, "_handle_batch_retain", quota_limited_retain)
+
+        with pytest.raises(DeferOperation) as exc_info:
+            await memory.execute_task(
+                {
+                    "type": "batch_retain",
+                    "bank_id": "test-provider-quota-defer",
+                    "contents": [{"content": "x"}],
+                }
+            )
+
+        assert exc_info.value.exec_date == retry_at
+        assert exc_info.value.reason == "quota resets later"
+        assert not isinstance(exc_info.value, RetryTaskAt)
+
+    @pytest.mark.asyncio
     async def test_claim_batch_skips_consolidation_when_same_bank_processing(self, pool, backend, clean_operations):
         """Test that pending consolidation is skipped if same bank has one processing."""
         from hindsight_api.worker import WorkerPoller


### PR DESCRIPTION
## Summary
- detect provider 429 quota reset windows from `Retry-After` and response-body reset timestamps
- preserve provider quota reset errors through retain fact chunk aggregation
- convert provider quota reset errors into worker `DeferOperation` scheduling instead of failed retries

## Tests
- `uv run pytest tests/test_provider_quota_reset_defer.py tests/test_worker.py::TestWorkerPoller::test_memory_engine_provider_quota_reset_becomes_defer_operation tests/test_retain_transient_extraction_failure.py -q`
- `uv run ruff check --fix hindsight_api/engine/llm_interface.py hindsight_api/engine/providers/openai_compatible_llm.py hindsight_api/engine/retain/fact_extraction.py hindsight_api/engine/memory_engine.py tests/test_provider_quota_reset_defer.py tests/test_worker.py`
- `uv run ruff format hindsight_api/engine/llm_interface.py hindsight_api/engine/providers/openai_compatible_llm.py hindsight_api/engine/retain/fact_extraction.py hindsight_api/engine/memory_engine.py tests/test_provider_quota_reset_defer.py tests/test_worker.py`
- `uv run ty check hindsight_api/engine/llm_interface.py hindsight_api/engine/providers/openai_compatible_llm.py hindsight_api/engine/retain/fact_extraction.py hindsight_api/engine/memory_engine.py`

Note: `bash scripts/hooks/lint.sh` is not runnable in this Windows checkout because the script is CRLF-encoded; the affected API lint/format/typecheck commands above were run directly.