### PR TITLE
fix(api): reject empty/whitespace content in dry-run extraction before the LLM call

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1442,6 +1442,13 @@ class DryRunExtractRequest(BaseModel):
     entities_allow_free_form: bool | None = None
     llm_output_language: str | None = None
 
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("content cannot be empty")
+        return v
+
 
 class ListDocumentsResponse(BaseModel):
     """Response model for list documents endpoint."""

--- a/hindsight-api-slim/tests/test_extract_dry_run_http.py
+++ b/hindsight-api-slim/tests/test_extract_dry_run_http.py
@@ -78,6 +78,27 @@ async def test_dry_run_extracts_without_persisting(api_client, memory):
 
 
 @pytest.mark.asyncio
+async def test_dry_run_rejects_empty_content(api_client, memory):
+    """Empty/whitespace-only content is rejected by request validation (422) before the
+    billable LLM extraction call runs — matching retain (RetainItem.content) and recall
+    (RecallRequest.query), which already reject empty input."""
+    bank_id = f"dryrun-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
+
+    before = await memory.list_memory_units(bank_id=bank_id, request_context=RequestContext())
+    for content in ("", "   ", "\n\t "):
+        resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/memories/dry-run-extract",
+            json={"content": content},
+        )
+        assert resp.status_code == 422, resp.text
+
+    # Rejected before extraction: nothing was persisted.
+    after = await memory.list_memory_units(bank_id=bank_id, request_context=RequestContext())
+    assert after["total"] == before["total"]
+
+
+@pytest.mark.asyncio
 async def test_dry_run_disabled_returns_404(api_client, memory):
     """With HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT=false the endpoint is removed (returns 404)."""
     bank_id = f"dryrun-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
The dry-run fact-extraction endpoint added in #2205 makes a real, billable LLM call, but `DryRunExtractRequest.content` has no empty-check — so empty/whitespace input burns a billable round-trip and returns no facts. Both retain (`RetainItem.content`) and recall (`RecallRequest.query`) already reject empty input.

This adds the same `field_validator` to `DryRunExtractRequest.content` (verbatim mirror of the existing `RetainItem` validator), so empty/whitespace content is rejected at request validation (422) before extraction runs. It's a `field_validator`, not a `Field(min_length=...)` constraint, so the generated OpenAPI schema and clients are unchanged. Added a regression test covering empty and whitespace-only content.

Refs #2205.