### PR TITLE
fix(worker): warn for unstable standalone worker ids

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3069,29 +3069,9 @@ def create_app(
         # All current backends (PostgreSQL, Oracle) support async worker/poller.
         if config.worker_enabled and memory._backend.supports_worker_poller:
             from ..config import DEFAULT_DATABASE_SCHEMA
+            from ..utils import warn_if_container_default_worker_id
 
-            if not config.worker_id:
-                from ..utils import detect_container_runtime
-
-                runtime = detect_container_runtime()
-                if runtime:
-                    logging.warning(
-                        "\n"
-                        "============================================================\n"
-                        "  WARNING: HINDSIGHT_API_WORKER_ID is not set and Hindsight\n"
-                        f"  appears to be running inside {runtime}.\n"
-                        "\n"
-                        "  The worker id is defaulting to the container hostname,\n"
-                        "  which CHANGES every time the container is recreated.\n"
-                        "  When that happens, tasks left in 'processing' under the\n"
-                        "  old hostname are never recovered — consolidation and other\n"
-                        "  async operations can get stuck indefinitely.\n"
-                        "\n"
-                        "  Set HINDSIGHT_API_WORKER_ID to a STABLE value (e.g. the\n"
-                        "  compose service name or StatefulSet pod name) to avoid this.\n"
-                        "============================================================"
-                    )
-
+            warn_if_container_default_worker_id(config.worker_id)
             worker_id = config.worker_id or socket.gethostname()
             worker_id_source = "HINDSIGHT_API_WORKER_ID" if config.worker_id else "hostname (default)"
             logging.info(f"Worker id: {worker_id} (source: {worker_id_source})")

--- a/hindsight-api-slim/hindsight_api/utils.py
+++ b/hindsight-api-slim/hindsight_api/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from urllib.parse import urlparse, urlunparse
 
@@ -23,6 +24,33 @@ def detect_container_runtime() -> str | None:
     except OSError:
         pass
     return None
+
+
+def warn_if_container_default_worker_id(worker_id: str | None) -> None:
+    """Warn when worker id will fall back to an unstable container hostname."""
+    if worker_id:
+        return
+
+    runtime = detect_container_runtime()
+    if not runtime:
+        return
+
+    logging.warning(
+        "\n"
+        "============================================================\n"
+        "  WARNING: HINDSIGHT_API_WORKER_ID is not set and Hindsight\n"
+        f"  appears to be running inside {runtime}.\n"
+        "\n"
+        "  The worker id is defaulting to the container hostname,\n"
+        "  which CHANGES every time the container is recreated.\n"
+        "  When that happens, tasks left in 'processing' under the\n"
+        "  old hostname are never recovered — consolidation and other\n"
+        "  async operations can get stuck indefinitely.\n"
+        "\n"
+        "  Set HINDSIGHT_API_WORKER_ID to a STABLE value (e.g. the\n"
+        "  compose service name or StatefulSet pod name) to avoid this.\n"
+        "============================================================"
+    )
 
 
 def mask_network_location(url):

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -136,7 +136,7 @@ def main():
     # Worker options
     parser.add_argument(
         "--worker-id",
-        default=config.worker_id or socket.gethostname(),
+        default=config.worker_id,
         help="Worker identifier (default: hostname, env: HINDSIGHT_API_WORKER_ID)",
     )
     parser.add_argument(
@@ -178,10 +178,17 @@ def main():
     # Configure logging
     config.configure_logging()
 
+    from ..utils import warn_if_container_default_worker_id
+
+    warn_if_container_default_worker_id(args.worker_id)
+    worker_id = args.worker_id or socket.gethostname()
+    worker_id_source = "HINDSIGHT_API_WORKER_ID/--worker-id" if args.worker_id else "hostname (default)"
+    logger.info(f"Worker id: {worker_id} (source: {worker_id_source})")
+
     # Import MemoryEngine here to avoid circular imports
     from .. import MemoryEngine
 
-    print(f"Starting Hindsight Worker: {args.worker_id}")
+    print(f"Starting Hindsight Worker: {worker_id}")
     print(f"  Poll interval: {args.poll_interval}ms")
     print(f"  Max retries: {args.max_retries}")
     print(f"  Max slots: {config.worker_max_slots}")
@@ -249,7 +256,7 @@ def main():
         schema = None if config.database_schema == DEFAULT_DATABASE_SCHEMA else config.database_schema
         poller = WorkerPoller(
             backend=memory._backend,
-            worker_id=args.worker_id,
+            worker_id=worker_id,
             executor=memory.execute_task,
             poll_interval_ms=args.poll_interval,
             schema=schema,

--- a/hindsight-api-slim/tests/test_container_detection.py
+++ b/hindsight-api-slim/tests/test_container_detection.py
@@ -2,7 +2,7 @@
 
 import builtins
 
-from hindsight_api.utils import detect_container_runtime
+from hindsight_api.utils import detect_container_runtime, warn_if_container_default_worker_id
 
 
 def test_detects_kubernetes_via_env(monkeypatch):
@@ -42,3 +42,28 @@ def test_returns_none_when_not_containerized(monkeypatch):
 
     monkeypatch.setattr("builtins.open", fake_open)
     assert detect_container_runtime() is None
+
+
+def test_warns_when_default_worker_id_is_used_in_container(monkeypatch, caplog):
+    monkeypatch.setattr("hindsight_api.utils.detect_container_runtime", lambda: "docker")
+
+    warn_if_container_default_worker_id(None)
+
+    assert "HINDSIGHT_API_WORKER_ID is not set" in caplog.text
+    assert "appears to be running inside docker" in caplog.text
+
+
+def test_skips_warning_when_worker_id_is_explicit(monkeypatch, caplog):
+    monkeypatch.setattr("hindsight_api.utils.detect_container_runtime", lambda: "docker")
+
+    warn_if_container_default_worker_id("worker-1")
+
+    assert caplog.text == ""
+
+
+def test_skips_warning_outside_containers(monkeypatch, caplog):
+    monkeypatch.setattr("hindsight_api.utils.detect_container_runtime", lambda: None)
+
+    warn_if_container_default_worker_id(None)
+
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- reuse the container/default worker-id warning helper from the API embedded worker startup path
- apply the same warning before standalone `hindsight-worker` falls back to `socket.gethostname()`
- keep explicit `--worker-id` / `HINDSIGHT_API_WORKER_ID` values quiet and covered by tests

## Tests
- `cd hindsight-api-slim && uv run pytest tests/test_container_detection.py`
- `cd hindsight-api-slim && uv run ruff check hindsight_api/utils.py hindsight_api/api/http.py hindsight_api/worker/main.py tests/test_container_detection.py`
- `cd hindsight-api-slim && uv run ruff format --check hindsight_api/utils.py hindsight_api/api/http.py hindsight_api/worker/main.py tests/test_container_detection.py`
- `git diff --check origin/main...HEAD`

Note: the full pre-commit hook reached the repository-wide control-plane lint and stopped because local Node dependencies for `@eslint/js` / `vitest/config` were not installed. The scoped Python checks above pass.
