### PR TITLE
Add TypeScript client getVersion helper

### DIFF
--- a/hindsight-clients/typescript/README.md
+++ b/hindsight-clients/typescript/README.md
@@ -74,6 +74,35 @@ const response = await client.reflect("my-bank", "What should I do this weekend?
 console.log(response.text);
 ```
 
+### `getVersion(options?)`
+
+Read the connected Hindsight API version and feature flags. This is useful for
+integrations that need to enforce a minimum server version before enabling a
+workflow.
+
+```typescript
+const version = await client.getVersion();
+
+const isAtLeast = (actual: string, minimum: string) => {
+  const actualParts = actual.split(".").map(Number);
+  const minimumParts = minimum.split(".").map(Number);
+  for (let i = 0; i < Math.max(actualParts.length, minimumParts.length); i++) {
+    const actualPart = actualParts[i] ?? 0;
+    const minimumPart = minimumParts[i] ?? 0;
+    if (actualPart !== minimumPart) return actualPart > minimumPart;
+  }
+  return true;
+};
+
+if (!isAtLeast(version.api_version, "0.8.2")) {
+  throw new Error(`Hindsight ${version.api_version} is too old for this integration`);
+}
+
+if (version.features.observations) {
+  console.log("Observation consolidation is enabled.");
+}
+```
+
 ### `createBank(bankId, options)`
 
 Create or update a memory bank with personality.

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -60,6 +60,7 @@ import type {
   MentalModelListResponse,
   MentalModelResponse,
   UpdateDocumentResponse,
+  VersionResponse,
 } from "../generated/types.gen";
 
 // __CLIENT_VERSION__ is replaced by tsup's `define` with package.json's version
@@ -135,6 +136,18 @@ export class HindsightClient {
         headers,
       })
     );
+  }
+
+  /**
+   * Get API version and feature flags for the connected Hindsight deployment.
+   */
+  async getVersion(options?: { signal?: AbortSignal }): Promise<VersionResponse> {
+    const response = await sdk.getVersion({
+      client: this.client,
+      signal: options?.signal,
+    });
+
+    return this.validateResponse(response, "getVersion");
   }
 
   /**
@@ -1098,6 +1111,7 @@ export type {
   MentalModelListResponse,
   MentalModelResponse,
   UpdateDocumentResponse,
+  VersionResponse,
 };
 
 // Also export low-level SDK functions for advanced usage

--- a/hindsight-clients/typescript/tests/version.test.ts
+++ b/hindsight-clients/typescript/tests/version.test.ts
@@ -1,0 +1,42 @@
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+function makeClient(): HindsightClient {
+  return new HindsightClient({ baseUrl: "http://localhost:8888" });
+}
+
+describe("getVersion", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = jest.spyOn(sdk, "getVersion").mockResolvedValue({
+      data: {
+        api_version: "0.8.2",
+        features: {
+          observations: true,
+          mcp: true,
+          document_upload: true,
+          bank_config: true,
+          directives: true,
+          metrics: true,
+          custom_llm_provider: true,
+          bank_llm_health: true,
+          file_conversion: true,
+        },
+      },
+    } as any);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  test("calls the version endpoint through the generated client", async () => {
+    const version = await makeClient().getVersion();
+
+    expect(version.api_version).toBe("0.8.2");
+    expect(version.features.observations).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toHaveProperty("client");
+  });
+});


### PR DESCRIPTION
## Summary
- add HindsightClient.getVersion() for the existing /version endpoint
- re-export VersionResponse for typed callers
- document a minimum-version guard example for integrations

Fixes #2248.

## Tests
- npm test -- --runTestsByPath tests/version.test.ts
- npm run build

Note: the repo pre-commit hook currently also runs unrelated workspace-wide checks that fail locally because hindsight-control-plane dependencies are not installed (@eslint/js, vitest/config) and existing Python vulture findings are reported. The TypeScript client targeted test and build above pass.