### PR TITLE
fix(api): gate dry-run extraction behind the operation precheck

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3541,6 +3541,20 @@ def _register_routes(app: FastAPI):
             logger.error(f"Error in /v1/default/banks/{bank_id}/memories/list: {error_detail}")
             raise HTTPException(status_code=500, detail=str(e))
 
+    async def _require_dry_run_enabled() -> None:
+        """Feature-flag gate for dry-run extraction.
+
+        Declared as a dependency BEFORE ``precheck_for("dry_run_extract")`` so a
+        disabled route returns 404 regardless of tenant/billing state — FastAPI
+        resolves path-operation dependencies in signature order, so this runs
+        first and preserves the original "disabled → 404" contract.
+        """
+        if not get_config().enable_dry_run_extract:
+            raise HTTPException(
+                status_code=404,
+                detail="Dry-run extraction is disabled. Set HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT=true to re-enable.",
+            )
+
     @app.post(
         "/v1/default/banks/{bank_id}/memories/dry-run-extract",
         response_model=DryRunExtractionResult,
@@ -3559,12 +3573,9 @@ def _register_routes(app: FastAPI):
         bank_id: str,
         body: DryRunExtractRequest,
         request_context: RequestContext = Depends(get_request_context),
+        _enabled: None = Depends(_require_dry_run_enabled),
+        _precheck: None = Depends(precheck_for("dry_run_extract")),
     ):
-        if not get_config().enable_dry_run_extract:
-            raise HTTPException(
-                status_code=404,
-                detail="Dry-run extraction is disabled. Set HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT=true to re-enable.",
-            )
         try:
             override_fields = (
                 "retain_mission",

--- a/hindsight-api-slim/tests/test_extract_dry_run_http.py
+++ b/hindsight-api-slim/tests/test_extract_dry_run_http.py
@@ -16,6 +16,11 @@ import pytest_asyncio
 from hindsight_api import RequestContext
 from hindsight_api.api import create_app
 from hindsight_api.config import clear_config_cache
+from hindsight_api.extensions import (
+    OperationValidatorExtension,
+    PrecheckContext,
+    ValidationResult,
+)
 
 # Dry-run facts are a subset of the memory-unit shape — only fields a fresh extraction produces
 # (no storage/consolidation/curation fields, since nothing is persisted).
@@ -102,3 +107,73 @@ async def test_dry_run_rejects_unknown_override(memory):
             overrides={"embeddings_provider": "evil"},
             request_context=RequestContext(),
         )
+
+
+class _DryRunRejectingValidator(OperationValidatorExtension):
+    """Operation validator that rejects the dry-run-extract precheck.
+
+    Models an extension that gates LLM-billable routes (revoked key / exhausted
+    balance / rate-limited tenant). It rejects only the ``dry_run_extract``
+    operation so the test asserts the dry-run route is actually wired to the
+    precheck, not that the validator rejects everything.
+    """
+
+    async def precheck(self, ctx: PrecheckContext) -> ValidationResult:
+        if ctx.operation == "dry_run_extract":
+            return ValidationResult.reject("dry-run extraction not allowed", status_code=402)
+        return ValidationResult.accept()
+
+    async def validate_retain(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_recall(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+    async def validate_reflect(self, ctx) -> ValidationResult:
+        return ValidationResult.accept()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_honors_operation_precheck(api_client, memory):
+    """dry-run-extract makes a real LLM call, so it must run the same billing/quota/rate-limit
+    precheck the other LLM-billable POST routes (retain/recall/reflect/mental_model_*/files_retain)
+    already wire. A validator that rejects the operation must short-circuit the request before any
+    extraction runs — without the precheck dependency the route would proceed to a 200."""
+    bank_id = f"dryrun-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
+
+    previous = getattr(memory, "_operation_validator", None)
+    memory._operation_validator = _DryRunRejectingValidator({})
+    try:
+        resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/memories/dry-run-extract",
+            json={"content": "Alice moved to Berlin in 2021."},
+        )
+        assert resp.status_code == 402, resp.text
+        assert "not allowed" in resp.json()["detail"].lower()
+    finally:
+        memory._operation_validator = previous
+
+
+@pytest.mark.asyncio
+async def test_dry_run_disabled_returns_404_even_with_validator(api_client, memory):
+    """A disabled dry-run route must 404 before the billing/quota precheck runs, even with a
+    configured validator — the feature-flag gate is declared as a dependency before the precheck,
+    so it preserves the original "disabled → 404" contract instead of leaking a 402/401/429."""
+    bank_id = f"dryrun-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
+
+    previous = getattr(memory, "_operation_validator", None)
+    memory._operation_validator = _DryRunRejectingValidator({})
+    try:
+        with patch.dict(os.environ, {"HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT": "false"}):
+            clear_config_cache()  # force get_config() to re-read the patched env
+            resp = await api_client.post(
+                f"/v1/default/banks/{bank_id}/memories/dry-run-extract",
+                json={"content": "Alice moved to Berlin in 2021."},
+            )
+        assert resp.status_code == 404, resp.text
+        assert "disabled" in resp.json()["detail"].lower()
+    finally:
+        clear_config_cache()  # env restored on with-exit; reset so later tests see the default
+        memory._operation_validator = previous


### PR DESCRIPTION
## Summary

`POST .../memories/dry-run-extract` (added in #2205, enabled by default) performs a real LLM call (fact extraction), but it was the only enabled-by-default LLM-billable route with **no `OperationValidator` gating** — neither a route-level `precheck` nor an engine-level `validate_*` hook.

Every other LLM-billable POST route already wires `Depends(precheck_for(...))`: `retain`, `recall`, `reflect`, `mental_model_create`, `mental_model_refresh`, `files_retain`. This brings `dry-run-extract` in line with that documented gating contract, so an extension that gates LLM spend (exhausted balance / revoked key / rate-limited tenant) can reject a dry-run **before the model is invoked** — exactly the cost/abuse audience `precheck_for`'s own docstring describes.

## Change

- `http.py`: add `_precheck: None = Depends(precheck_for("dry_run_extract"))` to the route, mirroring `retain`/`recall`/etc.
- The feature-flag (`enable_dry_run_extract`) check is moved into a small `_require_dry_run_enabled` dependency declared **before** `_precheck`. FastAPI resolves path-operation dependencies in signature order, so a disabled route still returns its 404 first — no behavior change for the disabled case, including when a validator is configured.
- Regression tests: (1) a rejecting validator → dry-run returns `402`; (2) disabled **+** rejecting validator still returns `404` (locks the ordering contract).

When no operation validator is configured (the default), `precheck_for` is a silent no-op, so default deployments are unaffected.

If this overlaps something already landing via a different patch, feel free to close — happy to adjust.
