### PR TITLE
Arch Linux systemd packaging with dependency ordering

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -190,7 +190,7 @@ class LocalSTEmbeddings(Embeddings):
             device = "cpu"
             logger.info("Embeddings: forcing CPU mode")
         else:
-            # Check for GPU (CUDA) or Apple Silicon (MPS)
+            # Check for GPU (CUDA), Apple Silicon (MPS), or Intel XPU
             # Wrap in try-except to gracefully handle any device detection issues
             # (e.g., in CI environments or when PyTorch is built without GPU support)
             device = "cpu"  # Default to CPU
@@ -198,10 +198,13 @@ class LocalSTEmbeddings(Embeddings):
                 has_gpu = torch.cuda.is_available() or (
                     hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
                 )
+                # Intel Arc XPU support — torch.xpu is available when the XPU build is loaded
+                if not has_gpu and hasattr(torch, "xpu"):
+                    has_gpu = torch.xpu.is_available()
                 if has_gpu:
-                    device = None  # Let sentence-transformers auto-detect GPU/MPS
+                    device = None  # Let sentence-transformers auto-detect GPU/MPS/XPU
             except Exception as e:
-                logger.warning(f"Failed to detect GPU/MPS, falling back to CPU: {e}")
+                logger.warning(f"Failed to detect GPU/MPS/XPU, falling back to CPU: {e}")
 
         # Suppress verbose transformers warnings during model loading
         # This suppresses the "UNEXPECTED" warnings from BertModel which are harmless

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,0 +1,102 @@
+# Maintainer: Raudbjorn <raudbjorn@github>
+# PKGBUILD for hindsight — Agent memory that works like human memory
+
+pkgname=hindsight
+pkgver=0.8.2
+pkgrel=1
+pkgdesc="Agent memory that works like human memory — API server, CLI, and web UI"
+arch=("x86_64")
+url="https://github.com/Raudbjorn/hindsight"
+license=("ISC")
+depends=(
+  "python>=3.11"
+  "python-pip"
+  "nodejs>=20"
+  "npm"
+  "postgresql"
+  "uv"
+)
+makedepends=(
+  "python-build"
+  "python-installer"
+)
+optdepends=(
+  "postgresql: External database (optional; uses embedded pg0 by default)"
+)
+provides=(
+  "hindsight-api-slim=${pkgver}"
+  "hindsight-embed=${pkgver}"
+  "hindsight-control-plane=${pkgver}"
+)
+conflicts=(
+  "hindsight-api-slim"
+  "hindsight-embed"
+  "hindsight-control-plane"
+)
+install="hindsight.install"
+
+source=("git+https://github.com/Raudbjorn/hindsight.git#tag=v${pkgver}")
+sha256sums=("SKIP")
+
+pkgver() {
+  cd "$srcdir/hindsight"
+  git describe --tags --match 'v*' | sed 's/^v//'
+}
+
+build() {
+  cd "$srcdir/hindsight"
+
+  # The control plane depends on @vectorize-io/hindsight-client as a workspace
+  # path dependency. Build the entire monorepo so the workspace link resolves.
+  npm ci
+  npm run build --workspaces
+}
+
+package() {
+  cd "$srcdir/hindsight"
+  local pkgsrc="$srcdir/hindsight"
+  local pkgdst="$pkgdir"
+
+  # Create Python venv and bootstrap uv into it
+  python -m venv "$pkgdst/opt/hindsight/venv"
+  "$pkgdst/opt/hindsight/venv/bin/pip" install --quiet uv
+  local venv_python="$pkgdst/opt/hindsight/venv/bin/python"
+
+  # Install local packages using uv — uv handles building hatchling packages
+  # from source and installs the resulting wheel.
+  # The [all] extra includes:
+  #   embedded-db  (pg0-embedded for local PostgreSQL)
+  #   local-ml     (sentence-transformers, torch for local embeddings/reranking)
+  #   local-onnx   (onnxruntime for ONNX embeddings)
+  #   local-llm    (llama-cpp-python for local LLM inference)
+  "$pkgdst/opt/hindsight/venv/bin/uv" pip install \
+    --python "$venv_python" \
+    "$pkgsrc/hindsight-api-slim[all]"
+
+  "$pkgdst/opt/hindsight/venv/bin/uv" pip install \
+    --python "$venv_python" \
+    "$pkgsrc/hindsight-embed"
+
+  # Install Node.js control plane standalone build
+  install -d "$pkgdst/opt/hindsight/control-plane"
+  cp -r hindsight-control-plane/standalone "$pkgdst/opt/hindsight/control-plane/"
+
+  # Create data directory (owned by hindsight:hindsight — set by post_install)
+  install -d -m 0750 "$pkgdst/var/lib/hindsight"
+
+  # Create config directory and install env template
+  install -d -m 0755 "$pkgdst/etc/hindsight"
+  install -m 0640 "$startdir/env.env.systemd" "$pkgdst/etc/hindsight/env"
+
+  # Install systemd service units
+  install -d -m 0755 "$pkgdst/usr/lib/systemd/system/"
+  install -m 0644 "$startdir/systemd/hindsight-api.service" "$pkgdst/usr/lib/systemd/system/"
+  install -m 0644 "$startdir/systemd/hindsight-control-plane.service" "$pkgdst/usr/lib/systemd/system/"
+
+  # Create symlinks for CLI entry points
+  install -d -m 0755 "$pkgdst/usr/bin/"
+  ln -sf /opt/hindsight/venv/bin/hindsight-api "$pkgdst/usr/bin/hindsight-api"
+  ln -sf /opt/hindsight/venv/bin/hindsight-worker "$pkgdst/usr/bin/hindsight-worker"
+  ln -sf /opt/hindsight/venv/bin/hindsight-admin "$pkgdst/usr/bin/hindsight-admin"
+  ln -sf /opt/hindsight/venv/bin/hindsight-embed "$pkgdst/usr/bin/hindsight-embed"
+}

--- a/packaging/env.env.systemd
+++ b/packaging/env.env.systemd
@@ -1,0 +1,22 @@
+# Hindsight Environment Variables
+# Copy this file to /etc/hindsight/env and fill in your values
+
+# LLM Configuration (Required)
+HINDSIGHT_API_LLM_PROVIDER=openai
+HINDSIGHT_API_LLM_API_KEY=your-api-key-here
+HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
+HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
+
+# API Configuration
+HINDSIGHT_API_HOST=0.0.0.0
+HINDSIGHT_API_PORT=8888
+HINDSIGHT_API_LOG_LEVEL=info
+
+# Database (Optional - uses embedded pg0 by default)
+# To use an external PostgreSQL database instead, uncomment and fill in:
+# HINDSIGHT_API_DATABASE_URL=postgresql://user:pass@host:5432/db
+
+# Control Plane
+HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888
+HINDSIGHT_CP_HOST=0.0.0.0
+HINDSIGHT_CP_PORT=9999

--- a/packaging/env.env.systemd
+++ b/packaging/env.env.systemd
@@ -2,21 +2,23 @@
 # Copy this file to /etc/hindsight/env and fill in your values
 
 # LLM Configuration (Required)
-HINDSIGHT_API_LLM_PROVIDER=openai
-HINDSIGHT_API_LLM_API_KEY=your-api-key-here
-HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
-HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
-
-# API Configuration
-HINDSIGHT_API_HOST=0.0.0.0
-HINDSIGHT_API_PORT=8888
+# For Ollama (local), leave API_KEY empty and set BASE_URL to your Ollama endpoint.
+# SKIP_VERIFICATION=true avoids blocking startup on LLM availability checks.
+HINDSIGHT_API_LLM_PROVIDER=ollama
+HINDSIGHT_API_LLM_API_KEY=
+HINDSIGHT_API_LLM_MODEL=llama3.2:latest
+HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:11434/v1
+HINDSIGHT_API_LLM_SKIP_VERIFICATION=true
+HINDSIGHT_API_PORT=6699
 HINDSIGHT_API_LOG_LEVEL=info
 
 # Database (Optional - uses embedded pg0 by default)
 # To use an external PostgreSQL database instead, uncomment and fill in:
 # HINDSIGHT_API_DATABASE_URL=postgresql://user:pass@host:5432/db
 
-# Control Plane
-HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888
+HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:6699
 HINDSIGHT_CP_HOST=0.0.0.0
-HINDSIGHT_CP_PORT=9999
+HINDSIGHT_CP_PORT=9966
+# Embeddings (local on Arc A770 XPU)
+HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
+HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=all-MiniLM-L6-v2

--- a/packaging/hindsight.install
+++ b/packaging/hindsight.install
@@ -1,0 +1,46 @@
+post_install() {
+  # Create hindsight system user if it doesn't exist
+  if ! id -u hindsight &>/dev/null; then
+    useradd -r -d /var/lib/hindsight -s /usr/bin/nologin -c "Hindsight Service Account" hindsight
+  fi
+
+  # Ensure data directory exists with correct ownership
+  install -d -o hindsight -g hindsight -m 0750 /var/lib/hindsight
+
+  # Fix shebangs in venv entry point scripts — hatchling bakes the build-time Python path
+  # into the shebang, which is wrong at install time. Replace with the installed venv Python.
+  local venv_python="/opt/hindsight/venv/bin/python"
+  local venv_bin="/opt/hindsight/venv/bin"
+  for script in "$venv_bin"/hindsight-* "$venv_bin"/hindsight-local-mcp; do
+    if [ -f "$script" ]; then
+      sed -i "1s|^#!/.*python|#!$venv_python|" "$script"
+    fi
+  done
+
+  # Reload systemd to pick up new unit files (non-fatal in containers/boot environments)
+  systemctl daemon-reload 2>/dev/null || true
+}
+
+post_upgrade() {
+  # Ensure user still exists after upgrades
+  if ! id -u hindsight &>/dev/null; then
+    useradd -r -d /var/lib/hindsight -s /usr/bin/nologin -c "Hindsight Service Account" hindsight
+  fi
+  install -d -o hindsight -g hindsight -m 0750 /var/lib/hindsight
+
+  # Re-fix shebangs on upgrade (package may have new entry points)
+  local venv_python="/opt/hindsight/venv/bin/python"
+  local venv_bin="/opt/hindsight/venv/bin"
+  for script in "$venv_bin"/hindsight-* "$venv_bin"/hindsight-local-mcp; do
+    if [ -f "$script" ]; then
+      sed -i "1s|^#!/.*python|#!$venv_python|" "$script"
+    fi
+  done
+
+  systemctl daemon-reload 2>/dev/null || true
+}
+
+pre_remove() {
+  # Stop services before removing files
+  systemctl --no-reload disable --now hindsight-api.service hindsight-control-plane.service 2>/dev/null || true
+}

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -1,0 +1,59 @@
+# Hindsight systemd Services
+
+This directory contains systemd service units for Hindsight.
+
+## Services
+
+- `hindsight-api.service` — FastAPI API server (port 8888)
+- `hindsight-control-plane.service` — Next.js web UI (port 9999)
+
+## Installation
+
+1. Copy the env template to the config location:
+
+   ```bash
+   sudo cp /opt/hindsight/env /etc/hindsight/env
+   ```
+
+2. Edit `/etc/hindsight/env` and set your `HINDSIGHT_API_LLM_API_KEY`:
+
+   ```bash
+   sudo $EDITOR /etc/hindsight/env
+   ```
+
+3. Enable and start the services:
+
+   ```bash
+   sudo systemctl enable --now hindsight-api
+   sudo systemctl enable --now hindsight-control-plane
+   ```
+
+## Verification
+
+```bash
+# Check service status
+sudo systemctl status hindsight-api
+sudo systemctl status hindsight-control-plane
+
+# Verify API is responding
+curl http://localhost:8888/health
+
+# View logs
+sudo journalctl -u hindsight-api --no-pager -f
+sudo journalctl -u hindsight-control-plane --no-pager -f
+```
+
+## Ports
+
+| Service | Port | URL |
+|---------|------|-----|
+| API | 8888 | http://localhost:8888 |
+| Control Plane | 9999 | http://localhost:9999 |
+
+## Notes
+
+- The API service starts before the control plane (via `Wants=`/`After=`).
+- Both services run under the `hindsight` system user.
+- Config is read from `/etc/hindsight/env`.
+- Data is stored in `/var/lib/hindsight`.
+- Graceful shutdown timeout is 30 seconds.

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -4,8 +4,8 @@ This directory contains systemd service units for Hindsight.
 
 ## Services
 
-- `hindsight-api.service` — FastAPI API server (port 8888)
-- `hindsight-control-plane.service` — Next.js web UI (port 9999)
+- `hindsight-api.service` — FastAPI API server (port 6699)
+- `hindsight-control-plane.service` — Next.js web UI (port 9966)
 
 ## Installation
 
@@ -36,7 +36,7 @@ sudo systemctl status hindsight-api
 sudo systemctl status hindsight-control-plane
 
 # Verify API is responding
-curl http://localhost:8888/health
+curl http://localhost:6699/health
 
 # View logs
 sudo journalctl -u hindsight-api --no-pager -f
@@ -47,9 +47,8 @@ sudo journalctl -u hindsight-control-plane --no-pager -f
 
 | Service | Port | URL |
 |---------|------|-----|
-| API | 8888 | http://localhost:8888 |
-| Control Plane | 9999 | http://localhost:9999 |
-
+| API | 6699 | http://localhost:6699 |
+| Control Plane | 9966 | http://localhost:9966 |
 ## Notes
 
 - The API service starts before the control plane (via `Wants=`/`After=`).

--- a/packaging/systemd/hindsight-api.service
+++ b/packaging/systemd/hindsight-api.service
@@ -1,14 +1,26 @@
 [Unit]
 Description=Hindsight API Server
-After=network.target
+After=network.target postgresql.service
 
 [Service]
 Type=simple
+TimeoutStartSec=180s
 User=hindsight
 Group=hindsight
 WorkingDirectory=/var/lib/hindsight
 Environment="PATH=/opt/hindsight/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 Environment="HOME=/var/lib/hindsight"
+# LLM — set BASE_URL for local Ollama
+Environment="HINDSIGHT_API_LLM_PROVIDER=ollama"
+Environment="HINDSIGHT_API_LLM_API_KEY="
+Environment="HINDSIGHT_API_LLM_MODEL=llama3.2:latest"
+Environment="HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:11434/v1"
+Environment="HINDSIGHT_API_SKIP_LLM_VERIFICATION=true"
+# Server
+Environment="HINDSIGHT_API_PORT=6699"
+# Embeddings — local CPU (XPU torch caused iGPU init spin; CPU works)
+Environment="HINDSIGHT_API_EMBEDDINGS_PROVIDER=local"
+Environment="HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=all-MiniLM-L6-v2"
 ExecStart=/opt/hindsight/venv/bin/hindsight-api
 Restart=on-failure
 RestartSec=5s
@@ -16,16 +28,19 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=hindsight-api
 
-# Graceful shutdown: give process 30s to finish
-TimeoutStopSec=30s
+# Graceful shutdown
+TimeoutStopSec=300s
 
 # Security hardening
+# NOTE: PrivateTmp=false + ProtectSystem=full is the working combo.
+# PrivateTmp=false shares the host's /tmp which is in the ProtectSystem=full whitelist.
+# PrivateTmp=true with NoNewPrivileges makes the tmpfs read-only for the service user.
+# ProtectSystem=strict denies access to /tmp entirely even with PrivateTmp=false.
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
+PrivateTmp=false
+ProtectSystem=full
 ProtectHome=read-only
 ReadWritePaths=/var/lib/hindsight
-EnvironmentFile=/etc/hindsight/env
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/hindsight-api.service
+++ b/packaging/systemd/hindsight-api.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Hindsight API Server
+After=network.target
+
+[Service]
+Type=simple
+User=hindsight
+Group=hindsight
+WorkingDirectory=/var/lib/hindsight
+Environment="PATH=/opt/hindsight/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
+Environment="HOME=/var/lib/hindsight"
+ExecStart=/opt/hindsight/venv/bin/hindsight-api
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hindsight-api
+
+# Graceful shutdown: give process 30s to finish
+TimeoutStopSec=30s
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/hindsight
+EnvironmentFile=/etc/hindsight/env
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/hindsight-control-plane.service
+++ b/packaging/systemd/hindsight-control-plane.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Hindsight Control Plane Web UI
+After=network.target hindsight-api.service
+Wants=hindsight-api.service
+
+[Service]
+Type=simple
+User=hindsight
+Group=hindsight
+WorkingDirectory=/opt/hindsight/control-plane
+Environment="HOME=/var/lib/hindsight"
+ExecStart=/opt/hindsight/control-plane/standalone/server.js
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hindsight-cp
+TimeoutStopSec=30s
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/hindsight /opt/hindsight/control-plane
+EnvironmentFile=/etc/hindsight/env
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/hindsight-control-plane.service
+++ b/packaging/systemd/hindsight-control-plane.service
@@ -1,3 +1,11 @@
+# hindsight-control-plane.service — Hindsight Control Plane Web UI
+#
+# NOTE: HINDSIGHT_CP_DATAPLANE_API_URL is set inline below (not via EnvironmentFile).
+# The CP proxies /api/* requests to the API at this URL. Without it, all CP→API
+# proxied requests return 502 Bad Gateway.
+#
+# If you add an EnvironmentFile line later, ensure it sets HINDSIGHT_CP_DATAPLANE_API_URL.
+#
 [Unit]
 Description=Hindsight Control Plane Web UI
 After=network.target hindsight-api.service
@@ -11,6 +19,8 @@ Group=hindsight
 WorkingDirectory=/opt/hindsight/control-plane/standalone
 Environment="HOME=/var/lib/hindsight"
 Environment="PORT=9966"
+# CP→API dataplane proxy — must match the API's HINDSIGHT_API_PORT
+Environment="HINDSIGHT_CP_DATAPLANE_API_URL=http://127.0.0.1:6699"
 ExecStart=/usr/bin/node /opt/hindsight/control-plane/standalone/server.js
 Restart=on-failure
 RestartSec=5s

--- a/packaging/systemd/hindsight-worker.service
+++ b/packaging/systemd/hindsight-worker.service
@@ -1,30 +1,28 @@
 [Unit]
-Description=Hindsight Control Plane Web UI
+Description=Hindsight Worker (async task processor)
 After=network.target hindsight-api.service
-Requires=hindsight-api.service
 Wants=hindsight-api.service
 
 [Service]
 Type=simple
 User=hindsight
 Group=hindsight
-WorkingDirectory=/opt/hindsight/control-plane/standalone
+WorkingDirectory=/var/lib/hindsight
 Environment="HOME=/var/lib/hindsight"
-Environment="PORT=9966"
-ExecStart=/usr/bin/node /opt/hindsight/control-plane/standalone/server.js
+Environment="PATH=/opt/hindsight/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/opt/hindsight/venv/bin/hindsight-worker
 Restart=on-failure
 RestartSec=5s
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=hindsight-cp
+SyslogIdentifier=hindsight-worker
 TimeoutStopSec=30s
 
-# Security hardening
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/var/lib/hindsight /opt/hindsight/control-plane
+ReadWritePaths=/var/lib/hindsight
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Packaging for Arch Linux with systemd service units, dependency ordering, and Arc A770 XPU support.

### Changes

- **hindsight-api.service**: 
  - Inline all env vars (fixes startup freeze caused by EnvironmentFile parsing issues)
  - , 
  -  for startup ordering
  -  +  — the working combo that allows PostgreSQL's  socket file while still hardening the service

- **hindsight-control-plane.service**:
  -  for dependency ordering
  -  
  -  (via env, Next.js standalone ignores most port env vars)

- **hindsight-worker.service**:
  - New service for async import processing
  - Depends on 

- **embeddings.py**: Added  detection for Arc A770 XPU embedding acceleration

### Deployment

The installed package at  provides:
- : API on   
- : CP on 
- : Async worker

Ports 6699 and 9966 are reachable over Tailscale at  and .

### Known limitations

- Arc A770 XPU for Ollama LLM is fragile when shared with the Wayland compositor (KWin). The GPU can deadlock under heavy concurrent use.
- Embeddings run on CPU (XPU torch causes iGPU initialization spin with  override).
-  on Arc A770 via Ollama Vulkan is slow (~30s+ per response); smaller models like  are more responsive.
- Control plane  endpoint returns 500 (calls  but API has ).
- Reflect operations can time out on large banks (54K+ pending ops).
