### PR TITLE
fix(api): prevent reflect from creating banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8755,8 +8755,17 @@ class MemoryEngine(MemoryEngineInterface):
         tags_info = f", tags={tags} ({tags_match})" if tags else ""
         logger.info(f"[REFLECT {reflect_id}] Starting agentic reflect for query: {query[:50]}...{tags_info}")
 
-        # Get bank profile for agent identity
-        profile = await self.get_bank_profile(bank_id, request_context=request_context)
+        # Get bank profile for agent identity. Reflect is read-only and must
+        # not create a missing bank as a side effect.
+        profile = await self.get_bank_profile(
+            bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        if profile is None:
+            from hindsight_api.extensions.operation_validator import OperationValidationError
+
+            raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
 
         # NOTE: Mental models are NOT pre-loaded to keep the initial prompt small.
         # The agent can call lookup() to list available models if needed.

--- a/hindsight-api-slim/tests/test_reflect_empty_based_on.py
+++ b/hindsight-api-slim/tests/test_reflect_empty_based_on.py
@@ -6,9 +6,10 @@ This test verifies that the API returns the correct based_on format:
 - v0.4.0+ (current): returns based_on as object {"memories": [], "mental_models": [], "directives": []}
 """
 
+import httpx
 import pytest
 import pytest_asyncio
-import httpx
+
 from hindsight_api.api import create_app
 
 
@@ -26,7 +27,10 @@ async def test_reflect_with_no_memories_empty_bank(api_client):
     """Test reflect on an empty bank (no memories) with include.facts enabled."""
     bank_id = "test_empty_bank"
 
-    # Reflect on empty bank with facts requested
+    create_response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+    assert create_response.status_code == 200
+
+    # Reflect on an existing empty bank with facts requested
     response = await api_client.post(
         f"/v1/default/banks/{bank_id}/reflect",
         json={
@@ -80,9 +84,29 @@ async def test_reflect_with_no_memories_empty_bank(api_client):
 
 
 @pytest.mark.asyncio
+async def test_reflect_does_not_create_missing_bank(api_client):
+    """Reflect is read-only and must not create a missing bank."""
+    bank_id = "test_missing_reflect_bank"
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/reflect",
+        json={"query": "What do you know?", "budget": "low"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Bank '{bank_id}' not found"
+
+    profile = await api_client.get(f"/v1/default/banks/{bank_id}/profile")
+    assert profile.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_reflect_without_include_facts(api_client):
     """Test reflect without requesting facts (based_on should be None)."""
     bank_id = "test_no_facts"
+
+    create_response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+    assert create_response.status_code == 200
 
     response = await api_client.post(
         f"/v1/default/banks/{bank_id}/reflect",


### PR DESCRIPTION
## Summary

- Treat reflect as a read-only operation when resolving bank identity.
- Use a non-creating bank profile lookup before starting reflect.
- Return `404` when the target bank does not exist instead of creating an empty bank.
- Update empty-bank reflect tests to create the bank explicitly and add a missing-bank regression test.

## Why

`reflect` is documented in the engine as read-only: it synthesizes an answer from stored bank data and does not persist new memories or profile changes. However, the reflect path fetched the bank profile with the default `get_bank_profile()` behavior, which auto-creates the bank if it is missing.

That means a caller could create an empty bank simply by reflecting against a stale or mistyped `bank_id`. This is surprising for a read-only operation and makes lifecycle and authorization semantics harder to reason about, because reflect ends up carrying an implicit create side effect.

This change keeps creation on explicit write/create paths and makes reflect return a clear `404` for missing banks.

## Test

- `uv run pytest tests/test_reflect_empty_based_on.py -q -n 1`
- `uv run ruff check hindsight_api/engine/memory_engine.py tests/test_reflect_empty_based_on.py`
- `git diff --check`
