### PR TITLE
feat(mcp): add ToolAnnotations (read-only/destructive hints) to MCP tools

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import TypeAdapter
 
 from hindsight_api import MemoryEngine
@@ -197,6 +198,46 @@ def build_content_dict(
         content_dict["update_mode"] = update_mode
 
     return content_dict, None
+
+
+# MCP tool annotations. Hindsight is a closed memory store (no open-world / internet
+# access), so openWorldHint=False throughout. readOnlyHint lets clients group and
+# auto-approve safe reads; destructiveHint flags tools that delete or clear memory.
+_READ_ONLY_TOOLS = {
+    "recall",
+    "list_banks",
+    "get_bank",
+    "get_bank_stats",
+    "list_mental_models",
+    "get_mental_model",
+    "list_directives",
+    "list_memories",
+    "get_memory",
+    "list_documents",
+    "get_document",
+    "list_operations",
+    "get_operation",
+    "list_tags",
+}
+_DESTRUCTIVE_TOOLS = {
+    "delete_bank",
+    "clear_memories",
+    "clear_mental_model",
+    "delete_mental_model",
+    "delete_directive",
+    "delete_document",
+    "invalidate_memory",
+}
+
+
+def _tool_annotations(name: str) -> ToolAnnotations:
+    if name in _READ_ONLY_TOOLS:
+        return ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+    if name in _DESTRUCTIVE_TOOLS:
+        return ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=False)
+    # Everything else writes but does not destructively delete/clear memory
+    # (retain, reflect, create_*, update_*, refresh_mental_model, cancel_operation).
+    return ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=False)
 
 
 def register_mcp_tools(
@@ -552,7 +593,7 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
     if config.include_bank_id_param:
 
-        @mcp.tool(description=description)
+        @mcp.tool(description=description, annotations=_tool_annotations("retain"))
         async def retain(
             content: str,
             context: str = "general",
@@ -608,7 +649,7 @@ def _register_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
     else:
 
-        @mcp.tool(description=description)
+        @mcp.tool(description=description, annotations=_tool_annotations("retain"))
         async def retain(
             content: str,
             context: str = "general",
@@ -666,7 +707,7 @@ def _register_sync_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("sync_retain"))
         async def sync_retain(
             content: str,
             context: str = "general",
@@ -724,7 +765,7 @@ def _register_sync_retain(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("sync_retain"))
         async def sync_retain(
             content: str,
             context: str = "general",
@@ -785,7 +826,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
     if config.include_bank_id_param:
 
-        @mcp.tool(description=description)
+        @mcp.tool(description=description, annotations=_tool_annotations("recall"))
         async def recall(
             query: str,
             max_tokens: int = 4096,
@@ -857,7 +898,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
 
     else:
 
-        @mcp.tool(description=description)
+        @mcp.tool(description=description, annotations=_tool_annotations("recall"))
         async def recall(
             query: str,
             max_tokens: int = 4096,
@@ -931,7 +972,7 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("reflect"))
         async def reflect(
             query: str,
             context: str | None = None,
@@ -1012,7 +1053,7 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("reflect"))
         async def reflect(
             query: str,
             context: str | None = None,
@@ -1093,7 +1134,7 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
 def _register_list_banks(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
     """Register the list_banks tool."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=_tool_annotations("list_banks"))
     async def list_banks() -> str:
         """
         List all available memory banks.
@@ -1118,7 +1159,7 @@ def _register_list_banks(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
 def _register_create_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
     """Register the create_bank tool."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=_tool_annotations("create_bank"))
     async def create_bank(bank_id: str, name: str | None = None, mission: str | None = None) -> str:
         """
         Create a new memory bank or get an existing one.
@@ -1182,7 +1223,7 @@ def _register_list_mental_models(mcp: FastMCP, memory: MemoryEngine, config: MCP
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_mental_models"))
         async def list_mental_models(
             tags: list[str] | None = None,
             detail: str = "full",
@@ -1221,7 +1262,7 @@ def _register_list_mental_models(mcp: FastMCP, memory: MemoryEngine, config: MCP
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_mental_models"))
         async def list_mental_models(
             tags: list[str] | None = None,
             detail: str = "full",
@@ -1262,7 +1303,7 @@ def _register_get_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_mental_model"))
         async def get_mental_model(
             mental_model_id: str,
             detail: str = "full",
@@ -1302,7 +1343,7 @@ def _register_get_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_mental_model"))
         async def get_mental_model(
             mental_model_id: str,
             detail: str = "full",
@@ -1344,7 +1385,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("create_mental_model"))
         async def create_mental_model(
             name: str,
             source_query: str,
@@ -1428,7 +1469,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("create_mental_model"))
         async def create_mental_model(
             name: str,
             source_query: str,
@@ -1510,7 +1551,7 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("update_mental_model"))
         async def update_mental_model(
             mental_model_id: str,
             name: str | None = None,
@@ -1571,7 +1612,7 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("update_mental_model"))
         async def update_mental_model(
             mental_model_id: str,
             name: str | None = None,
@@ -1634,7 +1675,7 @@ def _register_delete_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_mental_model"))
         async def delete_mental_model(
             mental_model_id: str,
             bank_id: str | None = None,
@@ -1670,7 +1711,7 @@ def _register_delete_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_mental_model"))
         async def delete_mental_model(
             mental_model_id: str,
         ) -> dict:
@@ -1708,7 +1749,7 @@ def _register_refresh_mental_model(mcp: FastMCP, memory: MemoryEngine, config: M
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("refresh_mental_model"))
         async def refresh_mental_model(
             mental_model_id: str,
             bank_id: str | None = None,
@@ -1752,7 +1793,7 @@ def _register_refresh_mental_model(mcp: FastMCP, memory: MemoryEngine, config: M
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("refresh_mental_model"))
         async def refresh_mental_model(
             mental_model_id: str,
         ) -> dict:
@@ -1796,7 +1837,7 @@ def _register_clear_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MCP
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("clear_mental_model"))
         async def clear_mental_model(
             mental_model_id: str,
             bank_id: str | None = None,
@@ -1842,7 +1883,7 @@ def _register_clear_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MCP
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("clear_mental_model"))
         async def clear_mental_model(
             mental_model_id: str,
         ) -> dict:
@@ -1893,7 +1934,7 @@ def _register_list_directives(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_directives"))
         async def list_directives(
             tags: list[str] | None = None,
             active_only: bool = True,
@@ -1931,7 +1972,7 @@ def _register_list_directives(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_directives"))
         async def list_directives(
             tags: list[str] | None = None,
             active_only: bool = True,
@@ -1971,7 +2012,7 @@ def _register_create_directive(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("create_directive"))
         async def create_directive(
             name: str,
             content: str,
@@ -2017,7 +2058,7 @@ def _register_create_directive(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("create_directive"))
         async def create_directive(
             name: str,
             content: str,
@@ -2065,7 +2106,7 @@ def _register_delete_directive(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_directive"))
         async def delete_directive(
             directive_id: str,
             bank_id: str | None = None,
@@ -2101,7 +2142,7 @@ def _register_delete_directive(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_directive"))
         async def delete_directive(
             directive_id: str,
         ) -> dict:
@@ -2144,7 +2185,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_memories"))
         async def list_memories(
             type: str | None = None,
             q: str | None = None,
@@ -2188,7 +2229,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_memories"))
         async def list_memories(
             type: str | None = None,
             q: str | None = None,
@@ -2234,7 +2275,7 @@ def _register_get_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_memory"))
         async def get_memory(
             memory_id: str,
             bank_id: str | None = None,
@@ -2270,7 +2311,7 @@ def _register_get_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_memory"))
         async def get_memory(
             memory_id: str,
         ) -> dict:
@@ -2321,7 +2362,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     if config.include_bank_id_param:
 
-        @mcp.tool(description=_EDIT_DOC)
+        @mcp.tool(description=_EDIT_DOC, annotations=_tool_annotations("update_memory"))
         async def update_memory(
             memory_id: str,
             text: str | None = None,
@@ -2367,7 +2408,7 @@ def _register_update_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     else:
 
-        @mcp.tool(description=_EDIT_DOC)
+        @mcp.tool(description=_EDIT_DOC, annotations=_tool_annotations("update_memory"))
         async def update_memory(
             memory_id: str,
             text: str | None = None,
@@ -2426,7 +2467,7 @@ def _register_invalidate_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPT
 
     if config.include_bank_id_param:
 
-        @mcp.tool(description=_INVALIDATE_DOC)
+        @mcp.tool(description=_INVALIDATE_DOC, annotations=_tool_annotations("invalidate_memory"))
         async def invalidate_memory(
             memory_id: str,
             reason: str | None = None,
@@ -2466,7 +2507,7 @@ def _register_invalidate_memory(mcp: FastMCP, memory: MemoryEngine, config: MCPT
 
     else:
 
-        @mcp.tool(description=_INVALIDATE_DOC)
+        @mcp.tool(description=_INVALIDATE_DOC, annotations=_tool_annotations("invalidate_memory"))
         async def invalidate_memory(
             memory_id: str,
             reason: str | None = None,
@@ -2513,7 +2554,7 @@ def _register_list_documents(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_documents"))
         async def list_documents(
             q: str | None = None,
             limit: int = 100,
@@ -2551,7 +2592,7 @@ def _register_list_documents(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_documents"))
         async def list_documents(
             q: str | None = None,
             limit: int = 100,
@@ -2591,7 +2632,7 @@ def _register_get_document(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsC
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_document"))
         async def get_document(
             document_id: str,
             bank_id: str | None = None,
@@ -2627,7 +2668,7 @@ def _register_get_document(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsC
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_document"))
         async def get_document(
             document_id: str,
         ) -> dict:
@@ -2665,7 +2706,7 @@ def _register_delete_document(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_document"))
         async def delete_document(
             document_id: str,
             bank_id: str | None = None,
@@ -2699,7 +2740,7 @@ def _register_delete_document(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_document"))
         async def delete_document(
             document_id: str,
         ) -> dict:
@@ -2740,7 +2781,7 @@ def _register_list_operations(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_operations"))
         async def list_operations(
             status: str | None = None,
             limit: int = 20,
@@ -2777,7 +2818,7 @@ def _register_list_operations(mcp: FastMCP, memory: MemoryEngine, config: MCPToo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_operations"))
         async def list_operations(
             status: str | None = None,
             limit: int = 20,
@@ -2816,7 +2857,7 @@ def _register_get_operation(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_operation"))
         async def get_operation(
             operation_id: str,
             bank_id: str | None = None,
@@ -2850,7 +2891,7 @@ def _register_get_operation(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_operation"))
         async def get_operation(
             operation_id: str,
         ) -> dict:
@@ -2886,7 +2927,7 @@ def _register_cancel_operation(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("cancel_operation"))
         async def cancel_operation(
             operation_id: str,
             bank_id: str | None = None,
@@ -2918,7 +2959,7 @@ def _register_cancel_operation(mcp: FastMCP, memory: MemoryEngine, config: MCPTo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("cancel_operation"))
         async def cancel_operation(
             operation_id: str,
         ) -> dict:
@@ -2957,7 +2998,7 @@ def _register_list_tags(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConf
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_tags"))
         async def list_tags(
             q: str | None = None,
             limit: int = 100,
@@ -2994,7 +3035,7 @@ def _register_list_tags(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConf
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("list_tags"))
         async def list_tags(
             q: str | None = None,
             limit: int = 100,
@@ -3033,7 +3074,7 @@ def _register_get_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfi
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_bank"))
         async def get_bank(
             bank_id: str | None = None,
         ) -> str:
@@ -3066,7 +3107,7 @@ def _register_get_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfi
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("get_bank"))
         async def get_bank() -> dict:
             """
             Get the profile of this memory bank.
@@ -3096,7 +3137,7 @@ def _register_get_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfi
 def _register_get_bank_stats(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:
     """Register the get_bank_stats tool (multi-bank only)."""
 
-    @mcp.tool()
+    @mcp.tool(annotations=_tool_annotations("get_bank_stats"))
     async def get_bank_stats(
         bank_id: str | None = None,
     ) -> str:
@@ -3169,7 +3210,7 @@ def _register_update_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("update_bank"))
         async def update_bank(
             name: str | None = None,
             mission: str | None = None,
@@ -3230,7 +3271,7 @@ def _register_update_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("update_bank"))
         async def update_bank(
             name: str | None = None,
             mission: str | None = None,
@@ -3293,7 +3334,7 @@ def _register_delete_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_bank"))
         async def delete_bank(
             bank_id: str | None = None,
         ) -> str:
@@ -3325,7 +3366,7 @@ def _register_delete_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("delete_bank"))
         async def delete_bank() -> dict:
             """
             Delete this memory bank and all its data.
@@ -3356,7 +3397,7 @@ def _register_clear_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
 
     if config.include_bank_id_param:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("clear_memories"))
         async def clear_memories(
             type: str | None = None,
             bank_id: str | None = None,
@@ -3391,7 +3432,7 @@ def _register_clear_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
 
     else:
 
-        @mcp.tool()
+        @mcp.tool(annotations=_tool_annotations("clear_memories"))
         async def clear_memories(
             type: str | None = None,
         ) -> dict:

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -205,6 +205,7 @@ def build_content_dict(
 # auto-approve safe reads; destructiveHint flags tools that delete or clear memory.
 _READ_ONLY_TOOLS = {
     "recall",
+    "reflect",
     "list_banks",
     "get_bank",
     "get_bank_stats",
@@ -236,7 +237,7 @@ def _tool_annotations(name: str) -> ToolAnnotations:
     if name in _DESTRUCTIVE_TOOLS:
         return ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=False)
     # Everything else writes but does not destructively delete/clear memory
-    # (retain, reflect, create_*, update_*, refresh_mental_model, cancel_operation).
+    # (retain, create_*, update_*, refresh_mental_model, cancel_operation).
     return ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=False)
 
 

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1923,6 +1923,14 @@ class TestToolAnnotations:
         assert ann.readOnlyHint is True
         assert ann.openWorldHint is False
 
+    async def test_reflect_is_read_only(self, mock_memory):
+        # reflect synthesizes an answer and persists nothing (memory_engine.reflect_async),
+        # so it carries readOnlyHint=True like recall.
+        ann = _tools(_make_mcp_server(mock_memory, {"reflect"}))["reflect"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is True
+        assert ann.openWorldHint is False
+
     async def test_destructive_tool(self, mock_memory):
         ann = _tools(_make_mcp_server(mock_memory, {"delete_bank"}))["delete_bank"].annotations
         assert ann is not None

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1911,3 +1911,31 @@ class TestBankToolFiltering:
         # Filter bypassed — config resolver was never consulted, all tools visible
         assert "recall" in visible
         mock_memory_with_resolver._config_resolver.get_bank_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestToolAnnotations:
+    """Every MCP tool must carry read-only / destructive hints (openWorldHint=False)."""
+
+    async def test_read_only_tool(self, mock_memory):
+        ann = _tools(_make_mcp_server(mock_memory, {"recall"}))["recall"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is True
+        assert ann.openWorldHint is False
+
+    async def test_destructive_tool(self, mock_memory):
+        ann = _tools(_make_mcp_server(mock_memory, {"delete_bank"}))["delete_bank"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is True
+
+    async def test_write_tool_is_not_destructive(self, mock_memory):
+        ann = _tools(_make_mcp_server(mock_memory, {"retain"}))["retain"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+
+    async def test_annotations_apply_in_single_bank_mode(self, mock_memory):
+        ann = _tools(_make_mcp_server(mock_memory, {"recall"}, include_bank_id=False))["recall"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is True

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -403,12 +403,7 @@ function BankSelectorInner() {
         timestamp?: string;
         document_id?: string;
         tags?: string[];
-        observation_scopes?:
-          | "per_tag"
-          | "combined"
-          | "all_combinations"
-          | "shared"
-          | string[][];
+        observation_scopes?: "per_tag" | "combined" | "all_combinations" | "shared" | string[][];
         metadata?: Record<string, string>;
         entities?: Array<{ text: string }>;
         strategy?: string;


### PR DESCRIPTION
## Problem

All MCP tools register with bare `@mcp.tool()` and expose no [`ToolAnnotations`](https://modelcontextprotocol.io/specification/server/tools#tool-annotations). MCP clients (claude.ai, Notion, …) therefore can't:

- group read tools separately from write tools,
- surface a destructive-action warning for `delete_bank` / `clear_memories`,
- auto-approve safe reads.

## Change

A small `_tool_annotations(name)` helper classifies each tool and is applied to every registration (both the multi-bank and single-bank variants). `openWorldHint=False` throughout — Hindsight is a closed memory store. Pure metadata; no behavioural change.

| class | hints | tools |
|---|---|---|
| read-only | `readOnlyHint=True` | recall, list_banks, get_bank, get_bank_stats, list_mental_models, get_mental_model, list_directives, list_memories, get_memory, list_documents, get_document, list_operations, get_operation, list_tags |
| destructive | `readOnlyHint=False, destructiveHint=True` | delete_bank, clear_memories, clear_mental_model, delete_mental_model, delete_directive, delete_document, invalidate_memory |
| write (non-destructive) | `readOnlyHint=False, destructiveHint=False` | retain, sync_retain, reflect, create_bank, create_mental_model, create_directive, update_bank, update_memory, update_mental_model, refresh_mental_model, cancel_operation |

## Two judgment calls for maintainers

- **`reflect`** — classified as a non-destructive *write* because it can form and persist opinions during synthesis. If the engine never persists on reflect, it should be `readOnlyHint=True` (nicer for clients — groups/auto-approves with reads).
- **`update_*`** — treated as non-destructive (modifies, doesn't delete). Flip to `destructiveHint=True` if you consider an overwrite destructive.

## Testing

- `tests/test_mcp_tools.py::TestToolAnnotations` (new) — read-only / destructive / write classification + single-bank mode.
- Full `test_mcp_tools.py`: **185 passed**. `ruff check` / `format` clean.
