### PR TITLE
Expose recall scores and filter CLI recall results

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -258,6 +258,7 @@ class RecallResult(BaseModel):
                 "document_id": "session_abc123",
                 "metadata": {"source": "slack"},
                 "chunk_id": "456e7890-e12b-34d5-a678-901234567890",
+                "score": 0.95,
                 "tags": ["user_a", "user_b"],
             }
         },
@@ -274,6 +275,7 @@ class RecallResult(BaseModel):
     document_id: str | None = None  # Document this memory belongs to
     metadata: dict[str, str] | None = None  # User-defined metadata
     chunk_id: str | None = None  # Chunk this fact was extracted from
+    score: float | None = None  # Normalized relevance score; higher means more relevant
     tags: list[str] | None = None  # Visibility scope tags
     source_fact_ids: list[str] | None = (
         None  # IDs of source facts (observation type only, when source_facts is enabled)
@@ -3653,6 +3655,7 @@ def _register_routes(app: FastAPI):
                     document_id=fact.document_id,
                     metadata=fact.metadata,
                     chunk_id=fact.chunk_id,
+                    score=fact.score,
                     tags=fact.tags,
                     source_fact_ids=fact.source_fact_ids,
                 )

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1492,11 +1492,7 @@ async def _process_memory_batch(
     if max_obs >= 0 and fact_tags:
         # max_obs == 0 means "no new observations": there are no slots regardless
         # of the current count, so skip the count query for that case.
-        current_count = (
-            await _count_observations_for_scope(conn, bank_id, fact_tags)
-            if max_obs > 0
-            else 0
-        )
+        current_count = await _count_observations_for_scope(conn, bank_id, fact_tags) if max_obs > 0 else 0
         remaining_observation_slots = max(max_obs - current_count, 0)
         if remaining_observation_slots == 0:
             logger.info(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -4913,6 +4913,7 @@ class MemoryEngine(MemoryEngineInterface):
                         mentioned_at=result_dict.get("mentioned_at"),
                         document_id=result_dict.get("document_id"),
                         metadata=result_dict.get("metadata"),
+                        score=result_dict.get("cross_encoder_score_normalized"),
                         chunk_id=result_dict.get("chunk_id"),
                         tags=result_dict.get("tags"),
                         source_fact_ids=source_fact_ids_by_obs.get(result_id) if include_source_facts else None,

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -145,6 +145,7 @@ class MemoryFact(BaseModel):
                 "metadata": {"source": "slack"},
                 "chunk_id": "bank123_session_abc123_0",
                 "activation": 0.95,
+                "score": 0.95,
                 "tags": ["user_a", "session_123"],
             }
         }
@@ -160,6 +161,9 @@ class MemoryFact(BaseModel):
     mentioned_at: str | None = Field(None, description="ISO format date when the fact was mentioned/learned")
     document_id: str | None = Field(None, description="ID of the document this memory belongs to")
     metadata: dict[str, str] | None = Field(None, description="User-defined metadata")
+    score: float | None = Field(
+        None, description="Normalized relevance score for this recall result; higher means more relevant"
+    )
 
     @field_validator("metadata", mode="before")
     @classmethod

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -64,8 +64,7 @@ async def test_full_api_workflow(api_client, test_bank_id):
     # List banks (should be empty initially or have other test banks)
     response = await api_client.get("/v1/default/banks")
     assert response.status_code == 200
-    initial_banks_data = response.json()["banks"]
-    initial_banks = [a["bank_id"] for a in initial_banks_data]
+    assert isinstance(response.json()["banks"], list)
 
     # ================================================================
     # 2. Memory Storage (implicitly creates the bank)
@@ -119,10 +118,21 @@ async def test_full_api_workflow(api_client, test_bank_id):
     search_results = response.json()
     assert "results" in search_results
     assert len(search_results["results"]) > 0
+    assert all(isinstance(r.get("score"), int | float) for r in search_results["results"])
 
     # Verify we found Alice
     found_alice = any("Alice" in r["text"] for r in search_results["results"])
     assert found_alice, "Should find Alice in search results"
+
+    traced_response = await api_client.post(
+        f"/v1/default/banks/{test_bank_id}/memories/recall",
+        json={"query": "Who works on machine learning?", "budget": "low", "trace": True},
+    )
+    assert traced_response.status_code == 200
+    traced_results = traced_response.json()
+    final_results_by_id = {r["id"]: r for r in traced_results["trace"]["final_results"]}
+    for result in traced_results["results"]:
+        assert result["score"] == pytest.approx(final_results_by_id[result["id"]]["cross_encoder_score_normalized"])
 
     # ================================================================
     # 4. Reflect (Reasoning)

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -100,11 +100,12 @@ pub struct ApiClient {
     client: AsyncClient,
     http_client: reqwest::Client,
     base_url: String,
+    recall_score_min: f64,
     runtime: std::sync::Arc<tokio::runtime::Runtime>,
 }
 
 impl ApiClient {
-    pub fn new(base_url: String, api_key: Option<String>) -> Result<Self> {
+    pub fn new(base_url: String, api_key: Option<String>, recall_score_min: f64) -> Result<Self> {
         let runtime = std::sync::Arc::new(tokio::runtime::Runtime::new()?);
 
         // Create HTTP client with 2-minute timeout and optional auth header
@@ -128,6 +129,7 @@ impl ApiClient {
             client,
             http_client,
             base_url,
+            recall_score_min,
             runtime,
         })
     }
@@ -220,7 +222,11 @@ impl ApiClient {
                 Ok(r) => r,
                 Err(e) => return Err(humanize_client_error(e).await),
             };
-            Ok(response.into_inner())
+            let mut response = response.into_inner();
+            response
+                .results
+                .retain(|result| result.score.unwrap_or(0.0) >= self.recall_score_min);
+            Ok(response)
         })
     }
 

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -223,9 +223,12 @@ impl ApiClient {
                 Err(e) => return Err(humanize_client_error(e).await),
             };
             let mut response = response.into_inner();
-            response
-                .results
-                .retain(|result| result.score.unwrap_or(0.0) >= self.recall_score_min);
+            response.results.retain(|result| {
+                result
+                    .score
+                    .map(|score| score >= self.recall_score_min)
+                    .unwrap_or(true)
+            });
             Ok(response)
         })
     }

--- a/hindsight-cli/src/config.rs
+++ b/hindsight-cli/src/config.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 const DEFAULT_API_URL: &str = "http://localhost:8888";
+const DEFAULT_RECALL_SCORE_MIN: f64 = 0.25;
 const CONFIG_FILE_NAME: &str = "config";
 const CONFIG_DIR_NAME: &str = ".hindsight";
 const PROFILE_DIR_NAME: &str = "cli-profiles";
@@ -14,6 +15,7 @@ const PROFILE_ENV_VAR: &str = "HINDSIGHT_PROFILE";
 pub struct Config {
     pub api_url: String,
     pub api_key: Option<String>,
+    pub recall_score_min: f64,
     pub source: ConfigSource,
 }
 
@@ -50,10 +52,16 @@ impl Config {
     /// 4. Default (http://localhost:8888)
     pub fn load_with_profile(profile_name: Option<&str>) -> Result<Self> {
         let env_api_key = env::var("HINDSIGHT_API_KEY").ok();
+        let env_recall_score_min = Self::env_recall_score_min()?;
 
         // 1. Environment variable takes highest priority
         if let Ok(api_url) = env::var("HINDSIGHT_API_URL") {
-            return Self::validate_and_create(api_url, env_api_key, ConfigSource::Environment);
+            return Self::validate_and_create(
+                api_url,
+                env_api_key,
+                env_recall_score_min.unwrap_or(DEFAULT_RECALL_SCORE_MIN),
+                ConfigSource::Environment,
+            );
         }
 
         // 2. Named profile (explicit flag takes precedence over env var)
@@ -62,19 +70,38 @@ impl Config {
             .or_else(|| env::var(PROFILE_ENV_VAR).ok().filter(|s| !s.is_empty()));
 
         if let Some(name) = resolved_profile {
-            let (api_url, file_api_key) = Self::load_profile(&name)?;
+            let (api_url, file_api_key, file_recall_score_min) = Self::load_profile(&name)?;
             let api_key = env_api_key.or(file_api_key);
-            return Self::validate_and_create(api_url, api_key, ConfigSource::Profile(name));
+            return Self::validate_and_create(
+                api_url,
+                api_key,
+                env_recall_score_min
+                    .or(file_recall_score_min)
+                    .unwrap_or(DEFAULT_RECALL_SCORE_MIN),
+                ConfigSource::Profile(name),
+            );
         }
 
         // 3. Local config file
-        if let Some((api_url, file_api_key)) = Self::load_from_file()? {
+        if let Some((api_url, file_api_key, file_recall_score_min)) = Self::load_from_file()? {
             let api_key = env_api_key.or(file_api_key);
-            return Self::validate_and_create(api_url, api_key, ConfigSource::LocalFile);
+            return Self::validate_and_create(
+                api_url,
+                api_key,
+                env_recall_score_min
+                    .or(file_recall_score_min)
+                    .unwrap_or(DEFAULT_RECALL_SCORE_MIN),
+                ConfigSource::LocalFile,
+            );
         }
 
         // 4. Fall back to default
-        Self::validate_and_create(DEFAULT_API_URL.to_string(), env_api_key, ConfigSource::Default)
+        Self::validate_and_create(
+            DEFAULT_API_URL.to_string(),
+            env_api_key,
+            env_recall_score_min.unwrap_or(DEFAULT_RECALL_SCORE_MIN),
+            ConfigSource::Default,
+        )
     }
 
     /// Legacy method for backwards compatibility
@@ -82,14 +109,32 @@ impl Config {
         Self::load()
     }
 
-    fn validate_and_create(api_url: String, api_key: Option<String>, source: ConfigSource) -> Result<Self> {
+    fn validate_and_create(
+        api_url: String,
+        api_key: Option<String>,
+        recall_score_min: f64,
+        source: ConfigSource,
+    ) -> Result<Self> {
         if !api_url.starts_with("http://") && !api_url.starts_with("https://") {
             anyhow::bail!(
                 "Invalid API URL: {}. Must start with http:// or https://",
                 api_url
             );
         }
-        Ok(Config { api_url, api_key, source })
+        validate_recall_score_min(recall_score_min)?;
+        Ok(Config {
+            api_url,
+            api_key,
+            recall_score_min,
+            source,
+        })
+    }
+
+    fn env_recall_score_min() -> Result<Option<f64>> {
+        env::var("HINDSIGHT_RECALL_SCORE_MIN")
+            .ok()
+            .map(|value| parse_recall_score_min(&value, "HINDSIGHT_RECALL_SCORE_MIN"))
+            .transpose()
     }
 
     fn config_dir() -> Option<PathBuf> {
@@ -100,7 +145,7 @@ impl Config {
         Self::config_dir().map(|dir| dir.join(CONFIG_FILE_NAME))
     }
 
-    fn load_from_file() -> Result<Option<(String, Option<String>)>> {
+    fn load_from_file() -> Result<Option<(String, Option<String>, Option<f64>)>> {
         let config_path = match Self::config_file_path() {
             Some(path) => path,
             None => return Ok(None),
@@ -115,6 +160,7 @@ impl Config {
 
         let mut api_url: Option<String> = None;
         let mut api_key: Option<String> = None;
+        let mut recall_score_min: Option<f64> = None;
 
         // Simple TOML parsing for api_url and api_key
         for line in content.lines() {
@@ -133,33 +179,49 @@ impl Config {
                         api_key = Some(value.to_string());
                     }
                 }
+            } else if let Some(value) = parse_config_value(line, "recall_score_min") {
+                recall_score_min = Some(parse_recall_score_min(&value, "recall_score_min")?);
             }
         }
 
         match api_url {
-            Some(url) => Ok(Some((url, api_key))),
+            Some(url) => Ok(Some((url, api_key, recall_score_min))),
             None => Ok(None),
         }
     }
 
     pub fn save_api_url(api_url: &str) -> Result<PathBuf> {
-        Self::save_config(api_url, None)
+        Self::save_config(api_url, None, None)
     }
 
-    pub fn save_config(api_url: &str, api_key: Option<&str>) -> Result<PathBuf> {
+    pub fn save_config(
+        api_url: &str,
+        api_key: Option<&str>,
+        recall_score_min: Option<f64>,
+    ) -> Result<PathBuf> {
+        if let Some(value) = recall_score_min {
+            validate_recall_score_min(value)?;
+        }
         let config_dir = Self::config_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
 
         // Create config directory if it doesn't exist
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .with_context(|| format!("Failed to create config directory: {}", config_dir.display()))?;
+            fs::create_dir_all(&config_dir).with_context(|| {
+                format!(
+                    "Failed to create config directory: {}",
+                    config_dir.display()
+                )
+            })?;
         }
 
         let config_path = config_dir.join(CONFIG_FILE_NAME);
         let mut content = format!("api_url = \"{}\"\n", api_url);
         if let Some(key) = api_key {
             content.push_str(&format!("api_key = \"{}\"\n", key));
+        }
+        if let Some(value) = recall_score_min {
+            content.push_str(&format!("recall_score_min = {}\n", value));
         }
 
         fs::write(&config_path, content)
@@ -184,7 +246,7 @@ impl Config {
 
     /// Load a named profile. Returns (api_url, api_key) or an error if the profile
     /// file is missing / malformed.
-    pub fn load_profile(name: &str) -> Result<(String, Option<String>)> {
+    pub fn load_profile(name: &str) -> Result<(String, Option<String>, Option<f64>)> {
         validate_profile_name(name)?;
         let dir = Self::profile_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
@@ -193,11 +255,16 @@ impl Config {
 
     /// Save a named profile to `~/.hindsight/cli-profiles/<name>.toml`.
     /// Sets file permissions to 0600 on Unix to protect the API key.
-    pub fn save_profile(name: &str, api_url: &str, api_key: Option<&str>) -> Result<PathBuf> {
+    pub fn save_profile(
+        name: &str,
+        api_url: &str,
+        api_key: Option<&str>,
+        recall_score_min: Option<f64>,
+    ) -> Result<PathBuf> {
         validate_profile_name(name)?;
         let dir = Self::profile_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-        save_profile_to_dir(&dir, name, api_url, api_key)
+        save_profile_to_dir(&dir, name, api_url, api_key, recall_score_min)
     }
 
     /// List profile names (without `.toml` extension), sorted alphabetically.
@@ -224,7 +291,10 @@ impl Config {
     }
 }
 
-fn load_profile_from_dir(dir: &std::path::Path, name: &str) -> Result<(String, Option<String>)> {
+fn load_profile_from_dir(
+    dir: &std::path::Path,
+    name: &str,
+) -> Result<(String, Option<String>, Option<f64>)> {
     let path = dir.join(format!("{}.toml", name));
     if !path.exists() {
         anyhow::bail!(
@@ -240,12 +310,15 @@ fn load_profile_from_dir(dir: &std::path::Path, name: &str) -> Result<(String, O
 
     let mut api_url: Option<String> = None;
     let mut api_key: Option<String> = None;
+    let mut recall_score_min: Option<f64> = None;
 
     for line in content.lines() {
         if let Some(v) = parse_config_value(line, "api_url") {
             api_url = Some(v);
         } else if let Some(v) = parse_config_value(line, "api_key") {
             api_key = Some(v);
+        } else if let Some(v) = parse_config_value(line, "recall_score_min") {
+            recall_score_min = Some(parse_recall_score_min(&v, "recall_score_min")?);
         }
     }
 
@@ -257,7 +330,22 @@ fn load_profile_from_dir(dir: &std::path::Path, name: &str) -> Result<(String, O
         )
     })?;
 
-    Ok((api_url, api_key))
+    Ok((api_url, api_key, recall_score_min))
+}
+
+fn parse_recall_score_min(value: &str, label: &str) -> Result<f64> {
+    let parsed = value
+        .parse::<f64>()
+        .with_context(|| format!("Invalid {}: {}", label, value))?;
+    validate_recall_score_min(parsed)?;
+    Ok(parsed)
+}
+
+fn validate_recall_score_min(value: f64) -> Result<()> {
+    if !value.is_finite() || value < 0.0 || value > 1.0 {
+        anyhow::bail!("recall_score_min must be a finite number between 0.0 and 1.0");
+    }
+    Ok(())
 }
 
 fn save_profile_to_dir(
@@ -265,12 +353,16 @@ fn save_profile_to_dir(
     name: &str,
     api_url: &str,
     api_key: Option<&str>,
+    recall_score_min: Option<f64>,
 ) -> Result<PathBuf> {
     if !api_url.starts_with("http://") && !api_url.starts_with("https://") {
         anyhow::bail!(
             "Invalid API URL: {}. Must start with http:// or https://",
             api_url
         );
+    }
+    if let Some(value) = recall_score_min {
+        validate_recall_score_min(value)?;
     }
 
     if !dir.exists() {
@@ -283,6 +375,9 @@ fn save_profile_to_dir(
     if let Some(key) = api_key {
         content.push_str(&format!("api_key = \"{}\"\n", key));
     }
+    if let Some(value) = recall_score_min {
+        content.push_str(&format!("recall_score_min = {}\n", value));
+    }
 
     fs::write(&path, content)
         .with_context(|| format!("Failed to write profile file: {}", path.display()))?;
@@ -292,7 +387,10 @@ fn save_profile_to_dir(
         use std::os::unix::fs::PermissionsExt;
         let perms = fs::Permissions::from_mode(0o600);
         fs::set_permissions(&path, perms).with_context(|| {
-            format!("Failed to set permissions on profile file: {}", path.display())
+            format!(
+                "Failed to set permissions on profile file: {}",
+                path.display()
+            )
         })?;
     }
 
@@ -370,9 +468,16 @@ pub fn parse_config_value(line: &str, key: &str) -> Option<String> {
     if !line.starts_with(key) {
         return None;
     }
-    line.split('=').nth(1).map(|value| {
-        value.trim().trim_matches('"').trim_matches('\'').to_string()
-    }).filter(|v| !v.is_empty())
+    line.split('=')
+        .nth(1)
+        .map(|value| {
+            value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string()
+        })
+        .filter(|v| !v.is_empty())
 }
 
 #[cfg(test)]
@@ -382,7 +487,10 @@ mod tests {
     #[test]
     fn test_config_source_display() {
         assert_eq!(format!("{}", ConfigSource::LocalFile), "config file");
-        assert_eq!(format!("{}", ConfigSource::Environment), "environment variable");
+        assert_eq!(
+            format!("{}", ConfigSource::Environment),
+            "environment variable"
+        );
         assert_eq!(format!("{}", ConfigSource::Default), "default");
         assert_eq!(
             format!("{}", ConfigSource::Profile("prod".to_string())),
@@ -424,13 +532,20 @@ mod tests {
     #[test]
     fn test_save_and_load_profile_roundtrip() {
         let dir = tempdir();
-        let path = save_profile_to_dir(&dir, "prod", "https://api.example.com", Some("hsk_abc"))
-            .unwrap();
+        let path = save_profile_to_dir(
+            &dir,
+            "prod",
+            "https://api.example.com",
+            Some("hsk_abc"),
+            None,
+        )
+        .unwrap();
         assert!(path.exists());
 
-        let (url, key) = load_profile_from_dir(&dir, "prod").unwrap();
+        let (url, key, recall_score_min) = load_profile_from_dir(&dir, "prod").unwrap();
         assert_eq!(url, "https://api.example.com");
         assert_eq!(key.as_deref(), Some("hsk_abc"));
+        assert_eq!(recall_score_min, None);
 
         #[cfg(unix)]
         {
@@ -443,8 +558,17 @@ mod tests {
     #[test]
     fn test_save_profile_rejects_invalid_url() {
         let dir = tempdir();
-        let err = save_profile_to_dir(&dir, "foo", "localhost:8888", None).unwrap_err();
+        let err = save_profile_to_dir(&dir, "foo", "localhost:8888", None, None).unwrap_err();
         assert!(err.to_string().contains("Invalid API URL"));
+    }
+
+    #[test]
+    fn test_save_profile_persists_recall_score_min() {
+        let dir = tempdir();
+        save_profile_to_dir(&dir, "prod", "https://api.example.com", None, Some(0.6)).unwrap();
+
+        let (_, _, recall_score_min) = load_profile_from_dir(&dir, "prod").unwrap();
+        assert_eq!(recall_score_min, Some(0.6));
     }
 
     #[test]
@@ -460,16 +584,32 @@ mod tests {
         let dir = tempdir();
         let path = dir.join("broken.toml");
         std::fs::write(&path, "api_key = \"x\"\n").unwrap();
-        let err = load_profile_from_dir(&dir, "broken").unwrap_err().to_string();
+        let err = load_profile_from_dir(&dir, "broken")
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("missing required 'api_url'"));
+    }
+
+    #[test]
+    fn test_load_profile_parses_recall_score_min() {
+        let dir = tempdir();
+        let path = dir.join("prod.toml");
+        std::fs::write(
+            &path,
+            "api_url = \"https://api.example.com\"\nrecall_score_min = 0.4\n",
+        )
+        .unwrap();
+
+        let (_, _, recall_score_min) = load_profile_from_dir(&dir, "prod").unwrap();
+        assert_eq!(recall_score_min, Some(0.4));
     }
 
     #[test]
     fn test_list_profiles_returns_sorted_names() {
         let dir = tempdir();
-        save_profile_to_dir(&dir, "prod", "https://prod.example.com", None).unwrap();
-        save_profile_to_dir(&dir, "dev", "https://dev.example.com", None).unwrap();
-        save_profile_to_dir(&dir, "staging", "https://staging.example.com", None).unwrap();
+        save_profile_to_dir(&dir, "prod", "https://prod.example.com", None, None).unwrap();
+        save_profile_to_dir(&dir, "dev", "https://dev.example.com", None, None).unwrap();
+        save_profile_to_dir(&dir, "staging", "https://staging.example.com", None, None).unwrap();
         // Non-toml files should be ignored.
         std::fs::write(dir.join("README"), "hi").unwrap();
 
@@ -489,11 +629,13 @@ mod tests {
         let config = Config::validate_and_create(
             "http://localhost:8888".to_string(),
             None,
+            DEFAULT_RECALL_SCORE_MIN,
             ConfigSource::Default,
         );
         assert!(config.is_ok());
         let config = config.unwrap();
         assert_eq!(config.api_url, "http://localhost:8888");
+        assert_eq!(config.recall_score_min, DEFAULT_RECALL_SCORE_MIN);
         assert_eq!(config.source, ConfigSource::Default);
     }
 
@@ -502,12 +644,14 @@ mod tests {
         let config = Config::validate_and_create(
             "https://api.example.com".to_string(),
             Some("secret-key".to_string()),
+            0.5,
             ConfigSource::Environment,
         );
         assert!(config.is_ok());
         let config = config.unwrap();
         assert_eq!(config.api_url, "https://api.example.com");
         assert_eq!(config.api_key, Some("secret-key".to_string()));
+        assert_eq!(config.recall_score_min, 0.5);
         assert_eq!(config.source, ConfigSource::Environment);
     }
 
@@ -516,6 +660,7 @@ mod tests {
         let config = Config::validate_and_create(
             "localhost:8888".to_string(),
             None,
+            DEFAULT_RECALL_SCORE_MIN,
             ConfigSource::Default,
         );
         assert!(config.is_err());
@@ -529,9 +674,34 @@ mod tests {
         let config = Config::validate_and_create(
             "ftp://example.com".to_string(),
             None,
+            DEFAULT_RECALL_SCORE_MIN,
             ConfigSource::Default,
         );
         assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_parse_recall_score_min_rejects_invalid_values() {
+        assert!(parse_recall_score_min("-0.1", "recall_score_min").is_err());
+        assert!(parse_recall_score_min("1.1", "recall_score_min").is_err());
+        assert!(parse_recall_score_min("nan", "recall_score_min").is_err());
+        assert!(parse_recall_score_min("not-a-number", "recall_score_min").is_err());
+    }
+
+    #[test]
+    fn test_parse_recall_score_min_accepts_bounds() {
+        assert_eq!(
+            parse_recall_score_min("0", "recall_score_min").unwrap(),
+            0.0
+        );
+        assert_eq!(
+            parse_recall_score_min("1", "recall_score_min").unwrap(),
+            1.0
+        );
+        assert_eq!(
+            parse_recall_score_min("0.25", "recall_score_min").unwrap(),
+            0.25
+        );
     }
 
     #[test]
@@ -585,22 +755,13 @@ mod tests {
 
     #[test]
     fn test_parse_config_value_wrong_key() {
-        assert_eq!(
-            parse_config_value("api_key = secret", "api_url"),
-            None
-        );
+        assert_eq!(parse_config_value("api_key = secret", "api_url"), None);
     }
 
     #[test]
     fn test_parse_config_value_empty() {
-        assert_eq!(
-            parse_config_value("api_url = ", "api_url"),
-            None
-        );
-        assert_eq!(
-            parse_config_value("api_url = \"\"", "api_url"),
-            None
-        );
+        assert_eq!(parse_config_value("api_url = ", "api_url"), None);
+        assert_eq!(parse_config_value("api_url = \"\"", "api_url"), None);
     }
 
     #[test]
@@ -608,6 +769,7 @@ mod tests {
         let config = Config {
             api_url: "http://test:8080".to_string(),
             api_key: None,
+            recall_score_min: DEFAULT_RECALL_SCORE_MIN,
             source: ConfigSource::Default,
         };
         assert_eq!(config.api_url(), "http://test:8080");

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1921,15 +1921,18 @@ fn handle_configure(
 
     // Use provided api_key, or keep existing one if not provided
     let new_api_key = api_key.or_else(|| current_config.as_ref().and_then(|c| c.api_key.clone()));
+    let new_recall_score_min =
+        recall_score_min.or_else(|| current_config.as_ref().map(|c| c.recall_score_min));
 
     // Save to config file
-    let config_path = Config::save_config(&new_api_url, new_api_key.as_deref(), recall_score_min)?;
+    let config_path =
+        Config::save_config(&new_api_url, new_api_key.as_deref(), new_recall_score_min)?;
 
     if output_format == OutputFormat::Pretty {
         ui::print_success(&format!("Configuration saved to {}", config_path.display()));
         println!();
         println!("  API URL: {}", new_api_url);
-        if let Some(score_min) = recall_score_min {
+        if let Some(score_min) = new_recall_score_min {
             println!("  Recall score min: {}", score_min);
         }
         if let Some(ref key) = new_api_key {
@@ -1946,7 +1949,7 @@ fn handle_configure(
         let result = serde_json::json!({
             "api_url": new_api_url,
             "api_key_set": new_api_key.is_some(),
-            "recall_score_min": recall_score_min,
+            "recall_score_min": new_recall_score_min,
             "config_path": config_path.display().to_string(),
         });
         output::print_output(&result, output_format)?;

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -135,7 +135,7 @@ enum Commands {
 
     /// Configure the CLI (API URL, API key, etc.)
     #[command(
-        after_help = "Configuration priority:\n  1. Environment variables (HINDSIGHT_API_URL, HINDSIGHT_API_KEY) - highest priority\n  2. Named profile (-p / HINDSIGHT_PROFILE, see 'hindsight profile')\n  3. Config file (~/.hindsight/config)\n  4. Default (http://localhost:8888)"
+        after_help = "Configuration priority:\n  1. Environment variables (HINDSIGHT_API_URL, HINDSIGHT_API_KEY, HINDSIGHT_RECALL_SCORE_MIN) - highest priority\n  2. Named profile (-p / HINDSIGHT_PROFILE, see 'hindsight profile')\n  3. Config file (~/.hindsight/config)\n  4. Default (http://localhost:8888)"
     )]
     Configure {
         /// API URL to connect to (interactive prompt if not provided)
@@ -144,6 +144,9 @@ enum Commands {
         /// API key for authentication (sent as Bearer token)
         #[arg(long)]
         api_key: Option<String>,
+        /// Minimum recall score required for CLI recall results (0.0 to 1.0)
+        #[arg(long)]
+        recall_score_min: Option<f64>,
     },
 
     /// Manage named connection profiles (~/.hindsight/cli-profiles/<name>.toml)
@@ -163,6 +166,9 @@ enum ProfileCommands {
         /// API key (optional; stored in profile file with 0600 permissions)
         #[arg(long)]
         api_key: Option<String>,
+        /// Minimum recall score required for CLI recall results (0.0 to 1.0)
+        #[arg(long)]
+        recall_score_min: Option<f64>,
     },
     /// List all known profiles
     List,
@@ -1155,8 +1161,13 @@ fn run() -> Result<()> {
     let profile = cli.profile.clone();
 
     // Handle configure command before loading full config (it doesn't need API client)
-    if let Commands::Configure { api_url, api_key } = cli.command {
-        return handle_configure(api_url, api_key, output_format);
+    if let Commands::Configure {
+        api_url,
+        api_key,
+        recall_score_min,
+    } = cli.command
+    {
+        return handle_configure(api_url, api_key, recall_score_min, output_format);
     }
 
     // Handle profile management commands — no API client required.
@@ -1180,9 +1191,10 @@ fn run() -> Result<()> {
     let api_key = config.api_key.clone();
 
     // Create API client
-    let client = ApiClient::new(api_url.clone(), api_key).unwrap_or_else(|e| {
-        errors::handle_api_error(e, &api_url);
-    });
+    let client =
+        ApiClient::new(api_url.clone(), api_key, config.recall_score_min).unwrap_or_else(|e| {
+            errors::handle_api_error(e, &api_url);
+        });
 
     // Execute command and handle errors
     let result: Result<()> = match cli.command {
@@ -1860,6 +1872,7 @@ fn run() -> Result<()> {
 fn handle_configure(
     api_url: Option<String>,
     api_key: Option<String>,
+    recall_score_min: Option<f64>,
     output_format: OutputFormat,
 ) -> Result<()> {
     // Load current config to show current state
@@ -1881,6 +1894,7 @@ fn handle_configure(
                 };
                 println!("  Current API Key: {}", masked);
             }
+            println!("  Current recall score min: {}", config.recall_score_min);
             println!("  Source: {}", config.source);
             println!();
         }
@@ -1909,12 +1923,15 @@ fn handle_configure(
     let new_api_key = api_key.or_else(|| current_config.as_ref().and_then(|c| c.api_key.clone()));
 
     // Save to config file
-    let config_path = Config::save_config(&new_api_url, new_api_key.as_deref())?;
+    let config_path = Config::save_config(&new_api_url, new_api_key.as_deref(), recall_score_min)?;
 
     if output_format == OutputFormat::Pretty {
         ui::print_success(&format!("Configuration saved to {}", config_path.display()));
         println!();
         println!("  API URL: {}", new_api_url);
+        if let Some(score_min) = recall_score_min {
+            println!("  Recall score min: {}", score_min);
+        }
         if let Some(ref key) = new_api_key {
             let masked = if key.len() > 8 {
                 format!("{}...{}", &key[..4], &key[key.len() - 4..])
@@ -1929,6 +1946,7 @@ fn handle_configure(
         let result = serde_json::json!({
             "api_url": new_api_url,
             "api_key_set": new_api_key.is_some(),
+            "recall_score_min": recall_score_min,
             "config_path": config_path.display().to_string(),
         });
         output::print_output(&result, output_format)?;
@@ -1998,12 +2016,16 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
             name,
             api_url,
             api_key,
+            recall_score_min,
         } => {
-            let path = Config::save_profile(&name, &api_url, api_key.as_deref())?;
+            let path = Config::save_profile(&name, &api_url, api_key.as_deref(), recall_score_min)?;
             if output_format == OutputFormat::Pretty {
                 ui::print_success(&format!("Profile '{}' saved to {}", name, path.display()));
                 println!();
                 println!("  API URL: {}", api_url);
+                if let Some(score_min) = recall_score_min {
+                    println!("  Recall score min: {}", score_min);
+                }
                 if let Some(ref key) = api_key {
                     println!("  API Key: {}", mask_api_key(key));
                 }
@@ -2017,6 +2039,7 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
                     "name": name,
                     "api_url": api_url,
                     "api_key_set": api_key.is_some(),
+                    "recall_score_min": recall_score_min,
                     "path": path.display().to_string(),
                 });
                 output::print_output(&result, output_format)?;
@@ -2042,7 +2065,7 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
             Ok(())
         }
         ProfileCommands::Show { name } => {
-            let (api_url, api_key) = Config::load_profile(&name)?;
+            let (api_url, api_key, recall_score_min) = Config::load_profile(&name)?;
             let path = Config::profile_file_path(&name)
                 .map(|p| p.display().to_string())
                 .unwrap_or_default();
@@ -2051,6 +2074,7 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
                 println!();
                 println!("  Path:    {}", path);
                 println!("  API URL: {}", api_url);
+                println!("  Recall score min: {}", recall_score_min.unwrap_or(0.25));
                 if let Some(ref key) = api_key {
                     println!("  API Key: {}", mask_api_key(key));
                 }
@@ -2060,6 +2084,7 @@ fn handle_profile(cmd: ProfileCommands, output_format: OutputFormat) -> Result<(
                     "path": path,
                     "api_url": api_url,
                     "api_key_set": api_key.is_some(),
+                    "recall_score_min": recall_score_min.unwrap_or(0.25),
                 });
                 output::print_output(&result, output_format)?;
             }

--- a/hindsight-cli/src/utils.rs
+++ b/hindsight-cli/src/utils.rs
@@ -1,12 +1,16 @@
-use anyhow::{Context, Result};
 use crate::api::ApiClient;
 use crate::config::Config;
 use crate::output::OutputFormat;
+use anyhow::{Context, Result};
 
 /// Get API client from config
 pub fn get_client(config: &Config) -> Result<ApiClient> {
-    ApiClient::new(config.api_url.clone(), config.api_key.clone())
-        .context("Failed to create API client")
+    ApiClient::new(
+        config.api_url.clone(),
+        config.api_key.clone(),
+        config.recall_score_min,
+    )
+    .context("Failed to create API client")
 }
 
 /// Get output format, preferring CLI arg over default

--- a/hindsight-cli/tests/cli_profile.rs
+++ b/hindsight-cli/tests/cli_profile.rs
@@ -83,6 +83,37 @@ fn stderr(out: &Output) -> String {
 }
 
 #[test]
+fn configure_preserves_existing_recall_score_min_when_omitted() {
+    let home = unique_tempdir("configure-score-preserve");
+    let out = run_with_home(
+        &home,
+        &[
+            "configure",
+            "--api-url",
+            "https://api.example.com",
+            "--recall-score-min",
+            "0",
+        ],
+    );
+    assert_success(&out);
+
+    let out = run_with_home(
+        &home,
+        &[
+            "configure",
+            "--api-url",
+            "https://other.example.com",
+        ],
+    );
+    assert_success(&out);
+
+    let path = home.join(".hindsight/config");
+    let body = std::fs::read_to_string(&path).unwrap();
+    assert!(body.contains("api_url = \"https://other.example.com\""));
+    assert!(body.contains("recall_score_min = 0"));
+}
+
+#[test]
 fn profile_create_writes_toml_and_json_output() {
     let home = unique_tempdir("create");
     let out = run_with_home(

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -7030,6 +7030,7 @@ components:
           source: slack
         occurred_end: 2024-01-15T10:30:00Z
         occurred_start: 2024-01-15T10:30:00Z
+        score: 0.95
         tags:
         - user_a
         - user_b
@@ -7072,6 +7073,9 @@ components:
         chunk_id:
           nullable: true
           type: string
+        score:
+          nullable: true
+          type: number
         tags:
           items:
             type: string

--- a/hindsight-clients/go/model_recall_result.go
+++ b/hindsight-clients/go/model_recall_result.go
@@ -699,3 +699,4 @@ func (v *NullableRecallResult) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
+

--- a/hindsight-clients/go/model_recall_result.go
+++ b/hindsight-clients/go/model_recall_result.go
@@ -32,6 +32,7 @@ type RecallResult struct {
 	DocumentId NullableString `json:"document_id,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 	ChunkId NullableString `json:"chunk_id,omitempty"`
+	Score NullableFloat32 `json:"score,omitempty"`
 	Tags []string `json:"tags,omitempty"`
 	SourceFactIds []string `json:"source_fact_ids,omitempty"`
 }
@@ -465,6 +466,48 @@ func (o *RecallResult) UnsetChunkId() {
 	o.ChunkId.Unset()
 }
 
+// GetScore returns the Score field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *RecallResult) GetScore() float32 {
+	if o == nil || IsNil(o.Score.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.Score.Get()
+}
+
+// GetScoreOk returns a tuple with the Score field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RecallResult) GetScoreOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Score.Get(), o.Score.IsSet()
+}
+
+// HasScore returns a boolean if a field has been set.
+func (o *RecallResult) HasScore() bool {
+	if o != nil && o.Score.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetScore gets a reference to the given NullableFloat32 and assigns it to the Score field.
+func (o *RecallResult) SetScore(v float32) {
+	o.Score.Set(&v)
+}
+// SetScoreNil sets the value for Score to be an explicit nil
+func (o *RecallResult) SetScoreNil() {
+	o.Score.Set(nil)
+}
+
+// UnsetScore ensures that no value is present for Score, not even an explicit nil
+func (o *RecallResult) UnsetScore() {
+	o.Score.Unset()
+}
+
 // GetTags returns the Tags field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *RecallResult) GetTags() []string {
 	if o == nil {
@@ -570,6 +613,9 @@ func (o RecallResult) ToMap() (map[string]interface{}, error) {
 	if o.ChunkId.IsSet() {
 		toSerialize["chunk_id"] = o.ChunkId.Get()
 	}
+	if o.Score.IsSet() {
+		toSerialize["score"] = o.Score.Get()
+	}
 	if o.Tags != nil {
 		toSerialize["tags"] = o.Tags
 	}
@@ -652,5 +698,4 @@ func (v *NullableRecallResult) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
 

--- a/hindsight-clients/python/hindsight_client_api/models/recall_result.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_result.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -37,9 +37,10 @@ class RecallResult(BaseModel):
     document_id: Optional[StrictStr] = None
     metadata: Optional[Dict[str, StrictStr]] = None
     chunk_id: Optional[StrictStr] = None
+    score: Optional[StrictFloat | StrictInt] = None
     tags: Optional[List[StrictStr]] = None
     source_fact_ids: Optional[List[StrictStr]] = None
-    __properties: ClassVar[List[str]] = ["id", "text", "type", "entities", "context", "occurred_start", "occurred_end", "mentioned_at", "document_id", "metadata", "chunk_id", "tags", "source_fact_ids"]
+    __properties: ClassVar[List[str]] = ["id", "text", "type", "entities", "context", "occurred_start", "occurred_end", "mentioned_at", "document_id", "metadata", "chunk_id", "score", "tags", "source_fact_ids"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -125,6 +126,11 @@ class RecallResult(BaseModel):
         if self.chunk_id is None and "chunk_id" in self.model_fields_set:
             _dict['chunk_id'] = None
 
+        # set to None if score (nullable) is None
+        # and model_fields_set contains the field
+        if self.score is None and "score" in self.model_fields_set:
+            _dict['score'] = None
+
         # set to None if tags (nullable) is None
         # and model_fields_set contains the field
         if self.tags is None and "tags" in self.model_fields_set:
@@ -158,9 +164,9 @@ class RecallResult(BaseModel):
             "document_id": obj.get("document_id"),
             "metadata": obj.get("metadata"),
             "chunk_id": obj.get("chunk_id"),
+            "score": obj.get("score"),
             "tags": obj.get("tags"),
             "source_fact_ids": obj.get("source_fact_ids")
         })
         return _obj
-
 

--- a/hindsight-clients/python/hindsight_client_api/models/recall_result.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_result.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -37,7 +37,7 @@ class RecallResult(BaseModel):
     document_id: Optional[StrictStr] = None
     metadata: Optional[Dict[str, StrictStr]] = None
     chunk_id: Optional[StrictStr] = None
-    score: Optional[StrictFloat | StrictInt] = None
+    score: Optional[Union[StrictFloat, StrictInt]] = None
     tags: Optional[List[StrictStr]] = None
     source_fact_ids: Optional[List[StrictStr]] = None
     __properties: ClassVar[List[str]] = ["id", "text", "type", "entities", "context", "occurred_start", "occurred_end", "mentioned_at", "document_id", "metadata", "chunk_id", "score", "tags", "source_fact_ids"]
@@ -169,4 +169,5 @@ class RecallResult(BaseModel):
             "source_fact_ids": obj.get("source_fact_ids")
         })
         return _obj
+
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2885,6 +2885,10 @@ export type RecallResult = {
    */
   chunk_id?: string | null;
   /**
+   * Score
+   */
+  score?: number | null;
+  /**
    * Tags
    */
   tags?: Array<string> | null;

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -343,7 +343,7 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 The main list of recalled facts, ordered by relevance. Relevance is computed by running four retrieval strategies in parallel — semantic similarity, BM25 keyword, graph traversal, and temporal — fusing their rankings with Reciprocal Rank Fusion (RRF), then re-scoring the merged candidates with a cross-encoder reranker against the original query.
 
-Results do not include a numeric score. Raw retrieval scores are not meaningful on an absolute scale — a score of 0.8 from one query tells you nothing useful compared to a score of 0.8 from another. What matters is the relative ordering, which is already reflected in the list order. Agents should consume memories in order and let `max_tokens` determine how many fit, rather than filtering by score.
+Each result includes a `score` field with the normalized query-memory relevance score from the reranker. Higher scores mean the result is more relevant to the current query. Scores are most useful for client-side filtering within one recall response; they should not be treated as a stable absolute scale across unrelated queries.
 
 Each item in `results` has the following fields:
 
@@ -390,6 +390,10 @@ The document ID this fact belongs to, as set during retain.
 #### chunk_id
 
 The ID of the source text chunk this fact was extracted from. Used to cross-reference with `chunks` in the response when `include.chunks` is enabled.
+
+#### score
+
+The normalized relevance score for this result. Higher values are more relevant to the recall query.
 
 #### source_fact_ids
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10839,6 +10839,17 @@
             ],
             "title": "Chunk Id"
           },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
           "tags": {
             "anyOf": [
               {
@@ -10890,6 +10901,7 @@
           },
           "occurred_end": "2024-01-15T10:30:00Z",
           "occurred_start": "2024-01-15T10:30:00Z",
+          "score": 0.95,
           "tags": [
             "user_a",
             "user_b"

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -223,6 +223,7 @@ Auto-recall runs on every user prompt. It queries Hindsight for relevant memorie
 | `autoRecall` | `HINDSIGHT_AUTO_RECALL` | `true` | Master switch for auto-recall. Set to `false` to disable memory retrieval entirely. |
 | `recallBudget` | `HINDSIGHT_RECALL_BUDGET` | `"mid"` | Controls how hard Hindsight searches for memories. `"low"` = fast, fewer strategies; `"mid"` = balanced; `"high"` = thorough, slower. Affects latency directly. |
 | `recallMaxTokens` | `HINDSIGHT_RECALL_MAX_TOKENS` | `1024` | Maximum number of tokens in the recalled memory block. Lower values reduce context usage but may truncate relevant memories. |
+| `recallScoreMin` | `HINDSIGHT_RECALL_SCORE_MIN` | `0.25` | Minimum recall score required for auto-recall and knowledge-tool recall results. |
 | `recallTypes` | — | `["observation"]` | Which memory types to retrieve. `"world"` = general facts; `"experience"` = personal experiences; `"observation"` = consolidated, deduplicated beliefs built from multiple facts. Defaults to observations so the same answer doesn't surface multiple times when many raw memories say the same thing. |
 | `recallContextTurns` | `HINDSIGHT_RECALL_CONTEXT_TURNS` | `1` | How many prior conversation turns to include when composing the recall query. `1` = only the latest user message; higher values give more context but may dilute the query. |
 | `recallMaxQueryChars` | `HINDSIGHT_RECALL_MAX_QUERY_CHARS` | `800` | Maximum character length of the query sent to Hindsight. Longer queries are truncated. |

--- a/hindsight-integrations/claude-code/scripts/lib/config.py
+++ b/hindsight-integrations/claude-code/scripts/lib/config.py
@@ -5,6 +5,7 @@ variable overrides. Full config schema matching Openclaw's 30+ options.
 """
 
 import json
+import math
 import os
 import sys
 
@@ -13,6 +14,7 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    "recallScoreMin": 0.25,
     "recallTypes": ["observation"],
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
@@ -71,6 +73,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recallScoreMin", float),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),
@@ -93,9 +96,21 @@ def _cast_env(value: str, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config: dict) -> None:
+    try:
+        value = float(config.get("recallScoreMin", DEFAULTS["recallScoreMin"]))
+    except (TypeError, ValueError):
+        value = DEFAULTS["recallScoreMin"]
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = DEFAULTS["recallScoreMin"]
+    config["recallScoreMin"] = value
 
 
 def _load_settings_file(path: str, config: dict) -> None:
@@ -143,6 +158,7 @@ def load_config() -> dict:
             if cast_val is not None:
                 config[key] = cast_val
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -199,6 +199,24 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 # ---------------------------------------------------------------------------
 
 
+def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results: list) -> str:
     """Format recall results into human-readable text.
 

--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -200,7 +200,7 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
 
 def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -208,10 +208,15 @@ def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -19,12 +19,12 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Launched via scripts/run_mcp.sh which execs the venv's interpreter, so
 # `mcp` and friends resolve from ${CLAUDE_PLUGIN_DATA}/venv/site-packages.
-from mcp.server.fastmcp import FastMCP
-
+from lib.bank import derive_bank_id
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
+from lib.content import filter_memories_by_score
 from lib.daemon import get_api_url
-from lib.bank import derive_bank_id
+from mcp.server.fastmcp import FastMCP
 
 # ── Server setup ────────────────────────────────────────
 
@@ -32,7 +32,10 @@ mcp = FastMCP("hindsight")
 
 # Resolve config at startup
 _config = load_config()
-_dbg = lambda *a: debug_log(_config, *a)
+
+
+def _dbg(*args):
+    debug_log(_config, *args)
 
 if not _config.get("enableKnowledgeTools"):
     # Knowledge tools are opt-out. When disabled we must NOT exit: the plugin
@@ -163,6 +166,7 @@ def agent_knowledge_delete_page(page_id: str) -> str:
 def agent_knowledge_recall(query: str, max_tokens: int = 1024) -> str:
     """Search across all retained conversations and documents for specific facts, numbers, or details not covered by your knowledge pages. max_tokens is the result token budget (server returns whatever fits)."""
     resp = _client.recall(bank_id=_default_bank_id, query=query, max_tokens=max_tokens, budget="mid", timeout=10)
+    resp["results"] = filter_memories_by_score(resp.get("results", []), _config.get("recallScoreMin", 0.25))
     return json.dumps(resp, indent=2)
 
 

--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -31,6 +31,7 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     truncate_recall_query,
@@ -180,6 +181,8 @@ def main():
                 results = results + extra_results
         except Exception as e:
             debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
+
+    results = filter_memories_by_score(results, config.get("recallScoreMin", 0.25))
 
     if not results:
         debug_log(config, "No memories found")

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -8,6 +8,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTypes": ["observation"],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,

--- a/hindsight-integrations/claude-code/tests/conftest.py
+++ b/hindsight-integrations/claude-code/tests/conftest.py
@@ -73,8 +73,8 @@ def make_recall_response(memories):
     return {"results": memories}
 
 
-def make_memory(text, mem_type="experience", mentioned_at="2024-01-15"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def make_memory(text, mem_type="experience", mentioned_at="2024-01-15", score=0.9):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at, "score": score}
 
 
 class FakeHTTPResponse:

--- a/hindsight-integrations/claude-code/tests/test_config.py
+++ b/hindsight-integrations/claude-code/tests/test_config.py
@@ -4,7 +4,6 @@ import json
 import os
 
 import pytest
-
 from lib.config import _cast_env, load_config
 
 
@@ -20,8 +19,14 @@ class TestCastEnv:
     def test_int_cast(self):
         assert _cast_env("42", int) == 42
 
+    def test_float_cast(self):
+        assert _cast_env("0.3", float) == 0.3
+
     def test_int_invalid_returns_none(self):
         assert _cast_env("notanint", int) is None
+
+    def test_float_invalid_returns_none(self):
+        assert _cast_env("notafloat", float) is None
 
     def test_str_passthrough(self):
         assert _cast_env("hello", str) == "hello"
@@ -43,6 +48,7 @@ class TestLoadConfig:
         assert cfg["autoRecall"] is True
         assert cfg["autoRetain"] is True
         assert cfg["recallBudget"] == "mid"
+        assert cfg["recallScoreMin"] == 0.25
         assert cfg["retainEveryNTurns"] == 10
 
     def test_settings_json_overrides_defaults(self, tmp_path, monkeypatch):
@@ -70,6 +76,12 @@ class TestLoadConfig:
         monkeypatch.setenv("HINDSIGHT_API_PORT", "9999")
         cfg = load_config()
         assert cfg["apiPort"] == 9999
+
+    def test_float_env_var_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.6
 
     def test_request_timeout_default_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -3,11 +3,11 @@
 import re
 
 import pytest
-
 from lib.content import (
     _extract_text_content,
     _is_channel_message_tool,
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     prepare_retention_transcript,
@@ -16,7 +16,6 @@ from lib.content import (
     strip_memory_tags,
     truncate_recall_query,
 )
-
 
 # ---------------------------------------------------------------------------
 # strip_channel_envelope
@@ -200,6 +199,20 @@ class TestTruncateRecallQuery:
 
 
 class TestFormatMemories:
+    def test_filter_memories_by_score_keeps_threshold_and_above(self):
+        mems = [
+            {"text": "weak", "score": 0.24},
+            {"text": "edge", "score": 0.25},
+            {"text": "strong", "score": 0.9},
+        ]
+        result = filter_memories_by_score(mems, 0.25)
+        assert [m["text"] for m in result] == ["edge", "strong"]
+
+    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+        mems = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
+        assert filter_memories_by_score(mems, 0.25) == []
+        assert [m["text"] for m in filter_memories_by_score(mems, 0.0)] == ["missing", "zero"]
+
     def test_formats_single_memory(self):
         mems = [{"text": "Paris is the capital", "type": "world", "mentioned_at": "2024-01-01"}]
         result = format_memories(mems)

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -208,9 +208,9 @@ class TestFormatMemories:
         result = filter_memories_by_score(mems, 0.25)
         assert [m["text"] for m in result] == ["edge", "strong"]
 
-    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+    def test_filter_memories_by_score_passes_missing_score_through(self):
         mems = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
-        assert filter_memories_by_score(mems, 0.25) == []
+        assert [m["text"] for m in filter_memories_by_score(mems, 0.25)] == ["missing"]
         assert [m["text"] for m in filter_memories_by_score(mems, 0.0)] == ["missing", "zero"]
 
     def test_formats_single_memory(self):

--- a/hindsight-integrations/cline/README.md
+++ b/hindsight-integrations/cline/README.md
@@ -75,6 +75,7 @@ Defaults live in the installed `settings.json`; put personal overrides in `~/.hi
 | `autoRecall`        | `true`                   | Inject memories before tasks/prompts.                             |
 | `autoRetain`        | `true`                   | Retain the task transcript when it ends.                          |
 | `recallBudget`      | `mid`                    | Recall depth: `low` / `mid` / `high`.                             |
+| `recallScoreMin`    | `0.25`                   | Minimum recall score required for injected memories.               |
 | `recallTypes`       | `["world","experience"]` | Memory types to recall.                                           |
 | `dynamicBankId`     | `false`                  | Separate bank per project/session (see `dynamicBankGranularity`). |
 | `debug`             | `false`                  | Log to stderr.                                                    |

--- a/hindsight-integrations/cline/hindsight_cline/hooks/lib/config.py
+++ b/hindsight-integrations/cline/hindsight_cline/hooks/lib/config.py
@@ -9,6 +9,7 @@ keys (see the integration README for the rationale).
 """
 
 import json
+import math
 import os
 import re
 import sys
@@ -26,6 +27,7 @@ class HindsightClineConfig:
     auto_recall: bool = True
     recall_budget: str = "mid"
     recall_max_tokens: int = 1024
+    recall_score_min: float = 0.25
     recall_timeout: int = 10
     recall_types: list[str] = field(default_factory=lambda: ["world", "experience"])
     recall_context_turns: int = 1
@@ -76,6 +78,7 @@ ENV_OVERRIDES: dict[str, tuple[str, type]] = {
     "HINDSIGHT_AUTO_RETAIN": ("auto_retain", bool),
     "HINDSIGHT_RECALL_BUDGET": ("recall_budget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recall_max_tokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recall_score_min", float),
     "HINDSIGHT_RECALL_TIMEOUT": ("recall_timeout", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recall_max_query_chars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recall_context_turns", int),
@@ -116,9 +119,21 @@ def _cast_env(value: str, typ: type) -> Any:
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config: HindsightClineConfig) -> None:
+    try:
+        value = float(config.recall_score_min)
+    except (TypeError, ValueError):
+        value = HindsightClineConfig.recall_score_min
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = HindsightClineConfig.recall_score_min
+    config.recall_score_min = value
 
 
 def _merge_settings_file(path: str, config: HindsightClineConfig) -> None:
@@ -162,6 +177,7 @@ def load_config() -> HindsightClineConfig:
             if cast_val is not None:
                 setattr(config, field_name, cast_val)
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/cline/hindsight_cline/hooks/lib/content.py
+++ b/hindsight-integrations/cline/hindsight_cline/hooks/lib/content.py
@@ -160,7 +160,7 @@ def truncate_recall_query(query: str, latest_query: str, max_chars: int) -> str:
 
 
 def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -168,10 +168,15 @@ def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/cline/hindsight_cline/hooks/lib/content.py
+++ b/hindsight-integrations/cline/hindsight_cline/hooks/lib/content.py
@@ -159,6 +159,24 @@ def truncate_recall_query(query: str, latest_query: str, max_chars: int) -> str:
     return latest_only
 
 
+def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results: list) -> str:
     """Format recall results into human-readable bullet lines."""
     if not results:

--- a/hindsight-integrations/cline/hindsight_cline/hooks/lib/hooks_impl.py
+++ b/hindsight-integrations/cline/hindsight_cline/hooks/lib/hooks_impl.py
@@ -48,6 +48,7 @@ def _recall_context(hook: HookInput, config: HindsightClineConfig, query: str) -
         timeout=config.recall_timeout,
     )
     results = resp.get("results", []) if isinstance(resp, dict) else []
+    results = content.filter_memories_by_score(results, config.recall_score_min)
     memories = content.format_memories(results)
     if not memories:
         return ""

--- a/hindsight-integrations/cline/hindsight_cline/hooks/settings.json
+++ b/hindsight-integrations/cline/hindsight_cline/hooks/settings.json
@@ -8,6 +8,7 @@
   "autoRecall": true,
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTimeout": 10,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,

--- a/hindsight-integrations/cline/tests/conftest.py
+++ b/hindsight-integrations/cline/tests/conftest.py
@@ -50,8 +50,8 @@ def make_hook(hook_name="UserPromptSubmit", prompt="", task="", task_id="t1", wo
     )
 
 
-def make_memory(text, mem_type="experience", mentioned_at="2026-01-15"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def make_memory(text, mem_type="experience", mentioned_at="2026-01-15", score=0.9):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at, "score": score}
 
 
 class _FakeHTTPResponse:

--- a/hindsight-integrations/cline/tests/test_config.py
+++ b/hindsight-integrations/cline/tests/test_config.py
@@ -1,0 +1,24 @@
+"""Configuration loading tests."""
+
+from lib.config import _cast_env, load_config
+
+
+def test_default_recall_score_min():
+    cfg = load_config()
+    assert cfg.recall_score_min == 0.25
+
+
+def test_float_env_override(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+    cfg = load_config()
+    assert cfg.recall_score_min == 0.6
+
+
+def test_invalid_float_env_is_ignored(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "not-a-float")
+    cfg = load_config()
+    assert cfg.recall_score_min == 0.25
+
+
+def test_cast_float():
+    assert _cast_env("0.3", float) == 0.3

--- a/hindsight-integrations/cline/tests/test_content.py
+++ b/hindsight-integrations/cline/tests/test_content.py
@@ -61,9 +61,9 @@ def test_filter_memories_by_score_keeps_threshold_and_above():
     assert [r["text"] for r in out] == ["edge", "strong"]
 
 
-def test_filter_memories_by_score_treats_missing_score_as_zero():
+def test_filter_memories_by_score_passes_missing_score_through():
     results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
-    assert content.filter_memories_by_score(results, 0.25) == []
+    assert [r["text"] for r in content.filter_memories_by_score(results, 0.25)] == ["missing"]
     assert [r["text"] for r in content.filter_memories_by_score(results, 0.0)] == ["missing", "zero"]
 
 

--- a/hindsight-integrations/cline/tests/test_content.py
+++ b/hindsight-integrations/cline/tests/test_content.py
@@ -51,6 +51,22 @@ def test_format_memories_empty():
     assert content.format_memories([]) == ""
 
 
+def test_filter_memories_by_score_keeps_threshold_and_above():
+    results = [
+        {"text": "weak", "score": 0.24},
+        {"text": "edge", "score": 0.25},
+        {"text": "strong", "score": 0.9},
+    ]
+    out = content.filter_memories_by_score(results, 0.25)
+    assert [r["text"] for r in out] == ["edge", "strong"]
+
+
+def test_filter_memories_by_score_treats_missing_score_as_zero():
+    results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
+    assert content.filter_memories_by_score(results, 0.25) == []
+    assert [r["text"] for r in content.filter_memories_by_score(results, 0.0)] == ["missing", "zero"]
+
+
 def test_compose_recall_query_single_turn_is_latest_only():
     msgs = [{"role": "user", "content": "old"}, {"role": "assistant", "content": "reply"}]
     assert content.compose_recall_query("latest", msgs, 1) == "latest"

--- a/hindsight-integrations/codex/README.md
+++ b/hindsight-integrations/codex/README.md
@@ -86,6 +86,7 @@ export ANTHROPIC_API_KEY=your-key
 | `retainEveryNTurns` | `10` | Retain every N turns (1 = every turn) |
 | `recallBudget` | `"mid"` | Recall depth: `"low"`, `"mid"`, `"high"` |
 | `recallMaxTokens` | `1024` | Max tokens for injected memories |
+| `recallScoreMin` | `0.25` | Minimum recall score required for injected memories |
 | `recallTimeout` | `10` | Timeout in seconds for recall API calls |
 | `dynamicBankId` | `false` | Separate bank per project/session |
 | `dynamicBankGranularity` | `["agent", "project"]` | Fields for dynamic bank ID |

--- a/hindsight-integrations/codex/scripts/lib/config.py
+++ b/hindsight-integrations/codex/scripts/lib/config.py
@@ -5,6 +5,7 @@ variable overrides. Full config schema matching Openclaw's 30+ options.
 """
 
 import json
+import math
 import os
 import sys
 
@@ -13,6 +14,7 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    "recallScoreMin": 0.25,
     "recallTimeout": 10,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
@@ -66,6 +68,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recallScoreMin", float),
     "HINDSIGHT_RECALL_TIMEOUT": ("recallTimeout", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
@@ -88,9 +91,21 @@ def _cast_env(value: str, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config: dict) -> None:
+    try:
+        value = float(config.get("recallScoreMin", DEFAULTS["recallScoreMin"]))
+    except (TypeError, ValueError):
+        value = DEFAULTS["recallScoreMin"]
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = DEFAULTS["recallScoreMin"]
+    config["recallScoreMin"] = value
 
 
 def _load_settings_file(path: str, config: dict) -> None:
@@ -135,6 +150,7 @@ def load_config() -> dict:
             if cast_val is not None:
                 config[key] = cast_val
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/codex/scripts/lib/content.py
+++ b/hindsight-integrations/codex/scripts/lib/content.py
@@ -527,6 +527,24 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 # ---------------------------------------------------------------------------
 
 
+def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results: list) -> str:
     """Format recall results into human-readable text."""
     if not results:

--- a/hindsight-integrations/codex/scripts/lib/content.py
+++ b/hindsight-integrations/codex/scripts/lib/content.py
@@ -528,7 +528,7 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
 
 def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -536,10 +536,15 @@ def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/codex/scripts/recall.py
+++ b/hindsight-integrations/codex/scripts/recall.py
@@ -30,6 +30,7 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     read_transcript,
@@ -124,7 +125,10 @@ def main():
         print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
         return
 
-    results = response.get("results", [])
+    results = filter_memories_by_score(
+        response.get("results", []),
+        config.get("recallScoreMin", 0.25),
+    )
     if not results:
         debug_log(config, "No memories found")
         return

--- a/hindsight-integrations/codex/settings.json
+++ b/hindsight-integrations/codex/settings.json
@@ -9,6 +9,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTimeout": 10,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,

--- a/hindsight-integrations/codex/tests/conftest.py
+++ b/hindsight-integrations/codex/tests/conftest.py
@@ -59,8 +59,8 @@ def make_transcript_file(tmp_path, messages, codex_format=False):
     return str(f)
 
 
-def make_memory(text, mem_type="experience", mentioned_at="2024-01-15"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def make_memory(text, mem_type="experience", mentioned_at="2024-01-15", score=0.9):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at, "score": score}
 
 
 def make_user_config(tmp_path, overrides=None):

--- a/hindsight-integrations/codex/tests/test_config.py
+++ b/hindsight-integrations/codex/tests/test_config.py
@@ -1,0 +1,33 @@
+"""Tests for lib/config.py."""
+
+import os
+
+import pytest
+
+from lib.config import _cast_env, load_config
+
+
+class TestConfig:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for key in list(os.environ):
+            if key.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(key, raising=False)
+
+    def test_default_recall_score_min(self):
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.25
+
+    def test_float_env_override(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.6
+
+    def test_invalid_float_env_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "not-a-float")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.25
+
+    def test_cast_float(self):
+        assert _cast_env("0.3", float) == 0.3

--- a/hindsight-integrations/codex/tests/test_content.py
+++ b/hindsight-integrations/codex/tests/test_content.py
@@ -8,6 +8,7 @@ import pytest
 
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_memories,
     is_synthetic_codex_user_message,
     prepare_retention_transcript,
@@ -330,6 +331,20 @@ class TestTruncateRecallQuery:
 
 
 class TestFormatMemories:
+    def test_filter_memories_by_score_keeps_threshold_and_above(self):
+        mems = [
+            {"text": "weak", "score": 0.24},
+            {"text": "edge", "score": 0.25},
+            {"text": "strong", "score": 0.9},
+        ]
+        result = filter_memories_by_score(mems, 0.25)
+        assert [m["text"] for m in result] == ["edge", "strong"]
+
+    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+        mems = [{"text": "missing"}, {"text": "disabled", "score": 0.0}]
+        assert filter_memories_by_score(mems, 0.25) == []
+        assert [m["text"] for m in filter_memories_by_score(mems, 0.0)] == ["missing", "disabled"]
+
     def test_formats_single_memory(self):
         mems = [{"text": "Paris is the capital", "type": "world", "mentioned_at": "2024-01-01"}]
         result = format_memories(mems)

--- a/hindsight-integrations/codex/tests/test_content.py
+++ b/hindsight-integrations/codex/tests/test_content.py
@@ -340,9 +340,9 @@ class TestFormatMemories:
         result = filter_memories_by_score(mems, 0.25)
         assert [m["text"] for m in result] == ["edge", "strong"]
 
-    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+    def test_filter_memories_by_score_passes_missing_score_through(self):
         mems = [{"text": "missing"}, {"text": "disabled", "score": 0.0}]
-        assert filter_memories_by_score(mems, 0.25) == []
+        assert [m["text"] for m in filter_memories_by_score(mems, 0.25)] == ["missing"]
         assert [m["text"] for m in filter_memories_by_score(mems, 0.0)] == ["missing", "disabled"]
 
     def test_formats_single_memory(self):

--- a/hindsight-integrations/cursor-cli/README.md
+++ b/hindsight-integrations/cursor-cli/README.md
@@ -81,6 +81,7 @@ Default config lives in `~/.cursor/hooks/cursor-cli/settings.json`. For personal
 | `retainEveryNTurns` | `10` | Retain every N turns (1 = every turn) |
 | `recallBudget` | `"mid"` | Recall depth: `"low"`, `"mid"`, `"high"` |
 | `recallMaxTokens` | `1024` | Max tokens for injected memories |
+| `recallScoreMin` | `0.25` | Minimum recall score required for injected memories |
 | `recallTimeout` | `10` | Timeout in seconds for recall API calls |
 | `dynamicBankId` | `false` | Separate bank per project |
 | `dynamicBankGranularity` | `["agent", "project"]` | Fields for dynamic bank ID |

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/config.py
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/config.py
@@ -14,6 +14,7 @@ integration — stable across updates.
 """
 
 import json
+import math
 import os
 import sys
 
@@ -22,6 +23,7 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    "recallScoreMin": 0.25,
     "recallTimeout": 10,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
@@ -82,6 +84,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recallScoreMin", float),
     "HINDSIGHT_RECALL_TIMEOUT": ("recallTimeout", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
@@ -104,9 +107,21 @@ def _cast_env(value, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config):
+    try:
+        value = float(config.get("recallScoreMin", DEFAULTS["recallScoreMin"]))
+    except (TypeError, ValueError):
+        value = DEFAULTS["recallScoreMin"]
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = DEFAULTS["recallScoreMin"]
+    config["recallScoreMin"] = value
 
 
 def _load_settings_file(path, config):
@@ -142,6 +157,7 @@ def load_config():
             if cast_val is not None:
                 config[key] = cast_val
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/content.py
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/content.py
@@ -406,6 +406,24 @@ def slice_last_turns_by_user_boundary(messages, turns):
 # ---------------------------------------------------------------------------
 
 
+def filter_memories_by_score(results, min_score=0.25):
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results):
     """Format recall results into human-readable text."""
     if not results:

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/content.py
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/content.py
@@ -407,7 +407,7 @@ def slice_last_turns_by_user_boundary(messages, turns):
 
 
 def filter_memories_by_score(results, min_score=0.25):
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -415,10 +415,15 @@ def filter_memories_by_score(results, min_score=0.25):
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/recall.py
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/recall.py
@@ -33,6 +33,7 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     read_transcript,
@@ -127,7 +128,10 @@ def main():
         print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
         return
 
-    results = response.get("results", [])
+    results = filter_memories_by_score(
+        response.get("results", []),
+        config.get("recallScoreMin", 0.25),
+    )
     if not results:
         debug_log(config, "No memories found")
         return

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/settings.json
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/settings.json
@@ -8,6 +8,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTimeout": 10,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,

--- a/hindsight-integrations/cursor-cli/tests/conftest.py
+++ b/hindsight-integrations/cursor-cli/tests/conftest.py
@@ -72,8 +72,8 @@ def make_transcript_file(tmp_path, messages, cursor_format=False):
     return str(f)
 
 
-def make_memory(text, mem_type="experience", mentioned_at="2024-01-15"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def make_memory(text, mem_type="experience", mentioned_at="2024-01-15", score=0.9):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at, "score": score}
 
 
 def make_user_config(tmp_path, overrides=None):

--- a/hindsight-integrations/cursor-cli/tests/test_config.py
+++ b/hindsight-integrations/cursor-cli/tests/test_config.py
@@ -1,0 +1,33 @@
+"""Tests for lib/config.py."""
+
+import os
+
+import pytest
+
+from lib.config import _cast_env, load_config
+
+
+class TestConfig:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for key in list(os.environ):
+            if key.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(key, raising=False)
+
+    def test_default_recall_score_min(self):
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.25
+
+    def test_float_env_override(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.6
+
+    def test_invalid_float_env_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "not-a-float")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.25
+
+    def test_cast_float(self):
+        assert _cast_env("0.3", float) == 0.3

--- a/hindsight-integrations/cursor-cli/tests/test_content.py
+++ b/hindsight-integrations/cursor-cli/tests/test_content.py
@@ -5,6 +5,7 @@ import os
 
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     prepare_retention_transcript,
@@ -171,6 +172,20 @@ class TestSliceLastTurns:
 
 
 class TestFormatMemories:
+    def test_filter_memories_by_score_keeps_threshold_and_above(self):
+        results = [
+            {"text": "weak", "score": 0.24},
+            {"text": "edge", "score": 0.25},
+            {"text": "strong", "score": 0.9},
+        ]
+        out = filter_memories_by_score(results, 0.25)
+        assert [r["text"] for r in out] == ["edge", "strong"]
+
+    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+        results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
+        assert filter_memories_by_score(results, 0.25) == []
+        assert [r["text"] for r in filter_memories_by_score(results, 0.0)] == ["missing", "zero"]
+
     def test_empty(self):
         assert format_memories([]) == ""
 

--- a/hindsight-integrations/cursor-cli/tests/test_content.py
+++ b/hindsight-integrations/cursor-cli/tests/test_content.py
@@ -181,9 +181,9 @@ class TestFormatMemories:
         out = filter_memories_by_score(results, 0.25)
         assert [r["text"] for r in out] == ["edge", "strong"]
 
-    def test_filter_memories_by_score_treats_missing_score_as_zero(self):
+    def test_filter_memories_by_score_passes_missing_score_through(self):
         results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
-        assert filter_memories_by_score(results, 0.25) == []
+        assert [r["text"] for r in filter_memories_by_score(results, 0.25)] == ["missing"]
         assert [r["text"] for r in filter_memories_by_score(results, 0.0)] == ["missing", "zero"]
 
     def test_empty(self):

--- a/hindsight-integrations/cursor/README.md
+++ b/hindsight-integrations/cursor/README.md
@@ -179,6 +179,7 @@ All settings live in `~/.hindsight/cursor.json`. Every setting can also be overr
 | `autoRecall` | `HINDSIGHT_AUTO_RECALL` | `true` | Enable/disable session-start recall |
 | `recallBudget` | `HINDSIGHT_RECALL_BUDGET` | `"mid"` | Search thoroughness: low, mid, high |
 | `recallMaxTokens` | `HINDSIGHT_RECALL_MAX_TOKENS` | `1024` | Max tokens in recalled memory block |
+| `recallScoreMin` | `HINDSIGHT_RECALL_SCORE_MIN` | `0.25` | Minimum recall score required for injected memories |
 | `recallTypes` | — | `["world", "experience"]` | Memory types to recall |
 | `recallMaxQueryChars` | `HINDSIGHT_RECALL_MAX_QUERY_CHARS` | `800` | Max characters in the recall query |
 | `recallPromptPreamble` | — | *(see settings.json)* | Text prepended to recalled memories |
@@ -229,4 +230,3 @@ python -m pytest tests/ -v
 ## License
 
 MIT
-

--- a/hindsight-integrations/cursor/scripts/lib/config.py
+++ b/hindsight-integrations/cursor/scripts/lib/config.py
@@ -5,6 +5,7 @@ variable overrides. Follows the same layering as the Claude Code integration.
 """
 
 import json
+import math
 import os
 import sys
 
@@ -18,6 +19,7 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    "recallScoreMin": 0.25,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
@@ -78,6 +80,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recallScoreMin", float),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),
@@ -104,9 +107,21 @@ def _cast_env(value: str, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config: dict) -> None:
+    try:
+        value = float(config.get("recallScoreMin", DEFAULTS["recallScoreMin"]))
+    except (TypeError, ValueError):
+        value = DEFAULTS["recallScoreMin"]
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = DEFAULTS["recallScoreMin"]
+    config["recallScoreMin"] = value
 
 
 def _load_settings_file(path: str, config: dict) -> None:
@@ -150,6 +165,7 @@ def load_config() -> dict:
             if cast_val is not None:
                 config[key] = cast_val
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/cursor/scripts/lib/content.py
+++ b/hindsight-integrations/cursor/scripts/lib/content.py
@@ -85,6 +85,24 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 # ---------------------------------------------------------------------------
 
 
+def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results: list) -> str:
     """Format recall results into human-readable text.
 

--- a/hindsight-integrations/cursor/scripts/lib/content.py
+++ b/hindsight-integrations/cursor/scripts/lib/content.py
@@ -86,7 +86,7 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
 
 def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -94,10 +94,15 @@ def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/cursor/scripts/session_start.py
+++ b/hindsight-integrations/cursor/scripts/session_start.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
-from lib.content import format_current_time, format_memories
+from lib.content import filter_memories_by_score, format_current_time, format_memories
 from lib.daemon import get_api_url
 from lib.rules_file import (
     ensure_gitignored,
@@ -165,7 +165,10 @@ def main():
         _write_recall_status("error", reason=str(e)[:200], bank_id=bank_id)
         return
 
-    results = response.get("results", [])
+    results = filter_memories_by_score(
+        response.get("results", []),
+        config.get("recallScoreMin", 0.25),
+    )
     if not results:
         debug_log(config, "No memories found for session start")
         _write_recall_status("empty", bank_id=bank_id, query_length=len(query))

--- a/hindsight-integrations/cursor/settings.json
+++ b/hindsight-integrations/cursor/settings.json
@@ -8,6 +8,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,

--- a/hindsight-integrations/cursor/tests/test_config.py
+++ b/hindsight-integrations/cursor/tests/test_config.py
@@ -17,6 +17,7 @@ class TestLoadConfig:
         assert config["autoRecall"] is True
         assert config["autoRetain"] is True
         assert config["recallBudget"] == "mid"
+        assert config["recallScoreMin"] == 0.25
         assert config["retainContext"] == "cursor"
         assert config["agentName"] == "cursor"
 
@@ -31,6 +32,12 @@ class TestLoadConfig:
         monkeypatch.setenv("HINDSIGHT_RECALL_MAX_TOKENS", "2048")
         config = load_config()
         assert config["recallMaxTokens"] == 2048
+
+    def test_env_overrides_float(self, monkeypatch):
+        monkeypatch.setenv("CURSOR_PLUGIN_ROOT", "/nonexistent")
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+        config = load_config()
+        assert config["recallScoreMin"] == 0.6
 
     def test_env_overrides_string(self, monkeypatch):
         monkeypatch.setenv("CURSOR_PLUGIN_ROOT", "/nonexistent")

--- a/hindsight-integrations/cursor/tests/test_content.py
+++ b/hindsight-integrations/cursor/tests/test_content.py
@@ -2,6 +2,7 @@
 
 import pytest
 from lib.content import (
+    filter_memories_by_score,
     format_memories,
     prepare_retention_transcript,
     slice_last_turns_by_user_boundary,
@@ -48,6 +49,15 @@ class TestSliceLastTurns:
 
 
 class TestFormatMemories:
+    def test_filter_memories_by_score_keeps_threshold_and_above(self):
+        results = [
+            {"text": "weak", "score": 0.24},
+            {"text": "edge", "score": 0.25},
+            {"text": "strong", "score": 0.9},
+        ]
+        out = filter_memories_by_score(results, 0.25)
+        assert [r["text"] for r in out] == ["edge", "strong"]
+
     def test_formats_with_type_and_date(self):
         results = [
             {"text": "User likes Python", "type": "world", "mentioned_at": "2026-01-01"},

--- a/hindsight-integrations/cursor/tests/test_content.py
+++ b/hindsight-integrations/cursor/tests/test_content.py
@@ -58,6 +58,11 @@ class TestFormatMemories:
         out = filter_memories_by_score(results, 0.25)
         assert [r["text"] for r in out] == ["edge", "strong"]
 
+    def test_filter_memories_by_score_passes_missing_score_through(self):
+        results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
+        assert [r["text"] for r in filter_memories_by_score(results, 0.25)] == ["missing"]
+        assert [r["text"] for r in filter_memories_by_score(results, 0.0)] == ["missing", "zero"]
+
     def test_formats_with_type_and_date(self):
         results = [
             {"text": "User likes Python", "type": "world", "mentioned_at": "2026-01-01"},

--- a/hindsight-integrations/cursor/tests/test_hooks.py
+++ b/hindsight-integrations/cursor/tests/test_hooks.py
@@ -33,7 +33,9 @@ class TestSessionStartHook:
 
         mock_client = MagicMock()
         mock_client.recall.return_value = {
-            "results": [{"text": "User prefers TypeScript", "type": "world", "mentioned_at": "2026-01-01"}]
+            "results": [
+                {"text": "User prefers TypeScript", "type": "world", "mentioned_at": "2026-01-01", "score": 0.9}
+            ]
         }
 
         hook_input = {"workspace_roots": ["/tmp/test-project"], "cwd": "/tmp/test-project"}
@@ -84,7 +86,7 @@ class TestSessionStartHook:
         monkeypatch.setenv("CURSOR_PLUGIN_ROOT", "/nonexistent")
 
         mock_client = MagicMock()
-        mock_client.recall.return_value = {"results": [{"text": "Uses FastAPI", "type": "world"}]}
+        mock_client.recall.return_value = {"results": [{"text": "Uses FastAPI", "type": "world", "score": 0.9}]}
 
         hook_input = {"workspace_roots": ["/home/user/projects/my-app"]}
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))

--- a/hindsight-integrations/omo/README.md
+++ b/hindsight-integrations/omo/README.md
@@ -107,6 +107,7 @@ Settings are loaded in order (later wins):
 | `autoRetain` | `HINDSIGHT_AUTO_RETAIN` | `true` | Auto-retain after responses |
 | `retainEveryNTurns` | — | `10` | Retain frequency (turns) |
 | `recallBudget` | `HINDSIGHT_RECALL_BUDGET` | `mid` | Recall depth (`low`/`mid`/`high`) |
+| `recallScoreMin` | `HINDSIGHT_RECALL_SCORE_MIN` | `0.25` | Minimum recall score required for injected memories |
 | `dynamicBankId` | `HINDSIGHT_DYNAMIC_BANK_ID` | `false` | Per-project bank isolation |
 | `debug` | `HINDSIGHT_DEBUG` | `false` | Enable debug logging to stderr |
 

--- a/hindsight-integrations/omo/scripts/lib/config.py
+++ b/hindsight-integrations/omo/scripts/lib/config.py
@@ -8,6 +8,7 @@ Set HINDSIGHT_API_URL to use a self-hosted instance instead.
 """
 
 import json
+import math
 import os
 import sys
 
@@ -16,6 +17,7 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    "recallScoreMin": 0.25,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
@@ -65,6 +67,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    "HINDSIGHT_RECALL_SCORE_MIN": ("recallScoreMin", float),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_REQUEST_TIMEOUT_SECONDS": ("requestTimeoutSeconds", int),
@@ -81,9 +84,21 @@ def _cast_env(value: str, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None
+
+
+def _normalize_recall_score_min(config: dict) -> None:
+    try:
+        value = float(config.get("recallScoreMin", DEFAULTS["recallScoreMin"]))
+    except (TypeError, ValueError):
+        value = DEFAULTS["recallScoreMin"]
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
+        value = DEFAULTS["recallScoreMin"]
+    config["recallScoreMin"] = value
 
 
 def _load_settings_file(path: str, config: dict) -> None:
@@ -127,6 +142,7 @@ def load_config() -> dict:
             if cast_val is not None:
                 config[key] = cast_val
 
+    _normalize_recall_score_min(config)
     return config
 
 

--- a/hindsight-integrations/omo/scripts/lib/content.py
+++ b/hindsight-integrations/omo/scripts/lib/content.py
@@ -116,6 +116,24 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
     return messages[start_index:]
 
 
+def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
+    """Return recall results whose score meets the configured threshold."""
+    try:
+        threshold = float(min_score)
+    except (TypeError, ValueError):
+        threshold = 0.25
+
+    filtered = []
+    for result in results or []:
+        try:
+            score = float(result.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        if score >= threshold:
+            filtered.append(result)
+    return filtered
+
+
 def format_memories(results: list) -> str:
     """Format recall results into human-readable text."""
     if not results:

--- a/hindsight-integrations/omo/scripts/lib/content.py
+++ b/hindsight-integrations/omo/scripts/lib/content.py
@@ -117,7 +117,7 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
 
 def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
-    """Return recall results whose score meets the configured threshold."""
+    """Return scored recall results whose score meets the configured threshold."""
     try:
         threshold = float(min_score)
     except (TypeError, ValueError):
@@ -125,10 +125,15 @@ def filter_memories_by_score(results: list, min_score: float = 0.25) -> list:
 
     filtered = []
     for result in results or []:
+        raw_score = result.get("score")
+        if raw_score is None:
+            filtered.append(result)
+            continue
         try:
-            score = float(result.get("score") or 0.0)
+            score = float(raw_score)
         except (TypeError, ValueError):
-            score = 0.0
+            filtered.append(result)
+            continue
         if score >= threshold:
             filtered.append(result)
     return filtered

--- a/hindsight-integrations/omo/scripts/recall.py
+++ b/hindsight-integrations/omo/scripts/recall.py
@@ -20,6 +20,7 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
     compose_recall_query,
+    filter_memories_by_score,
     format_current_time,
     format_memories,
     truncate_recall_query,
@@ -143,6 +144,8 @@ def main():
                 results = results + extra_results
         except Exception as e:
             debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
+
+    results = filter_memories_by_score(results, config.get("recallScoreMin", 0.25))
 
     if not results:
         debug_log(config, "No memories found")

--- a/hindsight-integrations/omo/settings.json
+++ b/hindsight-integrations/omo/settings.json
@@ -10,6 +10,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallScoreMin": 0.25,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,

--- a/hindsight-integrations/omo/tests/conftest.py
+++ b/hindsight-integrations/omo/tests/conftest.py
@@ -63,8 +63,8 @@ def make_transcript_file(tmp_path, messages):
     return str(f)
 
 
-def make_memory(text, mem_type="experience", mentioned_at="2024-01-15"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def make_memory(text, mem_type="experience", mentioned_at="2024-01-15", score=0.9):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at, "score": score}
 
 
 class FakeHTTPResponse:

--- a/hindsight-integrations/omo/tests/test_config.py
+++ b/hindsight-integrations/omo/tests/test_config.py
@@ -4,7 +4,6 @@ import json
 import os
 
 import pytest
-
 from lib.config import _cast_env, load_config
 
 
@@ -19,6 +18,9 @@ class TestCastEnv:
 
     def test_int_cast(self):
         assert _cast_env("42", int) == 42
+
+    def test_float_cast(self):
+        assert _cast_env("0.3", float) == 0.3
 
     def test_int_invalid_returns_none(self):
         assert _cast_env("notanint", int) is None
@@ -47,6 +49,7 @@ class TestLoadConfig:
         assert cfg["autoRecall"] is True
         assert cfg["autoRetain"] is True
         assert cfg["recallBudget"] == "mid"
+        assert cfg["recallScoreMin"] == 0.25
         assert cfg["retainEveryNTurns"] == 10
         assert cfg["agentName"] == "omo"
         assert cfg["retainContext"] == "omo"
@@ -76,6 +79,12 @@ class TestLoadConfig:
         monkeypatch.setenv("HINDSIGHT_API_URL", "http://localhost:8888")
         cfg = load_config()
         assert cfg["hindsightApiUrl"] == "http://localhost:8888"
+
+    def test_float_env_var_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_RECALL_SCORE_MIN", "0.6")
+        cfg = load_config()
+        assert cfg["recallScoreMin"] == 0.6
 
     def test_api_token_env_override(self, tmp_path, monkeypatch):
         monkeypatch.setenv("PLUGIN_ROOT", str(tmp_path))

--- a/hindsight-integrations/omo/tests/test_content.py
+++ b/hindsight-integrations/omo/tests/test_content.py
@@ -13,7 +13,7 @@ def test_filter_memories_by_score_keeps_threshold_and_above():
     assert [r["text"] for r in out] == ["edge", "strong"]
 
 
-def test_filter_memories_by_score_treats_missing_score_as_zero():
+def test_filter_memories_by_score_passes_missing_score_through():
     results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
-    assert filter_memories_by_score(results, 0.25) == []
+    assert [r["text"] for r in filter_memories_by_score(results, 0.25)] == ["missing"]
     assert [r["text"] for r in filter_memories_by_score(results, 0.0)] == ["missing", "zero"]

--- a/hindsight-integrations/omo/tests/test_content.py
+++ b/hindsight-integrations/omo/tests/test_content.py
@@ -1,0 +1,19 @@
+"""Tests for lib/content.py."""
+
+from lib.content import filter_memories_by_score
+
+
+def test_filter_memories_by_score_keeps_threshold_and_above():
+    results = [
+        {"text": "weak", "score": 0.24},
+        {"text": "edge", "score": 0.25},
+        {"text": "strong", "score": 0.9},
+    ]
+    out = filter_memories_by_score(results, 0.25)
+    assert [r["text"] for r in out] == ["edge", "strong"]
+
+
+def test_filter_memories_by_score_treats_missing_score_as_zero():
+    results = [{"text": "missing"}, {"text": "zero", "score": 0.0}]
+    assert filter_memories_by_score(results, 0.25) == []
+    assert [r["text"] for r in filter_memories_by_score(results, 0.0)] == ["missing", "zero"]

--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -79,7 +79,8 @@ Pass options directly in `opencode.json`:
         "bankId": "my-project",
         "autoRecall": true,
         "autoRetain": true,
-        "recallBudget": "mid"
+        "recallBudget": "mid",
+        "recallScoreMin": 0.25
       }
     ]
   ]
@@ -95,6 +96,7 @@ Create `~/.hindsight/opencode.json` for persistent configuration:
   "hindsightApiUrl": "http://localhost:8888",
   "hindsightApiToken": "your-api-key",
   "recallBudget": "mid",
+  "recallScoreMin": 0.25,
   "retainEveryNTurns": 3,
   "debug": false
 }
@@ -113,6 +115,7 @@ Create `~/.hindsight/opencode.json` for persistent configuration:
 | `HINDSIGHT_RETAIN_MODE`       | `full-session` or `last-turn`       | `full-session`                        |
 | `HINDSIGHT_RECALL_BUDGET`     | Recall budget: `low`, `mid`, `high` | `mid`                                 |
 | `HINDSIGHT_RECALL_MAX_TOKENS` | Max tokens for recall results       | `1024`                                |
+| `HINDSIGHT_RECALL_SCORE_MIN`  | Minimum recall score to keep        | `0.25`                                |
 | `HINDSIGHT_DYNAMIC_BANK_ID`   | Enable dynamic bank ID derivation   | `false`                               |
 | `HINDSIGHT_BANK_MISSION`      | Bank mission/context                | (none)                                |
 

--- a/hindsight-integrations/opencode/src/config.test.ts
+++ b/hindsight-integrations/opencode/src/config.test.ts
@@ -23,6 +23,7 @@ describe("loadConfig", () => {
     expect(config.autoRetain).toBe(true);
     expect(config.recallBudget).toBe("mid");
     expect(config.recallMaxTokens).toBe(1024);
+    expect(config.recallScoreMin).toBe(0.25);
     expect(config.retainContext).toBe("opencode");
     expect(config.agentName).toBe("opencode");
     expect(config.dynamicBankId).toBe(false);
@@ -39,6 +40,7 @@ describe("loadConfig", () => {
     process.env.HINDSIGHT_AUTO_RECALL = "false";
     process.env.HINDSIGHT_AUTO_RETAIN = "0";
     process.env.HINDSIGHT_RECALL_MAX_TOKENS = "2048";
+    process.env.HINDSIGHT_RECALL_SCORE_MIN = "0.6";
 
     const config = loadConfig();
     expect(config.hindsightApiUrl).toBe("https://example.com");
@@ -47,6 +49,7 @@ describe("loadConfig", () => {
     expect(config.autoRecall).toBe(false);
     expect(config.autoRetain).toBe(false);
     expect(config.recallMaxTokens).toBe(2048);
+    expect(config.recallScoreMin).toBe(0.6);
   });
 
   it("does not read debug from the environment (config-only)", () => {
@@ -101,6 +104,14 @@ describe("loadConfig", () => {
     // Invalid integer keeps default
     process.env.HINDSIGHT_RECALL_MAX_TOKENS = "not-a-number";
     expect(loadConfig().recallMaxTokens).toBe(1024);
+  });
+
+  it("float env var parsing", () => {
+    process.env.HINDSIGHT_RECALL_SCORE_MIN = "0.4";
+    expect(loadConfig().recallScoreMin).toBe(0.4);
+
+    process.env.HINDSIGHT_RECALL_SCORE_MIN = "not-a-number";
+    expect(loadConfig().recallScoreMin).toBe(0.25);
   });
 
   it("null plugin options are ignored", () => {

--- a/hindsight-integrations/opencode/src/config.ts
+++ b/hindsight-integrations/opencode/src/config.ts
@@ -20,6 +20,7 @@ export interface HindsightConfig {
   autoRecall: boolean;
   recallBudget: string;
   recallMaxTokens: number;
+  recallScoreMin: number;
   recallTypes: string[];
   recallContextTurns: number;
   recallMaxQueryChars: number;
@@ -58,6 +59,7 @@ const DEFAULTS: HindsightConfig = {
   autoRecall: true,
   recallBudget: "mid",
   recallMaxTokens: 1024,
+  recallScoreMin: 0.25,
   recallTypes: ["world", "experience"],
   recallContextTurns: 1,
   recallMaxQueryChars: 800,
@@ -95,30 +97,39 @@ const DEFAULTS: HindsightConfig = {
 };
 
 /** Env var → config key + type mapping */
-const ENV_OVERRIDES: Record<string, [keyof HindsightConfig, "string" | "bool" | "int"]> = {
-  HINDSIGHT_API_URL: ["hindsightApiUrl", "string"],
-  HINDSIGHT_API_TOKEN: ["hindsightApiToken", "string"],
-  HINDSIGHT_BANK_ID: ["bankId", "string"],
-  HINDSIGHT_AGENT_NAME: ["agentName", "string"],
-  HINDSIGHT_AUTO_RECALL: ["autoRecall", "bool"],
-  HINDSIGHT_AUTO_RETAIN: ["autoRetain", "bool"],
-  HINDSIGHT_RETAIN_MODE: ["retainMode", "string"],
-  HINDSIGHT_RECALL_BUDGET: ["recallBudget", "string"],
-  HINDSIGHT_RECALL_MAX_TOKENS: ["recallMaxTokens", "int"],
-  HINDSIGHT_RECALL_MAX_QUERY_CHARS: ["recallMaxQueryChars", "int"],
-  HINDSIGHT_RECALL_CONTEXT_TURNS: ["recallContextTurns", "int"],
-  HINDSIGHT_DYNAMIC_BANK_ID: ["dynamicBankId", "bool"],
-  HINDSIGHT_BANK_MISSION: ["bankMission", "string"],
-  // NOTE: `debug` is intentionally NOT an env override. It is a proper config
-  // option set via opencode.json plugin options or ~/.hindsight/opencode.json,
-  // because env vars are unreliable to set for OpenCode's plugin runtime
-  // (notably on Windows).
-};
+const ENV_OVERRIDES: Record<string, [keyof HindsightConfig, "string" | "bool" | "int" | "float"]> =
+  {
+    HINDSIGHT_API_URL: ["hindsightApiUrl", "string"],
+    HINDSIGHT_API_TOKEN: ["hindsightApiToken", "string"],
+    HINDSIGHT_BANK_ID: ["bankId", "string"],
+    HINDSIGHT_AGENT_NAME: ["agentName", "string"],
+    HINDSIGHT_AUTO_RECALL: ["autoRecall", "bool"],
+    HINDSIGHT_AUTO_RETAIN: ["autoRetain", "bool"],
+    HINDSIGHT_RETAIN_MODE: ["retainMode", "string"],
+    HINDSIGHT_RECALL_BUDGET: ["recallBudget", "string"],
+    HINDSIGHT_RECALL_MAX_TOKENS: ["recallMaxTokens", "int"],
+    HINDSIGHT_RECALL_SCORE_MIN: ["recallScoreMin", "float"],
+    HINDSIGHT_RECALL_MAX_QUERY_CHARS: ["recallMaxQueryChars", "int"],
+    HINDSIGHT_RECALL_CONTEXT_TURNS: ["recallContextTurns", "int"],
+    HINDSIGHT_DYNAMIC_BANK_ID: ["dynamicBankId", "bool"],
+    HINDSIGHT_BANK_MISSION: ["bankMission", "string"],
+    // NOTE: `debug` is intentionally NOT an env override. It is a proper config
+    // option set via opencode.json plugin options or ~/.hindsight/opencode.json,
+    // because env vars are unreliable to set for OpenCode's plugin runtime
+    // (notably on Windows).
+  };
 
-function castEnv(value: string, typ: "string" | "bool" | "int"): string | boolean | number | null {
+function castEnv(
+  value: string,
+  typ: "string" | "bool" | "int" | "float"
+): string | boolean | number | null {
   if (typ === "bool") return ["true", "1", "yes"].includes(value.toLowerCase());
   if (typ === "int") {
     const n = parseInt(value, 10);
+    return isNaN(n) ? null : n;
+  }
+  if (typ === "float") {
+    const n = parseFloat(value);
     return isNaN(n) ? null : n;
   }
   return value;
@@ -207,6 +218,15 @@ export function loadConfig(pluginOptions?: Record<string, unknown>): HindsightCo
         `valid: ${VALID_BUDGETS.join(", ")}. Falling back to "mid".`
     );
     result.recallBudget = "mid";
+  }
+
+  if (
+    typeof result.recallScoreMin !== "number" ||
+    !Number.isFinite(result.recallScoreMin) ||
+    result.recallScoreMin < 0 ||
+    result.recallScoreMin > 1
+  ) {
+    result.recallScoreMin = DEFAULTS.recallScoreMin;
   }
 
   return result;

--- a/hindsight-integrations/opencode/src/content.test.ts
+++ b/hindsight-integrations/opencode/src/content.test.ts
@@ -42,9 +42,9 @@ describe("formatMemories", () => {
     expect(filterMemoriesByScore(results, 0.25).map((r) => r.text)).toEqual(["edge", "strong"]);
   });
 
-  it("treats missing scores as zero", () => {
+  it("passes through missing scores and filters explicit zero scores", () => {
     const results = [{ text: "missing" }, { text: "zero", score: 0.0 }];
-    expect(filterMemoriesByScore(results, 0.25)).toEqual([]);
+    expect(filterMemoriesByScore(results, 0.25).map((r) => r.text)).toEqual(["missing"]);
     expect(filterMemoriesByScore(results, 0.0).map((r) => r.text)).toEqual(["missing", "zero"]);
   });
 

--- a/hindsight-integrations/opencode/src/content.test.ts
+++ b/hindsight-integrations/opencode/src/content.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  filterMemoriesByScore,
   stripMemoryTags,
   formatMemories,
   formatCurrentTime,
@@ -32,6 +33,21 @@ describe("stripMemoryTags", () => {
 });
 
 describe("formatMemories", () => {
+  it("filters recall results by score threshold", () => {
+    const results = [
+      { text: "weak", score: 0.24 },
+      { text: "edge", score: 0.25 },
+      { text: "strong", score: 0.9 },
+    ];
+    expect(filterMemoriesByScore(results, 0.25).map((r) => r.text)).toEqual(["edge", "strong"]);
+  });
+
+  it("treats missing scores as zero", () => {
+    const results = [{ text: "missing" }, { text: "zero", score: 0.0 }];
+    expect(filterMemoriesByScore(results, 0.25)).toEqual([]);
+    expect(filterMemoriesByScore(results, 0.0).map((r) => r.text)).toEqual(["missing", "zero"]);
+  });
+
   it("formats recall results with type and date", () => {
     const results = [
       { text: "User likes Python", type: "world", mentioned_at: "2025-01-01" },

--- a/hindsight-integrations/opencode/src/content.ts
+++ b/hindsight-integrations/opencode/src/content.ts
@@ -22,7 +22,7 @@ export interface RecallResult {
   score?: number | null;
 }
 
-/** Return recall results whose score meets the configured threshold. */
+/** Return scored recall results whose score meets the configured threshold. */
 export function filterMemoriesByScore<T extends object>(
   results: T[],
   minScore: number = 0.25
@@ -30,7 +30,9 @@ export function filterMemoriesByScore<T extends object>(
   const threshold = Number.isFinite(minScore) ? minScore : 0.25;
   return results.filter((result) => {
     const rawScore = (result as { score?: unknown }).score;
-    const score = typeof rawScore === "number" && Number.isFinite(rawScore) ? rawScore : 0;
+    if (rawScore === undefined || rawScore === null) return true;
+    if (typeof rawScore !== "number" || !Number.isFinite(rawScore)) return true;
+    const score = rawScore;
     return score >= threshold;
   });
 }

--- a/hindsight-integrations/opencode/src/content.ts
+++ b/hindsight-integrations/opencode/src/content.ts
@@ -19,6 +19,20 @@ export interface RecallResult {
   text: string;
   type?: string | null;
   mentioned_at?: string | null;
+  score?: number | null;
+}
+
+/** Return recall results whose score meets the configured threshold. */
+export function filterMemoriesByScore<T extends object>(
+  results: T[],
+  minScore: number = 0.25
+): T[] {
+  const threshold = Number.isFinite(minScore) ? minScore : 0.25;
+  return results.filter((result) => {
+    const rawScore = (result as { score?: unknown }).score;
+    const score = typeof rawScore === "number" && Number.isFinite(rawScore) ? rawScore : 0;
+    return score >= threshold;
+  });
 }
 
 /** Format recall results into human-readable text for context injection. */

--- a/hindsight-integrations/opencode/src/hooks.test.ts
+++ b/hindsight-integrations/opencode/src/hooks.test.ts
@@ -166,7 +166,9 @@ describe("autoRecall is independent of session.created ordering (#1758)", () => 
   it("injects recall on the first system.transform even if session.created never fired", async () => {
     const state = makeState();
     const client = makeClient();
-    client.recall.mockResolvedValue({ results: [{ text: "User is a developer", type: "world" }] });
+    client.recall.mockResolvedValue({
+      results: [{ text: "User is a developer", type: "world", score: 0.9 }],
+    });
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
     // No session.created beforehand — this is the #1758 reproduction.
@@ -182,7 +184,9 @@ describe("autoRecall is independent of session.created ordering (#1758)", () => 
   it("injects recall even when system.transform fires BEFORE session.created", async () => {
     const state = makeState();
     const client = makeClient();
-    client.recall.mockResolvedValue({ results: [{ text: "User is a developer", type: "world" }] });
+    client.recall.mockResolvedValue({
+      results: [{ text: "User is a developer", type: "world", score: 0.9 }],
+    });
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());
 
     const out1: { system: string[] } = { system: [] };
@@ -203,7 +207,7 @@ describe("compacting hook", () => {
   it("retains before compaction and recalls context", async () => {
     const client = makeClient();
     client.recall.mockResolvedValue({
-      results: [{ text: "Important fact", type: "world" }],
+      results: [{ text: "Important fact", type: "world", score: 0.9 }],
     });
     const messages = [
       { info: { role: "user" }, parts: [{ type: "text", text: "Build the feature" }] },
@@ -311,7 +315,7 @@ describe("system transform hook", () => {
   it("injects memories on the first transform for a session", async () => {
     const client = makeClient();
     client.recall.mockResolvedValue({
-      results: [{ text: "User is a developer", type: "world" }],
+      results: [{ text: "User is a developer", type: "world", score: 0.9 }],
     });
     const state = makeState();
     const output = { system: [] as string[] };
@@ -325,12 +329,35 @@ describe("system transform hook", () => {
     expect(state.recalledSessions.has("sess-1")).toBe(true);
   });
 
+  it("filters low-score memories from automatic recall context", async () => {
+    const client = makeClient();
+    client.recall.mockResolvedValue({
+      results: [
+        { text: "weak memory", type: "world", score: 0.24 },
+        { text: "strong memory", type: "world", score: 0.7 },
+      ],
+    });
+    const output = { system: [] as string[] };
+    const hooks = createHooks(
+      client,
+      "bank",
+      makeConfig({ recallScoreMin: 0.25 }),
+      makeState(),
+      makeOpencodeClient()
+    );
+
+    await hooks["experimental.chat.system.transform"]({ sessionID: "sess-1", model: {} }, output);
+
+    expect(output.system[0]).toContain("strong memory");
+    expect(output.system[0]).not.toContain("weak memory");
+  });
+
   it("appends recall into the existing first system section, not a new one", async () => {
     // OpenCode emits each system[] entry as a separate system message and some
     // providers only honor the first; recall must fold into system[0].
     const client = makeClient();
     client.recall.mockResolvedValue({
-      results: [{ text: "User is a developer", type: "world" }],
+      results: [{ text: "User is a developer", type: "world", score: 0.9 }],
     });
     const state = makeState();
     const output = { system: ["You are a helpful coding assistant."] as string[] };
@@ -379,7 +406,7 @@ describe("system transform hook", () => {
     client.recall.mockRejectedValueOnce(new Error("Connection refused"));
     // Second call: succeeds
     client.recall.mockResolvedValueOnce({
-      results: [{ text: "Found it", type: "world" }],
+      results: [{ text: "Found it", type: "world", score: 0.9 }],
     });
     const state = makeState();
     const hooks = createHooks(client, "bank", makeConfig(), state, makeOpencodeClient());

--- a/hindsight-integrations/opencode/src/hooks.ts
+++ b/hindsight-integrations/opencode/src/hooks.ts
@@ -12,6 +12,7 @@ import type { HindsightClient } from "@vectorize-io/hindsight-client";
 import type { HindsightConfig } from "./config.js";
 import { Logger } from "./logger.js";
 import {
+  filterMemoriesByScore,
   formatMemories,
   formatCurrentTime,
   composeRecallQuery,
@@ -108,7 +109,7 @@ export function createHooks(
         tagsMatch: config.recallTags.length ? config.recallTagsMatch : undefined,
       });
 
-      const results = response.results || [];
+      const results = filterMemoriesByScore(response.results || [], config.recallScoreMin);
       if (!results.length) return { context: null, ok: true };
 
       const formatted = formatMemories(results);

--- a/hindsight-integrations/opencode/src/test-helpers.ts
+++ b/hindsight-integrations/opencode/src/test-helpers.ts
@@ -5,6 +5,7 @@ export function makeConfig(overrides: Partial<HindsightConfig> = {}): HindsightC
     autoRecall: true,
     recallBudget: "mid",
     recallMaxTokens: 1024,
+    recallScoreMin: 0.25,
     recallTypes: ["world", "experience"],
     recallContextTurns: 1,
     recallMaxQueryChars: 800,

--- a/hindsight-integrations/opencode/src/tools.test.ts
+++ b/hindsight-integrations/opencode/src/tools.test.ts
@@ -102,7 +102,9 @@ describe("createTools", () => {
       const client = {
         retain: vi.fn(),
         recall: vi.fn().mockResolvedValue({
-          results: [{ text: "User likes Python", type: "world", mentioned_at: "2025-01-01" }],
+          results: [
+            { text: "User likes Python", type: "world", mentioned_at: "2025-01-01", score: 0.9 },
+          ],
         }),
         reflect: vi.fn(),
       } as any;
@@ -132,6 +134,25 @@ describe("createTools", () => {
 
       const result = await tools.hindsight_recall.execute({ query: "unknown" }, mockContext);
       expect(result).toBe("No relevant memories found.");
+    });
+
+    it("filters out recall results below recallScoreMin", async () => {
+      const client = {
+        retain: vi.fn(),
+        recall: vi.fn().mockResolvedValue({
+          results: [
+            { text: "weak memory", type: "world", score: 0.24 },
+            { text: "strong memory", type: "world", score: 0.7 },
+          ],
+        }),
+        reflect: vi.fn(),
+      } as any;
+      const tools = createTools(client, "test-bank", makeConfig({ recallScoreMin: 0.25 }));
+
+      const result = await tools.hindsight_recall.execute({ query: "test" }, mockContext);
+
+      expect(result).toContain("strong memory");
+      expect(result).not.toContain("weak memory");
     });
 
     it("uses config budget settings", async () => {

--- a/hindsight-integrations/opencode/src/tools.ts
+++ b/hindsight-integrations/opencode/src/tools.ts
@@ -9,7 +9,7 @@ import { tool } from "@opencode-ai/plugin/tool";
 import type { ToolDefinition } from "@opencode-ai/plugin/tool";
 import type { HindsightClient } from "@vectorize-io/hindsight-client";
 import type { HindsightConfig } from "./config.js";
-import { formatMemories, formatCurrentTime } from "./content.js";
+import { filterMemoriesByScore, formatMemories, formatCurrentTime } from "./content.js";
 import { ensureBankMission } from "./bank.js";
 import { Logger } from "./logger.js";
 
@@ -75,7 +75,7 @@ export function createTools(
         tagsMatch: config.recallTags.length ? config.recallTagsMatch : undefined,
       });
 
-      const results = response.results || [];
+      const results = filterMemoriesByScore(response.results || [], config.recallScoreMin);
       if (!results.length) return "No relevant memories found.";
 
       const formatted = formatMemories(results);

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -587,7 +587,7 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 The main list of recalled facts, ordered by relevance. Relevance is computed by running four retrieval strategies in parallel — semantic similarity, BM25 keyword, graph traversal, and temporal — fusing their rankings with Reciprocal Rank Fusion (RRF), then re-scoring the merged candidates with a cross-encoder reranker against the original query.
 
-Results do not include a numeric score. Raw retrieval scores are not meaningful on an absolute scale — a score of 0.8 from one query tells you nothing useful compared to a score of 0.8 from another. What matters is the relative ordering, which is already reflected in the list order. Agents should consume memories in order and let `max_tokens` determine how many fit, rather than filtering by score.
+Each result includes a `score` field with the normalized query-memory relevance score from the reranker. Higher scores mean the result is more relevant to the current query. Scores are most useful for client-side filtering within one recall response; they should not be treated as a stable absolute scale across unrelated queries.
 
 Each item in `results` has the following fields:
 
@@ -634,6 +634,10 @@ The document ID this fact belongs to, as set during retain.
 #### chunk_id
 
 The ID of the source text chunk this fact was extracted from. Used to cross-reference with `chunks` in the response when `include.chunks` is enabled.
+
+#### score
+
+The normalized relevance score for this result. Higher values are more relevant to the recall query.
 
 #### source_fact_ids
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10839,6 +10839,17 @@
             ],
             "title": "Chunk Id"
           },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
           "tags": {
             "anyOf": [
               {
@@ -10890,6 +10901,7 @@
           },
           "occurred_end": "2024-01-15T10:30:00Z",
           "occurred_start": "2024-01-15T10:30:00Z",
+          "score": 0.95,
           "tags": [
             "user_a",
             "user_b"


### PR DESCRIPTION
## Summary

This PR exposes a normalized relevance score directly on each recall result and adds client-side recall score filtering for the CLI and bundled agent integrations.

This PR was written by an AI coding agent under the supervision of a human engineer.

## Changes

- Adds `score` to engine `MemoryFact` and public HTTP `RecallResult`.
- Populates `score` from `cross_encoder_score_normalized` during recall result construction.
- Updates OpenAPI specs, generated Python/TypeScript/Go client result types, and recall API docs.
- Adds `recall_score_min` / `recallScoreMin` configuration with a default threshold of `0.25` across the Rust CLI and Hindsight agent integrations.
- Filters explicitly low-scored recall results client-side while preserving results with missing scores for compatibility with older Hindsight servers.
- Preserves existing `recall_score_min` when running `hindsight configure` to update only API URL/key.
- Adds regression coverage for score exposure, CLI config parsing/preservation, and integration filtering behavior.

## Plan

Based on `docs/plans/260615_recall_result_score.md`.

## Verification

- `cd hindsight-api-slim && uv run pytest tests/test_http_api_integration.py::test_full_api_workflow -q`
- `cd hindsight-clients/python && uv run python - <<'PY' ... PY` for `RecallResult.score` roundtrip
- `cd hindsight-clients/typescript && npm run build`
- `cd hindsight-api-slim && uv run ruff check hindsight_api/api/http.py hindsight_api/engine/memory_engine.py hindsight_api/engine/response_models.py tests/test_http_api_integration.py`
- `cd hindsight-api-slim && uv run ruff format --check hindsight_api/api/http.py hindsight_api/engine/memory_engine.py hindsight_api/engine/response_models.py tests/test_http_api_integration.py`
- `cd hindsight-api-slim && uv run ty check hindsight_api`
- `cd hindsight-docs && npm run build`
- `cargo test --manifest-path hindsight-cli/Cargo.toml config::tests`
- `cargo test --manifest-path hindsight-cli/Cargo.toml configure_preserves_existing_recall_score_min_when_omitted`
- Codex/Cursor CLI/Claude Code/Cursor/OMO/Cline targeted pytest suites for config/content/hook paths
- OpenCode: `npm test -- --run` and `npm run build`
- `git diff --check`
- repo pre-commit hooks passed during commit

## Notes

- `./scripts/generate-openapi.sh` succeeded after installing Node workspace dependencies.
- Full `./scripts/generate-clients.sh` was attempted: Rust generation completed, but Python generation needs Docker/OrbStack and failed because the local Docker socket was unavailable. The affected generated client types were updated manually to match the regenerated OpenAPI schema.
- `go`/`gofmt` are not installed in this local environment, so the Go model change follows the existing generated file pattern but was not gofmt-verified locally.
