### PR TITLE
feat(gemini): opt-in 4xx request-dump for diagnosing rejected calls

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -11,6 +11,7 @@ import base64
 import io
 import json
 import logging
+import os
 import time
 from contextvars import ContextVar
 from typing import Any
@@ -27,6 +28,45 @@ from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
 logger = logging.getLogger(__name__)
+
+
+def _dump_request_on_4xx(scope: str, contents: Any, config: Any, err: Any) -> None:
+    """Diagnostic: when ``HINDSIGHT_API_LLM_DEBUG_DUMP_4XX`` is truthy, log the exact
+    request that produced a Gemini 4xx — the serialized GenerateContentConfig (response
+    schema as the SDK renders it on the wire, plus generation params, safety settings,
+    cached-content ref) and the per-message role/size with a truncated text preview.
+
+    Off by default (the env var is unset in normal operation). The config carries no
+    user content; message previews are capped so an enabled dump can't flood logs or
+    spill large bodies. Use only to capture an otherwise-unreproducible rejected request.
+    """
+    if os.getenv("HINDSIGHT_API_LLM_DEBUG_DUMP_4XX", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return
+    try:
+        try:
+            cfg_repr = config.model_dump_json(exclude_none=True) if config is not None else "null"
+        except Exception:
+            cfg_repr = repr(config)[:8000]
+        parts_summary = []
+        for c in contents or []:
+            text = ""
+            for p in getattr(c, "parts", None) or []:
+                t = getattr(p, "text", None)
+                if t:
+                    text += t
+            parts_summary.append(
+                {"role": getattr(c, "role", "?"), "chars": len(text), "preview": text[:1500]}
+            )
+        logger.error(
+            "[LLM_4XX_DUMP] scope=%s code=%s err=%s config=%s contents=%s",
+            scope,
+            getattr(err, "code", "?"),
+            str(err)[:200],
+            cfg_repr,
+            json.dumps(parts_summary, ensure_ascii=False),
+        )
+    except Exception as dump_exc:  # never let diagnostics break the request path
+        logger.warning("[LLM_4XX_DUMP] failed to serialize rejected request: %s", dump_exc)
 
 # Per-request Gemini safety settings override.
 # Set exclusively by ConfiguredLLMProvider.call() / call_with_tools() via token-based
@@ -478,6 +518,11 @@ class GeminiLLM(LLMInterface):
                 if e.code in (401, 403):
                     logger.error(f"Gemini auth error (HTTP {e.code}), not retrying: {str(e)}")
                     raise
+
+                # Diagnostic dump (opt-in) of the exact request behind any 4xx, captured
+                # before the cache-drop retry rebuilds the config so we see what failed.
+                if e.code and 400 <= e.code < 500:
+                    _dump_request_on_4xx(scope, gemini_contents, generation_config, e)
 
                 # Cached-request safety net: a stale/invalid/expired CachedContent
                 # (or an incompatibility like cache + tool_config) surfaces as a 400.

--- a/hindsight-api-slim/tests/test_gemini_4xx_dump.py
+++ b/hindsight-api-slim/tests/test_gemini_4xx_dump.py
@@ -1,0 +1,65 @@
+"""Unit tests for the opt-in 4xx request-dump diagnostic in the Gemini provider.
+
+The dump must be a no-op unless ``HINDSIGHT_API_LLM_DEBUG_DUMP_4XX`` is enabled,
+must serialize the request config + a capped message preview when enabled, and
+must never raise (diagnostics can't break the request path).
+"""
+
+import logging
+from types import SimpleNamespace
+
+from hindsight_api.engine.providers.gemini_llm import _dump_request_on_4xx
+
+ENV = "HINDSIGHT_API_LLM_DEBUG_DUMP_4XX"
+
+
+def _config(json_str: str = '{"response_schema": {"maxItems": 0}}'):
+    return SimpleNamespace(model_dump_json=lambda **_: json_str)
+
+
+def _contents(text: str):
+    return [SimpleNamespace(role="user", parts=[SimpleNamespace(text=text)])]
+
+
+def _err(code: int = 400):
+    return SimpleNamespace(code=code)
+
+
+def test_dump_is_noop_when_disabled(monkeypatch, caplog):
+    monkeypatch.delenv(ENV, raising=False)
+    with caplog.at_level(logging.ERROR):
+        _dump_request_on_4xx("consolidation", _contents("hello"), _config(), _err())
+    assert "[LLM_4XX_DUMP]" not in caplog.text
+
+
+def test_dump_emits_config_and_preview_when_enabled(monkeypatch, caplog):
+    monkeypatch.setenv(ENV, "true")
+    with caplog.at_level(logging.ERROR):
+        _dump_request_on_4xx("consolidation", _contents("hello world"), _config(), _err(400))
+    assert "[LLM_4XX_DUMP]" in caplog.text
+    assert "maxItems" in caplog.text  # the serialized config (what's on the wire)
+    assert "hello world" in caplog.text  # message preview
+    assert "code=400" in caplog.text
+
+
+def test_dump_truncates_long_message_preview(monkeypatch, caplog):
+    monkeypatch.setenv(ENV, "1")
+    long_text = "x" * 5000
+    with caplog.at_level(logging.ERROR):
+        _dump_request_on_4xx("consolidation", _contents(long_text), _config(), _err())
+    # preview is capped at 1500 chars, so the full 5000-char body is not logged
+    assert "x" * 1500 in caplog.text
+    assert "x" * 1600 not in caplog.text
+
+
+def test_dump_never_raises_on_unserializable_config(monkeypatch, caplog):
+    monkeypatch.setenv(ENV, "yes")
+
+    class Bad:
+        def model_dump_json(self, **_):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.ERROR):
+        # must not raise even though model_dump_json fails (falls back to repr)
+        _dump_request_on_4xx("consolidation", _contents("hi"), Bad(), _err())
+    assert "[LLM_4XX_DUMP]" in caplog.text


### PR DESCRIPTION
## What

Adds an **opt-in** diagnostic to the Gemini/Vertex provider that logs the exact request behind any Gemini `4xx`, gated by the env var `HINDSIGHT_API_LLM_DEBUG_DUMP_4XX` (off by default).

When enabled, on a `4xx` the provider logs `[LLM_4XX_DUMP]` with:
- the serialized `GenerateContentConfig` — the response schema as the SDK renders it on the wire, plus generation params, safety settings, and the cached-content reference;
- per-message `role` + character count and a length-capped text preview.

It fires before the cache-drop retry rebuilds the config, so both the cached and uncached request forms are captured.

## Why

Some `400 INVALID_ARGUMENT` rejections from structured-output calls are not reproducible by reconstructing the request after the fact — the failing factor is in the request as actually assembled at runtime. Reconstructed replays of the same inputs return `200`, so the only reliable way to see what the model rejected is to capture the real request at the moment it fails. This gives an operator a way to do that without standing up bespoke instrumentation.

## Safety / scope

- **Off by default** — the env var is unset in normal operation.
- The serialized config carries no message content; message previews are length-capped, so an enabled dump can't flood logs or spill large bodies.
- The helper **never raises** — diagnostics must not break the request path (falls back to `repr()` if serialization fails).
- Scoped to the Gemini provider's `APIError` handler; no behavior change when the flag is off.

## Tests

`tests/test_gemini_4xx_dump.py` covers:
- disabled → no-op (no log emitted)
- enabled → emits serialized config + capped preview + error code
- preview truncation (long bodies capped)
- unserializable config → falls back, never raises

All pass; ruff clean.