### PR TITLE
Fix archived memory embedding dimension migration

### DIFF
--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -565,7 +565,8 @@ def ensure_embedding_dimension(
     """
     Ensure the embedding column dimension matches the model's dimension for all tables.
 
-    Checks and adjusts memory_units.embedding and mental_models.embedding:
+    Checks and adjusts memory_units.embedding, invalidated_memory_units.embedding,
+    and mental_models.embedding:
     - If dimensions match: no action needed
     - If dimensions differ and table is empty: ALTER COLUMN to new dimension
     - If dimensions differ and table has data: raise error with migration guidance
@@ -602,8 +603,37 @@ def ensure_embedding_dimension(
         vector_ext = _detect_vector_extension(conn, vector_extension)
         logger.info(f"Using vector extension: {vector_ext}")
 
-        _migrate_table_embedding_dimension(conn, schema_name, "memory_units", required_dimension, vector_ext)
-        _migrate_table_embedding_dimension(conn, schema_name, "mental_models", required_dimension, vector_ext)
+        embedding_tables = ("memory_units", "invalidated_memory_units", "mental_models")
+        for table_name in embedding_tables:
+            current_dim = conn.execute(
+                text("""
+                    SELECT atttypmod
+                    FROM pg_attribute a
+                    JOIN pg_class c ON a.attrelid = c.oid
+                    JOIN pg_namespace n ON c.relnamespace = n.oid
+                    WHERE n.nspname = :schema
+                      AND c.relname = :table
+                      AND a.attname = 'embedding'
+                """),
+                {"schema": schema_name, "table": table_name},
+            ).scalar()
+            if current_dim is None or current_dim == required_dimension:
+                continue
+
+            row_count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {schema_name}.{table_name} WHERE embedding IS NOT NULL")
+            ).scalar()
+            if row_count > 0:
+                raise RuntimeError(
+                    f"Cannot change embedding dimension from {current_dim} to {required_dimension}: "
+                    f"{table_name} table contains {row_count} rows with embeddings. "
+                    f"To change dimensions, you must either:\n"
+                    f"  1. Re-embed all data: DELETE FROM {schema_name}.{table_name}; then restart\n"
+                    f"  2. Use a model with {current_dim}-dimensional embeddings"
+                )
+
+        for table_name in embedding_tables:
+            _migrate_table_embedding_dimension(conn, schema_name, table_name, required_dimension, vector_ext)
 
 
 def ensure_vector_extension(

--- a/hindsight-api-slim/tests/test_custom_embedding_dimension.py
+++ b/hindsight-api-slim/tests/test_custom_embedding_dimension.py
@@ -21,7 +21,7 @@ from hindsight_api.engine.cross_encoder import (
     SiliconFlowCrossEncoder,
     ZeroEntropyCrossEncoder,
 )
-from hindsight_api.engine.embeddings import CohereEmbeddings, LocalSTEmbeddings, OpenAIEmbeddings
+from hindsight_api.engine.embeddings import CohereEmbeddings, OpenAIEmbeddings
 from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 from hindsight_api.extensions import TenantContext, TenantExtension
@@ -160,11 +160,11 @@ def get_column_dimension(db_url: str, schema: str = "public", table: str = "memo
         return result
 
 
-def get_row_count(db_url: str, schema: str = "public") -> int:
-    """Get the number of rows with embeddings in memory_units."""
+def get_row_count(db_url: str, schema: str = "public", table: str = "memory_units") -> int:
+    """Get the number of rows with embeddings in a table."""
     engine = create_engine(db_url)
     with engine.connect() as conn:
-        return conn.execute(text(f"SELECT COUNT(*) FROM {schema}.memory_units WHERE embedding IS NOT NULL")).scalar()
+        return conn.execute(text(f"SELECT COUNT(*) FROM {schema}.{table} WHERE embedding IS NOT NULL")).scalar()
 
 
 def insert_test_embedding(db_url: str, schema: str, dimension: int):
@@ -188,6 +188,30 @@ def clear_embeddings(db_url: str, schema: str):
     engine = create_engine(db_url)
     with engine.connect() as conn:
         conn.execute(text(f"DELETE FROM {schema}.memory_units"))
+        conn.commit()
+
+
+def insert_test_invalidated_embedding(db_url: str, schema: str, dimension: int):
+    """Insert an archived memory row with a dummy embedding."""
+    engine = create_engine(db_url)
+    embedding = [0.1] * dimension
+    embedding_str = "[" + ",".join(str(x) for x in embedding) + "]"
+
+    with engine.connect() as conn:
+        conn.execute(
+            text(f"""
+                INSERT INTO {schema}.invalidated_memory_units (bank_id, text, embedding, event_date, fact_type)
+                VALUES ('test-bank', 'archived test text', '{embedding_str}'::vector, NOW(), 'world')
+            """)
+        )
+        conn.commit()
+
+
+def clear_invalidated_embeddings(db_url: str, schema: str):
+    """Clear all rows from invalidated_memory_units."""
+    engine = create_engine(db_url)
+    with engine.connect() as conn:
+        conn.execute(text(f"DELETE FROM {schema}.invalidated_memory_units"))
         conn.commit()
 
 
@@ -273,6 +297,24 @@ class TestEmbeddingDimension:
         _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
         assert get_column_dimension(db_url, schema) == 384
 
+    def test_dimension_change_updates_invalidated_memory_units(self, dimension_test_schema):
+        """The archive table must track live memory embedding dimension changes."""
+        db_url, schema = dimension_test_schema
+
+        clear_embeddings(db_url, schema)
+        clear_invalidated_embeddings(db_url, schema)
+        assert get_row_count(db_url, schema, table="invalidated_memory_units") == 0
+
+        _ensure_embedding_dimension_with_retry(db_url, 768, schema=schema)
+
+        assert get_column_dimension(db_url, schema, table="memory_units") == 768
+        assert get_column_dimension(db_url, schema, table="invalidated_memory_units") == 768
+
+        # Change back for other tests
+        _ensure_embedding_dimension_with_retry(db_url, 384, schema=schema)
+        assert get_column_dimension(db_url, schema, table="memory_units") == 384
+        assert get_column_dimension(db_url, schema, table="invalidated_memory_units") == 384
+
     def test_dimension_change_blocked_with_data(self, dimension_test_schema):
         """When table has data, dimension change should be blocked."""
         db_url, schema = dimension_test_schema
@@ -298,6 +340,26 @@ class TestEmbeddingDimension:
 
         # Cleanup
         clear_embeddings(db_url, schema)
+
+    def test_invalidated_memory_units_dimension_change_blocked_with_data(self, dimension_test_schema):
+        """Archived embeddings must also block unsafe dimension changes."""
+        db_url, schema = dimension_test_schema
+
+        clear_embeddings(db_url, schema)
+        clear_invalidated_embeddings(db_url, schema)
+        insert_test_invalidated_embedding(db_url, schema, 384)
+
+        _assert_raises_runtime_error_with_retry(
+            db_url,
+            768,
+            schema,
+            expected_messages=["Cannot change embedding dimension", "invalidated_memory_units"],
+        )
+
+        assert get_column_dimension(db_url, schema, table="invalidated_memory_units") == 384
+
+        # Cleanup
+        clear_invalidated_embeddings(db_url, schema)
 
     def test_mental_models_dimension_matches_no_change(self, dimension_test_schema):
         """When mental_models dimension matches, no changes should be made."""


### PR DESCRIPTION
Problem
- Switching embedding dimensions updates memory_units and mental_models, but leaves invalidated_memory_units at the old vector dimension.
- After that, invalidating a memory can fail when the row moves into the archive table.

Fix
- Include invalidated_memory_units in ensure_embedding_dimension.
- Add a preflight over all embedding tables before ALTERs so a populated table blocks the migration before any table is partially changed.
- Add regression coverage for empty archive-table migration and populated archive-table blocking.

Test
- uv run ruff format hindsight_api/migrations.py tests/test_custom_embedding_dimension.py
- uv run ruff check hindsight_api/migrations.py tests/test_custom_embedding_dimension.py
- uv run pytest tests/test_custom_embedding_dimension.py::TestEmbeddingDimension -q -k "not local_embeddings_dimension_detection"

Risk
- Low: this uses the existing single-table migration helper and only adds the archive table to the same dimension sync path.
- Full TestEmbeddingDimension also runs the local embedding model test; locally that unrelated test hit a missing socksio dependency for the configured SOCKS proxy.

Closes #2209