### PR TITLE
fix(openclaw): always session-scope retained documents

### DIFF
--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -160,7 +160,7 @@ Glob syntax:
 
 ## Retention details
 
-Retained documents use stable session-scoped IDs derived from the OpenClaw `sessionKey`. By default (`retainDocumentScope: 'session'`) every retain in a session shares one document id like `openclaw:agent:agentname:discord:channel:123`, so all turns of the conversation accumulate under a single Hindsight document. Set `retainDocumentScope: 'turn'` to fall back to the per-retain ids (`...:turn:000001`, `...:window:000002` for chunked retention). Either way, retained documents include richer metadata such as `session_key`, `agent_id`, `provider`, `channel_id`, `thread_id`, `sender_id`, `turn_index`, and `retention_scope`. Each message in the retained JSON also carries a structured `timestamp` field (ISO 8601) lifted from OpenClaw's per-message time, so facts are not polluted by inline weekday/date prefixes.
+Retained documents use stable session-scoped IDs derived from the OpenClaw `sessionKey`. Every retain in a session shares one document id like `openclaw:agent:agentname:discord:channel:123`, so all turns of the conversation accumulate under a single Hindsight document (on legacy APIs without `update_mode: 'append'` support, the integration falls back to per-retain ids — `...:turn:000001`, `...:window:000002` for chunked retention — so prior turns aren't overwritten). Retained documents include richer metadata such as `session_key`, `agent_id`, `provider`, `channel_id`, `thread_id`, `sender_id`, `turn_index`, and `retention_scope`. Each message in the retained JSON also carries a structured `timestamp` field (ISO 8601) lifted from OpenClaw's per-message time, so facts are not polluted by inline weekday/date prefixes.
 
 ## Documentation
 

--- a/hindsight-integrations/openclaw/openclaw.plugin.json
+++ b/hindsight-integrations/openclaw/openclaw.plugin.json
@@ -176,12 +176,6 @@
         "minimum": 0,
         "default": 0
       },
-      "retainDocumentScope": {
-        "type": "string",
-        "description": "Granularity of the retained document_id. 'session' (default) groups all retains under a single document per OpenClaw session. 'turn' produces a new document per retain.",
-        "enum": ["session", "turn"],
-        "default": "session"
-      },
       "recallBudget": {
         "type": "string",
         "description": "Recall effort level. Higher budgets use more retrieval strategies for better results but take longer.",
@@ -422,10 +416,6 @@
     "retainOverlapTurns": {
       "label": "Retain Overlap Turns",
       "placeholder": "0 (no overlap, default)"
-    },
-    "retainDocumentScope": {
-      "label": "Retain Document Scope",
-      "placeholder": "session (default) or turn"
     },
     "recallBudget": {
       "label": "Recall Budget",

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -419,28 +419,6 @@ describe("buildRetainRequest", () => {
     expect(request.updateMode).toBeUndefined();
   });
 
-  it("uses per-turn document ids when retainDocumentScope is 'turn'", () => {
-    const request = buildRetainRequest(
-      "hello world",
-      2,
-      {
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        messageProvider: "discord",
-        channelId: "channel:123",
-        senderId: "user:456",
-      },
-      {
-        retainSource: "openclaw",
-        retainDocumentScope: "turn",
-      },
-      1700000000000,
-      { turnIndex: 7 }
-    );
-
-    expect(request.documentId).toBe("openclaw:agent:main:main:turn:000007");
-  });
-
   it("uses window ids and metadata for chunked retention", () => {
     const request = buildRetainRequest(
       "hello world",
@@ -453,7 +431,6 @@ describe("buildRetainRequest", () => {
       },
       {
         retainSource: "openclaw",
-        retainDocumentScope: "turn",
       },
       1700000000000,
       {

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -2675,11 +2675,10 @@ export function buildRetainRequest(
     tags?: string[];
     /**
      * Whether the live Hindsight API supports `update_mode: 'append'`. When
-     * true with `retainDocumentScope: 'session'`, the request gets a stable
-     * per-session document id and `updateMode: 'append'` so each retain
-     * concatenates to the existing document. When false, falls back to a
-     * unique per-turn document id so prior turns aren't overwritten.
-     * Defaults to false (conservative).
+     * true, the request gets a stable per-session document id and
+     * `updateMode: 'append'` so each retain concatenates to the existing
+     * document. When false, falls back to a unique per-turn document id so
+     * prior turns aren't overwritten. Defaults to false (conservative).
      */
     appendSupported?: boolean;
   }
@@ -2689,12 +2688,12 @@ export function buildRetainRequest(
   const turnIndex = options?.turnIndex ?? nextDocumentSequence(resolvedCtx);
   const retentionScope = options?.retentionScope || "turn";
   const documentBase = getSessionDocumentBase(resolvedCtx);
-  const documentScope = pluginConfig.retainDocumentScope ?? "session";
   const documentKind = retentionScope === "window" ? "window" : "turn";
-  // Session-scope only stays session-scope when the API can append; otherwise
-  // every retain on the same id silently overwrites prior turns (behavior
-  // pre-#932). Force per-turn ids on legacy APIs.
-  const useSessionScopedDoc = documentScope === "session" && options?.appendSupported === true;
+  // Retains are session-scoped: all turns accumulate under one document id when
+  // the API can append. On legacy APIs without append support, every retain on
+  // the same id would silently overwrite prior turns (behavior pre-#932), so
+  // fall back to per-turn ids there.
+  const useSessionScopedDoc = options?.appendSupported === true;
   const documentId = useSessionScopedDoc
     ? documentBase
     : `${documentBase}:${documentKind}:${String(turnIndex).padStart(6, "0")}`;

--- a/hindsight-integrations/openclaw/src/types.ts
+++ b/hindsight-integrations/openclaw/src/types.ts
@@ -108,7 +108,6 @@ export interface PluginConfig {
   recallTypes?: Array<"world" | "experience" | "observation">; // Memory types to recall. Default: ['observation'] — surfaces only the consolidated, deduplicated view (raw world/experience facts can drive the same answer multiple times when many memories say the same thing).
   recallRoles?: Array<"user" | "assistant" | "system" | "tool">; // Roles to include when composing contextual recall query. Default: ['user', 'assistant']
   includeSenderContext?: boolean; // When true (default), prepend a session context block (sender, channel, provider) to retained transcripts so similarity search can distinguish memories by speaker even when dynamicBankGranularity does not include 'user'. Set false to omit.
-  retainDocumentScope?: "session" | "turn"; // Granularity of the retained document_id. 'session' (default) groups all retains under a single document per OpenClaw session (`openclaw:{sessionKey}`). 'turn' produces a new document per retain (`openclaw:{sessionKey}:turn:NNNNNN` / `:window:NNNNNN`).
   retainEveryNTurns?: number; // Retain every Nth turn (1 = every turn, default: 1). Values > 1 enable chunked retention.
   retainOverlapTurns?: number; // Extra prior turns included when chunked retention fires (default: 0). Window = retainEveryNTurns + retainOverlapTurns.
   recallTopK?: number; // Max number of memories to inject. Default: unlimited


### PR DESCRIPTION
## What

Removes the `retainDocumentScope` config option from the OpenClaw plugin. The retained `document_id` is now always session-scoped.

## Why

`retainDocumentScope` was only ever meaningfully used as `'session'` — that was already the default and the intended behavior. The `'turn'` value just opted out of document accumulation, which isn't a configuration users should reach for. Removing the knob simplifies the surface and makes the session-scoping behavior unconditional.

## Changes

- `src/types.ts` — drop the `retainDocumentScope` field from `PluginConfig`.
- `src/index.ts` — `buildRetainRequest` no longer reads the config; `useSessionScopedDoc` now depends solely on whether the live API supports `update_mode: 'append'`. On legacy APIs without append support it still falls back to per-turn ids so prior turns aren't overwritten.
- `openclaw.plugin.json` — remove the config schema entry and its label.
- `README.md` — update the retention-details section.
- `src/index.test.ts` — remove the now-invalid `'turn'`-scope test and the config field from the window-retention test.

## Testing

- `npm run build` ✓
- `npm test` — 238 tests pass ✓
- `./scripts/hooks/lint.sh` ✓