### PR TITLE
docs(python-client): drop removed 'opinion' fact type from recall()/arecall() docstrings

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -416,7 +416,7 @@ class Hindsight:
         Args:
             bank_id: The memory bank ID
             query: Search query
-            types: Optional list of fact types to filter (world, experience, opinion, observation)
+            types: Optional list of fact types to filter (world, experience, observation)
             max_tokens: Maximum tokens in results (default: 4096)
             budget: Budget level for recall - "low", "mid", or "high" (default: "mid")
             trace: Enable trace output (default: False)
@@ -890,7 +890,7 @@ class Hindsight:
         Args:
             bank_id: The memory bank ID
             query: Search query
-            types: Optional list of fact types to filter (world, experience, opinion, observation)
+            types: Optional list of fact types to filter (world, experience, observation)
             max_tokens: Maximum tokens in results (default: 4096)
             budget: Budget level for recall - "low", "mid", or "high" (default: "mid")
             trace: Enable trace output (default: False)


### PR DESCRIPTION
The maintained Python SDK wrapper's `recall()` and `arecall()` docstrings still list `opinion` as a valid fact-type filter:

```
types: Optional list of fact types to filter (world, experience, opinion, observation)
```

But `opinion` was removed in v0.8.0 (#1917); the API now enforces `fact_type IN ('world', 'experience', 'observation')`. The same file's `reflect()`/`areflect()` docstrings were already corrected to `(world, experience, observation)` — this brings `recall()`/`arecall()` in line, so callers copying the docstring no longer pass a value the API rejects.

Docstring-only; no behavior change. This file is the maintained wrapper (not auto-generated), so no client regeneration is needed.