### PR TITLE
Add Python client get_version helper

### DIFF
--- a/hindsight-clients/python/hindsight_client/__init__.py
+++ b/hindsight-clients/python/hindsight_client/__init__.py
@@ -53,6 +53,7 @@ from hindsight_client_api.models.reflect_response import ReflectResponse
 
 # Re-export response types for convenient access
 from hindsight_client_api.models.retain_response import RetainResponse
+from hindsight_client_api.models.version_response import VersionResponse
 
 from .hindsight_client import Hindsight
 
@@ -159,4 +160,5 @@ __all__ = [
     "ListMemoryUnitsResponse",
     "BankProfileResponse",
     "DispositionTraits",
+    "VersionResponse",
 ]

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -46,6 +46,7 @@ from hindsight_client_api.models.list_memory_units_response import ListMemoryUni
 from hindsight_client_api.models.recall_response import RecallResponse
 from hindsight_client_api.models.reflect_response import ReflectResponse
 from hindsight_client_api.models.retain_response import RetainResponse
+from hindsight_client_api.models.version_response import VersionResponse
 
 
 def _run_async(coro):
@@ -244,6 +245,29 @@ class Hindsight:
         """Close the API client (async version)."""
         if self._api_client:
             await self._api_client.close()
+
+    def get_version(self) -> VersionResponse:
+        """
+        Read the connected Hindsight API version and feature flags
+        (sync wrapper — prefer :meth:`aget_version` in async code).
+
+        Useful for integrations that need to enforce a minimum server version
+        before enabling a workflow.
+
+        Returns:
+            VersionResponse with ``api_version`` and ``features``.
+        """
+        return _run_async(self._monitoring_api.get_version(_request_timeout=self._timeout))
+
+    async def aget_version(self) -> VersionResponse:
+        """
+        Read the connected Hindsight API version and feature flags
+        (async — preferred over :meth:`get_version`).
+
+        Returns:
+            VersionResponse with ``api_version`` and ``features``.
+        """
+        return await self._monitoring_api.get_version(_request_timeout=self._timeout)
 
     # Simplified methods for main operations
 

--- a/hindsight-clients/python/tests/test_version.py
+++ b/hindsight-clients/python/tests/test_version.py
@@ -1,0 +1,57 @@
+"""
+Tests for the get_version()/aget_version() convenience wrappers.
+
+These mock the underlying MonitoringApi so no running server is required —
+they verify the wrapper delegates to the generated client and returns the
+typed VersionResponse (parity with the TypeScript client's getVersion helper).
+"""
+
+from unittest.mock import AsyncMock
+
+from hindsight_client import Hindsight, VersionResponse
+from hindsight_client_api.models.features_info import FeaturesInfo
+
+
+def _make_client() -> Hindsight:
+    return Hindsight(base_url="http://localhost:8888")
+
+
+def _version_response() -> VersionResponse:
+    features = FeaturesInfo(
+        observations=True,
+        mcp=True,
+        worker=True,
+        bank_config_api=True,
+        bank_llm_health=True,
+        file_upload_api=True,
+        document_export_api=True,
+        document_import_api=True,
+        audit_log=True,
+        llm_trace=True,
+        store_document_text=True,
+    )
+    return VersionResponse(api_version="0.8.2", features=features)
+
+
+async def test_aget_version_delegates_to_monitoring_api():
+    """aget_version() should call MonitoringApi.get_version and return its result."""
+    client = _make_client()
+    client._monitoring_api.get_version = AsyncMock(return_value=_version_response())
+
+    version = await client.aget_version()
+
+    assert version.api_version == "0.8.2"
+    assert version.features.observations is True
+    client._monitoring_api.get_version.assert_awaited_once()
+
+
+def test_get_version_delegates_to_monitoring_api():
+    """get_version() (sync) should call MonitoringApi.get_version and return its result."""
+    client = _make_client()
+    # AsyncMock returns an awaitable when called, which the sync wrapper awaits via _run_async.
+    client._monitoring_api.get_version = AsyncMock(return_value=_version_response())
+
+    version = client.get_version()
+
+    assert version.api_version == "0.8.2"
+    client._monitoring_api.get_version.assert_called_once()


### PR DESCRIPTION
## Summary
Python parity for #2252 (TypeScript `getVersion`). Adds a convenience wrapper for the existing `/version` endpoint to the hand-written `Hindsight` client, so callers don't have to drop down to the low-level `client.monitoring.get_version()`.

- add `Hindsight.get_version()` (sync) and `Hindsight.aget_version()` (async, preferred) — delegate to `MonitoringApi.get_version`, mirroring the existing `delete_bank`/`adelete_bank` pattern
- re-export `VersionResponse` for typed callers
- add tests covering both sync and async paths against a mocked `MonitoringApi`

Fixes #2248.

## Tests
- `uv run pytest tests/test_version.py -v` — both tests pass (no running server required; the underlying API is mocked)

## Notes
- No README example added: the Python client README is an empty stub (unlike the TypeScript one that has a per-method reference), so a one-off section would be inconsistent.
