### PR TITLE
Add Gemini service tier config

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -142,6 +142,7 @@ ENV_LLM_REASONING_EFFORT = "HINDSIGHT_API_LLM_REASONING_EFFORT"
 ENV_LLM_GROQ_SERVICE_TIER = "HINDSIGHT_API_LLM_GROQ_SERVICE_TIER"
 ENV_LLM_OPENAI_SERVICE_TIER = "HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER"
 ENV_LLM_BEDROCK_SERVICE_TIER = "HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER"
+ENV_LLM_GEMINI_SERVICE_TIER = "HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER"
 ENV_LLM_EXTRA_BODY = "HINDSIGHT_API_LLM_EXTRA_BODY"
 ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 ENV_LLM_STRICT_SCHEMA = "HINDSIGHT_API_LLM_STRICT_SCHEMA"
@@ -159,10 +160,23 @@ ENV_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG"
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
 DEFAULT_LLM_BEDROCK_SERVICE_TIER = None  # None (default), "flex", "priority", or "reserved"
+DEFAULT_LLM_GEMINI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper best-effort tier)
 DEFAULT_LLM_EXTRA_BODY = None  # None = no extra body params; JSON dict merged into OpenAI extra_body
 DEFAULT_LLM_DEFAULT_HEADERS = (
     None  # None = no extra headers; JSON dict passed as default_headers to provider SDK clients
 )
+
+
+def parse_gemini_service_tier(value: str | None) -> str | None:
+    """Normalize and validate the Gemini service tier."""
+    tier = value or None
+    valid_tiers = (None, "flex")
+    if tier not in valid_tiers:
+        raise ValueError(
+            f"Invalid HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER: "
+            f"{tier!r}. Must be one of: {', '.join(t for t in valid_tiers if t is not None)}."
+        )
+    return tier
 
 # Per-operation LLM configuration (optional, falls back to global LLM config)
 ENV_RETAIN_LLM_PROVIDER = "HINDSIGHT_API_RETAIN_LLM_PROVIDER"
@@ -1298,6 +1312,7 @@ class HindsightConfig:
     llm_groq_service_tier: str  # Groq: "on_demand", "flex", or "auto"
     llm_openai_service_tier: str | None  # OpenAI: None (default) or "flex" (50% cheaper)
     llm_bedrock_service_tier: str | None  # Bedrock: None (default), "flex", "priority", or "reserved"
+    llm_gemini_service_tier: str | None  # Gemini: None (default) or "flex" (50% cheaper)
     llm_extra_body: (
         dict | None
     )  # Extra body params merged into OpenAI-compatible API calls (e.g. {"chat_template_kwargs": {"enable_thinking": true}})
@@ -1879,6 +1894,9 @@ class HindsightConfig:
                 f"Note: 'standard' is not a valid Bedrock service tier -- use unset for default tier."
             )
 
+        # Validate gemini_service_tier
+        self.llm_gemini_service_tier = parse_gemini_service_tier(self.llm_gemini_service_tier)
+
         # When LLM provider is "none", force chunks-only mode and disable LLM-dependent features
         if self.llm_provider == "none":
             self.retain_extraction_mode = "chunks"
@@ -1996,6 +2014,11 @@ class HindsightConfig:
             llm_groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
             llm_openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
             llm_bedrock_service_tier=os.getenv(ENV_LLM_BEDROCK_SERVICE_TIER) or None,
+            llm_gemini_service_tier=(
+                parse_gemini_service_tier(os.getenv(ENV_LLM_GEMINI_SERVICE_TIER) or DEFAULT_LLM_GEMINI_SERVICE_TIER)
+                if llm_provider.lower() == "gemini"
+                else None
+            ),
             llm_extra_body=json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null")),
             llm_default_headers=json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null")),
             llm_strict_schema=os.getenv(ENV_LLM_STRICT_SCHEMA, str(DEFAULT_LLM_STRICT_SCHEMA)).lower() in ("true", "1"),

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -178,6 +178,7 @@ def parse_gemini_service_tier(value: str | None) -> str | None:
         )
     return tier
 
+
 # Per-operation LLM configuration (optional, falls back to global LLM config)
 ENV_RETAIN_LLM_PROVIDER = "HINDSIGHT_API_RETAIN_LLM_PROVIDER"
 ENV_RETAIN_LLM_API_KEY = "HINDSIGHT_API_RETAIN_LLM_API_KEY"

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -253,6 +253,7 @@ def create_llm_provider(
     gemini_safety_settings: list | None = None,
     prompt_cache_enabled: bool = False,
     litellmrouter_config: dict[str, Any] | None = None,
+    gemini_service_tier: str | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -266,6 +267,7 @@ def create_llm_provider(
         groq_service_tier: Groq service tier (for Groq provider) - "on_demand", "flex", or "auto".
         openai_service_tier: OpenAI service tier (for OpenAI provider) - None (default) or "flex" (50% cheaper).
         bedrock_service_tier: Bedrock service tier (for Bedrock provider) - None (default), "flex", "priority", or "reserved".
+        gemini_service_tier: Gemini service tier (for Gemini provider) - None (default) or "flex" (50% cheaper).
         extra_body: Extra request-body params merged into the provider's native
             call. Threaded into OpenAI-compatible, Fireworks, Anthropic, Gemini/
             VertexAI and LiteLLM providers (each merges them in its own parameter
@@ -296,6 +298,12 @@ def create_llm_provider(
     )
 
     provider_lower = provider.lower()
+    if provider_lower == "gemini":
+        from ..config import parse_gemini_service_tier
+
+        gemini_service_tier = parse_gemini_service_tier(gemini_service_tier)
+    else:
+        gemini_service_tier = None
 
     if provider_lower == "openai-codex":
         return CodexLLM(
@@ -344,6 +352,7 @@ def create_llm_provider(
             vertexai_region=vertexai_region,
             vertexai_credentials=vertexai_credentials,
             gemini_safety_settings=gemini_safety_settings,
+            gemini_service_tier=gemini_service_tier,
             prompt_cache_enabled=prompt_cache_enabled,
             extra_body=extra_body,
         )
@@ -496,6 +505,7 @@ class LLMProvider:
         extra_body: dict[str, Any] | None = None,
         default_headers: dict[str, str] | None = None,
         litellmrouter_config: dict[str, Any] | None = None,
+        gemini_service_tier: str | None = None,
     ):
         """
         Initialize LLM provider.
@@ -509,6 +519,7 @@ class LLMProvider:
             groq_service_tier: Groq service tier ("on_demand", "flex", "auto") - from config.
             openai_service_tier: OpenAI service tier (None or "flex") - from config.
             bedrock_service_tier: Bedrock service tier (None, "flex", "priority", "reserved") - from config.
+            gemini_service_tier: Gemini service tier (None or "flex") - from config.
             gemini_safety_settings: Safety settings for Gemini/VertexAI providers.
             extra_body: Extra request-body params merged into the provider's native call
                 (OpenAI-compatible, Fireworks, Anthropic, Gemini/VertexAI, LiteLLM).
@@ -532,6 +543,7 @@ class LLMProvider:
         self.groq_service_tier = groq_service_tier
         self.openai_service_tier = openai_service_tier
         self.bedrock_service_tier = bedrock_service_tier
+        self.gemini_service_tier = gemini_service_tier
         # Gemini safety settings (instance default; can be overridden per-request via context var)
         self.gemini_safety_settings = gemini_safety_settings
         # Gemini prompt caching: when True, retain extraction (and any future
@@ -660,6 +672,22 @@ class LLMProvider:
             except Exception:
                 pass  # Config may not be initialized in test environments
 
+        if self.provider == "gemini":
+            from ..config import parse_gemini_service_tier
+
+            self.gemini_service_tier = parse_gemini_service_tier(self.gemini_service_tier)
+
+        if self.provider == "gemini" and self.gemini_service_tier is None:
+            from ..config import _get_raw_config
+
+            try:
+                raw_config = _get_raw_config()
+                self.gemini_service_tier = raw_config.llm_gemini_service_tier
+            except Exception:
+                pass  # Config may not be initialized in test environments
+        elif self.provider != "gemini":
+            self.gemini_service_tier = None
+
         # Prompt-prefix caching is a provider-agnostic toggle (default on): resolve
         # it from the static server config for every provider when the caller didn't
         # pass an explicit override. Providers that don't support caching ignore the
@@ -698,6 +726,7 @@ class LLMProvider:
             groq_service_tier=self.groq_service_tier,
             openai_service_tier=self.openai_service_tier,
             bedrock_service_tier=self.bedrock_service_tier,
+            gemini_service_tier=self.gemini_service_tier,
             extra_body=self.extra_body,
             default_headers=self.default_headers,
             vertexai_project_id=vertexai_project_id,
@@ -1142,10 +1171,12 @@ class LLMProvider:
             ENV_LLM_BEDROCK_SERVICE_TIER,
             ENV_LLM_DEFAULT_HEADERS,
             ENV_LLM_EXTRA_BODY,
+            ENV_LLM_GEMINI_SERVICE_TIER,
             ENV_LLM_MODEL,
             ENV_LLM_PROVIDER,
             ENV_LLM_REASONING_EFFORT,
             _get_default_model_for_provider,
+            parse_gemini_service_tier,
         )
 
         provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER)
@@ -1172,6 +1203,11 @@ class LLMProvider:
             extra_body=extra_body,
             default_headers=default_headers,
             bedrock_service_tier=os.getenv(ENV_LLM_BEDROCK_SERVICE_TIER) or None,
+            gemini_service_tier=(
+                parse_gemini_service_tier(os.getenv(ENV_LLM_GEMINI_SERVICE_TIER))
+                if provider.lower() == "gemini"
+                else None
+            ),
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -933,6 +933,7 @@ class MemoryEngine(MemoryEngineInterface):
             default_headers=config.llm_default_headers,
             litellmrouter_config=config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
+            gemini_service_tier=config.llm_gemini_service_tier,
         )
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
@@ -966,6 +967,7 @@ class MemoryEngine(MemoryEngineInterface):
             default_headers=config.llm_default_headers,
             litellmrouter_config=config.retain_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
+            gemini_service_tier=config.llm_gemini_service_tier,
         )
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
@@ -994,6 +996,7 @@ class MemoryEngine(MemoryEngineInterface):
             default_headers=config.llm_default_headers,
             litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
+            gemini_service_tier=config.llm_gemini_service_tier,
         )
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
@@ -1022,6 +1025,7 @@ class MemoryEngine(MemoryEngineInterface):
             default_headers=config.llm_default_headers,
             litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
+            gemini_service_tier=config.llm_gemini_service_tier,
         )
 
         # Initialize cross-encoder reranker (cached for performance)

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -76,6 +76,7 @@ class GeminiLLM(LLMInterface):
 
         # Safety settings: None means use Gemini's defaults
         self._safety_settings: list | None = kwargs.get("gemini_safety_settings")
+        self._service_tier: str | None = kwargs.get("gemini_service_tier")
 
         # User-configured extra params merged into the GenerateContentConfig of
         # every call. Gemini's request body nests generation params, so we expose
@@ -105,6 +106,16 @@ class GeminiLLM(LLMInterface):
 
         self._client = genai.Client(api_key=self.api_key)
         logger.info(f"Gemini API: model={self.model}")
+
+    def _apply_service_tier(self, config_kwargs: dict[str, Any]) -> None:
+        if not self._service_tier:
+            return
+
+        http_options = dict(config_kwargs.get("http_options") or {})
+        extra_body = dict(http_options.get("extra_body") or {})
+        extra_body.setdefault("service_tier", self._service_tier)
+        http_options["extra_body"] = extra_body
+        config_kwargs["http_options"] = http_options
 
     def _init_vertexai(self, **kwargs: Any) -> None:
         """Initialize Vertex AI client with project, region, and credentials."""
@@ -273,6 +284,7 @@ class GeminiLLM(LLMInterface):
         def _build_generation_config(use_cache: bool) -> "genai_types.GenerateContentConfig | None":
             # Seed with user-configured extra params; explicit settings below win.
             config_kwargs: dict[str, Any] = dict(self._extra_body)
+            self._apply_service_tier(config_kwargs)
             if use_cache:
                 config_kwargs["cached_content"] = cached_prefix
             elif system_instruction:
@@ -604,6 +616,7 @@ class GeminiLLM(LLMInterface):
         def _build_tools_config(use_cache: bool) -> "genai_types.GenerateContentConfig":
             # Seed with user-configured extra params; explicit settings below win.
             config_kwargs: dict[str, Any] = dict(self._extra_body)
+            self._apply_service_tier(config_kwargs)
             if use_cache:
                 config_kwargs["cached_content"] = cached_prefix
             else:

--- a/hindsight-api-slim/tests/test_config_validation.py
+++ b/hindsight-api-slim/tests/test_config_validation.py
@@ -25,6 +25,7 @@ def setup_test_env():
         "HINDSIGHT_API_LLM_MODEL",
         "HINDSIGHT_API_LLM_REASONING_EFFORT",
         "HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER",
+        "HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER",
         "HINDSIGHT_API_SEMANTIC_MIN_SIMILARITY",
         "HINDSIGHT_API_DATABASE_URL",
         "HINDSIGHT_API_MIGRATION_DATABASE_URL",
@@ -580,3 +581,81 @@ def test_bedrock_service_tier_rejects_invalid_value(monkeypatch):
     assert "HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER" in error_message
     assert "standard" in error_message
     assert "'standard' is not a valid Bedrock service tier" in error_message
+
+
+# ---------------------------------------------------------------------------
+# Gemini service tier (HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER)
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_service_tier_defaults_to_none(monkeypatch):
+    """Gemini service tier defaults to None (standard tier) when unset."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.delenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.llm_gemini_service_tier is None
+
+
+def test_gemini_service_tier_flex(monkeypatch):
+    """Flex tier is accepted for Gemini."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "flex")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+
+    config = HindsightConfig.from_env()
+    assert config.llm_gemini_service_tier == "flex"
+
+
+def test_gemini_service_tier_accepts_mixed_case_provider(monkeypatch):
+    """Gemini tier parsing follows provider's case-insensitive handling."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "flex")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "Gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+
+    config = HindsightConfig.from_env()
+    assert config.llm_gemini_service_tier == "flex"
+
+
+def test_gemini_service_tier_rejects_invalid_value(monkeypatch):
+    """Unknown Gemini service tiers are rejected early."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "standard")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+
+    with pytest.raises(ValueError) as exc_info:
+        HindsightConfig.from_env()
+
+    error_message = str(exc_info.value)
+    assert "HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER" in error_message
+    assert "standard" in error_message
+
+
+def test_gemini_service_tier_ignored_for_non_gemini_provider(monkeypatch):
+    """Invalid Gemini-only tiers do not break unrelated providers."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "standard")
+
+    config = HindsightConfig.from_env()
+    assert config.llm_gemini_service_tier is None
+
+
+def test_gemini_service_tier_empty_env_is_unset(monkeypatch):
+    """Empty env values are treated as unset for templated deployments."""
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+
+    config = HindsightConfig.from_env()
+    assert config.llm_gemini_service_tier is None

--- a/hindsight-api-slim/tests/test_gemini_service_tier.py
+++ b/hindsight-api-slim/tests/test_gemini_service_tier.py
@@ -1,0 +1,103 @@
+"""Plumbing tests for the Gemini service tier flag."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.llm_wrapper import LLMConfig
+
+
+def test_llm_config_threads_gemini_service_tier_to_provider_impl():
+    """End-to-end: LLMConfig -> create_llm_provider -> GeminiLLM carries the tier."""
+    pytest.importorskip("google.genai")
+    with patch("google.genai.Client", return_value=MagicMock()):
+        llm = LLMConfig(
+            provider="gemini",
+            api_key="fake-key",
+            base_url="",
+            model="gemini-2.5-flash",
+            gemini_service_tier="flex",
+        )
+
+    assert llm._provider_impl._service_tier == "flex"
+
+
+def test_llm_provider_from_env_validates_gemini_service_tier(monkeypatch):
+    """Direct env construction rejects the same invalid tiers as HindsightConfig."""
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "standard")
+    clear_config_cache()
+
+    with pytest.raises(ValueError, match="HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER"):
+        LLMProvider.from_env()
+
+    clear_config_cache()
+
+
+def test_llm_provider_from_env_ignores_gemini_tier_for_non_gemini(monkeypatch):
+    """Invalid Gemini-only tier env values do not break other providers."""
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "standard")
+    clear_config_cache()
+
+    provider = LLMProvider.from_env()
+
+    assert provider.gemini_service_tier is None
+    clear_config_cache()
+
+
+def test_llm_provider_from_env_keeps_lightweight_loader(monkeypatch):
+    """Reading the Gemini tier must not construct the full application config."""
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "flex")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", "1000")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_CHUNK_SIZE", "2000")
+    clear_config_cache()
+
+    with patch("google.genai.Client", return_value=MagicMock()):
+        provider = LLMProvider.from_env()
+
+    assert provider.gemini_service_tier == "flex"
+    clear_config_cache()
+
+
+def test_llm_provider_constructor_validates_gemini_service_tier():
+    """Direct Gemini construction rejects invalid tiers before API calls."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    with pytest.raises(ValueError, match="HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER"):
+        LLMProvider(
+            provider="gemini",
+            api_key="fake-key",
+            base_url="",
+            model="gemini-2.5-flash",
+            gemini_service_tier="standard",
+        )
+
+
+def test_vertexai_ignores_gemini_service_tier():
+    """The Gemini-only tier flag is not forwarded to Vertex AI providers."""
+    from hindsight_api.engine.llm_wrapper import create_llm_provider
+
+    with patch("hindsight_api.engine.providers.GeminiLLM") as mock_gemini:
+        create_llm_provider(
+            provider="vertexai",
+            api_key="",
+            base_url="",
+            model="gemini-2.5-flash",
+            reasoning_effort="low",
+            gemini_service_tier="flex",
+        )
+
+    assert mock_gemini.call_args.kwargs["gemini_service_tier"] is None

--- a/hindsight-api-slim/tests/test_llm_extra_body.py
+++ b/hindsight-api-slim/tests/test_llm_extra_body.py
@@ -205,8 +205,6 @@ async def test_gemini_extra_body_service_tier_takes_precedence():
     assert provider._extra_body["http_options"]["extra_body"]["service_tier"] == "standard"
 
 
-
-
 # ─── LiteLLM ──────────────────────────────────────────────────────────────────
 
 

--- a/hindsight-api-slim/tests/test_llm_extra_body.py
+++ b/hindsight-api-slim/tests/test_llm_extra_body.py
@@ -120,7 +120,7 @@ async def test_anthropic_no_extra_body_omits_key():
 # ─── Gemini ───────────────────────────────────────────────────────────────────
 
 
-def _make_gemini_provider(extra_body=None):
+def _make_gemini_provider(extra_body=None, gemini_service_tier=None):
     pytest.importorskip("google.genai")
     with patch("google.genai.Client") as mock_client_cls:
         mock_client_cls.return_value = MagicMock()
@@ -132,6 +132,7 @@ def _make_gemini_provider(extra_body=None):
             base_url="",
             model="gemini-2.5-flash",
             extra_body=extra_body,
+            gemini_service_tier=gemini_service_tier,
         )
     provider._client = MagicMock()
     return provider
@@ -174,6 +175,36 @@ async def test_gemini_explicit_temperature_overrides_extra_body():
 
     config_arg = provider._client.aio.models.generate_content.call_args.kwargs.get("config")
     assert config_arg.temperature == 0.9
+
+
+@pytest.mark.asyncio
+async def test_gemini_service_tier_applies_to_http_options_extra_body():
+    """The native Gemini service tier flag reaches GenerateContentConfig."""
+    provider = _make_gemini_provider(gemini_service_tier="flex")
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_gemini_response())
+
+    await provider.call(messages=[{"role": "user", "content": "hi"}], scope="test")
+
+    config_arg = provider._client.aio.models.generate_content.call_args.kwargs.get("config")
+    assert config_arg.http_options.extra_body["service_tier"] == "flex"
+
+
+@pytest.mark.asyncio
+async def test_gemini_extra_body_service_tier_takes_precedence():
+    """The explicit extra_body escape hatch wins over the native flag."""
+    provider = _make_gemini_provider(
+        extra_body={"http_options": {"extra_body": {"service_tier": "standard"}}},
+        gemini_service_tier="flex",
+    )
+    provider._client.aio.models.generate_content = AsyncMock(return_value=_fake_gemini_response())
+
+    await provider.call(messages=[{"role": "user", "content": "hi"}], scope="test")
+
+    config_arg = provider._client.aio.models.generate_content.call_args.kwargs.get("config")
+    assert config_arg.http_options.extra_body["service_tier"] == "standard"
+    assert provider._extra_body["http_options"]["extra_body"]["service_tier"] == "standard"
+
+
 
 
 # ─── LiteLLM ──────────────────────────────────────────────────────────────────

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -178,6 +178,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER` | Bedrock service tier: `flex` for 50% cost savings (best-effort inference), `priority` (guaranteed throughput), or `reserved` (provisioned capacity) | Unset (default tier) |
+| `HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER` | Gemini service tier: `flex` for 50% cost savings (best-effort inference) | Unset (default tier) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict of extra request-body params (e.g. `temperature`, `top_p`, `max_tokens`) merged into every LLM call. Applied across the OpenAI-compatible, Fireworks, Anthropic, Gemini/VertexAI and LiteLLM (incl. Bedrock/Router) providers. Each provider merges them in its own native parameter space, so use that provider's field names (e.g. `max_tokens` for OpenAI/Anthropic vs `max_output_tokens` for Gemini). Also useful for custom model servers (e.g. vLLM `chat_template_kwargs`). | `null` |
 | `HINDSIGHT_API_LLM_DEFAULT_HEADERS` | JSON dict passed as `default_headers` to provider SDK clients. Used by operators routing through proxies / request-tracing middleware (e.g. Cloudflare AI Gateway, Helicone, corporate proxies). Currently wired into the Anthropic provider; other providers can opt in. | `null` |
 | `HINDSIGHT_API_LLM_STRICT_SCHEMA` | Grammar-enforce structured output via `json_schema` `strict: true` instead of the soft "schema-in-prompt + `json_object`" path. Use it with weaker self-hosted models that return prose preambles, markdown ` ```json ` fences, or invalid JSON — which otherwise fail to parse and wedge retain/consolidation. Applies to OpenAI-compatible backends (OpenAI, llama.cpp, vLLM) and LiteLLM; Gemini already enforces its native `response_schema` regardless, and providers without a strict mode ignore it. | `false` |
@@ -205,6 +206,8 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash
+# Optional: Use Gemini Flex for 50% cost savings (best-effort inference)
+# export HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER=flex
 
 # Anthropic
 export HINDSIGHT_API_LLM_PROVIDER=anthropic

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -178,6 +178,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |
 | `HINDSIGHT_API_LLM_BEDROCK_SERVICE_TIER` | Bedrock service tier: `flex` for 50% cost savings (best-effort inference), `priority` (guaranteed throughput), or `reserved` (provisioned capacity) | Unset (default tier) |
+| `HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER` | Gemini service tier: `flex` for 50% cost savings (best-effort inference) | Unset (default tier) |
 | `HINDSIGHT_API_LLM_EXTRA_BODY` | JSON dict of extra request-body params (e.g. `temperature`, `top_p`, `max_tokens`) merged into every LLM call. Applied across the OpenAI-compatible, Fireworks, Anthropic, Gemini/VertexAI and LiteLLM (incl. Bedrock/Router) providers. Each provider merges them in its own native parameter space, so use that provider's field names (e.g. `max_tokens` for OpenAI/Anthropic vs `max_output_tokens` for Gemini). Also useful for custom model servers (e.g. vLLM `chat_template_kwargs`). | `null` |
 | `HINDSIGHT_API_LLM_DEFAULT_HEADERS` | JSON dict passed as `default_headers` to provider SDK clients. Used by operators routing through proxies / request-tracing middleware (e.g. Cloudflare AI Gateway, Helicone, corporate proxies). Currently wired into the Anthropic provider; other providers can opt in. | `null` |
 | `HINDSIGHT_API_LLM_STRICT_SCHEMA` | Grammar-enforce structured output via `json_schema` `strict: true` instead of the soft "schema-in-prompt + `json_object`" path. Use it with weaker self-hosted models that return prose preambles, markdown ` ```json ` fences, or invalid JSON — which otherwise fail to parse and wedge retain/consolidation. Applies to OpenAI-compatible backends (OpenAI, llama.cpp, vLLM) and LiteLLM; Gemini already enforces its native `response_schema` regardless, and providers without a strict mode ignore it. | `false` |
@@ -205,6 +206,8 @@ export HINDSIGHT_API_LLM_MODEL=gpt-4o
 export HINDSIGHT_API_LLM_PROVIDER=gemini
 export HINDSIGHT_API_LLM_API_KEY=xxxxxxxxxxxx
 export HINDSIGHT_API_LLM_MODEL=gemini-2.0-flash
+# Optional: Use Gemini Flex for 50% cost savings (best-effort inference)
+# export HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER=flex
 
 # Anthropic
 export HINDSIGHT_API_LLM_PROVIDER=anthropic


### PR DESCRIPTION
## Summary

Adds a native server-level Gemini Flex knob:

```bash
HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER=flex
```

The flag mirrors the existing service-tier config style while keeping the implementation deliberately narrow:

- validates the tier as Gemini-only (`flex` or unset)
- threads it through `HindsightConfig` -> `LLMConfig` / `LLMProvider` -> `GeminiLLM`
- injects it as `http_options.extra_body.service_tier` in Gemini `GenerateContentConfig`
- preserves explicit `HINDSIGHT_API_LLM_EXTRA_BODY` precedence
- ignores invalid/stale Gemini-tier env values for non-Gemini providers, including Vertex AI

This does not add automatic 503 fallback or wait-budget policy; it only makes the maintainer-verified #1000 workaround discoverable and less fragile.

## Tests

- `uv run pytest hindsight-api-slim/tests/test_config_validation.py::test_gemini_service_tier_defaults_to_none hindsight-api-slim/tests/test_config_validation.py::test_gemini_service_tier_flex hindsight-api-slim/tests/test_config_validation.py::test_gemini_service_tier_rejects_invalid_value hindsight-api-slim/tests/test_config_validation.py::test_gemini_service_tier_ignored_for_non_gemini_provider hindsight-api-slim/tests/test_config_validation.py::test_gemini_service_tier_empty_env_is_unset hindsight-api-slim/tests/test_llm_extra_body.py::test_gemini_service_tier_applies_to_http_options_extra_body hindsight-api-slim/tests/test_llm_extra_body.py::test_gemini_extra_body_service_tier_takes_precedence hindsight-api-slim/tests/test_gemini_service_tier.py hindsight-api-slim/tests/test_hierarchical_config.py::test_hierarchical_fields_categorization -q`

Refs #1000.
