### PR TITLE
docs(api): correct ReflectResult.based_on key names (mental-models hyphen + add observation)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -307,7 +307,8 @@ class ReflectResult(BaseModel):
                     ],
                     "experience": [],
                     "opinion": [],
-                    "mental_models": [],
+                    "observation": [],
+                    "mental-models": [],
                     "directives": [
                         {
                             "id": "directive-123",
@@ -324,7 +325,7 @@ class ReflectResult(BaseModel):
 
     text: str = Field(description="The formulated answer text")
     based_on: dict[str, Any] = Field(
-        description="Facts used to formulate the answer, organized by type (world, experience, mental_models, directives)"
+        description="Facts used to formulate the answer, organized by type (world, experience, observation, mental-models, directives)"
     )
     structured_output: dict[str, Any] | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

The in-process engine builds `ReflectResult.based_on` with the keys `world`, `experience`, `opinion`, `observation`, `mental-models` (**hyphen**), `directives` (`memory_engine.py`). But the exported model's self-documentation drifted:

- The `based_on` `Field` description named the key `mental_models` (**underscore**) and omitted `observation`.
- The `json_schema_extra` example had the same drift (`mental_models`, no `observation`).

So a consumer doing `result.based_on["mental_models"]` hits a `KeyError` (the real key is hyphenated), and never discovers the `observation` bucket. The maintainer's own comment already documents the hyphen:

```python
elif fact_type == "mental-models":  # ... (note: hyphen, not underscore)
```

This corrects the description and example to the real keys. The dead `opinion` key is intentionally left untouched (handled by #2323/#2335), and the separate wire model `ReflectBasedOn` (typed underscore field) is unaffected — this is a description/example-only change, so it's backwards-compatible.

If this has already been addressed via a separate patch, please feel free to close.
