### PR TITLE
docs(reflect): align reflect_async docstring with read-only tool set

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5980,11 +5980,14 @@ class MemoryEngine(MemoryEngineInterface):
         """
         Reflect and formulate an answer using an agentic loop with tools.
 
-        The reflect agent iteratively uses tools to:
+        The reflect agent iteratively uses read-only tools to:
         1. lookup: Get mental models (synthesized knowledge)
         2. recall: Search facts (semantic + temporal retrieval)
-        3. learn: Create/update mental models with new insights
+        3. search observations: Retrieve prior observations
         4. expand: Get chunk/document context for memories
+
+        Reflect is read-only: it synthesizes an answer from the bank's stored
+        memories and persists nothing.
 
         The agent starts with empty context and must call tools to gather
         information. On the last iteration, tools are removed to force a


### PR DESCRIPTION
## What

`reflect_async`'s docstring lists a step:

> 3. learn: Create/update mental models with new insights

but no such tool is wired into the reflect agent. `reflect_async` only passes the agent **read** tools — `search_mental_models_fn`, `search_observations_fn`, `recall_fn`, `expand_fn` — so reflect synthesizes an answer from stored memories and **persists nothing**.

This updates the docstring to match the actual implementation and states explicitly that reflect is read-only.

## Why

The stale `learn` step misleads readers into thinking `reflect` mutates bank state (e.g. when reasoning about whether it is a read or write operation for access-control purposes). Documentation only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)