### PR TITLE
Strip reasoning tags on non-structured LLM output (and unclosed blocks)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -83,6 +83,49 @@ def _strip_code_fences(content: str) -> str:
         return content
 
 
+# Reasoning/thinking tags emitted by extended-thinking models. Some providers
+# (e.g. MiniMax-M3) leak the chain-of-thought wrapped in these tags into the
+# response body instead of a separate reasoning_content field. Each entry is
+# (open_tag, close_tag); the open tag also matches when the close tag is missing
+# (truncated output) so a dangling block is removed to end-of-string.
+_REASONING_TAG_PAIRS: tuple[tuple[str, str], ...] = (
+    ("<think>", "</think>"),
+    ("<thinking>", "</thinking>"),
+    ("<thought>", "</thought>"),
+    ("<reasoning>", "</reasoning>"),
+    ("|startthink|", "|endthink|"),
+)
+
+
+def _strip_reasoning_tags(text: str) -> str:
+    """Strip extended-thinking/reasoning blocks from an LLM response.
+
+    Removes the full set of tag styles emitted by reasoning models:
+    ``<think>``, ``<thinking>``, ``<thought>``, ``<reasoning>`` and the
+    ``|startthink|...|endthink|`` markers. Both the structured (JSON) path and
+    the free-form path must call this — otherwise a non-structured response
+    (e.g. a mental-model markdown blob from MiniMax-M3) leaks the raw
+    ``<think>...</think>`` verbatim into stored memories.
+
+    Handles two cases:
+    1. Closed blocks: ``<think>...</think>`` removed wherever they appear.
+    2. Unclosed blocks: a dangling ``<think>`` with no closing tag (model output
+       truncated mid-thought) is removed from the open tag to end-of-string.
+
+    Returns the input unchanged (modulo surrounding whitespace) when no tags are
+    present.
+    """
+    if not text:
+        return text
+    for open_tag, close_tag in _REASONING_TAG_PAIRS:
+        open_re = re.escape(open_tag)
+        close_re = re.escape(close_tag)
+        # Closed blocks first, then any remaining unclosed (truncated) block.
+        text = re.sub(rf"{open_re}.*?{close_re}", "", text, flags=re.DOTALL)
+        text = re.sub(rf"{open_re}.*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
 def _response_get(response: Any, key: str, default: Any = None) -> Any:
     if isinstance(response, dict):
         return response.get(key, default)
@@ -617,15 +660,10 @@ class OpenAICompatibleLLM(LLMInterface):
                         scope=scope,
                     )
 
-                    # Strip reasoning model thinking tags
+                    # Strip reasoning model thinking tags (closed and unclosed).
                     # Supports: <think>, <thinking>, <thought>, <reasoning>, |startthink|/|endthink|
                     original_len = len(content)
-                    content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
-                    content = re.sub(r"<thinking>.*?</thinking>", "", content, flags=re.DOTALL)
-                    content = re.sub(r"<thought>.*?</thought>", "", content, flags=re.DOTALL)
-                    content = re.sub(r"<reasoning>.*?</reasoning>", "", content, flags=re.DOTALL)
-                    content = re.sub(r"\|startthink\|.*?\|endthink\|", "", content, flags=re.DOTALL)
-                    content = content.strip()
+                    content = _strip_reasoning_tags(content)
                     if len(content) < original_len:
                         logger.debug(f"Stripped {original_len - len(content)} chars of reasoning tokens")
 
@@ -673,6 +711,13 @@ class OpenAICompatibleLLM(LLMInterface):
                         model=self.model,
                         scope=scope,
                     )
+
+                    # Free-form (non-structured) output also leaks reasoning tags:
+                    # reasoning models like MiniMax-M3 wrap their chain-of-thought
+                    # in <think>...</think> in the response body. Without this strip
+                    # a mental-model markdown blob is stored verbatim with the raw
+                    # thinking tags. Mirrors the structured-output path above.
+                    result = _strip_reasoning_tags(result)
 
                 # Record token usage metrics
                 duration = time.time() - start_time

--- a/hindsight-api-slim/tests/test_strip_reasoning_tags.py
+++ b/hindsight-api-slim/tests/test_strip_reasoning_tags.py
@@ -1,0 +1,78 @@
+"""Tests for _strip_reasoning_tags helper in OpenAI-compatible LLM provider."""
+
+from hindsight_api.engine.providers.openai_compatible_llm import _strip_reasoning_tags
+
+
+class TestStripReasoningTags:
+    """Test reasoning/thinking tag stripping from LLM responses."""
+
+    def test_plain_text_unchanged(self):
+        """Text without reasoning tags passes through (modulo edge whitespace)."""
+        content = "User prefers functional programming patterns."
+        assert _strip_reasoning_tags(content) == content
+
+    def test_empty_string(self):
+        """Empty string passes through."""
+        assert _strip_reasoning_tags("") == ""
+
+    def test_closed_think_stripped(self):
+        """A closed <think>...</think> block is removed."""
+        content = "<think>let me reason</think>The answer is 42."
+        assert _strip_reasoning_tags(content) == "The answer is 42."
+
+    def test_closed_thinking_stripped(self):
+        assert _strip_reasoning_tags("<thinking>reasoning</thinking>Result") == "Result"
+
+    def test_closed_thought_stripped(self):
+        assert _strip_reasoning_tags("<thought>hmm</thought>Result") == "Result"
+
+    def test_closed_reasoning_stripped(self):
+        assert _strip_reasoning_tags("<reasoning>step by step</reasoning>Result") == "Result"
+
+    def test_startthink_endthink_stripped(self):
+        """The |startthink|...|endthink| marker style is removed."""
+        content = "|startthink|internal monologue|endthink|Final output"
+        assert _strip_reasoning_tags(content) == "Final output"
+
+    def test_multiline_think_stripped(self):
+        """DOTALL: a multi-line thinking block is fully removed."""
+        content = "<think>\nline one\nline two\n</think>\nThe real content."
+        assert _strip_reasoning_tags(content) == "The real content."
+
+    def test_unclosed_think_stripped_to_end(self):
+        """An unclosed <think> (truncated output) is removed to end-of-string."""
+        content = "Partial answer.\n<think>I started thinking but got cut off"
+        assert _strip_reasoning_tags(content) == "Partial answer."
+
+    def test_unclosed_thinking_stripped_to_end(self):
+        content = "result text\n<thinking>dangling reasoning with no close"
+        assert _strip_reasoning_tags(content) == "result text"
+
+    def test_only_unclosed_think_becomes_empty(self):
+        """Content that is entirely an unclosed thinking block collapses to empty."""
+        content = "<think>everything is reasoning and it never closed"
+        assert _strip_reasoning_tags(content) == ""
+
+    def test_multiple_blocks_stripped(self):
+        """Multiple closed blocks are all removed."""
+        content = "<think>a</think>Hello <think>b</think>World"
+        assert _strip_reasoning_tags(content) == "Hello World"
+
+    def test_mental_model_markdown_contamination(self):
+        """Real-world MiniMax-M3 free-form leak: <think> wrapping a markdown mental model."""
+        content = (
+            "<think>\n"
+            "The user keeps asking about FP. I should consolidate this.\n"
+            "</think>\n"
+            "# Mental Model: Coding Preferences\n\n"
+            "The user prefers functional programming patterns and immutable data."
+        )
+        result = _strip_reasoning_tags(content)
+        assert "<think>" not in result
+        assert "</think>" not in result
+        assert result.startswith("# Mental Model: Coding Preferences")
+
+    def test_unclosed_think_after_json_payload(self):
+        """Truncated <think> trailing valid JSON is stripped (closing tag absent)."""
+        content = '{"facts": [{"what": "test"}]}\n<think>oops truncated'
+        assert _strip_reasoning_tags(content) == '{"facts": [{"what": "test"}]}'


### PR DESCRIPTION
## The bug

`OpenAICompatibleLLM.call()` strips reasoning/thinking tags **only inside the structured-output branch**. In `hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py`:

- The `if response_format is not None:` branch strips `<think>`/`<thinking>`/`<thought>`/`<reasoning>`/`|startthink|…|endthink|` from the content.
- The `else:` branch — free-form, **non-structured** output — returns the raw provider content from `_content_or_error(...)` with **no strip at all**.

Reasoning models that emit their chain-of-thought in the response body (rather than a separate `reasoning_content` field) therefore leak the raw thinking block verbatim through the non-structured path.

### Symptom

Mental-model consolidation produces free-form markdown via the non-structured path. With a reasoning model as the extraction/consolidation LLM (reproduced with **MiniMax-M3**), stored mental models come out wrapped in literal `<think>...</think>` — the model's chain-of-thought saved verbatim into long-term memory. On one deployment 17/25 consolidated mental models were contaminated this way.

### Second, related defect

Every existing strip regex used the lazy `<tag>.*?</tag>` form, which **requires a closing tag**. When output is truncated mid-thought the closing tag never arrives, so a dangling `<think>` slips through even on the JSON path.

## The fix

1. Factor a module-level helper `_strip_reasoning_tags(text)` covering the full tag set (`think`, `thinking`, `thought`, `reasoning`, and `|startthink|…|endthink|`).
2. For each tag it strips **closed** blocks (`<tag>...</tag>`, DOTALL) **and then any remaining unclosed** block (`<tag>.*` to end-of-string), so truncated thinking is removed too.
3. Call the helper from **both** branches: the structured path (replacing the inline regex block, behavior-preserving) and the free-form `else:` path (which previously had no strip).

## Tests

Adds `tests/test_strip_reasoning_tags.py` (pure-function, no LLM), mirroring the existing `test_strip_code_fences.py` pattern: closed/unclosed blocks, every tag style, multi-line + multi-block input, and the real-world mental-model markdown contamination case.

```
tests/test_strip_reasoning_tags.py ...... 14 passed
tests/test_strip_code_fences.py ........  10 passed (unchanged, still green)
```

`ruff check` and `ruff format --check` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)