### PR TITLE
fix(cli): pass u64 limit/offset to regenerated client

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -425,8 +425,8 @@ impl ApiClient {
                 .client
                 .list_documents(
                     agent_id,
-                    limit.map(|l| l as i64),
-                    offset.map(|o| o as i64),
+                    limit.map(|l| l as u64),
+                    offset.map(|o| o as u64),
                     q,
                     None,
                     None,
@@ -524,8 +524,8 @@ impl ApiClient {
                     bank_id,
                     None, // consolidation_state
                     None, // document_id
-                    limit,
-                    offset,
+                    limit.map(|l| l as u64),
+                    offset.map(|o| o as u64),
                     q,
                     None, // state
                     type_filter,
@@ -546,7 +546,12 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .list_entities(bank_id, limit, offset, None)
+                .list_entities(
+                    bank_id,
+                    limit.map(|l| l as u64),
+                    offset.map(|o| o as u64),
+                    None,
+                )
                 .await?;
             Ok(response.into_inner())
         })
@@ -664,7 +669,17 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .get_graph(bank_id, None, None, limit, None, None, None, type_filter, None)
+                .get_graph(
+                    bank_id,
+                    None,
+                    None,
+                    limit.map(|l| l as u64),
+                    None,
+                    None,
+                    None,
+                    type_filter,
+                    None,
+                )
                 .await?;
             Ok(response.into_inner())
         })
@@ -726,7 +741,14 @@ impl ApiClient {
         self.runtime.block_on(async {
             let response = self
                 .client
-                .list_tags(bank_id, limit, offset, q, None, None)
+                .list_tags(
+                    bank_id,
+                    limit.map(|l| l as u64),
+                    offset.map(|o| o as u64),
+                    q,
+                    None,
+                    None,
+                )
                 .await?;
             Ok(response.into_inner())
         })


### PR DESCRIPTION
## Problem

`cargo build` for the Rust CLI fails on `main`, breaking the `test-rust-cli` and `test-doc-examples (cli)` CI jobs:

```
error[E0308]: arguments to this method are incorrect
  --> src/api.rs:426
note: expected `Option<u64>`, found `Option<i64>`
```

The generated `hindsight-client` was regenerated with `limit`/`offset` typed as `Option<u64>` (the OpenAPI spec marks them as unsigned, `minimum: 0`), but the hand-written `api.rs` wrappers still passed `Option<i64>`.

## Fix

Cast `limit`/`offset` to `u64` at each affected call site — `list_documents`, `list_memories`, `list_entities`, `get_graph`, `list_tags` — matching the `as i64`→`as u64` pattern already used for `list_documents`. No wrapper signatures or callers change.

## Verification

- `cargo build` — clean
- `cargo test` — 57 + 24 + 11 + 7 tests pass
- `cargo fmt --check` — clean
