### PR TITLE
fix(claude-code): use realpath for directoryBankMap symlink resolution

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -95,9 +95,9 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
         # case-sensitive compare silently misses the map and falls through
         # to the default bank. normcase is a no-op on POSIX, preserving
         # case-sensitive matching there.
-        normalized_cwd = os.path.normcase(os.path.normpath(cwd))
+        normalized_cwd = os.path.normcase(os.path.realpath(cwd))
         for dir_path, bank_id in dir_map.items():
-            if os.path.normcase(os.path.normpath(dir_path)) == normalized_cwd:
+            if os.path.normcase(os.path.realpath(dir_path)) == normalized_cwd:
                 return f"{prefix}-{bank_id}" if prefix else bank_id
 
     if not config.get("dynamicBankId", False):

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -296,3 +296,14 @@ class TestEnsureBankMission:
         ensure_bank_mission(client, "bank-x", cfg)
         ensure_bank_mission(client, "bank-y", cfg)
         assert client.set_bank_mission.call_count == 2
+
+    @pytest.mark.skipif(not hasattr(__import__("os"), "symlink"), reason="symlinks not supported")
+    def test_directorybankmap_matches_symlinked_cwd(self, tmp_path):
+        import os
+        real = os.path.realpath(tmp_path / "proj")
+        os.makedirs(real)
+        link = str(tmp_path / "proj-link")
+        os.symlink(real, link)
+        cfg = _cfg(directoryBankMap={real: "myproj"}, bankId="fallback")
+        assert derive_bank_id({"cwd": real, "session_id": "s"}, cfg) == "myproj"
+        assert derive_bank_id({"cwd": link, "session_id": "s"}, cfg) == "myproj"


### PR DESCRIPTION
## Problem

`directoryBankMap` entries are matched against the session `cwd` using `os.path.normpath`, which does **not** resolve symlinks. When the `cwd` is a symlink to a mapped directory (or when the map key itself is a symlink), the comparison silently fails and memory is routed to the wrong bank with no error.

Reported in #2312.

## Fix

Replace `os.path.normpath` with `os.path.realpath` on both sides of the comparison in `derive_bank_id()`. `realpath` resolves symlinks before normalizing, so a directory and any symlink pointing to it produce the same canonical path string.

```python
# Before
normalized_cwd = os.path.normcase(os.path.normpath(cwd))
if os.path.normcase(os.path.normpath(dir_path)) == normalized_cwd:

# After
normalized_cwd = os.path.normcase(os.path.realpath(cwd))
if os.path.normcase(os.path.realpath(dir_path)) == normalized_cwd:
```

`os.path.realpath` is available on all platforms (POSIX and Windows). `normcase` is preserved for Windows drive-letter case-folding.

## Test

Added `test_directorybankmap_matches_symlinked_cwd` to `TestDirectoryBankMap` — creates a real directory and a symlink to it, verifies both paths resolve to the mapped bank. The test is skipped on platforms that don't support symlinks.

## Affected scope

- `hindsight-integrations/claude-code/scripts/lib/bank.py` — 2-line change
- `hindsight-integrations/claude-code/tests/test_bank.py` — 1 new test