### PR TITLE
test(openai): fix tool-call mocks crashing reasoning-token accounting (#2378)

### DIFF
--- a/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
+++ b/hindsight-api-slim/tests/test_deepseek_tool_call_compat.py
@@ -77,6 +77,9 @@ def _make_tool_call_response(tool_name: str = "search_observations") -> MagicMoc
     mock_response.usage.prompt_tokens = 100
     mock_response.usage.completion_tokens = 20
     mock_response.usage.total_tokens = 120
+    # Explicit None: an auto-MagicMock here is truthy, so the reasoning-token
+    # accounting (#2378) would do arithmetic on a MagicMock and crash.
+    mock_response.usage.completion_tokens_details = None
     mock_response.choices[0].finish_reason = "tool_calls"
     mock_response.choices[0].message.content = None
     mock_response.choices[0].message.tool_calls = [mock_tc]

--- a/hindsight-api-slim/tests/test_lmstudio_tool_choice.py
+++ b/hindsight-api-slim/tests/test_lmstudio_tool_choice.py
@@ -106,6 +106,9 @@ def _make_tool_call_response(tool_name: str, arguments: dict) -> MagicMock:
     mock_response.usage.prompt_tokens = 120
     mock_response.usage.completion_tokens = 40
     mock_response.usage.total_tokens = 160
+    # Explicit None: an auto-MagicMock here is truthy, so the reasoning-token
+    # accounting (#2378) would do arithmetic on a MagicMock and crash.
+    mock_response.usage.completion_tokens_details = None
     mock_response.choices[0].finish_reason = "tool_calls"
     mock_response.choices[0].message.content = None
     mock_response.choices[0].message.tool_calls = [mock_tc]

--- a/hindsight-api-slim/tests/test_openrouter_null_content.py
+++ b/hindsight-api-slim/tests/test_openrouter_null_content.py
@@ -38,6 +38,7 @@ def _make_chat_response(content: str | None) -> MagicMock:
     - response.error = None          (otherwise truthy MagicMock triggers error path)
     - response.model_dump()          (returns dict without 'error' key)
     - choice.message.tool_calls/refusal  (otherwise truthy MagicMock in error msg)
+    - usage.completion_tokens_details  (otherwise reasoning-token math crashes, #2378)
     """
     choice = MagicMock()
     choice.finish_reason = "stop"
@@ -51,6 +52,7 @@ def _make_chat_response(content: str | None) -> MagicMock:
     response.usage.prompt_tokens = 10
     response.usage.completion_tokens = 0 if content is None else 5
     response.usage.total_tokens = 10 if content is None else 15
+    response.usage.completion_tokens_details = None
     response.choices = [choice]
     return response
 

--- a/hindsight-api-slim/tests/test_tool_choice_required_downgrade.py
+++ b/hindsight-api-slim/tests/test_tool_choice_required_downgrade.py
@@ -73,6 +73,9 @@ def _tool_call_response() -> MagicMock:
     resp.usage.prompt_tokens = 10
     resp.usage.completion_tokens = 5
     resp.usage.total_tokens = 15
+    # Explicit None: an auto-MagicMock here is truthy, so the reasoning-token
+    # accounting (#2378) would do arithmetic on a MagicMock and crash.
+    resp.usage.completion_tokens_details = None
     resp.choices[0].finish_reason = "tool_calls"
     resp.choices[0].message.content = None
     resp.choices[0].message.tool_calls = [tc]


### PR DESCRIPTION
## What

Fixes the `test-api` failures on `main` caused by **PR #2378** (reasoning-token accounting for OpenAI-compatible providers).

## Why

#2378 added, in `OpenAICompatibleLLM.call()` / `call_with_tools()`:

```python
thoughts_tokens = 0
if usage and getattr(usage, "completion_tokens_details", None):
    thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
if thoughts_tokens:
    output_tokens = max(0, output_tokens - thoughts_tokens)   # arithmetic
    total_tokens = max(0, total_tokens - thoughts_tokens)
```

Several tool-call tests build their mock response with `MagicMock()` and set only `prompt_tokens` / `completion_tokens` / `total_tokens`, leaving `usage.completion_tokens_details` as a **truthy auto-`MagicMock`**. The new code then computes `getattr(<MagicMock>, "reasoning_tokens", 0)` → a truthy `MagicMock`, and `max(0, output_tokens - <MagicMock>)` raises `TypeError: '>' not supported between instances of 'MagicMock' and 'int'`. This fails every `test-api` shard:

- `test_deepseek_tool_call_compat.py`
- `test_lmstudio_tool_choice.py`
- `test_openrouter_null_content.py`
- `test_tool_choice_required_downgrade.py`

The production code is correct for real providers (`reasoning_tokens` is always an int, or the field is absent). Only the unrealistic mocks trip it.

## How

Set `usage.completion_tokens_details = None` in the affected mock helpers — matching the explicit-field convention already documented in `test_openrouter_null_content._make_chat_response` ("must be explicitly set, not left as auto-MagicMock"). No production change.

## Test

```
uv run pytest tests/test_deepseek_tool_call_compat.py tests/test_lmstudio_tool_choice.py \
  tests/test_openrouter_null_content.py tests/test_tool_choice_required_downgrade.py -n0
# 28 passed
```
