### PR TITLE
feat: configurable embedded PostgreSQL port via HINDSIGHT_EMBED_DB_PORT (#2379)

### DIFF
--- a/hindsight-api-slim/hindsight_api/pg0.py
+++ b/hindsight-api-slim/hindsight_api/pg0.py
@@ -36,13 +36,22 @@ class EmbeddedPostgres:
             env_port = os.getenv("HINDSIGHT_EMBED_DB_PORT")
             if env_port:
                 try:
-                    port = int(env_port)
+                    parsed = int(env_port)
                 except ValueError:
                     logger.warning(
                         "Ignoring invalid HINDSIGHT_EMBED_DB_PORT=%r (not an integer)",
                         env_port,
                     )
-        self.port = port  # None means pg0 will auto-assign a free port
+                else:
+                    if 1 <= parsed <= 65535:
+                        port = parsed
+                    else:
+                        logger.warning(
+                            "Ignoring out-of-range HINDSIGHT_EMBED_DB_PORT=%r "
+                            "(must be a TCP port 1-65535)",
+                            env_port,
+                        )
+        self.port = port  # None => port not passed to pg0 (it uses its own default)
         self.username = username
         self.password = password
         self.database = database

--- a/hindsight-api-slim/hindsight_api/pg0.py
+++ b/hindsight-api-slim/hindsight_api/pg0.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -27,7 +28,21 @@ class EmbeddedPostgres:
         config: dict[str, str] | None = None,
         **kwargs,
     ):
-        self.port = port  # None means pg0 will auto-assign
+        # Fall back to HINDSIGHT_EMBED_DB_PORT when no explicit port is given, so
+        # the embedded PostgreSQL can be pinned to a known port (e.g. to avoid a
+        # collision with another local Postgres on the default 5432). An explicit
+        # ``port=`` argument always takes precedence.
+        if port is None:
+            env_port = os.getenv("HINDSIGHT_EMBED_DB_PORT")
+            if env_port:
+                try:
+                    port = int(env_port)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid HINDSIGHT_EMBED_DB_PORT=%r (not an integer)",
+                        env_port,
+                    )
+        self.port = port  # None means pg0 will auto-assign a free port
         self.username = username
         self.password = password
         self.database = database

--- a/hindsight-api-slim/tests/test_embedded_db_port_env.py
+++ b/hindsight-api-slim/tests/test_embedded_db_port_env.py
@@ -1,0 +1,35 @@
+"""HINDSIGHT_EMBED_DB_PORT controls the embedded PostgreSQL port.
+
+Loads ``pg0.py`` in isolation so the test exercises only the constructor's port
+resolution without importing the full ``hindsight_api`` package or starting a
+real PostgreSQL.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_PG0 = Path(__file__).resolve().parents[1] / "hindsight_api" / "pg0.py"
+_spec = importlib.util.spec_from_file_location("hindsight_api_pg0_under_test", _PG0)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+EmbeddedPostgres = _mod.EmbeddedPostgres
+
+
+def test_env_sets_port(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_EMBED_DB_PORT", "5544")
+    assert EmbeddedPostgres().port == 5544
+
+
+def test_explicit_port_overrides_env(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_EMBED_DB_PORT", "5544")
+    assert EmbeddedPostgres(port=5999).port == 5999
+
+
+def test_invalid_env_is_ignored(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_EMBED_DB_PORT", "not-a-port")
+    assert EmbeddedPostgres().port is None
+
+
+def test_unset_env_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("HINDSIGHT_EMBED_DB_PORT", raising=False)
+    assert EmbeddedPostgres().port is None

--- a/hindsight-api-slim/tests/test_embedded_db_port_env.py
+++ b/hindsight-api-slim/tests/test_embedded_db_port_env.py
@@ -8,6 +8,8 @@ real PostgreSQL.
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _PG0 = Path(__file__).resolve().parents[1] / "hindsight_api" / "pg0.py"
 _spec = importlib.util.spec_from_file_location("hindsight_api_pg0_under_test", _PG0)
 _mod = importlib.util.module_from_spec(_spec)
@@ -33,3 +35,15 @@ def test_invalid_env_is_ignored(monkeypatch):
 def test_unset_env_defaults_to_none(monkeypatch):
     monkeypatch.delenv("HINDSIGHT_EMBED_DB_PORT", raising=False)
     assert EmbeddedPostgres().port is None
+
+
+@pytest.mark.parametrize("bad_port", ["0", "-1", "70000", "99999"])
+def test_out_of_range_env_is_ignored(monkeypatch, bad_port):
+    monkeypatch.setenv("HINDSIGHT_EMBED_DB_PORT", bad_port)
+    assert EmbeddedPostgres().port is None
+
+
+@pytest.mark.parametrize("edge_port", ["1", "65535"])
+def test_valid_edge_ports_accepted(monkeypatch, edge_port):
+    monkeypatch.setenv("HINDSIGHT_EMBED_DB_PORT", edge_port)
+    assert EmbeddedPostgres().port == int(edge_port)


### PR DESCRIPTION
## Summary

Adds an env var, **`HINDSIGHT_EMBED_DB_PORT`**, to pin the embedded PostgreSQL port in local-embedded mode. Fixes #2379.

## Problem

`EmbeddedPostgres(port=None)` → pg0 doesn't pass `--port` → PostgreSQL falls back to its default **5432**, and there's no way to override it. The embedded daemon constructs the default instance as `EmbeddedPostgres()` (`hindsight_api/pg0.py`), so on a host already running Postgres on 5432 (a Docker container, another project) the embedded instance silently collides — and a client pointed at `127.0.0.1:5432` can reach the wrong server (`password authentication failed for user "hindsight"`).

## Change

`EmbeddedPostgres.__init__` now falls back to `HINDSIGHT_EMBED_DB_PORT` when no explicit `port` is passed:

- explicit `port=` always wins (unchanged behavior for callers that pass one, incl. tests),
- env var pins the port for the daemon's default `EmbeddedPostgres()`,
- invalid values are ignored with a warning (falls back to pg0 auto-assign),
- unset → `None` → existing auto-assign behavior (unchanged default).

pg0 already accepts a port; this just wires a config surface to it.

## Tests

Added `hindsight-api-slim/tests/test_embedded_db_port_env.py` (4 cases: env sets port / explicit overrides env / invalid ignored / unset → None). It loads `pg0.py` in isolation so it doesn't require a running PostgreSQL.

Verified locally by exec'ing the constructor directly (the full pytest harness pulls the embedded-PG fixtures, so I ran the port-resolution logic standalone):

```
Ignoring invalid HINDSIGHT_EMBED_DB_PORT='not-a-port' (not an integer)
OK: all 4 cases pass (env set / explicit overrides / invalid ignored / unset=None)
```

## Related

Complementary pg0 fix so auto-allocation also avoids IPv6/dual-stack collisions: vectorize-io/pg0#20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
