### PR TITLE
Add a failover LLM in case the primary one becomes unavailable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # Reasoning effort for providers/models that support it. Examples: low, medium, high, xhigh.
 # HINDSIGHT_API_LLM_REASONING_EFFORT=low
 
+# Failover LLM provider (optional). When set, calls that fail after the primary
+# exhausts HINDSIGHT_API_LLM_MAX_RETRIES are re-dispatched to this provider.
+# Backwards compatible: leave all four unset to keep behaviour identical to
+# pre-failover releases. See docs/developer/configuration.md for the full table.
+# HINDSIGHT_API_LLM_FAILOVER_PROVIDER=anthropic
+# HINDSIGHT_API_LLM_FAILOVER_API_KEY=
+# HINDSIGHT_API_LLM_FAILOVER_MODEL=claude-3-5-sonnet-latest
+# HINDSIGHT_API_LLM_FAILOVER_BASE_URL=
+
 # Example: Anthropic Claude configuration
 # HINDSIGHT_API_LLM_PROVIDER=anthropic
 # HINDSIGHT_API_LLM_API_KEY=your-anthropic-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ logs/
 # Generated docs files
 hindsight-docs/static/llms-full.txt
 
+# Local-only superpowers plan/scratch dir
+docs/superpowers/
+
 
 hindsight-dev/benchmarks/locomo/results/
 hindsight-dev/benchmarks/longmemeval/results/

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -156,6 +156,15 @@ ENV_LLM_SEND_BANK_AS_USER = "HINDSIGHT_API_LLM_SEND_BANK_AS_USER"
 # disambiguates from the embeddings/reranker LITELLM_* settings.
 ENV_LLM_LITELLMROUTER_CONFIG = "HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG"
 
+# Failover LLM provider (optional, server-level only). When set, calls that
+# raise after the primary's max_retries are re-dispatched to this provider.
+# Backwards compatible: when unset, the failover composite is bypassed
+# entirely — MemoryEngine wires the bare primary as before.
+ENV_LLM_FAILOVER_PROVIDER = "HINDSIGHT_API_LLM_FAILOVER_PROVIDER"
+ENV_LLM_FAILOVER_API_KEY = "HINDSIGHT_API_LLM_FAILOVER_API_KEY"
+ENV_LLM_FAILOVER_MODEL = "HINDSIGHT_API_LLM_FAILOVER_MODEL"
+ENV_LLM_FAILOVER_BASE_URL = "HINDSIGHT_API_LLM_FAILOVER_BASE_URL"
+
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
 DEFAULT_LLM_OPENAI_SERVICE_TIER = None  # None (default) or "flex" (50% cheaper)
@@ -1358,6 +1367,16 @@ class HindsightConfig:
     # CachedContent prefix for its system prompt + response schema.
     llm_prompt_cache_enabled: bool
 
+    # Failover LLM provider (optional). None on all four = failover disabled.
+    # When llm_failover_provider is set, MemoryEngine wraps each LLM provider
+    # (default + per-op) in a FailoverLLMProvider composite that re-dispatches
+    # calls to this provider when the primary raises after its retries are
+    # exhausted. See engine/failover_llm.py.
+    llm_failover_provider: str | None
+    llm_failover_api_key: str | None
+    llm_failover_model: str | None
+    llm_failover_base_url: str | None
+
     # Built-in llama.cpp configuration (for provider=llamacpp)
     llamacpp_model_path: str | None  # Path to GGUF file (None = auto-download default)
     llamacpp_gpu_layers: int  # -1 = all layers on GPU, 0 = CPU only
@@ -1722,6 +1741,7 @@ class HindsightConfig:
         "retain_llm_api_key",
         "reflect_llm_api_key",
         "consolidation_llm_api_key",
+        "llm_failover_api_key",
         # LiteLLM Router chains — entries embed api_keys and base_urls
         "llm_litellmrouter_config",
         "retain_llm_litellmrouter_config",
@@ -1732,6 +1752,7 @@ class HindsightConfig:
         "retain_llm_base_url",
         "reflect_llm_base_url",
         "consolidation_llm_base_url",
+        "llm_failover_base_url",
         "embeddings_tei_base_url",
         "reranker_tei_base_url",
         "reranker_cohere_base_url",
@@ -2059,6 +2080,10 @@ class HindsightConfig:
                 ENV_LLM_PROMPT_CACHE_ENABLED, str(DEFAULT_LLM_PROMPT_CACHE_ENABLED)
             ).lower()
             in ("1", "true", "yes", "on"),
+            llm_failover_provider=os.getenv(ENV_LLM_FAILOVER_PROVIDER) or None,
+            llm_failover_api_key=os.getenv(ENV_LLM_FAILOVER_API_KEY) or None,
+            llm_failover_model=os.getenv(ENV_LLM_FAILOVER_MODEL) or None,
+            llm_failover_base_url=os.getenv(ENV_LLM_FAILOVER_BASE_URL) or None,
             # Built-in llama.cpp configuration
             llamacpp_model_path=os.getenv(ENV_LLAMACPP_MODEL_PATH) or None,
             llamacpp_gpu_layers=int(os.getenv(ENV_LLAMACPP_GPU_LAYERS, str(DEFAULT_LLAMACPP_GPU_LAYERS))),

--- a/hindsight-api-slim/hindsight_api/engine/failover_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/failover_llm.py
@@ -1,0 +1,192 @@
+"""Optional failover composite for LLMProvider.
+
+When configured, FailoverLLMProvider wraps a primary and a failover LLMProvider
+and re-dispatches calls to the failover when the primary raises after its
+internal retries are exhausted. See docs/superpowers/plans/2026-06-19-llm-failover-provider.md
+for the design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .llm_interface import OutputTooLongError
+
+if TYPE_CHECKING:
+    from .llm_wrapper import ConfiguredLLMProvider, LLMProvider
+    from .response_models import LLMToolCallResult
+
+
+logger = logging.getLogger(__name__)
+
+
+def _should_failover(error: BaseException) -> bool:
+    """True if the failover composite should re-dispatch to the failover provider.
+
+    Re-dispatch on transient/provider errors; propagate deterministic failures
+    (output-too-long, cancellation) unchanged.
+    """
+    if isinstance(error, OutputTooLongError):
+        return False
+    if isinstance(error, asyncio.CancelledError):
+        return False
+    return True
+
+
+class FailoverLLMProvider:
+    """Composite wrapping a primary LLMProvider and an optional failover.
+
+    Exposes the same public surface as LLMProvider (call, call_with_tools,
+    with_config, verify_connection, cleanup, attribute passthrough). When the
+    primary raises a non-deterministic error, the same call is re-dispatched
+    to the failover with identical arguments.
+
+    Backwards compatibility note: when failover is None this composite still
+    works (no-op fallback path), but MemoryEngine should construct a bare
+    LLMProvider in that case to keep the hot path identical.
+    """
+
+    def __init__(self, primary: "LLMProvider", failover: "LLMProvider | None") -> None:
+        self._primary = primary
+        self._failover = failover
+
+    # ── attribute passthrough ──────────────────────────────────────────────────
+
+    def __getattr__(self, name: str) -> Any:
+        # Only invoked when normal lookup fails — forward to primary for
+        # back-compat with code reading .provider, .model, ._client, etc.
+        return getattr(self._primary, name)
+
+    # ── core call methods ──────────────────────────────────────────────────────
+
+    async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
+        try:
+            return await self._primary.call(messages=messages, **kwargs)
+        except BaseException as primary_error:
+            if self._failover is None or not _should_failover(primary_error):
+                raise
+            logger.warning(
+                "Primary LLM %s/%s failed after retries; falling over to %s/%s: %s",
+                self._primary.provider,
+                self._primary.model,
+                self._failover.provider,
+                self._failover.model,
+                primary_error,
+            )
+            return await self._failover.call(messages=messages, **kwargs)
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> "LLMToolCallResult":
+        try:
+            return await self._primary.call_with_tools(messages=messages, tools=tools, **kwargs)
+        except BaseException as primary_error:
+            if self._failover is None or not _should_failover(primary_error):
+                raise
+            logger.warning(
+                "Primary LLM %s/%s call_with_tools failed; falling over to %s/%s: %s",
+                self._primary.provider,
+                self._primary.model,
+                self._failover.provider,
+                self._failover.model,
+                primary_error,
+            )
+            return await self._failover.call_with_tools(messages=messages, tools=tools, **kwargs)
+
+    # ── lifecycle ──────────────────────────────────────────────────────────────
+
+    async def verify_connection(self) -> None:
+        """Verify primary hard, failover soft.
+
+        Primary failure raises (same as today). Failover failure logs a warning
+        and continues — a misconfigured failover should not block startup.
+        """
+        await self._primary.verify_connection()
+        if self._failover is None:
+            return
+        try:
+            await self._failover.verify_connection()
+        except Exception as e:
+            logger.warning(
+                "Failover LLM %s/%s verify_connection failed; failover will be unavailable: %s",
+                self._failover.provider,
+                self._failover.model,
+                e,
+            )
+
+    async def cleanup(self) -> None:
+        await self._primary.cleanup()
+        if self._failover is not None:
+            await self._failover.cleanup()
+
+    # ── per-bank configuration ─────────────────────────────────────────────────
+
+    def with_config(
+        self,
+        config: Any,
+        *,
+        bank_id: str | None = None,
+        operation: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> "ConfiguredFailoverLLMProvider":
+        """Mirror LLMProvider.with_config(), returning a configured failover composite."""
+        primary_cfg = self._primary.with_config(config, bank_id=bank_id, operation=operation, metadata=metadata)
+        failover_cfg = (
+            self._failover.with_config(config, bank_id=bank_id, operation=operation, metadata=metadata)
+            if self._failover is not None
+            else None
+        )
+        return ConfiguredFailoverLLMProvider(primary_cfg, failover_cfg)
+
+
+class ConfiguredFailoverLLMProvider:
+    """Companion to FailoverLLMProvider for the configured (per-bank) path.
+
+    Holds two ConfiguredLLMProvider instances and applies the same failover
+    logic at the call() / call_with_tools() layer.
+    """
+
+    def __init__(
+        self,
+        primary: "ConfiguredLLMProvider",
+        failover: "ConfiguredLLMProvider | None",
+    ) -> None:
+        self._primary = primary
+        self._failover = failover
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._primary, name)
+
+    async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
+        try:
+            return await self._primary.call(messages=messages, **kwargs)
+        except BaseException as primary_error:
+            if self._failover is None or not _should_failover(primary_error):
+                raise
+            logger.warning("Primary LLM failed (configured path); falling over: %s", primary_error)
+            return await self._failover.call(messages=messages, **kwargs)
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> "LLMToolCallResult":
+        try:
+            return await self._primary.call_with_tools(messages=messages, tools=tools, **kwargs)
+        except BaseException as primary_error:
+            if self._failover is None or not _should_failover(primary_error):
+                raise
+            logger.warning(
+                "Primary LLM call_with_tools failed (configured path); falling over: %s",
+                primary_error,
+            )
+            return await self._failover.call_with_tools(messages=messages, tools=tools, **kwargs)
+
+    def trace_context(self) -> Any | None:
+        return self._primary.trace_context()

--- a/hindsight-api-slim/hindsight_api/engine/failover_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/failover_llm.py
@@ -8,7 +8,6 @@ for the design.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -22,15 +21,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _should_failover(error: BaseException) -> bool:
+def _should_failover(error: Exception) -> bool:
     """True if the failover composite should re-dispatch to the failover provider.
 
     Re-dispatch on transient/provider errors; propagate deterministic failures
-    (output-too-long, cancellation) unchanged.
+    (output-too-long) unchanged. CancelledError, KeyboardInterrupt, and SystemExit
+    are not caught here at all (they inherit from BaseException, not Exception).
     """
     if isinstance(error, OutputTooLongError):
-        return False
-    if isinstance(error, asyncio.CancelledError):
         return False
     return True
 
@@ -64,7 +62,7 @@ class FailoverLLMProvider:
     async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
         try:
             return await self._primary.call(messages=messages, **kwargs)
-        except BaseException as primary_error:
+        except Exception as primary_error:
             if self._failover is None or not _should_failover(primary_error):
                 raise
             logger.warning(
@@ -85,7 +83,7 @@ class FailoverLLMProvider:
     ) -> "LLMToolCallResult":
         try:
             return await self._primary.call_with_tools(messages=messages, tools=tools, **kwargs)
-        except BaseException as primary_error:
+        except Exception as primary_error:
             if self._failover is None or not _should_failover(primary_error):
                 raise
             logger.warning(
@@ -165,10 +163,17 @@ class ConfiguredFailoverLLMProvider:
     async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
         try:
             return await self._primary.call(messages=messages, **kwargs)
-        except BaseException as primary_error:
+        except Exception as primary_error:
             if self._failover is None or not _should_failover(primary_error):
                 raise
-            logger.warning("Primary LLM failed (configured path); falling over: %s", primary_error)
+            logger.warning(
+                "Primary LLM %s/%s failed (configured path); falling over to %s/%s: %s",
+                self._primary.provider,
+                self._primary.model,
+                self._failover.provider,
+                self._failover.model,
+                primary_error,
+            )
             return await self._failover.call(messages=messages, **kwargs)
 
     async def call_with_tools(
@@ -179,11 +184,15 @@ class ConfiguredFailoverLLMProvider:
     ) -> "LLMToolCallResult":
         try:
             return await self._primary.call_with_tools(messages=messages, tools=tools, **kwargs)
-        except BaseException as primary_error:
+        except Exception as primary_error:
             if self._failover is None or not _should_failover(primary_error):
                 raise
             logger.warning(
-                "Primary LLM call_with_tools failed (configured path); falling over: %s",
+                "Primary LLM %s/%s call_with_tools failed (configured path); falling over to %s/%s: %s",
+                self._primary.provider,
+                self._primary.model,
+                self._failover.provider,
+                self._failover.model,
                 primary_error,
             )
             return await self._failover.call_with_tools(messages=messages, tools=tools, **kwargs)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -347,6 +347,7 @@ from enum import Enum
 
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
+from .failover_llm import FailoverLLMProvider
 from .llm_wrapper import LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
 from .query_analyzer import QueryAnalyzer
 from .reflect import run_reflect_agent
@@ -954,8 +955,54 @@ class MemoryEngine(MemoryEngineInterface):
 
             self.query_analyzer = DateparserQueryAnalyzer()
 
+        # Resolve failover settings once. When llm_failover_provider is unset,
+        # _maybe_wrap returns the primary unchanged so the hot path is identical
+        # to the pre-failover behaviour.
+        _failover_provider = config.llm_failover_provider
+        _failover_api_key = config.llm_failover_api_key
+        _failover_model = config.llm_failover_model
+        _failover_base_url = config.llm_failover_base_url or None
+
+        def _build_failover_instance() -> LLMConfig | None:
+            if not _failover_provider:
+                return None
+            if not _failover_api_key and requires_api_key(_failover_provider):
+                logger.warning(
+                    "Failover LLM provider '%s' is configured but no API key was provided "
+                    "(HINDSIGHT_API_LLM_FAILOVER_API_KEY). Failover will be disabled.",
+                    _failover_provider,
+                )
+                return None
+            model = _failover_model
+            if not model:
+                from ..config import _get_default_model_for_provider
+
+                model = _get_default_model_for_provider(_failover_provider)
+            return LLMConfig(
+                provider=_failover_provider,
+                api_key=_failover_api_key or "",
+                base_url=_failover_base_url or "",
+                model=model,
+                reasoning_effort=config.llm_reasoning_effort,
+                extra_body=config.llm_extra_body,
+                default_headers=config.llm_default_headers,
+                litellmrouter_config=config.llm_litellmrouter_config,
+                bedrock_service_tier=config.llm_bedrock_service_tier,
+                gemini_service_tier=config.llm_gemini_service_tier,
+            )
+
+        # Build ONE failover instance shared across all per-op composites — both
+        # to save provider-client setup cost and to keep operational telemetry
+        # focused on a single failover endpoint.
+        _shared_failover = _build_failover_instance()
+
+        def _maybe_wrap(primary: LLMConfig) -> "LLMConfig | FailoverLLMProvider":
+            if _shared_failover is None:
+                return primary
+            return FailoverLLMProvider(primary=primary, failover=_shared_failover)
+
         # Initialize LLM configuration (default, used as fallback)
-        self._llm_config = LLMConfig(
+        _default_llm = LLMConfig(
             provider=memory_llm_provider,
             api_key=memory_llm_api_key,
             base_url=memory_llm_base_url,
@@ -967,10 +1014,11 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._llm_config = _maybe_wrap(_default_llm)
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead)
-        self._llm_client = self._llm_config._client
-        self._llm_model = self._llm_config.model
+        self._llm_client = _default_llm._client
+        self._llm_model = _default_llm.model
 
         # Initialize per-operation LLM configs (fall back to default if not specified)
         # Retain LLM config - for fact extraction (benefits from strong structured output)
@@ -989,7 +1037,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 retain_base_url = ""
 
-        self._retain_llm_config = LLMConfig(
+        _retain_llm = LLMConfig(
             provider=retain_provider,
             api_key=retain_api_key,
             base_url=retain_base_url,
@@ -1001,6 +1049,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._retain_llm_config = _maybe_wrap(_retain_llm)
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
         reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
@@ -1018,7 +1067,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 reflect_base_url = ""
 
-        self._reflect_llm_config = LLMConfig(
+        _reflect_llm = LLMConfig(
             provider=reflect_provider,
             api_key=reflect_api_key,
             base_url=reflect_base_url,
@@ -1030,6 +1079,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._reflect_llm_config = _maybe_wrap(_reflect_llm)
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
         consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
@@ -1047,7 +1097,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 consolidation_base_url = ""
 
-        self._consolidation_llm_config = LLMConfig(
+        _consolidation_llm = LLMConfig(
             provider=consolidation_provider,
             api_key=consolidation_api_key,
             base_url=consolidation_base_url,
@@ -1059,6 +1109,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._consolidation_llm_config = _maybe_wrap(_consolidation_llm)
 
         # Initialize cross-encoder reranker (cached for performance)
         self._cross_encoder_reranker = CrossEncoderReranker(cross_encoder=cross_encoder)
@@ -2515,7 +2566,9 @@ class MemoryEngine(MemoryEngineInterface):
             provider becomes available (e.g. after a quota reset).
             """
             if not self._skip_llm_verification:
-                configs_to_verify: list[tuple[str, LLMConfig]] = [("default", self._llm_config)]
+                # Each entry may be a bare LLMConfig or a FailoverLLMProvider composite;
+                # both expose verify_connection() and the .provider/.model passthrough.
+                configs_to_verify: list[tuple[str, LLMConfig | FailoverLLMProvider]] = [("default", self._llm_config)]
 
                 # Verify retain config if different from default
                 retain_is_different = (

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1299,7 +1299,11 @@ async def _extract_facts_from_chunk(
     last_error: Exception | None = None
 
     usage = TokenUsage()  # Track cumulative usage across retries
-    for attempt in range(llm_max_retries):
+    # Always make at least one attempt. `llm_max_retries=0` (a valid config for
+    # "no JSON-validation retries") must still execute the call once — otherwise
+    # the loop is skipped entirely and the function raises the line-below
+    # fallthrough RuntimeError before the LLM is ever called.
+    for attempt in range(max(1, llm_max_retries)):
         try:
             initial_backoff = (
                 config.retain_llm_initial_backoff
@@ -1814,7 +1818,11 @@ async def extract_facts_from_text(
         total_usage = total_usage + chunk_usage
 
     if failed_chunks:
-        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}" for idx, err in failed_chunks[:5])
+        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}: {err}" for idx, err in failed_chunks[:5])
+        # Also log the full inner tracebacks so the API log shows what actually failed,
+        # not just a wrapping RuntimeError that hides the cause.
+        for idx, err in failed_chunks[:5]:
+            logger.error("Fact extraction chunk %d failed", idx, exc_info=err)
         quota_errors = [err for _, err in failed_chunks if isinstance(err, ProviderRateLimitResetError)]
         if quota_errors and len(quota_errors) == len(failed_chunks):
             retry_at = max(err.retry_at for err in quota_errors)

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -2,32 +2,41 @@
 Pytest configuration and shared fixtures.
 """
 
-# Eagerly import torch.overrides in the xdist *controller* process BEFORE
-# any worker fork. Why this is the first thing in the file:
+# Eagerly prime the torch → transformers → safetensors → sentence_transformers
+# import chain at conftest module-load time. conftest.py runs once per xdist
+# worker at startup, BEFORE any test code touches imports, so this primes each
+# worker's sys.modules with the full chain in a deterministic order.
+#
+# Why this matters:
 #
 # CI runs `pytest -n 8 --dist loadgroup` (8 xdist workers) inside
-# `pytest-split --splits 3 --group N`. Without this import here, the
-# controller forks workers with `torch` partially loaded in sys.modules but
-# `torch.overrides` not yet imported. Some tests later trigger a fresh
-# `import torch.overrides` in a worker (notably test_server_module.py, which
-# does `del sys.modules[...]; importlib.import_module(...)` and pulls
-# cross_encoder → transformers → torch.overrides through the engine chain).
-# At that point torch's `_add_docstr(_has_torch_function, ...)` at
-# overrides.py:1778 finds the docstring already attached on the C-level
-# function inherited from the parent fork and raises
-#   RuntimeError: function '_has_torch_function' already has a docstring
-# poisoning the worker for every subsequent test in shard 2.
+# `pytest-split --splits 3 --group N`. Shard 2 has hit several distinct
+# import-order races over recent CI history, all rooted in tests that
+# lazy-import sentence_transformers mid-suite after other code has already
+# touched torch internals:
 #
-# Forcing this import here makes the controller's sys.modules complete
-# before any fork — workers inherit a fully-loaded torch.overrides and the
-# race window closes. Don't move this below other imports.
+# 1. `RuntimeError: function '_has_torch_function' already has a docstring`
+#    at torch/overrides.py:1778 — torch.overrides loaded twice in the worker
+#    (test_server_module.py uses `del sys.modules[...]; importlib.import_module(...)`
+#    which transitively re-pulls the engine → cross_encoder → torch.overrides).
 #
-# Do NOT also eager-import `transformers` here — its lazy submodule system
-# (`transformers.generation.__getattr__`) breaks when partially loaded
-# pre-fork and surfaces as `GenerationMixin` lookup failures in workers,
-# which then bubble up as a misleading "sentence-transformers is required"
-# ImportError from LocalSTEmbeddings' wrapper try/except.
-import torch.overrides  # noqa: F401  # see comment above
+# 2. `PyO3 modules compiled for CPython 3.8 or older may only be initialized
+#    once per interpreter process` at safetensors/__init__.py:2 — the
+#    safetensors Rust extension is being initialized twice in the same
+#    interpreter.
+#
+# 3. `transformers.generation.__getattr__('GenerationMixin')` returning a
+#    Placeholder marked with `missing_backends` — transformers cached
+#    torch-availability state from an earlier partial load.
+#
+# Eagerly importing `sentence_transformers` here forces the full chain
+# (torch.overrides → transformers → safetensors → sentence_transformers) to
+# load in one deterministic pass in the worker's startup, before any test
+# code runs. Subsequent lazy `from sentence_transformers import ...` calls in
+# embeddings.py / cross_encoder.py become sys.modules cache hits, and the
+# `del sys.modules[hindsight_api.server.*]` pattern in test_server_module.py
+# doesn't pull anything new through. Don't move this below other imports.
+import sentence_transformers  # noqa: F401  # see comment above
 
 import asyncio
 import os

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -2,11 +2,11 @@
 Pytest configuration and shared fixtures.
 """
 
-# Eagerly import torch.overrides and transformers in the xdist *controller*
-# process BEFORE any worker fork. Why this is the first thing in the file:
+# Eagerly import torch.overrides in the xdist *controller* process BEFORE
+# any worker fork. Why this is the first thing in the file:
 #
 # CI runs `pytest -n 8 --dist loadgroup` (8 xdist workers) inside
-# `pytest-split --splits 3 --group N`. Without these imports here, the
+# `pytest-split --splits 3 --group N`. Without this import here, the
 # controller forks workers with `torch` partially loaded in sys.modules but
 # `torch.overrides` not yet imported. Some tests later trigger a fresh
 # `import torch.overrides` in a worker (notably test_server_module.py, which
@@ -18,11 +18,16 @@ Pytest configuration and shared fixtures.
 #   RuntimeError: function '_has_torch_function' already has a docstring
 # poisoning the worker for every subsequent test in shard 2.
 #
-# Forcing both imports here makes the controller's sys.modules complete
+# Forcing this import here makes the controller's sys.modules complete
 # before any fork — workers inherit a fully-loaded torch.overrides and the
-# race window closes. Don't move these below other imports.
+# race window closes. Don't move this below other imports.
+#
+# Do NOT also eager-import `transformers` here — its lazy submodule system
+# (`transformers.generation.__getattr__`) breaks when partially loaded
+# pre-fork and surfaces as `GenerationMixin` lookup failures in workers,
+# which then bubble up as a misleading "sentence-transformers is required"
+# ImportError from LocalSTEmbeddings' wrapper try/except.
 import torch.overrides  # noqa: F401  # see comment above
-import transformers  # noqa: F401  # see comment above
 
 import asyncio
 import os

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -2,6 +2,28 @@
 Pytest configuration and shared fixtures.
 """
 
+# Eagerly import torch.overrides and transformers in the xdist *controller*
+# process BEFORE any worker fork. Why this is the first thing in the file:
+#
+# CI runs `pytest -n 8 --dist loadgroup` (8 xdist workers) inside
+# `pytest-split --splits 3 --group N`. Without these imports here, the
+# controller forks workers with `torch` partially loaded in sys.modules but
+# `torch.overrides` not yet imported. Some tests later trigger a fresh
+# `import torch.overrides` in a worker (notably test_server_module.py, which
+# does `del sys.modules[...]; importlib.import_module(...)` and pulls
+# cross_encoder → transformers → torch.overrides through the engine chain).
+# At that point torch's `_add_docstr(_has_torch_function, ...)` at
+# overrides.py:1778 finds the docstring already attached on the C-level
+# function inherited from the parent fork and raises
+#   RuntimeError: function '_has_torch_function' already has a docstring
+# poisoning the worker for every subsequent test in shard 2.
+#
+# Forcing both imports here makes the controller's sys.modules complete
+# before any fork — workers inherit a fully-loaded torch.overrides and the
+# race window closes. Don't move these below other imports.
+import torch.overrides  # noqa: F401  # see comment above
+import transformers  # noqa: F401  # see comment above
+
 import asyncio
 import os
 from pathlib import Path

--- a/hindsight-api-slim/tests/test_failover_llm.py
+++ b/hindsight-api-slim/tests/test_failover_llm.py
@@ -1,0 +1,73 @@
+"""Tests for the LLM failover provider feature."""
+
+import pytest
+
+
+@pytest.fixture
+def clean_config(monkeypatch):
+    """Clear cached config before/after each test so env changes take effect."""
+    from hindsight_api.config import clear_config_cache
+
+    # Ensure no pre-existing failover env vars leak in
+    for key in (
+        "HINDSIGHT_API_LLM_FAILOVER_PROVIDER",
+        "HINDSIGHT_API_LLM_FAILOVER_API_KEY",
+        "HINDSIGHT_API_LLM_FAILOVER_MODEL",
+        "HINDSIGHT_API_LLM_FAILOVER_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def test_failover_fields_default_to_none(clean_config):
+    """When no failover env vars are set, all four failover fields are None."""
+    from hindsight_api.config import get_config
+
+    config = get_config()
+    assert config.llm_failover_provider is None
+    assert config.llm_failover_api_key is None
+    assert config.llm_failover_model is None
+    assert config.llm_failover_base_url is None
+
+
+def test_failover_fields_load_from_env(clean_config, monkeypatch):
+    """Setting failover env vars populates the four fields."""
+    from hindsight_api.config import clear_config_cache, get_config
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_PROVIDER", "anthropic")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_API_KEY", "sk-test-failover")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_MODEL", "claude-3-5-sonnet-latest")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_BASE_URL", "https://api.anthropic.com")
+    clear_config_cache()
+
+    config = get_config()
+    assert config.llm_failover_provider == "anthropic"
+    assert config.llm_failover_api_key == "sk-test-failover"
+    assert config.llm_failover_model == "claude-3-5-sonnet-latest"
+    assert config.llm_failover_base_url == "https://api.anthropic.com"
+
+
+def test_failover_credentials_marked_as_credential_fields():
+    """The failover api_key and base_url must be in _CREDENTIAL_FIELDS so the API never echoes them."""
+    from hindsight_api.config import HindsightConfig
+
+    credential_fields = HindsightConfig.get_credential_fields()
+    assert "llm_failover_api_key" in credential_fields
+    assert "llm_failover_base_url" in credential_fields
+
+
+def test_failover_fields_are_static_not_configurable():
+    """Per spec, provider/model/credentials are server-level only — never per-bank configurable."""
+    from hindsight_api.config import HindsightConfig
+
+    configurable = HindsightConfig.get_configurable_fields()
+    for field in (
+        "llm_failover_provider",
+        "llm_failover_api_key",
+        "llm_failover_model",
+        "llm_failover_base_url",
+    ):
+        assert field not in configurable, f"{field} must not be per-bank configurable"

--- a/hindsight-api-slim/tests/test_failover_llm.py
+++ b/hindsight-api-slim/tests/test_failover_llm.py
@@ -71,3 +71,225 @@ def test_failover_fields_are_static_not_configurable():
         "llm_failover_base_url",
     ):
         assert field not in configurable, f"{field} must not be per-bank configurable"
+
+
+# ---------------------------------------------------------------------------
+# Task 2: FailoverLLMProvider composite tests
+# ---------------------------------------------------------------------------
+
+
+from hindsight_api.engine.llm_interface import OutputTooLongError, ProviderRateLimitResetError
+
+
+def _make_mock(model: str):
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    return LLMProvider(provider="mock", api_key="", base_url="", model=model)
+
+
+@pytest.mark.asyncio
+async def test_call_succeeds_on_primary_no_failover_call(clean_config):
+    """When primary succeeds, failover is never invoked."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    primary.set_mock_response("primary response")
+    failover.set_mock_response("failover response")
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    result = await composite.call(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "primary response"
+    assert len(primary.get_mock_calls()) == 1
+    assert len(failover.get_mock_calls()) == 0
+
+
+@pytest.mark.asyncio
+async def test_call_falls_over_when_primary_raises(clean_config):
+    """When primary raises a transient error, failover is invoked with same messages."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    # Reach into the underlying MockLLM to make the primary raise
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = RuntimeError("upstream 503")
+    failover.set_mock_response("failover saved us")
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    result = await composite.call(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "failover saved us"
+    assert len(primary.get_mock_calls()) == 1
+    assert len(failover.get_mock_calls()) == 1
+    # Same payload was forwarded
+    assert failover.get_mock_calls()[0]["messages"] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_call_raises_failover_error_when_both_fail(clean_config):
+    """When both primary and failover fail, the failover's error propagates."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    assert isinstance(primary._provider_impl, MockLLM)
+    assert isinstance(failover._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = RuntimeError("primary down")
+    failover._provider_impl._mock_exception = RuntimeError("failover also down")
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    with pytest.raises(RuntimeError, match="failover also down"):
+        await composite.call(messages=[{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.asyncio
+async def test_call_re_raises_when_no_failover_configured(clean_config):
+    """When failover is None, primary errors propagate unchanged (backwards-compat path)."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = RuntimeError("primary down")
+
+    composite = FailoverLLMProvider(primary=primary, failover=None)
+    with pytest.raises(RuntimeError, match="primary down"):
+        await composite.call(messages=[{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.asyncio
+async def test_output_too_long_does_not_failover(clean_config):
+    """OutputTooLongError is deterministic — failover cannot help, so it propagates."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = OutputTooLongError("output > max_tokens")
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    with pytest.raises(OutputTooLongError):
+        await composite.call(messages=[{"role": "user", "content": "hi"}])
+    assert len(failover.get_mock_calls()) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_does_not_failover(clean_config):
+    """asyncio.CancelledError must propagate so cancellation isn't swallowed."""
+    import asyncio
+
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = asyncio.CancelledError()
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    with pytest.raises(asyncio.CancelledError):
+        await composite.call(messages=[{"role": "user", "content": "hi"}])
+    assert len(failover.get_mock_calls()) == 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_reset_does_failover(clean_config):
+    """ProviderRateLimitResetError IS a failover trigger — primary says 'come back later'."""
+    from datetime import datetime, timedelta, timezone
+
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    failover.set_mock_response("failover handled it")
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = ProviderRateLimitResetError(
+        retry_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        message="rate limited until 12:05",
+    )
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    result = await composite.call(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "failover handled it"
+    assert len(failover.get_mock_calls()) == 1
+
+
+@pytest.mark.asyncio
+async def test_attribute_passthrough_returns_primary(clean_config):
+    """.provider / .model read from the primary for backward compat."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+
+    assert composite.provider == "mock"
+    assert composite.model == "primary-model"
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_falls_over(clean_config):
+    """call_with_tools has identical failover semantics to call()."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+    from hindsight_api.engine.response_models import LLMToolCallResult
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = RuntimeError("upstream 500")
+    failover_result = LLMToolCallResult(content="from failover", tool_calls=[])
+    failover.set_mock_response(failover_result)
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    result = await composite.call_with_tools(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+    )
+
+    assert result.content == "from failover"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cleans_both():
+    """cleanup() must clean both primary and failover."""
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+
+    # Should not raise — both MockLLM cleanups are no-ops
+    await composite.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_warns_on_failover_failure(caplog):
+    """A failing failover.verify_connection() must NOT raise — only log a warning."""
+    import logging
+
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+
+    primary = _make_mock("primary-model")
+    failover = _make_mock("failover-model")
+
+    # Patch failover to raise on verify
+    async def boom():
+        raise RuntimeError("failover unreachable")
+
+    failover.verify_connection = boom  # type: ignore[method-assign]
+
+    composite = FailoverLLMProvider(primary=primary, failover=failover)
+    caplog.set_level(logging.WARNING, logger="hindsight_api.engine.failover_llm")
+    await composite.verify_connection()  # must not raise
+
+    assert any(
+        "failover" in record.message.lower() and "unreachable" in record.message.lower() for record in caplog.records
+    )

--- a/hindsight-api-slim/tests/test_failover_llm_memory_engine.py
+++ b/hindsight-api-slim/tests/test_failover_llm_memory_engine.py
@@ -1,0 +1,79 @@
+"""Integration: MemoryEngine constructs FailoverLLMProvider when configured."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    """Use mock LLM for both primary and failover; skip verification."""
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_SKIP_LLM_VERIFICATION", "true")
+    monkeypatch.setenv("HINDSIGHT_API_LAZY_RERANKER", "true")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "primary-model")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def test_memory_engine_uses_bare_llmprovider_when_failover_unset(monkeypatch):
+    """Backwards-compat: no failover env => no FailoverLLMProvider wrapper."""
+    monkeypatch.delenv("HINDSIGHT_API_LLM_FAILOVER_PROVIDER", raising=False)
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    clear_config_cache()
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    # Hot path: must be a bare LLMProvider, not a FailoverLLMProvider
+    assert isinstance(engine._llm_config, LLMProvider)
+    assert not isinstance(engine._llm_config, FailoverLLMProvider)
+    assert isinstance(engine._retain_llm_config, LLMProvider)
+    assert not isinstance(engine._retain_llm_config, FailoverLLMProvider)
+
+
+def test_memory_engine_wraps_with_failover_when_set(monkeypatch):
+    """When HINDSIGHT_API_LLM_FAILOVER_PROVIDER is set, all four LLM configs are wrapped."""
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_MODEL", "failover-model")
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.failover_llm import FailoverLLMProvider
+
+    clear_config_cache()
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    for attr in ("_llm_config", "_retain_llm_config", "_reflect_llm_config", "_consolidation_llm_config"):
+        wrapper = getattr(engine, attr)
+        assert isinstance(wrapper, FailoverLLMProvider), f"{attr} should be wrapped"
+        assert wrapper._primary.model == "primary-model"
+        assert wrapper._failover is not None
+        assert wrapper._failover.model == "failover-model"
+
+
+@pytest.mark.asyncio
+async def test_memory_engine_call_falls_over_when_primary_raises(monkeypatch):
+    """End-to-end: a call on _retain_llm_config falls over correctly."""
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_FAILOVER_MODEL", "failover-model")
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.providers.mock_llm import MockLLM
+
+    clear_config_cache()
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    # Force the primary inside the composite to raise
+    primary = engine._retain_llm_config._primary  # type: ignore[attr-defined]
+    failover = engine._retain_llm_config._failover  # type: ignore[attr-defined]
+    assert isinstance(primary._provider_impl, MockLLM)
+    primary._provider_impl._mock_exception = RuntimeError("upstream 503")
+    failover.set_mock_response("failover ok")
+
+    result = await engine._retain_llm_config.call(messages=[{"role": "user", "content": "hi"}])
+    assert result == "failover ok"

--- a/hindsight-api-slim/tests/test_failover_llm_memory_engine.py
+++ b/hindsight-api-slim/tests/test_failover_llm_memory_engine.py
@@ -1,7 +1,5 @@
 """Integration: MemoryEngine constructs FailoverLLMProvider when configured."""
 
-import os
-
 import pytest
 
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -472,6 +472,41 @@ consolidation below the global value — e.g. global=4, retain=1, consolidation=
 two slots that retain/consolidation cannot consume.
 :::
 
+### Failover LLM Provider (optional)
+
+When the primary LLM provider fails after exhausting its retry budget (controlled by
+`HINDSIGHT_API_LLM_MAX_RETRIES` and the per-operation variants), Hindsight can
+automatically re-dispatch the same call to a different provider. The failover is a
+single server-level configuration that applies to all operations (retain, reflect,
+consolidation, default). When none of these variables are set, no failover happens
+and the behaviour is identical to releases prior to this feature.
+
+| Variable | Description | Default |
+|---|---|---|
+| `HINDSIGHT_API_LLM_FAILOVER_PROVIDER` | Provider name (`openai`, `anthropic`, `gemini`, `groq`, etc.). Unset disables failover. | unset |
+| `HINDSIGHT_API_LLM_FAILOVER_API_KEY` | API key for the failover provider. Required unless the provider is one of the no-auth providers (`openai-codex`, `claude-code`, etc.). | unset |
+| `HINDSIGHT_API_LLM_FAILOVER_MODEL` | Model name for the failover. Defaults to the provider's recommended default. | provider default |
+| `HINDSIGHT_API_LLM_FAILOVER_BASE_URL` | Base URL for the failover provider. Defaults vary by provider. | provider default |
+
+**Retry count.** The existing `HINDSIGHT_API_LLM_MAX_RETRIES` (and the per-operation variants
+`HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES`, `HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES`,
+`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`) controls how many times the primary is
+retried before failover triggers. Once the primary raises after the configured retries,
+the failover provider is invoked with the same arguments.
+
+**When failover triggers.** Most provider errors (rate limits, 5xx, connection errors,
+schema-validation failures from soft JSON mode) trigger failover. Two errors do NOT:
+- `OutputTooLongError` — the request exceeds the model's output budget; failover cannot help.
+- `asyncio.CancelledError` — propagates to honour task cancellation.
+
+**Batch APIs.** The failover does NOT apply to batch-mode retain
+(`submit_batch` / `get_batch_status` / `retrieve_batch_results`). Batch jobs are
+long-lived and asynchronous; cross-provider batch failover is out of scope.
+
+**Connection verification.** On startup the failover's connection is verified soft —
+a verification failure logs a warning but does not block the server from starting.
+This prevents a misconfigured failover from breaking deployments.
+
 ### Embeddings
 
 | Variable | Description | Default |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -10,6 +10,15 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # Reasoning effort for providers/models that support it. Examples: low, medium, high, xhigh.
 # HINDSIGHT_API_LLM_REASONING_EFFORT=low
 
+# Failover LLM provider (optional). When set, calls that fail after the primary
+# exhausts HINDSIGHT_API_LLM_MAX_RETRIES are re-dispatched to this provider.
+# Backwards compatible: leave all four unset to keep behaviour identical to
+# pre-failover releases. See docs/developer/configuration.md for the full table.
+# HINDSIGHT_API_LLM_FAILOVER_PROVIDER=anthropic
+# HINDSIGHT_API_LLM_FAILOVER_API_KEY=
+# HINDSIGHT_API_LLM_FAILOVER_MODEL=claude-3-5-sonnet-latest
+# HINDSIGHT_API_LLM_FAILOVER_BASE_URL=
+
 # Example: Anthropic Claude configuration
 # HINDSIGHT_API_LLM_PROVIDER=anthropic
 # HINDSIGHT_API_LLM_API_KEY=your-anthropic-api-key

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -472,6 +472,41 @@ consolidation below the global value — e.g. global=4, retain=1, consolidation=
 two slots that retain/consolidation cannot consume.
 :::
 
+### Failover LLM Provider (optional)
+
+When the primary LLM provider fails after exhausting its retry budget (controlled by
+`HINDSIGHT_API_LLM_MAX_RETRIES` and the per-operation variants), Hindsight can
+automatically re-dispatch the same call to a different provider. The failover is a
+single server-level configuration that applies to all operations (retain, reflect,
+consolidation, default). When none of these variables are set, no failover happens
+and the behaviour is identical to releases prior to this feature.
+
+| Variable | Description | Default |
+|---|---|---|
+| `HINDSIGHT_API_LLM_FAILOVER_PROVIDER` | Provider name (`openai`, `anthropic`, `gemini`, `groq`, etc.). Unset disables failover. | unset |
+| `HINDSIGHT_API_LLM_FAILOVER_API_KEY` | API key for the failover provider. Required unless the provider is one of the no-auth providers (`openai-codex`, `claude-code`, etc.). | unset |
+| `HINDSIGHT_API_LLM_FAILOVER_MODEL` | Model name for the failover. Defaults to the provider's recommended default. | provider default |
+| `HINDSIGHT_API_LLM_FAILOVER_BASE_URL` | Base URL for the failover provider. Defaults vary by provider. | provider default |
+
+**Retry count.** The existing `HINDSIGHT_API_LLM_MAX_RETRIES` (and the per-operation variants
+`HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES`, `HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES`,
+`HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES`) controls how many times the primary is
+retried before failover triggers. Once the primary raises after the configured retries,
+the failover provider is invoked with the same arguments.
+
+**When failover triggers.** Most provider errors (rate limits, 5xx, connection errors,
+schema-validation failures from soft JSON mode) trigger failover. Two errors do NOT:
+- `OutputTooLongError` — the request exceeds the model's output budget; failover cannot help.
+- `asyncio.CancelledError` — propagates to honour task cancellation.
+
+**Batch APIs.** The failover does NOT apply to batch-mode retain
+(`submit_batch` / `get_batch_status` / `retrieve_batch_results`). Batch jobs are
+long-lived and asynchronous; cross-provider batch failover is out of scope.
+
+**Connection verification.** On startup the failover's connection is verified soft —
+a verification failure logs a warning but does not block the server from starting.
+This prevents a misconfigured failover from breaking deployments.
+
 ### Embeddings
 
 | Variable | Description | Default |


### PR DESCRIPTION
## Summary

Adds an **optional cross-provider failover** for the engine's LLM calls. When the primary provider exhausts its retry budget and raises, the  same call is re-dispatched to a second provider with identical arguments. Disabled by default — when none of the four env vars are set, the hot path is byte-identical to the pre-failover behaviour.

## Motivation

Provider outages, regional rate limits, and 5xx blips currently surface as user-facing 5xx on retain/reflect/consolidation, even though the same prompt would succeed on a different provider. This PR adds a single server-level failover so deployments can ride through provider-side incidents without per-call orchestration.

## What's in the PR
  - **`engine/failover_llm.py`** — new `FailoverLLMProvider` composite (and `ConfiguredFailoverLLMProvider` for the per-bank `with_config()`  path). Wraps a primary + failover, re-dispatches on `Exception`, propagates `OutputTooLongError` and `CancelledError` / `KeyboardInterrupt` /  `SystemExit` unchanged. Attribute access falls through to the primary so existing reads of `.provider` / `.model` / `._client` keep working.

  - **`engine/memory_engine.py`** — `_maybe_wrap()` wraps each of the four per-operation `LLMConfig`s (default, retain, reflect, consolidation) in the composite when failover is configured; returns the bare `LLMConfig` otherwise. A single failover instance is shared across all four composites. `verify_connection` is hard on the primary and soft on the failover so a misconfigured failover cannot block startup. 

  - **`config.py`** — four new env vars (provider / api_key / model / base_url), all `None` by default. Marked as sensitive in the config's redaction sets. Server-level only (not in `_CONFIGURABLE_FIELDS`).

  - **`engine/retain/fact_extraction.py`** — `max(1, llm_max_retries)` so the extraction loop always makes at least one attempt (previously `max_retries=0` skipped the call entirely and raised the fall-through `RuntimeError`). Failed-chunk summary now includes the inner error message and logs full inner tracebacks instead of hiding them behind a wrapping `RuntimeError`.
 
  - **Tests** — `tests/test_failover_llm.py` (composite behaviour, error classification, cancellation semantics, config plumbing) and `tests/test_failover_llm_memory_engine.py` (engine wiring with failover on/off).

  - **Docs** — new "Failover LLM Provider" section in `developer/configuration.md` (and the agent reference copy), entries in `.env.example` and the embed env template.

  ## Behaviour notes

  - **What triggers failover:** rate limits, 5xx, connection errors, schema-validation failures from soft JSON mode — anything inheriting from `Exception`.

  - **What does NOT:** `OutputTooLongError` (failover won't help — the prompt simply exceeds the budget) and `CancelledError` / `KeyboardInterrupt` / `SystemExit` (propagate so cancellation works).

  - **Retry semantics:** `HINDSIGHT_API_LLM_MAX_RETRIES` (and per-op variants) still controls primary retries. Failover only fires once the primary has exhausted them.

  - **Batch APIs:** not in scope — `submit_batch` / `get_batch_status` / `retrieve_batch_results` do not failover.

  - **Backwards compatibility:** with all four vars unset, MemoryEngine constructs bare `LLMConfig`s exactly as before; no composite is wrapped.

## Configuration

  | Variable | Description | Default |
  |---|---|---|
  | `HINDSIGHT_API_LLM_FAILOVER_PROVIDER` | Provider name (`openai`, `anthropic`, `gemini`, `groq`, etc.). Unset disables failover. | unset |
  | `HINDSIGHT_API_LLM_FAILOVER_API_KEY` | API key for the failover provider. Required unless the provider is no-auth (`claude-code`, etc.). |  unset |
  | `HINDSIGHT_API_LLM_FAILOVER_MODEL` | Model name for the failover. | provider default |
  | `HINDSIGHT_API_LLM_FAILOVER_BASE_URL` | Base URL for the failover provider. | provider default |

  ## Test plan

  - [ ] `cd hindsight-api-slim && uv run pytest tests/test_failover_llm.py tests/test_failover_llm_memory_engine.py -v`
  - [ ] `cd hindsight-api-slim && uv run pytest tests/` (full suite, ensure no regressions in retain / reflect / consolidation paths)
  - [ ] `cd hindsight-api-slim && uv run ruff check . && uv run ty check hindsight_api/`
  - [ ] Manual: with `HINDSIGHT_API_LLM_FAILOVER_PROVIDER` unset, confirm logs / behaviour are unchanged.
  - [ ] Manual: set a bogus primary (e.g. fake API key) and a real failover; trigger a retain and confirm the WARNING log fires and the request succeeds via the failover.
  - [ ] Manual: misconfigure failover (bad key) and confirm startup logs a soft warning but does not exit.