### PR TITLE
docs(admin-cli): document run-db-migration --skip-extension-reconcile and --embedding-dimension

### DIFF
--- a/hindsight-docs/docs/developer/admin-cli.md
+++ b/hindsight-docs/docs/developer/admin-cli.md
@@ -49,6 +49,8 @@ hindsight-admin run-db-migration [OPTIONS]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--schema`, `-s` | Database schema to run migrations on. If omitted, migrate the base schema plus all discovered tenant schemas. | All schemas |
+| `--embedding-dimension` | Expected embedding dimension to enforce after migrations. Omit to skip the post-migration dimension sync. | Skipped |
+| `--skip-extension-reconcile` | Skip the post-migration vector / text-search index reconcile (it only does work when `HINDSIGHT_API_VECTOR_EXTENSION` / `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` differs from a schema's existing indexes). Makes a no-change re-migration across many tenant schemas much faster; only use when the backend is unchanged. | Reconcile runs |
 
 **Examples:**
 

--- a/skills/hindsight-docs/references/developer/admin-cli.md
+++ b/skills/hindsight-docs/references/developer/admin-cli.md
@@ -49,6 +49,8 @@ hindsight-admin run-db-migration [OPTIONS]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--schema`, `-s` | Database schema to run migrations on. If omitted, migrate the base schema plus all discovered tenant schemas. | All schemas |
+| `--embedding-dimension` | Expected embedding dimension to enforce after migrations. Omit to skip the post-migration dimension sync. | Skipped |
+| `--skip-extension-reconcile` | Skip the post-migration vector / text-search index reconcile (it only does work when `HINDSIGHT_API_VECTOR_EXTENSION` / `HINDSIGHT_API_TEXT_SEARCH_EXTENSION` differs from a schema's existing indexes). Makes a no-change re-migration across many tenant schemas much faster; only use when the backend is unchanged. | Reconcile runs |
 
 **Examples:**
 


### PR DESCRIPTION
## Problem

The `run-db-migration` Options table in `developer/admin-cli.md` lists only `--schema`, but `hindsight-api-slim/hindsight_api/admin/cli.py` exposes two more operator-facing flags:

- `--embedding-dimension` — enforce an expected embedding dimension after migrations (omit to skip the dimension sync).
- `--skip-extension-reconcile` — added in #2309; skip the post-migration vector/text-search index reconcile to speed up no-change re-migrations across many tenant schemas when the backend is unchanged.

Operators running migrations manually (CI/CD, large multi-tenant deployments) can't discover these from the docs today.

## Fix

Add both rows to the existing Options table on the canonical source doc and regenerate the docs skill mirror:

- `hindsight-docs/docs/developer/admin-cli.md`
- `skills/hindsight-docs/references/developer/admin-cli.md` — regenerated via `./scripts/generate-docs-skill.sh`

Descriptions are taken from the flags' `typer.Option` help text. Pure docs, no behavior change.