### PR TITLE
fix(stats): invalidate bank stats cache on unit/document deletes and observation clears

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5620,7 +5620,9 @@ class MemoryEngine(MemoryEngineInterface):
             try:
                 await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
             except Exception as e:
-                logger.warning(f"Failed to invalidate bank stats cache after memory unit deletion for bank {bank_id}: {e}")
+                logger.warning(
+                    f"Failed to invalidate bank stats cache after memory unit deletion for bank {bank_id}: {e}"
+                )
 
         if bank_id_for_consolidation:
             config = await self._config_resolver.resolve_full_config(bank_id_for_consolidation, request_context)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -5334,6 +5334,17 @@ class MemoryEngine(MemoryEngineInterface):
                     "memory_units_deleted": units_count if deleted else 0,
                 }
 
+        # Drop any cached stats for this bank — deleting the document changed
+        # the document count and (via cascade) the memory-unit/link counts
+        # get_bank_stats reports, which the TTL would otherwise serve at
+        # pre-delete values for up to a minute (mirrors delete_bank). Best-effort:
+        # a cache-eviction failure must not fail an already-committed delete.
+        if deleted:
+            try:
+                await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
+            except Exception as e:
+                logger.warning(f"Failed to invalidate bank stats cache after document deletion for bank {bank_id}: {e}")
+
         if invalidated_obs > 0:
             config = await self._config_resolver.resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
@@ -5501,6 +5512,14 @@ class MemoryEngine(MemoryEngineInterface):
                             )
 
         if invalidated_obs > 0:
+            # Observation units were deleted, changing the counts get_bank_stats
+            # reports — drop the cached stats so the TTL does not serve pre-update
+            # values for up to a minute (mirrors delete_bank). Best-effort: a
+            # cache-eviction failure must not fail an already-committed update.
+            try:
+                await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
+            except Exception as e:
+                logger.warning(f"Failed to invalidate bank stats cache after document update for bank {bank_id}: {e}")
             config = await self._config_resolver.resolve_full_config(bank_id, request_context)
             if config.enable_auto_consolidation:
                 try:
@@ -5591,6 +5610,17 @@ class MemoryEngine(MemoryEngineInterface):
                     if deleted
                     else "Memory unit not found",
                 }
+
+        # Drop any cached stats for this bank — the deleted unit (and its
+        # cascaded links/entities) changed the counts get_bank_stats reports,
+        # which the TTL would otherwise serve at pre-delete values for up to a
+        # minute (mirrors delete_bank). Best-effort: a cache-eviction failure
+        # must not fail an already-committed delete.
+        if deleted and bank_id:
+            try:
+                await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
+            except Exception as e:
+                logger.warning(f"Failed to invalidate bank stats cache after memory unit deletion for bank {bank_id}: {e}")
 
         if bank_id_for_consolidation:
             config = await self._config_resolver.resolve_full_config(bank_id_for_consolidation, request_context)
@@ -5814,7 +5844,17 @@ class MemoryEngine(MemoryEngineInterface):
                     bank_id,
                 )
 
-                return {"deleted_count": count or 0}
+        # Drop any cached stats for this bank — clearing observations changed
+        # the memory-unit/observation counts and the consolidation timestamps
+        # get_bank_stats reports, which the TTL would otherwise serve at stale
+        # values for up to a minute (mirrors delete_bank). Best-effort: a
+        # cache-eviction failure must not fail an already-committed clear.
+        try:
+            await self._bank_stats_cache.invalidate(get_current_schema(), bank_id)
+        except Exception as e:
+            logger.warning(f"Failed to invalidate bank stats cache after clearing observations for bank {bank_id}: {e}")
+
+        return {"deleted_count": count or 0}
 
     async def list_observation_scopes(
         self,

--- a/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
@@ -112,9 +112,7 @@ class TestBankStatsCacheInvalidation:
             await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
-    async def test_delete_document_invalidates_stats_cache(
-        self, memory: MemoryEngine, request_context: RequestContext
-    ):
+    async def test_delete_document_invalidates_stats_cache(self, memory: MemoryEngine, request_context: RequestContext):
         bank_id = f"test-stats-cache-deldoc-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
 

--- a/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache_invalidation.py
@@ -1,0 +1,166 @@
+"""Regression tests: get_bank_stats cache must be invalidated by mutations.
+
+`get_bank_stats` is served from a short-TTL per-process cache (`BankStatsCache`).
+`delete_bank` already invalidates that cache after it mutates counts, but the
+other operations that change the same counts — `delete_memory_unit`,
+`delete_document`, `clear_observations`, and `update_document` (when a tag
+change deletes observations) — did not, so a client polling stats right after a
+deletion would see pre-mutation counts until the TTL expired (up to a minute).
+
+Each test pins a long TTL on the engine's stats cache so that, *without* the
+invalidation fix, the second `get_bank_stats` call would be served the stale
+cached value and the assertion would fail.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.bank_stats_cache import BankStatsCache
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+# A TTL long enough that, absent invalidation, the warmed cache would still be
+# served on the post-mutation read within the same test.
+_PINNED_TTL_SECONDS = 300.0
+
+
+async def _insert_memory(conn, bank_id: str, text: str, fact_type: str = "experience") -> uuid.UUID:
+    """Insert a memory unit directly, bypassing the LLM retain pipeline."""
+    mem_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, event_date, created_at, updated_at, consolidated_at)
+        VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW(), NOW())
+        """,
+        mem_id,
+        bank_id,
+        text,
+        fact_type,
+    )
+    return mem_id
+
+
+async def _insert_observation(conn, bank_id: str, text: str, source_memory_ids: list[uuid.UUID]) -> uuid.UUID:
+    """Insert an observation unit directly."""
+    obs_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (
+            id, bank_id, text, fact_type, event_date, source_memory_ids, proof_count, created_at, updated_at
+        ) VALUES ($1, $2, $3, 'observation', NOW(), $4, $5, NOW(), NOW())
+        """,
+        obs_id,
+        bank_id,
+        text,
+        source_memory_ids,
+        len(source_memory_ids),
+    )
+    return obs_id
+
+
+async def _insert_document(conn, bank_id: str, doc_id: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO documents (id, bank_id, original_text, content_hash)
+        VALUES ($1, $2, $3, $4)
+        """,
+        doc_id,
+        bank_id,
+        f"text-for-{doc_id}",
+        doc_id,
+    )
+
+
+async def _attach_unit_to_doc(conn, unit_id: uuid.UUID, doc_id: str) -> None:
+    await conn.execute("UPDATE memory_units SET document_id = $1 WHERE id = $2", doc_id, unit_id)
+
+
+async def _ensure_bank(memory: MemoryEngine, bank_id: str, request_context: RequestContext) -> None:
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+
+def _pin_cache(memory: MemoryEngine) -> None:
+    """Replace the stats cache with one that has a deterministic long TTL."""
+    memory._bank_stats_cache = BankStatsCache(ttl_seconds=_PINNED_TTL_SECONDS, max_entries=128)
+
+
+class TestBankStatsCacheInvalidation:
+    @pytest.mark.asyncio
+    async def test_delete_memory_unit_invalidates_stats_cache(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-stats-cache-delunit-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, bank_id, "Alice loves hiking.")
+            await _insert_memory(conn, bank_id, "Bob enjoys cycling.")
+
+        _pin_cache(memory)
+        try:
+            before = await memory.get_bank_stats(bank_id, request_context=request_context)
+            assert before["node_counts"].get("experience") == 2
+
+            await memory.delete_memory_unit(str(m1), request_context=request_context)
+
+            after = await memory.get_bank_stats(bank_id, request_context=request_context)
+            # Without invalidation the long-TTL cache would still report 2.
+            assert after["node_counts"].get("experience") == 1
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_delete_document_invalidates_stats_cache(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-stats-cache-deldoc-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        document_id = f"doc-{uuid.uuid4().hex[:8]}"
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            await _insert_document(conn, bank_id, document_id)
+            unit_id = await _insert_memory(conn, bank_id, "Alice works at Acme.")
+            await _attach_unit_to_doc(conn, unit_id, document_id)
+
+        _pin_cache(memory)
+        try:
+            before = await memory.get_bank_stats(bank_id, request_context=request_context)
+            assert before["total_documents"] == 1
+            assert before["node_counts"].get("experience") == 1
+
+            await memory.delete_document(document_id, bank_id, request_context=request_context)
+
+            after = await memory.get_bank_stats(bank_id, request_context=request_context)
+            # Without invalidation the long-TTL cache would still report 1 document.
+            assert after["total_documents"] == 0
+            assert after["node_counts"].get("experience", 0) == 0
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_clear_observations_invalidates_stats_cache(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-stats-cache-clearobs-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            m1 = await _insert_memory(conn, bank_id, "Alice loves hiking.")
+            await _insert_observation(conn, bank_id, "Alice enjoys hiking regularly.", [m1])
+
+        _pin_cache(memory)
+        try:
+            before = await memory.get_bank_stats(bank_id, request_context=request_context)
+            assert before["total_observations"] == 1
+
+            await memory.clear_observations(bank_id, request_context=request_context)
+
+            after = await memory.get_bank_stats(bank_id, request_context=request_context)
+            # Without invalidation the long-TTL cache would still report 1 observation.
+            assert after["total_observations"] == 0
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

`get_bank_stats` is served from a 60s-TTL `BankStatsCache`. `delete_bank` invalidates it after mutating counts (with a comment to that effect), but the other operations that change the same counts did not — so a client polling stats right after a deletion saw pre-mutation node/link/document/observation counts for up to a minute.

Follow-up to #2315, which hardened the cache primitive (`bank_stats_cache.py`) but did not touch the `memory_engine.py` mutation call sites. This wires the same `delete_bank`-style invalidation into every path that changes the counts `get_bank_stats` reports:

- `delete_memory_unit` — on an actual delete (cascades to links/entities)
- `delete_document` — on an actual delete (cascades to memory units/links)
- `clear_observations` — bulk observation delete + consolidation-timestamp reset
- `update_document` — when a tag change deletes observations (`invalidated_obs > 0`)

High-frequency inserts intentionally keep tolerating TTL staleness (only `delete_bank` invalidated before); this matches that intent by invalidating on the explicit user-initiated delete/clear paths only. Invalidation is best-effort (guarded `try/except` + warning, like the other post-commit side-effects in these methods), so a cache-eviction failure can never fail an already-committed operation. `delete_bank` is intentionally left untouched.

## Tests

`tests/test_bank_stats_cache_invalidation.py` pins a long cache TTL, warms `get_bank_stats`, mutates, and asserts the next read reflects the change immediately — without the fix the long-TTL cache would still serve the stale value. Covers `delete_memory_unit`, `delete_document`, and `clear_observations`.

If this has already been addressed via a separate patch, please feel free to close.
