### PR TITLE
feat(embeddings): detect Intel XPU for local embedding acceleration

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -190,7 +190,7 @@ class LocalSTEmbeddings(Embeddings):
             device = "cpu"
             logger.info("Embeddings: forcing CPU mode")
         else:
-            # Check for GPU (CUDA) or Apple Silicon (MPS)
+            # Check for GPU (CUDA), Apple Silicon (MPS), or Intel XPU
             # Wrap in try-except to gracefully handle any device detection issues
             # (e.g., in CI environments or when PyTorch is built without GPU support)
             device = "cpu"  # Default to CPU
@@ -198,10 +198,13 @@ class LocalSTEmbeddings(Embeddings):
                 has_gpu = torch.cuda.is_available() or (
                     hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
                 )
+                # Intel Arc XPU support — torch.xpu is available when the XPU build is loaded
+                if not has_gpu and hasattr(torch, "xpu"):
+                    has_gpu = torch.xpu.is_available()
                 if has_gpu:
-                    device = None  # Let sentence-transformers auto-detect GPU/MPS
+                    device = None  # Let sentence-transformers auto-detect GPU/MPS/XPU
             except Exception as e:
-                logger.warning(f"Failed to detect GPU/MPS, falling back to CPU: {e}")
+                logger.warning(f"Failed to detect GPU/MPS/XPU, falling back to CPU: {e}")
 
         # Suppress verbose transformers warnings during model loading
         # This suppresses the "UNEXPECTED" warnings from BertModel which are harmless


### PR DESCRIPTION
## Summary

Extends local embedding device detection to recognize an **Intel XPU** (e.g. Arc A770), so `sentence-transformers` can run on it when a torch XPU build is loaded — falling back to CPU otherwise.

The check is guarded (`hasattr(torch, "xpu")` + `torch.xpu.is_available()`) and sits inside the existing try/except, so it's a no-op on machines without an XPU build and cannot regress CUDA/MPS/CPU paths.

## Provenance

Split out from #2233, which bundled this product-code change with Arch Linux distro packaging. This PR carries **only** the embeddings change so it can be reviewed and merged on its own. Original authorship credited via `Co-authored-by`.

## Testing

No new test — mirrors the existing untested CUDA/MPS detection branch; behavior is unchanged on all current CI/dev hardware (no XPU build present).
