### PR TITLE
fix(api): keep dry-run extract from creating banks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7106,10 +7106,11 @@ class MemoryEngine(MemoryEngineInterface):
             setattr(resolved_config, key, value)
 
         backend = await self._get_backend()
-        # Narrator primes the "Narrator:" line in the prompt — resolve it the same way retain does.
+        # Narrator primes the "Narrator:" line in the prompt. Dry-run must not
+        # create a bank just to resolve that optional display name.
         if agent_name is None:
-            profile = await bank_utils.get_bank_profile(backend, bank_id)
-            profile_name = profile["name"] if profile else bank_id
+            profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
+            profile_name = profile["name"] if profile is not None else bank_id
             agent_name = None if profile_name == bank_id else profile_name
 
         retain_llm = self._retain_llm_config.with_config(resolved_config, bank_id=bank_id, operation="retain")

--- a/hindsight-api-slim/tests/test_extract_dry_run_http.py
+++ b/hindsight-api-slim/tests/test_extract_dry_run_http.py
@@ -78,6 +78,37 @@ async def test_dry_run_extracts_without_persisting(api_client, memory):
 
 
 @pytest.mark.asyncio
+async def test_dry_run_does_not_create_missing_bank(api_client, memory):
+    bank_id = f"dryrun-missing-{uuid.uuid4().hex[:8]}"
+    request_context = RequestContext()
+
+    assert (
+        await memory.get_bank_profile(
+            bank_id=bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        is None
+    )
+
+    resp = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories/dry-run-extract",
+        json={"content": "Alice moved to Berlin in 2021."},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["facts"]
+
+    assert (
+        await memory.get_bank_profile(
+            bank_id=bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_dry_run_rejects_empty_content(api_client, memory):
     """Empty/whitespace-only content is rejected by request validation (422) before the
     billable LLM extraction call runs — matching retain (RetainItem.content) and recall


### PR DESCRIPTION
## Summary

Use the non-creating bank-profile lookup when dry-run extraction resolves the optional narrator name. This keeps the dry-run endpoint aligned with its documented read-only, no-persistence behavior.

## Why

`POST /v1/default/banks/{bank_id}/memories/dry-run-extract` is documented as a preview endpoint: it should run extraction without storing memories or mutating the bank. When `agent_name` was omitted, the engine resolved the narrator by calling the creating bank-profile helper, so probing a missing bank could insert a new bank row even though the request was supposed to be side-effect-free.

## Validation

- `uv run pytest hindsight-api-slim/tests/test_extract_dry_run_http.py`