### PR TITLE
test: fix flaky test_llm_trace via leaked global recorder (#2229)

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -16,6 +16,27 @@ from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
 from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 from hindsight_api.pg0 import EmbeddedPostgres
+from hindsight_api.tracing import unregister_span_recorder
+
+
+async def _teardown_memory_engine(mem: MemoryEngine) -> None:
+    """Tear down a test MemoryEngine, guaranteeing its span recorder is unregistered.
+
+    LLM-trace recorders live in a process-global registry; ``MemoryEngine.close()`` is
+    the only thing that removes the engine's recorder from it. If close() is skipped
+    (pool already closing) or raises before that step, the recorder leaks and a later
+    test's LLM calls get recorded into the shared DB — the flaky
+    test_llm_trace::test_disabled_writes_no_rows (#2229). Unregister unconditionally;
+    it's a no-op when close() already did it.
+    """
+    try:
+        if mem._pool and not mem._pool._closing:
+            await mem.close()
+    except Exception:
+        pass
+    finally:
+        unregister_span_recorder(mem._llm_recorder)
+
 
 # Default pg0 instance configuration for tests
 DEFAULT_PG0_INSTANCE_NAME = "hindsight-test"
@@ -342,10 +363,7 @@ async def oracle_memory(oracle_db_url, embeddings, cross_encoder, query_analyzer
         )
         await mem.initialize()
         yield mem
-        try:
-            await mem.close()
-        except Exception:
-            pass
+        await _teardown_memory_engine(mem)
     finally:
         # Restore original env var and clear config cache
         if old_backend is None:
@@ -463,11 +481,7 @@ async def memory(pg0_db_url, embeddings, cross_encoder, query_analyzer):
     )
     await mem.initialize()
     yield mem
-    try:
-        if mem._pool and not mem._pool._closing:
-            await mem.close()
-    except Exception:
-        pass
+    await _teardown_memory_engine(mem)
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -496,11 +510,7 @@ async def memory_real_llm(pg0_db_url, embeddings, cross_encoder, query_analyzer)
     )
     await mem.initialize()
     yield mem
-    try:
-        if mem._pool and not mem._pool._closing:
-            await mem.close()
-    except Exception:
-        pass
+    await _teardown_memory_engine(mem)
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -527,11 +537,7 @@ async def memory_no_llm_verify(pg0_db_url, embeddings, cross_encoder, query_anal
     )
     await mem.initialize()
     yield mem
-    try:
-        if mem._pool and not mem._pool._closing:
-            await mem.close()
-    except Exception:
-        pass
+    await _teardown_memory_engine(mem)
 
 
 @pytest_asyncio.fixture

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -222,6 +222,41 @@ async def test_configured_provider_binds_bank_context(registered_recorder):
     assert current_trace_context() is None  # unwound after the call
 
 
+@pytest.mark.asyncio
+async def test_engine_teardown_unregisters_recorder_even_when_close_skipped():
+    """Regression for #2229.
+
+    Span recorders live in a process-global registry, and providers fan every call
+    out to ALL registered recorders. The engine fixtures must remove their recorder
+    on teardown even when ``close()`` is skipped (pool already closing/absent) or
+    raises before the unregister step — otherwise a leaked, still-enabled recorder
+    from an earlier test records a later test's LLM calls into the shared DB, which
+    is what made ``test_disabled_writes_no_rows`` flaky. The teardown helper must
+    leave the registry exactly as it found it.
+    """
+    from hindsight_api import tracing
+
+    from tests.conftest import _teardown_memory_engine
+
+    sentinel = object()
+    tracing.register_span_recorder(sentinel)
+    try:
+        assert sentinel in tracing.get_span_recorder()._recorders
+
+        # _pool=None makes the helper's gated close() a no-op, exercising the exact
+        # leak path; the finally must still unregister the recorder.
+        class _FakeEngine:
+            _pool = None
+            _llm_recorder = sentinel
+
+        await _teardown_memory_engine(_FakeEngine())
+        assert sentinel not in tracing.get_span_recorder()._recorders
+    finally:
+        # Belt-and-suspenders: don't leave the sentinel in the global registry if an
+        # assertion above fails (idempotent — the helper normally already removed it).
+        tracing.unregister_span_recorder(sentinel)
+
+
 # ── HTTP read API (integration) ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #2229.

## Problem

`tests/test_llm_trace.py::test_disabled_writes_no_rows` was intermittently flaky (`assert 6 == 0`). LLM-trace recorders live in a **process-global registry**, and the provider layer fans every call out to **all** registered recorders regardless of which engine issued it.

`MemoryEngine.__init__` registers its recorder; `MemoryEngine.close()` is the only thing that unregisters it. But the engine test fixtures' teardown gated `close()` on `if mem._pool and not mem._pool._closing` and swallowed exceptions:

```python
try:
    if mem._pool and not mem._pool._closing:
        await mem.close()
except Exception:
    pass
```

So when `close()` was skipped (pool falsy/already closing) or raised before reaching the unregister step, the engine's recorder **leaked** into the global registry while still `_enabled=True`. A later test (e.g. `test_disabled_writes_no_rows`, which disables only *its own* recorder) then had its retain LLM calls captured by the leaked recorder and written to the shared DB under its bank_id — `total > 0`. The leak only fires when a prior enabled-recorder test ran on the same xdist worker and its teardown didn't reach the unregister, which is why it was intermittent.

## Fix

Route all four engine fixtures (`memory`, `memory_real_llm`, `memory_no_llm_verify`, and the Oracle engine fixture) through a shared `_teardown_memory_engine` helper that **always** unregisters the recorder in a `finally`, independent of pool state. `unregister_span_recorder` is guarded (`if recorder in self._recorders`), so the call is a no-op when `close()` already did it.

## Test

Added `test_engine_teardown_unregisters_recorder_even_when_close_skipped` — a fast, deterministic unit test that registers a sentinel recorder, runs the teardown helper with `_pool=None` (forcing the close-skipped leak path), and asserts the registry is left clean.

## Verification

- New regression test passes; `test_disabled_writes_no_rows` passes.
- Full `tests/test_llm_trace.py` — 22 passed locally.
- `lint.sh` green.
