### PR TITLE
fix(retain): preserve exception message in fact_extraction error summary

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1814,7 +1814,14 @@ async def extract_facts_from_text(
         total_usage = total_usage + chunk_usage
 
     if failed_chunks:
-        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}" for idx, err in failed_chunks[:5])
+        # Include the exception message — not just the type — so operators
+        # can tell a structured-JSON parse failure apart from a rate limit
+        # apart from a network 5xx, all of which can surface as the same
+        # exception types. The error_message we propagate to the
+        # async_operations row is the only inspection surface a worker-side
+        # failure leaves behind, and a bare "chunk 0: RuntimeError" is not
+        # actionable.
+        failed_summary = ", ".join(f"chunk {idx}: {type(err).__name__}: {err}" for idx, err in failed_chunks[:5])
         quota_errors = [err for _, err in failed_chunks if isinstance(err, ProviderRateLimitResetError)]
         if quota_errors and len(quota_errors) == len(failed_chunks):
             retry_at = max(err.retry_at for err in quota_errors)


### PR DESCRIPTION
## Summary

Preserve the exception **message** (not just the type) in the `fact_extraction` failure summary that gets propagated to `async_operations.error_message`.

The formatter joined only `type(err).__name__`, producing rows like `chunk 0: RuntimeError`. The exception message was discarded, leaving worker-side extraction failures unactionable — an operator couldn't tell a structured-JSON parse failure apart from a rate-limit reset apart from a network 5xx, all of which can surface as the same exception types in different code paths.

Now the summary includes the message:
`chunk 0: RuntimeError: structured JSON parse failed after all retain_extract_facts attempts`

## Why now

`test_extraction_failure_at_retry_cap_fails_terminally` (in `test_retain_transient_extraction_failure.py`) asserts `"structured JSON parse failed" in error_message`. With the old formatter the propagated message is only `chunk 0: RuntimeError`, so the test fails on `main`. This is the one-line fix that makes it pass — same shape, just the field the test was added to enforce.

Cherry-picked from 37fb1dde2d877e2fc5f4dcaf5232cb7776ca636f.
