### PR TITLE
docs(mental-models): document scheduled refresh triggers

### DIFF
--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -118,8 +118,11 @@ Mental models can be configured to **automatically refresh** when observations a
 |---------|------|---------|-------------|
 | `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
+| `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
+
+When `refresh_cron` is set, Hindsight checks the schedule on the server's mental-model refresh tick and refreshes the model only if memories in its scope have changed since the last refresh. `refresh_cron` and `refresh_after_consolidation` are mutually exclusive, so a model refreshes either after consolidation or on a fixed UTC schedule, not both.
 
 ### Refresh Mode
 

--- a/hindsight-docs/examples/api/mental-models.mjs
+++ b/hindsight-docs/examples/api/mental-models.mjs
@@ -55,10 +55,10 @@ const result2 = await client.createMentalModel(
     BANK_ID,
     'Project Status',
     'What is the current project status?',
-    { trigger: { refreshAfterConsolidation: true } },
+    { trigger: { refreshCron: '0 3 * * *' } },
 );
 
-// This mental model will automatically refresh when observations are updated
+// This mental model checks daily at 03:00 UTC and refreshes when scoped memories changed
 console.log(`Operation ID: ${result2.operation_id}`);
 // [/docs:create-mental-model-with-trigger]
 

--- a/hindsight-docs/examples/api/mental-models.py
+++ b/hindsight-docs/examples/api/mental-models.py
@@ -63,10 +63,10 @@ result = client.create_mental_model(
     bank_id=BANK_ID,
     name="Project Status",
     source_query="What is the current project status?",
-    trigger={"refresh_after_consolidation": True}
+    trigger={"refresh_cron": "0 3 * * *"}
 )
 
-# This mental model will automatically refresh when observations are updated
+# This mental model checks daily at 03:00 UTC and refreshes when scoped memories changed
 print(f"Operation ID: {result.operation_id}")
 # [/docs:create-mental-model-with-trigger]
 

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -165,8 +165,11 @@ Mental models can be configured to **automatically refresh** when observations a
 |---------|------|---------|-------------|
 | `mode` | `"full"` \| `"delta"` | `"full"` | Refresh strategy. See [Refresh Mode](#refresh-mode) below. |
 | `refresh_after_consolidation` | bool | false | Automatically refresh after observations consolidation |
+| `refresh_cron` | string \| null | null | UTC 5-field cron expression for scheduled refreshes, such as `"0 3 * * *"` for daily at 03:00 UTC |
 
 When `refresh_after_consolidation` is enabled, the mental model will be re-generated every time the bank's observations are consolidated — ensuring it always reflects the latest synthesized knowledge.
+
+When `refresh_cron` is set, Hindsight checks the schedule on the server's mental-model refresh tick and refreshes the model only if memories in its scope have changed since the last refresh. `refresh_cron` and `refresh_after_consolidation` are mutually exclusive, so a model refreshes either after consolidation or on a fixed UTC schedule, not both.
 
 ### Refresh Mode
 
@@ -197,10 +200,10 @@ result = client.create_mental_model(
     bank_id=BANK_ID,
     name="Project Status",
     source_query="What is the current project status?",
-    trigger={"refresh_after_consolidation": True}
+    trigger={"refresh_cron": "0 3 * * *"}
 )
 
-# This mental model will automatically refresh when observations are updated
+# This mental model checks daily at 03:00 UTC and refreshes when scoped memories changed
 print(f"Operation ID: {result.operation_id}")
 ```
 
@@ -212,10 +215,10 @@ const result2 = await client.createMentalModel(
     BANK_ID,
     'Project Status',
     'What is the current project status?',
-    { trigger: { refreshAfterConsolidation: true } },
+    { trigger: { refreshCron: '0 3 * * *' } },
 );
 
-// This mental model will automatically refresh when observations are updated
+// This mental model checks daily at 03:00 UTC and refreshes when scoped memories changed
 console.log(`Operation ID: ${result2.operation_id}`);
 ```
 


### PR DESCRIPTION
## Summary
- document the `refresh_cron` trigger for mental models
- show Python and JS examples that schedule a daily UTC refresh
- regenerate the Hindsight docs skill mirror for the updated API page

## Context
`refresh_cron` was added in #2377, but the mental-model docs still only described `refresh_after_consolidation`. This fills the docs gap and calls out that the two trigger modes are mutually exclusive.

## Tests
- `bash scripts/generate-docs-skill.sh`
- `python3 -m py_compile hindsight-docs/examples/api/mental-models.py`
- checked generated skill mirror includes the new `refresh_cron` docs/examples
