### PR TITLE
chore(ci): disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## What

Removes `.github/dependabot.yml`, which disables Dependabot **version-update** PRs (currently the `github-actions` ecosystem).

## Why

We no longer want automated dependency-bump PRs from Dependabot.

## Note on security updates

Dependabot **security** updates (the `uv` / `npm_and_yarn` group PRs) are governed by a repository setting, not this file. They must be turned off separately under **Settings → Code security → Dependabot** if we want them gone too.

All currently-open Dependabot PRs are being closed alongside this change.