### PR TITLE
fix(clients): thread recall min_scores through the maintained TypeScript SDK wrapper

### DIFF
--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -51,6 +51,7 @@ import type {
   TagGroupAndInput,
   TagGroupOrInput,
   TagGroupNotInput,
+  MinScores,
   AsyncOperationSubmitResponse,
   CreateMentalModelResponse,
   DirectiveListResponse,
@@ -337,6 +338,8 @@ export class HindsightClient {
       tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
       /** Compound tag filter using boolean groups. Groups are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}. Mutually exclusive with tags/tagsMatch. */
       tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
+      /** Optional per-stage score floors, e.g. {semantic: 0.2, final: 0.5}. 'semantic' and 'keyword' are retrieval-level cutoffs; 'reranker' and 'final' are applied to the scored results after reranking. Any omitted stage imposes no floor. */
+      minScores?: MinScores;
       signal?: AbortSignal;
     }
   ): Promise<RecallResponse> {
@@ -368,6 +371,7 @@ export class HindsightClient {
         tags: options?.tags,
         tags_match: options?.tagsMatch,
         tag_groups: options?.tagGroups,
+        min_scores: options?.minScores,
       },
       signal: options?.signal,
     });
@@ -1105,6 +1109,7 @@ export type {
   TagGroupAndInput,
   TagGroupOrInput,
   TagGroupNotInput,
+  MinScores,
   AsyncOperationSubmitResponse,
   CreateMentalModelResponse,
   DirectiveListResponse,

--- a/hindsight-clients/typescript/tests/main_operations.test.ts
+++ b/hindsight-clients/typescript/tests/main_operations.test.ts
@@ -520,6 +520,40 @@ const canSpyOnModules = typeof (globalThis as any).Deno === "undefined";
     spy.mockRestore();
   });
 
+  test("recall threads minScores into request body", async () => {
+    const bankId = randomBankId();
+    const spy = jest.spyOn(sdk, "recallMemories").mockResolvedValue({
+      data: { results: [] },
+    } as any);
+
+    await client.recall(bankId, "test", {
+      minScores: { semantic: 0.2, final: 0.5 },
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ min_scores: { semantic: 0.2, final: 0.5 } }),
+      })
+    );
+    spy.mockRestore();
+  });
+
+  test("recall omits min_scores when not provided", async () => {
+    const bankId = randomBankId();
+    const spy = jest.spyOn(sdk, "recallMemories").mockResolvedValue({
+      data: { results: [] },
+    } as any);
+
+    await client.recall(bankId, "test");
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ min_scores: undefined }),
+      })
+    );
+    spy.mockRestore();
+  });
+
   test("getBankProfile passes abort signal to SDK", async () => {
     const bankId = randomBankId();
     const controller = new AbortController();


### PR DESCRIPTION
Sibling to #2446, which threaded `RecallRequest.min_scores` (two-level retrieval/post-query score floors, added in #2422) through the **maintained Python** SDK wrapper. The hand-maintained TypeScript wrapper (`typescript/src/index.ts`) had the same gap — it forwards every other public `RecallRequest` field into `sdk.recallMemories` but never referenced `min_scores`, so the most-used surface couldn't reach the feature without dropping to the raw generated client.

**Change**
- Add an optional `minScores?: MinScores` to `recall()`, threaded into the request body as `min_scores` — mirroring the existing `tagGroups` / `preferObservations` pattern.
- Re-export the generated `MinScores` type for convenience (`{ semantic?, keyword?, reranker?, final? }`), so callers get compile-time rejection of unknown stage keys (the TS analogue of the Python wrapper's `ValueError` on typos).
- Two unit tests mirroring the existing `recall threads preferObservations into request body` test: one asserts `min_scores` is threaded into the SDK body, one asserts it is `undefined` when omitted (no floor).

No codegen and no behavior change for callers who don't pass `minScores`. The generated TS SDK already carries `MinScores` / `RecallRequest.min_scores` from #2422.
