### PR TITLE
fix(litellm): hard-cap completions with asyncio.wait_for so a hung call can't block forever

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -253,7 +253,6 @@ def create_llm_provider(
     gemini_safety_settings: list | None = None,
     prompt_cache_enabled: bool = False,
     litellmrouter_config: dict[str, Any] | None = None,
-    timeout: float | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -278,10 +277,6 @@ def create_llm_provider(
         vertexai_project_id: Vertex AI project ID (for VertexAI provider).
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
-        timeout: Per-call timeout in seconds for providers that honor it (LiteLLM
-            and Bedrock). ``None`` keeps the provider's own default. Bounds the
-            LiteLLM provider's hard ``asyncio.wait_for`` cap so a hung completion
-            cannot block a worker slot indefinitely.
 
     Returns:
         LLMInterface implementation for the specified provider.
@@ -372,7 +367,6 @@ def create_llm_provider(
             model=model,
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
-            timeout=timeout,
         )
 
     elif provider_lower == "litellmrouter":
@@ -391,7 +385,6 @@ def create_llm_provider(
             config=litellmrouter_config,
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
-            timeout=timeout,
         )
 
     elif provider_lower == "bedrock":
@@ -405,7 +398,6 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
             bedrock_service_tier=bedrock_service_tier,
-            timeout=timeout,
         )
 
     elif provider_lower == "llamacpp":
@@ -504,7 +496,6 @@ class LLMProvider:
         extra_body: dict[str, Any] | None = None,
         default_headers: dict[str, str] | None = None,
         litellmrouter_config: dict[str, Any] | None = None,
-        timeout: float | None = None,
     ):
         """
         Initialize LLM provider.
@@ -548,10 +539,6 @@ class LLMProvider:
         # input-token cost. Off by default so the change is observable behind
         # a flip rather than a silent behaviour change on upgrade.
         self.prompt_cache_enabled = prompt_cache_enabled
-        # Per-call timeout (seconds) for providers that honor it. ``None`` lets
-        # the provider keep its own default. Bounds the LiteLLM provider's hard
-        # ``asyncio.wait_for`` cap so a hung completion cannot block forever.
-        self.timeout = timeout
         # Extra body params for OpenAI-compatible providers (e.g. chat_template_kwargs)
         self.extra_body = extra_body
         # Default headers passed to provider SDK clients (e.g. proxy auth, request tracing).
@@ -719,7 +706,6 @@ class LLMProvider:
             gemini_safety_settings=self.gemini_safety_settings,
             prompt_cache_enabled=self.prompt_cache_enabled,
             litellmrouter_config=router_config,
-            timeout=self.timeout,
         )
 
         # Backward compatibility: Keep mock provider properties

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -253,6 +253,7 @@ def create_llm_provider(
     gemini_safety_settings: list | None = None,
     prompt_cache_enabled: bool = False,
     litellmrouter_config: dict[str, Any] | None = None,
+    timeout: float | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -277,6 +278,10 @@ def create_llm_provider(
         vertexai_project_id: Vertex AI project ID (for VertexAI provider).
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
+        timeout: Per-call timeout in seconds for providers that honor it (LiteLLM
+            and Bedrock). ``None`` keeps the provider's own default. Bounds the
+            LiteLLM provider's hard ``asyncio.wait_for`` cap so a hung completion
+            cannot block a worker slot indefinitely.
 
     Returns:
         LLMInterface implementation for the specified provider.
@@ -367,6 +372,7 @@ def create_llm_provider(
             model=model,
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
+            timeout=timeout,
         )
 
     elif provider_lower == "litellmrouter":
@@ -385,6 +391,7 @@ def create_llm_provider(
             config=litellmrouter_config,
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
+            timeout=timeout,
         )
 
     elif provider_lower == "bedrock":
@@ -398,6 +405,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
             bedrock_service_tier=bedrock_service_tier,
+            timeout=timeout,
         )
 
     elif provider_lower == "llamacpp":
@@ -496,6 +504,7 @@ class LLMProvider:
         extra_body: dict[str, Any] | None = None,
         default_headers: dict[str, str] | None = None,
         litellmrouter_config: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ):
         """
         Initialize LLM provider.
@@ -539,6 +548,10 @@ class LLMProvider:
         # input-token cost. Off by default so the change is observable behind
         # a flip rather than a silent behaviour change on upgrade.
         self.prompt_cache_enabled = prompt_cache_enabled
+        # Per-call timeout (seconds) for providers that honor it. ``None`` lets
+        # the provider keep its own default. Bounds the LiteLLM provider's hard
+        # ``asyncio.wait_for`` cap so a hung completion cannot block forever.
+        self.timeout = timeout
         # Extra body params for OpenAI-compatible providers (e.g. chat_template_kwargs)
         self.extra_body = extra_body
         # Default headers passed to provider SDK clients (e.g. proxy auth, request tracing).
@@ -706,6 +719,7 @@ class LLMProvider:
             gemini_safety_settings=self.gemini_safety_settings,
             prompt_cache_enabled=self.prompt_cache_enabled,
             litellmrouter_config=router_config,
+            timeout=self.timeout,
         )
 
         # Backward compatibility: Keep mock provider properties

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -19,6 +19,8 @@ import os
 import time
 from typing import Any
 
+from litellm.exceptions import Timeout as LiteLLMTimeout
+
 from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
@@ -207,8 +209,6 @@ class LiteLLMLLM(LLMInterface):
                 },
             }
 
-        from litellm.exceptions import Timeout as LiteLLMTimeout
-
         last_exception = None
 
         for attempt in range(max_retries + 1):
@@ -376,8 +376,6 @@ class LiteLLMLLM(LLMInterface):
         call_kwargs = self._build_common_kwargs(messages, max_completion_tokens, temperature)
         call_kwargs["tools"] = tools
         call_kwargs["tool_choice"] = tool_choice
-
-        from litellm.exceptions import Timeout as LiteLLMTimeout
 
         last_exception = None
         for attempt in range(max_retries + 1):

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -15,9 +15,11 @@ is handled automatically by LiteLLM.
 import asyncio
 import json
 import logging
+import os
 import time
 from typing import Any
 
+from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
@@ -53,10 +55,9 @@ class LiteLLMLLM(LLMInterface):
         **kwargs: Any,
     ):
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
-        # ``None`` means "use the default"; keep the historical 300s cap so the
-        # hard ``asyncio.wait_for`` backstop in ``call`` is always bounded even
-        # when no timeout is configured by the caller.
-        self.timeout = timeout if timeout is not None else 300.0
+        # ``None`` falls back to HINDSIGHT_API_LLM_TIMEOUT, then DEFAULT_LLM_TIMEOUT — never None,
+        # so the hard ``asyncio.wait_for`` backstop in ``call`` is always bounded.
+        self.timeout = timeout if timeout is not None else float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
         self._litellm: Any = None
         # User-configured extra params merged as top-level kwargs into every
         # completion call so LiteLLM normalizes them per-provider (e.g. maps
@@ -206,6 +207,8 @@ class LiteLLMLLM(LLMInterface):
                 },
             }
 
+        from litellm.exceptions import Timeout as LiteLLMTimeout
+
         last_exception = None
 
         for attempt in range(max_retries + 1):
@@ -310,21 +313,23 @@ class LiteLLMLLM(LLMInterface):
                     logger.error(f"LiteLLM returned invalid JSON after {max_retries + 1} attempts")
                     raise
 
-            except (TimeoutError, asyncio.TimeoutError) as e:
-                # Hard cap on a single completion. litellm/httpx do not always
-                # honor their own ``timeout=`` kwarg (e.g. a connection held open
-                # with no token progress), so the bare ``await`` could otherwise
-                # block forever and pin the worker slot and concurrency permit —
-                # one such straggler in a concurrent fan-out stalls the whole
-                # ``asyncio.gather`` it belongs to. ``asyncio.wait_for`` cancels
-                # the call regardless, so it can be retried or fail cleanly.
+            except (TimeoutError, asyncio.TimeoutError, LiteLLMTimeout) as e:
+                # litellm/httpx don't always honor their own ``timeout=`` (e.g. a connection held
+                # open with no token progress), so ``wait_for`` is the hard cap that cancels a hung
+                # call regardless — otherwise one straggler pins a worker slot and stalls its gather.
                 last_exception = e
+                exc_name = type(e).__name__
                 if attempt < max_retries:
-                    logger.warning(f"LiteLLM call exceeded timeout={self.timeout}s (scope={scope}), retrying...")
+                    logger.warning(
+                        f"LiteLLM call exceeded timeout={self.timeout}s ({exc_name}, scope={scope}), retrying..."
+                    )
                     backoff = min(initial_backoff * (2**attempt), max_backoff)
                     await asyncio.sleep(backoff)
                     continue
-                logger.error(f"LiteLLM call timed out after {self.timeout}s on {attempt + 1} attempts (scope={scope})")
+                logger.error(
+                    f"LiteLLM call timed out after {self.timeout}s on {attempt + 1} attempts "
+                    f"({exc_name}, scope={scope})"
+                )
                 raise
 
             except Exception as e:
@@ -371,6 +376,8 @@ class LiteLLMLLM(LLMInterface):
         call_kwargs = self._build_common_kwargs(messages, max_completion_tokens, temperature)
         call_kwargs["tools"] = tools
         call_kwargs["tool_choice"] = tool_choice
+
+        from litellm.exceptions import Timeout as LiteLLMTimeout
 
         last_exception = None
         for attempt in range(max_retries + 1):
@@ -450,15 +457,21 @@ class LiteLLMLLM(LLMInterface):
                     output_tokens=output_tokens,
                 )
 
-            except (TimeoutError, asyncio.TimeoutError) as e:
+            except (TimeoutError, asyncio.TimeoutError, LiteLLMTimeout) as e:
                 # See ``call`` — hard cap so a hung completion cannot block
                 # forever and pin a worker slot / concurrency permit.
                 last_exception = e
+                exc_name = type(e).__name__
                 if attempt < max_retries:
-                    logger.warning(f"LiteLLM tool call exceeded timeout={self.timeout}s (scope={scope}), retrying...")
+                    logger.warning(
+                        f"LiteLLM tool call exceeded timeout={self.timeout}s ({exc_name}, scope={scope}), retrying..."
+                    )
                     await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
                     continue
-                logger.error(f"LiteLLM tool call timed out after {self.timeout}s on {attempt + 1} attempts (scope={scope})")
+                logger.error(
+                    f"LiteLLM tool call timed out after {self.timeout}s on {attempt + 1} attempts "
+                    f"({exc_name}, scope={scope})"
+                )
                 raise
 
             except Exception as e:

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -47,13 +47,16 @@ class LiteLLMLLM(LLMInterface):
         base_url: str,
         model: str,
         reasoning_effort: str = "low",
-        timeout: float = 300.0,
+        timeout: float | None = None,
         extra_body: dict[str, Any] | None = None,
         bedrock_service_tier: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
-        self.timeout = timeout
+        # ``None`` means "use the default"; keep the historical 300s cap so the
+        # hard ``asyncio.wait_for`` backstop in ``call`` is always bounded even
+        # when no timeout is configured by the caller.
+        self.timeout = timeout if timeout is not None else 300.0
         self._litellm: Any = None
         # User-configured extra params merged as top-level kwargs into every
         # completion call so LiteLLM normalizes them per-provider (e.g. maps
@@ -209,7 +212,10 @@ class LiteLLMLLM(LLMInterface):
             if attempt > 0:
                 set_stage(f"llm.{self._stage_label}.{scope}.attempt={attempt + 1}/{max_retries + 1}")
             try:
-                response = await self._acompletion(**call_kwargs)
+                response = await asyncio.wait_for(
+                    self._acompletion(**call_kwargs),
+                    timeout=self.timeout,
+                )
 
                 content = response.choices[0].message.content or ""
                 finish_reason = response.choices[0].finish_reason
@@ -304,6 +310,23 @@ class LiteLLMLLM(LLMInterface):
                     logger.error(f"LiteLLM returned invalid JSON after {max_retries + 1} attempts")
                     raise
 
+            except (TimeoutError, asyncio.TimeoutError) as e:
+                # Hard cap on a single completion. litellm/httpx do not always
+                # honor their own ``timeout=`` kwarg (e.g. a connection held open
+                # with no token progress), so the bare ``await`` could otherwise
+                # block forever and pin the worker slot and concurrency permit —
+                # one such straggler in a concurrent fan-out stalls the whole
+                # ``asyncio.gather`` it belongs to. ``asyncio.wait_for`` cancels
+                # the call regardless, so it can be retried or fail cleanly.
+                last_exception = e
+                if attempt < max_retries:
+                    logger.warning(f"LiteLLM call exceeded timeout={self.timeout}s (scope={scope}), retrying...")
+                    backoff = min(initial_backoff * (2**attempt), max_backoff)
+                    await asyncio.sleep(backoff)
+                    continue
+                logger.error(f"LiteLLM call timed out after {self.timeout}s on {attempt + 1} attempts (scope={scope})")
+                raise
+
             except Exception as e:
                 error_str = str(e).lower()
                 # Fast fail on auth errors
@@ -354,7 +377,10 @@ class LiteLLMLLM(LLMInterface):
             if attempt > 0:
                 set_stage(f"llm.{self._stage_label}.tools.attempt={attempt + 1}/{max_retries + 1}")
             try:
-                response = await self._acompletion(**call_kwargs)
+                response = await asyncio.wait_for(
+                    self._acompletion(**call_kwargs),
+                    timeout=self.timeout,
+                )
 
                 message = response.choices[0].message
                 content = message.content
@@ -423,6 +449,17 @@ class LiteLLMLLM(LLMInterface):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                 )
+
+            except (TimeoutError, asyncio.TimeoutError) as e:
+                # See ``call`` — hard cap so a hung completion cannot block
+                # forever and pin a worker slot / concurrency permit.
+                last_exception = e
+                if attempt < max_retries:
+                    logger.warning(f"LiteLLM tool call exceeded timeout={self.timeout}s (scope={scope}), retrying...")
+                    await asyncio.sleep(min(initial_backoff * (2**attempt), max_backoff))
+                    continue
+                logger.error(f"LiteLLM tool call timed out after {self.timeout}s on {attempt + 1} attempts (scope={scope})")
+                raise
 
             except Exception as e:
                 error_str = str(e).lower()

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_router_llm.py
@@ -67,7 +67,7 @@ class LiteLLMRouterLLM(LiteLLMLLM):
         model: str,
         config: dict[str, Any],
         reasoning_effort: str = "low",
-        timeout: float = 300.0,
+        timeout: float | None = None,
         **kwargs: Any,
     ):
         super().__init__(

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -269,7 +269,7 @@ class OpenAICompatibleLLM(LLMInterface):
             base_url: Base URL for the API (uses defaults for groq/ollama/lmstudio if empty).
             model: Model name.
             reasoning_effort: Reasoning effort level for supported models ("low", "medium", "high").
-            timeout: Request timeout in seconds (uses env var or 300s default).
+            timeout: Request timeout in seconds (uses env var or 120s default).
             groq_service_tier: Groq service tier ("on_demand", "flex", "auto").
             extra_body: Extra body params merged into every API call.
             **kwargs: Additional provider-specific parameters.

--- a/hindsight-api-slim/tests/test_litellm_timeout.py
+++ b/hindsight-api-slim/tests/test_litellm_timeout.py
@@ -14,6 +14,7 @@ import time
 
 import pytest
 
+from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
 
 
@@ -73,8 +74,9 @@ async def test_call_with_tools_cancels_hung_completion(monkeypatch):
         )
 
 
-async def test_unset_timeout_falls_back_to_default():
+async def test_unset_timeout_falls_back_to_default(monkeypatch):
     """``None`` must resolve to a finite default — never ``None``, which would
     make ``asyncio.wait_for`` wait forever and reintroduce the hang."""
+    monkeypatch.delenv(ENV_LLM_TIMEOUT, raising=False)
     provider = _make_provider(timeout=None)
-    assert provider.timeout == 300.0
+    assert provider.timeout == DEFAULT_LLM_TIMEOUT

--- a/hindsight-api-slim/tests/test_litellm_timeout.py
+++ b/hindsight-api-slim/tests/test_litellm_timeout.py
@@ -1,0 +1,80 @@
+"""
+Regression test for the hard timeout on the LiteLLM provider.
+
+A completion that never returns — a connection held open with no token
+progress, or one straggler inside a concurrent ``asyncio.gather`` fan-out —
+must not block forever. ``call`` / ``call_with_tools`` wrap the request in
+``asyncio.wait_for`` so it is cancelled after ``timeout`` seconds and surfaced
+as a retryable ``TimeoutError`` instead of pinning a worker slot and a
+concurrency permit indefinitely.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
+
+
+def _make_provider(timeout: float | None) -> LiteLLMLLM:
+    return LiteLLMLLM(
+        provider="litellm",
+        api_key="unused",
+        base_url="http://localhost:0/v1",
+        model="litellm_proxy/test-model",
+        timeout=timeout,
+    )
+
+
+async def test_call_cancels_hung_completion(monkeypatch):
+    """A hung ``_acompletion`` is cancelled per attempt and raises TimeoutError."""
+    provider = _make_provider(timeout=0.1)
+    calls = 0
+
+    async def _hang(**kwargs):
+        nonlocal calls
+        calls += 1
+        await asyncio.Event().wait()  # never resolves
+
+    monkeypatch.setattr(provider, "_acompletion", _hang)
+
+    started = time.monotonic()
+    with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=1,
+            initial_backoff=0.01,
+            max_backoff=0.01,
+        )
+    elapsed = time.monotonic() - started
+
+    # max_retries=1 -> attempts 0 and 1, each bounded by the timeout.
+    assert calls == 2
+    # Bounded by ~2 * timeout + backoff — nowhere near hanging forever.
+    assert elapsed < 2.0
+
+
+async def test_call_with_tools_cancels_hung_completion(monkeypatch):
+    provider = _make_provider(timeout=0.1)
+
+    async def _hang(**kwargs):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(provider, "_acompletion", _hang)
+
+    with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+        await provider.call_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_retries=0,
+            initial_backoff=0.01,
+            max_backoff=0.01,
+        )
+
+
+async def test_unset_timeout_falls_back_to_default():
+    """``None`` must resolve to a finite default — never ``None``, which would
+    make ``asyncio.wait_for`` wait forever and reintroduce the hang."""
+    provider = _make_provider(timeout=None)
+    assert provider.timeout == 300.0


### PR DESCRIPTION
## Problem

The LiteLLM provider issues completions as a bare `await self._acompletion(...)`. The only timeout is the `timeout=` kwarg handed to `litellm.acompletion()`, which is **not always honored** (e.g. a connection held open with no token progress). When that happens the coroutine awaits indefinitely, holding the worker slot and a concurrency-semaphore permit for the lifetime of the process.

Fact extraction fans these calls out through `asyncio.gather`, so a **single hung straggler stalls the entire operation** even though its sibling calls returned. The observable symptom is confusing: per-call `slow llm call` log lines keep appearing (siblings succeeding) while operation completion throughput collapses to zero and stuck ops sit at `...retain_extract_facts+structured` with a `stage_age` that grows 1:1 with wall-clock and never resets.

## Fix

- Wrap the request in `asyncio.wait_for(timeout=self.timeout)` in both `call` and `call_with_tools` (mirroring the Gemini provider, which already does this).
- Treat the resulting `TimeoutError` as a normal retryable attempt, so the task can retry or fail cleanly and release its slot. The existing `asyncio.gather(..., return_exceptions=True)` callers absorb the timeout with no extra handling.
- **Converge timeout handling:** litellm's own `Timeout` and the outer `wait_for` `TimeoutError` are armed at the same deadline, so catch both in the same except block. Otherwise which one trips is a race that flows through two different paths (dedicated vs generic) with different log lines and backoff. The exception class name is logged so the firing mechanism stays visible.
- **Make the cap configurable** by reading `HINDSIGHT_API_LLM_TIMEOUT` (default `DEFAULT_LLM_TIMEOUT` = **120s**) in `LiteLLMLLM.__init__` — the same one-line pattern `OpenAICompatibleLLM` already uses. A `None` timeout resolves to that env/default, never `None`, so the `wait_for` cap is always bounded.

### Scope

The hard `asyncio.wait_for` backstop added here covers the **LiteLLM family only** (`litellm`, `litellmrouter`, `bedrock`, which all subclass/reuse `LiteLLMLLM`). Gemini already has its own 90s hard cap. Other providers (anthropic, openai-compatible) are unchanged.

## Tests

`tests/test_litellm_timeout.py`:
- a hung `_acompletion` is cancelled per attempt and raises `TimeoutError` with bounded wall-clock and the correct retry count (`call` and `call_with_tools`);
- an unset timeout resolves to the finite `DEFAULT_LLM_TIMEOUT` (120s).

All new tests pass; existing router/provider tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

