### PR TITLE
fix(worker): count bank-serialized consolidation ops in [PENDING_BREAKDOWN] so a stuck-bank deadlock stops reporting phantom claimable (#2359)

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -1090,7 +1090,21 @@ class WorkerPoller:
                                 SUM(CASE WHEN task_payload IS NULL THEN 1 ELSE 0 END) AS payload_null,
                                 SUM(CASE WHEN next_retry_at IS NOT NULL AND next_retry_at > now()
                                     THEN 1 ELSE 0 END) AS retry_blocked,
-                                SUM(CASE WHEN worker_id IS NOT NULL THEN 1 ELSE 0 END) AS assigned
+                                SUM(CASE WHEN worker_id IS NOT NULL THEN 1 ELSE 0 END) AS assigned,
+                                -- bank_id is NOT NULL (schema), so this IN-set
+                                -- test is the exact negation of the claim
+                                -- query's ``bank_id != ALL(busy_bank_ids)`` with
+                                -- busy_bank_ids = the same DISTINCT processing set.
+                                SUM(CASE WHEN operation_type = 'consolidation'
+                                         AND task_payload IS NOT NULL
+                                         AND worker_id IS NULL
+                                         AND (next_retry_at IS NULL OR next_retry_at <= now())
+                                         AND bank_id IN (
+                                             SELECT bank_id FROM {table} busy
+                                             WHERE busy.operation_type = 'consolidation'
+                                               AND busy.status = 'processing'
+                                         )
+                                    THEN 1 ELSE 0 END) AS bank_serialized
                             FROM {table}
                             WHERE status = 'pending'
                             GROUP BY operation_type
@@ -1102,12 +1116,14 @@ class WorkerPoller:
                     for br in breakdown_rows:
                         op_type = br["operation_type"] or "unknown"
                         bucket = pending_breakdown.setdefault(
-                            op_type, {"total": 0, "payload_null": 0, "retry_blocked": 0, "assigned": 0}
+                            op_type,
+                            {"total": 0, "payload_null": 0, "retry_blocked": 0, "assigned": 0, "bank_serialized": 0},
                         )
                         bucket["total"] += br["total"]
                         bucket["payload_null"] += br["payload_null"]
                         bucket["retry_blocked"] += br["retry_blocked"]
                         bucket["assigned"] += br["assigned"]
+                        bucket["bank_serialized"] += br["bank_serialized"]
                         global_pending += br["total"]
 
                     try:
@@ -1225,15 +1241,42 @@ class WorkerPoller:
             logger.debug(f"Pool stats unavailable: {e}")
             return "unavailable"
 
+    @staticmethod
+    def _claimable_from_bucket(b: dict[str, int]) -> int:
+        """Residual pending rows that pass *every* claim predicate.
+
+        ``bank_serialized`` is the consolidation-specific exclusion the other
+        buckets miss: a pending consolidation op whose bank already has a
+        ``status='processing'`` consolidation is filtered out by the claim
+        query (``bank_id != ALL(busy_bank_ids)``) and can never be picked up
+        until that bank frees. Counting it keeps ``claimable`` honest — without
+        it a permanently bank-serialized op shows up as a phantom
+        ``claimable=1`` while nothing is ever claimed (#2359). The bucket is
+        defined as a subset of the otherwise-claimable rows, so the
+        subtraction stays non-negative; ``max(0, ...)`` is a belt-and-braces
+        floor against schema/portability surprises.
+        """
+        return max(
+            0,
+            b["total"]
+            - b["payload_null"]
+            - b["retry_blocked"]
+            - b["assigned"]
+            - b.get("bank_serialized", 0),
+        )
+
     def _log_pending_breakdown(self, breakdown: dict[str, dict[str, int]]) -> None:
         """Emit one [PENDING_BREAKDOWN] line bucketing pending rows by claimability.
 
         Each bucket mirrors a predicate in the claim query:
-          * payload_null   - row has no task_payload (e.g. batch_retain parent
-                             whose reconciliation never fired); claim query
-                             skips it forever
-          * retry_blocked  - next_retry_at is still in the future
-          * assigned       - worker_id already set; another worker owns it
+          * payload_null     - row has no task_payload (e.g. batch_retain parent
+                               whose reconciliation never fired); claim query
+                               skips it forever
+          * retry_blocked    - next_retry_at is still in the future
+          * assigned         - worker_id already set; another worker owns it
+          * bank_serialized  - pending consolidation op whose bank already has a
+                               'processing' consolidation; the claim query
+                               serializes it out until that bank frees (#2359)
 
         ``claimable`` is the residual that *should* be picked up on the next
         poll. If ``claimable > 0`` while workers report free slots, the bug is
@@ -1246,11 +1289,11 @@ class WorkerPoller:
         parts = []
         for op_type in sorted(breakdown):
             b = breakdown[op_type]
-            claimable = b["total"] - b["payload_null"] - b["retry_blocked"] - b["assigned"]
+            claimable = self._claimable_from_bucket(b)
             parts.append(
                 f"{op_type}: total={b['total']} claimable={claimable} "
                 f"payload_null={b['payload_null']} retry_blocked={b['retry_blocked']} "
-                f"assigned={b['assigned']}"
+                f"assigned={b['assigned']} bank_serialized={b.get('bank_serialized', 0)}"
             )
         logger.info(f"[PENDING_BREAKDOWN] {' | '.join(parts)}")
 

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3747,3 +3747,59 @@ class TestConsolidationBankPriority:
             high_pending_op,
         )
         assert row["status"] == "pending"
+
+
+class TestPendingBreakdownClaimable:
+    """_claimable_from_bucket must not report a bank-serialized consolidation op
+    as claimable — that phantom is exactly what made #2359 look like
+    'claimable=1 assigned=0' while the worker never claimed anything. No DB.
+    """
+
+    def test_bank_serialized_consolidation_is_not_claimable(self):
+        from hindsight_api.worker import WorkerPoller
+
+        # One stuck-bank pending op (bank_serialized), one payload_null parent,
+        # one genuinely free op -> only the free op is claimable.
+        bucket = {
+            "total": 3,
+            "payload_null": 1,
+            "retry_blocked": 0,
+            "assigned": 0,
+            "bank_serialized": 1,
+        }
+        assert WorkerPoller._claimable_from_bucket(bucket) == 1
+
+    def test_single_deadlocked_op_reports_zero_claimable(self):
+        from hindsight_api.worker import WorkerPoller
+
+        # The reporter's exact shape: a lone pending consolidation whose bank is
+        # serialized by a dead worker's 'processing' op. Old formula said
+        # claimable=1 (phantom); now it is correctly 0.
+        bucket = {
+            "total": 1,
+            "payload_null": 0,
+            "retry_blocked": 0,
+            "assigned": 0,
+            "bank_serialized": 1,
+        }
+        assert WorkerPoller._claimable_from_bucket(bucket) == 0
+
+    def test_no_bank_serialized_key_preserves_legacy_formula(self):
+        from hindsight_api.worker import WorkerPoller
+
+        # Buckets without the new key (e.g. non-consolidation op types) must
+        # behave exactly as before: total - payload_null - retry_blocked - assigned.
+        bucket = {"total": 5, "payload_null": 1, "retry_blocked": 1, "assigned": 1}
+        assert WorkerPoller._claimable_from_bucket(bucket) == 2
+
+    def test_claimable_is_floored_at_zero(self):
+        from hindsight_api.worker import WorkerPoller
+
+        bucket = {
+            "total": 1,
+            "payload_null": 1,
+            "retry_blocked": 0,
+            "assigned": 0,
+            "bank_serialized": 1,
+        }
+        assert WorkerPoller._claimable_from_bucket(bucket) == 0


### PR DESCRIPTION
## Addresses #2359

The reporter sees consolidation stalled in v0.8.3 with a `[PENDING_BREAKDOWN]`
line reporting `claimable=1 assigned=0` while no worker ever claims the op. This
PR makes that diagnostic honest; the full root cause and the remaining
(state-mutating) half are written up below for a maintainer call.

### Root cause — a permanent bank-serialization deadlock

1. `claim_batch` builds `busy_bank_ids = SELECT DISTINCT bank_id WHERE
   operation_type='consolidation' AND status='processing'`
   (`ops_postgresql.py`), and the consolidation claim excludes those banks via
   `bank_id != ALL($1::text[])` (`_claim_consolidation_plain`).
2. An op stuck in `status='processing'` under a **dead/foreign `worker_id`**
   keeps its bank in `busy_bank_ids` forever, so the pending op that new
   `/consolidate` POSTs dedupe to for that same bank is excluded on every poll.
3. The only reset of stuck `processing` rows, `recover_own_tasks`, filters
   `WHERE status='processing' AND worker_id=$1 AND result_metadata->>'batch_id'
   IS NULL` — **this** worker, at startup only. A foreign/dead `worker_id` is
   never reclaimed by any live worker, and the run loop has no periodic
   stale/orphan reaper. The repo has no worker liveness/heartbeat/registry, so
   "reclaim ops whose worker is dead" can only be keyed on `claimed_at` age.
4. The op also can't be cleared by hand: `cancel_operation` rejects non-pending
   ops and `retry_failed_consolidation` only clears unit flags, not the
   `async_operations` row.

### What this PR changes (diagnostic only)

`[PENDING_BREAKDOWN]`'s `claimable` was
`total - payload_null - retry_blocked - assigned` — it never modelled the
bank-serialization exclusion, so a permanently bank-blocked op showed up as
phantom `claimable`. This adds a `bank_serialized` bucket that mirrors the claim
query's bank exclusion (`bank_id` is `NOT NULL` by schema, so `bank_id IN
(busy)` is the exact negation of `bank_id != ALL(busy)`) and subtracts it from
`claimable` (floored at 0). The reporter's line now reads
`consolidation: total=1 claimable=0 ... bank_serialized=1`, pointing straight at
the stuck bank instead of an impossible "claimable" op.

This is read-only logging — it makes the deadlock legible but does **not** by
itself reclaim the orphaned op.

### The remaining half (deferred for a maintainer call)

To actually unstick it, an orphaned `processing` consolidation op needs to be
reset to `pending` so its bank un-serializes. Since there's no heartbeat, the
only signal is `claimed_at` age — e.g. broaden a `recover`-style reset to **any**
worker, gated on `claimed_at` older than a bounded threshold, run periodically
in the loop or as one of the existing maintenance routines. I deliberately did
**not** hard-code that threshold here: it's TOCTOU-sensitive (a legitimately
long-running op must not be double-claimed) and the right bound depends on the
deployment's max consolidation time, which is your call. Happy to follow up with
that change in whatever shape you prefer.

### Tests

`tests/test_worker.py::TestPendingBreakdownClaimable` (no DB) pins the new
formula: a bank-serialized op is not counted as claimable, the reporter's lone
deadlocked op reports `claimable=0`, buckets without the new key keep the legacy
formula, and the result is floored at 0. The SQL predicate was cross-checked
against `_claim_consolidation_plain` and the `bank_id` `NOT NULL` schema
constraint.
