### PR TITLE
fix(docs): remove trailing comma in integrations.json

### DIFF
--- a/hindsight-docs/src/data/integrations.json
+++ b/hindsight-docs/src/data/integrations.json
@@ -509,6 +509,6 @@
       "category": "tool",
       "link": "https://github.com/yugandhar-maram/agrasandhany",
       "icon": "/img/icons/obsidian.svg"
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Problem

`hindsight-docs/src/data/integrations.json` is invalid JSON on `main` — the `agrasandhany` entry added in #2268 left a trailing comma after the final array element:

\`\`\`json
      "icon": "/img/icons/obsidian.svg"
    },        <-- trailing comma before the closing ]
  ]
\`\`\`

`check-integrations.mjs` does `JSON.parse(readFileSync(integrationsJson))` at line 38, so the docs build crashes with `SyntaxError: Unexpected token ']'`. This fails the **build-docs** and **verify-generated-files** CI jobs on `main` and on every open PR, and breaks the "Deploy Docs to GitHub Pages" workflow.

## Fix

Remove the trailing comma (one character). No content change.

## Verification

\`\`\`
$ node hindsight-docs/scripts/check-integrations.mjs
[integrations] ✅ All 48 integration entries have a doc page.
[integrations] ✅ All 37 released integrations are present in integrations.json.
\`\`\`

`check-integration-seo.mjs` and `check-code-parity.mjs` also pass.