### PR TITLE
fix(llm): propagate per-scope LLM timeout + retry policy to the provider (#2452)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -253,6 +253,7 @@ def create_llm_provider(
     prompt_cache_enabled: bool = False,
     litellmrouter_config: dict[str, Any] | None = None,
     gemini_service_tier: str | None = None,
+    timeout: float | None = None,
 ) -> Any:  # Returns LLMInterface
     """
     Factory function to create the appropriate LLM provider implementation.
@@ -280,6 +281,12 @@ def create_llm_provider(
         vertexai_project_id: Vertex AI project ID (for VertexAI provider).
         vertexai_region: Vertex AI region (for VertexAI provider).
         vertexai_credentials: Vertex AI credentials object (for VertexAI provider).
+        timeout: Per-request LLM timeout in seconds (resolved by the caller from the
+            per-operation/global config). Threaded into the providers that honour a
+            configurable request timeout (LiteLLM, LiteLLM Router, OpenAI-compatible,
+            Nous). ``None`` lets each provider fall back to its own default
+            (``HINDSIGHT_API_LLM_TIMEOUT`` / ``DEFAULT_LLM_TIMEOUT`` for those four;
+            Anthropic and Gemini keep their provider-specific defaults).
 
     Returns:
         LLMInterface implementation for the specified provider.
@@ -378,6 +385,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
             default_headers=default_headers,
+            timeout=timeout,
         )
 
     elif provider_lower == "litellmrouter":
@@ -397,6 +405,7 @@ def create_llm_provider(
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
             default_headers=default_headers,
+            timeout=timeout,
         )
 
     elif provider_lower == "bedrock":
@@ -411,6 +420,7 @@ def create_llm_provider(
             extra_body=extra_body,
             default_headers=default_headers,
             bedrock_service_tier=bedrock_service_tier,
+            timeout=timeout,
         )
 
     elif provider_lower == "llamacpp":
@@ -457,6 +467,7 @@ def create_llm_provider(
             model=model,
             reasoning_effort=reasoning_effort,
             extra_body=extra_body,
+            timeout=timeout,
         )
 
     elif provider_lower in (
@@ -483,6 +494,7 @@ def create_llm_provider(
             groq_service_tier=groq_service_tier,
             openai_service_tier=openai_service_tier,
             extra_body=extra_body,
+            timeout=timeout,
         )
 
     else:
@@ -515,6 +527,10 @@ class LLMProvider:
         vertexai_project_id: str | None = None,
         vertexai_region: str | None = None,
         vertexai_service_account_key: str | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        initial_backoff: float | None = None,
+        max_backoff: float | None = None,
     ):
         """
         Initialize LLM provider.
@@ -543,6 +559,17 @@ class LLMProvider:
                 ``"us-central1"`` when ``None``).
             vertexai_service_account_key: Path to a Vertex AI service-account key file for
                 ``provider="vertexai"`` (uses ADC when ``None``).
+            timeout: Per-request LLM timeout in seconds. Resolved by the caller from the
+                per-operation/global config (``retain_llm_timeout`` falling back to
+                ``llm_timeout``, etc.). ``None`` lets each provider apply its own default.
+            max_retries: Default retry-attempt budget for ``call`` / ``call_with_tools``
+                when the per-call argument is omitted. Resolved by the caller from the
+                per-operation/global config (``reflect_llm_max_retries`` falling back to
+                ``llm_max_retries``, etc.). ``None`` keeps each method's own fallback.
+            initial_backoff: Default initial retry backoff (seconds), same resolution as
+                ``max_retries``. ``None`` keeps each method's own fallback.
+            max_backoff: Default maximum retry backoff (seconds), same resolution as
+                ``max_retries``. ``None`` keeps each method's own fallback.
 
         This constructor uses every argument as passed and does not read global
         ``HindsightConfig``: resolving the server-level default for a ``None`` argument is the
@@ -556,6 +583,15 @@ class LLMProvider:
         self.base_url = base_url
         self.model = model
         self.reasoning_effort = reasoning_effort
+        # Per-request timeout (seconds). Used verbatim — the caller resolves the
+        # per-operation/global fallback. ``None`` defers to the provider default.
+        self.timeout = timeout
+        # Default retry policy for call()/call_with_tools(). The caller resolves the
+        # per-operation/global fallback; ``None`` keeps each method's own fallback so
+        # providers built without a resolved config (from_env, tests) are unchanged.
+        self.max_retries = max_retries
+        self.initial_backoff = initial_backoff
+        self.max_backoff = max_backoff
         self.litellmrouter_config = litellmrouter_config
         # Service tiers from hierarchical config (not env vars)
         self.groq_service_tier = groq_service_tier
@@ -706,6 +742,7 @@ class LLMProvider:
             gemini_safety_settings=self.gemini_safety_settings,
             prompt_cache_enabled=self.prompt_cache_enabled,
             litellmrouter_config=router_config,
+            timeout=self.timeout,
         )
 
         # Backward compatibility: Keep mock provider properties
@@ -762,9 +799,9 @@ class LLMProvider:
         max_completion_tokens: int | None = None,
         temperature: float | None = None,
         scope: str = "memory",
-        max_retries: int = 10,
-        initial_backoff: float = 1.0,
-        max_backoff: float = 60.0,
+        max_retries: int | None = None,
+        initial_backoff: float | None = None,
+        max_backoff: float | None = None,
         skip_validation: bool = False,
         strict_schema: bool = False,
         return_usage: bool = False,
@@ -779,9 +816,12 @@ class LLMProvider:
             max_completion_tokens: Maximum tokens in response.
             temperature: Sampling temperature (0.0-2.0).
             scope: Scope identifier for tracking.
-            max_retries: Maximum retry attempts.
-            initial_backoff: Initial backoff time in seconds.
-            max_backoff: Maximum backoff time in seconds.
+            max_retries: Maximum retry attempts. ``None`` uses the provider's configured
+                default (per-operation/global ``llm_max_retries``), else 10.
+            initial_backoff: Initial backoff time in seconds. ``None`` uses the provider's
+                configured default (``llm_initial_backoff``), else 1.0.
+            max_backoff: Maximum backoff time in seconds. ``None`` uses the provider's
+                configured default (``llm_max_backoff``), else 60.0.
             skip_validation: Return raw JSON without Pydantic validation.
             strict_schema: Per-call override requesting grammar-enforced (json_schema strict)
                 structured output instead of the soft json_object path. The server-level
@@ -805,6 +845,20 @@ class LLMProvider:
 
         structured = "+structured" if response_format is not None else ""
         set_stage(f"llm.{self.provider}.{scope}{structured}")
+
+        # Resolve the retry policy: explicit per-call arg wins, else the provider's
+        # configured per-operation/global default, else this method's own fallback.
+        max_retries = (
+            max_retries if max_retries is not None else (self.max_retries if self.max_retries is not None else 10)
+        )
+        initial_backoff = (
+            initial_backoff
+            if initial_backoff is not None
+            else (self.initial_backoff if self.initial_backoff is not None else 1.0)
+        )
+        max_backoff = (
+            max_backoff if max_backoff is not None else (self.max_backoff if self.max_backoff is not None else 60.0)
+        )
 
         # Resolve strict-schema once, here, rather than in each provider: the
         # per-call argument OR the server-level HINDSIGHT_API_LLM_STRICT_SCHEMA
@@ -908,9 +962,9 @@ class LLMProvider:
         max_completion_tokens: int | None = None,
         temperature: float | None = None,
         scope: str = "tools",
-        max_retries: int = 5,
-        initial_backoff: float = 1.0,
-        max_backoff: float = 30.0,
+        max_retries: int | None = None,
+        initial_backoff: float | None = None,
+        max_backoff: float | None = None,
         tool_choice: str | dict[str, Any] = "auto",
         cached_prefix: str | None = None,
     ) -> "LLMToolCallResult":
@@ -923,9 +977,12 @@ class LLMProvider:
             max_completion_tokens: Maximum tokens in response.
             temperature: Sampling temperature (0.0-2.0).
             scope: Scope identifier for tracking.
-            max_retries: Maximum retry attempts.
-            initial_backoff: Initial backoff time in seconds.
-            max_backoff: Maximum backoff time in seconds.
+            max_retries: Maximum retry attempts. ``None`` uses the provider's configured
+                default (per-operation/global ``llm_max_retries``), else 5.
+            initial_backoff: Initial backoff time in seconds. ``None`` uses the provider's
+                configured default (``llm_initial_backoff``), else 1.0.
+            max_backoff: Maximum backoff time in seconds. ``None`` uses the provider's
+                configured default (``llm_max_backoff``), else 30.0.
             tool_choice: How to choose tools - "auto", "none", "required", or {"type": "function", "function": {"name": "..."}}
 
         Returns:
@@ -934,6 +991,20 @@ class LLMProvider:
         from ..worker.stage import set_stage
 
         set_stage(f"llm.{self.provider}.{scope}+tools")
+
+        # Resolve the retry policy: explicit per-call arg wins, else the provider's
+        # configured per-operation/global default, else this method's own fallback.
+        max_retries = (
+            max_retries if max_retries is not None else (self.max_retries if self.max_retries is not None else 5)
+        )
+        initial_backoff = (
+            initial_backoff
+            if initial_backoff is not None
+            else (self.initial_backoff if self.initial_backoff is not None else 1.0)
+        )
+        max_backoff = (
+            max_backoff if max_backoff is not None else (self.max_backoff if self.max_backoff is not None else 30.0)
+        )
 
         # Failures forwarded to the GenAI recorder; successes recorded by providers.
         from ..tracing import get_span_recorder
@@ -1178,6 +1249,7 @@ class LLMProvider:
             DEFAULT_LLM_PROMPT_CACHE_ENABLED,
             DEFAULT_LLM_PROVIDER,
             DEFAULT_LLM_REASONING_EFFORT,
+            DEFAULT_LLM_TIMEOUT,
             ENV_LLM_API_KEY,
             ENV_LLM_BASE_URL,
             ENV_LLM_BEDROCK_SERVICE_TIER,
@@ -1192,6 +1264,7 @@ class LLMProvider:
             ENV_LLM_PROMPT_CACHE_ENABLED,
             ENV_LLM_PROVIDER,
             ENV_LLM_REASONING_EFFORT,
+            ENV_LLM_TIMEOUT,
             ENV_LLM_VERTEXAI_PROJECT_ID,
             ENV_LLM_VERTEXAI_REGION,
             ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY,
@@ -1245,6 +1318,7 @@ class LLMProvider:
             vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or None,
             vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION) or None,
             vertexai_service_account_key=os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY) or None,
+            timeout=float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT))),
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -388,7 +388,33 @@ RetainOutboxCallback = Callable[[asyncpg.Connection], Awaitable[None]]
 RetainOutboxCallbackFactory = Callable[[list[RetainContentDict]], RetainOutboxCallback | None]
 
 
-def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMConfig:
+@dataclass(frozen=True)
+class _LLMCallDefaults:
+    """An operation's resolved per-request defaults, threaded into every provider
+    of its multi-LLM chain.
+
+    Each field is the effective value after the per-op-override-else-global
+    resolution (e.g. ``retain_llm_timeout`` falling back to ``llm_timeout``). They
+    are carried on the ``LLMProvider`` and used by ``call``/``call_with_tools`` when
+    the per-call argument is omitted — previously these per-op config fields were
+    resolved but never reached the provider (issue #2452).
+    """
+
+    timeout: float | None
+    max_retries: int | None
+    initial_backoff: float | None
+    max_backoff: float | None
+
+    def as_kwargs(self) -> dict[str, Any]:
+        return {
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "initial_backoff": self.initial_backoff,
+            "max_backoff": self.max_backoff,
+        }
+
+
+def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig, defaults: _LLMCallDefaults) -> LLMConfig:
     """Build an LLMProvider from one indexed multi-LLM member.
 
     ``LLMProvider`` uses its arguments verbatim (it no longer reads global config),
@@ -397,6 +423,10 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMCon
     (``gemini_safety_settings``, ``prompt_cache_enabled``) take the global default.
     ``gemini_safety_settings`` is bank-configurable so it comes from the raw config
     (the proxy blocks it); the per-bank value is applied per-call downstream.
+
+    ``defaults`` are the operation's already-resolved request defaults (timeout +
+    retry policy). Members have no per-member knobs for these, so every member of a
+    chain shares its operation's values.
     """
     from ..config import _get_raw_config
 
@@ -416,6 +446,7 @@ def _member_to_llm(member: "LLMMemberConfig", config: HindsightConfig) -> LLMCon
         vertexai_region=member.vertexai_region or config.llm_vertexai_region,
         vertexai_service_account_key=member.vertexai_service_account_key or config.llm_vertexai_service_account_key,
         litellmrouter_config=member.litellmrouter_config or config.llm_litellmrouter_config,
+        **defaults.as_kwargs(),
     )
 
 
@@ -423,6 +454,7 @@ def _build_llm(
     base: LLMConfig,
     config: HindsightConfig,
     prefix: str,
+    defaults: _LLMCallDefaults,
 ) -> "LLMConfig | MultiLLMProvider":
     """Resolve an operation's multi-LLM chain and wrap ``base`` (member 0) in it.
 
@@ -431,6 +463,9 @@ def _build_llm(
     inherits the global chain, mirroring how per-op base config falls back to the
     global LLM config. Returns ``base`` unchanged when no chain is configured
     (byte-identical hot path).
+
+    ``defaults`` are the operation's resolved request defaults, applied to every
+    fallback member so the whole chain shares the operation's effective settings.
     """
     members: list[LLMMemberConfig] = getattr(config, f"{prefix}llm_members")
     strategy: LLMStrategyConfig | None = getattr(config, f"{prefix}llm_strategy")
@@ -442,7 +477,7 @@ def _build_llm(
 
     if not strategy or not members:
         return base
-    extra = [_member_to_llm(m, config) for m in members]
+    extra = [_member_to_llm(m, config, defaults) for m in members]
     return MultiLLMProvider([base, *extra], strategy)
 
 
@@ -1023,6 +1058,29 @@ class MemoryEngine(MemoryEngineInterface):
 
             self.query_analyzer = DateparserQueryAnalyzer()
 
+        # Resolve each operation's effective per-request defaults: a per-op override
+        # (``HINDSIGHT_API_RETAIN_LLM_TIMEOUT``, ``..._MAX_RETRIES``, ``..._INITIAL_BACKOFF``,
+        # ``..._MAX_BACKOFF``) wins, otherwise the global ``llm_*``. Threaded all the way
+        # into the provider so the configured value actually governs the call (issue #2452);
+        # previously these per-op fields were resolved into config but never reached the
+        # provider, which silently used the global/method default.
+        def _op_defaults(prefix: str) -> _LLMCallDefaults:
+            def pick(field: str) -> Any:
+                per_op = getattr(config, f"{prefix}llm_{field}") if prefix else None
+                return per_op if per_op is not None else getattr(config, f"llm_{field}")
+
+            return _LLMCallDefaults(
+                timeout=pick("timeout"),
+                max_retries=pick("max_retries"),
+                initial_backoff=pick("initial_backoff"),
+                max_backoff=pick("max_backoff"),
+            )
+
+        default_call_defaults = _op_defaults("")
+        retain_call_defaults = _op_defaults("retain_")
+        reflect_call_defaults = _op_defaults("reflect_")
+        consolidation_call_defaults = _op_defaults("consolidation_")
+
         # Initialize LLM configuration (default, used as fallback)
         _default_base_llm = LLMConfig(
             provider=memory_llm_provider,
@@ -1042,8 +1100,9 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_project_id=config.llm_vertexai_project_id,
             vertexai_region=config.llm_vertexai_region,
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
+            **default_call_defaults.as_kwargs(),
         )
-        self._llm_config = _build_llm(_default_base_llm, config, "")
+        self._llm_config = _build_llm(_default_base_llm, config, "", default_call_defaults)
 
         # Store client and model for convenience (deprecated: use _llm_config.call() instead).
         # Read from the primary member so a multi-LLM chain behaves like the base config here.
@@ -1085,8 +1144,9 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_project_id=config.llm_vertexai_project_id,
             vertexai_region=config.llm_vertexai_region,
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
+            **retain_call_defaults.as_kwargs(),
         )
-        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_")
+        self._retain_llm_config = _build_llm(_retain_base_llm, config, "retain_", retain_call_defaults)
 
         # Reflect LLM config - for think/observe operations (can use lighter models)
         reflect_provider = reflect_llm_provider or config.reflect_llm_provider or memory_llm_provider
@@ -1122,8 +1182,9 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_project_id=config.llm_vertexai_project_id,
             vertexai_region=config.llm_vertexai_region,
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
+            **reflect_call_defaults.as_kwargs(),
         )
-        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_")
+        self._reflect_llm_config = _build_llm(_reflect_base_llm, config, "reflect_", reflect_call_defaults)
 
         # Consolidation LLM config - for mental model consolidation (can use efficient models)
         consolidation_provider = consolidation_llm_provider or config.consolidation_llm_provider or memory_llm_provider
@@ -1159,8 +1220,11 @@ class MemoryEngine(MemoryEngineInterface):
             vertexai_project_id=config.llm_vertexai_project_id,
             vertexai_region=config.llm_vertexai_region,
             vertexai_service_account_key=config.llm_vertexai_service_account_key,
+            **consolidation_call_defaults.as_kwargs(),
         )
-        self._consolidation_llm_config = _build_llm(_consolidation_base_llm, config, "consolidation_")
+        self._consolidation_llm_config = _build_llm(
+            _consolidation_base_llm, config, "consolidation_", consolidation_call_defaults
+        )
 
         # Initialize cross-encoder reranker (cached for performance)
         self._cross_encoder_reranker = CrossEncoderReranker(cross_encoder=cross_encoder)

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -194,6 +194,7 @@ def _make_router_provider(config: dict[str, Any], mock_router: Any) -> LiteLLMRo
         provider.model = "unused"
         provider.reasoning_effort = "low"
         provider.timeout = 300.0
+        provider._default_headers = {}
         provider.config = config
         provider._litellm = fake_litellm
         provider._router = mock_router

--- a/hindsight-api-slim/tests/test_llm_timeout_propagation.py
+++ b/hindsight-api-slim/tests/test_llm_timeout_propagation.py
@@ -1,0 +1,180 @@
+"""Plumbing tests for the per-operation / global LLM request defaults (issue #2452).
+
+These assert the *wiring* — that a resolved timeout / retry policy actually reaches
+the provider that uses it — not just that the env var parses into config (covered by
+test_config_validation.py).
+
+The values are threaded
+``config -> MemoryEngine per-op resolve -> LLMProvider -> (create_llm_provider /
+call())``. Before the fix the per-operation ``*_llm_timeout`` / ``*_llm_max_retries`` /
+``*_llm_initial_backoff`` / ``*_llm_max_backoff`` fields (and even the global ``llm_*``)
+were resolved into ``HindsightConfig`` but never reached the provider, so a configured
+``HINDSIGHT_API_RETAIN_LLM_TIMEOUT`` silently used the global default
+(``LiteLLM call exceeded timeout=120.0s``) and the per-op retry knobs were inert.
+"""
+
+import pytest
+
+from hindsight_api.config import DEFAULT_LLM_TIMEOUT
+from hindsight_api.engine.llm_wrapper import LLMConfig
+
+
+def _mock_llm(**kwargs) -> LLMConfig:
+    return LLMConfig(provider="mock", api_key="", base_url="", model="m", **kwargs)
+
+
+def _spy_provider_call(monkeypatch, llm: LLMConfig) -> dict:
+    """Replace the provider impl's call() with a kwargs-capturing stub."""
+    captured: dict = {}
+
+    async def fake_call(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(llm._provider_impl, "call", fake_call)
+    return captured
+
+
+def test_litellm_provider_impl_receives_timeout():
+    """LLMConfig -> create_llm_provider -> LiteLLMLLM carries the resolved timeout."""
+    llm = LLMConfig(provider="litellm", api_key="k", base_url="", model="gpt-4o-mini", timeout=300.0)
+    assert llm.timeout == 300.0
+    assert llm._provider_impl.timeout == 300.0
+
+
+def test_openai_compatible_provider_impl_receives_timeout():
+    """The OpenAI-compatible path (openai/groq/ollama/...) carries the timeout too."""
+    llm = LLMConfig(provider="openai", api_key="k", base_url="", model="gpt-4o-mini", timeout=250.0)
+    assert llm._provider_impl.timeout == 250.0
+
+
+def test_timeout_none_falls_back_to_provider_default():
+    """No timeout passed -> provider falls back to its env/DEFAULT_LLM_TIMEOUT default.
+
+    Guards against a regression where threading the value would override the
+    long-standing default for callers that never configured a timeout.
+    """
+    llm = LLMConfig(provider="litellm", api_key="k", base_url="", model="gpt-4o-mini")
+    assert llm._provider_impl.timeout == DEFAULT_LLM_TIMEOUT
+
+
+@pytest.fixture
+def _clean_timeout_env(monkeypatch):
+    """Mock provider + verification off, with all timeout env vars cleared."""
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_SKIP_LLM_VERIFICATION", "true")
+    monkeypatch.setenv("HINDSIGHT_API_LAZY_RERANKER", "true")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "default-model")
+    for op in ("LLM", "RETAIN_LLM", "REFLECT_LLM", "CONSOLIDATION_LLM"):
+        for knob in ("TIMEOUT", "MAX_RETRIES", "INITIAL_BACKOFF", "MAX_BACKOFF"):
+            monkeypatch.delenv(f"HINDSIGHT_API_{op}_{knob}", raising=False)
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+async def test_call_uses_instance_retry_defaults(monkeypatch):
+    """call() falls back to the provider's configured retry policy when no per-call
+    arg is given — this is what makes a per-op ``*_llm_max_retries`` take effect."""
+    llm = _mock_llm(max_retries=7, initial_backoff=2.0, max_backoff=9.0)
+    captured = _spy_provider_call(monkeypatch, llm)
+
+    await llm.call(messages=[{"role": "user", "content": "hi"}], scope="x")
+
+    assert captured["max_retries"] == 7
+    assert captured["initial_backoff"] == 2.0
+    assert captured["max_backoff"] == 9.0
+
+
+async def test_call_explicit_arg_overrides_instance_default(monkeypatch):
+    """An explicit per-call value still wins over the configured default."""
+    llm = _mock_llm(max_retries=7)
+    captured = _spy_provider_call(monkeypatch, llm)
+
+    await llm.call(messages=[{"role": "user", "content": "hi"}], scope="x", max_retries=2)
+
+    assert captured["max_retries"] == 2
+
+
+async def test_call_falls_back_to_method_default_when_unconfigured(monkeypatch):
+    """No instance config and no per-call arg -> the method's own fallback (10),
+    so providers built outside MemoryEngine (from_env, tests) are unchanged."""
+    llm = _mock_llm()
+    captured = _spy_provider_call(monkeypatch, llm)
+
+    await llm.call(messages=[{"role": "user", "content": "hi"}], scope="x")
+
+    assert captured["max_retries"] == 10
+    assert captured["initial_backoff"] == 1.0
+    assert captured["max_backoff"] == 60.0
+
+
+def test_memory_engine_threads_per_operation_timeout(monkeypatch, _clean_timeout_env):
+    """Each per-operation override reaches its own LLM config; the rest fall back
+    to the global ``llm_timeout``."""
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_TIMEOUT", "100")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_LLM_TIMEOUT", "300")
+    monkeypatch.setenv("HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT", "450")
+    # reflect intentionally unset -> inherits the global 100
+    clear_config_cache()
+
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    assert engine._llm_config.timeout == 100.0
+    assert engine._retain_llm_config.timeout == 300.0
+    assert engine._reflect_llm_config.timeout == 100.0
+    assert engine._consolidation_llm_config.timeout == 450.0
+
+
+def test_memory_engine_threads_per_operation_retry_policy(monkeypatch, _clean_timeout_env):
+    """Per-op retry/backoff overrides reach their own config; unset ops fall back
+    to the global ``llm_max_retries`` / ``llm_initial_backoff`` / ``llm_max_backoff``."""
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import clear_config_cache
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MAX_RETRIES", "4")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_INITIAL_BACKOFF", "0.5")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_MAX_BACKOFF", "20")
+    monkeypatch.setenv("HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES", "2")
+    monkeypatch.setenv("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF", "99")
+    clear_config_cache()
+
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    # Global applies everywhere unless overridden.
+    assert engine._llm_config.max_retries == 4
+    assert engine._retain_llm_config.max_retries == 4
+    # reflect overrides only max_retries; backoff inherits global.
+    assert engine._reflect_llm_config.max_retries == 2
+    assert engine._reflect_llm_config.initial_backoff == 0.5
+    # consolidation overrides only max_backoff; retries inherit global.
+    assert engine._consolidation_llm_config.max_retries == 4
+    assert engine._consolidation_llm_config.max_backoff == 99.0
+
+
+def test_memory_engine_per_op_defaults_to_global_default(_clean_timeout_env):
+    """With nothing configured, every operation uses the documented global defaults."""
+    from hindsight_api import MemoryEngine
+    from hindsight_api.config import (
+        DEFAULT_LLM_INITIAL_BACKOFF,
+        DEFAULT_LLM_MAX_BACKOFF,
+        DEFAULT_LLM_MAX_RETRIES,
+    )
+
+    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+
+    for cfg in (
+        engine._llm_config,
+        engine._retain_llm_config,
+        engine._reflect_llm_config,
+        engine._consolidation_llm_config,
+    ):
+        assert cfg.timeout == DEFAULT_LLM_TIMEOUT
+        assert cfg.max_retries == DEFAULT_LLM_MAX_RETRIES
+        assert cfg.initial_backoff == DEFAULT_LLM_INITIAL_BACKOFF
+        assert cfg.max_backoff == DEFAULT_LLM_MAX_BACKOFF

--- a/hindsight-api-slim/tests/test_multi_llm_config.py
+++ b/hindsight-api-slim/tests/test_multi_llm_config.py
@@ -15,8 +15,12 @@ from hindsight_api.config import (
     _parse_llm_strategy,
 )
 from hindsight_api.engine.llm_wrapper import LLMProvider
-from hindsight_api.engine.memory_engine import _build_llm
+from hindsight_api.engine.memory_engine import _build_llm, _LLMCallDefaults
 from hindsight_api.engine.multi_llm import MultiLLMProvider
+
+# No per-request overrides — exercises the chain-resolution logic without
+# touching timeout/retry defaults (those have their own tests).
+_NO_CALL_DEFAULTS = _LLMCallDefaults(timeout=None, max_retries=None, initial_backoff=None, max_backoff=None)
 
 
 @pytest.fixture
@@ -248,7 +252,7 @@ def _base_llm() -> LLMProvider:
 
 def test_build_llm_no_chain_returns_plain_provider(clean_llm_env):
     base = _base_llm()
-    result = _build_llm(base, _empty_config(), "")
+    result = _build_llm(base, _empty_config(), "", _NO_CALL_DEFAULTS)
     assert result is base
     assert not isinstance(result, MultiLLMProvider)
 
@@ -259,7 +263,7 @@ def test_build_llm_global_chain_wraps(clean_llm_env):
         llm_strategy=LLMStrategyConfig(mode="failover"),
     )
     base = _base_llm()
-    result = _build_llm(base, config, "")
+    result = _build_llm(base, config, "", _NO_CALL_DEFAULTS)
     assert isinstance(result, MultiLLMProvider)
     assert result.members[0] is base  # primary stays index 0
     assert result.members[1].provider == "ollama"
@@ -272,7 +276,7 @@ def test_build_llm_per_op_inherits_global(clean_llm_env):
         retain_llm_members=[],
         retain_llm_strategy=None,
     )
-    result = _build_llm(_base_llm(), config, "retain_")
+    result = _build_llm(_base_llm(), config, "retain_", _NO_CALL_DEFAULTS)
     assert isinstance(result, MultiLLMProvider)
     assert [m.provider for m in result.members[1:]] == ["ollama"]  # inherited
 
@@ -284,7 +288,7 @@ def test_build_llm_per_op_overrides_global(clean_llm_env):
         retain_llm_members=[_member("lmstudio")],
         retain_llm_strategy=LLMStrategyConfig(mode="round-robin"),
     )
-    result = _build_llm(_base_llm(), config, "retain_")
+    result = _build_llm(_base_llm(), config, "retain_", _NO_CALL_DEFAULTS)
     assert isinstance(result, MultiLLMProvider)
     assert [m.provider for m in result.members[1:]] == ["lmstudio"]
     assert result._strategy.mode == "round-robin"
@@ -294,7 +298,7 @@ def test_build_llm_members_without_strategy_stays_plain(clean_llm_env):
     # Members configured but no strategy → no wrapping (strategy is required).
     config = _empty_config(llm_members=[_member("ollama")], llm_strategy=None)
     base = _base_llm()
-    assert _build_llm(base, config, "") is base
+    assert _build_llm(base, config, "", _NO_CALL_DEFAULTS) is base
 
 
 # ── vertexai member build path (_member_to_llm) ─────────────────────────────────
@@ -333,7 +337,7 @@ def test_member_to_llm_passes_vertexai_project_and_region(clean_llm_env, monkeyp
         vertexai_project_id="member-proj",
         vertexai_region="europe-west1",
     )
-    provider = _member_to_llm(member, _empty_config())
+    provider = _member_to_llm(member, _empty_config(), _NO_CALL_DEFAULTS)
 
     assert provider.provider == "vertexai"
     # Project/region flowed all the way to the Vertex AI SDK client.
@@ -386,7 +390,7 @@ def test_member_to_llm_passes_vertexai_service_account_key(clean_llm_env, monkey
         vertexai_project_id="member-proj",
         vertexai_service_account_key="/keys/member-sa.json",
     )
-    provider = _member_to_llm(member, _empty_config())
+    provider = _member_to_llm(member, _empty_config(), _NO_CALL_DEFAULTS)
 
     assert provider.provider == "vertexai"
     # The member's key path was loaded, and the credentials reached the SDK client.
@@ -432,7 +436,7 @@ def test_member_to_llm_passes_litellmrouter_config(clean_llm_env, monkeypatch):
         gemini_service_tier=None,
         litellmrouter_config=router_cfg,
     )
-    provider = _member_to_llm(member, _empty_config())
+    provider = _member_to_llm(member, _empty_config(), _NO_CALL_DEFAULTS)
 
     assert provider.provider == "litellmrouter"
     # The member's own router config flowed to the LiteLLM router build.

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -517,6 +517,10 @@ global cap; a reflect call without a per-op cap is bounded only by the global ca
 To reserve headroom for live chat/reflect on a rate-limited provider, cap retain and
 consolidation below the global value — e.g. global=4, retain=1, consolidation=1 leaves
 two slots that retain/consolidation cannot consume.
+
+Unlike the per-operation timeout and retry/backoff knobs, the `*_LLM_MAX_CONCURRENT`
+caps are process-global semaphores read from the environment once at startup. They are
+server-level only (not overridable per tenant/bank) and a change requires a restart.
 :::
 
 ### Embeddings

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -517,6 +517,10 @@ global cap; a reflect call without a per-op cap is bounded only by the global ca
 To reserve headroom for live chat/reflect on a rate-limited provider, cap retain and
 consolidation below the global value — e.g. global=4, retain=1, consolidation=1 leaves
 two slots that retain/consolidation cannot consume.
+
+Unlike the per-operation timeout and retry/backoff knobs, the `*_LLM_MAX_CONCURRENT`
+caps are process-global semaphores read from the environment once at startup. They are
+server-level only (not overridable per tenant/bank) and a change requires a restart.
 :::
 
 ### Embeddings


### PR DESCRIPTION
## Summary

Fixes #2452. Several per-operation LLM request settings were resolved into `HindsightConfig` but **never reached the provider that uses them**, so configuring them was a silent no-op. This PR threads them through for all operation scopes (default / retain / reflect / consolidation).

### What was dead

- **`*_llm_timeout`** (retain/reflect/consolidation) **and the global `llm_timeout`** never reached the provider impl — it fell back to `HINDSIGHT_API_LLM_TIMEOUT`/120s, so `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=300` did nothing (`LiteLLM call exceeded timeout=120.0s`).
- **`reflect_llm_max_retries` / `initial_backoff` / `max_backoff`** and **`consolidation_llm_initial_backoff` / `max_backoff`** were never consumed. Reflect and consolidation used the hardcoded `call()`/`call_with_tools()` defaults (10/5), ignoring the documented *"falls back to `llm_max_retries`"* contract.

## Fix

`MemoryEngine` resolves each operation's effective request defaults (per-op override else global) into a small `_LLMCallDefaults` bundle and carries them on the `LLMProvider`:

- **timeout** → threaded `config → LLMProvider → create_llm_provider → provider impl` for the providers that honour a configurable request timeout (LiteLLM, LiteLLM Router, OpenAI-compatible, Nous). `None` preserves each provider's own default, so **Anthropic/Gemini keep their bespoke timeouts** and the no-config path is byte-identical.
- **max_retries / initial_backoff / max_backoff** → become `LLMProvider` instance defaults that `call()`/`call_with_tools()` use when the per-call argument is omitted. Explicit per-call args still win (retain's resolved values; reflect's deliberately-fast structured-extraction call). Providers built without config (`from_env`, tests) keep the 10/5 method fallback.

The four operation scopes and multi-LLM chain members all share their operation's resolved values.

### Behaviour note

Reflect/consolidation calls that previously fell through to the hardcoded `call()` default of 10 retries now follow the documented `llm_max_retries` (default **3**) — i.e. the config the docs always claimed governed them. Per-op overrides (`HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES`, …) now take effect.

## `max_concurrent` — left as-is + doc clarified

The per-op `*_LLM_MAX_CONCURRENT` caps are already wired (process-global composed semaphores, added in a prior PR). They're intentionally **not** moved onto the per-op config path — they're server-level, env-only, fixed at startup. The docs are updated to call out that distinction vs. the timeout/retry/backoff knobs.

## Drive-by

Fixes a **pre-existing** breakage in `test_llm_router_provider`'s `__new__`-based helper (missing `_default_headers` after #2466) so the suite is green on this branch.

## Tests

`tests/test_llm_timeout_propagation.py`:
- timeout reaches `_provider_impl.timeout` (LiteLLM + OpenAI-compatible); `None` → `DEFAULT_LLM_TIMEOUT` regression guard;
- `call()` retry policy: falls back to the provider's configured default, an explicit per-call arg overrides it, and an unconfigured provider keeps the 10 method fallback;
- `MemoryEngine` resolves each per-op timeout + retry/backoff override and falls back to global / default.

Verified locally: full focused LLM/provider/per-op/retry suite green (115 passed); `ruff`/`ty` clean.
