### PR TITLE
perf(graph-maintenance): prune stale cooccurrences via INTERSECT, not a self-join (7.1x, 289x fewer buffers)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -406,6 +406,15 @@ class PostgreSQLOps(DataAccessOps):
         # cycle (the deadlock is prevented, not merely retried). The Pass 2/3
         # retry wrap in run_graph_maintenance_job stays as a backstop for the
         # residual paths (FK cascade from prune_orphan_entities, Oracle).
+        #
+        # The staleness predicate is an INTERSECT of the two entities' unit sets
+        # rather than the equivalent `unit_entities u1 JOIN u2 ON u1.unit_id =
+        # u2.unit_id` self-join (#2473): both INTERSECT branches resolve as Index
+        # Only Scans on idx_unit_entities_entity_unit (entity_id, unit_id), so the
+        # per-pair cost is bounded by the two entities' degrees. The self-join let
+        # the planner pick an anti-join that rescanned a high-degree hub entity's
+        # membership set for every pair — 28-30min on a bank with a ~100K-membership
+        # hub, even when zero rows were stale. Don't "simplify" it back.
         result = await conn.execute(
             f"""
             WITH victims AS (
@@ -414,11 +423,9 @@ class PostgreSQLOps(DataAccessOps):
                 JOIN {entities_table} e ON e.id = c.entity_id_1
                 WHERE e.bank_id = $1
                   AND NOT EXISTS (
-                      SELECT 1
-                      FROM {ue_table} u1
-                      JOIN {ue_table} u2 ON u1.unit_id = u2.unit_id
-                      WHERE u1.entity_id = c.entity_id_1
-                        AND u2.entity_id = c.entity_id_2
+                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_1
+                      INTERSECT
+                      SELECT unit_id FROM {ue_table} WHERE entity_id = c.entity_id_2
                   )
                 ORDER BY c.entity_id_1, c.entity_id_2
                 FOR UPDATE OF c


### PR DESCRIPTION
## Problem

`prune_stale_cooccurrences` decided staleness with a correlated self-join on `unit_entities`:

```sql
AND NOT EXISTS (
    SELECT 1
    FROM unit_entities u1
    JOIN unit_entities u2 ON u1.unit_id = u2.unit_id
    WHERE u1.entity_id = c.entity_id_1
      AND u2.entity_id = c.entity_id_2
)
```

The planner turns this into a **Nested Loop Anti Join** whose hash side rebuilds a high-degree ("hub") entity's entire membership set once per cooccurrence pair. Cost scales with `hub_degree x pairs` regardless of how many rows will actually be deleted, so the sweep runs for tens of minutes on a bank with a large hub **even when zero rows are stale**.

## Fix

Replace the self-join with an `INTERSECT` of the two entities' unit sets:

```sql
AND NOT EXISTS (
    SELECT unit_id FROM unit_entities WHERE entity_id = c.entity_id_1
    INTERSECT
    SELECT unit_id FROM unit_entities WHERE entity_id = c.entity_id_2
)
```

Both branches resolve as **Index Only Scans** on the existing `idx_unit_entities_entity_unit (entity_id, unit_id)`, so per-pair cost is bounded by the two entities' degrees instead of being re-derived from a hash build each time. Semantically identical: "does any unit witness both entities". `unit_id` is `NOT NULL` (part of `pk_unit_entities`), so the usual INTERSECT NULL-equality caveat doesn't apply.

**No schema change** — the index already exists (migration `h3i4j5k6l7m8`).

## Benchmark

Measured with `EXPLAIN (ANALYZE, BUFFERS)` against the **current** ordered-locking CTE form (post-#2534), on a hub-skewed fixture: 40K-membership hub entity, 2,999 cooccurrence pairs, all pairs live so **zero rows are deleted** — the worst case. Tables `VACUUM`ed so the visibility map is set and the index-only scans are genuinely index-only (`Heap Fetches: 0`).

| Variant | Execution time | Shared buffers |
|---|---|---|
| self-join | 18,182 ms | 73,613,239 |
| INTERSECT | 2,555 ms | 255,045 |

**7.1x faster, 289x fewer buffers.** Production banks carry ~260K pairs against a ~100K-membership hub, so the real-world gap is wider than this fixture shows.

The self-join plan confirms the mechanism — the hub's 19,048-row set is rebuilt on every one of the 2,999 loops:

```
Nested Loop Anti Join  (actual time=18181.969..18181.969 rows=0 loops=1)
  ->  Hash Join  (actual time=5.995..5.995 rows=1.00 loops=2999)
        ->  Hash  (actual time=4.936..4.936 rows=19047.92 loops=2999)
              Buffers: shared hit=57411912          <- 78% of all buffer traffic
```

versus INTERSECT:

```
SetOp Intersect  (actual time=0.851..0.851 rows=1.00 loops=2999)
  ->  Index Only Scan using idx_unit_entities_entity_unit  (rows=5373.25 loops=2999)
        Heap Fetches: 0
  ->  Index Only Scan using idx_unit_entities_entity_unit  (rows=4737.69 loops=2999)
        Heap Fetches: 0
```

## Notes for reviewers

- **Rebased onto current main.** The original patch was written against the pre-#2534 `DELETE ... USING` form and conflicted after the ordered-locking work landed. The rewrite is now confined to the `NOT EXISTS` predicate *inside* the `victims` CTE, so victims are still selected `FOR UPDATE` in sorted `(entity_id_1, entity_id_2)` order — the #2529 deadlock-avoidance property is untouched.
- **Earlier claim corrected:** the first revision of this PR said `NOT EXISTS` + `HashSetOp Intersect` "short-circuits on the first shared unit_id". It does not — `SetOp` fully consumes both inputs before emitting a row (visible above: both scans return thousands of rows per loop). The win is bounded index-only scans, not early exit. The original "~45 sec" figure was extrapolated from a planner-cost ratio rather than measured; the table above is measured.
- **Oracle is unchanged.** `ops_oracle.py` carries the same shape (arguably worse — an uncorrelated `NOT IN` over a full `u1 JOIN u2`). Left out of scope; worth a follow-up issue.
- **No perf-suite coverage.** Neither `graph-maintenance` nor `graph-maintenance-contention` would have caught this: the sweep is untimed (folded into the `other (claim/count/insert/sweep)` bucket), neither suite has a latency threshold, and no fixture builds a skewed `unit_entities` fan-out — contention seeds exactly 1 unit per entity, stats caps at 2. A hub-skewed, zero-deletion prune suite with a p95 gate is the follow-up that would close the gap.

Original patch by @sergattic; rebased and benchmarked on merge.
