### PR TITLE
docs(observations): stop claiming a per-observation freshness trend

### DIFF
--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -79,7 +79,7 @@ Each type runs the full four-strategy retrieval pipeline independently, so narro
 </Tabs>
 
 :::tip About Observations
-Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes) and carries a computed freshness trend, and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
+Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes), and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
 :::
 
 ### budget

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1398,7 +1398,7 @@ For production deployments, use `s3`, `gcs`, or `azure` to avoid storing large b
 
 ### Observations (Experimental) {#observations}
 
-Observations are deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories, a proof count, and a computed freshness trend, and is refined — not overwritten — when new evidence arrives.
+Observations are deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories and a proof count, and is refined — not overwritten — when new evidence arrives.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/hindsight-docs/docs/developer/index.mdx
+++ b/hindsight-docs/docs/developer/index.mdx
@@ -101,7 +101,7 @@ After memories are retained, Hindsight automatically consolidates related facts 
 - **Deduplication**: Overlapping facts are merged into a single durable observation instead of piling up as repeats
 - **Evidence tracking**: Each observation references the source memories (with exact quotes) that support it, plus a proof count
 - **Continuous refinement**: Observations are updated — not overwritten — when new evidence supports, contradicts, or extends them; history is preserved
-- **Freshness trend**: Each observation carries a computed trend (stable / strengthening / weakening / stale) based on when its evidence arrived
+- **Freshness awareness**: when newer memories have been retained but not yet consolidated, `reflect` treats the affected observations as stale and verifies them against raw facts before relying on them
 
 ### Mission, Directives & Disposition
 

--- a/hindsight-docs/docs/developer/observations.mdx
+++ b/hindsight-docs/docs/developer/observations.mdx
@@ -8,7 +8,7 @@ import memoryBanksPy from '!!raw-loader!@site/examples/api/memory-banks.py';
 
 # Observations: Knowledge Consolidation
 
-After memories are retained, Hindsight automatically consolidates related facts into **observations** — deduplicated, evidence-grounded beliefs the bank has built up from multiple memories. Each observation tracks its supporting evidence (with exact quotes), a proof count, and a computed freshness trend, and is refined rather than overwritten when new evidence arrives.
+After memories are retained, Hindsight automatically consolidates related facts into **observations** — deduplicated, evidence-grounded beliefs the bank has built up from multiple memories. Each observation tracks its supporting evidence (with exact quotes) and a proof count, and is refined rather than overwritten when new evidence arrives.
 
 ```mermaid
 graph LR
@@ -36,7 +36,7 @@ Observations provide:
 - **Deduplication**: One durable belief instead of many overlapping facts
 - **Grounding**: Every observation references the specific memories (with quotes) that support it
 - **Evolution**: Refined as evidence strengthens, weakens, or contradicts it — history is preserved
-- **Freshness signal**: A computed trend (stable / strengthening / weakening / new / stale) tells you whether the belief still holds
+- **Freshness awareness**: when newer memories haven't been consolidated yet, `reflect` treats the affected observations as stale and verifies them against raw facts
 - **Efficiency**: Condensed knowledge for faster retrieval
 
 ---

--- a/hindsight-docs/src/pages/best-practices.mdx
+++ b/hindsight-docs/src/pages/best-practices.mdx
@@ -40,7 +40,7 @@ Banks are auto-created on first use. Configure them before ingesting data to ste
 | **Retain** | Ingests raw content (conversations, documents, notes). The LLM extracts facts, entities, and relationships — raw content is never stored verbatim. | After each conversation turn or session ends |
 | **Recall** | Retrieves relevant memories using 4 parallel strategies: semantic search, BM25, graph traversal, and temporal ranking. Returns a ranked list of facts. | Before generating a response that benefits from past context |
 | **Reflect** | Autonomous reasoning loop: searches memory, synthesizes an answer, and returns it directly. Uses mental models and observations hierarchically. | When you want Hindsight to answer a question, not just retrieve facts |
-| **Observations** | Deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories with exact quotes, proof counts, and a computed freshness trend (stable/strengthening/weakening/stale). Refined — not overwritten — when new evidence supports, contradicts, or extends them. | Triggered automatically after retain — not part of the retain call itself |
+| **Observations** | Deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories with exact quotes and proof counts. Refined — not overwritten — when new evidence supports, contradicts, or extends them. | Triggered automatically after retain — not part of the retain call itself |
 | **Mental Models** | Pre-computed reflect responses stored for common queries. Return instantly and consistently. | Create for repeated high-traffic queries or slowly-changing user profiles |
 
 ---
@@ -53,7 +53,7 @@ Facts extracted during retain are classified into three types:
 |------|-------------|---------|
 | `world` | General knowledge, external facts | "The Eiffel Tower is in Paris" |
 | `experience` | Personal events, user-specific facts | "User moved to Berlin in 2024" |
-| `observation` | Consolidated belief grounded in multiple supporting facts; deduplicated and refined over time with tracked evidence and freshness | "User consistently prefers async communication (5 supporting memories, strengthening)" |
+| `observation` | Consolidated belief grounded in multiple supporting facts; deduplicated and refined over time with tracked evidence | "User consistently prefers async communication (5 supporting memories)" |
 
 Use `types` filtering in recall to target specific memory types.
 

--- a/skills/hindsight-docs/references/best-practices.md
+++ b/skills/hindsight-docs/references/best-practices.md
@@ -34,7 +34,7 @@ Banks are auto-created on first use. Configure them before ingesting data to ste
 | **Retain** | Ingests raw content (conversations, documents, notes). The LLM extracts facts, entities, and relationships — raw content is never stored verbatim. | After each conversation turn or session ends |
 | **Recall** | Retrieves relevant memories using 4 parallel strategies: semantic search, BM25, graph traversal, and temporal ranking. Returns a ranked list of facts. | Before generating a response that benefits from past context |
 | **Reflect** | Autonomous reasoning loop: searches memory, synthesizes an answer, and returns it directly. Uses mental models and observations hierarchically. | When you want Hindsight to answer a question, not just retrieve facts |
-| **Observations** | Deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories with exact quotes, proof counts, and a computed freshness trend (stable/strengthening/weakening/stale). Refined — not overwritten — when new evidence supports, contradicts, or extends them. | Triggered automatically after retain — not part of the retain call itself |
+| **Observations** | Deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories with exact quotes and proof counts. Refined — not overwritten — when new evidence supports, contradicts, or extends them. | Triggered automatically after retain — not part of the retain call itself |
 | **Mental Models** | Pre-computed reflect responses stored for common queries. Return instantly and consistently. | Create for repeated high-traffic queries or slowly-changing user profiles |
 
 ---
@@ -47,7 +47,7 @@ Facts extracted during retain are classified into three types:
 |------|-------------|---------|
 | `world` | General knowledge, external facts | "The Eiffel Tower is in Paris" |
 | `experience` | Personal events, user-specific facts | "User moved to Berlin in 2024" |
-| `observation` | Consolidated belief grounded in multiple supporting facts; deduplicated and refined over time with tracked evidence and freshness | "User consistently prefers async communication (5 supporting memories, strengthening)" |
+| `observation` | Consolidated belief grounded in multiple supporting facts; deduplicated and refined over time with tracked evidence | "User consistently prefers async communication (5 supporting memories)" |
 
 Use `types` filtering in recall to target specific memory types.
 

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -152,7 +152,7 @@ hindsight memory recall my-bank "query" --fact-type world,observation
 
 > **💡 About Observations**
 > 
-Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes) and carries a computed freshness trend, and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
+Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes), and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1398,7 +1398,7 @@ For production deployments, use `s3`, `gcs`, or `azure` to avoid storing large b
 
 ### Observations (Experimental) {#observations}
 
-Observations are deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories, a proof count, and a computed freshness trend, and is refined — not overwritten — when new evidence arrives.
+Observations are deduplicated, evidence-grounded knowledge consolidated from multiple facts. Each observation tracks its supporting memories and a proof count, and is refined — not overwritten — when new evidence arrives.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/skills/hindsight-docs/references/developer/index.md
+++ b/skills/hindsight-docs/references/developer/index.md
@@ -96,7 +96,7 @@ After memories are retained, Hindsight automatically consolidates related facts 
 - **Deduplication**: Overlapping facts are merged into a single durable observation instead of piling up as repeats
 - **Evidence tracking**: Each observation references the source memories (with exact quotes) that support it, plus a proof count
 - **Continuous refinement**: Observations are updated — not overwritten — when new evidence supports, contradicts, or extends them; history is preserved
-- **Freshness trend**: Each observation carries a computed trend (stable / strengthening / weakening / stale) based on when its evidence arrived
+- **Freshness awareness**: when newer memories have been retained but not yet consolidated, `reflect` treats the affected observations as stale and verifies them against raw facts before relying on them
 
 ### Mission, Directives & Disposition
 

--- a/skills/hindsight-docs/references/developer/observations.md
+++ b/skills/hindsight-docs/references/developer/observations.md
@@ -2,7 +2,7 @@
 
 # Observations: Knowledge Consolidation
 
-After memories are retained, Hindsight automatically consolidates related facts into **observations** — deduplicated, evidence-grounded beliefs the bank has built up from multiple memories. Each observation tracks its supporting evidence (with exact quotes), a proof count, and a computed freshness trend, and is refined rather than overwritten when new evidence arrives.
+After memories are retained, Hindsight automatically consolidates related facts into **observations** — deduplicated, evidence-grounded beliefs the bank has built up from multiple memories. Each observation tracks its supporting evidence (with exact quotes) and a proof count, and is refined rather than overwritten when new evidence arrives.
 
 ```mermaid
 graph LR
@@ -30,7 +30,7 @@ Observations provide:
 - **Deduplication**: One durable belief instead of many overlapping facts
 - **Grounding**: Every observation references the specific memories (with quotes) that support it
 - **Evolution**: Refined as evidence strengthens, weakens, or contradicts it — history is preserved
-- **Freshness signal**: A computed trend (stable / strengthening / weakening / new / stale) tells you whether the belief still holds
+- **Freshness awareness**: when newer memories haven't been consolidated yet, `reflect` treats the affected observations as stale and verifies them against raw facts
 - **Efficiency**: Condensed knowledge for faster retrieval
 
 ---


### PR DESCRIPTION
## Problem
The developer docs describe observations as carrying a **"computed freshness trend (stable / strengthening / weakening / new / stale)."** That maps to code in `hindsight-api-slim/.../engine/reflect/observations.py` (`Trend` + `compute_trend`) which is **unreferenced**: nothing imports or calls it, it's not in the OpenAPI schema, and it's exposed in no client or the control-plane UI. It is not a surfaced feature, so the docs overstate it. (Surfaced during review of a draft blog post on the topic.)

## Fix
Replace the trend claims with the freshness behavior that **is** shipped and wired in: when newer memories haven't been consolidated yet, `reflect` treats the affected observations as stale (`is_stale`) and verifies them against raw facts before relying on them.

Files touched (current docs):
- `developer/index.mdx`
- `developer/observations.mdx`
- `developer/configuration.md`
- `developer/api/recall.mdx`
- `src/pages/best-practices.mdx`
- regenerated `skills/hindsight-docs/` mirror (via the pre-commit generator)

## Not touched
- `versioned_docs/` (0.6/0.7/0.8) still contain the old wording — left as historical snapshots. Happy to update those too if you'd prefer.
- The dead code in `reflect/observations.py` itself — separate decision (wire it up vs. remove it).

## Build
`npm run build` green, no broken links. `grep` confirms zero `computed freshness trend` / `strengthening` / `weakening` left in current docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)