### PR TITLE
feat(extensions): expose Content-Length on PrecheckContext

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3333,6 +3333,7 @@ def _register_routes(app: FastAPI):
 
         async def _precheck_dep(
             bank_id: str,
+            request: Request,
             request_context: RequestContext = Depends(get_request_context),
         ) -> None:
             validator = getattr(app.state.memory, "_operation_validator", None)
@@ -3341,10 +3342,20 @@ def _register_routes(app: FastAPI):
             from hindsight_api.extensions import PrecheckContext
 
             await app.state.memory._authenticate_tenant(request_context)
+            cl_header = request.headers.get("content-length")
+            content_length: int | None = None
+            if cl_header is not None:
+                try:
+                    parsed = int(cl_header)
+                except ValueError:
+                    parsed = -1
+                if parsed >= 0:
+                    content_length = parsed
             ctx = PrecheckContext(
                 operation=operation,
                 bank_id=bank_id,
                 request_context=request_context,
+                content_length=content_length,
             )
             result = await validator.precheck(ctx)
             if not result.allowed:

--- a/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
+++ b/hindsight-api-slim/hindsight_api/extensions/operation_validator.py
@@ -97,6 +97,10 @@ class PrecheckContext:
     - ``bank_id``: parsed from the URL path.
     - ``request_context``: the authenticated :class:`RequestContext` (tenant
       already resolved by the tenant extension).
+    - ``content_length``: value of the ``Content-Length`` request header as an
+      int, or ``None`` when the header is absent or unparseable (e.g. chunked
+      transfer encoding). Lets a precheck make size-aware decisions — such as
+      an upper-bound cost estimate — without reading or deserialising the body.
 
     Implementations should keep precheck cheap and side-effect-free. The
     full per-request validators (``validate_retain`` / ``validate_recall``
@@ -107,6 +111,7 @@ class PrecheckContext:
     operation: str
     bank_id: str
     request_context: "RequestContext"
+    content_length: int | None = None
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_extensions.py
+++ b/hindsight-api-slim/tests/test_extensions.py
@@ -911,7 +911,7 @@ class TestPrecheckHttpWiring:
     def _build_app(validator):
         """Mirror the precheck wiring from ``hindsight_api.api.http`` in a
         standalone FastAPI app."""
-        from fastapi import Depends, FastAPI, HTTPException
+        from fastapi import Depends, FastAPI, HTTPException, Request
         from pydantic import BaseModel, model_validator
 
         from hindsight_api.extensions import PrecheckContext
@@ -952,12 +952,23 @@ class TestPrecheckHttpWiring:
         def _precheck_for(operation: str):
             async def _dep(
                 bank_id: str,
+                request: Request,
                 request_context: RequestContext = Depends(_request_context),
             ) -> None:
+                cl_header = request.headers.get("content-length")
+                content_length: int | None = None
+                if cl_header is not None:
+                    try:
+                        parsed = int(cl_header)
+                    except ValueError:
+                        parsed = -1
+                    if parsed >= 0:
+                        content_length = parsed
                 ctx = PrecheckContext(
                     operation=operation,
                     bank_id=bank_id,
                     request_context=request_context,
+                    content_length=content_length,
                 )
                 result = await validator.precheck(ctx)
                 if not result.allowed:
@@ -1081,3 +1092,86 @@ class TestPrecheckHttpWiring:
         resp = client.get("/v1/default/banks/precheck-bank/memories/list")
         assert resp.status_code == 200
         assert len(validator.precheck_calls) == 0
+
+    def test_precheck_context_carries_content_length(self):
+        """Content-Length header is exposed to the precheck so a validator
+        can make size-aware decisions (e.g. upper-bound cost estimate)
+        before the body is deserialised."""
+        validator = RecordingPrecheckValidator(reject=False)
+        app, _ = self._build_app(validator)
+        client = TestClient(app)
+
+        # Body must contain at least 500 'x' bytes; check the surfaced
+        # Content-Length is within a tight band around that floor (allows
+        # for JSON envelope + httpx's serialisation choices without
+        # depending on exact byte counts).
+        payload = {"items": [{"content": "x" * 500}]}
+        resp = client.post(
+            "/v1/default/banks/precheck-bank/memories",
+            json=payload,
+        )
+        assert resp.status_code == 200
+        assert len(validator.precheck_calls) == 1
+        ctx = validator.precheck_calls[0]
+        assert ctx.content_length is not None
+        assert 500 <= ctx.content_length <= 600
+
+    def test_precheck_context_content_length_zero_is_not_none(self):
+        """An empty POST body has Content-Length: 0. That should surface
+        as the int 0, not None — None means 'unknown', 0 means 'known to
+        be empty'."""
+        validator = RecordingPrecheckValidator(reject=False)
+        app, _ = self._build_app(validator)
+        client = TestClient(app)
+
+        # Empty body fails Pydantic parse (422), but precheck runs first
+        # and records the Content-Length.
+        client.post(
+            "/v1/default/banks/precheck-bank/memories",
+            content=b"",
+            headers={"content-type": "application/json"},
+        )
+        assert len(validator.precheck_calls) >= 1
+        ctx = validator.precheck_calls[-1]
+        assert ctx.content_length == 0
+
+    @pytest.mark.asyncio
+    async def test_precheck_context_content_length_none_when_header_missing(self):
+        """When the Content-Length header isn't set (e.g. chunked transfer
+        encoding) the validator sees None, not a crash and not a default 0."""
+        from starlette.requests import Request as _StarletteRequest
+
+        from hindsight_api.extensions import PrecheckContext
+        from hindsight_api.models import RequestContext
+
+        validator = RecordingPrecheckValidator(reject=False)
+
+        # Replicate the wiring's parse step inline so the test exercises
+        # the same code-path semantics introduced in
+        # ``hindsight_api.api.http._precheck_dep``.
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/default/banks/bank-x/memories",
+            "headers": [],  # no content-length
+            "query_string": b"",
+        }
+        req = _StarletteRequest(scope)
+        cl_header = req.headers.get("content-length")
+        content_length: int | None = None
+        if cl_header is not None:
+            try:
+                parsed = int(cl_header)
+            except ValueError:
+                parsed = -1
+            if parsed >= 0:
+                content_length = parsed
+
+        ctx = PrecheckContext(
+            operation="retain",
+            bank_id="bank-x",
+            request_context=RequestContext(),
+            content_length=content_length,
+        )
+        await validator.precheck(ctx)
+        assert validator.precheck_calls[-1].content_length is None


### PR DESCRIPTION
## Summary
Add an optional `content_length: int | None` field to `PrecheckContext` and populate it from the request's `Content-Length` header in the `_precheck_dep` FastAPI dependency wired by the billable POST routes.

Surfacing the header lets a precheck make size-aware decisions — for example, computing an upper-bound cost estimate (`bytes / tokens-per-byte * per-op-rate`) and rejecting **before** the body is read or deserialised — without changing the contract that precheck runs before body parse.

## Why
`PrecheckContext` exists to let validators reject a request before FastAPI/Pydantic materialise its body in memory. Today the context carries only `operation`, `bank_id`, and `request_context` — purely auth/routing state — so a size-aware precheck has no signal to work with even though `Content-Length` is sitting on the request, cheap and free.

Without this field, any validator wanting to reject "this body is too expensive for this caller's balance" has to either (a) wait for the body to be parsed (defeating the purpose of precheck) or (b) reach around the validator interface to grab the raw `Request`, which couples cloud validators to FastAPI.

## What changes
- `PrecheckContext` gains `content_length: int | None = None`.
- `_precheck_dep` parses `request.headers["content-length"]` and populates the field. Missing or malformed header → `None`. Empty body (`0`) → `0` (preserved as "known empty", distinct from "unknown").
- Backward-compatible: existing extension implementations and any direct `PrecheckContext(...)` constructors keep working unchanged because the field is optional with a default.

## Tests
Three new tests in `tests/test_extensions.py::TestPrecheckHttpWiring`:
- `test_precheck_context_carries_content_length` — POST with a JSON body → validator sees the int.
- `test_precheck_context_content_length_zero_is_not_none` — empty body → `0`, not `None`.
- `test_precheck_context_content_length_none_when_header_missing` — header absent → `None`.

All 41 tests in `test_extensions.py` pass locally.

## Test plan
- [x] `pytest tests/test_extensions.py -v` green (41/41).
- [ ] CI green on this PR.