### PR TITLE
fix(consolidation): handle single-value source_fact_ids from LLM

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -218,6 +218,13 @@ class _CreateAction(BaseModel):
     def sanitize_text(cls, v: str) -> str:
         return sanitize_llm_output(v) or ""
 
+    @field_validator("source_fact_ids", mode="before")
+    @classmethod
+    def ensure_list(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return [v]
+        return v
+
 
 class _UpdateAction(BaseModel):
     text: str
@@ -229,6 +236,13 @@ class _UpdateAction(BaseModel):
     @classmethod
     def sanitize_text(cls, v: str) -> str:
         return sanitize_llm_output(v) or ""
+
+    @field_validator("source_fact_ids", mode="before")
+    @classmethod
+    def ensure_list(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return [v]
+        return v
 
 
 class _DeleteAction(BaseModel):


### PR DESCRIPTION
Some LLMs return source_fact_ids as a string instead of a list when there is only one source ID. Add field_validator on both _CreateAction and _UpdateAction to auto-wrap into a single-element list.

Relates-to: https://github.com/vectorize-io/hindsight/issues/1566