### PR TITLE
fix(control-plane): add filter active message

### DIFF
--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "Global (keine Tags)",
     "groupByScope": "Nach Bereich gruppieren",
     "scopeSearch": "Bereiche suchen…",
-    "scopeNoResults": "Keine Bereiche gefunden"
+    "scopeNoResults": "Keine Bereiche gefunden",
+    "filterActive": "Filter aktiv"
   },
   "documentsView": {
     "loadingDocuments": "Dokumente werden geladen...",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "Global (no tags)",
     "groupByScope": "Group by scope",
     "scopeSearch": "Search scopes…",
-    "scopeNoResults": "No scopes found"
+    "scopeNoResults": "No scopes found",
+    "filterActive": "Filter Active"
   },
   "documentsView": {
     "loadingDocuments": "Loading documents...",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "Global (sin etiquetas)",
     "groupByScope": "Agrupar por ámbito",
     "scopeSearch": "Buscar ámbitos…",
-    "scopeNoResults": "No se encontraron ámbitos"
+    "scopeNoResults": "No se encontraron ámbitos",
+    "filterActive": "Filtro activo"
   },
   "documentsView": {
     "loadingDocuments": "Cargando documentos...",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "Global (sans tags)",
     "groupByScope": "Grouper par portée",
     "scopeSearch": "Rechercher des portées…",
-    "scopeNoResults": "Aucune portée trouvée"
+    "scopeNoResults": "Aucune portée trouvée",
+    "filterActive": "Filtre actif"
   },
   "documentsView": {
     "loadingDocuments": "Chargement des documents...",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "グローバル（タグなし）",
     "groupByScope": "スコープでグループ化",
     "scopeSearch": "スコープを検索…",
-    "scopeNoResults": "スコープが見つかりません"
+    "scopeNoResults": "スコープが見つかりません",
+    "filterActive": "フィルター有効"
   },
   "documentsView": {
     "loadingDocuments": "ドキュメントを読み込み中...",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "전역(태그 없음)",
     "groupByScope": "범위별 그룹화",
     "scopeSearch": "범위 검색…",
-    "scopeNoResults": "범위를 찾을 수 없음"
+    "scopeNoResults": "범위를 찾을 수 없음",
+    "filterActive": "필터 활성"
   },
   "documentsView": {
     "loadingDocuments": "문서 불러오는 중...",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "Global (sem tags)",
     "groupByScope": "Agrupar por escopo",
     "scopeSearch": "Pesquisar escopos…",
-    "scopeNoResults": "Nenhum escopo encontrado"
+    "scopeNoResults": "Nenhum escopo encontrado",
+    "filterActive": "Filtro ativo"
   },
   "documentsView": {
     "loadingDocuments": "Carregando documentos...",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "全域（冇標籤）",
     "groupByScope": "按範圍分組",
     "scopeSearch": "搜尋範圍…",
-    "scopeNoResults": "搵唔到範圍"
+    "scopeNoResults": "搵唔到範圍",
+    "filterActive": "篩選器已啟用"
   },
   "documentsView": {
     "loadingDocuments": "載入文件中...",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "全局（无标签）",
     "groupByScope": "按范围分组",
     "scopeSearch": "搜索范围…",
-    "scopeNoResults": "未找到范围"
+    "scopeNoResults": "未找到范围",
+    "filterActive": "筛选器已启用"
   },
   "documentsView": {
     "loadingDocuments": "正在加载文档...",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -603,7 +603,8 @@
     "scopeGlobal": "全域（無標籤）",
     "groupByScope": "按範圍分組",
     "scopeSearch": "搜尋範圍…",
-    "scopeNoResults": "找不到範圍"
+    "scopeNoResults": "找不到範圍",
+    "filterActive": "篩選器已啟用"
   },
   "documentsView": {
     "loadingDocuments": "正在載入文件…",


### PR DESCRIPTION
## Summary
- Add missing `dataView.filterActive` translation to every locale catalog.

## Tests
- `npx vitest run tests/messages/messages.test.ts`
- `npm run i18n:check`