### PR TITLE
docs(models): sync anthropic default model to claude-haiku-4-5 alias

### DIFF
--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -106,7 +106,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 
 **Example:** Setting just the provider uses its default model:
 ```bash
-# Uses claude-haiku-4-5-20251001 automatically
+# Uses claude-haiku-4-5 automatically
 export HINDSIGHT_API_LLM_PROVIDER=anthropic
 export HINDSIGHT_API_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
 ```
@@ -124,7 +124,7 @@ This also applies to per-operation overrides:
 # Global: OpenAI gpt-4o-mini (default)
 export HINDSIGHT_API_LLM_PROVIDER=openai
 
-# Retain: Anthropic claude-haiku-4-5-20251001 (default)
+# Retain: Anthropic claude-haiku-4-5 (default)
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=anthropic
 ```
 

--- a/hindsight-docs/src/data/llmProviders.json
+++ b/hindsight-docs/src/data/llmProviders.json
@@ -1,6 +1,6 @@
 [
   {"id": "openai",        "label": "OpenAI",            "iconKey": "openai",             "defaultModel": "gpt-4o-mini", "batchApi": true},
-  {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5-20251001"},
+  {"id": "anthropic",     "label": "Anthropic",         "iconKey": "anthropic",          "defaultModel": "claude-haiku-4-5"},
   {"id": "gemini",        "label": "Google Gemini",     "iconKey": "gemini",             "defaultModel": "gemini-3.5-flash", "batchApi": true, "promptCaching": true},
   {"id": "vertexai",      "label": "Vertex AI",         "iconKey": "gemini",             "defaultModel": "google/gemini-3.1-flash-lite", "promptCaching": true},
   {"id": "groq",          "label": "Groq",              "iconKey": "zap",                "defaultModel": "openai/gpt-oss-120b", "batchApi": true},

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -139,7 +139,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 | Provider | Default Model |
 |----------|--------------|
 | `openai` | `gpt-4o-mini` |
-| `anthropic` | `claude-haiku-4-5-20251001` |
+| `anthropic` | `claude-haiku-4-5` |
 | `gemini` | `gemini-3.5-flash` |
 | `vertexai` | `google/gemini-3.1-flash-lite` |
 | `groq` | `openai/gpt-oss-120b` |
@@ -162,7 +162,7 @@ Each provider has a recommended default model that's used when `HINDSIGHT_API_LL
 
 **Example:** Setting just the provider uses its default model:
 ```bash
-# Uses claude-haiku-4-5-20251001 automatically
+# Uses claude-haiku-4-5 automatically
 export HINDSIGHT_API_LLM_PROVIDER=anthropic
 export HINDSIGHT_API_LLM_API_KEY=sk-ant-xxxxxxxxxxxx
 ```
@@ -180,7 +180,7 @@ This also applies to per-operation overrides:
 # Global: OpenAI gpt-4o-mini (default)
 export HINDSIGHT_API_LLM_PROVIDER=openai
 
-# Retain: Anthropic claude-haiku-4-5-20251001 (default)
+# Retain: Anthropic claude-haiku-4-5 (default)
 export HINDSIGHT_API_RETAIN_LLM_PROVIDER=anthropic
 ```
 


### PR DESCRIPTION
## Problem

The `anthropic` provider's runtime default model is the self-updating alias `claude-haiku-4-5` (`hindsight-api-slim/hindsight_api/config.py` `PROVIDER_DEFAULT_MODELS["anthropic"]`, enforced by `tests/test_provider_default_models.py`), but the Models docs advertised the date-pinned snapshot `claude-haiku-4-5-20251001`.

A pinned snapshot and a self-updating alias behave differently for pricing and model retirement, so the page misinforms anyone selecting the anthropic provider. It also contradicted `docs-integrations/hermes.md`, which already says `claude-haiku-4-5`.

## Fix

Sync the canonical sources to the alias and regenerate the docs skill mirror:

- `hindsight-docs/src/data/llmProviders.json` — anthropic `defaultModel`
- `hindsight-docs/docs/developer/models.mdx` — the two default-model examples
- `skills/hindsight-docs/references/developer/models.md` — regenerated via `./scripts/generate-docs-skill.sh`

Pure docs/data sync, no behavior change. Confirmed `generate-docs-skill.sh` produces no diff beyond this change. The historical `versioned_docs/` snapshots are intentionally left untouched.