### PR TITLE
docs(integrations): drop removed 'opinion' fact type from recall_types/fact_types across SDK wrappers

### DIFF
--- a/hindsight-integrations/ag2/hindsight_ag2/tools.py
+++ b/hindsight-integrations/ag2/hindsight_ag2/tools.py
@@ -64,7 +64,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/autogen/README.md
+++ b/hindsight-integrations/autogen/README.md
@@ -131,7 +131,7 @@ tools = create_hindsight_tools(
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any\_strict/all\_strict) |
 | `retain_metadata` | `None` | Default metadata dict for retain operations |
 | `retain_document_id` | `None` | Default document\_id for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `None` | Max tokens for reflect results (defaults to `max_tokens`) |

--- a/hindsight-integrations/autogen/hindsight_autogen/tools.py
+++ b/hindsight-integrations/autogen/hindsight_autogen/tools.py
@@ -71,7 +71,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/claude-agent-sdk/hindsight_claude_agent_sdk/tools.py
+++ b/hindsight-integrations/claude-agent-sdk/hindsight_claude_agent_sdk/tools.py
@@ -71,7 +71,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/continue/hindsight_continue/config.py
+++ b/hindsight-integrations/continue/hindsight_continue/config.py
@@ -44,7 +44,7 @@ class HindsightContinueConfig:
             it via ``options.bankId``).
         budget: Recall budget level (low/mid/high).
         max_tokens: Maximum tokens for recall results.
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_tags: Tags to filter recalled memories.
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         item_name: Title shown for the injected context item in Continue.

--- a/hindsight-integrations/google-adk/hindsight_google_adk/tools.py
+++ b/hindsight-integrations/google-adk/hindsight_google_adk/tools.py
@@ -58,7 +58,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (``any``/``all``/``any_strict``/``all_strict``).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (``world``, ``experience``, ``opinion``, ``observation``).
+        recall_types: Fact types to filter (``world``, ``experience``, ``observation``).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to ``max_tokens``).

--- a/hindsight-integrations/haystack/hindsight_haystack/tools.py
+++ b/hindsight-integrations/haystack/hindsight_haystack/tools.py
@@ -565,7 +565,7 @@ def create_hindsight_tools(
         retain_document_id: Default document_id for retain. If None,
             auto-generates per call.
         retain_context: Source label for retain operations.
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/langgraph/hindsight_langgraph/nodes.py
+++ b/hindsight-integrations/langgraph/hindsight_langgraph/nodes.py
@@ -96,7 +96,7 @@ def create_recall_node(
         max_results: Maximum number of memories to inject.
         tags: Tags to filter recall results.
         tags_match: Tag matching mode.
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         bank_id_from_config: Config key to read bank_id from at runtime.
             Looked up in ``config["configurable"][bank_id_from_config]``.

--- a/hindsight-integrations/langgraph/hindsight_langgraph/tools.py
+++ b/hindsight-integrations/langgraph/hindsight_langgraph/tools.py
@@ -63,7 +63,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/litellm/hindsight_litellm/config.py
+++ b/hindsight-integrations/litellm/hindsight_litellm/config.py
@@ -72,7 +72,7 @@ class HindsightCallSettings:
         injection_mode: How to inject memories (system_message or prepend_user)
 
         budget: Budget level for memory recall (low, mid, high)
-        fact_types: Filter by fact types (world, experience, opinion, observation)
+        fact_types: Filter by fact types (world, experience, observation)
         max_memories: Maximum memories to inject (None = no limit)
         max_memory_tokens: Maximum tokens for memory context
         include_entities: Include entity observations in recall results
@@ -109,7 +109,7 @@ class HindsightCallSettings:
 
     # Recall settings
     budget: str = "mid"  # low, mid, high
-    fact_types: Optional[List[str]] = None  # world, experience, opinion, observation
+    fact_types: Optional[List[str]] = None  # world, experience, observation
     max_memories: Optional[int] = None  # None = no limit
     max_memory_tokens: int = 4096
     include_entities: bool = True
@@ -282,7 +282,7 @@ def configure(
         inject_memories: Whether to inject memories (default: True)
         injection_mode: How to inject memories (system_message or prepend_user)
         budget: Recall budget level - low/mid/high (default: "mid")
-        fact_types: Filter by fact types (world/experience/opinion/observation)
+        fact_types: Filter by fact types (world/experience/observation)
         max_memories: Max memories to inject (None = no limit)
         max_memory_tokens: Max tokens for memory context (default: 4096)
         include_entities: Include entity observations in recall (default: True)
@@ -423,7 +423,7 @@ def set_defaults(
         inject_memories: Whether to inject memories
         injection_mode: How to inject memories (system_message or prepend_user)
         budget: Budget level for memory recall (low, mid, high)
-        fact_types: Fact types to filter (world, experience, opinion, observation)
+        fact_types: Fact types to filter (world, experience, observation)
         max_memories: Max number of memories to inject
         max_memory_tokens: Max tokens for memory context
         include_entities: Include entity observations in recall

--- a/hindsight-integrations/llamaindex/hindsight_llamaindex/tools.py
+++ b/hindsight-integrations/llamaindex/hindsight_llamaindex/tools.py
@@ -37,7 +37,7 @@ class HindsightToolSpec(BaseToolSpec):
         retain_document_id: Default document_id for retain. If None,
             auto-generates ``{session_id}-{timestamp_ms}`` per call.
         retain_context: Source label for retain operations (default: "llamaindex").
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).
@@ -386,7 +386,7 @@ def create_hindsight_tools(
         retain_document_id: Default document_id for retain. If None,
             auto-generates per call.
         retain_context: Source label for retain operations.
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).

--- a/hindsight-integrations/openai-agents/README.md
+++ b/hindsight-integrations/openai-agents/README.md
@@ -152,7 +152,7 @@ tools = create_hindsight_tools(
 | `recall_tags_match` | `"any"` | Tag matching mode (any/all/any\_strict/all\_strict) |
 | `retain_metadata` | `None` | Default metadata dict for retain operations |
 | `retain_document_id` | `None` | Default document\_id for retain (groups/upserts memories) |
-| `recall_types` | `None` | Fact types to filter (world, experience, opinion, observation) |
+| `recall_types` | `None` | Fact types to filter (world, experience, observation) |
 | `recall_include_entities` | `False` | Include entity information in recall results |
 | `reflect_context` | `None` | Additional context for reflect operations |
 | `reflect_max_tokens` | `None` | Max tokens for reflect results (defaults to `max_tokens`) |

--- a/hindsight-integrations/openai-agents/hindsight_openai_agents/tools.py
+++ b/hindsight-integrations/openai-agents/hindsight_openai_agents/tools.py
@@ -74,7 +74,7 @@ def create_hindsight_tools(
         recall_tags_match: Tag matching mode (any/all/any_strict/all_strict).
         retain_metadata: Default metadata dict for retain operations.
         retain_document_id: Default document_id for retain (groups/upserts memories).
-        recall_types: Fact types to filter (world, experience, opinion, observation).
+        recall_types: Fact types to filter (world, experience, observation).
         recall_include_entities: Include entity information in recall results.
         reflect_context: Additional context for reflect operations.
         reflect_max_tokens: Max tokens for reflect results (defaults to max_tokens).


### PR DESCRIPTION
## What

`opinion` was removed as a valid fact type in **v0.8.0** (#1917), but ten integration SDK packages still advertise it as a valid `recall_types` / `fact_types` value in their public tool docstrings, one inline comment, and two README tables. An agent (or developer) copying these passes a value the recall API now hard-rejects.

**Canonical truth on `main`:**

- `hindsight-api-slim/hindsight_api/engine/response_models.py`: `VALID_RECALL_FACT_TYPES = frozenset(["world", "experience", "observation"])`
- `hindsight-api-slim/hindsight_api/api/http.py` (recall + reflect): `fact_types: list[Literal["world", "experience", "observation"]] | None` → Pydantic rejects `opinion` at request parse (422)
- `hindsight-api-slim/hindsight_api/models.py`: `CheckConstraint("fact_type IN ('world', 'experience', 'observation')")`

## Change

Drop `opinion` from the fact-type enumeration in the integration wrappers — docstrings, one inline comment, and two README tables. Text only, no logic change:

| package | file(s) |
|---|---|
| ag2 | `hindsight_ag2/tools.py` |
| langgraph | `hindsight_langgraph/tools.py`, `nodes.py` |
| claude-agent-sdk | `hindsight_claude_agent_sdk/tools.py` |
| openai-agents | `hindsight_openai_agents/tools.py`, `README.md` |
| llamaindex | `hindsight_llamaindex/tools.py` (×2) |
| autogen | `hindsight_autogen/tools.py`, `README.md` |
| google-adk | `hindsight_google_adk/tools.py` |
| continue | `hindsight_continue/config.py` |
| haystack | `hindsight_haystack/tools.py` |
| litellm | `hindsight_litellm/config.py` (×4) |

This completes the sweep started by #2198 (litellm docs), #2302 (MCP + quickstart), and #2323 (python-client) — none of which touched `hindsight-integrations/*`.

## Notes

- `hindsight-integrations/*` is outside the `generate-docs-skill.sh` / `generate-clients.sh` inputs, so `verify-generated-files` is unaffected; the edits are docstring / comment / markdown only and ruff-clean.
- Out of scope (flagging for a separate follow-up): `hindsight-api-slim/.../response_models.py` still references `opinion` in a `Field(description=...)` and a `"opinion": []` default — those live in the API package, not the integration wrappers.
