### PR TITLE
fix(control-plane): make max upload size configurable (#2313)

### DIFF
--- a/hindsight-control-plane/next.config.ts
+++ b/hindsight-control-plane/next.config.ts
@@ -11,6 +11,18 @@ const distDir = process.env.PORT && process.env.PORT !== '9999'
   ? `.next-${process.env.PORT}`
   : '.next';
 
+// Maximum upload/request body size for file retain. Next.js buffers request
+// bodies that pass through middleware/proxy (the auth middleware does, for
+// /api/files/retain) and truncates anything over this limit (default 10MB),
+// which silently corrupts large document uploads. Default to 100MB to match the
+// dataplane's HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE_MB default; accepts a
+// human-readable size string ('100mb', '1gb') or a number of bytes.
+type SizeLimit = NonNullable<NonNullable<NextConfig['experimental']>['proxyClientMaxBodySize']>;
+const maxUploadEnv = process.env.HINDSIGHT_CP_MAX_UPLOAD_SIZE;
+const maxUploadBodySize: SizeLimit = maxUploadEnv
+  ? (/^\d+$/.test(maxUploadEnv) ? Number(maxUploadEnv) : (maxUploadEnv as SizeLimit))
+  : '100mb';
+
 const nextConfig: NextConfig = {
   output: 'standalone',
   distDir,
@@ -18,6 +30,9 @@ const nextConfig: NextConfig = {
   assetPrefix: basePath,
   // Disable request logging in production
   logging: false,
+  experimental: {
+    proxyClientMaxBodySize: maxUploadBodySize,
+  },
   // Set the monorepo root explicitly to avoid detecting wrong lockfiles in parent directories
   turbopack: {
     root: path.resolve(__dirname, '..'),

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1747,6 +1747,7 @@ The Control Plane is the web UI for managing memory banks.
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
 | `HINDSIGHT_CP_DATAPLANE_API_KEY` | Bearer token the Control Plane sends as `Authorization: Bearer <key>` on every request to the API service. Required when the API service is auth-protected; omit for a public API. | *(none — no `Authorization` header sent)* |
 | `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
+| `HINDSIGHT_CP_MAX_UPLOAD_SIZE` | Maximum size of a single file-upload request the Control Plane accepts before truncating it. Accepts a size string (`100mb`, `1gb`) or a number of bytes. Raise this to upload files larger than the default, and keep it in line with the API's `HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE_MB`. | `100mb` |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash


### PR DESCRIPTION
## Problem

Fixes #2313. Uploading a single file larger than 10MB via the Control Plane silently fails — the dialog never closes and the logs show:

```
Request body exceeded 10MB for /api/files/retain. Only the first 10MB will be available unless configured.
Error uploading files: TypeError: Failed to parse body as FormData.
```

## Root cause

This is the **Control Plane (Next.js)**, not the dataplane. The auth middleware sits in front of `/api/files/retain`, so Next.js buffers the proxied request body and truncates anything over its default **10MB** limit (`DEFAULT_BODY_CLONE_SIZE_LIMIT`, configured via `proxyClientMaxBodySize`). The route then tries to parse a truncated multipart body and throws `Failed to parse body as FormData`, so the request never reaches the dataplane.

The dataplane already allows 100MB and is already configurable (`HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE_MB`), so the Control Plane was the lone bottleneck.

## Fix

Set Next's `experimental.proxyClientMaxBodySize` in `next.config.ts`:

- **Default raised to `100mb`**, matching the dataplane's `HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE_MB` default.
- **Configurable** via the new `HINDSIGHT_CP_MAX_UPLOAD_SIZE` env var — accepts a size string (`100mb`, `1gb`) or a raw byte count.

Note: installed Next is 16.2.9, where the canonical key is `proxyClientMaxBodySize` (the older `middlewareClientMaxBodySize` alias is still in the schema but is no longer read).

## Verification

- Loaded the config through Next's own `loadConfig` + zod validation: default `100mb` → `104857600` bytes, override `250mb` → `262144000`, raw byte counts pass through. No validation errors or unknown-key warnings.
- `tsc --noEmit` and `./scripts/hooks/lint.sh` pass.

## Docs

Added `HINDSIGHT_CP_MAX_UPLOAD_SIZE` to the Control Plane table in `developer/configuration.md`.
