### PR TITLE
fix(cache): prevent stale bank stats after concurrent invalidation

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
@@ -96,7 +96,10 @@ class BankStatsCache:
             value = await loader()
         except BaseException as exc:
             async with self._lock:
-                self._in_flight.pop(key, None)
+                # Invalidation may have detached this loader and allowed a new
+                # one to claim the key. Never remove that newer loader's slot.
+                if self._in_flight.get(key) is in_flight:
+                    self._in_flight.pop(key, None)
             if not in_flight.done():
                 in_flight.set_exception(exc)
             # Suppress "Future exception was never retrieved" when no other
@@ -106,8 +109,12 @@ class BankStatsCache:
             raise
 
         async with self._lock:
-            self._store_unlocked(key, value)
-            self._in_flight.pop(key, None)
+            # Only the loader that still owns the key may populate the cache.
+            # An invalidated loader can finish for its original callers, but its
+            # pre-invalidation result must not overwrite a newer load.
+            if self._in_flight.get(key) is in_flight:
+                self._store_unlocked(key, value)
+                self._in_flight.pop(key, None)
         if not in_flight.done():
             in_flight.set_result(value)
         return value
@@ -115,8 +122,13 @@ class BankStatsCache:
     async def invalidate(self, schema: str, bank_id: str) -> None:
         """Drop any cached stats for `(schema, bank_id)`."""
         async with self._lock:
-            self._entries.pop((schema, bank_id), None)
+            key = (schema, bank_id)
+            self._entries.pop(key, None)
+            # Detach rather than cancel: existing callers may finish with the
+            # snapshot they requested, while post-invalidation callers reload.
+            self._in_flight.pop(key, None)
 
     async def clear(self) -> None:
         async with self._lock:
             self._entries.clear()
+            self._in_flight.clear()

--- a/hindsight-api-slim/tests/test_bank_stats_cache.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache.py
@@ -187,6 +187,43 @@ async def test_invalidate_drops_entry() -> None:
 
 
 @pytest.mark.asyncio
+async def test_invalidate_detaches_in_flight_loader() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    stale_started = asyncio.Event()
+    release_stale = asyncio.Event()
+    fresh_started = asyncio.Event()
+
+    async def stale_loader() -> dict[str, Any]:
+        stale_started.set()
+        await release_stale.wait()
+        return {"v": "stale"}
+
+    async def fresh_loader() -> dict[str, Any]:
+        fresh_started.set()
+        return {"v": "fresh"}
+
+    stale_task = asyncio.create_task(cache.get_or_load("schema", "bank", stale_loader))
+    await stale_started.wait()
+    await cache.invalidate("schema", "bank")
+
+    # A request after invalidation must start a new load instead of joining the
+    # pre-invalidation query, which may contain data from before a bank write.
+    fresh_result = await asyncio.wait_for(cache.get_or_load("schema", "bank", fresh_loader), timeout=1)
+    assert fresh_started.is_set()
+    assert fresh_result == {"v": "fresh"}
+
+    release_stale.set()
+    assert await stale_task == {"v": "stale"}
+
+    # The stale loader completed last, but must not overwrite the fresh value.
+    async def should_not_run() -> dict[str, Any]:
+        raise AssertionError("fresh value was not cached")
+
+    cached = await cache.get_or_load("schema", "bank", should_not_run)
+    assert cached == {"v": "fresh"}
+
+
+@pytest.mark.asyncio
 async def test_clear_drops_all_entries() -> None:
     cache = BankStatsCache(ttl_seconds=60, max_entries=100)
     loader, calls = make_loader({"v": 1})
@@ -199,3 +236,27 @@ async def test_clear_drops_all_entries() -> None:
     await cache.get_or_load("s", "a", loader)
     await cache.get_or_load("s", "b", loader)
     assert calls[0] == 4
+
+
+@pytest.mark.asyncio
+async def test_clear_detaches_in_flight_loaders() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    stale_started = asyncio.Event()
+    release_stale = asyncio.Event()
+
+    async def stale_loader() -> dict[str, Any]:
+        stale_started.set()
+        await release_stale.wait()
+        return {"v": "stale"}
+
+    async def fresh_loader() -> dict[str, Any]:
+        return {"v": "fresh"}
+
+    stale_task = asyncio.create_task(cache.get_or_load("schema", "bank", stale_loader))
+    await stale_started.wait()
+    await cache.clear()
+    assert await cache.get_or_load("schema", "bank", fresh_loader) == {"v": "fresh"}
+
+    release_stale.set()
+    assert await stale_task == {"v": "stale"}
+    assert await cache.get_or_load("schema", "bank", fresh_loader) == {"v": "fresh"}


### PR DESCRIPTION
## Summary

Prevent an in-flight bank stats query from repopulating the cache with stale
data after the cache has been invalidated or cleared.

## Root cause

`BankStatsCache` coalesces concurrent cache misses using an in-flight future
stored by `(schema, bank_id)`.

`invalidate()` previously removed only the cached entry. If a stats query was
already running:

1. A bank mutation invalidated the cache.
2. Requests arriving after the mutation joined the old in-flight query.
3. The old query completed with pre-mutation data.
4. That stale result was stored for the full cache TTL.

The same race existed in `clear()`.

## Fix

- Detach in-flight loaders when invalidating a key or clearing the cache.
- Allow post-invalidation requests to start a fresh loader immediately.
- Require a loader to still own the key's in-flight slot before it may populate
  the cache or remove that slot.
- Let callers that started before invalidation finish with their original
  snapshot without allowing it to overwrite newer data.

## Tests

Added concurrent regression coverage for:

- invalidation while a loader is in flight;
- clearing while a loader is in flight;
- a stale loader completing after the fresh loader;
- preservation of the fresh cached result.

## Verification

Run on Linux x86_64 with Python 3.11, Node.js 22, and PostgreSQL 17 + pgvector:

- `12 passed` - `tests/test_bank_stats_cache.py`
- `17 passed` - `tests/test_bank_stats.py`
- `ty check hindsight_api` passed
- Full `./scripts/hooks/lint.sh` passed
