### PR TITLE
fix(async-op): return 404 when bank doesn't exist instead of raw FK 500

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11755,6 +11755,8 @@ class MemoryEngine(MemoryEngineInterface):
             **task_payload,
         }
 
+        from hindsight_api.extensions.operation_validator import OperationValidationError
+
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
                 if dedupe_by_bank:
@@ -11776,10 +11778,20 @@ class MemoryEngine(MemoryEngineInterface):
                     # serialize) but not with FOR KEY SHARE (so those inserts proceed).
                     # On Oracle this rewrites to FOR UPDATE, which there does not block
                     # indexed-FK child inserts.
-                    await conn.execute(
+                    #
+                    # Use fetchval so we can also verify the bank actually exists.
+                    # Without this check, callers that race against bank deletion
+                    # or that derive bank IDs before creating the bank reach the
+                    # INSERT below and get an asyncpg.ForeignKeyViolationError, which
+                    # surfaces as an opaque 500 from the API. A clean
+                    # OperationValidationError(404) is the right shape — the FastAPI
+                    # handler already converts it via its existing except clause.
+                    bank_exists = await conn.fetchval(
                         f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
                         bank_id,
                     )
+                    if bank_exists is None:
+                        raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
                     # Only check 'pending', not 'processing': a processing task uses a
                     # watermark from when it started, so memories added after that need
                     # a fresh run regardless.
@@ -11809,6 +11821,16 @@ class MemoryEngine(MemoryEngineInterface):
                                 "operation_id": str(row["operation_id"]),
                                 "deduplicated": True,
                             }
+                else:
+                    # Scoped/non-dedupe submits skip the lock + dedup above.
+                    # Still verify the bank exists so an FK violation can't
+                    # escape as a 500.
+                    bank_exists = await conn.fetchval(
+                        f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1",
+                        bank_id,
+                    )
+                    if bank_exists is None:
+                        raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
 
                 await conn.execute(
                     f"""

--- a/hindsight-api-slim/tests/test_async_submit_bank_not_found.py
+++ b/hindsight-api-slim/tests/test_async_submit_bank_not_found.py
@@ -1,0 +1,90 @@
+"""Regression test: submitting an async op for a bank that doesn't exist must
+raise a clean validation error, not a raw asyncpg `ForeignKeyViolationError`.
+
+`_submit_async_operation` inserts into `async_operations`, which has an FK to
+`banks.bank_id`. If a caller submits for a missing bank (typo, race against a
+deletion, integration that derives bank IDs before the bank is created), the
+INSERT raises `asyncpg.exceptions.ForeignKeyViolationError`. The FastAPI
+endpoint's broad `except Exception` then surfaces it as a 500 — but this is
+a client error, not a server error, and should be a 404.
+
+This test exercises the call directly via `MemoryEngine.submit_async_*` so
+the failure mode is observable without spinning up the HTTP layer.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.extensions.operation_validator import OperationValidationError
+
+pytestmark = pytest.mark.xdist_group("async_submit_bank_not_found_tests")
+
+
+@pytest.fixture
+def no_inline_execution(memory):
+    """Prevent SyncTaskBackend from running the submitted op inline so we
+    only test the submit-path failure, not downstream execution."""
+
+    async def _noop(_payload):
+        return None
+
+    original = memory._task_backend.submit_task
+    memory._task_backend.submit_task = _noop
+    yield
+    memory._task_backend.submit_task = original
+
+
+@pytest.mark.asyncio
+async def test_consolidation_submit_on_missing_bank_raises_validation_error(
+    memory, request_context, no_inline_execution
+):
+    """A `/consolidate` submit against a bank that doesn't exist must raise
+    OperationValidationError(404), not a raw asyncpg FK violation that bubbles
+    out as a 500 from the API."""
+    missing_bank = f"does-not-exist-{uuid.uuid4().hex[:8]}"
+
+    with pytest.raises(OperationValidationError) as exc_info:
+        await memory.submit_async_consolidation(
+            bank_id=missing_bank,
+            request_context=request_context,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert missing_bank in exc_info.value.reason
+
+
+@pytest.mark.asyncio
+async def test_scoped_consolidation_submit_on_missing_bank_raises_validation_error(
+    memory, request_context, no_inline_execution
+):
+    """Scoped consolidates (with `observation_scopes`) take the
+    `dedupe_by_bank=False` branch, which historically skipped the bank lock
+    entirely and went straight to the FK-violating INSERT. Same 404 contract."""
+    missing_bank = f"does-not-exist-{uuid.uuid4().hex[:8]}"
+
+    with pytest.raises(OperationValidationError) as exc_info:
+        await memory.submit_async_consolidation(
+            bank_id=missing_bank,
+            request_context=request_context,
+            observation_scopes=[{"tag": "anything"}],
+        )
+
+    assert exc_info.value.status_code == 404
+    assert missing_bank in exc_info.value.reason
+
+
+@pytest.mark.asyncio
+async def test_graph_maintenance_on_missing_bank_short_circuits(memory, request_context, no_inline_execution):
+    """`submit_async_graph_maintenance` has its own short-circuit that checks
+    the per-bank queue before calling `_submit_async_operation`. A missing
+    bank means an empty queue, so it returns `no_work=True` without reaching
+    the FK-violating INSERT. This test pins that behaviour."""
+    missing_bank = f"does-not-exist-{uuid.uuid4().hex[:8]}"
+
+    result = await memory.submit_async_graph_maintenance(
+        bank_id=missing_bank,
+        request_context=request_context,
+    )
+
+    assert result == {"operation_id": None, "no_work": True}


### PR DESCRIPTION
## Summary

`_submit_async_operation` (the helper behind `submit_async_consolidation`,
`submit_async_retain`, `submit_async_file_retain`, and
`submit_async_refresh_mental_model`) always INSERTs into `async_operations`,
which has an FK to `banks(bank_id)`. If a caller submits for a bank that
doesn't exist — race against a concurrent bank deletion, or an integration
that derives bank IDs and submits before the bank's `CREATE` has been
issued — the INSERT raises `asyncpg.exceptions.ForeignKeyViolationError`.

The FastAPI endpoints wrap submit calls in a generic `except Exception` and
return HTTP 500 with the FK violation in the detail. This is a client-side
error misclassified as a server fault. It pollutes 5xx error-rate metrics
with what should be 404s, and exposes asyncpg internals to API consumers.

## Fix

Add a bank-existence precheck at the top of the INSERT path in both branches
of `_submit_async_operation`:

- **`dedupe_by_bank=True`** already runs
  `SELECT 1 FROM banks WHERE bank_id = $1 FOR NO KEY UPDATE` for
  serialization (issue #1842). Switch it from `conn.execute()` to
  `conn.fetchval()` so the returned value gates existence — same SQL,
  same lock semantics, but the rowcount becomes observable. If
  `bank_exists is None`, raise `OperationValidationError(404)`.

- **`dedupe_by_bank=False`** (scoped consolidation submits, etc.) had no
  lock and no check; add a plain `SELECT 1 FROM banks` for existence only.
  Same `OperationValidationError(404)` on miss.

The FastAPI endpoints' existing handler already converts
`OperationValidationError` to `HTTPException(status_code=e.status_code,
detail=e.reason)` — **no API-layer changes needed**.

## Test plan

`hindsight-api-slim/tests/test_async_submit_bank_not_found.py`:

- [x] `test_consolidation_submit_on_missing_bank_raises_validation_error` —
  unscoped submit on a non-existent bank asserts `OperationValidationError`
  with `status_code == 404` and bank ID in the reason.
- [x] `test_scoped_consolidation_submit_on_missing_bank_raises_validation_error` —
  same but with `observation_scopes` set (takes the `dedupe_by_bank=False`
  branch).
- [x] `test_graph_maintenance_on_missing_bank_short_circuits` — pins the
  pre-existing behaviour that `submit_async_graph_maintenance` returns
  `{"operation_id": None, "no_work": True}` before reaching the INSERT
  (its own queue precheck already covers the FK case).

Regression sweep on adjacent suites — **59/59 passing**:
- `test_async_submit_bank_not_found.py` (new) — 3
- `test_consolidation_submit_atomic_dedup.py` — verifies dedup lock semantics
  (lock behaviour was the only thing I worried about touching). All 4 pass.
- `test_consolidation_retry_dedup_by_bank.py`
- `test_consolidation_silent_requeue_failure.py`
- `test_consolidation_scope_parallelism.py`
- `test_op_cancellation.py`
- `test_async_batch_retain.py`
- `test_async_retain_tags.py`

`ruff check` + `ruff format` clean. Pre-commit hooks pass.

## Compatibility

- Postgres: no behavior change for normal flow (bank exists). The
  `FOR NO KEY UPDATE` lock is unchanged.
- Oracle: same — the `FOR NO KEY UPDATE` -> `FOR UPDATE` rewrite is
  identical, and the existence check is a plain `SELECT 1`.
- API contract: existing 500 path on a missing-bank submit becomes a 404.
  Callers that were relying on the 500 (unlikely — it surfaced asyncpg
  internals) should already be retrying or surfacing the error.