### PR TITLE
docs(api): correct stale memory-type taxonomy in published READMEs

### DIFF
--- a/hindsight-api-slim/README.md
+++ b/hindsight-api-slim/README.md
@@ -121,7 +121,7 @@ This runs a stdio-based MCP server that can be used directly with MCP-compatible
 - **Entity Graph** — Automatic entity extraction and relationship tracking
 - **Temporal Reasoning** — Native support for time-based queries
 - **Disposition Traits** — Configurable skepticism, literalism, and empathy influence opinion formation
-- **Three Memory Types** — World facts, bank actions, and formed opinions with confidence scores
+- **Three Memory Types** — World facts, experience facts (the bank's own actions), and observations
 
 ## Documentation
 

--- a/hindsight-api/README.md
+++ b/hindsight-api/README.md
@@ -121,7 +121,7 @@ This runs a stdio-based MCP server that can be used directly with MCP-compatible
 - **Entity Graph** — Automatic entity extraction and relationship tracking
 - **Temporal Reasoning** — Native support for time-based queries
 - **Disposition Traits** — Configurable skepticism, literalism, and empathy influence opinion formation
-- **Three Memory Types** — World facts, bank actions, and formed opinions with confidence scores
+- **Three Memory Types** — World facts, experience facts (the bank's own actions), and observations
 
 ## Documentation
 


### PR DESCRIPTION
The top "features" bullet of both primary published packages misstates the recall memory-type taxonomy:

`hindsight-api/README.md:124` and `hindsight-api-slim/README.md:124` (byte-identical):

> **Three Memory Types** — World facts, bank actions, and formed opinions with confidence scores

The live taxonomy is **world / experience / observation** (`VALID_RECALL_FACT_TYPES` in `hindsight-api-slim/hindsight_api/engine/response_models.py`, and the `fact_type IN (...)` CHECK constraint):

- `opinion` was removed (recall now 422-rejects it)
- `bank` was renamed to `experience`

So the first thing a PyPI/GitHub visitor reads tells them `opinion` is a valid recall `fact_type` (it isn't) and references `bank` (which no longer exists). This syncs the bullet to the live enum, matching `hindsight-docs/docs/developer/index.mdx`.

Scoped to that one bullet — opinion *formation* as a behavioral concept (e.g. `ReflectResult`) is untouched.
