### PR TITLE
refactor(llm): make LLMProvider constructor config-free

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -527,23 +527,23 @@ class LLMProvider:
             extra_body: Extra request-body params merged into the provider's native call
                 (OpenAI-compatible, Fireworks, Anthropic, Gemini/VertexAI, LiteLLM).
             default_headers: Custom headers passed as ``default_headers`` to provider SDK clients.
-                Used by operators routing through proxies / request-tracing middleware. Falls
-                back to ``HindsightConfig.llm_default_headers`` (env: ``HINDSIGHT_API_LLM_DEFAULT_HEADERS``)
-                when ``None``.
+                Used by operators routing through proxies / request-tracing middleware.
             litellmrouter_config: Provider-specific config for ``provider="litellmrouter"``.
                 JSON object passed verbatim to ``litellm.Router(**config)`` — see
                 https://docs.litellm.ai/docs/routing. Ignored unless ``provider == "litellmrouter"``.
-                When None and the provider is ``litellmrouter``, falls back to
-                ``HindsightConfig.llm_litellmrouter_config``.
-            vertexai_project_id: Vertex AI project ID for ``provider="vertexai"``. Lets a single
-                provider instance target a specific project (e.g. an indexed member of a multi-LLM
-                chain). When None, falls back to ``HindsightConfig.llm_vertexai_project_id``.
-            vertexai_region: Vertex AI region for ``provider="vertexai"``. When None, falls back to
-                ``HindsightConfig.llm_vertexai_region`` (then ``"us-central1"``).
+            vertexai_project_id: Vertex AI project ID for ``provider="vertexai"`` (required for
+                that provider).
+            vertexai_region: Vertex AI region for ``provider="vertexai"`` (defaults to
+                ``"us-central1"`` when ``None``).
             vertexai_service_account_key: Path to a Vertex AI service-account key file for
-                ``provider="vertexai"``. Lets a member target a project with its own credentials
-                (e.g. cross-project failover). When None, falls back to
-                ``HindsightConfig.llm_vertexai_service_account_key`` (then ADC).
+                ``provider="vertexai"`` (uses ADC when ``None``).
+
+        This constructor uses every argument as passed and does not read global
+        ``HindsightConfig``: resolving the server-level default for a ``None`` argument is the
+        caller's responsibility (see ``MemoryEngine``'s per-op builds, ``_member_to_llm``, and
+        ``LLMProvider.from_env``). Keeping it config-free makes a provider's effective settings a
+        pure function of its arguments — which is what lets each member of a multi-LLM chain be
+        configured independently.
         """
         self.provider = provider.lower()
         self.api_key = api_key
@@ -566,16 +566,9 @@ class LLMProvider:
         # Extra body params for OpenAI-compatible providers (e.g. chat_template_kwargs)
         self.extra_body = extra_body
         # Default headers passed to provider SDK clients (e.g. proxy auth, request tracing).
-        # Same pattern as ``gemini_safety_settings``: explicit override wins; otherwise read
-        # the static server-level default from ``HindsightConfig`` via ``_get_raw_config()``.
+        # Used verbatim — callers resolve the global fallback (see _member_to_llm /
+        # the per-op builds in MemoryEngine, and LLMProvider.from_env).
         self.default_headers = default_headers
-        if self.default_headers is None:
-            from ..config import _get_raw_config
-
-            try:
-                self.default_headers = _get_raw_config().llm_default_headers
-            except Exception:
-                pass  # Config may not be initialized in test environments
 
         # Validate provider
         valid_providers = [
@@ -633,25 +626,20 @@ class LLMProvider:
             elif self.provider == "nous":
                 self.base_url = "https://inference-api.nousresearch.com/v1"
 
-        # Prepare Vertex AI config (if applicable). Explicit per-instance values
-        # (e.g. from an indexed multi-LLM member) win; otherwise fall back to the
-        # global config so existing single-LLM setups are unchanged.
+        # Prepare Vertex AI config (if applicable). Values are used as passed; the
+        # caller resolves the global-config fallback (MemoryEngine builds /
+        # _member_to_llm / from_env). The region keeps a constant default here.
         vertexai_credentials = None
 
         if self.provider == "vertexai":
-            from ..config import get_config
-
-            config = get_config()
-
-            vertexai_project_id = vertexai_project_id or config.llm_vertexai_project_id
             if not vertexai_project_id:
                 raise ValueError(
                     "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required for Vertex AI provider. "
                     "Set it to your GCP project ID."
                 )
 
-            vertexai_region = vertexai_region or config.llm_vertexai_region or "us-central1"
-            service_account_key = vertexai_service_account_key or config.llm_vertexai_service_account_key
+            vertexai_region = vertexai_region or "us-central1"
+            service_account_key = vertexai_service_account_key
 
             # Load explicit service account credentials if provided
             if service_account_key:
@@ -675,61 +663,20 @@ class LLMProvider:
                 f"model={self.model}, auth={'service_account' if service_account_key else 'ADC'}"
             )
 
-        # For Gemini/VertexAI providers: read safety settings from global config if not explicitly provided
-        # Use _get_raw_config() to bypass StaticConfigProxy (which blocks configurable fields),
-        # since LLMProvider initialization legitimately needs the server-level default.
-        if self.provider in ("gemini", "vertexai") and self.gemini_safety_settings is None:
-            from ..config import _get_raw_config
-
-            try:
-                raw_config = _get_raw_config()
-                self.gemini_safety_settings = raw_config.llm_gemini_safety_settings
-            except Exception:
-                pass  # Config may not be initialized in test environments
-
+        # Normalize the Gemini service tier (pure: maps/validates the passed value,
+        # no global config read). Non-Gemini providers never carry a tier. The
+        # server-level default is resolved by the caller, like the other fields.
         if self.provider == "gemini":
             from ..config import parse_gemini_service_tier
 
             self.gemini_service_tier = parse_gemini_service_tier(self.gemini_service_tier)
-
-        if self.provider == "gemini" and self.gemini_service_tier is None:
-            from ..config import _get_raw_config
-
-            try:
-                raw_config = _get_raw_config()
-                self.gemini_service_tier = raw_config.llm_gemini_service_tier
-            except Exception:
-                pass  # Config may not be initialized in test environments
-        elif self.provider != "gemini":
+        else:
             self.gemini_service_tier = None
 
-        # Prompt-prefix caching is a provider-agnostic toggle (default on): resolve
-        # it from the static server config for every provider when the caller didn't
-        # pass an explicit override. Providers that don't support caching ignore the
-        # value; only those that implement get_or_create_cached_prefix act on it.
-        if not self.prompt_cache_enabled:
-            from ..config import DEFAULT_LLM_PROMPT_CACHE_ENABLED, _get_raw_config
-
-            try:
-                raw_config = _get_raw_config()
-                self.prompt_cache_enabled = bool(
-                    getattr(raw_config, "llm_prompt_cache_enabled", DEFAULT_LLM_PROMPT_CACHE_ENABLED)
-                )
-            except Exception:
-                pass  # Config may not be initialized in test environments
-
-        # For litellmrouter: prefer an explicit chain from the caller (per-op
-        # construction in MemoryEngine threads the right chain through). If the caller
-        # didn't supply one, fall back to the global ``llm_litellmrouter_config`` so
-        # ad-hoc constructions (e.g. ``LLMProvider.from_env()``) keep working.
+        # gemini_safety_settings / prompt_cache_enabled / litellmrouter_config are
+        # used as passed — the caller resolves the global-config fallback. Providers
+        # that don't support prompt caching ignore the flag.
         router_config: dict[str, Any] | None = self.litellmrouter_config
-        if self.provider == "litellmrouter" and router_config is None:
-            from ..config import _get_raw_config
-
-            try:
-                router_config = _get_raw_config().llm_litellmrouter_config
-            except Exception:
-                router_config = None
 
         # Create provider implementation using factory
         self._provider_impl = create_llm_provider(
@@ -1182,7 +1129,12 @@ class LLMProvider:
     @classmethod
     def from_env(cls) -> "LLMProvider":
         """Create provider from environment variables using config.py constants."""
+        # Read every field straight from the environment. The constructor no longer
+        # resolves global-config fallbacks, so this factory must supply them — and it
+        # does so without building the full HindsightConfig, keeping from_env() a
+        # lightweight env-only loader (see test_llm_provider_from_env_keeps_lightweight_loader).
         from ..config import (
+            DEFAULT_LLM_PROMPT_CACHE_ENABLED,
             DEFAULT_LLM_PROVIDER,
             DEFAULT_LLM_REASONING_EFFORT,
             ENV_LLM_API_KEY,
@@ -1190,11 +1142,18 @@ class LLMProvider:
             ENV_LLM_BEDROCK_SERVICE_TIER,
             ENV_LLM_DEFAULT_HEADERS,
             ENV_LLM_EXTRA_BODY,
+            ENV_LLM_GEMINI_SAFETY_SETTINGS,
             ENV_LLM_GEMINI_SERVICE_TIER,
+            ENV_LLM_LITELLMROUTER_CONFIG,
             ENV_LLM_MODEL,
+            ENV_LLM_PROMPT_CACHE_ENABLED,
             ENV_LLM_PROVIDER,
             ENV_LLM_REASONING_EFFORT,
+            ENV_LLM_VERTEXAI_PROJECT_ID,
+            ENV_LLM_VERTEXAI_REGION,
+            ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY,
             _get_default_model_for_provider,
+            _parse_llm_router_config,
             parse_gemini_service_tier,
         )
 
@@ -1212,6 +1171,14 @@ class LLMProvider:
         model = os.getenv(ENV_LLM_MODEL) or _get_default_model_for_provider(provider)
         extra_body = json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null"))
         default_headers = json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null"))
+        prompt_cache_enabled = os.getenv(
+            ENV_LLM_PROMPT_CACHE_ENABLED, str(DEFAULT_LLM_PROMPT_CACHE_ENABLED)
+        ).lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
 
         return cls(
             provider=provider,
@@ -1227,6 +1194,12 @@ class LLMProvider:
                 if provider.lower() == "gemini"
                 else None
             ),
+            gemini_safety_settings=json.loads(os.getenv(ENV_LLM_GEMINI_SAFETY_SETTINGS, "null")),
+            prompt_cache_enabled=prompt_cache_enabled,
+            litellmrouter_config=_parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG),
+            vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or None,
+            vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION) or None,
+            vertexai_service_account_key=os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY) or None,
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -389,10 +389,15 @@ RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCa
 def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMConfig:
     """Build an LLMProvider from one indexed multi-LLM member.
 
-    Member fields are self-contained; reasoning_effort falls back to the global
-    setting and default_headers / litellmrouter_config / vertexai credentials fall
-    back inside ``LLMProvider`` when unset.
+    ``LLMProvider`` uses its arguments verbatim (it no longer reads global config),
+    so resolve each fallback here: a member's explicit value wins, otherwise inherit
+    the global LLM default. Fields that aren't per-member configurable
+    (``gemini_safety_settings``, ``prompt_cache_enabled``) take the global default.
+    ``gemini_safety_settings`` is bank-configurable so it comes from the raw config
+    (the proxy blocks it); the per-bank value is applied per-call downstream.
     """
+    from ..config import _get_raw_config
+
     return LLMConfig(
         provider=member.provider,
         api_key=member.api_key or "",
@@ -400,13 +405,15 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMCon
         model=member.model,
         reasoning_effort=member.reasoning_effort or config.llm_reasoning_effort,
         extra_body=member.extra_body,
-        default_headers=member.default_headers,
+        default_headers=member.default_headers or config.llm_default_headers,
         bedrock_service_tier=member.bedrock_service_tier,
-        gemini_service_tier=member.gemini_service_tier,
-        vertexai_project_id=member.vertexai_project_id,
-        vertexai_region=member.vertexai_region,
-        vertexai_service_account_key=member.vertexai_service_account_key,
-        litellmrouter_config=member.litellmrouter_config,
+        gemini_service_tier=member.gemini_service_tier or config.llm_gemini_service_tier,
+        gemini_safety_settings=_get_raw_config().llm_gemini_safety_settings,
+        prompt_cache_enabled=config.llm_prompt_cache_enabled,
+        vertexai_project_id=member.vertexai_project_id or config.llm_vertexai_project_id,
+        vertexai_region=member.vertexai_region or config.llm_vertexai_region,
+        vertexai_service_account_key=member.vertexai_service_account_key or config.llm_vertexai_service_account_key,
+        litellmrouter_config=member.litellmrouter_config or config.llm_litellmrouter_config,
     )
 
 
@@ -920,9 +927,15 @@ class MemoryEngine(MemoryEngineInterface):
                           HINDSIGHT_API_LAZY_RERANKER env var or False.
         """
         # Load config from environment for any missing parameters
-        from ..config import get_config
+        from ..config import _get_raw_config, get_config
 
         config = get_config()
+        # Gemini safety settings are bank-configurable, so the StaticConfigProxy from
+        # get_config() blocks reading them. The server-level default legitimately seeds
+        # each provider at construction (per-bank values are applied per-call via
+        # ConfiguredLLMProvider), so read it from the raw config. The other LLM fields
+        # below are static and safe to read off the proxy.
+        _llm_gemini_safety_settings = _get_raw_config().llm_gemini_safety_settings
 
         # Apply optimization flags from config if not explicitly provided
         self._skip_llm_verification = (
@@ -1020,6 +1033,11 @@ class MemoryEngine(MemoryEngineInterface):
             litellmrouter_config=config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
+            gemini_safety_settings=_llm_gemini_safety_settings,
+            prompt_cache_enabled=config.llm_prompt_cache_enabled,
+            vertexai_project_id=config.llm_vertexai_project_id,
+            vertexai_region=config.llm_vertexai_region,
+            vertexai_service_account_key=config.llm_vertexai_service_account_key,
         )
         self._llm_config = _build_llm(_default_base_llm, config, "")
 
@@ -1056,6 +1074,11 @@ class MemoryEngine(MemoryEngineInterface):
             litellmrouter_config=config.retain_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
+            gemini_safety_settings=_llm_gemini_safety_settings,
+            prompt_cache_enabled=config.llm_prompt_cache_enabled,
+            vertexai_project_id=config.llm_vertexai_project_id,
+            vertexai_region=config.llm_vertexai_region,
+            vertexai_service_account_key=config.llm_vertexai_service_account_key,
         )
         self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_")
 
@@ -1086,6 +1109,11 @@ class MemoryEngine(MemoryEngineInterface):
             litellmrouter_config=config.reflect_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
+            gemini_safety_settings=_llm_gemini_safety_settings,
+            prompt_cache_enabled=config.llm_prompt_cache_enabled,
+            vertexai_project_id=config.llm_vertexai_project_id,
+            vertexai_region=config.llm_vertexai_region,
+            vertexai_service_account_key=config.llm_vertexai_service_account_key,
         )
         self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_")
 
@@ -1116,6 +1144,11 @@ class MemoryEngine(MemoryEngineInterface):
             litellmrouter_config=config.consolidation_llm_litellmrouter_config or config.llm_litellmrouter_config,
             bedrock_service_tier=config.llm_bedrock_service_tier,
             gemini_service_tier=config.llm_gemini_service_tier,
+            gemini_safety_settings=_llm_gemini_safety_settings,
+            prompt_cache_enabled=config.llm_prompt_cache_enabled,
+            vertexai_project_id=config.llm_vertexai_project_id,
+            vertexai_region=config.llm_vertexai_region,
+            vertexai_service_account_key=config.llm_vertexai_service_account_key,
         )
         self._consolidation_llm_config = _build_llm(_consolidation_base_llm, config, "consolidation_")
 

--- a/hindsight-api-slim/tests/test_gemini_safety_settings.py
+++ b/hindsight-api-slim/tests/test_gemini_safety_settings.py
@@ -106,8 +106,6 @@ def test_gemini_llm_no_safety_settings_is_none():
 @pytest.mark.asyncio
 async def test_call_applies_safety_settings():
     """call() includes safety_settings in GenerateContentConfig when configured."""
-    from google.genai import types as genai_types
-
     provider = _make_gemini_provider(safety_settings=SAMPLE_SAFETY_SETTINGS)
 
     # Build a fake successful response
@@ -319,8 +317,12 @@ async def test_with_config_resets_after_call():
 # ─── LLMProvider reads safety settings from config ────────────────────────────
 
 
-def test_llm_provider_reads_safety_settings_from_config():
-    """LLMProvider reads llm_gemini_safety_settings from global config for Gemini provider."""
+def test_llm_provider_from_env_reads_safety_settings():
+    """from_env() resolves llm_gemini_safety_settings from the environment.
+
+    The constructor itself is config-free; the env-reading factory supplies the
+    server default (the engine builds do the same from config).
+    """
     import json
 
     from hindsight_api.config import ENV_LLM_GEMINI_SAFETY_SETTINGS, clear_config_cache
@@ -338,12 +340,7 @@ def test_llm_provider_reads_safety_settings_from_config():
             mock_client_cls.return_value = MagicMock()
             from hindsight_api.engine.llm_wrapper import LLMProvider
 
-            provider = LLMProvider(
-                provider="gemini",
-                api_key="fake-key",
-                base_url="",
-                model="gemini-2.5-flash",
-            )
+            provider = LLMProvider.from_env()
 
             assert provider.gemini_safety_settings == SAMPLE_SAFETY_SETTINGS
 

--- a/hindsight-api-slim/tests/test_llm_wrapper.py
+++ b/hindsight-api-slim/tests/test_llm_wrapper.py
@@ -35,3 +35,56 @@ from hindsight_api.engine.llm_wrapper import sanitize_llm_output
 )
 def test_sanitize_llm_output(input_text, expected):
     assert sanitize_llm_output(input_text) == expected
+
+
+def test_llm_provider_constructor_ignores_global_config(monkeypatch):
+    """The constructor uses only its arguments — it never reads global config.
+
+    Resolving the server-level default for an omitted field is the caller's job
+    (MemoryEngine's per-op builds, _member_to_llm, and from_env). Keeping the
+    constructor config-free makes a provider's effective settings a pure function
+    of its arguments, which is what lets each member of a multi-LLM chain be
+    configured independently.
+    """
+    import json
+
+    from hindsight_api.config import (
+        ENV_LLM_DEFAULT_HEADERS,
+        ENV_LLM_PROMPT_CACHE_ENABLED,
+        clear_config_cache,
+    )
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    # Global config sets a non-default header map and enables prompt caching...
+    monkeypatch.setenv(ENV_LLM_DEFAULT_HEADERS, json.dumps({"x-from": "global"}))
+    monkeypatch.setenv(ENV_LLM_PROMPT_CACHE_ENABLED, "true")  # also the global default
+    clear_config_cache()
+
+    # ...but a directly-constructed provider that omits them does NOT inherit them.
+    provider = LLMProvider(provider="mock", api_key="", base_url="", model="m")
+    assert provider.default_headers is None
+    assert provider.prompt_cache_enabled is False  # constructor default, not the global True
+
+    clear_config_cache()
+
+
+def test_llm_provider_constructor_ignores_global_safety_settings(monkeypatch):
+    """A Gemini provider built directly does not pull safety settings from config."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_api.config import ENV_LLM_GEMINI_SAFETY_SETTINGS, clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv(
+        ENV_LLM_GEMINI_SAFETY_SETTINGS,
+        json.dumps([{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]),
+    )
+    clear_config_cache()
+
+    with patch("google.genai.Client", return_value=MagicMock()):
+        provider = LLMProvider(provider="gemini", api_key="k", base_url="", model="gemini-2.5-flash")
+
+    assert provider.gemini_safety_settings is None  # not inherited from global config
+
+    clear_config_cache()

--- a/hindsight-api-slim/tests/test_vertexai_provider.py
+++ b/hindsight-api-slim/tests/test_vertexai_provider.py
@@ -20,41 +20,7 @@ def test_llm_wrapper_vertexai_missing_dependency():
     try:
         llm_wrapper.VERTEXAI_AVAILABLE = False
 
-        with patch.dict(
-            os.environ,
-            {
-                "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": "test-project",
-                "HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY": "/path/to/key.json",
-            },
-            clear=False,
-        ):
-            from hindsight_api.config import clear_config_cache
-
-            clear_config_cache()
-
-            with pytest.raises(ValueError, match="google-auth"):
-                from hindsight_api.engine.llm_wrapper import LLMProvider
-
-                LLMProvider(
-                    provider="vertexai",
-                    api_key="",
-                    base_url="",
-                    model="google/gemini-2.0-flash-001",
-                )
-
-            clear_config_cache()
-    finally:
-        llm_wrapper.VERTEXAI_AVAILABLE = original_available
-
-
-def test_llm_wrapper_vertexai_missing_project_id():
-    """Test error when project ID is not configured."""
-    with patch.dict(os.environ, {"HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": ""}, clear=False):
-        from hindsight_api.config import clear_config_cache
-
-        clear_config_cache()
-
-        with pytest.raises(ValueError, match="HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"):
+        with pytest.raises(ValueError, match="google-auth"):
             from hindsight_api.engine.llm_wrapper import LLMProvider
 
             LLMProvider(
@@ -62,49 +28,52 @@ def test_llm_wrapper_vertexai_missing_project_id():
                 api_key="",
                 base_url="",
                 model="google/gemini-2.0-flash-001",
+                vertexai_project_id="test-project",
+                vertexai_service_account_key="/path/to/key.json",
             )
+    finally:
+        llm_wrapper.VERTEXAI_AVAILABLE = original_available
 
-        clear_config_cache()
+
+def test_llm_wrapper_vertexai_missing_project_id():
+    """Test error when no project ID is provided."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    with pytest.raises(ValueError, match="HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"):
+        LLMProvider(
+            provider="vertexai",
+            api_key="",
+            base_url="",
+            model="google/gemini-2.0-flash-001",
+        )
 
 
 def test_llm_wrapper_vertexai_adc_auth():
     """Test Vertex AI with ADC authentication creates native genai client."""
     from hindsight_api.engine.llm_wrapper import LLMProvider
 
-    with patch.dict(
-        os.environ,
-        {
-            "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": "test-project",
-            "HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY": "",  # Clear SA key to test ADC path
-        },
-        clear=False,
-    ):
-        from hindsight_api.config import clear_config_cache
+    # No service account key → ADC path. genai.Client handles ADC internally —
+    # just verify it creates the client with the project/region passed in.
+    with patch("google.genai.Client") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
 
-        clear_config_cache()
+        provider = LLMProvider(
+            provider="vertexai",
+            api_key="",
+            base_url="",
+            model="google/gemini-2.0-flash-001",
+            vertexai_project_id="test-project",
+        )
 
-        # genai.Client handles ADC internally — just verify it creates the client
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client_cls.return_value = MagicMock()
+        assert provider.provider == "vertexai"
+        assert provider.model == "gemini-2.0-flash-001"  # google/ prefix stripped
+        assert provider._gemini_client is not None
 
-            provider = LLMProvider(
-                provider="vertexai",
-                api_key="",
-                base_url="",
-                model="google/gemini-2.0-flash-001",
-            )
-
-            assert provider.provider == "vertexai"
-            assert provider.model == "gemini-2.0-flash-001"  # google/ prefix stripped
-            assert provider._gemini_client is not None
-
-            # Verify genai.Client was called with vertexai=True
-            call_kwargs = mock_client_cls.call_args.kwargs
-            assert call_kwargs["vertexai"] is True
-            assert call_kwargs["project"] == "test-project"
-            assert call_kwargs["location"] == "us-central1"
-
-        clear_config_cache()
+        # Verify genai.Client was called with vertexai=True
+        call_kwargs = mock_client_cls.call_args.kwargs
+        assert call_kwargs["vertexai"] is True
+        assert call_kwargs["project"] == "test-project"
+        assert call_kwargs["location"] == "us-central1"
 
 
 def test_llm_wrapper_vertexai_sa_auth():
@@ -113,99 +82,67 @@ def test_llm_wrapper_vertexai_sa_auth():
 
     mock_credentials = MagicMock()
 
-    with patch.dict(
-        os.environ,
-        {
-            "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": "test-project",
-            "HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY": "/path/to/key.json",
-        },
-        clear=False,
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=mock_credentials,
     ):
-        from hindsight_api.config import clear_config_cache
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value = MagicMock()
 
-        clear_config_cache()
+            provider = LLMProvider(
+                provider="vertexai",
+                api_key="",
+                base_url="",
+                model="google/gemini-2.0-flash-001",
+                vertexai_project_id="test-project",
+                vertexai_service_account_key="/path/to/key.json",
+            )
 
-        with patch(
-            "google.oauth2.service_account.Credentials.from_service_account_file",
-            return_value=mock_credentials,
-        ):
-            with patch("google.genai.Client") as mock_client_cls:
-                mock_client_cls.return_value = MagicMock()
+            assert provider.provider == "vertexai"
+            assert provider._gemini_client is not None
 
-                provider = LLMProvider(
-                    provider="vertexai",
-                    api_key="",
-                    base_url="",
-                    model="google/gemini-2.0-flash-001",
-                )
-
-                assert provider.provider == "vertexai"
-                assert provider._gemini_client is not None
-
-                # Verify credentials were passed to genai.Client
-                call_kwargs = mock_client_cls.call_args.kwargs
-                assert call_kwargs["vertexai"] is True
-                assert call_kwargs["project"] == "test-project"
-                assert call_kwargs["location"] == "us-central1"
-                assert call_kwargs["credentials"] is mock_credentials
-
-        clear_config_cache()
+            # Verify credentials were passed to genai.Client
+            call_kwargs = mock_client_cls.call_args.kwargs
+            assert call_kwargs["vertexai"] is True
+            assert call_kwargs["project"] == "test-project"
+            assert call_kwargs["location"] == "us-central1"
+            assert call_kwargs["credentials"] is mock_credentials
 
 
 def test_llm_wrapper_vertexai_strips_google_prefix():
     """Test that google/ prefix is stripped from model name for native SDK."""
     from hindsight_api.engine.llm_wrapper import LLMProvider
 
-    with patch.dict(
-        os.environ,
-        {"HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": "test-project"},
-        clear=False,
-    ):
-        from hindsight_api.config import clear_config_cache
+    with patch("google.genai.Client") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
 
-        clear_config_cache()
+        provider = LLMProvider(
+            provider="vertexai",
+            api_key="",
+            base_url="",
+            model="google/gemini-2.0-flash-lite-001",
+            vertexai_project_id="test-project",
+        )
 
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client_cls.return_value = MagicMock()
-
-            provider = LLMProvider(
-                provider="vertexai",
-                api_key="",
-                base_url="",
-                model="google/gemini-2.0-flash-lite-001",
-            )
-
-            assert provider.model == "gemini-2.0-flash-lite-001"
-
-        clear_config_cache()
+        assert provider.model == "gemini-2.0-flash-lite-001"
 
 
 def test_llm_wrapper_vertexai_no_prefix_model():
     """Test that model without google/ prefix is unchanged."""
     from hindsight_api.engine.llm_wrapper import LLMProvider
 
-    with patch.dict(
-        os.environ,
-        {"HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID": "test-project"},
-        clear=False,
-    ):
-        from hindsight_api.config import clear_config_cache
+    with patch("google.genai.Client") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
 
-        clear_config_cache()
+        provider = LLMProvider(
+            provider="vertexai",
+            api_key="",
+            base_url="",
+            model="gemini-2.0-flash-001",
+            vertexai_project_id="test-project",
+        )
 
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client_cls.return_value = MagicMock()
-
-            provider = LLMProvider(
-                provider="vertexai",
-                api_key="",
-                base_url="",
-                model="gemini-2.0-flash-001",
-            )
-
-            assert provider.model == "gemini-2.0-flash-001"
-
-        clear_config_cache()
+        assert provider.model == "gemini-2.0-flash-001"
 
 
 @pytest.mark.asyncio
@@ -228,6 +165,8 @@ async def test_vertexai_integration_actual_api():
         api_key="",
         base_url="",
         model="google/gemini-2.5-flash-lite",
+        vertexai_project_id=os.getenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"),
+        vertexai_service_account_key=os.getenv("HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY") or None,
     )
 
     try:


### PR DESCRIPTION
## Summary

> Stacked on #2401 — please merge that first (this PR's base is its branch; GitHub will retarget to `main` once #2401 merges).

Makes `LLMProvider.__init__` **config-free**: it uses its arguments verbatim and never reads global `HindsightConfig`. Resolving the server-level default for an omitted argument moves to the callers.

### Why

The constructor used to reach into global config (`get_config()` / `_get_raw_config()`) to backfill any `None` argument — `default_headers`, `gemini_safety_settings`, `gemini_service_tier`, `prompt_cache_enabled`, `litellmrouter_config`, and the Vertex project/region/SA key. That hidden global read is the root cause of the multi-LLM member bugs we just fixed: because the constructor always knew the *global* value, an indexed member couldn't override it, so #2384 and #2401 were each "thread one more field so an explicit value can win over the constructor's fallback." A pure constructor removes that whole bug class — a provider's effective settings become a pure function of its arguments, which is what lets each member of a chain be configured independently.

### Change

**`LLMProvider.__init__`** — remove all six global-config fallbacks. Kept: pure normalizations (Gemini tier parse, non-Gemini tier reset, `google/` model-prefix strip) and the `us-central1` region constant. Added a docstring note that resolution is the caller's job.

**Callers now resolve the fallbacks:**
- `MemoryEngine`'s four per-op base builds pass the global LLM config explicitly. `gemini_safety_settings` is read from the **raw** config because it's the one bank-configurable field here (the `StaticConfigProxy` from `get_config()` blocks it) — the server default seeds construction and the per-bank value is still applied per-call via `ConfiguredLLMProvider`. The rest are static and read off the proxy.
- `_member_to_llm` resolves member-value-or-global for each field, preserving how a chain member inherits global defaults.
- `LLMProvider.from_env` reads the remaining fields straight from `os.getenv`, staying a lightweight env-only loader (no full-config build — keeps `test_llm_provider_from_env_keeps_lightweight_loader` honest).

Behavior is unchanged for single-LLM, member, and `from_env` paths.

### Tests

- Updated `test_vertexai_provider.py` and one `test_gemini_safety_settings.py` test to the explicit-args contract — they previously fed the constructor via env and relied on the now-removed global read (the Vertex unit tests now pass `vertexai_project_id` directly; the safety test goes through `from_env()`). Dropped the now-dead env scaffolding.
- Added two tests in `test_llm_wrapper.py` asserting the constructor ignores global config for `default_headers`, `prompt_cache_enabled`, and `gemini_safety_settings`.
- Full affected suite: `test_vertexai_provider test_gemini_safety_settings test_llm_wrapper test_multi_llm_config test_multi_llm_provider test_gemini_service_tier test_opencode_go_provider test_llm_reasoning_effort_env test_llm_router_provider test_per_operation_llm_config test_none_llm_provider` → 141 passed, 1 skipped (live Vertex). `ruff` / `ruff format` / `ty` clean.
