### PR TITLE
docs: drop removed 'opinion' fact type from MCP tool docstrings and quickstart

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -2217,7 +2217,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             browse/search without relevance ranking.
 
             Args:
-                type: Filter by fact type: 'world', 'experience', or 'opinion'
+                type: Filter by fact type: 'world', 'experience', or 'observation'
                 q: Optional text search query to filter memories
                 limit: Maximum number of results (default: 100)
                 offset: Pagination offset (default: 0)
@@ -2260,7 +2260,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             browse/search without relevance ranking.
 
             Args:
-                type: Filter by fact type: 'world', 'experience', or 'opinion'
+                type: Filter by fact type: 'world', 'experience', or 'observation'
                 q: Optional text search query to filter memories
                 limit: Maximum number of results (default: 100)
                 offset: Pagination offset (default: 0)
@@ -3425,7 +3425,7 @@ def _register_clear_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
             Optionally filter by fact type to only clear specific kinds of memories.
 
             Args:
-                type: Optional fact type filter: 'world', 'experience', or 'opinion'. If not specified, clears all.
+                type: Optional fact type filter: 'world', 'experience', or 'observation'. If not specified, clears all.
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
             """
             try:
@@ -3459,7 +3459,7 @@ def _register_clear_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTool
             Optionally filter by fact type to only clear specific kinds of memories.
 
             Args:
-                type: Optional fact type filter: 'world', 'experience', or 'opinion'. If not specified, clears all.
+                type: Optional fact type filter: 'world', 'experience', or 'observation'. If not specified, clears all.
             """
             try:
                 target_bank = config.bank_id_resolver()

--- a/hindsight-docs/src/pages/cookbook/recipes/quickstart.md
+++ b/hindsight-docs/src/pages/cookbook/recipes/quickstart.md
@@ -127,7 +127,7 @@ for r in results.results:
 
 ## Reflect: Generate Insights
 
-The `reflect` operation performs a more thorough analysis of existing memories. This allows the agent to form new connections between memories which are then persisted as opinions and/or observations.
+The `reflect` operation performs a more thorough analysis of existing memories. This allows the agent to form new connections between memories which are then persisted as observations.
 
 Example use cases:
 - An AI Project Manager reflecting on what risks need to be mitigated
@@ -142,11 +142,10 @@ print(response)
 
 ## Memory Types
 
-Hindsight organizes memory into four networks to mimic human memory:
+Hindsight organizes memory into three networks to mimic human memory:
 
 - **World**: Facts about the world ("The stove gets hot")
 - **Experiences**: Agent's own experiences ("I touched the stove and it really hurt")
-- **Opinion**: Beliefs with confidence scores ("I shouldn't touch the stove again" - .99 confidence)
 - **Observation**: Complex mental models derived by reflecting on facts and experiences
 
 ## Cleanup


### PR DESCRIPTION
The `opinion` fact type was removed in the v0.8.x fact-type consolidation
(`alembic/versions/g2h3i4j5k6l7_remove_opinion_fact_type.py`;
`models.py` now constrains `fact_type IN ('world', 'experience', 'observation')`),
but a couple of agent-facing surfaces still advertise it:

- **MCP tool docstrings** (`hindsight-api-slim/hindsight_api/mcp_tools.py`): the
  `list_memories` and `clear_memories` docstrings tell agents to filter `type`
  by `'world'`, `'experience'`, or `'opinion'`. An agent following the docstring
  now passes a fact type that no longer exists, so it gets empty/invalid results
  and never learns the current `'observation'` type.
- **Cookbook quickstart** (`hindsight-docs/.../cookbook/recipes/quickstart.md`):
  the "Memory Types" section still lists `Opinion` as a current type and says
  there are "four networks".

This replaces `opinion` → `observation` in the four MCP docstrings and drops the
removed `Opinion` entry from the quickstart memory-types list (four → three
networks). Follow-up to #2198, which fixed the LiteLLM integration doc but
missed these agent-facing surfaces.

Docs/docstring-only; no behavior change. `./scripts/generate-docs-skill.sh`
produces no generated-file diff (neither file is a generator input), so
`verify-generated-files` stays green.