### PR TITLE
perf(api): index memory_links.bank_id on PostgreSQL

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
@@ -16,7 +16,10 @@ is intentionally absent.
 CONCURRENTLY to avoid taking a write lock on the table. CONCURRENTLY cannot run
 inside a transaction block, so the statement runs in an ``autocommit_block()``;
 ``IF NOT EXISTS`` keeps it idempotent across retries and re-migrated tenant
-schemas.
+schemas. A CONCURRENTLY build interrupted partway (lock conflict, disk
+pressure, signal) leaves the index behind as *invalid*; ``IF NOT EXISTS`` would
+then skip over it forever, so the upgrade first drops any invalid leftover of
+this name before (re)creating it.
 
 Revision ID: 2071c7518f88
 Revises: a1d3f5b7c9e2
@@ -26,6 +29,7 @@ Create Date: 2026-06-16
 from collections.abc import Sequence
 
 from alembic import context, op
+from sqlalchemy import text
 
 from hindsight_api.alembic._dialect import run_for_dialect
 
@@ -42,12 +46,36 @@ def _get_schema_prefix() -> str:
 
 
 def _pg_upgrade() -> None:
+    bind = op.get_bind()
+    # `or None` collapses an unset option and an explicit empty string into NULL
+    # so the COALESCE below falls back to current_schema() in both cases.
+    target_schema = context.config.get_main_option("target_schema") or None
     schema = _get_schema_prefix()
 
     # CREATE INDEX CONCURRENTLY cannot run inside a transaction block; the
-    # autocommit_block runs the statement outside Alembic's migration
-    # transaction. IF NOT EXISTS makes it idempotent on retry.
+    # autocommit_block runs each statement outside Alembic's migration
+    # transaction.
     with op.get_context().autocommit_block():
+        # A CONCURRENTLY build that errored on a previous run leaves an INVALID
+        # index of this name behind. `CREATE INDEX ... IF NOT EXISTS` would see
+        # that relation and skip, so bank_id queries would keep seq-scanning.
+        # Drop only the invalid leftover — never a healthy index — so the retry
+        # actually rebuilds a usable one.
+        leftover_invalid = bind.execute(
+            text(
+                "SELECT NOT i.indisvalid "
+                "FROM pg_class c "
+                "JOIN pg_index i ON c.oid = i.indexrelid "
+                "JOIN pg_namespace n ON c.relnamespace = n.oid "
+                "WHERE c.relname = 'idx_memory_links_bank_id' "
+                "  AND n.nspname = COALESCE(:target_schema, current_schema())"
+            ),
+            {"target_schema": target_schema},
+        ).scalar()
+        if leftover_invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_bank_id")
+
+        # IF NOT EXISTS keeps the create idempotent across retries and schemas.
         op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_bank_id ON {schema}memory_links(bank_id)")
 
 

--- a/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
@@ -1,4 +1,4 @@
-"""Add an index on memory_links.bank_id for bank-scoped queries (PostgreSQL).
+"""Add a composite index on memory_links(bank_id, link_type) (PostgreSQL).
 
 ``bank_id`` was added to ``memory_links`` in ``c5d6e7f8a9b0`` precisely so that
 bank-scoped reads (e.g. the stats endpoint) could filter on the link table
@@ -7,10 +7,20 @@ banks with millions of links. The column landed without an index, so every
 ``bank_id = $1`` predicate still falls back to a sequential scan over the whole
 table.
 
-This adds the missing btree. The Oracle baseline (``o1a2b3c4d5e6``) already
-creates ``idx_ml_bank_id`` on ``memory_links(bank_id)``, so the asymmetry is
-deliberate: only the PostgreSQL dialect was missing the index. The Oracle slot
-is intentionally absent.
+This adds the missing btree. It is composite on ``(bank_id, link_type)`` rather
+than ``bank_id`` alone because the hot query is the stats endpoint's
+``SELECT link_type, COUNT(*) ... WHERE bank_id = $1 GROUP BY link_type``: a
+``(bank_id, link_type)`` index serves that filter, grouping and count as an
+index-only scan, never touching the heap, whereas a ``bank_id``-only index would
+still have to read every matching row to recover ``link_type``. ``link_type`` is
+low-cardinality (only ``temporal``/``semantic``/``caused_by`` are written —
+entity edges were dropped in ``e9b2c7d1f3a4``), so the trailing column adds
+little to the index size while removing the heap fetch.
+
+The Oracle baseline (``o1a2b3c4d5e6``) already creates ``idx_ml_bank_id`` on
+``memory_links(bank_id)``; that single-column index already covers Oracle's
+bank-scoped filter, so the Oracle slot here is intentionally absent and only the
+PostgreSQL dialect gets the composite index.
 
 ``memory_links`` can hold tens of millions of rows, so the index is built
 CONCURRENTLY to avoid taking a write lock on the table. CONCURRENTLY cannot run
@@ -37,6 +47,8 @@ revision: str = "2071c7518f88"
 down_revision: str | Sequence[str] | None = "a1d3f5b7c9e2"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "idx_memory_links_bank_id_link_type"
 
 
 def _get_schema_prefix() -> str:
@@ -67,22 +79,22 @@ def _pg_upgrade() -> None:
                 "FROM pg_class c "
                 "JOIN pg_index i ON c.oid = i.indexrelid "
                 "JOIN pg_namespace n ON c.relnamespace = n.oid "
-                "WHERE c.relname = 'idx_memory_links_bank_id' "
+                "WHERE c.relname = :index_name "
                 "  AND n.nspname = COALESCE(:target_schema, current_schema())"
             ),
-            {"target_schema": target_schema},
+            {"index_name": _INDEX_NAME, "target_schema": target_schema},
         ).scalar()
         if leftover_invalid:
-            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_bank_id")
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}{_INDEX_NAME}")
 
         # IF NOT EXISTS keeps the create idempotent across retries and schemas.
-        op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_bank_id ON {schema}memory_links(bank_id)")
+        op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} ON {schema}memory_links(bank_id, link_type)")
 
 
 def _pg_downgrade() -> None:
     schema = _get_schema_prefix()
     with op.get_context().autocommit_block():
-        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_bank_id")
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}{_INDEX_NAME}")
 
 
 def upgrade() -> None:

--- a/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/2071c7518f88_add_memory_links_bank_id_index.py
@@ -1,0 +1,65 @@
+"""Add an index on memory_links.bank_id for bank-scoped queries (PostgreSQL).
+
+``bank_id`` was added to ``memory_links`` in ``c5d6e7f8a9b0`` precisely so that
+bank-scoped reads (e.g. the stats endpoint) could filter on the link table
+directly instead of joining ``memory_units`` — that JOIN took 18+ seconds on
+banks with millions of links. The column landed without an index, so every
+``bank_id = $1`` predicate still falls back to a sequential scan over the whole
+table.
+
+This adds the missing btree. The Oracle baseline (``o1a2b3c4d5e6``) already
+creates ``idx_ml_bank_id`` on ``memory_links(bank_id)``, so the asymmetry is
+deliberate: only the PostgreSQL dialect was missing the index. The Oracle slot
+is intentionally absent.
+
+``memory_links`` can hold tens of millions of rows, so the index is built
+CONCURRENTLY to avoid taking a write lock on the table. CONCURRENTLY cannot run
+inside a transaction block, so the statement runs in an ``autocommit_block()``;
+``IF NOT EXISTS`` keeps it idempotent across retries and re-migrated tenant
+schemas.
+
+Revision ID: 2071c7518f88
+Revises: a1d3f5b7c9e2
+Create Date: 2026-06-16
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "2071c7518f88"
+down_revision: str | Sequence[str] | None = "a1d3f5b7c9e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_schema_prefix() -> str:
+    """Schema-qualifier for raw SQL on PG (multi-tenant search_path)."""
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _get_schema_prefix()
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block; the
+    # autocommit_block runs the statement outside Alembic's migration
+    # transaction. IF NOT EXISTS makes it idempotent on retry.
+    with op.get_context().autocommit_block():
+        op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_memory_links_bank_id ON {schema}memory_links(bank_id)")
+
+
+def _pg_downgrade() -> None:
+    schema = _get_schema_prefix()
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema}idx_memory_links_bank_id")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6420,9 +6420,10 @@ class MemoryEngine(MemoryEngineInterface):
                     source_memory_ids.extend(unit["source_memory_ids"])
             source_memory_ids = list(set(source_memory_ids))  # Deduplicate
 
-            # Fetch non-entity links where BOTH endpoints are in the visible set (or
-            # source memories). Entity edges are derived below from unit_entities so
-            # we don't materialize them in memory_links anymore.
+            # Fetch links where BOTH endpoints are in the visible set (or source
+            # memories). Entity edges are derived below from unit_entities so we
+            # don't materialize them in memory_links anymore (dropped in migration
+            # e9b2c7d1f3a4) — no link_type filter is needed.
             # Cap at 10k edges — the UI can't usefully render more, and uncapped queries
             # on highly-connected graphs (e.g. 1000 nodes with 500k+ edges) are too slow.
             max_edges = 10000
@@ -6436,8 +6437,7 @@ class MemoryEngine(MemoryEngineInterface):
                            ml.weight,
                            NULL::text AS entity_name
                     FROM {fq_table("memory_links")} ml
-                    WHERE ml.link_type <> 'entity'
-                      AND ml.from_unit_id = ANY($1::uuid[])
+                    WHERE ml.from_unit_id = ANY($1::uuid[])
                       AND ml.to_unit_id = ANY($1::uuid[])
                     ORDER BY ml.weight DESC NULLS LAST
                     LIMIT $2
@@ -9230,11 +9230,16 @@ class MemoryEngine(MemoryEngineInterface):
             # per-fact-type slice, and it tolerates empty maps (the section
             # prints with no rows). Response keys are kept populated below for
             # schema stability so existing SDK deserializers don't break.
+            # No link_type filter: entity edges are no longer stored in
+            # memory_links (dropped in migration e9b2c7d1f3a4 — derived on demand
+            # from unit_entities), so only temporal/semantic/caused_by rows exist
+            # here. Omitting the predicate lets the (bank_id, link_type) index
+            # serve this bank-scoped GROUP BY as an index-only scan.
             non_entity_link_rows = await conn.fetch(
                 f"""
                 SELECT link_type, COUNT(*) as count
                 FROM {fq_table("memory_links")}
-                WHERE bank_id = $1 AND link_type <> 'entity'
+                WHERE bank_id = $1
                 GROUP BY link_type
                 """,
                 bank_id,


### PR DESCRIPTION
## Problem

`bank_id` was added to `memory_links` in `c5d6e7f8a9b0` specifically so bank-scoped reads (e.g. the stats endpoint) could filter the link table directly instead of joining `memory_units` — that JOIN took 18+ seconds on banks with millions of links. The column landed **without an index**, so every `bank_id = $1` predicate still falls back to a sequential scan over the whole table.

On PostgreSQL, the surviving `memory_links` indexes lead with `from_unit_id` / `to_unit_id` / `entity_id` — none can serve a `bank_id`-only filter. The Oracle baseline (`o1a2b3c4d5e6`) already creates `idx_ml_bank_id ON memory_links(bank_id)`, so this is a PostgreSQL-only gap, not an intentional omission.

## Fix

Migration `2071c7518f88` (chains off head `a1d3f5b7c9e2`) adds a **composite** btree on `memory_links(bank_id, link_type)`:

- The hot query is the stats endpoint's `SELECT link_type, COUNT(*) ... WHERE bank_id = $1 GROUP BY link_type`. A `(bank_id, link_type)` index serves the filter, grouping and count as an **index-only scan** — never touching the heap. A `bank_id`-only index would still have to heap-read every matching row just to recover `link_type`.
- `link_type` is low-cardinality (only `temporal`/`semantic`/`caused_by` are written), so the trailing column barely grows the index while removing the heap fetch.
- Built `CONCURRENTLY` inside an `autocommit_block()` so it doesn't take a write lock on a table that can hold tens of millions of rows.
- `IF NOT EXISTS` for idempotency; the upgrade first drops any *invalid* leftover of this name (from a CONCURRENTLY build interrupted mid-flight) so a retry rebuilds a usable index.
- Schema-prefixed for the multi-tenant `search_path`.
- PostgreSQL-only via `run_for_dialect(pg=...)`; the Oracle slot is intentionally absent (the Oracle baseline already has a `bank_id` index).

### Why not a materialized view

`memory_links` is write-heavy (temporal/semantic/causal links are inserted on every retain, plus graph-maintenance jobs mutate links), so a matview would mean either a full-recompute `REFRESH` (the same scan cost, just moved) or trigger-based incremental maintenance (write-amplification on the hot retain path) — and per-bank counts would be stale the instant a retain commits. Stats responses are already TTL-cached, so the read frequency is mitigated; only the one cold computation needs to stop seq-scanning, which the index fixes. A low-cardinality composite btree (with Postgres btree dedup on the repeated `bank_id` values) stays compact.

## Dead-filter cleanup

Both the stats query and the `/graph` expansion query carried a `WHERE ... link_type <> 'entity'` predicate. That is now **dead**: entity edges were deleted from `memory_links` and are no longer written (migration `e9b2c7d1f3a4`) — they're derived on demand from `unit_entities`. Removing the predicate is a behavioral no-op today and lets the composite index fully cover the stats query.

## Verification

- DAG stays single-head (`2071c7518f88`), single-base — `tests/test_alembic_dag.py`.
- Passes `tests/test_migration_shape.py`: dispatches through `run_for_dialect`, no manual `op.execute("COMMIT")`, `CONCURRENTLY` DDL runs inside an `autocommit_block()`.
- `ruff check` and `ruff format --check` clean.
