### PR TITLE
fix(config): validate disposition_* range on bank-config write so one malformed bank can't 500 the whole bank list (#2348)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -402,6 +402,9 @@ class ConfigResolver:
         # Validate recall budget fields
         _validate_recall_budget_updates(normalized_updates)
 
+        # Validate disposition trait fields (1-5 integer scale)
+        _validate_disposition_updates(normalized_updates)
+
         chunking_fields_updated = (
             "retain_chunk_size" in normalized_updates
             or "retain_structured_chunk_size" in normalized_updates
@@ -514,6 +517,31 @@ def _validate_recall_budget_updates(updates: dict[str, Any]) -> None:
                 f"recall_budget_min ({updates['recall_budget_min']}) must be <= "
                 f"recall_budget_max ({updates['recall_budget_max']})"
             )
+
+
+_DISPOSITION_KEYS = (
+    "disposition_skepticism",
+    "disposition_literalism",
+    "disposition_empathy",
+)
+
+
+def _validate_disposition_updates(updates: dict[str, Any]) -> None:
+    """Validate disposition trait config updates. Raises ValueError on invalid input.
+
+    Each trait is an integer on a 1-5 scale (or None to clear the per-bank
+    override). The read overlay injects the stored value verbatim into a strict
+    ``DispositionTraits(int, ge=1, le=5)``; an out-of-contract value (a float, a
+    0-1 scale, or an int outside 1-5) accepted here would later 500 the whole
+    bank list when any bank profile is serialized (issue #2348).
+    """
+    for key in _DISPOSITION_KEYS:
+        if key in updates:
+            value = updates[key]
+            if value is None:
+                continue
+            if not isinstance(value, int) or isinstance(value, bool) or not (1 <= value <= 5):
+                raise ValueError(f"{key} must be an integer between 1 and 5, got {value!r}")
 
 
 def apply_strategy(config: HindsightConfig, strategy_name: str) -> HindsightConfig:

--- a/hindsight-api-slim/tests/test_disposition_config.py
+++ b/hindsight-api-slim/tests/test_disposition_config.py
@@ -1,0 +1,64 @@
+"""Tests for write-side validation of bank disposition config overrides.
+
+Disposition traits (skepticism / literalism / empathy) are integers on a 1-5
+scale. The ``PATCH /v1/{tenant}/banks/{id}/config`` write path must reject
+out-of-contract values (floats, 0-1 scales, ints outside 1-5) at write time;
+otherwise a single malformed bank 500s the entire bank list because the read
+overlay injects the stored value verbatim into a strict
+``DispositionTraits(int, ge=1, le=5)``. See issue #2348.
+"""
+
+import pytest
+
+from hindsight_api.config_resolver import _validate_disposition_updates
+
+
+_DISPOSITION_FIELD_NAMES = (
+    "disposition_skepticism",
+    "disposition_literalism",
+    "disposition_empathy",
+)
+
+
+class TestValidateDispositionUpdates:
+    def test_no_op_passes(self):
+        _validate_disposition_updates({})
+        _validate_disposition_updates({"unrelated_field": 123})
+
+    def test_valid_in_range_integers_pass(self):
+        for key in _DISPOSITION_FIELD_NAMES:
+            for value in (1, 2, 3, 4, 5):
+                _validate_disposition_updates({key: value})
+
+    def test_none_clears_override(self):
+        # None is the "unset this per-bank override" sentinel (field is int | None).
+        for key in _DISPOSITION_FIELD_NAMES:
+            _validate_disposition_updates({key: None})
+
+    def test_out_of_range_integer_raises(self):
+        for key in _DISPOSITION_FIELD_NAMES:
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: 0})
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: 6})
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: -1})
+
+    def test_float_raises(self):
+        # The reported v0.8.3 case: a 0-1 scale used by mistake.
+        for key in _DISPOSITION_FIELD_NAMES:
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: 0.7})
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: 3.0})  # float, even if in 1-5 range
+
+    def test_bool_raises(self):
+        # bool is an int subclass and would sneak past a naive isinstance(int) check.
+        for key in _DISPOSITION_FIELD_NAMES:
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: True})
+
+    def test_string_raises(self):
+        for key in _DISPOSITION_FIELD_NAMES:
+            with pytest.raises(ValueError, match=key):
+                _validate_disposition_updates({key: "3"})


### PR DESCRIPTION
## Problem

Closes #2348.

`PATCH /v1/{tenant}/banks/{id}/config` validates field **names** only — it never checks scalar type/range. So an out-of-contract `disposition_skepticism` / `disposition_literalism` / `disposition_empathy` (a float, a 0-1 scale, or an int outside 1-5) is accepted and `json.dumps`-ed verbatim into `banks.config` JSONB. The read overlay then injects it into a strict `DispositionTraits(skepticism/literalism/empathy: int, ge=1, le=5)`. Because that model is built while serializing `BankListResponse`, a **single** malformed bank 500s `GET /v1/{tenant}/banks` for the **entire tenant** (and the per-bank profile) — a self-hoster can't list or manage *any* bank until manual JSONB surgery. This is the reported v0.8.3 case (a 0-1 scale used by mistake).

`update_bank_config` already validates names, credentials, permissions, entity_labels, retain_strategies and recall_budget, but has no disposition value check — the per-bank API is the only unguarded numeric entry point (the env path coerces via `int(os.getenv(...))`).

## Fix

Add a write-side `_validate_disposition_updates` that raises `ValueError` (the route already maps `ValueError → 400`), called from `update_bank_config` right after `_validate_recall_budget_updates`. It mirrors the existing, accepted `_validate_recall_budget_updates` shape exactly: rejects floats (incl. in-range `3.0`), bools, strings, and ints outside 1-5; accepts ints 1-5. Plus a unit test mirroring `tests/test_recall_budget_config.py::TestValidateRecallBudgetUpdates`.

**On `None`:** the validator allows `None` as the "clear this per-bank override" sentinel (the field is `int | None`). This is safe and does **not** reintroduce the 500: the read overlay `_overlay_bank_config_disposition_mission` resolves each trait as `cfg_value if cfg_value is not None else <legacy banks.disposition column>`, so a stored `null` falls back to the bank's legacy disposition and never reaches `DispositionTraits` — it can't poison the list.

## Scope

This closes the issue as stated — the write path is the entry point that lets bad values in. Already-poisoned **legacy** rows (written before this guard) would still need either a one-time cleanup or read-side hardening; I kept a read-side clamp/round out of this PR since "reject-at-write + migrate" vs "clamp-on-read" is a design call. Happy to add a clamp in `_overlay_bank_config_disposition_mission` as a follow-up if you'd prefer the list to self-heal poisoned rows.
