### PR TITLE
docs: fix stale documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ client.reflect(bank_id="my-bank", query="What should I know about Alice?")
 | **macOS** (Intel / x86_64) | ✅ | ⚠️ | ✅ |
 | **Windows** (x86_64) | ✅ | ✅ | ✅ |
 
-⚠️ Intel Macs: use `hindsight-all-slim` — see the [installation guide](https://docs.hindsight.vectorize.io/docs/developer/installation#supported-platforms) for details.
+⚠️ Intel Macs: use `hindsight-all-slim` — see the [installation guide](https://hindsight.vectorize.io/developer/installation#supported-platforms) for details.
 
 ---
 

--- a/hindsight-docs/blog/2026-03-30-llamaindex-agent-memory.md
+++ b/hindsight-docs/blog/2026-03-30-llamaindex-agent-memory.md
@@ -279,7 +279,7 @@ Persistent memory isn't always the right tool.
 | **Framework coupling** | LlamaIndex only | LlamaIndex only | None | None |
 | **Best for** | Single-session chat | Simple cross-session recall within LlamaIndex | Document search (RAG) | Long-term user/agent memory across frameworks |
 
-**vs. LangGraph/LangChain:** If you're using LangGraph instead of LlamaIndex, see [`hindsight-langgraph`](https://docs.hindsight.vectorize.io/docs/sdks/integrations/langgraph) which offers tools, graph nodes, and a `BaseStore` adapter.
+**vs. LangGraph/LangChain:** If you're using LangGraph instead of LlamaIndex, see [`hindsight-langgraph`](https://hindsight.vectorize.io/sdks/integrations/langgraph) which offers tools, graph nodes, and a `BaseStore` adapter.
 
 ## FAQ
 
@@ -307,5 +307,5 @@ Try it now: `pip install hindsight-all hindsight-llamaindex` and run the example
 
 ## Next Steps
 
-- **Docs**: [LlamaIndex integration guide](https://docs.hindsight.vectorize.io/docs/sdks/integrations/llamaindex)
-- **Other integrations**: [LangGraph](https://docs.hindsight.vectorize.io/docs/sdks/integrations/langgraph), [Pydantic AI](https://docs.hindsight.vectorize.io/docs/sdks/integrations/pydantic-ai), [CrewAI](https://docs.hindsight.vectorize.io/docs/sdks/integrations/crewai)
+- **Docs**: [LlamaIndex integration guide](https://hindsight.vectorize.io/sdks/integrations/llamaindex)
+- **Other integrations**: [LangGraph](https://hindsight.vectorize.io/sdks/integrations/langgraph), [Pydantic AI](https://hindsight.vectorize.io/sdks/integrations/pydantic-ai), [CrewAI](https://hindsight.vectorize.io/sdks/integrations/crewai)

--- a/hindsight-integrations/agentcore/pyproject.toml
+++ b/hindsight-integrations/agentcore/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/vectorize-io/hindsight"
-Documentation = "https://docs.hindsight.vectorize.io/sdks/integrations/agentcore"
+Documentation = "https://hindsight.vectorize.io/sdks/integrations/agentcore"
 Repository = "https://github.com/vectorize-io/hindsight"
 
 [build-system]

--- a/hindsight-integrations/autogen/README.md
+++ b/hindsight-integrations/autogen/README.md
@@ -150,6 +150,6 @@ tools = create_hindsight_tools(
 
 ## Documentation
 
-- [Integration docs](https://docs.hindsight.vectorize.io/docs/sdks/integrations/autogen)
+- [Integration docs](https://hindsight.vectorize.io/sdks/integrations/autogen)
 - [Cookbook: AutoGen assistant with memory](https://docs.hindsight.vectorize.io/cookbook/recipes/autogen-assistant-agent)
 - [Hindsight API docs](https://docs.hindsight.vectorize.io)

--- a/hindsight-integrations/claude-agent-sdk/pyproject.toml
+++ b/hindsight-integrations/claude-agent-sdk/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/vectorize-io/hindsight"
-Documentation = "https://docs.hindsight.vectorize.io/docs/sdks/integrations/claude-agent-sdk"
+Documentation = "https://hindsight.vectorize.io/sdks/integrations/claude-agent-sdk"
 Repository = "https://github.com/vectorize-io/hindsight"
 
 [build-system]

--- a/hindsight-integrations/haystack/README.md
+++ b/hindsight-integrations/haystack/README.md
@@ -103,6 +103,6 @@ tools = create_hindsight_tools(bank_id="user-123")
 
 ## Documentation
 
-- [Integration docs](https://docs.hindsight.vectorize.io/docs/sdks/integrations/haystack)
+- [Integration docs](https://hindsight.vectorize.io/sdks/integrations/haystack)
 - [Hindsight API docs](https://docs.hindsight.vectorize.io)
 

--- a/hindsight-integrations/langgraph/README.md
+++ b/hindsight-integrations/langgraph/README.md
@@ -153,6 +153,6 @@ All factory functions accept `client`, `hindsight_api_url`, and `api_key` to ove
 
 ## Documentation
 
-- [Integration docs](https://docs.hindsight.vectorize.io/docs/sdks/integrations/langgraph)
+- [Integration docs](https://hindsight.vectorize.io/sdks/integrations/langgraph)
 - [Cookbook: ReAct agent with memory](https://docs.hindsight.vectorize.io/cookbook/recipes/langgraph-react-agent)
 - [Hindsight API docs](https://docs.hindsight.vectorize.io)

--- a/hindsight-integrations/llamaindex/README.md
+++ b/hindsight-integrations/llamaindex/README.md
@@ -78,5 +78,5 @@ configure(
 
 ## Documentation
 
-- [Integration docs](https://docs.hindsight.vectorize.io/docs/sdks/integrations/llamaindex)
+- [Integration docs](https://hindsight.vectorize.io/sdks/integrations/llamaindex)
 - [Hindsight API docs](https://docs.hindsight.vectorize.io)

--- a/hindsight-integrations/openai-agents/README.md
+++ b/hindsight-integrations/openai-agents/README.md
@@ -220,5 +220,5 @@ shared_tools = create_hindsight_tools(
 
 ## Documentation
 
-- [Integration docs](https://docs.hindsight.vectorize.io/docs/sdks/integrations/openai-agents)
+- [Integration docs](https://hindsight.vectorize.io/sdks/integrations/openai-agents)
 - [Hindsight API docs](https://docs.hindsight.vectorize.io)

--- a/hindsight-integrations/openai-agents/pyproject.toml
+++ b/hindsight-integrations/openai-agents/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/vectorize-io/hindsight"
-Documentation = "https://docs.hindsight.vectorize.io/docs/sdks/integrations/openai-agents"
+Documentation = "https://hindsight.vectorize.io/sdks/integrations/openai-agents"
 Repository = "https://github.com/vectorize-io/hindsight"
 
 [build-system]


### PR DESCRIPTION
## Summary
- update stale docs.hindsight.vectorize.io/docs links to current docs paths
- point open-source integration and installation docs to hindsight.vectorize.io

## Verification
- checked every new URL returns HTTP 200
- confirmed canonical URLs and page titles match expected docs pages
- git diff --check
