### PR TITLE
fix(retain): make chunk_text idempotent to avoid duplicate chunk_id crash (#2301)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -473,6 +473,15 @@ def chunk_text(text: str, max_chars: int, structured_chunk_size: int | None = No
         if isinstance(parsed, list) and all(isinstance(turn, dict) for turn in parsed):
             # This looks like a conversation - chunk at turn boundaries
             return _chunk_conversation(parsed, max_chars, structured_limit)
+        if isinstance(parsed, dict) and len(text) <= structured_limit:
+            # A lone structured unit (a single JSON object) is kept whole up to the
+            # structured-chunk cap, mirroring how a single JSONL line or conversation
+            # turn is kept whole. Keeping it whole here makes chunk_text a fixed point:
+            # extraction re-runs chunk_text on every pre-chunk, so a kept-whole line
+            # re-chunked on its own must come back unchanged. Otherwise it expands into
+            # several sub-chunks that all collapse onto one chunk_index and crash the
+            # ON CONFLICT upsert with duplicate chunk_ids (#2301).
+            return [text]
     except (json.JSONDecodeError, ValueError):
         pass
 
@@ -519,7 +528,7 @@ def _chunk_conversation(turns: list[dict], max_chars: int, structured_limit: int
         # text so no chunk runs far over budget (the extractor won't re-chunk).
         if turn_unit_size > structured_limit:
             _flush()
-            chunks.extend(_split_oversized_unit(turn_json, structured_limit))
+            chunks.extend(_split_oversized_unit(turn_json, min(structured_limit, max_chars)))
             continue
 
         # If adding this turn would exceed limit and we have turns, save current chunk
@@ -585,7 +594,7 @@ def _chunk_jsonl(text: str, max_chars: int, structured_limit: int) -> list[str] 
         # text so no chunk runs far over budget (the extractor won't re-chunk).
         if line_unit_size > structured_limit:
             _flush()
-            chunks.extend(_split_oversized_unit(line, structured_limit))
+            chunks.extend(_split_oversized_unit(line, min(structured_limit, max_chars)))
             continue
 
         # If adding this line would exceed the limit and we have lines, flush.

--- a/hindsight-api-slim/tests/test_chunking.py
+++ b/hindsight-api-slim/tests/test_chunking.py
@@ -322,3 +322,60 @@ def test_plain_text_lines_not_treated_as_jsonl():
     # Sanity: these are not JSON objects (so the JSONL path correctly declined).
     with pytest.raises(json.JSONDecodeError):
         json.loads(chunks[0])
+
+
+# ---------------------------------------------------------------------------
+# Re-chunk stability (idempotence)
+# ---------------------------------------------------------------------------
+# Extraction re-runs ``chunk_text`` on every pre-chunk, so each emitted chunk
+# must be a fixed point. When the structured-chunk cap is raised above
+# ``max_chars``, a pre-chunk that re-chunks into several pieces makes them all
+# collapse onto one chunk_index and crashes the retain upsert with duplicate
+# chunk_ids (CardinalityViolationError, #2301).
+
+
+def _assert_rechunk_stable(chunks, max_chars, structured_chunk_size):
+    """Every produced chunk must re-chunk to exactly itself (a fixed point)."""
+    for chunk in chunks:
+        assert chunk_text(
+            chunk, max_chars=max_chars, structured_chunk_size=structured_chunk_size
+        ) == [chunk], f"chunk re-splits on the extractor's second pass: {chunk[:60]!r}..."
+
+
+def test_chunk_conversation_oversized_turn_is_rechunk_stable():
+    """A turn larger than the structured cap is split to max_chars (not the cap),
+    so the extractor's re-chunk pass is a no-op (#2301)."""
+    text = json.dumps([{"role": "assistant", "content": "x" * 6000}])
+
+    chunks = chunk_text(text, max_chars=3000, structured_chunk_size=5000)
+
+    for chunk in chunks:
+        assert len(chunk) <= 3000
+    _assert_rechunk_stable(chunks, max_chars=3000, structured_chunk_size=5000)
+
+
+def test_chunk_jsonl_kept_whole_line_is_rechunk_stable():
+    """A JSONL line kept whole (between max_chars and the structured cap) must
+    survive the extractor's re-chunk pass unchanged (#2301)."""
+    big_line = json.dumps({"event": "x" * 3800})  # > max_chars 3000, <= cap 5000
+    small_line = json.dumps({"event": "ok"})
+    text = "\n".join([big_line, small_line])
+
+    chunks = chunk_text(text, max_chars=3000, structured_chunk_size=5000)
+
+    assert big_line in chunks  # kept whole as its own pre-chunk
+    _assert_rechunk_stable(chunks, max_chars=3000, structured_chunk_size=5000)
+
+
+def test_chunk_jsonl_oversized_line_is_rechunk_stable():
+    """A JSONL line past the structured cap is split to max_chars so every
+    fragment is a fixed point (#2301)."""
+    huge_line = json.dumps({"event": "z" * 8000})  # > cap 5000
+    small_line = json.dumps({"event": "ok"})
+    text = "\n".join([huge_line, small_line])
+
+    chunks = chunk_text(text, max_chars=3000, structured_chunk_size=5000)
+
+    for chunk in chunks:
+        assert len(chunk) <= 3000
+    _assert_rechunk_stable(chunks, max_chars=3000, structured_chunk_size=5000)


### PR DESCRIPTION
Fixes #2301.

### Problem
Raising `HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE` above `retain_chunk_size` makes retaining a doc with an oversized conversation turn / JSONL line crash with `asyncpg.CardinalityViolationError: ON CONFLICT DO UPDATE command cannot affect row a second time`.

### Root cause
`chunk_text()` is not a fixed point in this regime, but the pipeline assumes **one pre-chunk → one stored chunk** — the consumer maps every extracted chunk back to a single `global_idx`-derived `chunk_index`. When `structured_chunk_size > max_chars`:

- an oversized unit is split via `_split_oversized_unit(unit, structured_limit)` into fragments up to `structured_limit`, i.e. **larger than `max_chars`** (the comment *"so no chunk runs far over budget — the extractor won't re-chunk"* is violated);
- extraction re-runs `chunk_text` on every pre-chunk and re-splits those fragments into >1 sub-chunks, which all collapse onto one `chunk_index` → duplicate `chunk_id`s in one `ON CONFLICT` upsert → crash.

A second variant: a JSONL line kept whole between `max_chars` and the structured cap is re-chunked on its own, where `_chunk_jsonl` declines (needs ≥2 lines) and it falls back to `_split_oversized_unit` → the same collapse.

### Fix (producer-side; preserves the 1:1 pre-chunk→chunk invariant)
Make `chunk_text` idempotent so the extractor's re-chunk pass is a no-op:

1. Split oversized units to `min(structured_limit, max_chars)` — fragments never exceed `max_chars`, so they are fixed points. This keeps the existing `structured_limit < max_chars` behaviour (still splits down to the smaller cap).
2. Keep a lone single JSON object whole only up to `structured_limit`, mirroring how a single JSONL line / conversation turn is kept whole — so a kept-whole line re-chunked alone comes back unchanged.

### Tests
Added re-chunk-stability tests covering the conversation-oversized-turn (the issue repro), the kept-whole JSONL line, and the oversized JSONL line — each asserts every produced chunk is a fixed point of `chunk_text`. All existing `test_chunking.py` cases still pass (the `min()` leaves the `structured_limit < max_chars` outputs identical). Pure-function tests, no DB required.
