### PR TITLE
test: fix flaky test-api shard (migration pg0 provisioning race)

### DIFF
--- a/hindsight-api-slim/tests/test_migration_remaining_bank_id_text.py
+++ b/hindsight-api-slim/tests/test_migration_remaining_bank_id_text.py
@@ -26,6 +26,14 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, text
 
+# Both tests in this module share one module-scoped pg0 on a fixed port (5568).
+# CI runs with `--dist loadgroup`, which, absent an xdist_group, may scatter the
+# two tests across workers that then each instantiate the module fixture and race
+# to provision the SAME instance — surfacing as flaky "Instance already running",
+# a pg_type UniqueViolation (concurrent CREATE EXTENSION), or "server closed the
+# connection". Pinning the module to a single worker serialises that provisioning.
+pytestmark = pytest.mark.xdist_group("migration-remaining-bankid-pg0")
+
 _SCRIPT_LOCATION = str(Path(__file__).parent.parent / "hindsight_api" / "alembic")
 
 _WIDEN_TABLES = ("directives", "mental_models")


### PR DESCRIPTION
## Problem

The `test-api` shards flake repeatedly on a single test module, blocking otherwise-green PRs (observed across four consecutive runs on #2210). The failing test changed every run, but always within `test_migration_remaining_bank_id_text.py`:

| Symptom | Cause |
|---|---|
| `RuntimeError: ... Instance already running (pid: …)` | two workers start the same pg0 |
| `psycopg2.errors.UniqueViolation: "pg_type_typname_nsp_index"` | concurrent `CREATE EXTENSION` during migrate-to-head |
| `OperationalError: server closed the connection unexpectedly` | one worker's pg0 torn down under the other |

## Root cause

That module runs **two** tests sharing a **module-scoped** `EmbeddedPostgres` on a **fixed port (5568)**. CI runs pytest with `--dist loadgroup` (`-n 8`). With no `xdist_group` on the module, loadgroup can scatter the two tests across different workers; each worker then instantiates the module fixture and they race to provision the *same* pg0 instance.

The sibling dedicated-pg0 modules (`test_migration_history_long_bank_id.py`, `test_migration_backsweep.py`) each have only **one** test, so they can't split and don't race.

## Fix

Add a module-level `pytestmark = pytest.mark.xdist_group("migration-remaining-bankid-pg0")` so both tests are pinned to one worker and the fixture provisions the instance exactly once. Test-only change.

## Verification

Run under CI's scheduler (`-n 8 --dist loadgroup`) — both tests now carry the group tag and execute on the same worker (`gw0`):

```
test_remaining_bank_id_columns_are_text@migration-remaining-bankid-pg0  [gw0] PASSED
test_long_bank_id_round_trips_through_widened_tables@migration-remaining-bankid-pg0  [gw0] PASSED
```

## Out of scope

A separate, rarer flake — `test_llm_trace.py::test_disabled_writes_no_rows` (`assert 6 == 0`) — stems from toggling `_enabled` on the shared session-scoped `memory` fixture while a background retain task is still recording. Different root cause; left for a follow-up.
