### PR TITLE
fix(memory-defense): correct displayed pattern count

### DIFF
--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "Schwärzen",
     "memoryDefenseAction_block": "Blockieren",
     "memoryDefenseSecretLeakTitle": "Geheimnislecks verhindern",
-    "memoryDefenseSecretLeakDescription": "Gespeicherte Inhalte auf Geheimnisse prüfen. 44 Muster für gängige Anbieter-Schlüssel, AWS und persönliche Daten.",
+    "memoryDefenseSecretLeakDescription": "Gespeicherte Inhalte auf Geheimnisse prüfen. 45 Muster für gängige Anbieter-Schlüssel, AWS und persönliche Daten.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Mehr erkennen, intelligenter redigieren, alles auditieren — verfügbar in Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Erweiterte Geheimnis-Erkennung: 200+ Muster für Anbieter-Schlüssel, AWS, GitHub und CI-Token",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "Redact",
     "memoryDefenseAction_block": "Block",
     "memoryDefenseSecretLeakTitle": "Secret leak prevention",
-    "memoryDefenseSecretLeakDescription": "Scan retained content for secrets. 44 patterns covering common provider keys, AWS, and PII.",
+    "memoryDefenseSecretLeakDescription": "Scan retained content for secrets. 45 patterns covering common provider keys, AWS, and PII.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detect more, redact smarter, and audit everything — available in Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Advanced secret detection: 200+ patterns covering provider keys, AWS, GitHub, and CI tokens",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "Redactar",
     "memoryDefenseAction_block": "Bloquear",
     "memoryDefenseSecretLeakTitle": "Prevención de fugas de secretos",
-    "memoryDefenseSecretLeakDescription": "Analiza el contenido retenido en busca de secretos. 44 patrones que cubren claves comunes de proveedores, AWS e información personal.",
+    "memoryDefenseSecretLeakDescription": "Analiza el contenido retenido en busca de secretos. 45 patrones que cubren claves comunes de proveedores, AWS e información personal.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detecta más, redacta más inteligentemente y audita todo: disponible en Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Detección avanzada de secretos: más de 200 patrones que cubren claves de proveedores, AWS, GitHub y tokens de CI",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "Censurer",
     "memoryDefenseAction_block": "Bloquer",
     "memoryDefenseSecretLeakTitle": "Prévention des fuites de secrets",
-    "memoryDefenseSecretLeakDescription": "Analyse le contenu retenu à la recherche de secrets. 44 motifs couvrant les clés de fournisseurs courants, AWS et les informations personnelles.",
+    "memoryDefenseSecretLeakDescription": "Analyse le contenu retenu à la recherche de secrets. 45 motifs couvrant les clés de fournisseurs courants, AWS et les informations personnelles.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Détectez davantage, expurgez plus intelligemment et auditez tout — disponible dans Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Détection avancée de secrets : plus de 200 motifs couvrant les clés de fournisseurs, AWS, GitHub et tokens CI",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "マスク",
     "memoryDefenseAction_block": "ブロック",
     "memoryDefenseSecretLeakTitle": "シークレット漏洩防止",
-    "memoryDefenseSecretLeakDescription": "保持されたコンテンツのシークレットをスキャンします。一般的なプロバイダーキー、AWS、個人情報をカバーする44パターン。",
+    "memoryDefenseSecretLeakDescription": "保持されたコンテンツのシークレットをスキャンします。一般的なプロバイダーキー、AWS、個人情報をカバーする45パターン。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "より多くを検出し、よりスマートに編集し、すべてを監査 — Hindsight Cloudで利用可能。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "高度なシークレット検出:プロバイダーキー、AWS、GitHub、CIトークンをカバーする200以上のパターン",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "마스킹",
     "memoryDefenseAction_block": "차단",
     "memoryDefenseSecretLeakTitle": "시크릿 유출 방지",
-    "memoryDefenseSecretLeakDescription": "보존된 콘텐츠에서 시크릿을 검사합니다. 일반적인 공급자 키, AWS, 개인 정보를 포함하는 44개 패턴.",
+    "memoryDefenseSecretLeakDescription": "보존된 콘텐츠에서 시크릿을 검사합니다. 일반적인 공급자 키, AWS, 개인 정보를 포함하는 45개 패턴.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "더 많이 감지하고, 더 똑똑하게 편집하며, 모든 것을 감사하세요 — Hindsight Cloud에서 사용 가능.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "고급 시크릿 감지: 공급자 키, AWS, GitHub, CI 토큰을 포함하는 200개 이상의 패턴",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "Redigir",
     "memoryDefenseAction_block": "Bloquear",
     "memoryDefenseSecretLeakTitle": "Prevenção de vazamento de segredos",
-    "memoryDefenseSecretLeakDescription": "Verifica o conteúdo retido em busca de segredos. 44 padrões cobrindo chaves comuns de provedores, AWS e informações pessoais.",
+    "memoryDefenseSecretLeakDescription": "Verifica o conteúdo retido em busca de segredos. 45 padrões cobrindo chaves comuns de provedores, AWS e informações pessoais.",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "Detecte mais, edite com mais inteligência e audite tudo: disponível no Hindsight Cloud.",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "Detecção avançada de segredos: mais de 200 padrões cobrindo chaves de provedores, AWS, GitHub e tokens de CI",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "遮蔽",
     "memoryDefenseAction_block": "封鎖",
     "memoryDefenseSecretLeakTitle": "密鑰外洩防護",
-    "memoryDefenseSecretLeakDescription": "掃描保留內容嘅密鑰。44 種樣式涵蓋常見供應商金鑰、AWS 同個人資料。",
+    "memoryDefenseSecretLeakDescription": "掃描保留內容嘅密鑰。45 種樣式涵蓋常見供應商金鑰、AWS 同個人資料。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "偵測更多、智能編輯、全面稽核 — Hindsight Cloud 提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "進階密鑰偵測:200+ 種樣式,涵蓋供應商金鑰、AWS、GitHub 同 CI 權杖",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "脱敏",
     "memoryDefenseAction_block": "拦截",
     "memoryDefenseSecretLeakTitle": "密钥泄露防护",
-    "memoryDefenseSecretLeakDescription": "扫描保留内容中的密钥。44 种模式,涵盖常见提供商密钥、AWS 和个人信息。",
+    "memoryDefenseSecretLeakDescription": "扫描保留内容中的密钥。45 种模式,涵盖常见提供商密钥、AWS 和个人信息。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "检测更多、智能编辑、全面审计 — Hindsight Cloud 中提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "高级密钥检测:200+ 模式,涵盖提供商密钥、AWS、GitHub 和 CI 令牌",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -433,7 +433,7 @@
     "memoryDefenseAction_redact": "去敏",
     "memoryDefenseAction_block": "阻擋",
     "memoryDefenseSecretLeakTitle": "密鑰外洩防護",
-    "memoryDefenseSecretLeakDescription": "掃描保留內容中的密鑰。44 種模式涵蓋常見供應商金鑰、AWS 與個人資訊。",
+    "memoryDefenseSecretLeakDescription": "掃描保留內容中的密鑰。45 種模式涵蓋常見供應商金鑰、AWS 與個人資訊。",
     "memoryDefenseEnterpriseTitle": "Memory Defense Enterprise",
     "memoryDefenseEnterpriseSubtitle": "偵測更多、智能編輯、全面稽核 — Hindsight Cloud 提供。",
     "memoryDefenseEnterpriseFeatureDetectSecrets": "進階密鑰偵測:200+ 種樣式,涵蓋供應商金鑰、AWS、GitHub 與 CI 權杖",

--- a/hindsight-docs/blog/2026-06-12-version-0-8-2.md
+++ b/hindsight-docs/blog/2026-06-12-version-0-8-2.md
@@ -22,7 +22,7 @@ Hindsight 0.8.2 builds on [0.8.1](/blog/2026/06/09/version-0-8-1) with a much bi
 
 Agents routinely see API keys, tokens, and personal data — and without guardrails, any of it can get written straight into long-term memory. **Memory Defense** is a new, open-source layer that scrubs sensitive data out of retained content before it's ever stored.
 
-When enabled on a bank, every memory the agent writes is scanned against a **44-pattern set** covering provider API keys (Anthropic, OpenAI, Google, and more), generic secrets, database connection strings, and common PII. Each match is replaced with a `[REDACTED:type]` marker before the content reaches memory units or the document body, so recall, exports, and reflect never see the original secret. You choose the action per rule:
+When enabled on a bank, every memory the agent writes is scanned against a **45-pattern set** covering provider API keys (Anthropic, OpenAI, Google, and more), generic secrets, database connection strings, and common PII. Each match is replaced with a `[REDACTED:type]` marker before the content reaches memory units or the document body, so recall, exports, and reflect never see the original secret. You choose the action per rule:
 
 - **`redact`** — replace each match with a `[REDACTED:type]` marker and store the scrubbed memory.
 - **`block`** — drop any item that contains a match; if every item in a retain request is blocked, the call returns `422`.

--- a/hindsight-docs/docs/developer/memory-defense/index.md
+++ b/hindsight-docs/docs/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 44-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 44 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 44 bundled patterns cover the categories below.
+The 45 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 

--- a/hindsight-docs/versioned_docs/version-0.8/developer/memory-defense/index.md
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 44-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 44 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 44 bundled patterns cover the categories below.
+The 45 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 

--- a/skills/hindsight-docs/references/developer/memory-defense/index.md
+++ b/skills/hindsight-docs/references/developer/memory-defense/index.md
@@ -4,7 +4,7 @@ sidebar_position: 95
 
 # Memory Defense
 
-Hindsight scrubs secrets and PII from retain content using a 44-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
+Hindsight scrubs secrets and PII from retain content using a 45-pattern regex set. Each match is replaced with a `[REDACTED:type]` marker before content reaches memory units or the document body. The feature is configured per bank and disabled by default.
 
 ## How it works
 
@@ -36,7 +36,7 @@ A minimal policy:
 }
 ```
 
-Once that policy is on a bank, every retain to that bank is screened with the 44 redaction patterns documented below.
+Once that policy is on a bank, every retain to that bank is screened with the 45 redaction patterns documented below.
 
 :::note Existing memories are not retroactively scanned
 Enabling Memory Defense on a bank only affects future retain calls. Memories already in the bank are not re-scanned or modified when you add or change a policy. If you need to scrub a bank that already contains unredacted content, you have to re-ingest the affected memories or remove them manually.
@@ -54,7 +54,7 @@ The same redact/block decisions are also recorded as `memory_defense` entries in
 
 ## Patterns covered
 
-The 44 bundled patterns cover the categories below.
+The 45 bundled patterns cover the categories below.
 
 ### AI and LLM providers
 


### PR DESCRIPTION
## Summary

- Correct the documented Memory Defense regex pattern count from 44 to 45.
- Update the current docs, versioned 0.8 docs, release blog, docs reference copy, and control-plane locale strings.

## Why

The built-in `_REDACTION_PATTERNS` list currently contains 45 entries, but several documentation and UI strings still described it as a 44-pattern set.

## Validation

- Counted `_REDACTION_PATTERNS` from `hindsight-api-slim/hindsight_api/extensions/memory_defense.py` with a small AST script.
- Searched for remaining `44-pattern` / `44 redaction patterns` / `44 bundled patterns` and control-plane Memory Defense `44` strings.
- Pre-commit hooks ran during commit; lint completed successfully.
