### PR TITLE
fix(control-plane): correct relative-time unit labels

### DIFF
--- a/hindsight-control-plane/src/lib/relative-time.ts
+++ b/hindsight-control-plane/src/lib/relative-time.ts
@@ -3,13 +3,18 @@ export function formatRelativeTime(dateStr: string): string {
   const diffSec = Math.round((Date.now() - then) / 1000);
   const abs = Math.abs(diffSec);
   if (abs < 60) return diffSec >= 0 ? "just now" : "in a moment";
+  // Each entry is [divisor, unit-after-dividing]: when the running value
+  // (still in the previous unit) is at least `divisor`, divide by it and the
+  // result is expressed in `nextUnit`. Labels must name the unit you convert
+  // INTO, not the one you came from — otherwise every duration renders one
+  // unit too small (e.g. 22 hours shown as "22 minutes ago").
   const units: [number, Intl.RelativeTimeFormatUnit][] = [
-    [60, "second"],
     [60, "minute"],
-    [24, "hour"],
-    [7, "day"],
-    [4.345, "week"],
-    [12, "month"],
+    [60, "hour"],
+    [24, "day"],
+    [7, "week"],
+    [4.345, "month"],
+    [12, "year"],
     [Number.POSITIVE_INFINITY, "year"],
   ];
   let value = diffSec;

--- a/hindsight-control-plane/tests/lib/relative-time.test.ts
+++ b/hindsight-control-plane/tests/lib/relative-time.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatRelativeTime } from "@/lib/relative-time";
+
+// Fixed reference point so "X ago" output is deterministic.
+const NOW = new Date("2026-06-25T13:57:00.000Z");
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+function ago(ms: number): string {
+  return new Date(NOW.getTime() - ms).toISOString();
+}
+
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders sub-minute durations as 'just now'", () => {
+    expect(formatRelativeTime(ago(30 * SEC))).toBe("just now");
+  });
+
+  // Regression: every duration used to render one unit too small, so a
+  // document created ~22 hours ago (i.e. yesterday) showed as "22 minutes ago".
+  it("labels minutes, hours and days with the correct unit", () => {
+    expect(formatRelativeTime(ago(22 * MIN))).toBe("22 minutes ago");
+    expect(formatRelativeTime(ago(13 * HOUR))).toBe("13 hours ago");
+    expect(formatRelativeTime(ago(22 * HOUR))).toBe("22 hours ago");
+  });
+
+  it("rolls 24h+ into days and uses 'yesterday' for one day", () => {
+    expect(formatRelativeTime(ago(25 * HOUR))).toBe("yesterday");
+    expect(formatRelativeTime(ago(2 * DAY))).toBe("2 days ago");
+  });
+
+  it("scales up to weeks, months and years", () => {
+    expect(formatRelativeTime(ago(8 * DAY))).toBe("last week");
+    expect(formatRelativeTime(ago(40 * DAY))).toBe("last month");
+    expect(formatRelativeTime(ago(400 * DAY))).toBe("last year");
+  });
+
+  it("handles future timestamps", () => {
+    expect(formatRelativeTime(new Date(NOW.getTime() + 3 * HOUR).toISOString())).toBe("in 3 hours");
+  });
+});


### PR DESCRIPTION
## Problem

A user reported that a memory bank's **documents list** showed `created 22 minutes ago` / `updated 13 minutes ago` for a document actually created **yesterday**, while the **document detail** panel showed yesterday's date correctly on both fields.

## Root cause

`formatRelativeTime` in `relative-time.ts` mislabeled the `units` table. Each `[divisor, label]` pair named the unit being *divided from* rather than the unit being *converted into*, so after dividing seconds by 60 the result (minutes) was still labeled `"second"`, and so on up the chain. Every duration rendered **one unit too small**:

| Actual age | Before | After |
|---|---|---|
| 22 minutes | `22 seconds ago` | `22 minutes ago` |
| 13 hours | `13 minutes ago` | `13 hours ago` |
| 22 hours | `22 minutes ago` | `22 hours ago` |
| 25 hours | `1 hour ago` | `yesterday` |
| 2 days | `2 hours ago` | `2 days ago` |

The reporter's document was ~22h old (created) / ~13h old (updated) — genuinely yesterday — so the list rendered them as "22 minutes / 13 minutes ago". The detail view uses `toLocaleString` (absolute date), which was correct, hence the apparent disagreement. The stored timestamps and the API are correct; this is purely a display bug.

It affects every relative timestamp this helper renders (documents list, mental-model and observation UI).

## Fix

Shift the `units` labels so each entry names the unit you convert **into**, and add a comment to prevent regression.

## Tests

Adds `tests/lib/relative-time.test.ts` covering the minute/hour/day/week/month/year boundaries (including the `22h → "22 hours ago"` and `25h → "yesterday"` cases) plus a future-timestamp case. Verified the test **fails** on the old labels and passes on the fix.

## Note

The same helper was ported into `hindsight-deployment`'s `cloud-ui` (the deployed dashboard) and has the identical bug; a sibling PR fixes that copy so the fix reaches production.