### PR TITLE
fix(retain): make chunk_text idempotent so raised structured chunk size doesn't fail retains (#2301)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -452,6 +452,11 @@ def chunk_text(text: str, max_chars: int, structured_chunk_size: int | None = No
     ``structured_chunk_size``. When unset, that limit defaults to ``max_chars``.
     For plain text, uses sentence-aware splitting.
 
+    The result is idempotent: re-chunking any chunk this returns yields that chunk
+    unchanged. The streaming retain pipeline pre-chunks each document once and then
+    re-chunks every piece during extraction; if a piece re-split, its sub-chunks
+    would inherit one chunk_index and collide on ``chunk_id`` (issue #2301).
+
     Args:
         text: Input text to chunk (plain text, JSON conversation, or JSONL)
         max_chars: Target maximum characters per chunk
@@ -470,11 +475,23 @@ def chunk_text(text: str, max_chars: int, structured_chunk_size: int | None = No
     # Try to parse as JSON conversation array
     try:
         parsed = json.loads(text)
-        if isinstance(parsed, list) and all(isinstance(turn, dict) for turn in parsed):
-            # This looks like a conversation - chunk at turn boundaries
-            return _chunk_conversation(parsed, max_chars, structured_limit)
     except (json.JSONDecodeError, ValueError):
-        pass
+        parsed = None
+
+    if isinstance(parsed, list) and all(isinstance(turn, dict) for turn in parsed):
+        # This looks like a conversation - chunk at turn boundaries
+        return _chunk_conversation(parsed, max_chars, structured_limit)
+
+    if isinstance(parsed, dict):
+        # A single JSON object — e.g. one JSONL line handed back to the extractor
+        # after the producer already pre-chunked it. It is one structured unit:
+        # keep it whole up to the structured limit, else split it as text within
+        # the chunk budget. Without this, a lone object (one line, so _chunk_jsonl
+        # declines) would fall through to plain-text splitting and re-split a chunk
+        # the producer deliberately kept whole — breaking idempotency (issue #2301).
+        if len(text) <= structured_limit:
+            return [text]
+        return _split_oversized_unit(text, max_chars)
 
     # Try to parse as JSONL (newline-delimited JSON objects, e.g. session logs)
     jsonl_chunks = _chunk_jsonl(text, max_chars, structured_limit)
@@ -516,10 +533,12 @@ def _chunk_conversation(turns: list[dict], max_chars: int, structured_limit: int
         turn_size = turn_unit_size + 1  # +1 for comma
 
         # A turn too large to keep whole even alone: flush, then split it as
-        # text so no chunk runs far over budget (the extractor won't re-chunk).
+        # text. Fragment within min(structured_limit, max_chars) so no fragment
+        # exceeds the chunk budget — otherwise a downstream re-chunk would split
+        # it again and collide on chunk_id (issue #2301).
         if turn_unit_size > structured_limit:
             _flush()
-            chunks.extend(_split_oversized_unit(turn_json, structured_limit))
+            chunks.extend(_split_oversized_unit(turn_json, min(structured_limit, max_chars)))
             continue
 
         # If adding this turn would exceed limit and we have turns, save current chunk
@@ -582,10 +601,12 @@ def _chunk_jsonl(text: str, max_chars: int, structured_limit: int) -> list[str] 
         line_size = len(line) + 1  # +1 for the joining newline
 
         # A line too large to keep whole even alone: flush, then split it as
-        # text so no chunk runs far over budget (the extractor won't re-chunk).
+        # text. Fragment within min(structured_limit, max_chars) so no fragment
+        # exceeds the chunk budget — otherwise a downstream re-chunk would split
+        # it again and collide on chunk_id (issue #2301).
         if line_unit_size > structured_limit:
             _flush()
-            chunks.extend(_split_oversized_unit(line, structured_limit))
+            chunks.extend(_split_oversized_unit(line, min(structured_limit, max_chars)))
             continue
 
         # If adding this line would exceed the limit and we have lines, flush.

--- a/hindsight-api-slim/tests/test_chunking.py
+++ b/hindsight-api-slim/tests/test_chunking.py
@@ -322,3 +322,76 @@ def test_plain_text_lines_not_treated_as_jsonl():
     # Sanity: these are not JSON objects (so the JSONL path correctly declined).
     with pytest.raises(json.JSONDecodeError):
         json.loads(chunks[0])
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-chunking a produced chunk must be a no-op (issue #2301)
+# ---------------------------------------------------------------------------
+#
+# The streaming retain pipeline pre-chunks each document once (producer) and then
+# re-chunks every piece during extraction (consumer), stamping all sub-chunks of
+# one piece with that piece's single chunk_index. If a piece re-split, its
+# sub-chunks would derive the same chunk_id = {bank}_{doc}_{index} and the
+# ON CONFLICT upsert would fail with CardinalityViolationError. This can only
+# happen when structured_chunk_size > max_chars (a chunk legitimately exceeds the
+# re-chunk budget); the defaults (structured == max_chars) never trip it.
+
+
+def _assert_idempotent(text: str, *, max_chars: int, structured_chunk_size: int) -> list[str]:
+    chunks = chunk_text(text, max_chars=max_chars, structured_chunk_size=structured_chunk_size)
+    for chunk in chunks:
+        rechunked = chunk_text(chunk, max_chars=max_chars, structured_chunk_size=structured_chunk_size)
+        assert rechunked == [chunk], (
+            f"re-chunking a produced chunk split it again ({len(chunk)} chars -> "
+            f"{len(rechunked)} pieces) — not idempotent (issue #2301)"
+        )
+    return chunks
+
+
+def test_conversation_turn_over_chunk_size_is_rechunk_stable():
+    """A conversation turn larger than max_chars but kept whole by the larger
+    structured cap must survive a re-chunk unchanged (issue #2301)."""
+    content = json.dumps([{"role": "assistant", "content": "x" * 6000}])
+
+    _assert_idempotent(content, max_chars=3000, structured_chunk_size=5000)
+
+
+def test_jsonl_line_over_chunk_size_is_rechunk_stable():
+    """A single oversized JSONL line, kept whole within the structured cap, must
+    not be re-split when handed back through chunk_text (issue #2301)."""
+    text = "\n".join([json.dumps({"event": "x" * 3800}), json.dumps({"event": "small"})])
+
+    _assert_idempotent(text, max_chars=3000, structured_chunk_size=4500)
+
+
+def test_oversized_unit_fragments_stay_within_chunk_budget():
+    """A unit past even the structured cap is fragmented as text; no fragment may
+    exceed max_chars, so a re-chunk leaves the fragments intact (issue #2301)."""
+    text = "\n".join([json.dumps({"event": "z" * 9000}), json.dumps({"e": "s"})])
+
+    chunks = _assert_idempotent(text, max_chars=3000, structured_chunk_size=4500)
+
+    assert all(len(c) <= 3000 for c in chunks)
+
+
+def test_single_json_object_kept_whole_within_structured_cap():
+    """A lone JSON object over max_chars but within the structured cap is returned
+    whole rather than plain-text-split (the basis of re-chunk stability)."""
+    obj = json.dumps({"role": "assistant", "content": "x" * 4000})
+
+    assert chunk_text(obj, max_chars=3000, structured_chunk_size=5000) == [obj]
+
+
+def test_rechunk_preserves_one_chunk_id_per_pre_chunk():
+    """End-to-end of the producer/consumer chunk_id derivation: each pre-chunk
+    (one global index) must re-chunk to exactly one piece, so the derived
+    chunk_ids stay unique within an upsert batch (issue #2301)."""
+    content = json.dumps([{"role": "assistant", "content": "x" * 6000}])
+
+    pre_chunks = chunk_text(content, max_chars=3000, structured_chunk_size=5000)
+    chunk_ids = []
+    for global_idx, pre in enumerate(pre_chunks):
+        for _ in chunk_text(pre, max_chars=3000, structured_chunk_size=5000):
+            chunk_ids.append(f"bank_doc_{global_idx}")
+
+    assert len(chunk_ids) == len(set(chunk_ids)), f"duplicate chunk_ids in one batch: {chunk_ids}"

--- a/hindsight-api-slim/tests/test_structured_chunk_size_retain.py
+++ b/hindsight-api-slim/tests/test_structured_chunk_size_retain.py
@@ -1,0 +1,81 @@
+"""Regression test for https://github.com/vectorize-io/hindsight/issues/2301
+
+Raising ``HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE`` above
+``HINDSIGHT_API_RETAIN_CHUNK_SIZE`` and retaining a JSONL/conversation document
+whose line/turn overflows the chunk size used to crash with::
+
+    asyncpg.exceptions.CardinalityViolationError:
+        ON CONFLICT DO UPDATE command cannot affect row a second time
+
+The streaming retain pipeline pre-chunks each document once (one ``chunk_index``
+per piece) and then re-chunks every piece during extraction. With the structured
+cap above the chunk size, a pre-chunk could legitimately exceed the re-chunk
+budget, so it re-split into several sub-chunks that all inherited the one
+``chunk_index`` — colliding on ``chunk_id = {bank}_{doc}_{index}`` in a single
+upsert batch. ``chunk_text`` is now idempotent, so the re-chunk is a no-op.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.config import clear_config_cache
+
+
+def _ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@pytest.fixture(autouse=True)
+def _structured_chunk_env(monkeypatch):
+    # Structured cap ABOVE the chunk size — the configuration that triggers #2301.
+    # Default-scale sizes (matching the issue) so the document yields only a
+    # handful of chunks: a smaller chunk size explodes the embedding/link work and
+    # destabilises the shared session fixture under xdist.
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_CHUNK_SIZE", "3000")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE", "4500")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_jsonl_line_over_chunk_size_retains_without_collision(memory, request_context):
+    """A JSONL document with a line longer than the chunk size retains cleanly
+    when the structured cap is raised above it (issue #2301)."""
+    import json
+
+    bank_id = f"test_2301_{_ts()}"
+    document_id = "doc-2301"
+
+    try:
+        body = "\n".join(
+            [
+                json.dumps({"role": "user", "content": "short opening line"}),
+                # Between chunk size (3000) and structured cap (4500): kept whole by
+                # the producer, would re-split on re-chunk without the fix.
+                json.dumps({"role": "assistant", "content": "k" * 3800}),
+                # Past even the structured cap: fragmented as text.
+                json.dumps({"role": "assistant", "content": "m" * 9000}),
+                json.dumps({"role": "user", "content": "short closing line"}),
+            ]
+        )
+
+        # The bug raised CardinalityViolationError here.
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=body,
+            context="jsonl with oversized line",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        chunks = await memory.list_document_chunks(bank_id, document_id, limit=10000, request_context=request_context)
+        indices = sorted(c["chunk_index"] for c in chunks["items"])
+        # No collisions: chunk_index values are unique.
+        assert len(indices) == len(set(indices)), f"duplicate chunk_index values: {indices}"
+        assert indices == list(range(len(indices))), f"chunk_index sequence not contiguous: {indices}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Fixes #2301. Raising `HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE` above `HINDSIGHT_API_RETAIN_CHUNK_SIZE` and then retaining a JSONL/conversation document whose line/turn exceeds the chunk size crashed with:

```
asyncpg.exceptions.CardinalityViolationError: ON CONFLICT DO UPDATE command cannot affect row a second time
```

## Root cause

The streaming retain pipeline pre-chunks each document **once** (`orchestrator.py` — one `chunk_index` per piece) and then **re-chunks every piece** during extraction (`fact_extraction.py`), stamping all sub-chunks of a piece with that single `chunk_index` (`orchestrator.py:1363`). The stored `chunk_id` is derived as `{bank}_{document}_{chunk_index}` (`chunk_storage.py:105`).

This relies on `chunk_text` being **idempotent** — re-chunking a chunk it produced must return that chunk unchanged. That held with the defaults (`structured_chunk_size == max_chars`), but broke once the structured cap was raised above the chunk size: a pre-chunk could legitimately exceed the re-chunk budget (a structured unit deliberately kept whole, or an oversized fragment split to `structured_limit`), so it re-split into several sub-chunks. Those sub-chunks all inherited the one `chunk_index` → duplicate `chunk_id`s in a single `ON CONFLICT` upsert → cardinality violation.

## Fix

Make `chunk_text` idempotent:

- A lone JSON object (one JSONL line handed back to the extractor after pre-chunking) is now kept whole up to the structured limit, instead of falling through to plain-text splitting (a single line isn't detected as JSONL).
- Oversized turns/lines are fragmented within `min(structured_limit, max_chars)` so no fragment ever exceeds the re-chunk budget.

With this, the consumer's re-chunk is always a no-op and the producer's "one pre-chunk = one `chunk_index`" invariant holds for any configuration.

## Tests

- `test_chunking.py`: idempotency unit tests (conversation turn, JSONL line, oversized fragments, single-object keep-whole) + an explicit `chunk_id`-uniqueness check mirroring the producer/consumer derivation. These reproduce the bug deterministically without a DB or LLM.
- `test_structured_chunk_size_retain.py`: end-to-end regression — retains a JSONL doc with an oversized line under a raised structured cap and asserts contiguous, collision-free `chunk_index` values.

## Verification

```
24 passed  tests/test_chunking.py
 1 passed  tests/test_structured_chunk_size_retain.py
```
Lints/type-checks (`ruff`, `ty`) clean; existing chunking tests unchanged and green.
