### PR TITLE
docs: document SDK version and MCP metadata helpers

### DIFF
--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -107,6 +107,21 @@ The MCP server operates in two modes depending on the URL:
 
 **Multi-bank mode** exposes all tools with an optional `bank_id` parameter, plus bank management tools (`list_banks`, `create_bank`, `get_bank_stats`).
 
+## Tool Metadata and Instructions
+
+Hindsight can append deployment-specific guidance to the `retain` and `recall` MCP tool descriptions. Set `HINDSIGHT_API_MCP_INSTRUCTIONS` on the API server when clients should see local rules, such as which tags to use or which memories should be retained.
+
+```bash
+export HINDSIGHT_API_MCP_INSTRUCTIONS="Use project:<name> tags for project-specific memories."
+```
+
+MCP clients that read tool annotations also receive safety hints from the built-in tools:
+
+- Read-only operations such as `recall`, `reflect`, `list_*`, and `get_*` are marked with `readOnlyHint: true`.
+- Delete, clear, and invalidate operations are marked with `destructiveHint: true`.
+- `openWorldHint` is `false` for the built-in tools because Hindsight operates on its configured memory store rather than the open internet.
+- Write operations such as `retain`, `create_*`, `update_*`, `refresh_mental_model`, and `cancel_operation` are not marked destructive.
+
 ---
 
 ## Available Tools

--- a/hindsight-docs/docs/sdks/nodejs.md
+++ b/hindsight-docs/docs/sdks/nodejs.md
@@ -55,6 +55,18 @@ const client = new HindsightClient({
 
 ## Core Operations
 
+### Version and Feature Checks
+
+```typescript
+const version = await client.getVersion();
+
+console.log(version.api_version);
+
+if (!version.features.mcp) {
+    throw new Error('This server does not expose the MCP endpoint');
+}
+```
+
 ### Retain (Store Memory)
 
 ```typescript

--- a/hindsight-docs/docs/sdks/python.md
+++ b/hindsight-docs/docs/sdks/python.md
@@ -58,6 +58,19 @@ memories = client.memories.list(bank_id="test")
 
 ## Core Operations
 
+### Version and Feature Checks
+
+```python
+version = client.get_version()
+
+print(version.api_version)
+
+if not version.features.mcp:
+    raise RuntimeError("This server does not expose the MCP endpoint")
+```
+
+The async client method is available as `await client.aget_version()`.
+
 ### Retain (Store Memory)
 
 ```python

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -107,6 +107,21 @@ The MCP server operates in two modes depending on the URL:
 
 **Multi-bank mode** exposes all tools with an optional `bank_id` parameter, plus bank management tools (`list_banks`, `create_bank`, `get_bank_stats`).
 
+## Tool Metadata and Instructions
+
+Hindsight can append deployment-specific guidance to the `retain` and `recall` MCP tool descriptions. Set `HINDSIGHT_API_MCP_INSTRUCTIONS` on the API server when clients should see local rules, such as which tags to use or which memories should be retained.
+
+```bash
+export HINDSIGHT_API_MCP_INSTRUCTIONS="Use project:<name> tags for project-specific memories."
+```
+
+MCP clients that read tool annotations also receive safety hints from the built-in tools:
+
+- Read-only operations such as `recall`, `reflect`, `list_*`, and `get_*` are marked with `readOnlyHint: true`.
+- Delete, clear, and invalidate operations are marked with `destructiveHint: true`.
+- `openWorldHint` is `false` for the built-in tools because Hindsight operates on its configured memory store rather than the open internet.
+- Write operations such as `retain`, `create_*`, `update_*`, `refresh_mental_model`, and `cancel_operation` are not marked destructive.
+
 ---
 
 ## Available Tools

--- a/skills/hindsight-docs/references/sdks/nodejs.md
+++ b/skills/hindsight-docs/references/sdks/nodejs.md
@@ -55,6 +55,18 @@ const client = new HindsightClient({
 
 ## Core Operations
 
+### Version and Feature Checks
+
+```typescript
+const version = await client.getVersion();
+
+console.log(version.api_version);
+
+if (!version.features.mcp) {
+    throw new Error('This server does not expose the MCP endpoint');
+}
+```
+
 ### Retain (Store Memory)
 
 ```typescript

--- a/skills/hindsight-docs/references/sdks/python.md
+++ b/skills/hindsight-docs/references/sdks/python.md
@@ -58,6 +58,19 @@ memories = client.memories.list(bank_id="test")
 
 ## Core Operations
 
+### Version and Feature Checks
+
+```python
+version = client.get_version()
+
+print(version.api_version)
+
+if not version.features.mcp:
+    raise RuntimeError("This server does not expose the MCP endpoint")
+```
+
+The async client method is available as `await client.aget_version()`.
+
 ### Retain (Store Memory)
 
 ```python


### PR DESCRIPTION
## Summary
- document `getVersion()` / `get_version()` in the TypeScript and Python SDK guides
- document `HINDSIGHT_API_MCP_INSTRUCTIONS` for MCP retain/recall tool guidance
- document built-in MCP tool annotations and regenerate the Hindsight docs skill mirrors

## Validation
- `./scripts/generate-docs-skill.sh`
- `git diff --check`
- verified touched docs match generated skill references with `cmp`
