### PR TITLE
deps(security): bump langsmith floor to >=0.8.18 (GHSA-f4xh-w4cj-qxq8 HIGH)

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "pyasn1>=0.6.3", # DoS vulnerability fix
     "urllib3>=2.7.0", # Decompression-bomb safeguards bypass + sensitive header forwarding fixes
     "langchain-core>=1.2.22", # Path traversal in legacy load_prompt functions fix
-    "langsmith>=0.6.3", # SSRF via tracing header injection fix
+    "langsmith>=0.8.18", # GHSA-f4xh-w4cj-qxq8: arbitrary server-side file read in TracingMiddleware fix (supersedes >=0.6.3 SSRF tracing-header-injection floor)
     "protobuf>=6.33.5", # JSON recursion depth bypass fix
     "pillow>=12.1.1", # Out-of-bounds write in PSD image loading fix
     "cryptography>=48.0.1", # GHSA-537c-gmf6-5ccf: bundled-OpenSSL OOB read fix needs >=48.0.1. Prior <47 cap (47.0.0 SIGILL on ARM64 Docker/Podman, pyca/cryptography#14733) lifted — 47/48/49 verified importing + RSA sign/verify cleanly on linux/arm64 (Docker on Apple Silicon) and native arm64 macOS; upstream issue closed unconfirmed.


### PR DESCRIPTION
## Summary

Bumps the `langsmith` security floor in `hindsight-api-slim/pyproject.toml` from `>=0.6.3` to `>=0.8.18` to clear **GHSA-f4xh-w4cj-qxq8** (HIGH) — *LangSmith SDK `TracingMiddleware`: arbitrary server-side file read*, fixed in `0.8.18`. The current `>=0.6.3` floor permits the vulnerable `0.6.3 – 0.8.17` range.

## Why

`langsmith` sits in the file's existing **"Transitive dependency security fixes"** block alongside `urllib3>=2.7.0`, `cryptography>=48.0.1`, `authlib>=1.6.9`, and `python-multipart>=0.0.22` — each a `>=` floor carrying a security-driver comment. This change follows that exact pattern.

- Advisory: [GHSA-f4xh-w4cj-qxq8](https://github.com/advisories/GHSA-f4xh-w4cj-qxq8) — HIGH, vulnerable range `< 0.8.18`, first patched `0.8.18` (verified published on PyPI).
- No lockfile re-resolve: this directory has no `uv.lock`, so a `>=` floor bump is sufficient.

Only the version + its inline comment change; no other edits.
