### PR TITLE
fix(deps): raise hindsight-litellm LiteLLM floor

### DIFF
--- a/hindsight-integrations/litellm/pyproject.toml
+++ b/hindsight-integrations/litellm/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 dependencies = [
     "hindsight-client>=0.4.0",  # provides both hindsight_client and hindsight_client_api
-    "litellm>=1.83.0", # 1.82.7/1.82.8 had a supply chain compromise (yanked); 1.83.0+ also fixes GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789
+    "litellm>=1.83.14", # 1.82.7/1.82.8 supply-chain fix plus GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789 / GHSA-qrc4-49gv-mv9m / GHSA-wpfp-gwwc-vwq6
     # Transitive dependency security fixes
     "aiohttp>=3.13.3",  # Multiple DoS vulnerabilities
     "filelock>=3.20.3",  # TOCTOU race condition

--- a/hindsight-integrations/litellm/uv.lock
+++ b/hindsight-integrations/litellm/uv.lock
@@ -679,7 +679,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "hindsight-client", specifier = ">=0.4.0" },
-    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "litellm", specifier = ">=1.83.14" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },


### PR DESCRIPTION
## Summary
- raise the published `hindsight-litellm` runtime LiteLLM floor from `>=1.83.0` to `>=1.83.14`
- keep the integration lock metadata in sync with the new floor
- preserve the older LiteLLM advisory context while adding the newer GHSA-qrc4-49gv-mv9m / GHSA-wpfp-gwwc-vwq6 floor

## Why
The main API package already requires a patched LiteLLM floor, but the published `hindsight-litellm` integration still allows fresh installs to resolve vulnerable `litellm` versions below `1.83.14`. Live advisory checks show `GHSA-qrc4-49gv-mv9m` is fixed in `1.83.14` and `GHSA-wpfp-gwwc-vwq6` in `1.83.10`; the stricter `1.83.14` floor covers both plus the earlier `<1.83.0` LiteLLM advisories noted in this file.

`hindsight-integrations/litellm/uv.lock` already resolves `litellm` to `1.87.0`, so this does not need a dependency re-resolve; it updates the declared project floor and lock metadata to match the already-safe locked package.

## Verification
- parsed the updated `pyproject.toml` and `uv.lock` with Python `tomllib`
- verified `uv.lock` still contains `litellm` version `1.87.0`
- checked GitHub advisories live for GHSA-qrc4-49gv-mv9m, GHSA-wpfp-gwwc-vwq6, GHSA-jjhc-v7c2-5hh6, and GHSA-53mr-6c8q-9789

## Review note
Codex adversarial review raised a low-confidence concern that the diff itself does not show the resolved lock package entry. I verified the lock entry separately: it remains `litellm` `1.87.0`, above the new floor.