### PR TITLE
fix(cli): show filenames in operation list

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -62,6 +62,7 @@ pub struct Operation {
     pub id: String,
     pub task_type: String,
     pub items_count: i32,
+    pub filename: Option<String>,
     pub document_id: Option<String>,
     pub created_at: String,
     pub status: String,
@@ -1312,6 +1313,7 @@ mod tests {
             "id": "test-op-123",
             "task_type": "retain",
             "items_count": 5,
+            "filename": "notes.md",
             "document_id": "doc-456",
             "created_at": "2024-01-15T10:00:00Z",
             "status": "pending",
@@ -1321,6 +1323,7 @@ mod tests {
         assert_eq!(op.id, "test-op-123");
         assert_eq!(op.task_type, "retain");
         assert_eq!(op.items_count, 5);
+        assert_eq!(op.filename, Some("notes.md".to_string()));
         assert_eq!(op.document_id, Some("doc-456".to_string()));
         assert_eq!(op.status, "pending");
         assert!(op.error_message.is_none());
@@ -1332,6 +1335,7 @@ mod tests {
             "id": "test-op-456",
             "task_type": "retain",
             "items_count": 3,
+            "filename": null,
             "document_id": null,
             "created_at": "2024-01-15T10:00:00Z",
             "status": "failed",
@@ -1339,6 +1343,7 @@ mod tests {
         }"#;
         let op: Operation = serde_json::from_str(json).unwrap();
         assert_eq!(op.status, "failed");
+        assert_eq!(op.filename, None);
         assert_eq!(op.error_message, Some("Something went wrong".to_string()));
     }
 
@@ -1380,6 +1385,7 @@ mod tests {
                     "id": "op-1",
                     "task_type": "retain",
                     "items_count": 2,
+                    "filename": "first.md",
                     "document_id": null,
                     "created_at": "2024-01-15T10:00:00Z",
                     "status": "pending",
@@ -1389,6 +1395,7 @@ mod tests {
                     "id": "op-2",
                     "task_type": "retain",
                     "items_count": 3,
+                    "filename": null,
                     "document_id": "doc-123",
                     "created_at": "2024-01-15T11:00:00Z",
                     "status": "completed",
@@ -1400,6 +1407,8 @@ mod tests {
         assert_eq!(ops.bank_id, "test-bank");
         assert_eq!(ops.operations.len(), 2);
         assert_eq!(ops.operations[0].status, "pending");
+        assert_eq!(ops.operations[0].filename, Some("first.md".to_string()));
         assert_eq!(ops.operations[1].status, "completed");
+        assert_eq!(ops.operations[1].filename, None);
     }
 }

--- a/hindsight-cli/src/commands/mental_model.rs
+++ b/hindsight-cli/src/commands/mental_model.rs
@@ -120,6 +120,7 @@ pub fn create(
         Some(types::MentalModelTriggerInput {
             mode: types::Mode::Full,
             refresh_after_consolidation: true,
+            refresh_cron: None,
             exclude_mental_models: false,
             exclude_mental_model_ids: None,
             fact_types: None,
@@ -198,6 +199,7 @@ pub fn update(
     let trigger = trigger_refresh_after_consolidation.map(|refresh| types::MentalModelTriggerInput {
         mode: types::Mode::Full,
         refresh_after_consolidation: refresh,
+        refresh_cron: None,
         exclude_mental_models: false,
         exclude_mental_model_ids: None,
         fact_types: None,

--- a/hindsight-cli/src/commands/operation.rs
+++ b/hindsight-cli/src/commands/operation.rs
@@ -3,6 +3,22 @@ use crate::output::{self, OutputFormat};
 use crate::ui;
 use anyhow::Result;
 
+fn operation_summary_lines(op: &crate::api::Operation) -> Vec<String> {
+    let mut lines = vec![
+        format!("\n  Operation ID: {}", op.id),
+        format!("    Type: {}", op.task_type),
+        format!("    Status: {}", op.status),
+        format!("    Items: {}", op.items_count),
+    ];
+    if let Some(filename) = &op.filename {
+        lines.push(format!("    Filename: {}", filename));
+    }
+    if let Some(doc_id) = &op.document_id {
+        lines.push(format!("    Document ID: {}", doc_id));
+    }
+    lines
+}
+
 pub fn list(
     client: &ApiClient,
     agent_id: &str,
@@ -32,12 +48,8 @@ pub fn list(
                         ops_response.operations.len()
                     ));
                     for op in &ops_response.operations {
-                        println!("\n  Operation ID: {}", op.id);
-                        println!("    Type: {}", op.task_type);
-                        println!("    Status: {}", op.status);
-                        println!("    Items: {}", op.items_count);
-                        if let Some(doc_id) = &op.document_id {
-                            println!("    Document ID: {}", doc_id);
+                        for line in operation_summary_lines(op) {
+                            println!("{line}");
                         }
                     }
                 }
@@ -47,6 +59,39 @@ pub fn list(
             Ok(())
         }
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::operation_summary_lines;
+    use crate::api::Operation;
+
+    fn operation(filename: Option<&str>) -> Operation {
+        Operation {
+            id: "op-1".to_string(),
+            task_type: "retain".to_string(),
+            items_count: 2,
+            filename: filename.map(str::to_string),
+            document_id: Some("doc-1".to_string()),
+            created_at: "2024-01-15T10:00:00Z".to_string(),
+            status: "completed".to_string(),
+            error_message: None,
+        }
+    }
+
+    #[test]
+    fn summary_lines_include_filename_when_present() {
+        let lines = operation_summary_lines(&operation(Some("notes.md")));
+        assert!(lines.iter().any(|line| line == "    Filename: notes.md"));
+        assert!(lines.iter().any(|line| line == "    Document ID: doc-1"));
+    }
+
+    #[test]
+    fn summary_lines_skip_filename_when_absent() {
+        let lines = operation_summary_lines(&operation(None));
+        assert!(!lines.iter().any(|line| line.starts_with("    Filename:")));
+        assert!(lines.iter().any(|line| line == "    Document ID: doc-1"));
     }
 }
 


### PR DESCRIPTION
## Summary
- carry the optional operation `filename` field through the CLI's operation list model
- show `Filename:` in pretty `hindsight operations list` output when the API provides it
- set `refresh_cron: None` on existing mental-model trigger requests so the CLI continues compiling against the current generated Rust client schema

## Context
#2420 made file-upload operations expose the original filename on the API response so operators can identify pending or failed uploads. The CLI still converted the response into its local `Operation` type without that field, so pretty output only showed opaque operation/document IDs.

While verifying the CLI tests, the current generated Rust client also required the newer nullable `refresh_cron` field on `MentalModelTriggerInput`; adding `None` preserves the existing CLI behavior and keeps the focused tests compiling.

## Tests
- `cargo test --manifest-path hindsight-cli/Cargo.toml --locked operation::tests`
- `cargo test --manifest-path hindsight-cli/Cargo.toml --locked api::tests::test_operation_deserialize`
- `cargo test --manifest-path hindsight-cli/Cargo.toml --locked api::tests::test_operation_deserialize_with_error`
- `cargo test --manifest-path hindsight-cli/Cargo.toml --locked api::tests::test_operations_response_deserialize`
