### PR TITLE
feat(config): let indexed multi-LLM members configure Vertex AI project/region

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1320,6 +1320,8 @@ class LLMMemberConfig:
     default_headers: dict | None
     bedrock_service_tier: str | None
     gemini_service_tier: str | None
+    vertexai_project_id: str | None = None
+    vertexai_region: str | None = None
 
 
 # Valid multi-LLM strategy modes.
@@ -1413,6 +1415,8 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
                 gemini_service_tier=(
                     parse_gemini_service_tier(gemini_service_tier) if provider.lower() == "gemini" else None
                 ),
+                vertexai_project_id=os.getenv(base + "VERTEXAI_PROJECT_ID") or None,
+                vertexai_region=os.getenv(base + "VERTEXAI_REGION") or None,
             )
         )
         index += 1

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -506,6 +506,8 @@ class LLMProvider:
         default_headers: dict[str, str] | None = None,
         litellmrouter_config: dict[str, Any] | None = None,
         gemini_service_tier: str | None = None,
+        vertexai_project_id: str | None = None,
+        vertexai_region: str | None = None,
     ):
         """
         Initialize LLM provider.
@@ -532,6 +534,11 @@ class LLMProvider:
                 https://docs.litellm.ai/docs/routing. Ignored unless ``provider == "litellmrouter"``.
                 When None and the provider is ``litellmrouter``, falls back to
                 ``HindsightConfig.llm_litellmrouter_config``.
+            vertexai_project_id: Vertex AI project ID for ``provider="vertexai"``. Lets a single
+                provider instance target a specific project (e.g. an indexed member of a multi-LLM
+                chain). When None, falls back to ``HindsightConfig.llm_vertexai_project_id``.
+            vertexai_region: Vertex AI region for ``provider="vertexai"``. When None, falls back to
+                ``HindsightConfig.llm_vertexai_region`` (then ``"us-central1"``).
         """
         self.provider = provider.lower()
         self.api_key = api_key
@@ -621,9 +628,9 @@ class LLMProvider:
             elif self.provider == "nous":
                 self.base_url = "https://inference-api.nousresearch.com/v1"
 
-        # Prepare Vertex AI config (if applicable)
-        vertexai_project_id = None
-        vertexai_region = None
+        # Prepare Vertex AI config (if applicable). Explicit per-instance values
+        # (e.g. from an indexed multi-LLM member) win; otherwise fall back to the
+        # global config so existing single-LLM setups are unchanged.
         vertexai_credentials = None
 
         if self.provider == "vertexai":
@@ -631,14 +638,14 @@ class LLMProvider:
 
             config = get_config()
 
-            vertexai_project_id = config.llm_vertexai_project_id
+            vertexai_project_id = vertexai_project_id or config.llm_vertexai_project_id
             if not vertexai_project_id:
                 raise ValueError(
                     "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required for Vertex AI provider. "
                     "Set it to your GCP project ID."
                 )
 
-            vertexai_region = config.llm_vertexai_region or "us-central1"
+            vertexai_region = vertexai_region or config.llm_vertexai_region or "us-central1"
             service_account_key = config.llm_vertexai_service_account_key
 
             # Load explicit service account credentials if provided

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -402,6 +402,8 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMCon
         default_headers=member.default_headers,
         bedrock_service_tier=member.bedrock_service_tier,
         gemini_service_tier=member.gemini_service_tier,
+        vertexai_project_id=member.vertexai_project_id,
+        vertexai_region=member.vertexai_region,
     )
 
 

--- a/hindsight-api-slim/tests/test_multi_llm_config.py
+++ b/hindsight-api-slim/tests/test_multi_llm_config.py
@@ -83,6 +83,38 @@ def test_parse_members_no_key_provider_ok(clean_llm_env):
     assert members[0].api_key is None
 
 
+def test_parse_members_vertexai_project_and_region(clean_llm_env):
+    # A vertexai member can carry its own project/region so it can be used as a
+    # member of a failover/round-robin chain.
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "vertexai")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_VERTEXAI_PROJECT_ID", "p")
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_VERTEXAI_REGION", "us-central1")
+    members = _parse_llm_members("")
+    assert members[0].provider == "vertexai"
+    assert members[0].vertexai_project_id == "p"
+    assert members[0].vertexai_region == "us-central1"
+
+
+def test_parse_members_vertexai_per_op_prefix(clean_llm_env):
+    clean_llm_env.setenv("HINDSIGHT_API_REFLECT_LLM_1_PROVIDER", "vertexai")
+    clean_llm_env.setenv("HINDSIGHT_API_REFLECT_LLM_1_VERTEXAI_PROJECT_ID", "reflect-proj")
+    clean_llm_env.setenv("HINDSIGHT_API_REFLECT_LLM_1_VERTEXAI_REGION", "europe-west1")
+    reflect = _parse_llm_members("REFLECT_")
+    assert reflect[0].vertexai_project_id == "reflect-proj"
+    assert reflect[0].vertexai_region == "europe-west1"
+    # The vertex fields are scoped to the prefix; the global chain is unaffected.
+    assert _parse_llm_members("") == []
+
+
+def test_parse_members_without_vertexai_fields_default_none(clean_llm_env):
+    # Non-vertex members (and members that omit the vars) leave the fields None —
+    # no regression for existing providers.
+    clean_llm_env.setenv("HINDSIGHT_API_LLM_1_PROVIDER", "ollama")
+    members = _parse_llm_members("")
+    assert members[0].vertexai_project_id is None
+    assert members[0].vertexai_region is None
+
+
 # ── strategy parsing ───────────────────────────────────────────────────────────
 
 
@@ -220,3 +252,47 @@ def test_build_llm_members_without_strategy_stays_plain(clean_llm_env):
     config = _empty_config(llm_members=[_member("ollama")], llm_strategy=None)
     base = _base_llm()
     assert _build_llm(base, config, "") is base
+
+
+# ── vertexai member build path (_member_to_llm) ─────────────────────────────────
+
+
+def test_member_to_llm_passes_vertexai_project_and_region(clean_llm_env, monkeypatch):
+    """A vertexai member's own project/region reach the provider build.
+
+    The global config has no Vertex project, so this also proves the member's
+    values are used (no "VERTEXAI_PROJECT_ID is required") instead of the global
+    fallback. The Vertex SDK client is patched so no live LLM/network call runs.
+    """
+    import hindsight_api.engine.providers.gemini_llm as gemini_llm
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.memory_engine import _member_to_llm
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(gemini_llm.genai, "Client", _FakeClient)
+    clear_config_cache()  # rebuild from the (vertex-less) test env
+
+    member = LLMMemberConfig(
+        provider="vertexai",
+        api_key=None,
+        model="gemini-2.0-flash",
+        base_url=None,
+        reasoning_effort=None,
+        extra_body=None,
+        default_headers=None,
+        bedrock_service_tier=None,
+        gemini_service_tier=None,
+        vertexai_project_id="member-proj",
+        vertexai_region="europe-west1",
+    )
+    provider = _member_to_llm(member, _empty_config())
+
+    assert provider.provider == "vertexai"
+    # Project/region flowed all the way to the Vertex AI SDK client.
+    assert captured["project"] == "member-proj"
+    assert captured["location"] == "europe-west1"


### PR DESCRIPTION
## Summary

Extends the indexed multi-LLM layer (#2365) so a `vertexai` member can actually be used in a failover / round-robin chain.

Today an indexed member (`HINDSIGHT_API_LLM_<n>_*`) carries only `provider / api_key / model / base_url`. The `vertexai` provider additionally needs a **project id** (and a region; it defaults to `us-central1`) — `GeminiLLM._init_vertexai` raises `"VERTEXAI_PROJECT_ID is required"` without one. And `LLMProvider.__init__` previously sourced Vertex project/region **only** from global config via `get_config()`, with no way to set them per instance. Net effect: `vertexai` could not be a member of a chain — only the global/primary provider.

## Change

- `LLMMemberConfig`: add optional `vertexai_project_id` / `vertexai_region`.
- `_parse_llm_members`: read `{prefix}LLM_{n}_VERTEXAI_PROJECT_ID` / `_VERTEXAI_REGION` (global and the `RETAIN_`/`REFLECT_`/`CONSOLIDATION_` per-op prefixes), mirroring the existing per-member env keys.
- `_member_to_llm`: thread the two fields into the member's `LLMConfig`.
- `LLMProvider.__init__`: accept `vertexai_project_id` / `vertexai_region`; an explicit per-instance value wins, otherwise fall back to global config (`llm_vertexai_project_id` / `llm_vertexai_region` → `us-central1`). Single-LLM setups are unchanged.

## Why

Without this, a multi-LLM chain can only fail over between key-based providers; a `vertexai` member can't initialize. This lets operators run, e.g., a key-based primary with a Vertex AI failover member (or vice-versa) targeting a specific project/region.

## Tests

`tests/test_multi_llm_config.py` (+4):
- vertexai member parses project/region (global prefix)
- per-op prefix (`REFLECT_`) parses them
- a non-vertex member leaves the fields `None` (no regression)
- build path: the member's own project/region reach the Vertex client (SDK client patched; no live call), proving per-instance values are used rather than the global fallback

`uv run pytest tests/test_multi_llm_config.py tests/test_multi_llm_provider.py` → 38 passed. `ruff check` / `ruff format --check` / `ty check` clean.

## Notes / non-goals

- Single-LLM / global-config Vertex behavior is unchanged (global fallback preserved).
- Retry/fast-fail behavior is unchanged — that's existing config (`HINDSIGHT_API_LLM_MAX_RETRIES`, per-op overrides) layered on top of the chain.