### PR TITLE
fix(search): guard CrossEncoderReranker.ensure_initialized with asyncio.Lock

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -214,6 +214,7 @@ class CrossEncoderReranker:
             cross_encoder = create_cross_encoder_from_env()
         self.cross_encoder = cross_encoder
         self._initialized = False
+        self._init_lock = None  # asyncio.Lock — created lazily inside async context
 
     async def ensure_initialized(self):
         """Ensure the cross-encoder model is initialized (for lazy initialization)."""
@@ -222,30 +223,39 @@ class CrossEncoderReranker:
 
         import asyncio
 
-        from hindsight_api.config import ENV_MODEL_INIT_TIMEOUT, get_config
+        # Lazy-create lock in async context (cannot create in __init__ which may
+        # run outside a running event loop).
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
 
-        cross_encoder = self.cross_encoder
-        # For local providers, run in thread pool to avoid blocking event loop
-        if cross_encoder.provider_name == "local":
-            loop = asyncio.get_event_loop()
-            init = loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
-        else:
-            init = cross_encoder.initialize()
+        async with self._init_lock:
+            if self._initialized:
+                return
 
-        # Cap lazy init with the same wall-clock timeout used at startup so a
-        # hung model download surfaces as a clear error on the request that
-        # triggered it, rather than hanging the caller forever.
-        init_timeout = get_config().model_init_timeout
-        try:
-            await asyncio.wait_for(init, timeout=init_timeout)
-        except TimeoutError as e:
-            raise RuntimeError(
-                f"Cross-encoder initialization did not complete within {init_timeout:g}s. "
-                f"The reranker model is likely blocked loading — e.g. an offline model "
-                f"download. Increase {ENV_MODEL_INIT_TIMEOUT} if the first-time download "
-                f"legitimately needs more time."
-            ) from e
-        self._initialized = True
+            from hindsight_api.config import ENV_MODEL_INIT_TIMEOUT, get_config
+
+            cross_encoder = self.cross_encoder
+            # For local providers, run in thread pool to avoid blocking event loop
+            if cross_encoder.provider_name == "local":
+                loop = asyncio.get_event_loop()
+                init = loop.run_in_executor(None, lambda: asyncio.run(cross_encoder.initialize()))
+            else:
+                init = cross_encoder.initialize()
+
+            # Cap lazy init with the same wall-clock timeout used at startup so a
+            # hung model download surfaces as a clear error on the request that
+            # triggered it, rather than hanging the caller forever.
+            init_timeout = get_config().model_init_timeout
+            try:
+                await asyncio.wait_for(init, timeout=init_timeout)
+            except TimeoutError as e:
+                raise RuntimeError(
+                    f"Cross-encoder initialization did not complete within {init_timeout:g}s. "
+                    f"The reranker model is likely blocked loading — e.g. an offline model "
+                    f"download. Increase {ENV_MODEL_INIT_TIMEOUT} if the first-time download "
+                    f"legitimately needs more time."
+                ) from e
+            self._initialized = True
 
     async def rerank(self, query: str, candidates: list[MergedCandidate]) -> list[ScoredResult]:
         """

--- a/hindsight-api-slim/tests/test_reranker_init_lock.py
+++ b/hindsight-api-slim/tests/test_reranker_init_lock.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for CrossEncoderReranker.ensure_initialized concurrency guard.
+
+Verifies that concurrent callers do not double-initialize the cross-encoder
+model (race condition where both see _initialized=False and both call initialize).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.engine.search.reranking import CrossEncoderReranker
+
+
+def _make_cross_encoder():
+    ce = AsyncMock()
+    ce.provider_name = "local"
+    ce.initialize = AsyncMock()
+    return ce
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_initialized_calls_initialize_once():
+    """Concurrent ensure_initialized calls must only initialize the model once."""
+    ce = _make_cross_encoder()
+    reranker = CrossEncoderReranker(cross_encoder=ce)
+
+    await asyncio.gather(
+        reranker.ensure_initialized(),
+        reranker.ensure_initialized(),
+        reranker.ensure_initialized(),
+    )
+
+    ce.initialize.assert_awaited_once()
+    assert reranker._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_second_call_after_init_skips_initialize():
+    """After first initialization, subsequent calls return immediately."""
+    ce = _make_cross_encoder()
+    reranker = CrossEncoderReranker(cross_encoder=ce)
+
+    await reranker.ensure_initialized()
+    await reranker.ensure_initialized()
+
+    ce.initialize.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Two concurrent requests that both observed `_initialized=False` would both
  call `initialize()`, double-loading the local model and causing a memory spike
- Added a lazily-created `asyncio.Lock` with double-checked locking pattern so
  only the first caller runs initialization; subsequent callers wait and return
  immediately once `_initialized=True`

## Tests

Added `tests/test_reranker_init_lock.py`:
- `test_concurrent_ensure_initialized_calls_initialize_once` — fires 3 concurrent
  `ensure_initialized()` calls via `asyncio.gather`, asserts `initialize` called once
- `test_second_call_after_init_skips_initialize`  sequential second call is a no-op

## Test plan
- [ ] Concurrent recall requests no longer double-initialize the reranker model
- [ ] Memory usage stable under concurrent load with local cross-encoder