### PR TITLE
docs(litellm): replace removed `opinion` fact-type with `observation`

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1492,11 +1492,7 @@ async def _process_memory_batch(
     if max_obs >= 0 and fact_tags:
         # max_obs == 0 means "no new observations": there are no slots regardless
         # of the current count, so skip the count query for that case.
-        current_count = (
-            await _count_observations_for_scope(conn, bank_id, fact_tags)
-            if max_obs > 0
-            else 0
-        )
+        current_count = await _count_observations_for_scope(conn, bank_id, fact_tags) if max_obs > 0 else 0
         remaining_observation_slots = max(max_obs - current_count, 0)
         if remaining_observation_slots == 0:
             logger.info(

--- a/hindsight-integrations/litellm/README.md
+++ b/hindsight-integrations/litellm/README.md
@@ -171,7 +171,7 @@ hindsight_litellm.set_defaults(
 
     # Optional - Memory retrieval
     budget="mid",                  # Budget level: "low", "mid", "high"
-    fact_types=["world", "opinion"],  # Filter fact types to retrieve
+    fact_types=["world", "observation"],  # Filter fact types to retrieve
     max_memories=10,               # Maximum memories to inject (None = unlimited)
     max_memory_tokens=4096,        # Maximum tokens for memory context
     include_entities=True,         # Include entity observations in recall
@@ -287,7 +287,7 @@ for m in memories:
 
 # Output:
 # - [world] User is building a FastAPI project
-# - [opinion] User prefers Python over JavaScript
+# - [observation] User prefers Python over JavaScript
 ```
 
 ### Reflect - Get synthesized context


### PR DESCRIPTION
v0.8.0 (#1917) removed the `opinion` fact-type — the enum now accepts only `world` / `experience` / `observation`, and `observation` is its successor. The litellm integration README still references `opinion` in two snippets, so anyone copying them hits an `Invalid fact_types` rejection:

- `set_defaults(... fact_types=["world", "opinion"], ...)` — the retrieval filter example
- `# - [opinion] User prefers Python over JavaScript` — the recall-output example

#1917 already applied the same `opinion` → `observation` correction to `cli-reference.sh`; this is the same fix for the litellm example it missed.
