### PR TITLE
fix(tests) backsweep migration test pg0 isolation

### DIFF
--- a/hindsight-api-slim/tests/test_migration_backsweep.py
+++ b/hindsight-api-slim/tests/test_migration_backsweep.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import create_engine, text, inspect
+from sqlalchemy import create_engine, text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -33,8 +33,17 @@ def _upgrade(db_url: str, revision: str) -> None:
     command.upgrade(_alembic_cfg(db_url), revision)
 
 
-def _downgrade(db_url: str, revision: str) -> None:
-    command.downgrade(_alembic_cfg(db_url), revision)
+def _reset_public_schema(db_url: str) -> None:
+    engine = create_engine(db_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            # This test rewinds/replays migration history against a persistent
+            # pg0 instance. Rebuild only its dedicated public schema so a
+            # previous run cannot leave alembic_version ahead of the real DDL.
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    finally:
+        engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -43,16 +52,16 @@ def _downgrade(db_url: str, revision: str) -> None:
 
 
 @pytest.fixture(scope="module")
-def pre_backsweep_db_url():
+def pre_backsweep_db_url() -> str:
     """
     Spin up a dedicated pg0 instance and ensure schema is at the revision
     just before the backsweep so each test can seed orphan data and then
     apply the backsweep itself.
 
-    Because pg0 data directories persist across test runs, the DB may
-    already be at head. We upgrade to head first (to ensure all tables
-    exist), then stamp the revision back to pre-backsweep so Alembic
-    treats the backsweep as not-yet-applied.
+    Because pg0 data directories persist across test runs, the DB may already
+    have schema from a previous test run. Reset this test's dedicated schema
+    first, then migrate to the real pre-backsweep revision instead of stamping
+    a head schema backward.
     """
     from hindsight_api.pg0 import EmbeddedPostgres
 
@@ -63,10 +72,8 @@ def pre_backsweep_db_url():
     finally:
         loop.close()
 
-    # Ensure all tables exist (upgrade to head), then stamp back to
-    # pre-backsweep so the backsweep migration will actually run.
-    _upgrade(url, "heads")
-    command.stamp(_alembic_cfg(url), "f6g7h8i9j0k1")
+    _reset_public_schema(url)
+    _upgrade(url, "f6g7h8i9j0k1")
     return url
 
 
@@ -75,7 +82,7 @@ def pre_backsweep_db_url():
 # ---------------------------------------------------------------------------
 
 
-def test_backsweep_removes_orphans_and_preserves_legit_rows(pre_backsweep_db_url):
+def test_backsweep_removes_orphans_and_preserves_legit_rows(pre_backsweep_db_url: str) -> None:
     """
     Seed four kinds of rows then apply the backsweep migration and verify:
 
@@ -114,15 +121,20 @@ def test_backsweep_removes_orphans_and_preserves_legit_rows(pre_backsweep_db_url
         conn.execute(text("INSERT INTO banks (bank_id) VALUES (:b)"), {"b": alive_bank})
 
         # --- seed memory_units ---
-        def insert_mu(uid, bank, fact_type, sources=None):
+        def insert_mu(
+            uid: uuid.UUID,
+            bank: str,
+            fact_type: str,
+            sources: list[uuid.UUID] | None = None,
+        ) -> None:
             src_arr = "{" + ",".join(str(s) for s in (sources or [])) + "}"
             conn.execute(
                 text(
                     """
                     INSERT INTO memory_units
-                        (id, bank_id, text, fact_type, source_memory_ids)
+                        (id, bank_id, text, event_date, fact_type, source_memory_ids)
                     VALUES
-                        (:id, :bank, :text, :ft, CAST(:src AS uuid[]))
+                        (:id, :bank, :text, now(), :ft, CAST(:src AS uuid[]))
                     """
                 ),
                 {"id": uid, "bank": bank, "text": "test", "ft": fact_type, "src": src_arr},
@@ -150,7 +162,7 @@ def test_backsweep_removes_orphans_and_preserves_legit_rows(pre_backsweep_db_url
     # --- verify ---
     with engine.connect() as conn:
 
-        def exists(uid):
+        def exists(uid: uuid.UUID) -> bool:
             return conn.execute(text("SELECT 1 FROM memory_units WHERE id = :id"), {"id": uid}).fetchone() is not None
 
         # Must be gone


### PR DESCRIPTION
## Summary

- reset the backsweep migration test's dedicated pg0 public schema before use
- migrate from an empty schema to the real pre-backsweep revision instead of stamping a head schema backward
- keep the test seed data valid for that historical schema by setting `event_date`

## Root Cause

The test uses a persistent dedicated pg0 instance and previously ran `upgrade heads` before stamping Alembic back to `f6g7h8i9j0k1`. That could leave the schema at a newer shape while `alembic_version` claimed an older revision, causing repeated local runs to fail when later migrations replayed against an unexpected schema.

## Validation

- `cd hindsight-api-slim && uv run pytest tests/test_migration_backsweep.py -q`
- repeated the same pytest command immediately afterward
- `./scripts/hooks/lint.sh`
