### PR TITLE
fix(mcp): omit reflect directives_applied alongside tool_trace/llm_trace by default

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -1014,7 +1014,7 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
                 tags: Optional tags to filter memories by (e.g., ['project:alpha'])
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
                 include_based_on: Include source facts used for synthesis. Defaults to false because broad reflections can exceed MCP client result limits.
-                include_trace: Include the reflection's internal tool_trace/llm_trace. Defaults to false because the trace can be tens of KB and overflow MCP client context; enable only for debugging.
+                include_trace: Include the reflection's internal trace fields (tool_trace/llm_trace and directives_applied). Defaults to false because the trace can be tens of KB and overflow MCP client context; enable only for debugging.
                 bank_id: Optional bank to reflect in (defaults to session bank). Use for cross-bank operations.
             """
             try:
@@ -1045,11 +1045,14 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
                 if not include_based_on:
                     result_data.pop("based_on", None)
                 if not include_trace:
-                    # The agentic reflect loop's tool_trace/llm_trace can be tens of KB
-                    # (full mental-model text) and silently overflow MCP client context;
-                    # the REST API omits it by default too. Opt in via include_trace.
+                    # The agentic reflect loop's trace fields can be tens of KB (full
+                    # mental-model text) and silently overflow MCP client context; the
+                    # REST API omits them by default too. directives_applied is built by
+                    # the engine "for the trace" and carries full directive content, so it
+                    # belongs with tool_trace/llm_trace here. Opt in via include_trace.
                     result_data.pop("tool_trace", None)
                     result_data.pop("llm_trace", None)
+                    result_data.pop("directives_applied", None)
                 if response_schema is not None and hasattr(reflect_result, "structured_output"):
                     result_data["structured_output"] = reflect_result.structured_output
                 return json.dumps(result_data, indent=2)
@@ -1102,7 +1105,7 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
                 tags: Optional tags to filter memories by (e.g., ['project:alpha'])
                 tags_match: How to match tags - 'any' (match any tag) or 'all' (match all tags). Default: 'any'
                 include_based_on: Include source facts used for synthesis. Defaults to false because broad reflections can exceed MCP client result limits.
-                include_trace: Include the reflection's internal tool_trace/llm_trace. Defaults to false because the trace can be tens of KB and overflow MCP client context; enable only for debugging.
+                include_trace: Include the reflection's internal trace fields (tool_trace/llm_trace and directives_applied). Defaults to false because the trace can be tens of KB and overflow MCP client context; enable only for debugging.
             """
             try:
                 target_bank = config.bank_id_resolver()
@@ -1132,11 +1135,14 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
                 if not include_based_on:
                     result_data.pop("based_on", None)
                 if not include_trace:
-                    # The agentic reflect loop's tool_trace/llm_trace can be tens of KB
-                    # (full mental-model text) and silently overflow MCP client context;
-                    # the REST API omits it by default too. Opt in via include_trace.
+                    # The agentic reflect loop's trace fields can be tens of KB (full
+                    # mental-model text) and silently overflow MCP client context; the
+                    # REST API omits them by default too. directives_applied is built by
+                    # the engine "for the trace" and carries full directive content, so it
+                    # belongs with tool_trace/llm_trace here. Opt in via include_trace.
                     result_data.pop("tool_trace", None)
                     result_data.pop("llm_trace", None)
+                    result_data.pop("directives_applied", None)
                 if response_schema is not None and hasattr(reflect_result, "structured_output"):
                     result_data["structured_output"] = reflect_result.structured_output
                 return result_data

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1959,6 +1959,7 @@ def _reflect_mcp_with_trace(include_bank_id_param: bool):
         "based_on": {"world": []},
         "tool_trace": [{"tool": "recall", "output": "x" * 1000}],
         "llm_trace": [{"model": "test", "output": "y" * 1000}],
+        "directives_applied": [{"id": "d1", "name": "Tone", "content": "z" * 1000}],
     }
     memory = MagicMock()
     memory.reflect_async = AsyncMock(
@@ -1985,7 +1986,7 @@ def _reflect_result_data(result) -> dict:
 
 @pytest.mark.asyncio
 class TestReflectTraceOmission:
-    """reflect must not leak the agentic tool_trace/llm_trace into MCP responses by default."""
+    """reflect must not leak the agentic tool_trace/llm_trace/directives_applied into MCP responses by default."""
 
     @pytest.mark.parametrize("multi_bank", [True, False])
     async def test_trace_omitted_by_default(self, multi_bank):
@@ -1994,6 +1995,9 @@ class TestReflectTraceOmission:
         assert data["text"] == "answer"
         assert "tool_trace" not in data
         assert "llm_trace" not in data
+        # directives_applied is built "for the trace" and carries full directive content,
+        # so it must be omitted by default like the other trace fields.
+        assert "directives_applied" not in data
 
     @pytest.mark.parametrize("multi_bank", [True, False])
     async def test_trace_included_when_requested(self, multi_bank):
@@ -2001,6 +2005,7 @@ class TestReflectTraceOmission:
         data = _reflect_result_data(await _tools(mcp)["reflect"].fn(query="q", include_trace=True))
         assert "tool_trace" in data
         assert "llm_trace" in data
+        assert "directives_applied" in data
 
     @pytest.mark.parametrize("multi_bank", [True, False])
     async def test_based_on_flag_is_independent_of_trace(self, multi_bank):
@@ -2009,3 +2014,4 @@ class TestReflectTraceOmission:
         data = _reflect_result_data(await _tools(mcp)["reflect"].fn(query="q", include_based_on=True))
         assert "based_on" in data
         assert "tool_trace" not in data
+        assert "directives_applied" not in data


### PR DESCRIPTION
## Problem

#2242 made the MCP `reflect` tool omit the agentic `tool_trace`/`llm_trace` by default (they can be tens of KB and overflow MCP client context; the REST API omits them too). But its `if not include_trace:` pop block forgot a third trace field: **`directives_applied`**.

`directives_applied` is a `list[DirectiveRef]` where each entry carries the **full directive content** (`DirectiveRef.content: str`, `response_models.py`). It is built *as part of the trace* — `engine/reflect/agent.py`:

```python
# Build directives_applied for the trace
directives_applied = _build_directives_applied(directives)
```

So every MCP `reflect` call against a bank that has directives configured force-injects the full directive text into the response, and it **cannot be suppressed** — not even via `include_based_on=False`. The REST transport never exposes it (`api/http.py` has zero references to `directives_applied`), so MCP is the only path leaking it, via the blanket `model_dump`.

## Fix

Gate `directives_applied` behind the existing `include_trace` flag in both `reflect` registrations (multi-bank and single-bank), alongside `tool_trace`/`llm_trace`, and update the `include_trace` docstrings to name it. This completes the default-omit-trace contract #2242 established and brings MCP in line with REST.

```python
if not include_trace:
    result_data.pop("tool_trace", None)
    result_data.pop("llm_trace", None)
    result_data.pop("directives_applied", None)   # built "for the trace", carries full directive text
```

`include_trace=True` still returns all three for debugging.

## Tests

Extended `TestReflectTraceOmission` (the suite #2242 added): `directives_applied` is now part of the mock reflect payload, and the parametrized (multi-bank / single-bank) cases assert it is omitted by default, returned under `include_trace=True`, and independent of `include_based_on`.

Scoped to `mcp_tools.py` response-shaping only — no schema/OpenAPI change, no generated-file impact.
