### PR TITLE
fix(codex): use a stable prompt_cache_key instead of a per-request uuid4 to enable Codex prompt-cache reuse

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -16,10 +16,11 @@ so that future server-side changes affect both clients identically.
 """
 
 import asyncio
+import functools
+import hashlib
 import json
 import logging
 import time
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -154,6 +155,20 @@ class CodexLLM(LLMInterface):
     @_auth_file.setter
     def _auth_file(self, v: Path) -> None:
         self._auth_manager._auth_file = v
+
+    @functools.cached_property
+    def _prompt_cache_key(self) -> str:
+        """Stable ``prompt_cache_key`` for OpenAI/Codex prompt-cache routing.
+
+        OpenAI uses ``prompt_cache_key`` as an explicit hint for routing
+        requests to a cached-prefix backend, so it must stay constant across
+        calls that share the same system instructions + tools prefix. A fresh
+        ``uuid4`` per request defeats that routing and forces a 100% cache miss.
+        Derive it once per provider instance from (account, model) so it is
+        stable across requests but still distinct per account/model.
+        """
+        seed = f"{self.account_id}:{self.model}"
+        return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
 
     # ------------------------------------------------------------------
     # Forwarding methods (keep surface area for tests / subclasses)
@@ -388,7 +403,7 @@ class CodexLLM(LLMInterface):
             "store": False,  # Codex uses stateless mode
             "stream": True,  # SSE streaming
             "include": ["reasoning.encrypted_content"],
-            "prompt_cache_key": str(uuid.uuid4()),
+            "prompt_cache_key": self._prompt_cache_key,
         }
 
         headers = {
@@ -711,7 +726,7 @@ class CodexLLM(LLMInterface):
             "store": False,
             "stream": True,
             "include": ["reasoning.encrypted_content"],
-            "prompt_cache_key": str(uuid.uuid4()),
+            "prompt_cache_key": self._prompt_cache_key,
         }
 
         headers = {


### PR DESCRIPTION
## What

In the Codex provider, `prompt_cache_key` is set to a fresh `uuid.uuid4()` on every request:

```python
# hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
"prompt_cache_key": str(uuid.uuid4()),   # in both call() and call_with_tools()
```

`prompt_cache_key` is OpenAI/Codex's explicit hint for routing a request to a cached-prefix backend, so it needs to stay **constant** across calls that share the same `instructions` + `tools[]` prefix. A new random value per request means that prefix is never matched, giving a ~100% prompt-cache miss on the hottest LLM path (recall/reflect/retain all funnel through these two methods) with no functional upside.

## Fix

Derive the key once per provider instance from `(account_id, model)` so it is stable across requests but still distinct per account/model, and use it at both call sites. Tiny, self-contained change; the now-unused `uuid` import is dropped.

```python
@functools.cached_property
def _prompt_cache_key(self) -> str:
    seed = f"{self.account_id}:{self.model}"
    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
```

If you'd prefer the key to be scoped more tightly (e.g. per bank/session/reflect-mission) rather than per provider instance, happy to adjust — I kept it to identifiers already in scope to stay minimal.

## How this was found

Spotted via static analysis of prompt-cache anti-patterns (a tool I'm experimenting with, CacheLint) and then confirmed by hand on `main` at `9dafadc` (lines ~391 and ~714). I have not been able to run the full integration suite against a live Codex account, so a maintainer sanity-check on the cache-key semantics would be appreciated.
