### PR TITLE
chore(control-plane): format bank-selector.tsx (lint drift from #2212)

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -403,12 +403,7 @@ function BankSelectorInner() {
         timestamp?: string;
         document_id?: string;
         tags?: string[];
-        observation_scopes?:
-          | "per_tag"
-          | "combined"
-          | "all_combinations"
-          | "shared"
-          | string[][];
+        observation_scopes?: "per_tag" | "combined" | "all_combinations" | "shared" | string[][];
         metadata?: Record<string, string>;
         entities?: Array<{ text: string }>;
         strategy?: string;


### PR DESCRIPTION
## Summary

`verify-generated-files` is currently red on **every** PR branched off main: #2212 added the `"shared"` `observation_scopes` option to `bank-selector.tsx` but committed it without running the lint hook, so the multi-line union type was never prettier-formatted. CI's `lint.sh` auto-formats it, which trips the "no uncommitted changes" check.

This applies that formatting (eslint --fix + prettier --write): the union collapses to a single line (fits in 120 cols). **No behavior change.**

## Verification
- The diff exactly matches what CI produces (`1 insertion, 6 deletions`).
- Re-running eslint + prettier produces no further change (idempotent), so `verify-generated-files` will be satisfied.

Unblocks the check for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)