### PR TITLE
fix(llm-trace): keep provider token usage on parse/validation failures (#2387)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_trace.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_trace.py
@@ -76,6 +76,51 @@ _request_ctx: ContextVar[dict[str, Any] | None] = ContextVar("hindsight_llm_requ
 _call_metadata_ctx: ContextVar[dict[str, Any] | None] = ContextVar("hindsight_llm_call_metadata_ctx", default=None)
 
 
+@dataclass
+class LLMResponseUsage:
+    """Provider-reported token usage for the in-flight LLM call.
+
+    Stashed by provider implementations as soon as a response is received —
+    *before* local JSON parsing / schema validation, which may still fail. The
+    wrapper reads it to attach real token counts to an error trace when the
+    provider call itself succeeded but the structured output couldn't be parsed
+    or validated (providers charge for those tokens regardless). See #2387.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+
+
+# Per-call provider usage, set by providers right after a response is received.
+_response_usage_ctx: ContextVar[LLMResponseUsage | None] = ContextVar("hindsight_llm_response_usage_ctx", default=None)
+
+
+def set_response_usage(usage: LLMResponseUsage | None) -> Token:
+    """Bind provider-reported usage for the current call. Returns a reset token."""
+    return _response_usage_ctx.set(usage)
+
+
+def stash_response_usage(usage: LLMResponseUsage | None) -> None:
+    """Record provider-reported usage so an error trace can attach it later.
+
+    Called by provider implementations once a response (with usage) is in hand,
+    before parsing/validation that may raise. Overwrites any prior value from an
+    earlier retry attempt so the last attempt's usage wins.
+    """
+    _response_usage_ctx.set(usage)
+
+
+def reset_response_usage(token: Token) -> None:
+    """Unwind a binding made by :func:`set_response_usage`."""
+    _response_usage_ctx.reset(token)
+
+
+def current_response_usage() -> LLMResponseUsage | None:
+    """Return the active call's provider-reported usage, or None."""
+    return _response_usage_ctx.get()
+
+
 def set_trace_context(ctx: LLMTraceContext | None) -> Token:
     """Bind trace attribution to the current context. Returns a reset token."""
     return _trace_ctx.set(ctx)

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -861,7 +861,13 @@ class LLMProvider:
         # The requested params are stashed in a contextvar (only what the caller
         # actually set) so the recorder can attach them to either path.
         from ..tracing import get_span_recorder
-        from .llm_trace import reset_request_context, set_request_context
+        from .llm_trace import (
+            current_response_usage,
+            reset_request_context,
+            reset_response_usage,
+            set_request_context,
+            set_response_usage,
+        )
 
         call_start = time.monotonic()
         request_token = set_request_context(
@@ -872,6 +878,9 @@ class LLMProvider:
                 response_format=response_format,
             )
         )
+        # Cleared per call; the provider stashes real usage once a response is in
+        # hand so the error path below can attach it if parsing/validation fails.
+        usage_token = set_response_usage(None)
         try:
             async with AsyncExitStack() as stack:
                 for sem in _semaphores_for_scope(scope):
@@ -899,14 +908,19 @@ class LLMProvider:
                         **cache_kwarg,
                     )
                 except Exception as e:
+                    # The provider call may have succeeded (and incurred token
+                    # cost) before local parsing/validation raised; attach the
+                    # provider-reported usage to the error trace when available.
+                    usage = current_response_usage()
                     get_span_recorder().record_llm_call(
                         provider=self.provider,
                         model=self.model,
                         scope=scope,
                         messages=messages,
                         response_content=None,
-                        input_tokens=0,
-                        output_tokens=0,
+                        input_tokens=usage.input_tokens if usage else 0,
+                        output_tokens=usage.output_tokens if usage else 0,
+                        cached_tokens=usage.cached_tokens if usage else 0,
                         duration=time.monotonic() - call_start,
                         error=e,
                     )
@@ -922,6 +936,7 @@ class LLMProvider:
                         self._mock_calls = self._provider_impl.get_mock_calls()
         finally:
             reset_request_context(request_token)
+            reset_response_usage(usage_token)
 
         return result
 
@@ -961,7 +976,13 @@ class LLMProvider:
 
         # Failures forwarded to the GenAI recorder; successes recorded by providers.
         from ..tracing import get_span_recorder
-        from .llm_trace import reset_request_context, set_request_context
+        from .llm_trace import (
+            current_response_usage,
+            reset_request_context,
+            reset_response_usage,
+            set_request_context,
+            set_response_usage,
+        )
 
         call_start = time.monotonic()
         request_token = set_request_context(
@@ -972,6 +993,9 @@ class LLMProvider:
                 tool_choice=tool_choice,
             )
         )
+        # Cleared per call; the provider stashes real usage once a response is in
+        # hand so the error path below can attach it if parsing/validation fails.
+        usage_token = set_response_usage(None)
         try:
             async with AsyncExitStack() as stack:
                 for sem in _semaphores_for_scope(scope):
@@ -996,14 +1020,19 @@ class LLMProvider:
                         **cache_kwarg,
                     )
                 except Exception as e:
+                    # The provider call may have succeeded (and incurred token
+                    # cost) before local parsing/validation raised; attach the
+                    # provider-reported usage to the error trace when available.
+                    usage = current_response_usage()
                     get_span_recorder().record_llm_call(
                         provider=self.provider,
                         model=self.model,
                         scope=scope,
                         messages=messages,
                         response_content=None,
-                        input_tokens=0,
-                        output_tokens=0,
+                        input_tokens=usage.input_tokens if usage else 0,
+                        output_tokens=usage.output_tokens if usage else 0,
+                        cached_tokens=usage.cached_tokens if usage else 0,
                         duration=time.monotonic() - call_start,
                         error=e,
                     )
@@ -1019,6 +1048,7 @@ class LLMProvider:
                         self._mock_calls = self._provider_impl.get_mock_calls()
         finally:
             reset_request_context(request_token)
+            reset_response_usage(usage_token)
 
         return result
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -15,10 +15,23 @@ import time
 from typing import Any
 
 from hindsight_api.engine.llm_interface import LLMInterface
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 
 logger = logging.getLogger(__name__)
+
+
+def _usage_from_anthropic_response(response: Any) -> LLMResponseUsage:
+    """Extract input/output/cached token counts from an Anthropic usage block."""
+    usage = getattr(response, "usage", None)
+    if not usage:
+        return LLMResponseUsage()
+    return LLMResponseUsage(
+        input_tokens=usage.input_tokens or 0,
+        output_tokens=usage.output_tokens or 0,
+        cached_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+    )
 
 
 class AnthropicLLM(LLMInterface):
@@ -211,6 +224,9 @@ class AnthropicLLM(LLMInterface):
         for attempt in range(max_retries + 1):
             try:
                 response = await self._client.messages.create(**call_params)
+                # Stash usage before parse/validate, which may raise locally
+                # even though the provider charged for these tokens (#2387).
+                stash_response_usage(_usage_from_anthropic_response(response))
 
                 if use_forced_tool:
                     # Forced tool_use → the validated args are already a dict; no parsing,
@@ -258,10 +274,11 @@ class AnthropicLLM(LLMInterface):
 
                 # Record metrics and log slow calls
                 duration = time.time() - start_time
-                input_tokens = response.usage.input_tokens or 0 if response.usage else 0
-                output_tokens = response.usage.output_tokens or 0 if response.usage else 0
+                response_usage = _usage_from_anthropic_response(response)
+                input_tokens = response_usage.input_tokens
+                output_tokens = response_usage.output_tokens
                 total_tokens = input_tokens + output_tokens
-                cached_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0 if response.usage else 0
+                cached_tokens = response_usage.cached_tokens
 
                 # Record LLM metrics
                 metrics = get_metrics_collector()
@@ -449,6 +466,7 @@ class AnthropicLLM(LLMInterface):
         for attempt in range(max_retries + 1):
             try:
                 response = await self._client.messages.create(**call_params)
+                stash_response_usage(_usage_from_anthropic_response(response))
 
                 # Extract content and tool calls
                 content_parts = []

--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -16,6 +16,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from hindsight_api.engine.llm_interface import LLMInterface
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 
@@ -225,6 +226,16 @@ class ClaudeCodeLLM(LLMInterface):
                         for block in message.content:
                             if isinstance(block, TextBlock):
                                 full_text += block.text
+
+                # The Claude Agent SDK doesn't report exact counts; stash the same
+                # char/4 estimate the success path traces so a later parse/validate
+                # failure records consistent (estimated) tokens, not zero (#2387).
+                stash_response_usage(
+                    LLMResponseUsage(
+                        input_tokens=sum(len(m.get("content", "")) for m in messages) // 4,
+                        output_tokens=len(full_text) // 4,
+                    )
+                )
 
                 # Handle structured output
                 if response_format is not None:

--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -26,6 +26,7 @@ from typing import Any
 import httpx
 
 from hindsight_api.engine.llm_interface import LLMInterface
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 
@@ -413,6 +414,16 @@ class CodexLLM(LLMInterface):
 
                 # Parse SSE stream
                 content = await self._parse_sse_stream(response)
+
+                # Codex SSE carries no usage block; stash the same char/4 estimate
+                # the success path traces so a later parse/validate failure records
+                # consistent (estimated) token counts rather than zero (#2387).
+                stash_response_usage(
+                    LLMResponseUsage(
+                        input_tokens=sum(len(m.get("content", "")) for m in messages) // 4,
+                        output_tokens=len(content) // 4,
+                    )
+                )
 
                 # Handle structured output
                 if response_format is not None:

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -20,6 +20,7 @@ from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from hindsight_api.engine.llm_interface import LLMInterface
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.llm_wrapper import parse_llm_json
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
@@ -48,6 +49,18 @@ def _to_int(value: Any) -> int:
         return int(value)
     except (ValueError, TypeError):
         return 0
+
+
+def _usage_from_gemini_response(response: Any) -> LLMResponseUsage:
+    """Extract prompt/candidate/cached token counts from a Gemini usage_metadata block."""
+    usage = getattr(response, "usage_metadata", None)
+    if not usage:
+        return LLMResponseUsage()
+    return LLMResponseUsage(
+        input_tokens=usage.prompt_token_count or 0,
+        output_tokens=usage.candidates_token_count or 0,
+        cached_tokens=getattr(usage, "cached_content_token_count", 0) or 0,
+    )
 
 
 class GeminiLLM(LLMInterface):
@@ -327,6 +340,9 @@ class GeminiLLM(LLMInterface):
                     ),
                     timeout=90.0,  # Safety net for network hangs; valid slow responses are <90s
                 )
+                # Stash usage before parse/validate, which may raise locally
+                # even though the provider charged for these tokens (#2387).
+                stash_response_usage(_usage_from_gemini_response(response))
 
                 content = response.text
 
@@ -693,6 +709,7 @@ class GeminiLLM(LLMInterface):
                     ),
                     timeout=90.0,  # Safety net for network hangs; valid slow responses are <90s
                 )
+                stash_response_usage(_usage_from_gemini_response(response))
 
                 # Extract content and tool calls
                 content = None

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -23,11 +23,28 @@ from litellm.exceptions import Timeout as LiteLLMTimeout
 
 from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
+
+
+def _usage_from_litellm_response(response: Any) -> LLMResponseUsage:
+    """Extract prompt/completion/cached token counts from a LiteLLM (OpenAI-shaped) usage block."""
+    usage = getattr(response, "usage", None)
+    if not usage:
+        return LLMResponseUsage()
+    cached_tokens = 0
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details:
+        cached_tokens = getattr(details, "cached_tokens", 0) or 0
+    return LLMResponseUsage(
+        input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+        output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+        cached_tokens=cached_tokens,
+    )
 
 
 class LiteLLMLLM(LLMInterface):
@@ -219,6 +236,10 @@ class LiteLLMLLM(LLMInterface):
                     self._acompletion(**call_kwargs),
                     timeout=self.timeout,
                 )
+                # Stash usage before the length check and parse/validate below,
+                # which may raise locally even though the provider charged for
+                # these tokens (#2387).
+                stash_response_usage(_usage_from_litellm_response(response))
 
                 content = response.choices[0].message.content or ""
                 finish_reason = response.choices[0].finish_reason
@@ -249,8 +270,9 @@ class LiteLLMLLM(LLMInterface):
                     result = content
 
                 # Extract usage
-                input_tokens = getattr(response.usage, "prompt_tokens", 0) or 0
-                output_tokens = getattr(response.usage, "completion_tokens", 0) or 0
+                response_usage = _usage_from_litellm_response(response)
+                input_tokens = response_usage.input_tokens
+                output_tokens = response_usage.output_tokens
                 total_tokens = input_tokens + output_tokens
 
                 # Record metrics

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -37,6 +37,7 @@ from openai import APIConnectionError, APIStatusError, AsyncOpenAI, LengthFinish
 from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.bank_attribution import apply_bank_attribution
 from hindsight_api.engine.llm_interface import LLMInterface, OutputTooLongError, ProviderRateLimitResetError
+from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
@@ -230,6 +231,21 @@ def _content_or_error(response: Any, *, provider: str, model: str, scope: str) -
             retryable=retryable,
         )
     return content, choice
+
+
+def _usage_from_openai_response(response: Any) -> LLMResponseUsage:
+    """Extract prompt/completion/cached token counts from an OpenAI-shaped usage block."""
+    usage = getattr(response, "usage", None)
+    input_tokens = (usage.prompt_tokens or 0) if usage else 0
+    output_tokens = (usage.completion_tokens or 0) if usage else 0
+    cached_tokens = 0
+    if usage and getattr(usage, "prompt_tokens_details", None):
+        cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+    return LLMResponseUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_tokens=cached_tokens,
+    )
 
 
 def _ensure_json_word_in_user_message(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -774,6 +790,9 @@ class OpenAICompatibleLLM(LLMInterface):
             try:
                 if response_format is not None:
                     response = await self._client.chat.completions.create(**call_params)
+                    # Stash usage before parse/validate, which may raise locally
+                    # even though the provider charged for these tokens (#2387).
+                    stash_response_usage(_usage_from_openai_response(response))
 
                     content, first_choice = _content_or_error(
                         response,
@@ -827,6 +846,7 @@ class OpenAICompatibleLLM(LLMInterface):
                         result = response_format.model_validate(json_data)
                 else:
                     response = await self._client.chat.completions.create(**call_params)
+                    stash_response_usage(_usage_from_openai_response(response))
                     result, first_choice = _content_or_error(
                         response,
                         provider=self.provider,
@@ -844,12 +864,11 @@ class OpenAICompatibleLLM(LLMInterface):
                 # Record token usage metrics
                 duration = time.time() - start_time
                 usage = response.usage
-                input_tokens = usage.prompt_tokens or 0 if usage else 0
-                output_tokens = usage.completion_tokens or 0 if usage else 0
+                response_usage = _usage_from_openai_response(response)
+                input_tokens = response_usage.input_tokens
+                output_tokens = response_usage.output_tokens
                 total_tokens = usage.total_tokens or 0 if usage else 0
-                cached_tokens = 0
-                if usage and getattr(usage, "prompt_tokens_details", None):
-                    cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+                cached_tokens = response_usage.cached_tokens
                 thoughts_tokens = 0
                 if usage and getattr(usage, "completion_tokens_details", None):
                     thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -206,6 +206,87 @@ async def test_wrapper_error_forwarded_and_reraised(registered_recorder):
     assert "kaboom" in r.error
 
 
+class _StashThenRaiseProvider:
+    """Provider impl that mimics a successful call whose response carries usage,
+    then fails locally during parsing/validation (#2387)."""
+
+    def __init__(self, usage: llm_trace.LLMResponseUsage | None, exc: Exception):
+        self._usage = usage
+        self._exc = exc
+
+    async def call(self, **_kwargs):
+        if self._usage is not None:
+            llm_trace.stash_response_usage(self._usage)
+        raise self._exc
+
+    async def call_with_tools(self, **_kwargs):
+        if self._usage is not None:
+            llm_trace.stash_response_usage(self._usage)
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_wrapper_error_attaches_provider_usage_on_parse_failure(registered_recorder):
+    """When the provider call succeeds (and reports usage) but local parsing/
+    validation raises, the error trace keeps the provider-reported tokens."""
+    llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock")
+    llm._provider_impl = _StashThenRaiseProvider(
+        usage=llm_trace.LLMResponseUsage(input_tokens=321, output_tokens=12, cached_tokens=64),
+        exc=ValueError("invalid structured output"),
+    )
+
+    with pytest.raises(ValueError, match="invalid structured output"):
+        await llm.call(messages=[{"role": "user", "content": "x"}], scope="memory")
+
+    assert len(registered_recorder.records) == 1
+    r = registered_recorder.records[0]
+    assert r.status == "error"
+    assert r.input_tokens == 321
+    assert r.output_tokens == 12
+    assert r.cached_tokens == 64
+    assert r.total_tokens == 333
+    # contextvar is unwound after the call so the next call starts clean
+    assert llm_trace.current_response_usage() is None
+
+
+@pytest.mark.asyncio
+async def test_wrapper_error_without_provider_usage_records_zero(registered_recorder):
+    """A failure before any response (no usage stashed) still records 0 tokens."""
+    llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock")
+    llm._provider_impl = _StashThenRaiseProvider(usage=None, exc=RuntimeError("connection reset"))
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        await llm.call(messages=[{"role": "user", "content": "x"}], scope="memory")
+
+    r = registered_recorder.records[0]
+    assert r.status == "error"
+    assert r.input_tokens is None
+    assert r.output_tokens is None
+    assert r.cached_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_wrapper_tools_error_attaches_provider_usage(registered_recorder):
+    """The tool-calling path forwards provider usage onto error traces too."""
+    llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock")
+    llm._provider_impl = _StashThenRaiseProvider(
+        usage=llm_trace.LLMResponseUsage(input_tokens=50, output_tokens=5),
+        exc=ValueError("bad tool args"),
+    )
+
+    with pytest.raises(ValueError, match="bad tool args"):
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "x"}],
+            tools=[],
+            scope="tools",
+        )
+
+    r = registered_recorder.records[0]
+    assert r.status == "error"
+    assert r.input_tokens == 50
+    assert r.output_tokens == 5
+
+
 @pytest.mark.asyncio
 async def test_configured_provider_binds_bank_context(registered_recorder):
     llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock")
@@ -235,7 +316,6 @@ async def test_engine_teardown_unregisters_recorder_even_when_close_skipped():
     leave the registry exactly as it found it.
     """
     from hindsight_api import tracing
-
     from tests.conftest import _teardown_memory_engine
 
     sentinel = object()

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -10,11 +10,13 @@ success/error paths, and the HTTP read API (list / stats / tokens).
 import asyncio
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 import pytest_asyncio
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from hindsight_api import tracing
 from hindsight_api.api import create_app
@@ -285,6 +287,106 @@ async def test_wrapper_tools_error_attaches_provider_usage(registered_recorder):
     assert r.status == "error"
     assert r.input_tokens == 50
     assert r.output_tokens == 5
+
+
+# ── real provider: structured-output failure keeps provider usage (#2387) ─────
+
+
+class _Extracted(BaseModel):
+    """Stand-in for a retain fact-extraction schema."""
+
+    fact: str
+
+
+def _openai_response_with_usage(content: str):
+    """A successful OpenAI-shaped response carrying usage, like the provider sees
+    right before it parses/validates ``content``."""
+    message = SimpleNamespace(content=content, tool_calls=None, refusal=None)
+    choice = SimpleNamespace(finish_reason="stop", message=message)
+    usage = SimpleNamespace(
+        prompt_tokens=140,
+        completion_tokens=18,
+        total_tokens=158,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=20),
+    )
+    return SimpleNamespace(error=None, usage=usage, choices=[choice])
+
+
+@pytest.mark.asyncio
+async def test_retain_extract_json_parse_failure_keeps_usage(registered_recorder):
+    """The provider call succeeds (and reports usage) but returns non-JSON for a
+    structured request; the retain-extraction error trace keeps the tokens."""
+    llm = LLMProvider(provider="openai", api_key="test-key", base_url="https://example.test/v1", model="gpt-4o-mini")
+    llm._provider_impl._client.chat.completions.create = AsyncMock(
+        return_value=_openai_response_with_usage("not valid json at all")
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        await llm.call(
+            messages=[{"role": "user", "content": "extract facts"}],
+            response_format=_Extracted,
+            scope="retain_extract_facts",
+            max_retries=0,
+        )
+
+    assert len(registered_recorder.records) == 1
+    r = registered_recorder.records[0]
+    assert r.status == "error"
+    assert r.scope == "retain_extract_facts"
+    assert r.input_tokens == 140
+    assert r.output_tokens == 18
+    assert r.cached_tokens == 20
+    assert r.total_tokens == 158
+
+
+@pytest.mark.asyncio
+async def test_retain_extract_validation_failure_keeps_usage(registered_recorder):
+    """Valid JSON that doesn't match the schema fails ``model_validate`` locally
+    after a successful (billed) provider call; usage must survive."""
+    llm = LLMProvider(provider="openai", api_key="test-key", base_url="https://example.test/v1", model="gpt-4o-mini")
+    # Parses fine, but ``fact`` is missing → pydantic ValidationError.
+    llm._provider_impl._client.chat.completions.create = AsyncMock(
+        return_value=_openai_response_with_usage('{"wrong_field": 1}')
+    )
+
+    with pytest.raises(ValidationError):
+        await llm.call(
+            messages=[{"role": "user", "content": "extract facts"}],
+            response_format=_Extracted,
+            scope="retain_extract_facts",
+            max_retries=0,
+        )
+
+    r = registered_recorder.records[0]
+    assert r.status == "error"
+    assert r.input_tokens == 140
+    assert r.output_tokens == 18
+    assert r.cached_tokens == 20
+
+
+@pytest.mark.asyncio
+async def test_retain_extract_success_records_usage_once(registered_recorder):
+    """Sanity check the happy path the failure tests are contrasted against:
+    valid structured output records a single success trace with the same usage."""
+    llm = LLMProvider(provider="openai", api_key="test-key", base_url="https://example.test/v1", model="gpt-4o-mini")
+    llm._provider_impl._client.chat.completions.create = AsyncMock(
+        return_value=_openai_response_with_usage('{"fact": "the sky is blue"}')
+    )
+
+    result = await llm.call(
+        messages=[{"role": "user", "content": "extract facts"}],
+        response_format=_Extracted,
+        scope="retain_extract_facts",
+        max_retries=0,
+    )
+
+    assert isinstance(result, _Extracted)
+    assert len(registered_recorder.records) == 1
+    r = registered_recorder.records[0]
+    assert r.status == "success"
+    assert r.input_tokens == 140
+    assert r.output_tokens == 18
+    assert r.cached_tokens == 20
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Closes #2387.

LLM request traces (`llm_requests`) now retain provider-reported token usage on `status="error"` rows when the **provider call succeeded** but local structured-output parsing or validation then failed.

## Why

Providers already record successful traces with full usage, but failures are forwarded by the LLM wrapper, which had no access to `response.usage` once an exception bubbled up — so it hardcoded `input_tokens=0, output_tokens=0`. When `json.loads(...)` or `response_format.model_validate(...)` raised *after* a successful provider call, the token cost was lost from the trace, even though the provider still charged for the prompt + completion tokens.

This makes the accounting split the issue asked for possible:
- **total provider-cost tokens** — successes + failures that carry usage
- **effective tokens** — filter `status="success"`
- **failed/retry tokens** — `status="error"` rows that now carry usage

## How

A contextvar mirroring the existing `set_request_context` pattern in `llm_trace.py`:

- **`engine/llm_trace.py`** — new `LLMResponseUsage` dataclass + `stash_response_usage()` / `current_response_usage()` / `set_/reset_response_usage()` helpers.
- **`engine/llm_wrapper.py`** — `call()` and `call_with_tools()` clear the usage contextvar per call and, in the error path, attach the provider-stashed usage (input/output/cached) to the error trace.
- **Providers** stash usage right after a response is received, *before* parse/validate:
  - `openai_compatible` (covers Fireworks, Nous, llamacpp, and all OpenAI-compatible providers — Groq/Ollama/LMStudio/MiniMax/…), `anthropic`, `gemini`, `litellm` (+ router) — real provider usage.
  - `codex` and `claude_code` — these SDKs don't report token counts, so they stash the same `char/4` **estimate** their success path already traces (parity, not zero).
  - Success-path extraction reuses the same helper where it doesn't drop extra fields (Gemini keeps its separate `thoughts_tokens` handling).

Per-call contextvar lifecycle is owned by the wrapper (set to `None` at call start, reset in `finally`), and gathered calls get isolated context copies, so there's no cross-call leakage.

## Tests

`tests/test_llm_trace.py`:
- a provider that succeeds-with-usage then raises → tokens recorded on the `status="error"` row
- a pre-response failure (no usage stashed) → still records zero/None
- the tool-calling path forwards usage onto error traces too

## Notes

- No API/MCP/config/migration surfaces touched — no client/OpenAPI regen needed.
- Not an LLM-behaviour change (no prompt changes), so no judge test required.
