### PR TITLE
docs(api): drop removed 'opinion' fact_type from MemoryFact schema description

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -243,7 +243,7 @@ class MemoryFact(BaseModel):
 
     id: str = Field(description="Unique identifier for the memory fact")
     text: str = Field(description="The actual text content of the memory")
-    fact_type: str = Field(description="Type of fact: 'world', 'experience', 'opinion', or 'observation'")
+    fact_type: str = Field(description="Type of fact: 'world', 'experience', or 'observation'")
     entities: list[str] | None = Field(None, description="Entity names mentioned in this fact")
     context: str | None = Field(None, description="Additional context for the memory")
     occurred_start: str | None = Field(None, description="ISO format date when the event started occurring")


### PR DESCRIPTION
## Problem

`MemoryFact.fact_type` (in `hindsight-api-slim/hindsight_api/engine/response_models.py`) describes itself as:

```python
fact_type: str = Field(description="Type of fact: 'world', 'experience', 'opinion', or 'observation'")
```

But `'opinion'` was removed from the fact-type enum. The current source of truth allows only three values:

- `models.py` — `CheckConstraint("fact_type IN ('world', 'experience', 'observation')")`
- `response_models.py` — `VALID_RECALL_FACT_TYPES = frozenset(["world", "experience", "observation"])`

So the API hard-rejects `'opinion'`, yet this response-schema description still advertises it. An SDK/API consumer reading the `MemoryFact` schema is told `'opinion'` is a valid `fact_type` when it no longer is.

## Fix

Drop `'opinion'` from the description so it matches what the API actually returns and accepts:

```python
fact_type: str = Field(description="Type of fact: 'world', 'experience', or 'observation'")
```

This is the same opinion-fact-type cleanup already merged for other surfaces (#2198 litellm README, #2302 `mcp_tools.py` docstrings, #2335 integration packages); this catches the remaining `MemoryFact` response-schema description. Description-only change — no behavior change, and this field description is not part of the committed `openapi.json`, so no regeneration is required.
