### PR TITLE
fix(clients): thread recall min_scores through the maintained Python SDK wrapper

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -410,6 +410,7 @@ class Hindsight:
         tags_match: Literal["any", "all", "any_strict", "all_strict", "exact"] = "any",
         tag_groups: list[dict[str, Any]] | None = None,
         prefer_observations: bool = False,
+        min_scores: dict[str, float] | None = None,
     ) -> RecallResponse:
         """
         Recall memories using semantic similarity (sync wrapper — prefer :meth:`arecall` in async code).
@@ -438,6 +439,10 @@ class Hindsight:
                 "observation", drop any raw fact a returned observation was consolidated from, so the
                 observation supersedes it (no duplicate content). Disabled by default; no effect unless
                 "observation" and at least one raw type are both in ``types``.
+            min_scores: Optional per-stage score floors, e.g. ``{"semantic": 0.2, "final": 0.5}``.
+                ``semantic`` and ``keyword`` are retrieval-level cutoffs; ``reranker`` and ``final``
+                are applied to the scored results after reranking. Any omitted stage imposes no floor.
+                Unknown keys raise ``ValueError`` (rather than silently applying no floor).
 
         Returns:
             RecallResponse with results, optional entities, optional chunks, optional source_facts, and optional trace
@@ -461,6 +466,7 @@ class Hindsight:
                 tags_match=tags_match,
                 tag_groups=tag_groups,
                 prefer_observations=prefer_observations,
+                min_scores=min_scores,
             )
         )
 
@@ -890,6 +896,7 @@ class Hindsight:
         tags_match: Literal["any", "all", "any_strict", "all_strict", "exact"] = "any",
         tag_groups: list[dict[str, Any]] | None = None,
         prefer_observations: bool = False,
+        min_scores: dict[str, float] | None = None,
     ) -> RecallResponse:
         """
         Recall memories using semantic similarity (async — preferred over :meth:`recall`).
@@ -923,6 +930,10 @@ class Hindsight:
                 "observation", drop any raw fact a returned observation was consolidated from, so the
                 observation supersedes it (no duplicate content). Disabled by default; no effect unless
                 "observation" and at least one raw type are both in ``types``.
+            min_scores: Optional per-stage score floors, e.g. ``{"semantic": 0.2, "final": 0.5}``.
+                ``semantic`` and ``keyword`` are retrieval-level cutoffs; ``reranker`` and ``final``
+                are applied to the scored results after reranking. Any omitted stage imposes no floor.
+                Unknown keys raise ``ValueError`` (rather than silently applying no floor).
 
         Returns:
             RecallResponse with results, optional entities, optional chunks, optional source_facts, and optional trace
@@ -950,6 +961,21 @@ class Hindsight:
 
             tag_groups_objs = [RecallRequestTagGroupsInner.from_dict(tg) for tg in tag_groups]
 
+        min_scores_obj = None
+        if min_scores is not None:
+            from hindsight_client_api.models.min_scores import MinScores
+
+            allowed_min_scores = {"semantic", "keyword", "reranker", "final"}
+            unknown = set(min_scores) - allowed_min_scores
+            if unknown:
+                # Fail loud instead of silently dropping a misspelled floor, which
+                # would make the caller believe filtering is active when it is not.
+                raise ValueError(
+                    f"Unknown min_scores keys: {sorted(unknown)}. "
+                    f"Allowed keys: {sorted(allowed_min_scores)}."
+                )
+            min_scores_obj = MinScores.from_dict(min_scores)
+
         request_obj = recall_request.RecallRequest(
             query=query,
             types=types,
@@ -962,6 +988,7 @@ class Hindsight:
             tags=tags,
             tags_match=tags_match,
             tag_groups=tag_groups_objs,
+            min_scores=min_scores_obj,
         )
 
         return await self._memory_api.recall_memories(bank_id, request_obj, _request_timeout=self._timeout)

--- a/hindsight-clients/python/tests/test_recall_min_scores.py
+++ b/hindsight-clients/python/tests/test_recall_min_scores.py
@@ -1,0 +1,57 @@
+"""The maintained wrapper threads min_scores into the recall request."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_client import Hindsight
+
+
+def _capture_recall(monkeypatch, client, captured):
+    async def fake_recall(bank_id, request_obj, _request_timeout=None):
+        captured["request"] = request_obj
+        return MagicMock(results=[])
+
+    monkeypatch.setattr(client._memory_api, "recall_memories", fake_recall)
+
+
+def test_recall_threads_min_scores(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_recall(monkeypatch, client, captured)
+
+    client.recall(
+        "test-bank",
+        "q",
+        min_scores={"semantic": 0.2, "final": 0.5},
+    )
+
+    min_scores = captured["request"].min_scores
+    assert min_scores is not None
+    assert min_scores.semantic == 0.2
+    assert min_scores.final == 0.5
+    # Unspecified stages impose no floor.
+    assert min_scores.keyword is None
+    assert min_scores.reranker is None
+
+
+def test_recall_min_scores_defaults_none(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_recall(monkeypatch, client, captured)
+
+    client.recall("test-bank", "q")
+
+    assert captured["request"].min_scores is None
+
+
+def test_recall_min_scores_rejects_unknown_key(monkeypatch):
+    client = Hindsight(base_url="http://example.invalid")
+    captured: dict[str, object] = {}
+    _capture_recall(monkeypatch, client, captured)
+
+    # A typo must fail loud, not silently apply no floor.
+    with pytest.raises(ValueError, match="sematic"):
+        client.recall("test-bank", "q", min_scores={"sematic": 0.8})
+
+    assert "request" not in captured


### PR DESCRIPTION
Follow-up to #2422, which added `RecallRequest.min_scores` (two-level retrieval/post-query score floors) to the HTTP/MCP API and the **generated** clients — but the hand-maintained high-level Python wrapper never got it.

`hindsight-clients/python/hindsight_client/hindsight_client.py` (header: *"This file is MAINTAINED and NOT auto-generated"*) threads every other public `RecallRequest` field through `recall()` / `arecall()` but has zero references to `min_scores`, so the most-used surface can't reach the headline feature without dropping down to the raw generated client.

**Change**
- Add an optional `min_scores: dict[str, float] | None = None` to `recall()` and `arecall()`, threaded into `RecallRequest` — mirroring the existing `tag_groups` dict → `from_dict` pattern.
- Unknown keys raise `ValueError` (e.g. a typo `{"sematic": 0.8}`) so a misspelled floor fails loud rather than silently applying no filter.
- Parity test mirrors the existing `tests/test_recall_prefer_observations.py` (threading, default `None`, and unknown-key rejection).

No codegen and no behavior change for callers who don't pass `min_scores`.

The TypeScript wrapper (`typescript/src/index.ts`) has the same gap; happy to send a follow-up there if you'd like it in this PR.
