### PR TITLE
revert(worker): trust schemas_with_pending_work() result, drop per-poll re-scan

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/optional_routines.py
@@ -106,6 +106,15 @@ SCHEMAS_WITH_PENDING_WORK = OptionalRoutine(
         deployment.
       * Should be cheap and idempotent — called every poll cycle (~30s).
 
+    The poller trusts the result wholesale: any schema the routine does
+    not return is treated as having no work this cycle. It does NOT
+    second-guess omissions with a per-schema scan — that would re-run the
+    exact queries this routine exists to avoid. Consequently the routine
+    is *only* appropriate for multi-tenant deployments. Single-schema
+    (default/public only) installs should NOT create it: the per-schema
+    fallback below is a single cheap EXISTS check that covers ``public``
+    correctly and cannot starve.
+
     Fallback when the routine is absent: per-schema ``EXISTS`` queries
     from Python (~4ms per schema). The server-side path is a single-
     round-trip optimisation worth ~200ms in deployments with thousands

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -226,38 +226,23 @@ class WorkerPoller:
         """
         async with self._backend.acquire() as conn:
             if await self._optional_routines.is_installed(conn, "schemas_with_pending_work"):
+                # The routine IS the authority on where work exists: every schema
+                # it returns is claimable, and every schema it does NOT return is
+                # treated as having nothing to do this cycle. That is the entire
+                # point of installing it — one round-trip replaces N per-schema
+                # EXISTS probes. We deliberately do NOT re-verify the omitted
+                # schemas with a per-schema scan: that re-runs the exact queries
+                # the routine exists to avoid, on every idle poll, silently
+                # negating the optimisation.
+                #
+                # Because the result is trusted wholesale, the routine is only
+                # appropriate for multi-tenant deployments. A single-schema
+                # (default/public only) install should NOT create it and instead
+                # falls through to the per-schema path below — a single cheap
+                # EXISTS check that cannot starve. See
+                # ``hindsight_api.engine.db.optional_routines``.
                 rows = await conn.fetch("SELECT * FROM public.schemas_with_pending_work()")
-                routine_active = {self._normalize_poll_schema(r[0]) for r in rows}
-                known_schemas = set(schemas)
-                active = routine_active & known_schemas
-                unknown = routine_active - known_schemas
-                if unknown:
-                    logger.warning(
-                        "Optional PG routine public.schemas_with_pending_work() returned schema(s) "
-                        "not present in tenant discovery: %s",
-                        sorted(str(s) for s in unknown),
-                    )
-
-                # The optional routine returns PostgreSQL schema names, but the poller uses
-                # None for the default schema. Older operator-supplied implementations also
-                # commonly scan tenant_% only; when the default schema is in scope but absent
-                # from the routine result, verify via the fully-correct per-schema fallback so
-                # public single-tenant deployments cannot silently starve.
-                should_verify_with_fallback = (None in known_schemas and None not in active) or (
-                    bool(routine_active) and not active
-                )
-                if not should_verify_with_fallback:
-                    return active
-
-                fallback_active = await self._scan_active_schemas_by_exists(conn, schemas)
-                missed = fallback_active - active
-                if missed:
-                    logger.warning(
-                        "Optional PG routine public.schemas_with_pending_work() missed claimable schema(s) %s; "
-                        "using per-schema fallback for this poll",
-                        sorted(str(s) for s in missed),
-                    )
-                return fallback_active
+                return {self._normalize_poll_schema(r[0]) for r in rows}
 
             return await self._scan_active_schemas_by_exists(conn, schemas)
 

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -2896,8 +2896,7 @@ class TestClaimBatchRotation:
         from hindsight_api.worker import WorkerPoller
 
         # Minimal contract-satisfying implementation: returns the empty
-        # set. Use a non-default schema so the default-schema consistency
-        # check does not intentionally fall back to the per-schema scan.
+        # set. Enough to prove the poller follows the server-side path.
         await pool.execute(
             "CREATE OR REPLACE FUNCTION public.schemas_with_pending_work() "
             "RETURNS SETOF text AS $$ BEGIN RETURN; END $$ LANGUAGE plpgsql STABLE"
@@ -2925,7 +2924,7 @@ class TestClaimBatchRotation:
             PostgresConnection.fetch = spy_fetch  # type: ignore[method-assign]
             PostgresConnection.fetchval = spy_fetchval  # type: ignore[method-assign]
             try:
-                await poller._scan_active_schemas(["tenant_alpha"])
+                await poller._scan_active_schemas([None])
             finally:
                 PostgresConnection.fetch = original_fetch  # type: ignore[method-assign]
                 PostgresConnection.fetchval = original_fetchval  # type: ignore[method-assign]
@@ -2970,42 +2969,6 @@ class TestClaimBatchRotation:
             result = await poller._scan_active_schemas([None])
 
             assert result == {None}
-        finally:
-            await pool.execute("DROP FUNCTION IF EXISTS public.schemas_with_pending_work()")
-
-    @pytest.mark.asyncio
-    async def test_scan_falls_back_when_optional_routine_misses_public(self, pool, backend, clean_operations, caplog):
-        """If an installed routine scans tenant schemas only, public
-        single-tenant workers must still use the correct per-schema fallback.
-        """
-        from hindsight_api.worker import WorkerPoller
-
-        bank_id = f"test-worker-missed-{uuid.uuid4().hex[:8]}"
-        await _ensure_bank(pool, bank_id)
-        await pool.execute(
-            """INSERT INTO async_operations
-               (operation_id, bank_id, operation_type, status, task_payload)
-               VALUES ($1, $2, 'test', 'pending', $3::jsonb)""",
-            uuid.uuid4(),
-            bank_id,
-            json.dumps({"type": "test", "bank_id": bank_id}),
-        )
-        await pool.execute(
-            "CREATE OR REPLACE FUNCTION public.schemas_with_pending_work() "
-            "RETURNS SETOF text AS $$ BEGIN RETURN; END $$ LANGUAGE plpgsql STABLE"
-        )
-        try:
-            poller = WorkerPoller(
-                backend=backend,
-                worker_id="test-routine-missed-public",
-                executor=lambda x: None,
-            )
-
-            with caplog.at_level("WARNING", logger="hindsight_api.worker.poller"):
-                result = await poller._scan_active_schemas([None])
-
-            assert None in result
-            assert any("missed claimable schema" in record.message for record in caplog.records)
         finally:
             await pool.execute("DROP FUNCTION IF EXISTS public.schemas_with_pending_work()")
 


### PR DESCRIPTION
## What

Reverts the stale-routine fallback added in #1666 (`fix(worker): handle stale pending schema routines`). The poller now trusts `public.schemas_with_pending_work()` wholesale again: **any schema the routine does not return is treated as having no work this cycle** — which is the routine's documented contract.

## Why #1666 was wrong

`schemas_with_pending_work()` is a pure **perf** optimisation: one DB round-trip instead of N per-schema `EXISTS` probes (~200ms saved at 1400+ schemas). Its contract is explicit — *"an empty set means nothing to do, skip the expensive claim query."*

#1666 added a re-verification step:

```python
should_verify_with_fallback = (None in known_schemas and None not in active) or (
    bool(routine_active) and not active
)
...
fallback_active = await self._scan_active_schemas_by_exists(conn, schemas)  # full N-schema scan
```

The first disjunct fires constantly:
- `None in known_schemas` → the default/`public` schema is essentially always in the tenant list → permanently true.
- `None not in active` → `public` has no claimable work → the **normal idle case**, i.e. most poll cycles.

So on **every idle poll**, the poller ran `_scan_active_schemas_by_exists` over the **full** schema list — re-introducing the exact per-schema query storm the routine exists to avoid, precisely in the large multi-tenant deployments where the routine matters. The "staleness" check wasn't detecting staleness; an absent `public` is the routine's *correct* signal for "public is idle," and it can't be distinguished from "routine never scans public," so it conservatively paid the full fallback cost almost every cycle. The optimisation was effectively disabled in steady state.

## The #1555 concern

#1666 targeted a real scenario: an operator routine scoped to `tenant_%` only would never return `public`, starving a single-tenant `public` deployment. The correct fix is **guidance, not per-poll re-verification**: don't install the routine in single-schema deployments. The per-schema fallback is a single cheap `EXISTS` check that covers `public` correctly and cannot starve. This is now documented on the routine contract in `optional_routines.py`.

## Changes

- `worker/poller.py` — drop the fallback re-verification; trust the routine result (with the `public`→`None` normalisation from #1666 kept, so a returned `'public'` still counts as work).
- `engine/db/optional_routines.py` — document that the result is trusted wholesale and the routine is **multi-tenant only**; single-schema installs should not create it.
- `tests/test_worker.py` — remove the test asserting the reverted fallback behavior; keep the trusted-routine and normalisation tests.

## Test plan

- [x] `pytest tests/test_worker.py::TestClaimBatchRotation` — 9 passed
- [x] `./scripts/hooks/lint.sh` — clean
