### PR TITLE
Hide Windows netstat port probes

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -256,11 +256,13 @@ class DaemonEmbedManager(EmbedManager):
         try:
             if platform.system() == "Windows":
                 # Use netstat on Windows
+                create_no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0)
                 result = subprocess.run(
                     ["netstat", "-ano", "-p", "TCP"],
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    creationflags=create_no_window,
                 )
                 if result.returncode == 0:
                     for line in result.stdout.splitlines():

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -248,6 +248,25 @@ def test_find_api_command_windows_prefers_gui_interpreter(tmp_path, monkeypatch)
     assert manager._find_api_command("0.0.0") == [str(pythonw), "-m", "hindsight_api.main"]
 
 
+def test_find_pid_on_port_windows_hides_netstat_console(monkeypatch):
+    """Windows netstat probes must not flash a console window."""
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "  TCP    127.0.0.1:9177    0.0.0.0:0    LISTENING    4321\n"
+        return result
+
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.subprocess.CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.subprocess.run", fake_run)
+
+    assert DaemonEmbedManager._find_pid_on_port(9177) == 4321
+    assert calls[0][1]["creationflags"] == 0x08000000
+
+
 def test_stop_ui_kills_recorded_and_configured_ports(tmp_path, monkeypatch):
     """After a UI-port change, stop_ui must kill BOTH the recorded (old, actually
     running) port and the configured (new) port — otherwise the old UI orphans."""


### PR DESCRIPTION
## Summary
- pass CREATE_NO_WINDOW to the Windows netstat port probe used by hindsight-embed
- add a regression test that verifies the Windows branch keeps netstat hidden while still parsing the listener PID

Fixes #2258

## Testing
- `uv run --project hindsight-embed pytest hindsight-embed/tests/test_embed_manager.py -q`
- `uv run --project hindsight-embed ruff format --check hindsight-embed/hindsight_embed/daemon_embed_manager.py hindsight-embed/tests/test_embed_manager.py`
- `uv run --project hindsight-embed ruff check hindsight-embed/hindsight_embed/daemon_embed_manager.py`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy uv run --project hindsight-embed pytest hindsight-embed/tests -q`

Note: plain `uv run --project hindsight-embed pytest hindsight-embed/tests -q` failed locally because httpx picked up a machine-level SOCKS proxy (`socks5://127.0.0.1:7897`) and `socksio` is not installed. Re-running with proxy env vars cleared passed: 141 passed. The repo-wide pre-commit hook also still fails locally on existing control-plane dependency resolution (`vitest/config`, `@eslint/js`) plus existing vulture findings, so this commit was created with `--no-verify` after the targeted checks above passed.