### PR TITLE
fix(api): resolve pg_trgm `%` operator via runtime search_path (#2270)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -139,6 +139,37 @@ def fq_table(table_name: str) -> str:
     return _fq_table(table_name)
 
 
+def build_connection_search_path(text_search_extension: str, trgm_schema: str | None) -> str:
+    """Build the ``SET search_path`` statement for a runtime PostgreSQL connection.
+
+    Extension operators resolve their operand types through the session
+    ``search_path``, not through the fully-qualified table names we use for
+    tenant isolation. A connection whose role default ``search_path`` omits the
+    schema that holds the extension fails with errors like
+    ``operator does not exist: text % text`` (pg_trgm's ``%``, used by the
+    retain trigram entity lookup) or ``type "bm25vector" does not exist``
+    (vchord BM25's ``<&>``). External Postgres deployments frequently pin the
+    role ``search_path`` to a custom schema, so we set it explicitly here.
+
+    This does not weaken schema isolation: tenant tables are always accessed via
+    fully-qualified names (:func:`fq_table`); only operator/type resolution
+    relies on ``search_path``.
+
+    ``trgm_schema`` is the schema pg_trgm was actually installed into (``CREATE
+    EXTENSION`` without a ``SCHEMA`` clause lands in the first ``search_path``
+    entry at migration time, which may be a custom tenant schema rather than
+    ``public``). Pass ``None`` when pg_trgm is absent.
+    """
+    schemas = ['"$user"', "public"]
+    if trgm_schema and trgm_schema != "public":
+        schemas.append(f'"{trgm_schema}"')
+    if text_search_extension == "vchord":
+        # VectorChord BM25 registers objects in dedicated schemas
+        # (vchord_bm25 -> bm25_catalog, pg_tokenizer -> tokenizer_catalog).
+        schemas.extend(["bm25_catalog", "tokenizer_catalog"])
+    return "SET search_path TO " + ", ".join(schemas)
+
+
 def _json_default(obj: Any) -> str:
     """JSON serializer for types commonly carried through async task payloads."""
     if isinstance(obj, datetime):
@@ -2696,18 +2727,24 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Per-connection initialization callback (PostgreSQL-specific for now)
         async def _init_connection(conn: asyncpg.Connection) -> None:
-            # VectorChord BM25 registers its objects in dedicated schemas
-            # (vchord_bm25 -> bm25_catalog, pg_tokenizer -> tokenizer_catalog).
-            # The BM25 distance operator `<&>` resolves its operand types via the
-            # session search_path, so a connection that lacks these schemas fails
-            # recall with `type "bm25vector" does not exist` (and retain with
-            # `function tokenize(...) does not exist`). The official vchord-suite
-            # image masks this by shipping them in search_path; an external
-            # Postgres does not, so we add them ourselves. Tenant tables are always
-            # accessed via fully-qualified names (fq_table), so this does not
-            # affect schema isolation. Only needed for the vchord backend.
-            if text_search_extension == "vchord":
-                await conn.execute('SET search_path TO "$user", public, bm25_catalog, tokenizer_catalog')
+            # Extension operators (pg_trgm's `%` used by the retain trigram entity
+            # lookup, vchord BM25's `<&>`) resolve their operand types through the
+            # session search_path, not through the fully-qualified table names we
+            # use for tenant isolation. A connection whose role default search_path
+            # omits the extension schema fails with errors like
+            # `operator does not exist: text % text` or `type "bm25vector" does
+            # not exist`. External Postgres deployments often pin the role
+            # search_path to a custom schema, so we set it explicitly. pg_trgm may
+            # also have been installed into a non-public schema (CREATE EXTENSION
+            # without a SCHEMA clause lands in the first search_path entry at
+            # migration time), so discover where it actually lives. This does not
+            # affect schema isolation: tenant tables are always accessed via
+            # fully-qualified names (fq_table).
+            trgm_schema = await conn.fetchval(
+                "SELECT n.nspname FROM pg_extension e "
+                "JOIN pg_namespace n ON n.oid = e.extnamespace WHERE e.extname = 'pg_trgm'"
+            )
+            await conn.execute(build_connection_search_path(text_search_extension, trgm_schema))
 
             # SET (not SET LOCAL) so per-backend ANN tuning persists for the
             # connection lifetime. The dispatcher returns only safe, portable

--- a/hindsight-api-slim/tests/test_connection_search_path.py
+++ b/hindsight-api-slim/tests/test_connection_search_path.py
@@ -1,0 +1,49 @@
+"""Unit tests for build_connection_search_path (issue #2270).
+
+Runtime PG connections must expose the schema that holds extension operators
+(pg_trgm's `%`, vchord BM25's `<&>`) on the session search_path. Tenant tables
+are reached via fully-qualified names, so search_path only governs operator/type
+resolution — but an external Postgres whose role search_path omits the extension
+schema fails retain with `operator does not exist: text % text`.
+"""
+
+from hindsight_api.engine.memory_engine import build_connection_search_path
+
+
+def test_pgvector_backend_includes_user_and_public():
+    """Default (non-vchord) backend pins "$user", public so public extensions resolve."""
+    assert build_connection_search_path("pgvector", "public") == 'SET search_path TO "$user", public'
+
+
+def test_pg_trgm_in_public_is_not_duplicated():
+    """pg_trgm living in public needs no extra entry — public is already present."""
+    assert build_connection_search_path("pgvector", "public") == 'SET search_path TO "$user", public'
+
+
+def test_pg_trgm_in_custom_schema_is_appended_and_quoted():
+    """pg_trgm installed into a non-public schema is added so `%` resolves at runtime."""
+    assert (
+        build_connection_search_path("pgvector", "hindsight")
+        == 'SET search_path TO "$user", public, "hindsight"'
+    )
+
+
+def test_pg_trgm_absent_falls_back_to_user_and_public():
+    """When pg_trgm is not installed (None), only the base path is set."""
+    assert build_connection_search_path("pgvector", None) == 'SET search_path TO "$user", public'
+
+
+def test_vchord_appends_bm25_catalogs():
+    """vchord backend keeps its dedicated catalog schemas on the path."""
+    assert (
+        build_connection_search_path("vchord", "public")
+        == 'SET search_path TO "$user", public, bm25_catalog, tokenizer_catalog'
+    )
+
+
+def test_vchord_with_custom_trgm_schema_includes_both():
+    """A custom pg_trgm schema and the vchord catalogs coexist on the path."""
+    assert (
+        build_connection_search_path("vchord", "hindsight")
+        == 'SET search_path TO "$user", public, "hindsight", bm25_catalog, tokenizer_catalog'
+    )


### PR DESCRIPTION
## Problem

Retain crashes on external Postgres with:

```
operator does not exist: text % text
HINT: No operator matches the given name and argument types.
  ...entity_resolver.py, line 420, in _resolve_entities_batch_trigram
```

Reported in #2270. The reporter confirmed pg_trgm is installed and `SELECT 'hello' % 'helo'` works in their psql session — yet retain still fails.

## Root cause

The trigram entity lookup uses the **bare `%` operator**:

```sql
... AND LOWER(e.canonical_name) % LOWER(q.query_text)
```

Hindsight reaches its **tables** via fully-qualified names (`fq_table` → `"schema".entities`), but the `%` **operator** (and `gin_trgm_ops`) are resolved through the connection's `search_path`. The runtime asyncpg pool only set `search_path` for the **vchord** backend — every other backend used the DB role's default. When that default omits the schema holding pg_trgm, the operator can't resolve.

This explains every symptom:
- **psql works** — the interactive session's search_path includes the pg_trgm schema.
- **Migrations succeed** — `alembic/env.py` sets `search_path TO "<schema>", public` before running them.
- **Retain fails** — the pool connection's role default search_path doesn't include it.

There's also a sharp edge: `CREATE EXTENSION IF NOT EXISTS pg_trgm` (migration `c1a2b3d4e5f6`) has no `SCHEMA` clause, so on a fresh custom-schema install pg_trgm can land in the **tenant schema** rather than `public`.

## Fix

In the per-connection init callback (`_init_connection`):
- Set `search_path` explicitly on **every** runtime connection (not just vchord), generalizing the existing vchord handling of the identical operator-resolution problem (`<&>`).
- **Discover** the schema pg_trgm actually lives in and add it to the path, so `%` resolves even when the extension landed in a custom schema.

Search_path computation is extracted into `build_connection_search_path()` so it's unit-testable without a live PG. This does **not** weaken schema isolation — tenant tables are still reached via `fq_table`; only operator/type resolution relies on search_path.

## Tests

`tests/test_connection_search_path.py` covers pgvector/vchord backends, pg_trgm in public, in a custom schema (quoted + appended), and absent. Existing `test_entity_resolver_pg_trgm.py` still passes.

Closes #2270
