### PR TITLE
feat(llm): multi-LLM failover & round-robin via indexed config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,19 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_BASE_URL=http://localhost:1234/v1
 # HINDSIGHT_API_LLM_MODEL=qwen2.5-32b-instruct
 
+# Multi-LLM strategies: configure extra LLMs by index alongside the primary above,
+# then pick a routing strategy. Unset = single primary LLM (default). Members are
+# numbered from 1; indices must be contiguous. Each operation can override with a
+# RETAIN_/REFLECT_/CONSOLIDATION_ prefix (e.g. HINDSIGHT_API_RETAIN_LLM_1_PROVIDER).
+# HINDSIGHT_API_LLM_1_PROVIDER=groq
+# HINDSIGHT_API_LLM_1_API_KEY=your-groq-api-key
+# HINDSIGHT_API_LLM_1_MODEL=openai/gpt-oss-120b
+# HINDSIGHT_API_LLM_2_PROVIDER=anthropic
+# HINDSIGHT_API_LLM_2_API_KEY=your-anthropic-api-key
+# Strategy JSON: {"mode": "failover"} or {"mode": "round-robin"}.
+# Round-robin accepts optional positive-int "weights" (one per member, primary first).
+# HINDSIGHT_API_LLM_STRATEGY={"mode": "failover"}
+
 # API Configuration (Optional)
 HINDSIGHT_API_HOST=0.0.0.0
 HINDSIGHT_API_PORT=8888

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -148,6 +148,16 @@ ENV_LLM_DEFAULT_HEADERS = "HINDSIGHT_API_LLM_DEFAULT_HEADERS"
 ENV_LLM_STRICT_SCHEMA = "HINDSIGHT_API_LLM_STRICT_SCHEMA"
 ENV_LLM_SEND_BANK_AS_USER = "HINDSIGHT_API_LLM_SEND_BANK_AS_USER"
 
+# Multi-LLM strategy. Extra LLMs are configured by index alongside the unindexed
+# primary (e.g. HINDSIGHT_API_LLM_1_PROVIDER, HINDSIGHT_API_LLM_2_PROVIDER, ...),
+# and HINDSIGHT_API_LLM_STRATEGY (JSON) selects how to route across them — see
+# _parse_llm_members / _parse_llm_strategy below. Each operation can override the
+# global chain with its own HINDSIGHT_API_<OP>_LLM_<n>_* members + _STRATEGY.
+ENV_LLM_STRATEGY = "HINDSIGHT_API_LLM_STRATEGY"
+ENV_RETAIN_LLM_STRATEGY = "HINDSIGHT_API_RETAIN_LLM_STRATEGY"
+ENV_REFLECT_LLM_STRATEGY = "HINDSIGHT_API_REFLECT_LLM_STRATEGY"
+ENV_CONSOLIDATION_LLM_STRATEGY = "HINDSIGHT_API_CONSOLIDATION_LLM_STRATEGY"
+
 # LiteLLM Router chain — provider-specific config consumed by the "litellmrouter"
 # provider. Each entry is a deployment; the Router tries them in declared order and
 # falls back to the next on transient errors (5xx, rate-limit, timeout).
@@ -1291,6 +1301,124 @@ def _parse_llm_router_config(env_var: str) -> dict | None:
         raise ValueError(f"Invalid {env_var}: invalid JSON: {e}") from e
 
 
+@dataclass
+class LLMMemberConfig:
+    """One extra LLM in a multi-LLM chain, configured via indexed env vars.
+
+    Mirrors the subset of LLM settings an indexed member supports
+    (``HINDSIGHT_API_<OP>LLM_<n>_*``). The unindexed config remains the primary
+    member (index 0); these describe members 1..N.
+    """
+
+    provider: str
+    api_key: str | None
+    model: str
+    base_url: str | None
+    reasoning_effort: str | None
+    extra_body: dict | None
+    default_headers: dict | None
+    bedrock_service_tier: str | None
+    gemini_service_tier: str | None
+
+
+# Valid multi-LLM strategy modes.
+LLM_STRATEGY_FAILOVER = "failover"
+LLM_STRATEGY_ROUND_ROBIN = "round-robin"
+_VALID_LLM_STRATEGY_MODES = (LLM_STRATEGY_FAILOVER, LLM_STRATEGY_ROUND_ROBIN)
+
+
+@dataclass
+class LLMStrategyConfig:
+    """How to route a request across the members of a multi-LLM chain.
+
+    ``mode`` is "failover" (try members in order) or "round-robin" (rotate the
+    starting member per request, then fall through the rest on error). ``weights``
+    is round-robin only: positive integers, one per member (primary first), giving
+    an unbalanced rotation; ``None`` means uniform.
+    """
+
+    mode: str
+    weights: list[int] | None = None
+
+
+def _parse_llm_strategy(raw: str | None) -> LLMStrategyConfig | None:
+    """Parse a multi-LLM strategy from a JSON env var.
+
+    Returns ``None`` when unset. The value must be a JSON object with a ``mode``
+    of "failover" or "round-robin"; ``weights`` (round-robin only) must be a list
+    of positive ints. Raises ``ValueError`` on any malformed input so
+    misconfiguration fails fast at startup rather than silently degrading.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid {ENV_LLM_STRATEGY}: invalid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Invalid LLM strategy: expected a JSON object, got {type(parsed).__name__}")
+
+    mode = parsed.get("mode")
+    if mode not in _VALID_LLM_STRATEGY_MODES:
+        raise ValueError(f"Invalid LLM strategy mode {mode!r}. Must be one of: {', '.join(_VALID_LLM_STRATEGY_MODES)}.")
+
+    weights = parsed.get("weights")
+    if weights is not None:
+        if mode != LLM_STRATEGY_ROUND_ROBIN:
+            raise ValueError(f"LLM strategy 'weights' is only valid with mode '{LLM_STRATEGY_ROUND_ROBIN}'.")
+        if not isinstance(weights, list) or not weights or not all(isinstance(w, int) and w > 0 for w in weights):
+            raise ValueError("LLM strategy 'weights' must be a non-empty list of positive integers.")
+
+    return LLMStrategyConfig(mode=mode, weights=weights)
+
+
+def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
+    """Parse indexed extra-LLM members for an operation env prefix.
+
+    ``prefix`` is the operation segment in the env name: ``""`` (global),
+    ``"RETAIN_"``, ``"REFLECT_"`` or ``"CONSOLIDATION_"``. Members are read from
+    ``HINDSIGHT_API_{prefix}LLM_{n}_PROVIDER`` for n = 1, 2, ... and scanning
+    stops at the first index whose ``_PROVIDER`` is unset (so indices must be
+    contiguous from 1). ``MODEL`` defaults to the provider's default model.
+    """
+    from .engine.llm_wrapper import requires_api_key
+
+    members: list[LLMMemberConfig] = []
+    index = 1
+    while True:
+        base = f"HINDSIGHT_API_{prefix}LLM_{index}_"
+        provider = os.getenv(base + "PROVIDER")
+        if not provider:
+            break
+
+        api_key = os.getenv(base + "API_KEY") or None
+        if not api_key and requires_api_key(provider):
+            raise ValueError(
+                f"{base}API_KEY is required for provider '{provider}' (member {index} of the multi-LLM chain)."
+            )
+
+        gemini_service_tier = os.getenv(base + "GEMINI_SERVICE_TIER")
+        members.append(
+            LLMMemberConfig(
+                provider=provider,
+                api_key=api_key,
+                model=os.getenv(base + "MODEL") or _get_default_model_for_provider(provider),
+                base_url=os.getenv(base + "BASE_URL") or None,
+                reasoning_effort=os.getenv(base + "REASONING_EFFORT") or None,
+                extra_body=json.loads(os.getenv(base + "EXTRA_BODY", "null")),
+                default_headers=json.loads(os.getenv(base + "DEFAULT_HEADERS", "null")),
+                bedrock_service_tier=os.getenv(base + "BEDROCK_SERVICE_TIER") or None,
+                gemini_service_tier=(
+                    parse_gemini_service_tier(gemini_service_tier) if provider.lower() == "gemini" else None
+                ),
+            )
+        )
+        index += 1
+
+    return members
+
+
 def _parse_default_bank_template(raw: str | None) -> dict | None:
     """
     Parse HINDSIGHT_API_DEFAULT_BANK_TEMPLATE as JSON.
@@ -1744,6 +1872,20 @@ class HindsightConfig:
     file_parser_markitdown_ocr_model: str | None = None
     file_parser_markitdown_ocr_prompt: str = DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
 
+    # Multi-LLM chains (static, server-level). Index 0 of each chain is the
+    # corresponding unindexed/base LLM config above; these hold the extra indexed
+    # members and the routing strategy. Per-op members fall back to the global
+    # members when unset (see MemoryEngine._build_llm). Credential fields (members
+    # embed api_keys/base_urls).
+    llm_members: list[LLMMemberConfig] = field(default_factory=list)
+    llm_strategy: LLMStrategyConfig | None = None
+    retain_llm_members: list[LLMMemberConfig] = field(default_factory=list)
+    retain_llm_strategy: LLMStrategyConfig | None = None
+    reflect_llm_members: list[LLMMemberConfig] = field(default_factory=list)
+    reflect_llm_strategy: LLMStrategyConfig | None = None
+    consolidation_llm_members: list[LLMMemberConfig] = field(default_factory=list)
+    consolidation_llm_strategy: LLMStrategyConfig | None = None
+
     # Class-level sets for configuration categorization
 
     # CREDENTIAL_FIELDS: Never exposed via API, never configurable per-tenant/bank
@@ -1758,6 +1900,11 @@ class HindsightConfig:
         "retain_llm_litellmrouter_config",
         "reflect_llm_litellmrouter_config",
         "consolidation_llm_litellmrouter_config",
+        # Multi-LLM chains — members embed api_keys and base_urls
+        "llm_members",
+        "retain_llm_members",
+        "reflect_llm_members",
+        "consolidation_llm_members",
         # Base URLs (could expose infrastructure)
         "llm_base_url",
         "retain_llm_base_url",
@@ -2177,6 +2324,15 @@ class HindsightConfig:
             if os.getenv(ENV_CONSOLIDATION_LLM_TIMEOUT)
             else None,
             consolidation_llm_litellmrouter_config=_parse_llm_router_config(ENV_CONSOLIDATION_LLM_LITELLMROUTER_CONFIG),
+            # Multi-LLM chains (indexed members + routing strategy)
+            llm_members=_parse_llm_members(""),
+            llm_strategy=_parse_llm_strategy(os.getenv(ENV_LLM_STRATEGY)),
+            retain_llm_members=_parse_llm_members("RETAIN_"),
+            retain_llm_strategy=_parse_llm_strategy(os.getenv(ENV_RETAIN_LLM_STRATEGY)),
+            reflect_llm_members=_parse_llm_members("REFLECT_"),
+            reflect_llm_strategy=_parse_llm_strategy(os.getenv(ENV_REFLECT_LLM_STRATEGY)),
+            consolidation_llm_members=_parse_llm_members("CONSOLIDATION_"),
+            consolidation_llm_strategy=_parse_llm_strategy(os.getenv(ENV_CONSOLIDATION_LLM_STRATEGY)),
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
             embeddings_local_model=os.getenv(ENV_EMBEDDINGS_LOCAL_MODEL, DEFAULT_EMBEDDINGS_LOCAL_MODEL),

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -128,6 +128,21 @@ class ConfigResolver:
         # Return full config object (dataclass doesn't have __init__ that accepts kwargs, so we update the object)
         # Create a new config instance by copying the global config and updating fields
         resolved_config = HindsightConfig(**config_dict)
+        # Multi-LLM chains are static credential fields (never tenant/bank-overridable),
+        # but asdict() above flattened their member dataclasses into plain dicts. Restore
+        # the original typed objects from the global config so the resolved object stays
+        # well-typed for any consumer that reads them.
+        resolved_config = replace(
+            resolved_config,
+            llm_members=self._global_config.llm_members,
+            llm_strategy=self._global_config.llm_strategy,
+            retain_llm_members=self._global_config.retain_llm_members,
+            retain_llm_strategy=self._global_config.retain_llm_strategy,
+            reflect_llm_members=self._global_config.reflect_llm_members,
+            reflect_llm_strategy=self._global_config.reflect_llm_strategy,
+            consolidation_llm_members=self._global_config.consolidation_llm_members,
+            consolidation_llm_strategy=self._global_config.consolidation_llm_strategy,
+        )
         validate_retain_chunking_config(
             resolved_config.retain_chunk_size,
             resolved_config.retain_structured_chunk_size,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -35,6 +35,8 @@ from ..config import (
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
     ENV_MODEL_INIT_TIMEOUT,
     HindsightConfig,
+    LLMMemberConfig,
+    LLMStrategyConfig,
     get_config,
 )
 from ..tracing import create_operation_span
@@ -348,6 +350,7 @@ from enum import Enum
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
 from .llm_wrapper import LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
+from .multi_llm import MultiLLMProvider
 from .query_analyzer import QueryAnalyzer
 from .reflect import run_reflect_agent
 from .reflect.tools import tool_expand, tool_recall, tool_search_mental_models, tool_search_observations
@@ -381,6 +384,52 @@ from .token_encoding import get_token_encoding
 
 RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
 RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
+
+
+def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMConfig:
+    """Build an LLMProvider from one indexed multi-LLM member.
+
+    Member fields are self-contained; reasoning_effort falls back to the global
+    setting and default_headers falls back inside ``LLMProvider`` when unset.
+    """
+    return LLMConfig(
+        provider=member.provider,
+        api_key=member.api_key or "",
+        base_url=member.base_url,
+        model=member.model,
+        reasoning_effort=member.reasoning_effort or config.llm_reasoning_effort,
+        extra_body=member.extra_body,
+        default_headers=member.default_headers,
+        bedrock_service_tier=member.bedrock_service_tier,
+        gemini_service_tier=member.gemini_service_tier,
+    )
+
+
+def _build_llm(
+    base: LLMConfig,
+    config: HindsightConfig,
+    prefix: str,
+) -> "LLMConfig | MultiLLMProvider":
+    """Resolve an operation's multi-LLM chain and wrap ``base`` (member 0) in it.
+
+    ``prefix`` is ``""`` (global) or ``"retain_"`` / ``"reflect_"`` /
+    ``"consolidation_"``. A per-op slot with no indexed members (or no strategy)
+    inherits the global chain, mirroring how per-op base config falls back to the
+    global LLM config. Returns ``base`` unchanged when no chain is configured
+    (byte-identical hot path).
+    """
+    members: list[LLMMemberConfig] = getattr(config, f"{prefix}llm_members")
+    strategy: LLMStrategyConfig | None = getattr(config, f"{prefix}llm_strategy")
+    if prefix:
+        if not members:
+            members = config.llm_members
+        if strategy is None:
+            strategy = config.llm_strategy
+
+    if not strategy or not members:
+        return base
+    extra = [_member_to_llm(m, config) for m in members]
+    return MultiLLMProvider([base, *extra], strategy)
 
 
 def _is_oracledb_connection_error(e: Exception) -> bool:
@@ -955,7 +1004,7 @@ class MemoryEngine(MemoryEngineInterface):
             self.query_analyzer = DateparserQueryAnalyzer()
 
         # Initialize LLM configuration (default, used as fallback)
-        self._llm_config = LLMConfig(
+        _default_base_llm = LLMConfig(
             provider=memory_llm_provider,
             api_key=memory_llm_api_key,
             base_url=memory_llm_base_url,
@@ -967,10 +1016,12 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._llm_config = _build_llm(_default_base_llm, config, "")
 
-        # Store client and model for convenience (deprecated: use _llm_config.call() instead)
-        self._llm_client = self._llm_config._client
-        self._llm_model = self._llm_config.model
+        # Store client and model for convenience (deprecated: use _llm_config.call() instead).
+        # Read from the primary member so a multi-LLM chain behaves like the base config here.
+        self._llm_client = _default_base_llm._client
+        self._llm_model = _default_base_llm.model
 
         # Initialize per-operation LLM configs (fall back to default if not specified)
         # Retain LLM config - for fact extraction (benefits from strong structured output)
@@ -989,7 +1040,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 retain_base_url = ""
 
-        self._retain_llm_config = LLMConfig(
+        _retain_base_llm = LLMConfig(
             provider=retain_provider,
             api_key=retain_api_key,
             base_url=retain_base_url,
@@ -1001,6 +1052,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_")
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
         reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
@@ -1018,7 +1070,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 reflect_base_url = ""
 
-        self._reflect_llm_config = LLMConfig(
+        _reflect_base_llm = LLMConfig(
             provider=reflect_provider,
             api_key=reflect_api_key,
             base_url=reflect_base_url,
@@ -1030,6 +1082,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_")
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
         consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
@@ -1047,7 +1100,7 @@ class MemoryEngine(MemoryEngineInterface):
             else:
                 consolidation_base_url = ""
 
-        self._consolidation_llm_config = LLMConfig(
+        _consolidation_base_llm = LLMConfig(
             provider=consolidation_provider,
             api_key=consolidation_api_key,
             base_url=consolidation_base_url,
@@ -1059,6 +1112,7 @@ class MemoryEngine(MemoryEngineInterface):
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
         )
+        self._consolidation_llm_config = _build_llm(_consolidation_base_llm, config, "consolidation_")
 
         # Initialize cross-encoder reranker (cached for performance)
         self._cross_encoder_reranker = CrossEncoderReranker(cross_encoder=cross_encoder)
@@ -2515,7 +2569,7 @@ class MemoryEngine(MemoryEngineInterface):
             provider becomes available (e.g. after a quota reset).
             """
             if not self._skip_llm_verification:
-                configs_to_verify: list[tuple[str, LLMConfig]] = [("default", self._llm_config)]
+                configs_to_verify: list[tuple[str, LLMConfig | MultiLLMProvider]] = [("default", self._llm_config)]
 
                 # Verify retain config if different from default
                 retain_is_different = (

--- a/hindsight-api-slim/hindsight_api/engine/multi_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_llm.py
@@ -1,0 +1,204 @@
+"""Multi-LLM routing: failover and (weighted) round-robin across N providers.
+
+``MultiLLMProvider`` wraps an ordered list of :class:`LLMProvider` members and a
+:class:`~hindsight_api.config.LLMStrategyConfig`, exposing the same public surface
+as a single ``LLMProvider`` so it drops into every existing call path (including
+``with_config()`` / ``ConfiguredLLMProvider``).
+
+Member 0 is the **primary** (the operation's unindexed/base LLM); members 1..N are
+the indexed extras (``HINDSIGHT_API_<OP>LLM_<n>_*``). Each member keeps its own
+internal retry budget, so we only advance to the next member after a member has
+exhausted its retries and raised.
+
+Strategies:
+- ``failover``: try members in declared order ``[0..N]``.
+- ``round-robin``: rotate the starting member per request (optionally weighted),
+  then fall through the remaining members on error.
+
+Batch retain and any direct ``_provider_impl`` access operate on the **primary
+member only** (via attribute passthrough) — failover/round-robin apply to the
+interactive ``call`` / ``call_with_tools`` paths.
+"""
+
+import logging
+import threading
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from ..config import LLM_STRATEGY_FAILOVER, LLMStrategyConfig
+from .llm_wrapper import LLMProvider, OutputTooLongError
+
+if TYPE_CHECKING:
+    from .llm_wrapper import ConfiguredLLMProvider, LLMToolCallResult
+
+logger = logging.getLogger(__name__)
+
+
+def _should_failover(exc: BaseException) -> bool:
+    """Whether ``exc`` from one member should trigger a try on the next member.
+
+    Generic ``Exception`` instances (network errors, provider 5xx, timeouts after
+    a member's own retries) fail over. ``OutputTooLongError`` is propagated — a
+    different provider won't fit an over-length output either. ``CancelledError``,
+    ``KeyboardInterrupt`` and ``SystemExit`` are ``BaseException`` (not
+    ``Exception``) and therefore propagate unchanged.
+    """
+    if isinstance(exc, OutputTooLongError):
+        return False
+    return isinstance(exc, Exception)
+
+
+class _WeightedRoundRobin:
+    """Smooth weighted round-robin scheduler (nginx SWRR).
+
+    Produces a starting member index per request such that, over time, member
+    ``i`` is chosen in proportion to ``weights[i]`` while keeping selections
+    interleaved rather than bursty. Uniform weights degrade to plain round-robin.
+    The tiny selection critical section is mutex-guarded so concurrent callers
+    don't corrupt the running totals (they may still interleave, which only
+    affects distribution, never correctness).
+    """
+
+    def __init__(self, weights: list[int]) -> None:
+        self._weights = list(weights)
+        self._current = [0] * len(weights)
+        self._total = sum(weights)
+        self._lock = threading.Lock()
+
+    def next(self) -> int:
+        with self._lock:
+            best = 0
+            for i, w in enumerate(self._weights):
+                self._current[i] += w
+                if self._current[i] > self._current[best]:
+                    best = i
+            self._current[best] -= self._total
+            return best
+
+
+class MultiLLMProvider:
+    """Route LLM calls across multiple members per a failover / round-robin strategy."""
+
+    def __init__(self, members: list[LLMProvider], strategy: LLMStrategyConfig) -> None:
+        if not members:
+            raise ValueError("MultiLLMProvider requires at least one member")
+        self._members = members
+        self._strategy = strategy
+
+        weights = strategy.weights or [1] * len(members)
+        if len(weights) != len(members):
+            raise ValueError(
+                f"LLM strategy 'weights' has {len(weights)} entries but the chain has "
+                f"{len(members)} members (primary + indexed); they must match."
+            )
+        self._scheduler = _WeightedRoundRobin(weights)
+
+    # ── routing ────────────────────────────────────────────────────────────────
+
+    def _member_order(self) -> list[int]:
+        """Indices to try, in order, for one request."""
+        n = len(self._members)
+        if self._strategy.mode == LLM_STRATEGY_FAILOVER:
+            return list(range(n))
+        start = self._scheduler.next()
+        return [(start + i) % n for i in range(n)]
+
+    async def _dispatch(self, method_name: str, **kwargs: Any) -> Any:
+        last_exc: BaseException | None = None
+        order = self._member_order()
+        for position, idx in enumerate(order):
+            member = self._members[idx]
+            try:
+                return await getattr(member, method_name)(**kwargs)
+            except BaseException as e:  # noqa: BLE001 - re-raised unless it should fail over
+                if not _should_failover(e):
+                    raise
+                last_exc = e
+                remaining = len(order) - position - 1
+                logger.warning(
+                    "LLM member %d (%s/%s) failed on %s: %s%s",
+                    idx,
+                    member.provider,
+                    member.model,
+                    method_name,
+                    e,
+                    f"; trying next member ({remaining} left)" if remaining else "; no members left",
+                )
+        # All members failed; surface the last error (loop ran at least once).
+        assert last_exc is not None
+        raise last_exc
+
+    async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
+        return await self._dispatch("call", messages=messages, **kwargs)
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> "LLMToolCallResult":
+        return await self._dispatch("call_with_tools", messages=messages, tools=tools, **kwargs)
+
+    # ── lifecycle ────────────────────────────────────────────────────────────────
+
+    async def verify_connection(self) -> None:
+        """Strictly verify the primary; soft-verify the rest (warn, don't fail).
+
+        A failover member being unreachable at startup must not block the server —
+        it may come back before it's needed. The primary is the steady-state path,
+        so its failure is still surfaced (the caller already wraps this in a
+        warn-only try/except at startup).
+        """
+        await self._members[0].verify_connection()
+        for member in self._members[1:]:
+            try:
+                await member.verify_connection()
+            except Exception as e:  # noqa: BLE001 - soft verification
+                logger.warning(
+                    "Failover LLM member %s/%s failed connection verification: %s. "
+                    "It will be tried at request time if the primary fails.",
+                    member.provider,
+                    member.model,
+                    e,
+                )
+
+    async def cleanup(self) -> None:
+        for member in self._members:
+            await member.cleanup()
+
+    def with_config(
+        self,
+        config: Any,
+        *,
+        bank_id: str | None = None,
+        operation: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> "ConfiguredLLMProvider":
+        """Mirror ``LLMProvider.with_config`` so the strategy runs inside the
+        per-operation configured wrapper (gemini-safety + trace contextvars wrap
+        every member call)."""
+        from .llm_trace import LLMTraceContext
+        from .llm_wrapper import ConfiguredLLMProvider
+
+        trace_ctx = None
+        if bank_id is not None or operation is not None or metadata:
+            trace_ctx = LLMTraceContext(
+                bank_id=bank_id,
+                operation=operation,
+                metadata=dict(metadata or {}),
+                trace_id=str(uuid.uuid4()),
+                operation_span_id=str(uuid.uuid4()),
+            )
+        return ConfiguredLLMProvider(self, config.llm_gemini_safety_settings, trace_ctx)
+
+    # ── attribute passthrough ────────────────────────────────────────────────────
+
+    @property
+    def members(self) -> list[LLMProvider]:
+        return self._members
+
+    def __getattr__(self, name: str) -> Any:
+        # Anything not defined here (provider, model, api_key, base_url,
+        # _provider_impl, mock helpers, batch helpers, ...) delegates to the
+        # primary member so existing call sites keep working unchanged.
+        return getattr(object.__getattribute__(self, "_members")[0], name)

--- a/hindsight-api-slim/tests/test_multi_llm_config.py
+++ b/hindsight-api-slim/tests/test_multi_llm_config.py
@@ -1,0 +1,222 @@
+"""Tests for multi-LLM env parsing and engine-chain resolution helpers.
+
+Covers indexed-member discovery, strategy JSON parsing/validation, and the
+per-slot resolution + wrapping logic (``_build_llm``)
+without constructing a full MemoryEngine.
+"""
+
+import pytest
+
+from hindsight_api.config import (
+    HindsightConfig,
+    LLMMemberConfig,
+    LLMStrategyConfig,
+    _parse_llm_members,
+    _parse_llm_strategy,
+)
+from hindsight_api.engine.llm_wrapper import LLMProvider
+from hindsight_api.engine.memory_engine import _build_llm
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+
+
+@pytest.fixture
+def clean_llm_env(monkeypatch):
+    """Strip all HINDSIGHT_API_*LLM* env so each test sets only what it needs."""
+    import os
+
+    for key in list(os.environ):
+        if key.startswith("HINDSIGHT_API_") and "LLM" in key:
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-primary")
+    return monkeypatch
+
+
+# ── member parsing ─────────────────────────────────────────────────────────────
+
+
+def test_parse_members_empty_when_unset(clean_llm_env):
+    assert _parse_llm_members("") == []
+    assert _parse_llm_members("RETAIN_") == []
+
+
+def test_parse_members_indexed(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "groq")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_API_KEY", "gsk-1")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_MODEL", "llama-x")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_2_PROVIDER", "anthropic")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_2_API_KEY", "ak-2")
+
+    members = _parse_llm_members("")
+    assert [(m.provider, m.model) for m in members] == [
+        ("groq", "llama-x"),
+        ("anthropic", "claude-haiku-4-5"),  # model defaulted from provider
+    ]
+    assert members[0].api_key == "gsk-1"
+
+
+def test_parse_members_stops_at_first_gap(clean_llm_env):
+    # Index 2 present but 1 missing → scan stops at 1, member 2 ignored.
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_2_PROVIDER", "groq")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_2_API_KEY", "gsk-2")
+    assert _parse_llm_members("") == []
+
+
+def test_parse_members_per_op_prefix(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_RETAIN_LLM_1_PROVIDER", "groq")
+    clean_llm_env.setenv("HINDSIGHT_API_RETAIN_LLM_1_API_KEY", "gsk-1")
+    retain = _parse_llm_members("RETAIN_")
+    assert [m.provider for m in retain] == ["groq"]
+    assert _parse_llm_members("") == []  # global still empty
+
+
+def test_parse_members_missing_api_key_raises(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "openai")  # requires key
+    with pytest.raises(ValueError, match="API_KEY is required"):
+        _parse_llm_members("")
+
+
+def test_parse_members_no_key_provider_ok(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "ollama")  # no key needed
+    members = _parse_llm_members("")
+    assert members[0].provider == "ollama"
+    assert members[0].api_key is None
+
+
+# ── strategy parsing ───────────────────────────────────────────────────────────
+
+
+def test_parse_strategy_none_when_unset():
+    assert _parse_llm_strategy(None) is None
+    assert _parse_llm_strategy("") is None
+    assert _parse_llm_strategy("   ") is None
+
+
+def test_parse_strategy_failover():
+    s = _parse_llm_strategy('{"mode": "failover"}')
+    assert s == LLMStrategyConfig(mode="failover", weights=None)
+
+
+def test_parse_strategy_weighted_round_robin():
+    s = _parse_llm_strategy('{"mode": "round-robin", "weights": [3, 1]}')
+    assert s.mode == "round-robin"
+    assert s.weights == [3, 1]
+
+
+def test_parse_strategy_invalid_json():
+    with pytest.raises(ValueError, match="invalid JSON"):
+        _parse_llm_strategy("{not json")
+
+
+def test_parse_strategy_invalid_mode():
+    with pytest.raises(ValueError, match="Invalid LLM strategy mode"):
+        _parse_llm_strategy('{"mode": "magic"}')
+
+
+def test_parse_strategy_weights_require_round_robin():
+    with pytest.raises(ValueError, match="only valid with mode"):
+        _parse_llm_strategy('{"mode": "failover", "weights": [1, 1]}')
+
+
+def test_parse_strategy_weights_must_be_positive_ints():
+    with pytest.raises(ValueError, match="positive integers"):
+        _parse_llm_strategy('{"mode": "round-robin", "weights": [1, 0]}')
+    with pytest.raises(ValueError, match="positive integers"):
+        _parse_llm_strategy('{"mode": "round-robin", "weights": []}')
+
+
+# ── from_env integration ────────────────────────────────────────────────────────
+
+
+def test_from_env_no_chain_is_empty(clean_llm_env):
+    config = HindsightConfig.from_env()
+    assert config.llm_members == []
+    assert config.llm_strategy is None
+
+
+def test_from_env_global_chain(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "ollama")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_STRATEGY", '{"mode": "failover"}')
+    config = HindsightConfig.from_env()
+    assert [m.provider for m in config.llm_members] == ["ollama"]
+    assert config.llm_strategy.mode == "failover"
+
+
+# ── chain resolution + wrapping (_build_llm) ────────────────────────────────────
+
+
+def _empty_config(**overrides) -> HindsightConfig:
+    """A minimal HindsightConfig from env, then patched with the given fields."""
+    import dataclasses
+
+    base = HindsightConfig.from_env()
+    return dataclasses.replace(base, **overrides)
+
+
+def _member(provider="ollama"):
+    return LLMMemberConfig(
+        provider=provider,
+        api_key=None,
+        model="m",
+        base_url=None,
+        reasoning_effort=None,
+        extra_body=None,
+        default_headers=None,
+        bedrock_service_tier=None,
+        gemini_service_tier=None,
+    )
+
+
+def _base_llm() -> LLMProvider:
+    return LLMProvider(provider="mock", api_key="", base_url="", model="m0")
+
+
+def test_build_llm_no_chain_returns_plain_provider(clean_llm_env):
+    base = _base_llm()
+    result = _build_llm(base, _empty_config(), "")
+    assert result is base
+    assert not isinstance(result, MultiLLMProvider)
+
+
+def test_build_llm_global_chain_wraps(clean_llm_env):
+    config = _empty_config(
+        llm_members=[_member("ollama")],
+        llm_strategy=LLMStrategyConfig(mode="failover"),
+    )
+    base = _base_llm()
+    result = _build_llm(base, config, "")
+    assert isinstance(result, MultiLLMProvider)
+    assert result.members[0] is base  # primary stays index 0
+    assert result.members[1].provider == "ollama"
+
+
+def test_build_llm_per_op_inherits_global(clean_llm_env):
+    config = _empty_config(
+        llm_members=[_member("ollama")],
+        llm_strategy=LLMStrategyConfig(mode="failover"),
+        retain_llm_members=[],
+        retain_llm_strategy=None,
+    )
+    result = _build_llm(_base_llm(), config, "retain_")
+    assert isinstance(result, MultiLLMProvider)
+    assert [m.provider for m in result.members[1:]] == ["ollama"]  # inherited
+
+
+def test_build_llm_per_op_overrides_global(clean_llm_env):
+    config = _empty_config(
+        llm_members=[_member("ollama")],
+        llm_strategy=LLMStrategyConfig(mode="failover"),
+        retain_llm_members=[_member("lmstudio")],
+        retain_llm_strategy=LLMStrategyConfig(mode="round-robin"),
+    )
+    result = _build_llm(_base_llm(), config, "retain_")
+    assert isinstance(result, MultiLLMProvider)
+    assert [m.provider for m in result.members[1:]] == ["lmstudio"]
+    assert result._strategy.mode == "round-robin"
+
+
+def test_build_llm_members_without_strategy_stays_plain(clean_llm_env):
+    # Members configured but no strategy → no wrapping (strategy is required).
+    config = _empty_config(llm_members=[_member("ollama")], llm_strategy=None)
+    base = _base_llm()
+    assert _build_llm(base, config, "") is base

--- a/hindsight-api-slim/tests/test_multi_llm_provider.py
+++ b/hindsight-api-slim/tests/test_multi_llm_provider.py
@@ -1,0 +1,200 @@
+"""Unit tests for MultiLLMProvider routing (failover + weighted round-robin).
+
+Deterministic: members are lightweight fakes that record calls and either return
+a sentinel or raise a chosen exception. No real providers / network.
+"""
+
+import asyncio
+
+import pytest
+
+from hindsight_api.config import LLMStrategyConfig
+from hindsight_api.engine.llm_wrapper import OutputTooLongError
+from hindsight_api.engine.multi_llm import (
+    MultiLLMProvider,
+    _should_failover,
+    _WeightedRoundRobin,
+)
+
+
+class FakeMember:
+    """Stands in for an LLMProvider member.
+
+    ``behavior`` is a value to return, or an exception instance/class to raise.
+    Each ``call`` / ``call_with_tools`` is recorded so tests can assert which
+    member served (and how many times).
+    """
+
+    def __init__(self, name: str, behavior):
+        self.provider = name
+        self.model = f"{name}-model"
+        self._provider_impl = object()
+        self.behavior = behavior
+        self.calls = 0
+        self.verified = 0
+
+    async def call(self, **kwargs):
+        self.calls += 1
+        return self._resolve()
+
+    async def call_with_tools(self, **kwargs):
+        self.calls += 1
+        return self._resolve()
+
+    async def verify_connection(self):
+        self.verified += 1
+        if isinstance(self.behavior, BaseException) or (
+            isinstance(self.behavior, type) and issubclass(self.behavior, BaseException)
+        ):
+            raise self.behavior if isinstance(self.behavior, BaseException) else self.behavior()
+
+    async def cleanup(self):
+        pass
+
+    def _resolve(self):
+        b = self.behavior
+        if isinstance(b, BaseException):
+            raise b
+        if isinstance(b, type) and issubclass(b, BaseException):
+            raise b()
+        return b
+
+
+def _failover(*members):
+    return MultiLLMProvider(list(members), LLMStrategyConfig(mode="failover"))
+
+
+def _round_robin(*members, weights=None):
+    return MultiLLMProvider(list(members), LLMStrategyConfig(mode="round-robin", weights=weights))
+
+
+# ── failover ─────────────────────────────────────────────────────────────────
+
+
+async def test_failover_uses_primary_on_success():
+    a, b = FakeMember("a", "RA"), FakeMember("b", "RB")
+    result = await _failover(a, b).call(messages=[])
+    assert result == "RA"
+    assert (a.calls, b.calls) == (1, 0)  # secondary untouched
+
+
+async def test_failover_advances_only_after_member_raises():
+    a = FakeMember("a", RuntimeError("primary down"))
+    b = FakeMember("b", "RB")
+    result = await _failover(a, b).call(messages=[])
+    assert result == "RB"
+    assert (a.calls, b.calls) == (1, 1)
+
+
+async def test_failover_reraises_last_exception_when_all_fail():
+    a = FakeMember("a", RuntimeError("first"))
+    b = FakeMember("b", ValueError("last"))
+    with pytest.raises(ValueError, match="last"):
+        await _failover(a, b).call(messages=[])
+    assert (a.calls, b.calls) == (1, 1)
+
+
+async def test_call_with_tools_fails_over_too():
+    a = FakeMember("a", RuntimeError("down"))
+    b = FakeMember("b", "tools-ok")
+    result = await _failover(a, b).call_with_tools(messages=[], tools=[])
+    assert result == "tools-ok"
+    assert (a.calls, b.calls) == (1, 1)
+
+
+# ── error classification ──────────────────────────────────────────────────────
+
+
+async def test_output_too_long_is_not_failed_over():
+    a = FakeMember("a", OutputTooLongError("too long"))
+    b = FakeMember("b", "RB")
+    with pytest.raises(OutputTooLongError):
+        await _failover(a, b).call(messages=[])
+    assert b.calls == 0  # never tried the secondary
+
+
+async def test_cancellation_propagates_without_failover():
+    a = FakeMember("a", asyncio.CancelledError())
+    b = FakeMember("b", "RB")
+    with pytest.raises(asyncio.CancelledError):
+        await _failover(a, b).call(messages=[])
+    assert b.calls == 0
+
+
+def test_should_failover_classification():
+    assert _should_failover(RuntimeError()) is True
+    assert _should_failover(ValueError()) is True
+    assert _should_failover(OutputTooLongError("x")) is False
+    assert _should_failover(asyncio.CancelledError()) is False
+    assert _should_failover(KeyboardInterrupt()) is False
+    assert _should_failover(SystemExit()) is False
+
+
+# ── round-robin ───────────────────────────────────────────────────────────────
+
+
+async def test_round_robin_rotates_start_member():
+    a, b, c = FakeMember("a", "RA"), FakeMember("b", "RB"), FakeMember("c", "RC")
+    rr = _round_robin(a, b, c)
+    results = [await rr.call(messages=[]) for _ in range(3)]
+    # Smooth WRR with uniform weights visits every member once per cycle.
+    assert sorted(results) == ["RA", "RB", "RC"]
+    assert (a.calls, b.calls, c.calls) == (1, 1, 1)
+
+
+async def test_round_robin_falls_over_when_selected_member_fails():
+    a = FakeMember("a", RuntimeError("a down"))
+    b = FakeMember("b", "RB")
+    # Two members, uniform weights: whichever is selected first, a failure must
+    # still produce a successful result via the other member.
+    rr = _round_robin(a, b)
+    result = await rr.call(messages=[])
+    assert result == "RB"
+
+
+async def test_weighted_round_robin_honors_ratio():
+    a, b = FakeMember("a", "RA"), FakeMember("b", "RB")
+    rr = _round_robin(a, b, weights=[3, 1])
+    for _ in range(8):
+        await rr.call(messages=[])
+    # 3:1 over 8 requests → a served 6, b served 2.
+    assert (a.calls, b.calls) == (6, 2)
+
+
+def test_weighted_scheduler_distribution():
+    sched = _WeightedRoundRobin([5, 1])
+    picks = [sched.next() for _ in range(6)]
+    assert picks.count(0) == 5
+    assert picks.count(1) == 1
+
+
+# ── construction / delegation ─────────────────────────────────────────────────
+
+
+def test_weights_length_must_match_members():
+    with pytest.raises(ValueError, match="weights"):
+        MultiLLMProvider(
+            [FakeMember("a", "x"), FakeMember("b", "y")],
+            LLMStrategyConfig(mode="round-robin", weights=[1, 1, 1]),
+        )
+
+
+def test_attribute_passthrough_to_primary():
+    a, b = FakeMember("a", "RA"), FakeMember("b", "RB")
+    multi = _failover(a, b)
+    assert multi.provider == "a"  # primary
+    assert multi.model == "a-model"
+    assert multi._provider_impl is a._provider_impl
+
+
+async def test_verify_connection_strict_primary_soft_secondary():
+    # Primary down → raises (strict).
+    down_primary = _failover(FakeMember("a", RuntimeError("down")), FakeMember("b", "RB"))
+    with pytest.raises(RuntimeError):
+        await down_primary.verify_connection()
+
+    # Secondary down → swallowed (soft), primary still verified.
+    a = FakeMember("a", "RA")
+    b = FakeMember("b", RuntimeError("down"))
+    await _failover(a, b).verify_connection()
+    assert a.verified == 1 and b.verified == 1

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -355,6 +355,46 @@ export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
 
 The config is a credential field — never returned by the bank-config API. Hindsight already retries calls; set `"num_retries": 0` in the Router config to avoid double-retries. Batch APIs aren't supported in router mode.
 
+### Multi-LLM Strategies (failover / round-robin)
+
+Configure additional LLMs **by index** alongside the primary, then choose a strategy for routing across them. This is a provider-agnostic alternative to the LiteLLM Router: the indexed LLMs can be any mix of providers, each fully configured.
+
+The unindexed `HINDSIGHT_API_LLM_*` config is the **primary** (member 1). Extra members are numbered from 1:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_LLM_<n>_PROVIDER` | Provider for extra member `n` (`n` = 1, 2, ...). Presence of this var defines the member; indices must be contiguous from 1. | - |
+| `HINDSIGHT_API_LLM_<n>_API_KEY` | API key for member `n` (required unless the provider needs none). | - |
+| `HINDSIGHT_API_LLM_<n>_MODEL` | Model for member `n`. | Provider default |
+| `HINDSIGHT_API_LLM_<n>_BASE_URL` | Base URL for member `n`. | Provider default |
+| `HINDSIGHT_API_LLM_<n>_REASONING_EFFORT` | Reasoning effort for member `n`. | `HINDSIGHT_API_LLM_REASONING_EFFORT` |
+| `HINDSIGHT_API_LLM_<n>_EXTRA_BODY` / `_DEFAULT_HEADERS` | Per-member JSON overrides. | - |
+| `HINDSIGHT_API_LLM_<n>_BEDROCK_SERVICE_TIER` / `_GEMINI_SERVICE_TIER` | Per-member service tier. | - |
+| `HINDSIGHT_API_LLM_STRATEGY` | JSON routing strategy across the chain. Unset = single primary LLM (no change). | - |
+
+The strategy JSON supports two modes:
+
+- `{"mode": "failover"}` — try members in order (primary first); on a member's failure (after its own retries) advance to the next.
+- `{"mode": "round-robin"}` — rotate the starting member per request to spread load, then fall through the rest on failure. Add `"weights": [3, 1, ...]` (positive ints, one per member, primary first) for an **unbalanced** rotation.
+
+```bash
+# Primary OpenAI, failover to Groq then Anthropic
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-...
+export HINDSIGHT_API_LLM_1_PROVIDER=groq
+export HINDSIGHT_API_LLM_1_API_KEY=gsk-...
+export HINDSIGHT_API_LLM_2_PROVIDER=anthropic
+export HINDSIGHT_API_LLM_2_API_KEY=sk-ant-...
+export HINDSIGHT_API_LLM_STRATEGY='{"mode": "failover"}'
+
+# Weighted round-robin: serve the primary 3x as often as member 1
+export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
+```
+
+**Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
+
+The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the primary member only; failover/round-robin apply to the interactive retain/reflect/consolidation calls.
+
 ### Built-in llama.cpp
 
 The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB). Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -43,6 +43,19 @@ HINDSIGHT_API_LLM_BASE_URL=https://api.openai.com/v1
 # HINDSIGHT_API_LLM_BASE_URL=http://localhost:1234/v1
 # HINDSIGHT_API_LLM_MODEL=qwen2.5-32b-instruct
 
+# Multi-LLM strategies: configure extra LLMs by index alongside the primary above,
+# then pick a routing strategy. Unset = single primary LLM (default). Members are
+# numbered from 1; indices must be contiguous. Each operation can override with a
+# RETAIN_/REFLECT_/CONSOLIDATION_ prefix (e.g. HINDSIGHT_API_RETAIN_LLM_1_PROVIDER).
+# HINDSIGHT_API_LLM_1_PROVIDER=groq
+# HINDSIGHT_API_LLM_1_API_KEY=your-groq-api-key
+# HINDSIGHT_API_LLM_1_MODEL=openai/gpt-oss-120b
+# HINDSIGHT_API_LLM_2_PROVIDER=anthropic
+# HINDSIGHT_API_LLM_2_API_KEY=your-anthropic-api-key
+# Strategy JSON: {"mode": "failover"} or {"mode": "round-robin"}.
+# Round-robin accepts optional positive-int "weights" (one per member, primary first).
+# HINDSIGHT_API_LLM_STRATEGY={"mode": "failover"}
+
 # API Configuration (Optional)
 HINDSIGHT_API_HOST=0.0.0.0
 HINDSIGHT_API_PORT=8888

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -355,6 +355,46 @@ export HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG='{
 
 The config is a credential field — never returned by the bank-config API. Hindsight already retries calls; set `"num_retries": 0` in the Router config to avoid double-retries. Batch APIs aren't supported in router mode.
 
+### Multi-LLM Strategies (failover / round-robin)
+
+Configure additional LLMs **by index** alongside the primary, then choose a strategy for routing across them. This is a provider-agnostic alternative to the LiteLLM Router: the indexed LLMs can be any mix of providers, each fully configured.
+
+The unindexed `HINDSIGHT_API_LLM_*` config is the **primary** (member 1). Extra members are numbered from 1:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_LLM_<n>_PROVIDER` | Provider for extra member `n` (`n` = 1, 2, ...). Presence of this var defines the member; indices must be contiguous from 1. | - |
+| `HINDSIGHT_API_LLM_<n>_API_KEY` | API key for member `n` (required unless the provider needs none). | - |
+| `HINDSIGHT_API_LLM_<n>_MODEL` | Model for member `n`. | Provider default |
+| `HINDSIGHT_API_LLM_<n>_BASE_URL` | Base URL for member `n`. | Provider default |
+| `HINDSIGHT_API_LLM_<n>_REASONING_EFFORT` | Reasoning effort for member `n`. | `HINDSIGHT_API_LLM_REASONING_EFFORT` |
+| `HINDSIGHT_API_LLM_<n>_EXTRA_BODY` / `_DEFAULT_HEADERS` | Per-member JSON overrides. | - |
+| `HINDSIGHT_API_LLM_<n>_BEDROCK_SERVICE_TIER` / `_GEMINI_SERVICE_TIER` | Per-member service tier. | - |
+| `HINDSIGHT_API_LLM_STRATEGY` | JSON routing strategy across the chain. Unset = single primary LLM (no change). | - |
+
+The strategy JSON supports two modes:
+
+- `{"mode": "failover"}` — try members in order (primary first); on a member's failure (after its own retries) advance to the next.
+- `{"mode": "round-robin"}` — rotate the starting member per request to spread load, then fall through the rest on failure. Add `"weights": [3, 1, ...]` (positive ints, one per member, primary first) for an **unbalanced** rotation.
+
+```bash
+# Primary OpenAI, failover to Groq then Anthropic
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-...
+export HINDSIGHT_API_LLM_1_PROVIDER=groq
+export HINDSIGHT_API_LLM_1_API_KEY=gsk-...
+export HINDSIGHT_API_LLM_2_PROVIDER=anthropic
+export HINDSIGHT_API_LLM_2_API_KEY=sk-ant-...
+export HINDSIGHT_API_LLM_STRATEGY='{"mode": "failover"}'
+
+# Weighted round-robin: serve the primary 3x as often as member 1
+export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
+```
+
+**Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
+
+The indexed members are credential fields — never returned by the bank-config API and server-level only (not per-bank configurable). **Batch retain** runs on the primary member only; failover/round-robin apply to the interactive retain/reflect/consolidation calls.
+
 ### Built-in llama.cpp
 
 The `llamacpp` provider runs a llama.cpp server as a managed subprocess — no external LLM server needed. On first run it auto-downloads a default GGUF model (~3.5 GB). Requires the `local-llm` extra: `pip install 'hindsight-api-slim[local-llm]'`.
@@ -1750,6 +1790,7 @@ The Control Plane is the web UI for managing memory banks.
 | `HINDSIGHT_CP_DATAPLANE_API_URL` | URL of the API service | `http://localhost:8888` |
 | `HINDSIGHT_CP_DATAPLANE_API_KEY` | Bearer token the Control Plane sends as `Authorization: Bearer <key>` on every request to the API service. Required when the API service is auth-protected; omit for a public API. | *(none — no `Authorization` header sent)* |
 | `HINDSIGHT_CP_ACCESS_KEY` | Access key to protect the Control Plane UI. When set, users must enter this key to log in. | *(none — auth disabled)* |
+| `HINDSIGHT_CP_MAX_UPLOAD_SIZE` | Maximum size of a single file-upload request the Control Plane accepts before truncating it. Accepts a size string (`100mb`, `1gb`) or a number of bytes. Raise this to upload files larger than the default, and keep it in line with the API's `HINDSIGHT_API_FILE_CONVERSION_MAX_BATCH_SIZE_MB`. | `100mb` |
 | `NEXT_PUBLIC_BASE_PATH` | Base path for Control Plane UI when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a general, **extensible multi-LLM layer**: configure N LLMs by index and pick a routing strategy. This is a provider-agnostic alternative to the LiteLLM Router and a more flexible replacement for a single hard-coded failover secondary (supersedes the direction of #2332).

The unindexed `HINDSIGHT_API_LLM_*` config stays the **primary** (member 1); extra members are numbered from 1, and `HINDSIGHT_API_LLM_STRATEGY` (JSON) selects how to route.

```bash
HINDSIGHT_API_LLM_PROVIDER=openai          # primary
HINDSIGHT_API_LLM_API_KEY=sk-...
HINDSIGHT_API_LLM_1_PROVIDER=groq          # member 2
HINDSIGHT_API_LLM_1_API_KEY=gsk-...
HINDSIGHT_API_LLM_2_PROVIDER=anthropic     # member 3
HINDSIGHT_API_LLM_2_API_KEY=sk-ant-...
HINDSIGHT_API_LLM_STRATEGY='{"mode":"failover"}'
# or load-spread:  {"mode":"round-robin"}
# or unbalanced:   {"mode":"round-robin","weights":[3,1,1]}
```

**Strategies**
- `failover` — try members in declared order; advance on a member's failure (after its own retries).
- `round-robin` — rotate the starting member per request to spread load, then fall through the rest on failure. Optional positive-int `weights` (one per member, primary first) for an unbalanced rotation (smooth weighted RR).

**Per-operation chains** — each operation can override the global chain with a `RETAIN_`/`REFLECT_`/`CONSOLIDATION_` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-op slot with no indexed members (or no strategy) inherits the global chain.

## Design

- `MultiLLMProvider` mirrors the `LLMProvider` public surface, so it drops into every existing call path — `with_config()` / `ConfiguredLLMProvider` and `_provider_impl` attribute passthrough are untouched.
- Each member keeps its own retry budget; we only advance to the next member after a member exhausts retries and raises.
- `OutputTooLongError` is propagated (a different provider won't fit it either); `CancelledError`/`KeyboardInterrupt`/`SystemExit` propagate unchanged.
- `verify_connection`: strict on the primary, soft (warn-only) on the rest, so a down failover member doesn't block startup.
- No-config path returns the plain `LLMProvider` unchanged (byte-identical hot path).

## Files
- `config.py` — `LLMMemberConfig`/`LLMStrategyConfig` dataclasses, `_parse_llm_members`/`_parse_llm_strategy`, 8 new `HindsightConfig` fields (credential, server-level static), `from_env()` wiring.
- `engine/multi_llm.py` (new) — `MultiLLMProvider`, `_should_failover`, smooth weighted RR scheduler.
- `engine/memory_engine.py` — `_build_llm` resolves + wraps each of the 4 LLM slots.
- `config_resolver.py` — restore typed member objects after the `asdict` round-trip.
- Docs (`configuration.md`), `.env.example` (+ embed sync), tests.

## Notes / non-goals (v1)
- **Batch retain** runs on the primary member only; failover/round-robin apply to the interactive `call`/`call_with_tools` paths.
- Server-level static config (not per-bank configurable), consistent with other LLM credential fields. The strategy JSON shape is forward-extensible (e.g. future `max_attempts`).

## Tests
- `tests/test_multi_llm_provider.py` — failover ordering, weighted round-robin distribution, error classification, all-fail re-raise, attribute passthrough, strict/soft verify.
- `tests/test_multi_llm_config.py` — indexed-member parsing (contiguity, per-op prefixes, missing-key), strategy JSON validation, per-op inherit/override, plain-vs-wrapped build.
- 34 new tests pass; `ruff` + `ty` + `lint.sh` clean; embed env-template sync test passes.
