### PR TITLE
docs: document MCP trace and precheck content length

### DIFF
--- a/hindsight-docs/docs/developer/extensions.md
+++ b/hindsight-docs/docs/developer/extensions.md
@@ -186,6 +186,7 @@ Routes from `get_root_router` are mounted at the app root (e.g., `/.well-known/m
 from hindsight_api.extensions import (
     OperationValidatorExtension,
     ValidationResult,
+    PrecheckContext,
     RetainContext,
     RecallContext,
     ReflectContext,
@@ -193,6 +194,12 @@ from hindsight_api.extensions import (
 )
 
 class MyValidator(OperationValidatorExtension):
+    # Pre-body validation (optional)
+    async def precheck(self, ctx: PrecheckContext) -> ValidationResult:
+        if ctx.content_length is not None and ctx.content_length > 10_000_000:
+            return ValidationResult.reject("Payload is too large")
+        return ValidationResult.accept()
+
     # Pre-operation validation (required)
     async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
         # Implement your validation logic
@@ -210,6 +217,13 @@ class MyValidator(OperationValidatorExtension):
         # Log usage, update metrics, send notifications, etc.
         pass
 ```
+
+`precheck` runs before the request body is read or deserialized. Its
+`PrecheckContext.content_length` is the parsed `Content-Length` header as an
+integer, or `None` when the header is missing or cannot be parsed (for example,
+chunked transfer encoding). Use it for cheap size-aware quota or cost guards;
+the full `validate_*` hooks still run after parsing and should enforce precise
+per-operation limits.
 
 #### Deferring an operation
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -223,6 +223,7 @@ Generate thoughtful analysis by synthesizing stored memories with the bank's per
 | `response_schema` | object | No | JSON Schema for structured output. When provided, the response includes a `structured_output` field |
 | `tags` | list[string] | No | Filter memories by tags before reflecting |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `include_trace` | boolean | No | Include `tool_trace` and `llm_trace` debugging output. Defaults to `false` to keep responses small |
 
 **Example:**
 ```json

--- a/skills/hindsight-docs/references/developer/extensions.md
+++ b/skills/hindsight-docs/references/developer/extensions.md
@@ -186,6 +186,7 @@ Routes from `get_root_router` are mounted at the app root (e.g., `/.well-known/m
 from hindsight_api.extensions import (
     OperationValidatorExtension,
     ValidationResult,
+    PrecheckContext,
     RetainContext,
     RecallContext,
     ReflectContext,
@@ -193,6 +194,12 @@ from hindsight_api.extensions import (
 )
 
 class MyValidator(OperationValidatorExtension):
+    # Pre-body validation (optional)
+    async def precheck(self, ctx: PrecheckContext) -> ValidationResult:
+        if ctx.content_length is not None and ctx.content_length > 10_000_000:
+            return ValidationResult.reject("Payload is too large")
+        return ValidationResult.accept()
+
     # Pre-operation validation (required)
     async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
         # Implement your validation logic
@@ -210,6 +217,13 @@ class MyValidator(OperationValidatorExtension):
         # Log usage, update metrics, send notifications, etc.
         pass
 ```
+
+`precheck` runs before the request body is read or deserialized. Its
+`PrecheckContext.content_length` is the parsed `Content-Length` header as an
+integer, or `None` when the header is missing or cannot be parsed (for example,
+chunked transfer encoding). Use it for cheap size-aware quota or cost guards;
+the full `validate_*` hooks still run after parsing and should enforce precise
+per-operation limits.
 
 #### Deferring an operation
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -223,6 +223,7 @@ Generate thoughtful analysis by synthesizing stored memories with the bank's per
 | `response_schema` | object | No | JSON Schema for structured output. When provided, the response includes a `structured_output` field |
 | `tags` | list[string] | No | Filter memories by tags before reflecting |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
+| `include_trace` | boolean | No | Include `tool_trace` and `llm_trace` debugging output. Defaults to `false` to keep responses small |
 
 **Example:**
 ```json


### PR DESCRIPTION
## Summary
- document the MCP `reflect` `include_trace` flag added in #2242
- document `PrecheckContext.content_length` in the operation validator example added by #2247
- regenerate the Hindsight docs skill mirror

## Testing
- `./scripts/generate-docs-skill.sh`
- `git diff --check`
- `cmp -s hindsight-docs/docs/developer/mcp-server.md skills/hindsight-docs/references/developer/mcp-server.md`
- `cmp -s hindsight-docs/docs/developer/extensions.md skills/hindsight-docs/references/developer/extensions.md`
