### PR TITLE
fix(ts-client): accept shared observation scope

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -114,7 +114,7 @@ export interface MemoryItemInput {
   document_id?: string;
   entities?: EntityInput[];
   tags?: string[];
-  observation_scopes?: "per_tag" | "combined" | "all_combinations" | string[][];
+  observation_scopes?: "per_tag" | "combined" | "all_combinations" | "shared" | string[][];
   strategy?: string;
   update_mode?: "replace" | "append";
 }
@@ -180,8 +180,8 @@ export class HindsightClient {
       tags?: string[];
       /** How to handle existing documents: 'replace' (default) or 'append' */
       updateMode?: "replace" | "append";
-      /** Observation scoping strategy: 'per_tag', 'combined', 'all_combinations', or explicit scope groups */
-      observationScopes?: "per_tag" | "combined" | "all_combinations" | string[][];
+      /** Observation scoping strategy: 'per_tag', 'combined', 'all_combinations', 'shared', or explicit scope groups */
+      observationScopes?: "per_tag" | "combined" | "all_combinations" | "shared" | string[][];
       /** Extraction strategy override */
       strategy?: string;
       signal?: AbortSignal;


### PR DESCRIPTION
## Summary
- allow the hand-written TypeScript client inputs to accept the new `observationScopes: "shared"` retain option
- keep the public helper type aligned with the generated client/OpenAPI union from #2202

## Tests
- `npm ci --workspace @vectorize-io/hindsight-client --include-workspace-root=false`
- `npm run build` from `hindsight-clients/typescript`
- `git diff --check`

Note: the repository pre-commit hook was not usable in this partial workspace install because the full control-plane eslint config could not resolve `@eslint/js`.