### PR TITLE
fix(claude-code): keep plugin manifest version current

### DIFF
--- a/hindsight-integrations/claude-code/.claude-plugin/plugin.json
+++ b/hindsight-integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hindsight-memory",
   "description": "Automatic long-term memory for Claude Code via Hindsight. Recalls relevant memories before each prompt, retains conversation transcripts, and provides knowledge page tools.",
-  "version": "0.7.2",
+  "version": "0.8.3",
   "author": {"name": "Hindsight Team", "url": "https://vectorize.io/hindsight"},
   "license": "MIT",
   "keywords": ["memory", "hindsight", "recall", "retain"]

--- a/hindsight-integrations/claude-code/tests/test_manifest.py
+++ b/hindsight-integrations/claude-code/tests/test_manifest.py
@@ -1,9 +1,11 @@
 """Validate that JSON manifests are strict-valid JSON (no trailing commas, etc.)."""
 
 import json
+import tomllib
 from pathlib import Path
 
 INTEGRATION_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = INTEGRATION_ROOT.parent.parent
 
 
 def test_hooks_json_is_valid():
@@ -12,3 +14,13 @@ def test_hooks_json_is_valid():
     parsed = json.loads(raw)
     assert "hooks" in parsed
     assert isinstance(parsed["hooks"], dict)
+
+
+def test_plugin_manifest_version_is_not_behind_core_release():
+    plugin_path = INTEGRATION_ROOT / ".claude-plugin" / "plugin.json"
+    core_pyproject_path = REPO_ROOT / "hindsight-dev" / "pyproject.toml"
+
+    plugin_version = json.loads(plugin_path.read_text())["version"]
+    core_version = tomllib.loads(core_pyproject_path.read_text())["project"]["version"]
+
+    assert tuple(map(int, plugin_version.split("."))) >= tuple(map(int, core_version.split(".")))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -145,6 +145,17 @@ else
     print_warn "File $CONTROL_PLANE_PKG not found, skipping"
 fi
 
+# Update Claude Code plugin manifest. Claude Code's plugin manager uses this
+# manifest version to decide whether an installed plugin should refresh.
+CLAUDE_CODE_PLUGIN_MANIFEST="hindsight-integrations/claude-code/.claude-plugin/plugin.json"
+if [ -f "$CLAUDE_CODE_PLUGIN_MANIFEST" ]; then
+    print_info "Updating $CLAUDE_CODE_PLUGIN_MANIFEST"
+    sed -i.bak "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" "$CLAUDE_CODE_PLUGIN_MANIFEST"
+    rm "${CLAUDE_CODE_PLUGIN_MANIFEST}.bak"
+else
+    print_warn "File $CLAUDE_CODE_PLUGIN_MANIFEST not found, skipping"
+fi
+
 # Update hindsight-all npm wrapper package.json
 ALL_NPM_PKG="hindsight-all-npm/package.json"
 if [ -f "$ALL_NPM_PKG" ]; then


### PR DESCRIPTION
Summary
- Bumps the Claude Code plugin manifest from 0.7.1 to 0.8.3 so plugin update checks can see the current shipped version.
- Updates the core release script to bump the Claude Code plugin manifest during v* releases.
- Adds a manifest test so the plugin version cannot fall behind the core release version again.

Tests
- uv run pytest tests/test_manifest.py -q
- uv run pytest tests/ -q
- bash -n scripts/release.sh scripts/release-integration.sh
- git diff --check HEAD~1..HEAD

Note
- The default commit hook did not complete locally because control-plane ESLint could not load @eslint/js in this checkout. The focused Claude Code integration tests and release-script syntax check above passed.

Closes #2386