### PR TITLE
fix(parsers): handle UTF-8 text files with ASCII prefix in markitdown

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
+++ b/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
@@ -5,12 +5,34 @@ import logging
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from hindsight_api.config import DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
 
 from .base import FileParser
 
+if TYPE_CHECKING:
+    from markitdown import StreamInfo
+
 logger = logging.getLogger(__name__)
+
+# Extensions whose markitdown converters decode the raw bytes as text. markitdown
+# samples only the first chunk for charset detection, so a UTF-8 file with a long
+# ASCII-only prefix is mis-detected as ASCII; the JSON/ipynb converter then crashes
+# decoding the first multibyte byte. Passing an explicit UTF-8 hint when the bytes
+# are valid UTF-8 sidesteps the faulty detection without affecting other encodings.
+_TEXT_EXTENSIONS = {
+    ".json",
+    ".jsonl",
+    ".ipynb",
+    ".txt",
+    ".text",
+    ".md",
+    ".markdown",
+    ".csv",
+    ".html",
+    ".htm",
+}
 
 
 @dataclass(frozen=True)
@@ -134,8 +156,9 @@ class MarkitdownParser(FileParser):
             tmp_path = tmp.name
 
         try:
-            # Parse using markitdown
-            result = self._markitdown.convert(tmp_path)
+            # Parse using markitdown, passing an explicit charset hint for text
+            # files to avoid markitdown's sample-based (and crash-prone) detection.
+            result = self._markitdown.convert(tmp_path, stream_info=self._utf8_stream_info(file_data, filename))
 
             if not result or not result.text_content:
                 raise RuntimeError(f"No content extracted from '{filename}'")
@@ -152,6 +175,23 @@ class MarkitdownParser(FileParser):
                 Path(tmp_path).unlink()
             except Exception:
                 pass
+
+    @staticmethod
+    def _utf8_stream_info(file_data: bytes, filename: str) -> "StreamInfo | None":
+        """Return a UTF-8 charset hint for text files that decode cleanly as UTF-8.
+
+        Returns None for binary files or non-UTF-8 text so markitdown falls back
+        to its own detection.
+        """
+        if Path(filename).suffix.lower() not in _TEXT_EXTENSIONS:
+            return None
+        try:
+            file_data.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        from markitdown import StreamInfo
+
+        return StreamInfo(charset="utf-8")
 
     @staticmethod
     def _is_image_file(filename: str) -> bool:

--- a/hindsight-api-slim/tests/test_markitdown_parser.py
+++ b/hindsight-api-slim/tests/test_markitdown_parser.py
@@ -1,0 +1,65 @@
+"""Unit tests for the markitdown file parser."""
+
+import json
+
+import pytest
+
+from hindsight_api.engine.parsers.markitdown import MarkitdownParser
+
+
+@pytest.fixture
+def parser() -> MarkitdownParser:
+    return MarkitdownParser()
+
+
+def _utf8_json_with_ascii_prefix() -> bytes:
+    """A JSON file whose first chunk is ASCII but contains multibyte UTF-8 later.
+
+    markitdown samples only the first chunk for charset detection, so this layout
+    used to be mis-detected as ASCII and crash the JSON/ipynb converter on the
+    first multibyte byte (0xc3).
+    """
+    payload = {"messages": [{"role": "user", "text": "x" * 6400 + " café à la crème naïve über"}]}
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    assert any(b > 127 for b in raw[6000:]), "fixture must have non-ASCII bytes past the sample window"
+    return raw
+
+
+async def test_convert_utf8_json_transcript(parser: MarkitdownParser):
+    """A UTF-8 JSON transcript with an ASCII prefix parses without a decode error."""
+    file_data = _utf8_json_with_ascii_prefix()
+
+    content = await parser.convert(file_data, "transcript.json")
+
+    assert "café" in content
+    assert "crème" in content
+
+
+async def test_convert_plain_utf8_text(parser: MarkitdownParser):
+    """A plain UTF-8 text file with non-ASCII content round-trips."""
+    file_data = ("über résumé\n" + "a" * 7000 + "\nfin: naïveté").encode("utf-8")
+
+    content = await parser.convert(file_data, "notes.txt")
+
+    assert "über" in content
+    assert "naïveté" in content
+
+
+def test_utf8_stream_info_for_text_extension():
+    """Text files that are valid UTF-8 get an explicit UTF-8 charset hint."""
+    info = MarkitdownParser._utf8_stream_info("über".encode("utf-8"), "a.json")
+
+    assert info is not None
+    assert info.charset == "utf-8"
+
+
+def test_utf8_stream_info_skips_binary_extension():
+    """Binary files are left to markitdown's own detection (no hint)."""
+    assert MarkitdownParser._utf8_stream_info(b"%PDF-1.4 ...", "a.pdf") is None
+
+
+def test_utf8_stream_info_skips_non_utf8_text():
+    """Non-UTF-8 text falls back to markitdown's detection (no hint)."""
+    latin1 = "café".encode("latin-1")  # 0xe9, invalid as standalone UTF-8
+
+    assert MarkitdownParser._utf8_stream_info(latin1, "a.txt") is None


### PR DESCRIPTION
## Problem

Uploading a UTF-8 text file (e.g. a JSON transcript) failed with:

```
Failed to parse file '..._transcript.json': 'ascii' codec can't decode byte 0xc3
in position 6337: ordinal not in range(128)
```

## Root cause

markitdown samples only the **first chunk** of a file for charset detection. A UTF-8 file with a long ASCII-only prefix (common for JSON transcripts) is therefore mis-detected as `ascii`. During converter selection, markitdown's `IpynbConverter.accepts()` matches the `application/json` MIME prefix, reads the **whole** file, and decodes it with the wrong `ascii` charset — crashing on the first multibyte byte (`0xc3`). This happens *before* the plain-text converter (which would have handled the file) ever runs.

This is fundamentally an upstream markitdown fragility (`accepts()` raising instead of returning `False`), worked around here on our side.

## Fix

Pass an explicit UTF-8 charset hint to markitdown for text-like files whose bytes are valid UTF-8, sidestepping the faulty sample-based detection. Forcing UTF-8 only when the bytes *are* valid UTF-8 is always safe (ASCII is a UTF-8 subset). Binary files and genuinely non-UTF-8 text return no hint and fall back to markitdown's own detection — no regression.

## Tests

New `tests/test_markitdown_parser.py`:
- Regression test reproducing the original failure (UTF-8 JSON with an ASCII prefix past the sample window).
- Plain UTF-8 text round-trip.
- Unit coverage for the charset-hint helper (text → hint, binary → none, non-UTF-8 → none).

All pass; ruff + ty clean.
