### PR TITLE
fix(mcp): prevent get_bank from creating banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -3129,7 +3129,10 @@ def _register_get_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfi
                 profile = await memory.get_bank_profile(
                     target_bank,
                     request_context=_get_request_context(config),
+                    create_if_missing=False,
                 )
+                if profile is None:
+                    return json.dumps({"error": f"Bank '{target_bank}' not found"})
                 if "disposition" in profile and hasattr(profile["disposition"], "model_dump"):
                     profile["disposition"] = profile["disposition"].model_dump()
                 return json.dumps(profile, indent=2, default=str)
@@ -3157,7 +3160,10 @@ def _register_get_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfi
                 profile = await memory.get_bank_profile(
                     target_bank,
                     request_context=_get_request_context(config),
+                    create_if_missing=False,
                 )
+                if profile is None:
+                    return {"error": f"Bank '{target_bank}' not found"}
                 if "disposition" in profile and hasattr(profile["disposition"], "model_dump"):
                     profile["disposition"] = profile["disposition"].model_dump()
                 return profile

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1511,6 +1511,14 @@ class TestTagsAndBankTools:
         mcp = _make_mcp_server(mock_memory, {"get_bank"}, include_bank_id=True)
         result = await _tools(mcp)["get_bank"].fn()
         assert '"test-bank"' in result or "test-bank" in result
+        assert mock_memory.get_bank_profile.call_args.kwargs["create_if_missing"] is False
+
+    async def test_get_bank_missing_does_not_create(self, mock_memory):
+        mock_memory.get_bank_profile.return_value = None
+        mcp = _make_mcp_server(mock_memory, {"get_bank"}, include_bank_id=True)
+        result = await _tools(mcp)["get_bank"].fn(bank_id="missing-bank")
+        assert json.loads(result)["error"] == "Bank 'missing-bank' not found"
+        assert mock_memory.get_bank_profile.call_args.kwargs["create_if_missing"] is False
 
     async def test_get_bank_stats(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"get_bank_stats"}, include_bank_id=True)
@@ -1556,6 +1564,14 @@ class TestTagsAndBankTools:
         mcp = _make_mcp_server(mock_memory, {"get_bank"}, include_bank_id=False)
         result = await _tools(mcp)["get_bank"].fn()
         assert isinstance(result, dict)
+        assert mock_memory.get_bank_profile.call_args.kwargs["create_if_missing"] is False
+
+    async def test_get_bank_single_bank_missing_does_not_create(self, mock_memory):
+        mock_memory.get_bank_profile.return_value = None
+        mcp = _make_mcp_server(mock_memory, {"get_bank"}, include_bank_id=False)
+        result = await _tools(mcp)["get_bank"].fn()
+        assert result["error"] == "Bank 'test-bank' not found"
+        assert mock_memory.get_bank_profile.call_args.kwargs["create_if_missing"] is False
 
     async def test_delete_bank_single_bank(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"delete_bank"}, include_bank_id=False)


### PR DESCRIPTION
## Summary

- Treat the core MCP `get_bank` tool as read-only.
- Look up bank profiles with `create_if_missing=False` in both single-bank and multi-bank MCP modes.
- Return a not-found error when the bank is missing instead of creating it.
- Add MCP regression tests for missing banks and for the non-creating lookup parameter.

## Why

`get_bank` is a read tool: it returns bank metadata such as name, disposition, and mission. Before this change, it called `get_bank_profile()` with the default behavior, which can create a missing bank as a side effect.

That makes a read-only MCP call mutate persistent state when a client passes a stale or mistyped bank id. It also makes lifecycle and authorization semantics harder to reason about, because `get_bank` effectively becomes a hidden create path.

Creation should stay on explicit write/create surfaces such as `create_bank`. This change keeps `get_bank` read-only while preserving its existing response shape for successful reads.

## Test

- `uv run pytest tests/test_mcp_tools.py::TestTagsAndBankTools -q`
- `git diff --check`
