### PR TITLE
Add systemd service units and PKGBUILD for Arch Linux

### DIFF
--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,0 +1,102 @@
+# Maintainer: Raudbjorn <raudbjorn@github>
+# PKGBUILD for hindsight — Agent memory that works like human memory
+
+pkgname=hindsight
+pkgver=0.8.2
+pkgrel=1
+pkgdesc="Agent memory that works like human memory — API server, CLI, and web UI"
+arch=("x86_64")
+url="https://github.com/Raudbjorn/hindsight"
+license=("ISC")
+depends=(
+  "python>=3.11"
+  "python-pip"
+  "nodejs>=20"
+  "npm"
+  "postgresql"
+  "uv"
+)
+makedepends=(
+  "python-build"
+  "python-installer"
+)
+optdepends=(
+  "postgresql: External database (optional; uses embedded pg0 by default)"
+)
+provides=(
+  "hindsight-api-slim=${pkgver}"
+  "hindsight-embed=${pkgver}"
+  "hindsight-control-plane=${pkgver}"
+)
+conflicts=(
+  "hindsight-api-slim"
+  "hindsight-embed"
+  "hindsight-control-plane"
+)
+install="hindsight.install"
+
+source=("git+https://github.com/Raudbjorn/hindsight.git#tag=v${pkgver}")
+sha256sums=("SKIP")
+
+pkgver() {
+  cd "$srcdir/hindsight"
+  git describe --tags --match 'v*' | sed 's/^v//'
+}
+
+build() {
+  cd "$srcdir/hindsight"
+
+  # The control plane depends on @vectorize-io/hindsight-client as a workspace
+  # path dependency. Build the entire monorepo so the workspace link resolves.
+  npm ci
+  npm run build --workspaces
+}
+
+package() {
+  cd "$srcdir/hindsight"
+  local pkgsrc="$srcdir/hindsight"
+  local pkgdst="$pkgdir"
+
+  # Create Python venv and bootstrap uv into it
+  python -m venv "$pkgdst/opt/hindsight/venv"
+  "$pkgdst/opt/hindsight/venv/bin/pip" install --quiet uv
+  local venv_python="$pkgdst/opt/hindsight/venv/bin/python"
+
+  # Install local packages using uv — uv handles building hatchling packages
+  # from source and installs the resulting wheel.
+  # The [all] extra includes:
+  #   embedded-db  (pg0-embedded for local PostgreSQL)
+  #   local-ml     (sentence-transformers, torch for local embeddings/reranking)
+  #   local-onnx   (onnxruntime for ONNX embeddings)
+  #   local-llm    (llama-cpp-python for local LLM inference)
+  "$pkgdst/opt/hindsight/venv/bin/uv" pip install \
+    --python "$venv_python" \
+    "$pkgsrc/hindsight-api-slim[all]"
+
+  "$pkgdst/opt/hindsight/venv/bin/uv" pip install \
+    --python "$venv_python" \
+    "$pkgsrc/hindsight-embed"
+
+  # Install Node.js control plane standalone build
+  install -d "$pkgdst/opt/hindsight/control-plane"
+  cp -r hindsight-control-plane/standalone "$pkgdst/opt/hindsight/control-plane/"
+
+  # Create data directory (owned by hindsight:hindsight — set by post_install)
+  install -d -m 0750 "$pkgdst/var/lib/hindsight"
+
+  # Create config directory and install env template
+  install -d -m 0755 "$pkgdst/etc/hindsight"
+  install -m 0640 "$startdir/env.env.systemd" "$pkgdst/etc/hindsight/env"
+
+  # Install systemd service units
+  install -d -m 0755 "$pkgdst/usr/lib/systemd/system/"
+  install -m 0644 "$startdir/systemd/hindsight-api.service" "$pkgdst/usr/lib/systemd/system/"
+  install -m 0644 "$startdir/systemd/hindsight-control-plane.service" "$pkgdst/usr/lib/systemd/system/"
+
+  # Create symlinks for CLI entry points
+  install -d -m 0755 "$pkgdst/usr/bin/"
+  ln -sf /opt/hindsight/venv/bin/hindsight-api "$pkgdst/usr/bin/hindsight-api"
+  ln -sf /opt/hindsight/venv/bin/hindsight-worker "$pkgdst/usr/bin/hindsight-worker"
+  ln -sf /opt/hindsight/venv/bin/hindsight-admin "$pkgdst/usr/bin/hindsight-admin"
+  ln -sf /opt/hindsight/venv/bin/hindsight-embed "$pkgdst/usr/bin/hindsight-embed"
+}

--- a/packaging/env.env.systemd
+++ b/packaging/env.env.systemd
@@ -1,0 +1,22 @@
+# Hindsight Environment Variables
+# Copy this file to /etc/hindsight/env and fill in your values
+
+# LLM Configuration (Required)
+HINDSIGHT_API_LLM_PROVIDER=openai
+HINDSIGHT_API_LLM_API_KEY=your-api-key-here
+HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
+HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
+
+# API Configuration
+HINDSIGHT_API_HOST=0.0.0.0
+HINDSIGHT_API_PORT=8888
+HINDSIGHT_API_LOG_LEVEL=info
+
+# Database (Optional - uses embedded pg0 by default)
+# To use an external PostgreSQL database instead, uncomment and fill in:
+# HINDSIGHT_API_DATABASE_URL=postgresql://user:pass@host:5432/db
+
+# Control Plane
+HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888
+HINDSIGHT_CP_HOST=0.0.0.0
+HINDSIGHT_CP_PORT=9999

--- a/packaging/hindsight.install
+++ b/packaging/hindsight.install
@@ -1,0 +1,46 @@
+post_install() {
+  # Create hindsight system user if it doesn't exist
+  if ! id -u hindsight &>/dev/null; then
+    useradd -r -d /var/lib/hindsight -s /usr/bin/nologin -c "Hindsight Service Account" hindsight
+  fi
+
+  # Ensure data directory exists with correct ownership
+  install -d -o hindsight -g hindsight -m 0750 /var/lib/hindsight
+
+  # Fix shebangs in venv entry point scripts — hatchling bakes the build-time Python path
+  # into the shebang, which is wrong at install time. Replace with the installed venv Python.
+  local venv_python="/opt/hindsight/venv/bin/python"
+  local venv_bin="/opt/hindsight/venv/bin"
+  for script in "$venv_bin"/hindsight-* "$venv_bin"/hindsight-local-mcp; do
+    if [ -f "$script" ]; then
+      sed -i "1s|^#!/.*python|#!$venv_python|" "$script"
+    fi
+  done
+
+  # Reload systemd to pick up new unit files (non-fatal in containers/boot environments)
+  systemctl daemon-reload 2>/dev/null || true
+}
+
+post_upgrade() {
+  # Ensure user still exists after upgrades
+  if ! id -u hindsight &>/dev/null; then
+    useradd -r -d /var/lib/hindsight -s /usr/bin/nologin -c "Hindsight Service Account" hindsight
+  fi
+  install -d -o hindsight -g hindsight -m 0750 /var/lib/hindsight
+
+  # Re-fix shebangs on upgrade (package may have new entry points)
+  local venv_python="/opt/hindsight/venv/bin/python"
+  local venv_bin="/opt/hindsight/venv/bin"
+  for script in "$venv_bin"/hindsight-* "$venv_bin"/hindsight-local-mcp; do
+    if [ -f "$script" ]; then
+      sed -i "1s|^#!/.*python|#!$venv_python|" "$script"
+    fi
+  done
+
+  systemctl daemon-reload 2>/dev/null || true
+}
+
+pre_remove() {
+  # Stop services before removing files
+  systemctl --no-reload disable --now hindsight-api.service hindsight-control-plane.service 2>/dev/null || true
+}

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -1,0 +1,59 @@
+# Hindsight systemd Services
+
+This directory contains systemd service units for Hindsight.
+
+## Services
+
+- `hindsight-api.service` — FastAPI API server (port 8888)
+- `hindsight-control-plane.service` — Next.js web UI (port 9999)
+
+## Installation
+
+1. Copy the env template to the config location:
+
+   ```bash
+   sudo cp /opt/hindsight/env /etc/hindsight/env
+   ```
+
+2. Edit `/etc/hindsight/env` and set your `HINDSIGHT_API_LLM_API_KEY`:
+
+   ```bash
+   sudo $EDITOR /etc/hindsight/env
+   ```
+
+3. Enable and start the services:
+
+   ```bash
+   sudo systemctl enable --now hindsight-api
+   sudo systemctl enable --now hindsight-control-plane
+   ```
+
+## Verification
+
+```bash
+# Check service status
+sudo systemctl status hindsight-api
+sudo systemctl status hindsight-control-plane
+
+# Verify API is responding
+curl http://localhost:8888/health
+
+# View logs
+sudo journalctl -u hindsight-api --no-pager -f
+sudo journalctl -u hindsight-control-plane --no-pager -f
+```
+
+## Ports
+
+| Service | Port | URL |
+|---------|------|-----|
+| API | 8888 | http://localhost:8888 |
+| Control Plane | 9999 | http://localhost:9999 |
+
+## Notes
+
+- The API service starts before the control plane (via `Wants=`/`After=`).
+- Both services run under the `hindsight` system user.
+- Config is read from `/etc/hindsight/env`.
+- Data is stored in `/var/lib/hindsight`.
+- Graceful shutdown timeout is 30 seconds.

--- a/packaging/systemd/hindsight-api.service
+++ b/packaging/systemd/hindsight-api.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Hindsight API Server
+After=network.target
+
+[Service]
+Type=simple
+User=hindsight
+Group=hindsight
+WorkingDirectory=/var/lib/hindsight
+Environment="PATH=/opt/hindsight/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
+Environment="HOME=/var/lib/hindsight"
+ExecStart=/opt/hindsight/venv/bin/hindsight-api
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hindsight-api
+
+# Graceful shutdown: give process 30s to finish
+TimeoutStopSec=30s
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/hindsight
+EnvironmentFile=/etc/hindsight/env
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/hindsight-control-plane.service
+++ b/packaging/systemd/hindsight-control-plane.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Hindsight Control Plane Web UI
+After=network.target hindsight-api.service
+Wants=hindsight-api.service
+
+[Service]
+Type=simple
+User=hindsight
+Group=hindsight
+WorkingDirectory=/opt/hindsight/control-plane
+Environment="HOME=/var/lib/hindsight"
+ExecStart=/opt/hindsight/control-plane/standalone/server.js
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hindsight-cp
+TimeoutStopSec=30s
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/hindsight /opt/hindsight/control-plane
+EnvironmentFile=/etc/hindsight/env
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- hindsight-api.service: FastAPI server on port 8888
- hindsight-control-plane.service: Next.js web UI on port 9999
- hindsight.install: post-install hook for user/group creation and shebang fix
- PKGBUILD: builds monorepo, installs Python packages via uv + local paths, bundles Node.js standalone build, creates hindsight user, installs systemd units
- env.env.systemd: env template for systemd deployment
- packaging/systemd/README.md: usage instructions