### PR TITLE
fix(search): use effective-time fallback (mentioned_at, occurred_end) for recency scoring

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1492,11 +1492,7 @@ async def _process_memory_batch(
     if max_obs >= 0 and fact_tags:
         # max_obs == 0 means "no new observations": there are no slots regardless
         # of the current count, so skip the count query for that case.
-        current_count = (
-            await _count_observations_for_scope(conn, bank_id, fact_tags)
-            if max_obs > 0
-            else 0
-        )
+        current_count = await _count_observations_for_scope(conn, bank_id, fact_tags) if max_obs > 0 else 0
         remaining_observation_slots = max(max_obs - current_count, 0)
         if remaining_observation_slots == 0:
             logger.info(

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -105,11 +105,7 @@ def apply_combined_scoring(
         # facts or ongoing states that intentionally lack occurred_start) still gets
         # correct recency ordering instead of a flat neutral 0.5.
         sr.recency = 0.5
-        effective = (
-            sr.retrieval.occurred_start
-            or sr.retrieval.mentioned_at
-            or sr.retrieval.occurred_end
-        )
+        effective = sr.retrieval.occurred_start or sr.retrieval.mentioned_at or sr.retrieval.occurred_end
         if effective:
             occurred = effective
             if occurred.tzinfo is None:

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -99,9 +99,19 @@ def apply_combined_scoring(
 
     for sr in scored_results:
         # Recency: linear decay over 365 days → [0.1, 1.0]; neutral 0.5 if no date.
+        # Use the unit's effective time (occurred_start, then mentioned_at, then
+        # occurred_end) — the same COALESCE order as retrieval._coalesce_date — so a
+        # memory that carries only a mentioned_at / occurred_end (e.g. conversation
+        # facts or ongoing states that intentionally lack occurred_start) still gets
+        # correct recency ordering instead of a flat neutral 0.5.
         sr.recency = 0.5
-        if sr.retrieval.occurred_start:
-            occurred = sr.retrieval.occurred_start
+        effective = (
+            sr.retrieval.occurred_start
+            or sr.retrieval.mentioned_at
+            or sr.retrieval.occurred_end
+        )
+        if effective:
+            occurred = effective
             if occurred.tzinfo is None:
                 occurred = occurred.replace(tzinfo=UTC)
             days_ago = (now - occurred).total_seconds() / 86400

--- a/hindsight-api-slim/tests/test_combined_scoring.py
+++ b/hindsight-api-slim/tests/test_combined_scoring.py
@@ -21,12 +21,16 @@ def _make_result(
     ce_norm: float,
     occurred_start: datetime | None = None,
     temporal_proximity: float | None = None,
+    mentioned_at: datetime | None = None,
+    occurred_end: datetime | None = None,
 ) -> ScoredResult:
     retrieval = RetrievalResult(
         id="test",
         text="test",
         fact_type="world",
         occurred_start=occurred_start,
+        occurred_end=occurred_end,
+        mentioned_at=mentioned_at,
         temporal_proximity=temporal_proximity,
     )
 
@@ -141,12 +145,35 @@ class TestBoostFormula:
         apply_combined_scoring([l_relevant, l_recent], now=NOW)
         assert l_relevant.weight > l_recent.weight, "Low-CE model: relevance should still win"
 
-    def test_no_occurred_start_defaults_recency_neutral(self):
-        """Missing occurred_start → recency=0.5 → no boost/penalty."""
-        sr = _make_result(ce_norm=0.5, occurred_start=None)
+    def test_no_effective_time_defaults_recency_neutral(self):
+        """No effective time at all (occurred_start/mentioned_at/occurred_end) → recency=0.5."""
+        sr = _make_result(ce_norm=0.5)
         apply_combined_scoring([sr], now=NOW)
         assert sr.recency == 0.5
         assert abs(sr.weight - 0.5) < 1e-9
+
+    def test_mentioned_at_drives_recency_when_no_occurred_start(self):
+        """A memory with only mentioned_at must derive recency from it, not stay neutral."""
+        sr = _make_result(ce_norm=0.5, mentioned_at=NOW)
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 1.0
+        assert sr.weight > 0.5
+
+    def test_occurred_end_is_last_recency_fallback(self):
+        """occurred_end feeds recency when neither occurred_start nor mentioned_at is set."""
+        old = NOW - timedelta(days=400)
+        sr = _make_result(ce_norm=0.5, occurred_end=old)
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 0.1
+        assert sr.weight < 0.5
+
+    def test_occurred_start_takes_precedence_over_mentioned_at(self):
+        """occurred_start wins over mentioned_at (matches _coalesce_date COALESCE order)."""
+        recent = NOW - timedelta(days=10)
+        old = NOW - timedelta(days=400)
+        sr = _make_result(ce_norm=0.5, occurred_start=recent, mentioned_at=old)
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency > 0.9
 
     def test_timezone_naive_occurred_start_handled(self):
         """Naive datetimes in occurred_start should not raise."""


### PR DESCRIPTION
## Problem

`apply_combined_scoring` (`reranking.py`) derives the recency boost from `occurred_start` only — when `occurred_start` is `None`, recency stays at the neutral `0.5` even if the memory carries a usable `mentioned_at` / `occurred_end`. Temporal retrieval already treats effective time as `COALESCE(occurred_start, mentioned_at, occurred_end)` via `_coalesce_date` (`retrieval.py`), so recency scoring is the one place that ignores the fallback.

Memories that intentionally lack `occurred_start` (conversation facts, ongoing states — `mentioned_at` set, `occurred_start` `None` per `retain/types.py`) therefore lose correct recency ordering in recall. This is most acute in slim / passthrough (`RRFPassthroughCrossEncoder`) deployments, where recency is the only signal modulating RRF rank.

## Fix

Derive recency from the same effective-time COALESCE order used by `_coalesce_date`: `occurred_start` → `mentioned_at` → `occurred_end`. The existing naive→UTC normalization and 365-day linear decay are unchanged and now apply to whichever timestamp is selected.

## Tests

`test_combined_scoring.py`: extended `_make_result` to accept `mentioned_at` / `occurred_end`, reworded the no-date test to reflect "no effective time at all → neutral", and added coverage for the `mentioned_at`-only path, the `occurred_end` last-fallback, and `occurred_start` precedence (matching `_coalesce_date`). The new tests fail on the prior `occurred_start`-only implementation.

Closes #2192.
