### PR TITLE
fix(skill-docs): convert all admonition keywords in the docs→skill generator

### DIFF
--- a/scripts/generate-docs-skill.sh
+++ b/scripts/generate-docs-skill.sh
@@ -182,10 +182,24 @@ content = re.sub(r'</Tabs>\s*', '', content)
 content = re.sub(r'<TabItem value="[^"]*" label="([^"]+)">', r'### \1\n', content)
 content = re.sub(r'</TabItem>', '', content)
 
-# Convert :::tip, :::warning, :::note to markdown blockquotes
-content = re.sub(r':::tip (.+?)\n', r'> **💡 \1**\n> \n', content)
-content = re.sub(r':::warning (.+?)\n', r'> **⚠️ \1**\n> \n', content)
-content = re.sub(r':::note (.+?)\n', r'> **📝 \1**\n> \n', content)
+# Convert Docusaurus admonitions (:::tip/:::note/:::warning/:::info/:::caution,
+# with or without an inline title) to markdown blockquotes. The title is
+# optional so title-less openers like a bare ':::note' are handled too, and
+# every supported keyword is covered so none leaks through as raw markdown.
+_ADMONITION_EMOJI = {
+    'tip': '💡',
+    'note': '📝',
+    'info': 'ℹ️',
+    'warning': '⚠️',
+    'caution': '🚨',
+}
+def _convert_admonition(m):
+    kind = m.group(1)
+    title = m.group(2)
+    emoji = _ADMONITION_EMOJI[kind]
+    heading = f'{emoji} {title}' if title else f'{emoji} {kind.capitalize()}'
+    return f'> **{heading}**\n> \n'
+content = re.sub(r':::(tip|note|warning|info|caution)(?: (.+?))?\n', _convert_admonition, content)
 content = re.sub(r':::\s*\n', '', content)
 
 # Clean up extra blank lines

--- a/skills/hindsight-docs/references/developer/api/documents.md
+++ b/skills/hindsight-docs/references/developer/api/documents.md
@@ -249,7 +249,8 @@ hindsight document update-tags my-bank meeting-2024-03-15
 # Section 'document-update' not found in api/documents.go
 ```
 
-:::info Observations are re-consolidated
+> **ℹ️ Observations are re-consolidated**
+> 
 When tags change, any consolidated observations derived from the document's memories are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
 ## Delete Document
 
@@ -301,7 +302,8 @@ hindsight document delete my-bank meeting-2024-03-15
 # Section 'document-delete' not found in api/documents.go
 ```
 
-:::warning
+> **⚠️ Warning**
+> 
 Deleting a document permanently removes all memories extracted from it. This action cannot be undone.
 ## List Documents
 

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -290,7 +290,8 @@ How much to weight emotional context when reasoning during `reflect`. Scale 1–
 | `3` *(default)* | Balanced |
 | `5` | Empathetic — considers emotional context |
 
-:::info
+> **ℹ️ Info**
+> 
 Disposition traits and `reflect_mission` only affect the `reflect` operation. `retain_mission` and `observations_mission` are separate per-operation settings.
 ### mcp_enabled_tools
 
@@ -508,7 +509,8 @@ You can also update configuration directly from the Control Plane UI — navigat
 
 Directives are hard rules that the agent must follow during [reflect](./reflect) operations. Unlike disposition traits which influence *how* the agent reasons, directives are explicit instructions that are *always* enforced.
 
-:::info
+> **ℹ️ Info**
+> 
 Directives only affect the `reflect` operation. They are injected into prompts and the agent is required to comply with them in all responses.
 ### When to Use Directives
 

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -150,7 +150,8 @@ hindsight mental-model create "$BANK_ID" \
 # Section 'create-mental-model-with-id' not found in api/mental-models.go
 ```
 
-:::tip
+> **💡 Tip**
+> 
 Custom IDs must be lowercase alphanumeric and may contain hyphens (e.g. `team-policies`, `q4-status`). If a mental model with that ID already exists, the request is rejected.
 ---
 
@@ -242,7 +243,8 @@ hindsight mental-model create "$BANK_ID" \
 | **User preferences** | ✅ Enabled | Preferences evolve with new interactions |
 | **FAQ answers** | ❌ Disabled | Answers are curated, should be reviewed before updating |
 
-:::tip
+> **💡 Tip**
+> 
 Enable automatic refresh for mental models that need to stay current. Disable it for curated content where you want to review changes before they go live.
 ---
 
@@ -342,7 +344,8 @@ The `detail` parameter is also available in the MCP tools:
 {"bank_id": "my-bank", "detail": "metadata"}
 ```
 
-:::tip
+> **💡 Tip**
+> 
 Use `detail=content` for agent orientation flows. It includes everything the agent needs to understand the models without the heavyweight `reflect_response` provenance chains, which can exceed 200KB for banks with many models.
 ### Response Fields
 
@@ -438,7 +441,8 @@ console.log(`Full refresh operation ID: ${fullRefreshResult.operation_id}`);
 
 The clear operation is synchronous and resets the content to an empty string. The model's configuration (name, source query, trigger settings) is preserved. Since the content is now empty, the next `/refresh` call will always perform a full regeneration — even if the model's trigger mode is set to `delta`.
 
-:::tip
+> **💡 Tip**
+> 
 For long-lived delta-mode mental models, consider scheduling a periodic clear + refresh (e.g. every 48 hours) to keep the content accurate while still benefiting from incremental delta updates in between.
 ---
 
@@ -513,7 +517,8 @@ Mental models support the same tag system as memories. When you assign tags to a
 
 ### How tags affect mental model refresh
 
-:::warning
+> **⚠️ Warning**
+> 
 Adding tags to a mental model narrows the pool of source memories its refresh can read from. If no memories carry those tags yet, refresh will return empty content (e.g. `"I cannot find any information…"`) even though direct `reflect` on the same query works. Backfill tags on the relevant memories first, or override the default via `trigger.tags_match` / `trigger.tag_groups`.
 When a mental model is refreshed (manually or automatically), it runs an internal reflect call to regenerate its content. If the mental model has tags, that reflect call uses `all_strict` tag matching — meaning it will only read memories that carry **all** of the mental model's tags. Untagged memories are excluded.
 
@@ -591,7 +596,8 @@ The endpoint returns a list of history entries, most recent first:
 
 Each entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
 
-:::note
+> **📝 Note**
+> 
 History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it.
 ---
 

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -7,7 +7,8 @@ When you **recall**, Hindsight runs four retrieval strategies in parallel — se
 
 {/* Import raw source files */}
 
-:::info How Recall Works
+> **ℹ️ How Recall Works**
+> 
 Learn about the four retrieval strategies (semantic, keyword, graph, temporal) and RRF fusion in the [Recall Architecture](../retrieval.md) guide.
 > **💡 Prerequisites**
 > 
@@ -244,7 +245,8 @@ An optional object controlling supplementary data returned alongside the main fa
 
 When enabled, the response includes the raw source text chunks from which each fact was extracted. Chunks are fetched before the `max_tokens` filter, so setting `max_tokens=0` returns no facts but can still return chunks. The `max_tokens` sub-option (default `8192`) controls the total chunk token budget independently of the main fact budget. This is useful when agents need surrounding context beyond the extracted fact text.
 
-:::note
+> **📝 Note**
+> 
 When `include_chunks` is enabled, chunks are fetched based on the top-scored reranked results before token filtering. The last chunk is truncated (not dropped) to fit exactly within the budget, and each chunk carries a `truncated` flag indicating whether it was cut.
 #### source_facts
 

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -7,7 +7,8 @@ When you call **reflect**, Hindsight runs an agentic loop that autonomously sear
 
 {/* Import raw source files */}
 
-:::info How Reflect Works
+> **ℹ️ How Reflect Works**
+> 
 Learn about disposition-driven reasoning in the [Reflect Architecture](../reflect.md) guide.
 > **💡 Prerequisites**
 > 

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -7,7 +7,8 @@ When you **retain** content, Hindsight doesn't just store the raw text—it inte
 
 {/* Import raw source files */}
 
-:::info How Retain Works
+> **ℹ️ How Retain Works**
+> 
 Learn about fact extraction, entity resolution, and graph construction in the [Retain Architecture](../retain.md) guide.
 > **💡 Prerequisites**
 > 
@@ -228,7 +229,8 @@ See [Recall API](./recall#tags) for filtering by tags during retrieval.
 
 Controls which [observations](../observations) this memory contributes to during consolidation. Each scope runs an independent pass, creating or updating observations tagged with only that scope's tags.
 
-:::info Scope isolation
+> **ℹ️ Scope isolation**
+> 
 During consolidation, Hindsight uses `all_strict` matching to find existing observations to update — only observations whose tags exactly match the current scope are considered. This keeps scopes isolated: a memory consolidated under `["student:alice"]` will never bleed into an observation tagged `["student:alice", "teacher:bob"]`.
 The examples below use a lesson transcript retained with `tags: ["student:alice", "teacher:bob", "session-id:s1"]`.
 
@@ -253,7 +255,8 @@ One consolidation pass over a single global, **untagged** scope. The memory's ow
 
 **Use when** your tags are per-call provenance (e.g. session ids) that you want for recall filtering and debugging but not as a consolidation boundary — keep the tag on `tags` and set `observation_scopes: "shared"`.
 
-:::caution `shared` vs `[[]]` vs `[]`
+> **🚨 `shared` vs `[[]]` vs `[]`**
+> 
 `shared` is equivalent to the explicit scope `[[]]` — a list containing one empty scope. Do **not** confuse it with `[]` (an empty list), which declares *zero* scopes and silently falls back to `combined`.
 #### per_tag
 
@@ -467,7 +470,8 @@ hindsight memory retain-files my-bank "$SCRIPT_DIR/" --async
 # Section 'retain-files' not found in api/retain.go
 ```
 
-:::info File Storage
+> **ℹ️ File Storage**
+> 
 Uploaded files are stored server-side (PostgreSQL by default, or S3/GCS/Azure for production). Configure storage via `HINDSIGHT_API_FILE_STORAGE_TYPE`. See [Configuration](../configuration#file-processing) for details.
 ---
 
@@ -528,5 +532,6 @@ export HINDSIGHT_API_RETAIN_BATCH_ENABLED=true
 
 Hindsight submits fact extraction calls as a batch job to the provider, polls for completion, and processes results automatically. No changes to your API calls are needed.
 
-:::note
+> **📝 Note**
+> 
 Batch API cost savings require `async=true` in your retain request and a compatible provider (OpenAI, Groq, or Gemini).

--- a/skills/hindsight-docs/references/developer/api/webhooks.md
+++ b/skills/hindsight-docs/references/developer/api/webhooks.md
@@ -18,7 +18,8 @@ Webhooks are registered per memory bank and fire automatically when matching eve
 
 A delivery is considered failed if your endpoint returns a non-2xx status code or does not respond within the configured timeout (default 30 seconds). After 6 failed attempts, the delivery is marked as permanently failed and no further retries are made.
 
-:::info At-least-once delivery
+> **ℹ️ At-least-once delivery**
+> 
 Webhook delivery tasks are queued in the same database transaction as the primary operation (e.g. the retain or consolidation write). This means if the server crashes after committing but before sending, the delivery task survives and will be retried. As a result, **your endpoint may receive the same event more than once** — use the `operation_id` field to deduplicate if needed.
 ## Event Types
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -102,7 +102,8 @@ Beyond basic generation, some providers support optional features that lower cos
 - **Batch API** — submits bulk retain extraction through the provider's asynchronous batch endpoint, typically at ~50% lower cost. Used automatically when available; otherwise calls run synchronously.
 - **Explicit prompt caching** — reuses the large, fixed system prefix that retain (fact extraction), consolidation, and the reflect tool-loop send on every call, billing it at the provider's cached-input rate. On Gemini/Vertex this uses the `CachedContent` API. **On by default**; disable with `HINDSIGHT_API_LLM_PROMPT_CACHE_ENABLED=false`. Hindsight structures these prompts so the cached prefix is **bank-agnostic** — one cache is shared across all banks rather than one per bank/mission, and creation soft-fails to an uncached call, so it never breaks a request.
 
-:::note
+> **📝 Note**
+> 
 A blank "Explicit prompt caching" cell does not mean a provider has no caching. OpenAI, for example, caches a stable leading prompt prefix **automatically** server-side, so it benefits with no configuration; Anthropic supports caching via `cache_control` breakpoints which can be wired up through the same provider hook. The column tracks only Hindsight's explicit `get_or_create_cached_prefix` hook, which Gemini/Vertex implement today.
 ### Benchmarks
 

--- a/skills/hindsight-docs/references/developer/reflect.md
+++ b/skills/hindsight-docs/references/developer/reflect.md
@@ -131,7 +131,8 @@ The reflect mission frames how the agent reasons and responds:
 - Shapes how disposition traits are applied in practice
 - Keeps reasoning consistent across conversations
 
-:::info Per-operation missions
+> **ℹ️ Per-operation missions**
+> 
 The reflect mission only affects `reflect()`. To steer what gets extracted during `retain()`, use [`retain_mission`](api/memory-banks.md#retain-configuration). To control what gets synthesised into observations, use [`observations_mission`](api/memory-banks.md#observations-configuration).
 ---
 
@@ -185,7 +186,8 @@ Use directives for constraints that must never be violated:
 | **Violation** | Acceptable (it's a tendency) | Not acceptable |
 | **Example** | High skepticism → questions claims | "Never make medical diagnoses" |
 
-:::tip
+> **💡 Tip**
+> 
 Use disposition for personality and character. Use directives for compliance and guardrails.
 See [Memory Banks: Directives](api/memory-banks.md#directives) for how to create and manage directives.
 


### PR DESCRIPTION
## Problem

The MDX→agent-skill generator (`scripts/generate-docs-skill.sh`) only converts `:::tip`, `:::warning`, and `:::note`, and each rule requires an inline title:

```python
content = re.sub(r':::tip (.+?)\n', ...)
content = re.sub(r':::warning (.+?)\n', ...)
content = re.sub(r':::note (.+?)\n', ...)
content = re.sub(r':::\s*\n', '', content)   # strips closing fences
```

So `:::info`, `:::caution`, and any title-less opener (e.g. a bare `:::note`) are never matched — they survive into the CI-enforced agent-facing mirror (`skills/hindsight-docs/references/**`) as raw `:::` markdown. The generic `:::\s*\n` cleanup then removes the *closing* fence, so the admonition body silently bleeds into the following section.

Most visibly, #2202 added a `:::caution` "shared vs `[[]]` vs `[]`" warning to `retain.mdx`; in the generated `retain.md` it renders as a raw `:::caution …` line with its closing fence gone, merging into the `#### per_tag` section that follows.

## Fix

Replace the three per-keyword rules with one combined, title-**optional** substitution over every supported keyword:

```python
content = re.sub(r':::(tip|note|warning|info|caution)(?: (.+?))?\n', _convert_admonition, content)
```

`_convert_admonition` maps each keyword to a blockquote, using the inline title when present and the capitalized keyword otherwise. Regenerating the skill (`./scripts/generate-docs-skill.sh`) repairs the `#2202` `:::caution` and clears the pre-existing `:::info`/`:::caution`/title-less leaks across the core API reference docs. The generated changes here are exactly that deterministic output (idempotent on re-run).

## Notes

- Source files that are plain `.md` (e.g. `configuration.md`) are **copied verbatim** by the generator rather than run through this converter, so their admonitions are out of scope for this PR — happy to extend the converter to that copy path as a follow-up if you'd like.
