### PR TITLE
fix(api): prevent PATCH bank from creating banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -5644,8 +5644,13 @@ def _register_routes(app: FastAPI):
     ):
         """Partially update an agent's profile (name, mission, disposition)."""
         try:
-            # Ensure bank exists
-            await app.state.memory.get_bank_profile(bank_id, request_context=request_context)
+            # PATCH is update-only; missing banks must not be created as a
+            # side effect of reading the profile.
+            existing_profile = await app.state.memory.get_bank_profile(
+                bank_id, request_context=request_context, create_if_missing=False
+            )
+            if existing_profile is None:
+                raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
 
             # Update name if provided (stored in DB for display only, deprecated)
             if request.name is not None:
@@ -5661,7 +5666,11 @@ def _register_routes(app: FastAPI):
                 await app.state.memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
 
             # Get final profile
-            final_profile = await app.state.memory.get_bank_profile(bank_id, request_context=request_context)
+            final_profile = await app.state.memory.get_bank_profile(
+                bank_id, request_context=request_context, create_if_missing=False
+            )
+            if final_profile is None:
+                raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
             disposition_dict = (
                 final_profile["disposition"].model_dump()
                 if hasattr(final_profile["disposition"], "model_dump")

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1354,6 +1354,26 @@ async def test_patch_config_persists_override_for_uncreated_bank(api_client, fie
     assert response.json()["name"] == test_bank_id
 
 
+@pytest.mark.asyncio
+async def test_patch_bank_does_not_create_missing_bank(api_client):
+    """PATCH /banks/{bank_id} updates existing banks only."""
+    test_bank_id = f"patch_missing_bank_{datetime.now().timestamp()}"
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{test_bank_id}",
+        json={"name": "Should Not Exist"},
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == f"Bank '{test_bank_id}' not found"
+
+    profile = await api_client.get(f"/v1/default/banks/{test_bank_id}/profile")
+    assert profile.status_code == 404, profile.text
+
+    banks = await api_client.get("/v1/default/banks")
+    assert banks.status_code == 200, banks.text
+    assert test_bank_id not in {bank["bank_id"] for bank in banks.json()["banks"]}
+
+
 @pytest.mark.hs_llm_core
 @pytest.mark.asyncio
 async def test_full_api_workflow_llm_quality(api_client_real_llm):


### PR DESCRIPTION
## Summary

- Treat `PATCH /v1/default/banks/{bank_id}` as update-only.
- Return `404` when the target bank does not exist instead of creating it through the bank profile lookup.
- Add a regression test proving PATCH does not create a missing bank as a side effect.

## Why

`PATCH /v1/default/banks/{bank_id}` is documented and named as a partial update operation (`operation_id="update_bank"`). Before this change, the handler called `get_bank_profile()` with its default behavior, which can create the bank when it is missing. That makes an update-only request behave like a create-or-update request.

This is surprising for clients and can create unintended banks when a caller passes a stale or mistyped `bank_id`. It also blurs authorization semantics: an implementation that wants to distinguish bank creation from bank updates cannot rely on the PATCH route being update-only.

`PUT /v1/default/banks/{bank_id}` remains the create-or-update endpoint. This change only narrows PATCH so missing banks return a clear `404`.

## Test

- `uv run pytest tests/test_http_api_integration.py::test_patch_bank_does_not_create_missing_bank -q`
- `uv run ruff check hindsight_api/api/http.py`
- `git diff --check`
