### PR TITLE
feat(consolidation): add "shared" observation_scopes keyword

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -545,13 +545,16 @@ class MemoryItem(BaseModel):
             return [v]
         return v
 
-    observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = Field(
+    observation_scopes: Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]] | None = Field(
         default=None,
         title="ObservationScopes",
         description=(
             "How to scope observations during consolidation. "
             "'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. "
             "'combined' (default) runs a single pass with all tags together. "
+            "'shared' runs a single pass over one global, untagged scope, so memories consolidate together "
+            "regardless of their tags — useful for deduplicating across volatile per-call provenance tags "
+            "(e.g. per-session ids) while keeping those tags on the source facts. "
             "A list of tag lists runs one pass per inner list, giving full control over which combinations to use."
         ),
     )

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -335,7 +335,15 @@ def _resolve_obs_tags_list(memory: dict[str, Any]) -> list[list[str]] | None:
 
     Returns ``None`` for the default ``combined``-mode single pass (caller uses
     the memory's own tags). Returns a list[list[str]] when the memory requested
-    multi-pass scoping (``per_tag``, ``all_combinations``, or an explicit list).
+    multi-pass scoping (``per_tag``, ``all_combinations``, ``shared``, or an
+    explicit list).
+
+    ``shared`` resolves to ``[[]]`` — a single pass over the empty (untagged)
+    scope. The created observation carries no tags and recall/dedup match it with
+    ``tags_match="any"``, so every memory consolidates into one shared observation
+    regardless of its own tags. Use it to deduplicate across volatile per-call
+    provenance tags (e.g. per-session ids) without dropping those tags from the
+    source facts.
     """
     parsed = _parse_observation_scopes(memory)
     tags = list(memory.get("tags") or [])
@@ -346,6 +354,8 @@ def _resolve_obs_tags_list(memory: dict[str, Any]) -> list[list[str]] | None:
         if not tags:
             return None
         return [list(c) for r in range(1, len(tags) + 1) for c in combinations(tags, r)]
+    if parsed == "shared":
+        return [[]]
     if parsed == "combined" or parsed is None:
         return None
     return parsed  # explicit list[list[str]]
@@ -362,6 +372,7 @@ def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
     - ``combined`` / ``None``    -> ``[frozenset(memory.tags)]``
     - ``per_tag``                -> ``[frozenset({t}) for t in memory.tags]``
     - ``all_combinations``       -> one frozenset per nonempty subset of tags
+    - ``shared``                 -> ``[frozenset()]`` (the single untagged scope)
     - explicit ``list[list[str]]`` -> one frozenset per declared scope
 
     Empty-tag memories collapse to a single ``frozenset()`` in all modes so they
@@ -376,6 +387,8 @@ def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
         if not tags:
             return [frozenset()]
         return [frozenset(c) for r in range(1, len(tags) + 1) for c in combinations(tags, r)]
+    if parsed == "shared":
+        return [frozenset()]
     if parsed == "combined" or parsed is None:
         return [frozenset(tags)]
     return [frozenset(s) for s in parsed]  # explicit list[list[str]]

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -24,7 +24,9 @@ class RetainContentDict(TypedDict, total=False):
         tags: Visibility scope tags for this content item (optional)
         observation_scopes: How to scope observations for consolidation (optional).
             "per_tag" runs one pass per individual tag; "combined" (default) runs a
-            single pass with all tags; a list[list[str]] specifies exact passes.
+            single pass with all tags; "shared" runs a single pass over one global,
+            untagged scope so memories consolidate together regardless of tags;
+            a list[list[str]] specifies exact passes.
         update_mode: How to handle existing documents with the same document_id (optional).
             "replace" (default) deletes old data and reprocesses. "append" concatenates
             new content to the existing document and reprocesses.
@@ -38,7 +40,7 @@ class RetainContentDict(TypedDict, total=False):
     entities: list[dict[str, str]]  # [{"text": "...", "type": "..."}]
     tags: list[str]  # Visibility scope tags
     observation_scopes: (
-        Literal["per_tag", "combined", "all_combinations"] | list[list[str]]
+        Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]]
     )  # Observation scopes for consolidation
     update_mode: Literal["replace", "append"]
 
@@ -57,7 +59,7 @@ class RetainContent:
     metadata: dict[str, str] = field(default_factory=dict)
     entities: list[dict[str, str]] = field(default_factory=list)  # User-provided entities
     tags: list[str] = field(default_factory=list)  # Visibility scope tags
-    observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = (
+    observation_scopes: Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]] | None = (
         None  # Observation scopes
     )
 
@@ -124,7 +126,7 @@ class ExtractedFact:
     mentioned_at: datetime | None = None
     metadata: dict[str, str] = field(default_factory=dict)
     tags: list[str] = field(default_factory=list)  # Visibility scope tags
-    observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = (
+    observation_scopes: Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]] | None = (
         None  # Observation scopes
     )
 
@@ -176,7 +178,7 @@ class ProcessedFact:
     tags: list[str] = field(default_factory=list)
 
     # Observation scopes for consolidation
-    observation_scopes: Literal["per_tag", "combined", "all_combinations"] | list[list[str]] | None = None
+    observation_scopes: Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]] | None = None
 
     @property
     def is_duplicate(self) -> bool:

--- a/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 # Bump when the archive layout changes in a backward-incompatible way.
 SCHEMA_VERSION = 1
 
-ObservationScopes = Literal["per_tag", "combined", "all_combinations"] | list[list[str]]
+ObservationScopes = Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]]
 
 
 class TransferCausalRelation(BaseModel):

--- a/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
+++ b/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
@@ -179,6 +179,42 @@ async def test_combined_mode_parallel_writes_to_memory_tag_set(memory: MemoryEng
 
 
 @pytest.mark.asyncio
+async def test_shared_mode_parallel_writes_only_untagged_scope(memory: MemoryEngine, request_context):
+    """shared → every memory writes to the single untagged scope, ignoring its
+    own tags. Three memories with disjoint tags therefore all consolidate into
+    the same global scope (the per-session-tag dedup use case) instead of one
+    isolated observation per tag."""
+    bank_id = f"test-shared-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea", ["session:s1"], "shared")
+            await _insert_memory(conn, bank_id, "Bob bikes daily", ["session:s2"], "shared")
+            await _insert_memory(conn, bank_id, "Carol reads books", ["session:s3"], "shared")
+
+        wrapper, _ = _mock_llm_one_obs_per_fact()
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=3, consolidation_llm_batch_size=1),
+                patch.object(memory, "submit_async_consolidation"),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        tag_sets = await _fetch_observation_tag_sets(memory, bank_id)
+        # Every observation lands at the untagged scope — none carries a session tag.
+        assert tag_sets and all(t == frozenset() for t in tag_sets), tag_sets
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_per_tag_mode_parallel_writes_one_observation_per_tag(memory: MemoryEngine, request_context):
     """per_tag with tags [a, b] → two observations, tagged [a] and [b] respectively.
 

--- a/hindsight-api-slim/tests/test_consolidation_write_scopes.py
+++ b/hindsight-api-slim/tests/test_consolidation_write_scopes.py
@@ -92,6 +92,18 @@ class TestResolveWriteScopesAllCombinations:
         assert _resolve_write_scopes(memory) == [frozenset()]
 
 
+class TestResolveWriteScopesShared:
+    def test_collapses_to_single_untagged_scope_regardless_of_tags(self):
+        # "shared" ignores the memory's own tags and writes to one global scope,
+        # so every memory deduplicates against the same observation.
+        memory = {"tags": ["alice", "session"], "observation_scopes": _as_json_string("shared")}
+        assert _resolve_write_scopes(memory) == [frozenset()]
+
+    def test_empty_tags_also_untagged_scope(self):
+        memory = {"tags": [], "observation_scopes": _as_json_string("shared")}
+        assert _resolve_write_scopes(memory) == [frozenset()]
+
+
 class TestResolveWriteScopesExplicitList:
     def test_uses_declared_scopes_verbatim(self):
         memory = {
@@ -166,6 +178,12 @@ class TestResolveObsTagsList:
         memory = {"tags": ["a", "b"], "observation_scopes": json.dumps(spec)}
         assert _resolve_obs_tags_list(memory) == spec
 
+    def test_shared_returns_single_empty_scope(self):
+        # One pass over the empty (untagged) scope; the memory's own tags are
+        # ignored so cross-tag memories consolidate into one observation.
+        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps("shared")}
+        assert _resolve_obs_tags_list(memory) == [[]]
+
 
 # ---------------------------------------------------------------------------
 # Agreement between obs_tags_list (dispatch) and write_scopes (locks)
@@ -185,6 +203,7 @@ class TestDispatchLockAgreement:
             {"tags": ["a", "b", "c"], "observation_scopes": json.dumps("combined")},
             {"tags": ["a", "b"], "observation_scopes": json.dumps("per_tag")},
             {"tags": ["a", "b", "c"], "observation_scopes": json.dumps("all_combinations")},
+            {"tags": ["a", "b"], "observation_scopes": json.dumps("shared")},
             {"tags": ["a", "b"], "observation_scopes": json.dumps([["a"], ["b"], ["a", "b"]])},
             {"tags": ["a"], "observation_scopes": json.dumps([["a"], ["x"]])},
             # Pre-parsed Python shape (defensive — covers callers that hand the

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -8166,6 +8166,7 @@ components:
         - per_tag
         - combined
         - all_combinations
+        - shared
         type: string
       - items:
           items:
@@ -8175,8 +8176,11 @@ components:
       description: "How to scope observations during consolidation. 'per_tag' runs\
         \ one consolidation pass per individual tag, creating separate observations\
         \ for each tag. 'combined' (default) runs a single pass with all tags together.\
-        \ A list of tag lists runs one pass per inner list, giving full control over\
-        \ which combinations to use."
+        \ 'shared' runs a single pass over one global, untagged scope, so memories\
+        \ consolidate together regardless of their tags — useful for deduplicating\
+        \ across volatile per-call provenance tags (e.g. per-session ids) while keeping\
+        \ those tags on the source facts. A list of tag lists runs one pass per inner\
+        \ list, giving full control over which combinations to use."
       nullable: true
       title: ObservationScopes
     MentalModelTrigger_Input_tag_groups_inner:

--- a/hindsight-clients/go/model_observation_scopes.go
+++ b/hindsight-clients/go/model_observation_scopes.go
@@ -16,7 +16,7 @@ import (
 )
 
 
-// ObservationScopes How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
+// ObservationScopes How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. 'shared' runs a single pass over one global, untagged scope, so memories consolidate together regardless of their tags — useful for deduplicating across volatile per-call provenance tags (e.g. per-session ids) while keeping those tags on the source facts. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
 type ObservationScopes struct {
 	ArrayOfArrayOfString *[][]string
 	String *string

--- a/hindsight-clients/python/hindsight_client_api/models/observation_scopes.py
+++ b/hindsight-clients/python/hindsight_client_api/models/observation_scopes.py
@@ -27,7 +27,7 @@ OBSERVATIONSCOPES_ANY_OF_SCHEMAS = ["List[List[str]]", "str"]
 
 class ObservationScopes(BaseModel):
     """
-    How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
+    How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. 'shared' runs a single pass over one global, untagged scope, so memories consolidate together regardless of their tags — useful for deduplicating across volatile per-call provenance tags (e.g. per-session ids) while keeping those tags on the source facts. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
     """
 
     # data type: str

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2235,9 +2235,15 @@ export type MemoryItem = {
   /**
    * ObservationScopes
    *
-   * How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
+   * How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. 'shared' runs a single pass over one global, untagged scope, so memories consolidate together regardless of their tags — useful for deduplicating across volatile per-call provenance tags (e.g. per-session ids) while keeping those tags on the source facts. A list of tag lists runs one pass per inner list, giving full control over which combinations to use.
    */
-  observation_scopes?: "per_tag" | "combined" | "all_combinations" | Array<Array<string>> | null;
+  observation_scopes?:
+    | "per_tag"
+    | "combined"
+    | "all_combinations"
+    | "shared"
+    | Array<Array<string>>
+    | null;
   /**
    * Strategy
    *

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -388,7 +388,7 @@ export class ControlPlaneClient {
       metadata?: Record<string, string>;
       entities?: Array<{ text: string; type?: string }>;
       tags?: string[];
-      observation_scopes?: "per_tag" | "combined" | "all_combinations" | string[][];
+      observation_scopes?: "per_tag" | "combined" | "all_combinations" | "shared" | string[][];
       strategy?: string;
     }>;
     document_id?: string;

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -179,6 +179,20 @@ One consolidation pass using all tags together. The resulting observation is tag
 
 **Use when** the memory is meaningful only as a whole and you never need to query any single tag in isolation.
 
+#### shared
+
+One consolidation pass over a single global, **untagged** scope. The memory's own tags are ignored for observation scoping (they stay on the source facts for recall filtering), so memories with *different* tags all consolidate into the **same** observation.
+
+- Observations created: one untagged observation (`[]`)
+- ✓ Untagged observations match every recall regardless of tag filter
+- Deduplicates across volatile per-call tags: if each session is retained with a unique `session-id:…` tag, `combined` and `per_tag` create a fresh observation every session (the tag never repeats), whereas `shared` folds them all into one.
+
+**Use when** your tags are per-call provenance (e.g. session ids) that you want for recall filtering and debugging but not as a consolidation boundary — keep the tag on `tags` and set `observation_scopes: "shared"`.
+
+:::caution `shared` vs `[[]]` vs `[]`
+`shared` is equivalent to the explicit scope `[[]]` — a list containing one empty scope. Do **not** confuse it with `[]` (an empty list), which declares *zero* scopes and silently falls back to `combined`.
+:::
+
 #### per_tag
 
 One consolidation pass per individual tag. Each tag gets its own isolated observation that grows with every new memory sharing that tag.

--- a/hindsight-docs/docs/developer/observations.mdx
+++ b/hindsight-docs/docs/developer/observations.mdx
@@ -60,6 +60,8 @@ When enabled, Hindsight reconciles them automatically. Whenever an observation i
 
 This is controlled by the [`HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD`](/developer/configuration#observations) setting: the cosine similarity at or above which two observations are reconciled. It is **enabled by default** (`0.97`); a lower value reconciles more aggressively, and `1.0` disables it. Reconciliation runs on PostgreSQL deployments only — it is skipped on Oracle regardless of the threshold.
 
+Reconciliation only compares observations **within the same tag scope**. If you tag retains with a unique per-call value (e.g. a `session-id`), each session lands in its own scope and never dedups against the others — producing one near-identical observation per session. To consolidate across those volatile tags, retain with [`observation_scopes: "shared"`](/developer/api/retain#shared), which scopes observations to one global, untagged belief while leaving the session tag on the source facts for recall filtering.
+
 ### Disabling Auto-Consolidation
 
 Set `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false` (or configure per-bank via the [bank config API](/developer/api/memory-banks#observations-configuration)) to prevent consolidation from running automatically after retain, delete, and update operations. When disabled, consolidation only runs when you explicitly call the [consolidate endpoint](#trigger-consolidation).

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9476,7 +9476,8 @@
                 "enum": [
                   "per_tag",
                   "combined",
-                  "all_combinations"
+                  "all_combinations",
+                  "shared"
                 ]
               },
               {
@@ -9493,7 +9494,7 @@
               }
             ],
             "title": "ObservationScopes",
-            "description": "How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. A list of tag lists runs one pass per inner list, giving full control over which combinations to use."
+            "description": "How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. 'shared' runs a single pass over one global, untagged scope, so memories consolidate together regardless of their tags \u2014 useful for deduplicating across volatile per-call provenance tags (e.g. per-session ids) while keeping those tags on the source facts. A list of tag lists runs one pass per inner list, giving full control over which combinations to use."
           },
           "strategy": {
             "anyOf": [

--- a/hindsight-docs/versioned_docs/version-0.8/developer/api/retain.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/api/retain.mdx
@@ -179,6 +179,20 @@ One consolidation pass using all tags together. The resulting observation is tag
 
 **Use when** the memory is meaningful only as a whole and you never need to query any single tag in isolation.
 
+#### shared
+
+One consolidation pass over a single global, **untagged** scope. The memory's own tags are ignored for observation scoping (they stay on the source facts for recall filtering), so memories with *different* tags all consolidate into the **same** observation.
+
+- Observations created: one untagged observation (`[]`)
+- ✓ Untagged observations match every recall regardless of tag filter
+- Deduplicates across volatile per-call tags: if each session is retained with a unique `session-id:…` tag, `combined` and `per_tag` create a fresh observation every session (the tag never repeats), whereas `shared` folds them all into one.
+
+**Use when** your tags are per-call provenance (e.g. session ids) that you want for recall filtering and debugging but not as a consolidation boundary — keep the tag on `tags` and set `observation_scopes: "shared"`.
+
+:::caution `shared` vs `[[]]` vs `[]`
+`shared` is equivalent to the explicit scope `[[]]` — a list containing one empty scope. Do **not** confuse it with `[]` (an empty list), which declares *zero* scopes and silently falls back to `combined`.
+:::
+
 #### per_tag
 
 One consolidation pass per individual tag. Each tag gets its own isolated observation that grows with every new memory sharing that tag.

--- a/hindsight-docs/versioned_docs/version-0.8/developer/observations.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/observations.mdx
@@ -60,6 +60,8 @@ When enabled, Hindsight reconciles them automatically. Whenever an observation i
 
 This is controlled by the [`HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD`](/developer/configuration#observations) setting: the cosine similarity at or above which two observations are reconciled. It is **enabled by default** (`0.97`); a lower value reconciles more aggressively, and `1.0` disables it. Reconciliation runs on PostgreSQL deployments only — it is skipped on Oracle regardless of the threshold.
 
+Reconciliation only compares observations **within the same tag scope**. If you tag retains with a unique per-call value (e.g. a `session-id`), each session lands in its own scope and never dedups against the others — producing one near-identical observation per session. To consolidate across those volatile tags, retain with [`observation_scopes: "shared"`](/developer/api/retain#shared), which scopes observations to one global, untagged belief while leaving the session tag on the source facts for recall filtering.
+
 ### Disabling Auto-Consolidation
 
 Set `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false` (or configure per-bank via the [bank config API](/developer/api/memory-banks#observations-configuration)) to prevent consolidation from running automatically after retain, delete, and update operations. When disabled, consolidation only runs when you explicitly call the [consolidate endpoint](#trigger-consolidation).

--- a/hindsight-integrations/opencode/src/plugin.test.ts
+++ b/hindsight-integrations/opencode/src/plugin.test.ts
@@ -172,9 +172,7 @@ describe("plugin default export", () => {
     // need them import from "@vectorize-io/opencode-hindsight/dist/config.js"
     // or rely on the plugin itself using them internally.
     const mod = await import("./index.js");
-    const functionValues = Object.values(mod).filter(
-      (v) => typeof v === "function"
-    );
+    const functionValues = Object.values(mod).filter((v) => typeof v === "function");
     // Exactly two function exports remain: the default export and the
     // HindsightPlugin named export, both pointing at the same function.
     expect(functionValues.length).toBe(2);

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -243,6 +243,18 @@ One consolidation pass using all tags together. The resulting observation is tag
 
 **Use when** the memory is meaningful only as a whole and you never need to query any single tag in isolation.
 
+#### shared
+
+One consolidation pass over a single global, **untagged** scope. The memory's own tags are ignored for observation scoping (they stay on the source facts for recall filtering), so memories with *different* tags all consolidate into the **same** observation.
+
+- Observations created: one untagged observation (`[]`)
+- ✓ Untagged observations match every recall regardless of tag filter
+- Deduplicates across volatile per-call tags: if each session is retained with a unique `session-id:…` tag, `combined` and `per_tag` create a fresh observation every session (the tag never repeats), whereas `shared` folds them all into one.
+
+**Use when** your tags are per-call provenance (e.g. session ids) that you want for recall filtering and debugging but not as a consolidation boundary — keep the tag on `tags` and set `observation_scopes: "shared"`.
+
+:::caution `shared` vs `[[]]` vs `[]`
+`shared` is equivalent to the explicit scope `[[]]` — a list containing one empty scope. Do **not** confuse it with `[]` (an empty list), which declares *zero* scopes and silently falls back to `combined`.
 #### per_tag
 
 One consolidation pass per individual tag. Each tag gets its own isolated observation that grows with every new memory sharing that tag.

--- a/skills/hindsight-docs/references/developer/observations.md
+++ b/skills/hindsight-docs/references/developer/observations.md
@@ -54,6 +54,8 @@ When enabled, Hindsight reconciles them automatically. Whenever an observation i
 
 This is controlled by the [`HINDSIGHT_API_CONSOLIDATION_DEDUP_THRESHOLD`](configuration.md#observations) setting: the cosine similarity at or above which two observations are reconciled. It is **enabled by default** (`0.97`); a lower value reconciles more aggressively, and `1.0` disables it. Reconciliation runs on PostgreSQL deployments only — it is skipped on Oracle regardless of the threshold.
 
+Reconciliation only compares observations **within the same tag scope**. If you tag retains with a unique per-call value (e.g. a `session-id`), each session lands in its own scope and never dedups against the others — producing one near-identical observation per session. To consolidate across those volatile tags, retain with [`observation_scopes: "shared"`](api/retain.md#shared), which scopes observations to one global, untagged belief while leaving the session tag on the source facts for recall filtering.
+
 ### Disabling Auto-Consolidation
 
 Set `HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION=false` (or configure per-bank via the [bank config API](api/memory-banks.md#observations-configuration)) to prevent consolidation from running automatically after retain, delete, and update operations. When disabled, consolidation only runs when you explicitly call the [consolidate endpoint](#trigger-consolidation).

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9476,7 +9476,8 @@
                 "enum": [
                   "per_tag",
                   "combined",
-                  "all_combinations"
+                  "all_combinations",
+                  "shared"
                 ]
               },
               {
@@ -9493,7 +9494,7 @@
               }
             ],
             "title": "ObservationScopes",
-            "description": "How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. A list of tag lists runs one pass per inner list, giving full control over which combinations to use."
+            "description": "How to scope observations during consolidation. 'per_tag' runs one consolidation pass per individual tag, creating separate observations for each tag. 'combined' (default) runs a single pass with all tags together. 'shared' runs a single pass over one global, untagged scope, so memories consolidate together regardless of their tags \u2014 useful for deduplicating across volatile per-call provenance tags (e.g. per-session ids) while keeping those tags on the source facts. A list of tag lists runs one pass per inner list, giving full control over which combinations to use."
           },
           "strategy": {
             "anyOf": [


### PR DESCRIPTION
## Summary

Adds a `"shared"` value for `observation_scopes` that resolves to a single global, untagged scope (`[[]]`). Memories consolidate into **one** observation regardless of their tags, while the tags stay on the source facts for recall filtering.

This is the supported, root-cause fix for **runaway observation duplication when agents use per-session tags** (#2188).

## The problem

When an agent tags every `retain()` with a unique per-call provenance tag (e.g. `session:hm-cron_<hex>_<ts>`), the default `combined` scoping derives the observation scope from the memory's **full tag set**. Since the session tag never repeats:

- consolidation groups facts per session → the LLM never sees cross-session twins,
- recall and the dedup probe both run `all_strict` on the unique tag → never match,

so each session creates its own near-identical observation. The reporter saw **211 near-duplicate observations** of the same fact over ~6 weeks.

## Why this approach

The scope is derived from tags at one place; the fix is to let a retain decouple *provenance tags* from *consolidation scope*. `"shared"` keeps **recall and the dedup probe on the same (empty) scope**, so it fixes consolidation *quality* (cross-session facts actually merge through the normal LLM path), not just the duplicate count.

This is an alternative to #2189, which instead desynced the dedup probe's tag-match mode (`any`) from the recall (`all_strict`) via a new config flag. That papers over the symptom at the create-time dedup net and, on a multi-tenant bank, widening the probe to `any` would expose cross-scope text to the LLM and fold cross-scope sources together. `"shared"` needs no new config flag and keeps both code paths consistent.

## Usage

```jsonc
// retain
{ "content": "...", "tags": ["session:s1"], "observation_scopes": "shared" }
```

The session tag stays on the facts (recall filtering / debugging); the observation is untagged and shared across all sessions.

> `"shared"` ≡ the explicit scope `[[]]` (one empty scope). Note `[]` (empty list) declares *zero* scopes and silently falls back to `combined` — documented as a caveat.

## Changes

- **engine**: `_resolve_obs_tags_list` → `[[]]`, `_resolve_write_scopes` → `[frozenset()]` for `"shared"`
- **API/engine types**: added `"shared"` to the `observation_scopes` literals; regenerated OpenAPI + Python/TS/Go/Rust clients; kept the control-plane client type in sync
- **docs**: new `shared` section in `retain.mdx` (+ `shared` vs `[[]]` vs `[]` caveat) and a dedup pointer in `observations.mdx`; regenerated `hindsight-docs` skill mirror
- **tests**:
  - `test_consolidation_write_scopes.py` — unit coverage of scope resolution + dispatch/lock agreement for `shared`
  - `test_consolidation_scope_parallelism.py` — e2e: three differently-tagged memories under `shared` all land at the untagged scope

No new env config flag (this is a retain parameter), so `.env.example`/embed-sync don't apply.

## Tests

```
uv run pytest tests/test_consolidation_write_scopes.py tests/test_consolidation_scope_parallelism.py
./scripts/hooks/lint.sh
uv run ty check hindsight_api/
```

Fixes #2188.
