### PR TITLE
fix(embed): find pythonw beside the installed API script on Windows

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -166,23 +166,27 @@ class DaemonEmbedManager(EmbedManager):
         return None
 
     @staticmethod
-    def _windows_gui_interpreter() -> str | None:
+    def _windows_gui_interpreter(preferred_dir: Path | None = None) -> str | None:
         """Path to the GUI-subsystem Python (pythonw.exe), or None.
 
         Returns None on non-Windows, or when pythonw.exe can't be located next
-        to the running interpreter.
+        to the preferred scripts directory or running interpreter.
 
         On Windows 11 with Windows Terminal as the default terminal app,
         spawning the console-subsystem (CUI, subsystem 3) hindsight-api.exe
         launcher makes ConPTY pop a visible terminal tab on daemon start, even
         with DETACHED_PROCESS / CREATE_NO_WINDOW (issue #1885). Launching the
         daemon through the GUI-subsystem (subsystem 2) pythonw.exe interpreter
-        never allocates a console, so no window appears. pythonw.exe sits next
-        to sys.executable, whose environment is the one we just confirmed has
-        hindsight-api installed, so `pythonw.exe -m hindsight_api.main` resolves.
+        never allocates a console, so no window appears. Prefer the scripts dir
+        that contains hindsight-api.exe because wrapper entry points can make
+        sys.executable point at a different launcher directory (issue #2389).
         """
         if platform.system() != "Windows":
             return None
+        if preferred_dir is not None:
+            pythonw = preferred_dir / "pythonw.exe"
+            if pythonw.exists():
+                return str(pythonw)
         pythonw = Path(sys.executable).with_name("pythonw.exe")
         return str(pythonw) if pythonw.exists() else None
 
@@ -221,7 +225,7 @@ class DaemonEmbedManager(EmbedManager):
             # The console exe lives in sys.executable's scripts dir, so
             # hindsight_api is importable by the GUI interpreter; prefer it on
             # Windows to avoid ConPTY popping a terminal tab (issue #1885).
-            gui_python = self._windows_gui_interpreter()
+            gui_python = self._windows_gui_interpreter(scripts_dir)
             if gui_python is not None:
                 return [gui_python, "-m", "hindsight_api.main"]
             return [str(candidate)]

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -248,6 +248,30 @@ def test_find_api_command_windows_prefers_gui_interpreter(tmp_path, monkeypatch)
     assert manager._find_api_command("0.0.0") == [str(pythonw), "-m", "hindsight_api.main"]
 
 
+def test_find_api_command_windows_prefers_scripts_dir_pythonw_for_wrappers(tmp_path, monkeypatch):
+    """pip/uv wrapper executables can make sys.executable differ from Scripts."""
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "hindsight-api.exe").touch()
+    pythonw = scripts_dir / "pythonw.exe"
+    pythonw.touch()
+
+    wrapper_dir = tmp_path / "wrapper"
+    wrapper_dir.mkdir()
+    (wrapper_dir / "hindsight-embed.exe").touch()
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.__file__",
+        str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py"),
+    )
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(wrapper_dir / "hindsight-embed.exe"))
+
+    assert manager._find_api_command("0.0.0") == [str(pythonw), "-m", "hindsight_api.main"]
+
+
 def test_find_pid_on_port_windows_hides_netstat_console(monkeypatch):
     """Windows netstat probes must not flash a console window."""
     calls = []


### PR DESCRIPTION
Closes #2389.

#1890 made Windows daemon startup prefer `pythonw.exe` so `hindsight-api.exe` does not flash a terminal window. The installed-wrapper path still misses that on common pip/uv installs because `sys.executable` can point at `hindsight-embed.exe`, not the Scripts directory that contains `hindsight-api.exe` and `pythonw.exe`.

This keeps the existing fallback behavior, but when `_find_api_command()` has already found `hindsight-api.exe` in the configured scripts directory, it probes that same directory for `pythonw.exe` first.

Tests:

```bash
uv run --project hindsight-embed pytest hindsight-embed/tests/test_embed_manager.py -q
```
