### PR TITLE
feat(recall): prefer_observations — dedupe raw facts superseded by observations

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -270,6 +270,16 @@ class RecallRequest(BaseModel):
         default=None,
         description="List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified.",
     )
+    prefer_observations: bool = Field(
+        default=False,
+        description=(
+            "When recalling raw facts ('world'/'experience') together with 'observation', drop any raw "
+            "fact that an observation in the results was consolidated from, so the observation supersedes "
+            "it and you don't get duplicate content. The freed slots are backfilled with the next results, "
+            "keeping the result count at the requested budget. Disabled by default; set to true to enable. "
+            "No effect unless 'observation' and at least one raw type are both requested."
+        ),
+    )
     budget: Budget = Budget.MID
     max_tokens: int = 4096
     trace: bool = False
@@ -3826,6 +3836,7 @@ def _register_routes(app: FastAPI):
                         max_tokens=request.max_tokens,
                         enable_trace=request.trace,
                         fact_type=fact_types,
+                        prefer_observations=request.prefer_observations,
                         question_date=question_date,
                         include_entities=include_entities,
                         max_entity_tokens=max_entity_tokens,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3843,6 +3843,10 @@ class MemoryEngine(MemoryEngineInterface):
         max_tokens: int = 4096,
         enable_trace: bool = False,
         fact_type: list[str] | None = None,
+        # Opt-in (default False). Internal callers that recall raw facts on purpose —
+        # notably consolidation, which needs the raw facts it folds into observations —
+        # must leave this off so they aren't silently deduped away.
+        prefer_observations: bool = False,
         question_date: datetime | None = None,
         include_entities: bool = False,
         max_entity_tokens: int = 500,
@@ -3875,6 +3879,10 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id: bank ID to recall for
             query: Recall query
             fact_type: List of fact types to recall (e.g., ['world', 'experience'])
+            prefer_observations: When True and both 'observation' and a raw type ('world'/'experience')
+                       are requested, drop raw facts that a returned observation was consolidated from
+                       (deduplication by provenance). Freed slots backfill, keeping the result count at
+                       the budget. No-op unless both observation and raw types are requested.
             budget: Budget level for graph traversal (low=100, mid=300, high=600 units)
             max_tokens: Maximum tokens to return (counts only 'text' field, default 4096)
                        Results are returned until token budget is reached, stopping before
@@ -4012,6 +4020,7 @@ class MemoryEngine(MemoryEngineInterface):
                             max_chunk_tokens,
                             request_context,
                             semaphore_wait=semaphore_wait,
+                            prefer_observations=prefer_observations,
                             tags=tags,
                             tags_match=tags_match,
                             tag_groups=tag_groups,
@@ -4148,6 +4157,7 @@ class MemoryEngine(MemoryEngineInterface):
         max_chunk_tokens: int = 8192,
         request_context: "RequestContext" = None,
         semaphore_wait: float = 0.0,
+        prefer_observations: bool = False,
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
@@ -4659,6 +4669,48 @@ class MemoryEngine(MemoryEngineInterface):
             # if the client disconnected while we were reranking (issue #2122).
             if request_context is not None:
                 request_context.raise_if_cancelled()
+
+            # Step 4.8: prefer-observations dedup. When the caller asked for observations
+            # alongside raw facts, an observation supersedes the raw facts it was
+            # consolidated from: drop those raw facts so the same content isn't returned
+            # twice. Runs BEFORE the Step 5 truncation so the freed slots backfill with
+            # the next-best results, keeping the result count at the budget. No-op unless
+            # 'observation' and at least one raw type were both requested.
+            raw_types_requested = {"world", "experience"} & set(fact_type)
+            if prefer_observations and "observation" in fact_type and raw_types_requested:
+                # "The observation list" = observations within the window we would return.
+                # Only those can supersede a raw fact; a far-down observation should not
+                # suppress a top raw fact it merely happens to reference.
+                observation_ids = [
+                    uuid.UUID(sr.id)
+                    for sr in scored_results[: thinking_budget * 2]
+                    if sr.retrieval.fact_type == "observation"
+                ]
+                if observation_ids:
+                    superseded_ids: set[str] = set()
+                    async with acquire_with_retry(backend) as dedup_conn:
+                        obs_rows = await dedup_conn.fetch(
+                            f"""
+                            SELECT source_memory_ids
+                            FROM {fq_table("memory_units")}
+                            WHERE id = ANY($1::uuid[]) AND fact_type = 'observation'
+                            """,
+                            observation_ids,
+                        )
+                    for obs_row in obs_rows:
+                        for sid in obs_row["source_memory_ids"] or []:
+                            superseded_ids.add(str(sid))
+                    if superseded_ids:
+                        before_count = len(scored_results)
+                        scored_results = [
+                            sr
+                            for sr in scored_results
+                            if not (sr.retrieval.fact_type in ("world", "experience") and sr.id in superseded_ids)
+                        ]
+                        log_buffer.append(
+                            f"  [4.8] prefer_observations: dropped {before_count - len(scored_results)} "
+                            f"raw fact(s) superseded by {len(observation_ids)} observation(s)"
+                        )
 
             # Step 5: Truncate to thinking_budget * 2 for token filtering
             rerank_limit = thinking_budget * 2

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -833,6 +833,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             max_tokens: int = 4096,
             budget: str = "high",
             types: list[str] | None = None,
+            prefer_observations: bool = False,
             tags: list[str] | None = None,
             tags_match: str = "any",
             tag_groups: list[dict] | None = None,
@@ -845,6 +846,10 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 max_tokens: Maximum tokens to return in results (default: 4096)
                 budget: Search budget - 'low', 'mid', or 'high' (default: 'high'). Higher budgets search more thoroughly.
                 types: Fact types to include (e.g., ['world', 'experience']). Default: all types.
+                prefer_observations: When recalling raw facts together with 'observation', drop any raw fact
+                    that a returned observation was consolidated from, so the observation supersedes it (no
+                    duplicate content). Disabled by default; set true to enable. No effect unless
+                    'observation' and a raw type are both in types. Default: False.
                 tags: Optional tags to filter results by (e.g., ['project:alpha']). Mutually exclusive with tag_groups.
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
                 tag_groups: Compound tag filter using boolean groups (AND-ed together). Each group is a leaf
@@ -873,6 +878,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     "bank_id": target_bank,
                     "query": query,
                     "fact_type": fact_types,
+                    "prefer_observations": prefer_observations,
                     "budget": budget_enum,
                     "max_tokens": max_tokens,
                     "request_context": _get_request_context(config),
@@ -905,6 +911,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
             max_tokens: int = 4096,
             budget: str = "high",
             types: list[str] | None = None,
+            prefer_observations: bool = False,
             tags: list[str] | None = None,
             tags_match: str = "any",
             tag_groups: list[dict] | None = None,
@@ -916,6 +923,10 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 max_tokens: Maximum tokens to return in results (default: 4096)
                 budget: Search budget - 'low', 'mid', or 'high' (default: 'high'). Higher budgets search more thoroughly.
                 types: Fact types to include (e.g., ['world', 'experience']). Default: all types.
+                prefer_observations: When recalling raw facts together with 'observation', drop any raw fact
+                    that a returned observation was consolidated from, so the observation supersedes it (no
+                    duplicate content). Disabled by default; set true to enable. No effect unless
+                    'observation' and a raw type are both in types. Default: False.
                 tags: Optional tags to filter results by (e.g., ['project:alpha']). Mutually exclusive with tag_groups.
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
                 tag_groups: Compound tag filter using boolean groups (AND-ed together). Each group is a leaf
@@ -943,6 +954,7 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                     "bank_id": target_bank,
                     "query": query,
                     "fact_type": fact_types,
+                    "prefer_observations": prefer_observations,
                     "budget": budget_enum,
                     "max_tokens": max_tokens,
                     "request_context": _get_request_context(config),

--- a/hindsight-api-slim/tests/test_recall_prefer_observations.py
+++ b/hindsight-api-slim/tests/test_recall_prefer_observations.py
@@ -1,0 +1,184 @@
+"""Tests for the recall `prefer_observations` deduplication flag.
+
+When the caller recalls raw facts ('world'/'experience') together with
+'observation' and sets prefer_observations=True, any raw fact that a returned
+observation was consolidated from (tracked via memory_units.source_memory_ids)
+is dropped so the observation supersedes it — no duplicate content.
+
+Dedup is provenance-based, not semantic: a raw fact that is semantically
+similar to an observation but NOT listed in its source_memory_ids must survive.
+
+No LLM required — inserts memory_units directly via SQL with real embeddings.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from hindsight_api import MemoryEngine, RequestContext
+from hindsight_api.engine.retain import embedding_utils
+
+RC = RequestContext(tenant_id="default")
+
+QUERY = "Alice mountain hiking"
+
+# Two raw facts the observation is consolidated from (must be dropped when the
+# flag is on), one raw fact that is semantically similar but NOT a source (must
+# survive), and the observation itself.
+SRC1_TEXT = "Alice loves hiking in the mountains"
+SRC2_TEXT = "Alice hikes the Alps every summer"
+NON_SRC_TEXT = "Alice enjoys exploring mountain hiking trails"
+OBS_TEXT = "Alice is an avid mountain hiker"
+
+
+async def _insert_unit(
+    conn,
+    *,
+    unit_id: str,
+    text: str,
+    bank_id: str,
+    embedding_str: str,
+    fact_type: str = "world",
+    source_memory_ids: list[uuid.UUID] | None = None,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, source_memory_ids)
+        VALUES ($1, $2, $3, $4, $5::vector, $6::uuid[])
+        """,
+        unit_id,
+        bank_id,
+        text,
+        fact_type,
+        embedding_str,
+        source_memory_ids,
+    )
+
+
+def _to_str(emb: list[float]) -> str:
+    return "[" + ",".join(str(v) for v in emb) + "]"
+
+
+def _result_ids(result) -> set[str]:
+    return {str(r.id) for r in result.results}
+
+
+@pytest_asyncio.fixture
+async def seeded_obs_memory(memory_no_llm_verify: MemoryEngine):
+    """Seed two source facts, one non-source fact, and an observation over the two sources."""
+    engine = memory_no_llm_verify
+    bank_id = f"test-prefer-obs-{uuid.uuid4().hex[:8]}"
+    await engine.get_bank_profile(bank_id, request_context=RC)
+
+    src1_id = str(uuid.uuid4())
+    src2_id = str(uuid.uuid4())
+    non_src_id = str(uuid.uuid4())
+    obs_id = str(uuid.uuid4())
+
+    embeddings = await embedding_utils.generate_embeddings_batch(
+        engine.embeddings,
+        [SRC1_TEXT, SRC2_TEXT, NON_SRC_TEXT, OBS_TEXT],
+    )
+
+    pool = await engine._get_pool()
+    async with pool.acquire() as conn:
+        await _insert_unit(conn, unit_id=src1_id, text=SRC1_TEXT, bank_id=bank_id, embedding_str=_to_str(embeddings[0]))
+        await _insert_unit(conn, unit_id=src2_id, text=SRC2_TEXT, bank_id=bank_id, embedding_str=_to_str(embeddings[1]))
+        await _insert_unit(
+            conn, unit_id=non_src_id, text=NON_SRC_TEXT, bank_id=bank_id, embedding_str=_to_str(embeddings[2])
+        )
+        await _insert_unit(
+            conn,
+            unit_id=obs_id,
+            text=OBS_TEXT,
+            bank_id=bank_id,
+            embedding_str=_to_str(embeddings[3]),
+            fact_type="observation",
+            source_memory_ids=[uuid.UUID(src1_id), uuid.UUID(src2_id)],
+        )
+
+    ids = {"src1": src1_id, "src2": src2_id, "non_src": non_src_id, "obs": obs_id}
+    yield engine, bank_id, ids
+
+    await engine.delete_bank(bank_id, request_context=RC)
+
+
+class TestPreferObservations:
+    async def test_disabled_returns_sources_and_observation(self, seeded_obs_memory):
+        """Without the flag, the source facts AND the observation are all returned."""
+        engine, bank_id, ids = seeded_obs_memory
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            fact_type=["world", "experience", "observation"],
+            prefer_observations=False,
+            max_tokens=10000,
+        )
+        found = _result_ids(result)
+        assert ids["src1"] in found
+        assert ids["src2"] in found
+        assert ids["obs"] in found
+
+    async def test_enabled_drops_source_facts_keeps_observation(self, seeded_obs_memory):
+        """With the flag, the observation supersedes the facts it was consolidated from."""
+        engine, bank_id, ids = seeded_obs_memory
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            fact_type=["world", "experience", "observation"],
+            prefer_observations=True,
+            max_tokens=10000,
+        )
+        found = _result_ids(result)
+        assert ids["obs"] in found, "the observation must remain"
+        assert ids["src1"] not in found, "source fact 1 is superseded by the observation"
+        assert ids["src2"] not in found, "source fact 2 is superseded by the observation"
+
+    async def test_enabled_keeps_non_source_fact(self, seeded_obs_memory):
+        """Dedup is provenance-based: a similar fact NOT in source_memory_ids survives."""
+        engine, bank_id, ids = seeded_obs_memory
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            fact_type=["world", "experience", "observation"],
+            prefer_observations=True,
+            max_tokens=10000,
+        )
+        found = _result_ids(result)
+        assert ids["non_src"] in found, "a non-source fact must not be dropped, even if semantically similar"
+
+    async def test_noop_without_observation_type(self, seeded_obs_memory):
+        """The flag is a no-op when 'observation' is not among the requested types."""
+        engine, bank_id, ids = seeded_obs_memory
+        result = await engine.recall_async(
+            bank_id=bank_id,
+            query=QUERY,
+            request_context=RC,
+            fact_type=["world", "experience"],
+            prefer_observations=True,
+            max_tokens=10000,
+        )
+        found = _result_ids(result)
+        assert ids["src1"] in found
+        assert ids["src2"] in found
+
+
+def test_flag_is_opt_in_by_default():
+    """prefer_observations is opt-in: off at the API surface and the engine method.
+
+    The engine default in particular must stay False so internal callers — notably
+    consolidation, which needs the raw facts it folds into observations — are never
+    silently deduped.
+    """
+    import inspect
+
+    from hindsight_api.api.http import RecallRequest
+    from hindsight_api.engine.memory_engine import MemoryEngine
+
+    assert RecallRequest(query="anything").prefer_observations is False
+    engine_default = inspect.signature(MemoryEngine.recall_async).parameters["prefer_observations"].default
+    assert engine_default is False

--- a/hindsight-cli/src/commands/explore.rs
+++ b/hindsight-cli/src/commands/explore.rs
@@ -340,6 +340,7 @@ impl App {
                             max_tokens: query_max_tokens,
                             trace: false,
                             query_timestamp: None,
+                            prefer_observations: false,
                             include: None,
                             tags: None,
                             tags_match: TagsMatch::Any,

--- a/hindsight-cli/src/commands/memory.rs
+++ b/hindsight-cli/src/commands/memory.rs
@@ -277,6 +277,7 @@ pub fn recall(
     tags: Vec<String>,
     tags_match: Option<String>,
     query_timestamp: Option<String>,
+    prefer_observations: bool,
     verbose: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
@@ -310,6 +311,7 @@ pub fn recall(
         max_tokens,
         trace,
         query_timestamp,
+        prefer_observations,
         include,
         tags: if tags.is_empty() { None } else { Some(tags) },
         tags_match: parse_tags_match(&tags_match),

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -532,6 +532,10 @@ enum MemoryCommands {
         /// Reference timestamp for recall (ISO 8601, e.g. 2023-05-30T23:40:00)
         #[arg(long)]
         query_timestamp: Option<String>,
+
+        /// Prefer observations: drop raw facts a returned observation was consolidated from (no effect unless observation + a raw type are both recalled)
+        #[arg(long)]
+        prefer_observations: bool,
     },
 
     /// Generate answers using bank identity (reflect/reasoning)
@@ -1401,6 +1405,7 @@ fn run() -> Result<()> {
                 tags,
                 tags_match,
                 query_timestamp,
+                prefer_observations,
             } => commands::memory::recall(
                 &client,
                 &bank_id,
@@ -1414,6 +1419,7 @@ fn run() -> Result<()> {
                 tags,
                 tags_match,
                 query_timestamp,
+                prefer_observations,
                 verbose,
                 output_format,
             ),

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -7113,6 +7113,17 @@ components:
             type: string
           nullable: true
           type: array
+        prefer_observations:
+          default: false
+          description: "When recalling raw facts ('world'/'experience') together with\
+            \ 'observation', drop any raw fact that an observation in the results\
+            \ was consolidated from, so the observation supersedes it and you don't\
+            \ get duplicate content. The freed slots are backfilled with the next\
+            \ results, keeping the result count at the requested budget. Disabled\
+            \ by default; set to true to enable. No effect unless 'observation' and\
+            \ at least one raw type are both requested."
+          title: Prefer Observations
+          type: boolean
         budget:
           $ref: '#/components/schemas/Budget'
         max_tokens:

--- a/hindsight-clients/go/model_recall_request.go
+++ b/hindsight-clients/go/model_recall_request.go
@@ -23,6 +23,8 @@ var _ MappedNullable = &RecallRequest{}
 type RecallRequest struct {
 	Query string `json:"query"`
 	Types []string `json:"types,omitempty"`
+	// When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact that an observation in the results was consolidated from, so the observation supersedes it and you don't get duplicate content. The freed slots are backfilled with the next results, keeping the result count at the requested budget. Disabled by default; set to true to enable. No effect unless 'observation' and at least one raw type are both requested.
+	PreferObservations *bool `json:"prefer_observations,omitempty"`
 	Budget *Budget `json:"budget,omitempty"`
 	MaxTokens *int32 `json:"max_tokens,omitempty"`
 	Trace *bool `json:"trace,omitempty"`
@@ -44,6 +46,8 @@ type _RecallRequest RecallRequest
 func NewRecallRequest(query string) *RecallRequest {
 	this := RecallRequest{}
 	this.Query = query
+	var preferObservations bool = false
+	this.PreferObservations = &preferObservations
 	var maxTokens int32 = 4096
 	this.MaxTokens = &maxTokens
 	var trace bool = false
@@ -58,6 +62,8 @@ func NewRecallRequest(query string) *RecallRequest {
 // but it doesn't guarantee that properties required by API are set
 func NewRecallRequestWithDefaults() *RecallRequest {
 	this := RecallRequest{}
+	var preferObservations bool = false
+	this.PreferObservations = &preferObservations
 	var maxTokens int32 = 4096
 	this.MaxTokens = &maxTokens
 	var trace bool = false
@@ -122,6 +128,38 @@ func (o *RecallRequest) HasTypes() bool {
 // SetTypes gets a reference to the given []string and assigns it to the Types field.
 func (o *RecallRequest) SetTypes(v []string) {
 	o.Types = v
+}
+
+// GetPreferObservations returns the PreferObservations field value if set, zero value otherwise.
+func (o *RecallRequest) GetPreferObservations() bool {
+	if o == nil || IsNil(o.PreferObservations) {
+		var ret bool
+		return ret
+	}
+	return *o.PreferObservations
+}
+
+// GetPreferObservationsOk returns a tuple with the PreferObservations field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RecallRequest) GetPreferObservationsOk() (*bool, bool) {
+	if o == nil || IsNil(o.PreferObservations) {
+		return nil, false
+	}
+	return o.PreferObservations, true
+}
+
+// HasPreferObservations returns a boolean if a field has been set.
+func (o *RecallRequest) HasPreferObservations() bool {
+	if o != nil && !IsNil(o.PreferObservations) {
+		return true
+	}
+
+	return false
+}
+
+// SetPreferObservations gets a reference to the given bool and assigns it to the PreferObservations field.
+func (o *RecallRequest) SetPreferObservations(v bool) {
+	o.PreferObservations = &v
 }
 
 // GetBudget returns the Budget field value if set, zero value otherwise.
@@ -405,6 +443,9 @@ func (o RecallRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["query"] = o.Query
 	if o.Types != nil {
 		toSerialize["types"] = o.Types
+	}
+	if !IsNil(o.PreferObservations) {
+		toSerialize["prefer_observations"] = o.PreferObservations
 	}
 	if !IsNil(o.Budget) {
 		toSerialize["budget"] = o.Budget

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -409,6 +409,7 @@ class Hindsight:
         tags: list[str] | None = None,
         tags_match: Literal["any", "all", "any_strict", "all_strict", "exact"] = "any",
         tag_groups: list[dict[str, Any]] | None = None,
+        prefer_observations: bool = False,
     ) -> RecallResponse:
         """
         Recall memories using semantic similarity (sync wrapper — prefer :meth:`arecall` in async code).
@@ -433,6 +434,10 @@ class Hindsight:
                 "any_strict" (OR, excludes untagged), "all_strict" (AND, excludes untagged),
                 "exact" (set equality, excludes untagged). Default: "any"
             tag_groups: Optional list of tag group filters for advanced boolean tag matching.
+            prefer_observations: When recalling raw facts ("world"/"experience") together with
+                "observation", drop any raw fact a returned observation was consolidated from, so the
+                observation supersedes it (no duplicate content). Disabled by default; no effect unless
+                "observation" and at least one raw type are both in ``types``.
 
         Returns:
             RecallResponse with results, optional entities, optional chunks, optional source_facts, and optional trace
@@ -455,6 +460,7 @@ class Hindsight:
                 tags=tags,
                 tags_match=tags_match,
                 tag_groups=tag_groups,
+                prefer_observations=prefer_observations,
             )
         )
 
@@ -883,6 +889,7 @@ class Hindsight:
         tags: list[str] | None = None,
         tags_match: Literal["any", "all", "any_strict", "all_strict", "exact"] = "any",
         tag_groups: list[dict[str, Any]] | None = None,
+        prefer_observations: bool = False,
     ) -> RecallResponse:
         """
         Recall memories using semantic similarity (async — preferred over :meth:`recall`).
@@ -911,6 +918,11 @@ class Hindsight:
                 TagGroupOr, or TagGroupNot). Example::
 
                     [{"tags": ["customer"], "match": "all"}, {"not": {"tags": ["internal"]}}]
+
+            prefer_observations: When recalling raw facts ("world"/"experience") together with
+                "observation", drop any raw fact a returned observation was consolidated from, so the
+                observation supersedes it (no duplicate content). Disabled by default; no effect unless
+                "observation" and at least one raw type are both in ``types``.
 
         Returns:
             RecallResponse with results, optional entities, optional chunks, optional source_facts, and optional trace
@@ -941,6 +953,7 @@ class Hindsight:
         request_obj = recall_request.RecallRequest(
             query=query,
             types=types,
+            prefer_observations=prefer_observations,
             budget=budget,
             max_tokens=max_tokens,
             trace=trace,

--- a/hindsight-clients/python/hindsight_client_api/models/recall_request.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_request.py
@@ -31,6 +31,7 @@ class RecallRequest(BaseModel):
     """ # noqa: E501
     query: StrictStr
     types: Optional[List[StrictStr]] = None
+    prefer_observations: Optional[StrictBool] = Field(default=False, description="When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact that an observation in the results was consolidated from, so the observation supersedes it and you don't get duplicate content. The freed slots are backfilled with the next results, keeping the result count at the requested budget. Disabled by default; set to true to enable. No effect unless 'observation' and at least one raw type are both requested.")
     budget: Optional[Budget] = None
     max_tokens: Optional[StrictInt] = 4096
     trace: Optional[StrictBool] = False
@@ -39,7 +40,7 @@ class RecallRequest(BaseModel):
     tags: Optional[List[StrictStr]] = None
     tags_match: Optional[StrictStr] = Field(default='any', description="How to match tags: 'any' (OR, includes untagged), 'all' (AND, includes untagged), 'any_strict' (OR, excludes untagged), 'all_strict' (AND, excludes untagged).")
     tag_groups: Optional[List[MentalModelTriggerInputTagGroupsInner]] = None
-    __properties: ClassVar[List[str]] = ["query", "types", "budget", "max_tokens", "trace", "query_timestamp", "include", "tags", "tags_match", "tag_groups"]
+    __properties: ClassVar[List[str]] = ["query", "types", "prefer_observations", "budget", "max_tokens", "trace", "query_timestamp", "include", "tags", "tags_match", "tag_groups"]
 
     @field_validator('tags_match')
     def tags_match_validate_enum(cls, value):
@@ -134,6 +135,7 @@ class RecallRequest(BaseModel):
         _obj = cls.model_validate({
             "query": obj.get("query"),
             "types": obj.get("types"),
+            "prefer_observations": obj.get("prefer_observations") if obj.get("prefer_observations") is not None else False,
             "budget": obj.get("budget"),
             "max_tokens": obj.get("max_tokens") if obj.get("max_tokens") is not None else 4096,
             "trace": obj.get("trace") if obj.get("trace") is not None else False,

--- a/hindsight-clients/python/tests/test_recall_prefer_observations.py
+++ b/hindsight-clients/python/tests/test_recall_prefer_observations.py
@@ -1,0 +1,38 @@
+"""The maintained wrapper threads prefer_observations into the recall request."""
+
+from unittest.mock import MagicMock
+
+from hindsight_client import Hindsight
+
+
+def _capture_recall(monkeypatch, client, captured):
+    async def fake_recall(bank_id, request_obj, _request_timeout=None):
+        captured["request"] = request_obj
+        return MagicMock(results=[])
+
+    monkeypatch.setattr(client._memory_api, "recall_memories", fake_recall)
+
+
+def test_recall_threads_prefer_observations(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_recall(monkeypatch, client, captured)
+
+    client.recall(
+        "test-bank",
+        "q",
+        types=["world", "experience", "observation"],
+        prefer_observations=True,
+    )
+
+    assert captured["request"].prefer_observations is True
+
+
+def test_recall_prefer_observations_defaults_false(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_recall(monkeypatch, client, captured)
+
+    client.recall("test-bank", "q")
+
+    assert captured["request"].prefer_observations is False

--- a/hindsight-clients/rust/src/lib.rs
+++ b/hindsight-clients/rust/src/lib.rs
@@ -140,6 +140,7 @@ mod tests {
             query: "Who is Alice?".to_string(),
             max_tokens: 4096,
             trace: false,
+            prefer_observations: false,
             budget: None,
             include: None,
             query_timestamp: None,

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2897,6 +2897,12 @@ export type RecallRequest = {
    * List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified.
    */
   types?: Array<string> | null;
+  /**
+   * Prefer Observations
+   *
+   * When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact that an observation in the results was consolidated from, so the observation supersedes it and you don't get duplicate content. The freed slots are backfilled with the next results, keeping the result count at the requested budget. Disabled by default; set to true to enable. No effect unless 'observation' and at least one raw type are both requested.
+   */
+  prefer_observations?: boolean;
   budget?: Budget;
   /**
    * Max Tokens

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -317,6 +317,8 @@ export class HindsightClient {
     query: string,
     options?: {
       types?: string[];
+      /** When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact a returned observation was consolidated from, so the observation supersedes it (no duplicate content). Disabled by default; no effect unless 'observation' and at least one raw type are both in types. */
+      preferObservations?: boolean;
       maxTokens?: number;
       budget?: Budget;
       trace?: boolean;
@@ -344,6 +346,7 @@ export class HindsightClient {
       body: {
         query,
         types: options?.types,
+        prefer_observations: options?.preferObservations,
         max_tokens: options?.maxTokens,
         budget: options?.budget || "mid",
         trace: options?.trace,

--- a/hindsight-clients/typescript/tests/main_operations.test.ts
+++ b/hindsight-clients/typescript/tests/main_operations.test.ts
@@ -501,6 +501,25 @@ const canSpyOnModules = typeof (globalThis as any).Deno === "undefined";
     spy.mockRestore();
   });
 
+  test("recall threads preferObservations into request body", async () => {
+    const bankId = randomBankId();
+    const spy = jest.spyOn(sdk, "recallMemories").mockResolvedValue({
+      data: { results: [] },
+    } as any);
+
+    await client.recall(bankId, "test", {
+      types: ["world", "experience", "observation"],
+      preferObservations: true,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ prefer_observations: true }),
+      })
+    );
+    spy.mockRestore();
+  });
+
   test("getBankProfile passes abort signal to SDK", async () => {
     const bankId = randomBankId();
     const controller = new AbortController();

--- a/hindsight-control-plane/src/app/api/recall/route.ts
+++ b/hindsight-control-plane/src/app/api/recall/route.ts
@@ -10,6 +10,7 @@ export async function POST(request: NextRequest) {
       query,
       types,
       fact_type,
+      prefer_observations,
       max_tokens,
       trace,
       budget,
@@ -25,6 +26,7 @@ export async function POST(request: NextRequest) {
       body: {
         query,
         types: types || fact_type,
+        prefer_observations,
         max_tokens,
         trace,
         budget: budget || "mid",

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -343,6 +343,7 @@ export class ControlPlaneClient {
   async recall(params: {
     query: string;
     types?: string[];
+    prefer_observations?: boolean;
     bank_id: string;
     budget?: string;
     max_tokens?: number;

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -82,6 +82,12 @@ Each type runs the full four-strategy retrieval pipeline independently, so narro
 Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes), and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
 :::
 
+### prefer_observations
+
+Because observations are consolidated from raw facts, recalling `observation` alongside `world` and `experience` can return the same information twice — once as the raw fact and once folded into an observation. With `prefer_observations` you get the best of both: you still recall every type, but whenever an observation in the results was built from a raw fact, that raw fact is dropped so the observation supersedes it. The freed slots are backfilled with the next-best results, so you don't lose coverage.
+
+This lets you ask for everything without choosing between "raw facts only" (no consolidation) and "observations only" (which may lag behind the latest retains while consolidation catches up). **Disabled by default** — set it to `true` to opt in. It has no effect unless both `observation` and at least one of `world`/`experience` are included in `types`.
+
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10795,6 +10795,12 @@
             "title": "Types",
             "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified."
           },
+          "prefer_observations": {
+            "type": "boolean",
+            "title": "Prefer Observations",
+            "description": "When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact that an observation in the results was consolidated from, so the observation supersedes it and you don't get duplicate content. The freed slots are backfilled with the next results, keeping the result count at the requested budget. Disabled by default; set to true to enable. No effect unless 'observation' and at least one raw type are both requested.",
+            "default": false
+          },
           "budget": {
             "$ref": "#/components/schemas/Budget",
             "default": "mid"

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -153,6 +153,12 @@ hindsight memory recall my-bank "query" --fact-type world,observation
 > **💡 About Observations**
 > 
 Observations are deduplicated, evidence-grounded beliefs consolidated from multiple facts — preferences, recurring patterns, and durable learnings the memory bank has built up. Each observation references its supporting memories (with exact quotes), and is refined rather than overwritten when new evidence arrives. They are created and maintained automatically in the background after retain operations.
+### prefer_observations
+
+Because observations are consolidated from raw facts, recalling `observation` alongside `world` and `experience` can return the same information twice — once as the raw fact and once folded into an observation. With `prefer_observations` you get the best of both: you still recall every type, but whenever an observation in the results was built from a raw fact, that raw fact is dropped so the observation supersedes it. The freed slots are backfilled with the next-best results, so you don't lose coverage.
+
+This lets you ask for everything without choosing between "raw facts only" (no consolidation) and "observations only" (which may lag behind the latest retains while consolidation catches up). **Disabled by default** — set it to `true` to opt in. It has no effect unless both `observation` and at least one of `world`/`experience` are included in `types`.
+
 ### budget
 
 Controls retrieval depth and breadth. Accepted values are `low`, `mid` (default), and `high`. Use `low` for fast simple lookups, `mid` for balanced everyday queries, and `high` when you need to find indirect connections or exhaustive coverage.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10795,6 +10795,12 @@
             "title": "Types",
             "description": "List of fact types to recall: 'world', 'experience', 'observation'. Defaults to world and experience if not specified."
           },
+          "prefer_observations": {
+            "type": "boolean",
+            "title": "Prefer Observations",
+            "description": "When recalling raw facts ('world'/'experience') together with 'observation', drop any raw fact that an observation in the results was consolidated from, so the observation supersedes it and you don't get duplicate content. The freed slots are backfilled with the next results, keeping the result count at the requested budget. Disabled by default; set to true to enable. No effect unless 'observation' and at least one raw type are both requested.",
+            "default": false
+          },
           "budget": {
             "$ref": "#/components/schemas/Budget",
             "default": "mid"


### PR DESCRIPTION
## What

Adds an opt-in `prefer_observations` flag to recall. When you recall raw facts (`world`/`experience`) together with `observation`, any raw fact that a returned observation was consolidated from is dropped, so the observation supersedes it — no duplicate content.

**Disabled by default** — set `prefer_observations: true` to enable.

## Why

Today, recalling all types returns the same information twice — once as a raw fact and once folded into an observation built from it. Users had to choose between:
- raw facts only (no consolidation benefit), or
- observations only (which lag behind the latest retains while consolidation catches up).

This flag gives the best of both: recall everything, but prefer the observation whenever it already covers a raw fact.

## How

- Observations already store their provenance in `memory_units.source_memory_ids`. Dedup is an **exact id-membership filter** over that set — not semantic guessing. A fact that is semantically similar to an observation but not in its source list survives.
- Runs **before** the recall truncation, so the freed slots backfill with the next-best results and the result count stays at the requested budget.
- **Opt-in everywhere.** The engine method `recall_async` also defaults it to `False`, so internal callers — notably **consolidation**, which needs the raw facts it folds into observations — are never affected.

## Scope of changes

- `api/http.py` — `RecallRequest.prefer_observations` (default `false`), threaded to engine
- `engine/memory_engine.py` — Step 4.8 dedup in the recall pipeline
- `mcp_tools.py` — flag on both recall tool variants
- **Maintained client wrappers** — Python `recall`/`arecall` and TypeScript `recall` (the hand-written first-level methods, which don't auto-pick-up new fields)
- Regenerated OpenAPI + low-level Python/TS/Go/Rust SDKs
- Control plane proxy route + `lib/api.ts` types
- `docs/developer/api/recall.mdx`

## Tests

- `hindsight-api-slim/tests/test_recall_prefer_observations.py` — 5 passing (provenance-based dedup is deterministic, no LLM): disabled → all returned; enabled → sources dropped, observation kept; enabled → non-source survives (provenance, not semantics); no-op without `observation` in `types`; opt-in by default (API + engine both `False`).
- Maintained-wrapper passthrough tests (Python + TypeScript) asserting the flag reaches the recall request body.

## Notes

Since the flag is opt-in, there is no behavior change for existing recall callers. If we later want dedup on by default, that would be a follow-up — and would need to stay scoped to the user-facing surface, since the engine default must remain `False` for consolidation.
