### PR TITLE
fix(release): build Linux CLI on ubuntu-22.04 (glibc 2.35) so binaries run on older distros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact_name: hindsight
             asset_name: hindsight-linux-amd64
@@ -278,7 +278,7 @@ jobs:
             target: aarch64-apple-darwin
             artifact_name: hindsight
             asset_name: hindsight-darwin-arm64
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             artifact_name: hindsight
             asset_name: hindsight-linux-arm64


### PR DESCRIPTION
### Problem (#2321)

The released Linux `hindsight` CLI binaries are built by the `release-rust-cli` job on **glibc-2.39** GitHub runners:

- `x86_64-unknown-linux-gnu` → `ubuntu-latest` (= Ubuntu 24.04, glibc 2.39)
- `aarch64-unknown-linux-gnu` → `ubuntu-24.04-arm` (glibc 2.39)

`cargo build --release` links dynamically against the build host's glibc, so the shipped binary requires `GLIBC_2.39`, which only Ubuntu 24.04 / Debian 13 provide. On anything older it fails at startup exactly as reported:

```
hindsight: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by hindsight)
```

### Fix

Pin both Linux build legs to **ubuntu-22.04** (glibc **2.35**), the oldest GitHub-hosted Ubuntu runner:

- `ubuntu-latest` → `ubuntu-22.04` (amd64)
- `ubuntu-24.04-arm` → `ubuntu-22.04-arm` (arm64)

`ubuntu-22.04-arm` is a maintained GitHub-hosted arm64 runner label ([actions/runner-images](https://github.com/actions/runner-images/blob/main/README.md)), so the arm64 leg keeps shipping. No `Cargo.toml` / TLS / dependency changes. macOS targets are untouched.

This restores runnability on **Ubuntu 22.04+, Debian 12, RHEL/Rocky/Alma 9**, etc.

### Scope / what this does *not* cover

The reporter's `### Option A` suggested Ubuntu **20.04** (glibc 2.31), but GitHub **retired the `ubuntu-20.04` hosted runner in April 2025**, so 22.04 (glibc 2.35) is the lowest floor reachable with hosted runners. This therefore does **not** fix systems on glibc < 2.35 — Ubuntu 20.04 (2.31), Debian 11, RHEL/CentOS 8 (2.28), or Alpine.

For *full* coverage including those, the reporter's `### Option B` (the fully-static `x86_64-unknown-linux-musl` target) is the complete fix. That's a larger change — `hindsight-cli` pulls `reqwest` with default features (native-tls/OpenSSL), so musl-static would mean `default-features = false` + `rustls-tls`, i.e. a TLS-stack swap worth reviewing on its own. Happy to send that as a follow-up if you'd prefer the broader floor; this PR is the clean, low-risk improvement that fixes the large majority of current LTS/enterprise deployments.

Addresses #2321 (leaving the issue open in case you want the musl path for glibc < 2.35).
