### PR TITLE
test: eagerly import torch in conftest to fix test-api shard flake

### DIFF
--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -11,6 +11,22 @@ import pytest
 import pytest_asyncio
 from dotenv import load_dotenv
 
+# Force torch to initialize exactly once, in the main thread, at conftest import
+# time — before any fixture spins up an event loop or sentence-transformers'
+# thread pools. torch's C-level `_add_docstr(_has_torch_function, ...)` in
+# torch/overrides.py is not re-entrancy-safe: when the first `import torch`
+# happens lazily from inside concurrent/async code (e.g.
+# embeddings.initialize() -> sentence_transformers -> transformers -> torch, or
+# cross_encoder's ThreadPoolExecutor), torch/overrides.py can execute twice and
+# raise "RuntimeError: function '_has_torch_function' already has a docstring",
+# failing collection of every test on the pytest-xdist shard. Importing it here
+# (single-threaded, before any concurrency) makes that registration happen once
+# per worker process. Guarded so slim/no-torch environments still collect.
+try:
+    import torch  # noqa: F401  # eager one-time init; see comment above
+except ImportError:
+    pass
+
 from hindsight_api import LLMConfig, LocalSTEmbeddings, MemoryEngine, RequestContext
 from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
 from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer


### PR DESCRIPTION
## Symptom

`test-api` shard 2/3 intermittently fails, with dozens of tests erroring at **collection** time:

```
RuntimeError: function '_has_torch_function' already has a docstring
../.venv/.../torch/overrides.py:1778: RuntimeError
```

The count drifts run-to-run (62 → 58 → 34 collection errors), and re-running sometimes clears it — a classic nondeterministic flake. It is unrelated to any individual PR; it just happens to land on whichever tests xdist schedules onto the affected worker.

## Root cause

The first `import torch` in a worker process happens **lazily, from inside concurrent/async code**:

```
tests/conftest.py:415  embeddings fixture -> emb.initialize()
hindsight_api/engine/embeddings.py:174  from sentence_transformers import SentenceTransformer
   -> transformers -> import torch
   -> torch/_tensor.py -> torch/overrides.py:1778
        has_torch_function = _add_docstr(_has_torch_function, "...")   # <-- raises
```

`cross_encoder.py` similarly imports torch lazily from inside a `ThreadPoolExecutor`. torch's C-level `_add_docstr(...)` registration in `torch/overrides.py` is **not re-entrancy-safe** — if `torch/overrides.py` gets executed twice in one process (which happens when the first import is driven from concurrent/threaded code), the second execution raises because the docstring is already set. That kills collection of every test on the shard.

## Fix

Import `torch` **once, in the main thread, at conftest import time** — before any fixture spins up an event loop or sentence-transformers' thread pools. This makes the `_add_docstr` registration happen exactly once per xdist worker process; every later lazy `import torch` is then just a `sys.modules` hit. Guarded with `try/except ImportError` so slim/no-torch environments still collect.

Test-only change (`tests/conftest.py`); no production code touched.

## Verification

- `ruff check` clean (the `# noqa: F401` keeps the intentional import).
- Local suite still collects and runs (`test_link_utils.py`: 40 passed).
- The flake is nondeterministic, so the real signal is repeated-green `test-api` shards in CI on this PR.
