### PR TITLE
test(retain): fix broken quota-defer test config mock

### DIFF
--- a/hindsight-api-slim/tests/test_provider_quota_reset_defer.py
+++ b/hindsight-api-slim/tests/test_provider_quota_reset_defer.py
@@ -103,7 +103,7 @@ async def test_extract_facts_from_text_preserves_provider_quota_reset(monkeypatc
             event_date=None,
             llm_config=object(),
             agent_name="TestAgent",
-            config=SimpleNamespace(retain_chunk_size=1000),
+            config=SimpleNamespace(retain_chunk_size=1000, retain_structured_chunk_size=None),
         )
 
     assert exc_info.value.retry_at == retry_at


### PR DESCRIPTION
## Summary

Fixes the `test-api` CI failure on `main`.

### `test_provider_quota_reset_defer` — broken mock config

`extract_facts_from_text` reads `config.retain_structured_chunk_size` (passed into `chunk_text`), but the test's `SimpleNamespace` mock only set `retain_chunk_size`. The test raised `AttributeError: ... no attribute 'retain_structured_chunk_size'` before ever reaching the quota-defer path it's meant to exercise. Added the field (`None` = plain chunking) so the test runs as intended.

```
$ uv run pytest tests/test_provider_quota_reset_defer.py -q -n0
3 passed
```

### paperclip/README.md drift — no change needed

The other `verify-generated-files` failure (paperclip README drift) was a **stale-base artifact**: #2260's CI ran against a base from before #1987 merged, and #1987 was the last commit to touch that README. On current `main` there is no drift — verified by running the full integration lint (`LINT_ALL_INTEGRATIONS=1 ./scripts/hooks/lint.sh`), which leaves the README unchanged. So that job passes on its own now; nothing to commit for it.
