### PR TITLE
fix(ci): unblock main — ruff format drift + CLI refresh_cron field

### DIFF
--- a/hindsight-api-slim/tests/test_chunking.py
+++ b/hindsight-api-slim/tests/test_chunking.py
@@ -455,4 +455,3 @@ def test_merged_json_array_routes_to_conversation_chunking():
         assert isinstance(parsed, list), f"Chunk must be a JSON array: {chunk[:60]}"
         assert all(isinstance(e, dict) for e in parsed), f"Every element must be a dict: {chunk[:60]}"
         assert all("role" in e for e in parsed), f"Every element must have a role key: {chunk[:60]}"
-        

--- a/hindsight-api-slim/tests/test_retain_append_mode.py
+++ b/hindsight-api-slim/tests/test_retain_append_mode.py
@@ -254,10 +254,12 @@ async def test_append_mode_conversation_arrays_produce_valid_json(memory, reques
 
     try:
         # First retain - JSON conversation array
-        turn1 = json.dumps([
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there"},
-        ])
+        turn1 = json.dumps(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+            ]
+        )
         await memory.retain_batch_async(
             bank_id=bank_id,
             contents=[
@@ -271,10 +273,12 @@ async def test_append_mode_conversation_arrays_produce_valid_json(memory, reques
         )
 
         # Second retain - append more turns
-        turn2 = json.dumps([
-            {"role": "user", "content": "How are you"},
-            {"role": "assistant", "content": "Doing well"},
-        ])
+        turn2 = json.dumps(
+            [
+                {"role": "user", "content": "How are you"},
+                {"role": "assistant", "content": "Doing well"},
+            ]
+        )
         await memory.retain_batch_async(
             bank_id=bank_id,
             contents=[
@@ -300,10 +304,12 @@ async def test_append_mode_conversation_arrays_produce_valid_json(memory, reques
         assert len(parsed) == 4, "Should contain all 4 messages from both retains"
 
         # Third retain - append again, verify no degradation
-        turn3 = json.dumps([
-            {"role": "user", "content": "What is new"},
-            {"role": "assistant", "content": "Not much"},
-        ])
+        turn3 = json.dumps(
+            [
+                {"role": "user", "content": "What is new"},
+                {"role": "assistant", "content": "Not much"},
+            ]
+        )
         await memory.retain_batch_async(
             bank_id=bank_id,
             contents=[
@@ -329,4 +335,3 @@ async def test_append_mode_conversation_arrays_produce_valid_json(memory, reques
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
-        

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -120,6 +120,7 @@ pub fn create(
         Some(types::MentalModelTriggerInput {
             mode: types::Mode::Full,
             refresh_after_consolidation: true,
+            refresh_cron: None,
             exclude_mental_models: false,
             exclude_mental_model_ids: None,
             fact_types: None,
@@ -198,6 +199,7 @@ pub fn update(
     let trigger = trigger_refresh_after_consolidation.map(|refresh| types::MentalModelTriggerInput {
         mode: types::Mode::Full,
         refresh_after_consolidation: refresh,
+        refresh_cron: None,
         exclude_mental_models: false,
         exclude_mental_model_ids: None,
         fact_types: None,


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main` are currently red on **every open PR** (e.g. #2385, #2417) even though those PRs don't touch the affected files. This unblocks them.

### 1. `verify-generated-files` — ruff-format drift
`hindsight-api-slim/tests/test_chunking.py` and `tests/test_retain_append_mode.py` were committed without running the formatter (trailing whitespace + `json.dumps([...])` that ruff reflows to multi-line). The job runs `lint.sh`, which reformats them → diff → fail. Fixed by running `./scripts/hooks/lint.sh`.

### 2. `test-doc-examples (cli)` — CLI out of sync with the client
`refresh_cron` was added to `MentalModelTriggerInput`, but `hindsight-cli/src/commands/mental_model.rs` was never updated, so the CLI no longer compiled (`missing field refresh_cron`, lines 120 & 198). Set `refresh_cron: None` in both trigger initializers (create + update), preserving existing behaviour.

## Verification

- `lint.sh` clean; the two test files now match formatter output.
- `cargo check` on `hindsight-cli` passes (regenerates the client from the spec and compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
