### PR TITLE
fix(missions): honor configured LLM temperature for bank mission merge (#2469 follow-up)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -160,6 +160,7 @@ ENV_LLM_TEMPERATURE_VERIFICATION = "HINDSIGHT_API_LLM_TEMPERATURE_VERIFICATION"
 ENV_LLM_TEMPERATURE_RETAIN = "HINDSIGHT_API_LLM_TEMPERATURE_RETAIN"
 ENV_LLM_TEMPERATURE_REFLECT = "HINDSIGHT_API_LLM_TEMPERATURE_REFLECT"
 ENV_LLM_TEMPERATURE_CONSOLIDATION = "HINDSIGHT_API_LLM_TEMPERATURE_CONSOLIDATION"
+ENV_LLM_TEMPERATURE_BANK_MISSION = "HINDSIGHT_API_LLM_TEMPERATURE_BANK_MISSION"
 
 # Multi-LLM strategy. Extra LLMs are configured by index alongside the unindexed
 # primary (e.g. HINDSIGHT_API_LLM_1_PROVIDER, HINDSIGHT_API_LLM_2_PROVIDER, ...),
@@ -184,6 +185,7 @@ DEFAULT_LLM_TEMPERATURE_VERIFICATION = 0.0  # connection check
 DEFAULT_LLM_TEMPERATURE_RETAIN = 0.1  # fact extraction
 DEFAULT_LLM_TEMPERATURE_REFLECT = 0.9  # reflect "thinking"
 DEFAULT_LLM_TEMPERATURE_CONSOLIDATION = 0.0  # mental-model delta / dedup
+DEFAULT_LLM_TEMPERATURE_BANK_MISSION = 0.3  # bank/folder mission merge
 
 # Defaults for service tiers
 DEFAULT_LLM_GROQ_SERVICE_TIER = "auto"  # "on_demand", "flex", or "auto"
@@ -1586,6 +1588,7 @@ class HindsightConfig:
     llm_temperature_retain: float | None
     llm_temperature_reflect: float | None
     llm_temperature_consolidation: float | None
+    llm_temperature_bank_mission: float | None
 
     # LiteLLM Router chain (provider-specific; consumed by the "litellmrouter" provider).
     # List of deployment dicts evaluated in order with fallback on transient errors.
@@ -2332,6 +2335,9 @@ class HindsightConfig:
             ),
             llm_temperature_consolidation=_resolve_operation_temperature(
                 ENV_LLM_TEMPERATURE_CONSOLIDATION, DEFAULT_LLM_TEMPERATURE_CONSOLIDATION
+            ),
+            llm_temperature_bank_mission=_resolve_operation_temperature(
+                ENV_LLM_TEMPERATURE_BANK_MISSION, DEFAULT_LLM_TEMPERATURE_BANK_MISSION
             ),
             llm_litellmrouter_config=_parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG),
             # Vertex AI

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -380,7 +380,10 @@ Merged mission:"""
         messages = [{"role": "user", "content": prompt}]
 
         content = await llm_config.call(
-            messages=messages, scope="bank_mission", temperature=0.3, max_completion_tokens=8192
+            messages=messages,
+            scope="bank_mission",
+            temperature=get_config().llm_temperature_bank_mission,
+            max_completion_tokens=8192,
         )
 
         logger.info(f"LLM response for mission merge (first 500 chars): {content[:500]}")

--- a/hindsight-api-slim/tests/test_llm_temperature_env.py
+++ b/hindsight-api-slim/tests/test_llm_temperature_env.py
@@ -14,6 +14,7 @@ _OP_FIELDS = {
     "HINDSIGHT_API_LLM_TEMPERATURE_RETAIN": ("llm_temperature_retain", 0.1),
     "HINDSIGHT_API_LLM_TEMPERATURE_REFLECT": ("llm_temperature_reflect", 0.9),
     "HINDSIGHT_API_LLM_TEMPERATURE_CONSOLIDATION": ("llm_temperature_consolidation", 0.0),
+    "HINDSIGHT_API_LLM_TEMPERATURE_BANK_MISSION": ("llm_temperature_bank_mission", 0.3),
 }
 
 

--- a/hindsight-api-slim/tests/test_llm_temperature_pipeline.py
+++ b/hindsight-api-slim/tests/test_llm_temperature_pipeline.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 import pytest
 
 from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.retain import bank_utils
 from hindsight_api.engine.search import think_utils
 
 
@@ -94,6 +95,44 @@ async def test_global_none_omits_temperature_on_real_call(memory, monkeypatch):
         think_calls = [c for c in reflect_config._provider_impl.get_mock_calls() if c["scope"] == "memory_think"]
         assert think_calls, "reflect should have made a memory_think LLM call"
         assert all(c["temperature"] is None for c in think_calls), "temperature should be omitted"
+    finally:
+        # Restore the cached config so later tests see default temperatures.
+        clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_bank_mission_merge_forwards_configured_temperature(memory):
+    """Bank/folder mission merge must call the LLM with the bank_mission temperature (0.3 default)."""
+    # The engine routes mission merging through the reflect provider (memory_engine
+    # passes self._reflect_llm_config to bank_utils.merge_bank_mission).
+    reflect_config = memory._reflect_llm_config
+    reflect_config._provider_impl.clear_mock_calls()
+
+    await bank_utils._llm_merge_mission(
+        reflect_config, "I help the team with ops.", "I now also handle billing questions."
+    )
+
+    merge_calls = [c for c in reflect_config._provider_impl.get_mock_calls() if c["scope"] == "bank_mission"]
+    assert merge_calls, "mission merge should have made a bank_mission LLM call"
+    assert all(c["temperature"] == 0.3 for c in merge_calls)
+
+
+@pytest.mark.asyncio
+async def test_bank_mission_global_none_omits_temperature(memory, monkeypatch):
+    """HINDSIGHT_API_LLM_TEMPERATURE=none must omit (None) the temperature on mission merge too."""
+    monkeypatch.setenv("HINDSIGHT_API_LLM_TEMPERATURE", "none")
+    clear_config_cache()
+    try:
+        reflect_config = memory._reflect_llm_config
+        reflect_config._provider_impl.clear_mock_calls()
+
+        await bank_utils._llm_merge_mission(
+            reflect_config, "I help the team with ops.", "I now also handle billing questions."
+        )
+
+        merge_calls = [c for c in reflect_config._provider_impl.get_mock_calls() if c["scope"] == "bank_mission"]
+        assert merge_calls, "mission merge should have made a bank_mission LLM call"
+        assert all(c["temperature"] is None for c in merge_calls), "temperature should be omitted"
     finally:
         # Restore the cached config so later tests see default temperatures.
         clear_config_cache()

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -179,6 +179,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 | `HINDSIGHT_API_LLM_TEMPERATURE_RETAIN` | Temperature for fact extraction during retain. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.1` |
 | `HINDSIGHT_API_LLM_TEMPERATURE_REFLECT` | Temperature for the reflect "thinking" step. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.9` |
 | `HINDSIGHT_API_LLM_TEMPERATURE_CONSOLIDATION` | Temperature for consolidation (mental-model delta and dedup). Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.0` |
+| `HINDSIGHT_API_LLM_TEMPERATURE_BANK_MISSION` | Temperature for merging bank/folder mission statements. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.3` |
 | `HINDSIGHT_API_LLM_SEND_BANK_AS_USER` | Tag outbound LLM and embedding calls with `user=<bank_id>` so gateways (OpenRouter usage accounting, LiteLLM, Helicone) can attribute spend per bank. When enabled, the bank id is transmitted to the upstream provider as the end-user identifier. | `false` |
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -179,6 +179,7 @@ For non-English banks (especially CJK) and the language/extraction-language trad
 | `HINDSIGHT_API_LLM_TEMPERATURE_RETAIN` | Temperature for fact extraction during retain. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.1` |
 | `HINDSIGHT_API_LLM_TEMPERATURE_REFLECT` | Temperature for the reflect "thinking" step. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.9` |
 | `HINDSIGHT_API_LLM_TEMPERATURE_CONSOLIDATION` | Temperature for consolidation (mental-model delta and dedup). Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.0` |
+| `HINDSIGHT_API_LLM_TEMPERATURE_BANK_MISSION` | Temperature for merging bank/folder mission statements. Number in `[0.0, 2.0]` or `none` to omit. Overrides `HINDSIGHT_API_LLM_TEMPERATURE`. | `0.3` |
 | `HINDSIGHT_API_LLM_SEND_BANK_AS_USER` | Tag outbound LLM and embedding calls with `user=<bank_id>` so gateways (OpenRouter usage accounting, LiteLLM, Helicone) can attribute spend per bank. When enabled, the bank id is transmitted to the upstream provider as the end-user identifier. | `false` |
 | `HINDSIGHT_API_LLM_GROQ_SERVICE_TIER` | Groq service tier: `on_demand`, `flex`, `auto` | `auto` |
 | `HINDSIGHT_API_LLM_OPENAI_SERVICE_TIER` | OpenAI service tier: `flex` for 50% cost savings (OpenAI Flex Processing) | None (default) |


### PR DESCRIPTION
### Problem

#2469 made the internal LLM temperature configurable and its docs state the global `HINDSIGHT_API_LLM_TEMPERATURE` "applies to every operation" and `none` "drops temperature from every operation" (the documented remedy for models that reject explicit temperatures, e.g. Azure `gpt-5.5`, issue #2459).

But bank/folder **mission merging** is a 5th internal LLM call that #2469 didn't reach. `_llm_merge_mission` (`engine/retain/bank_utils.py`, `scope="bank_mission"`, used by `merge_bank_mission`) still hardcodes `temperature=0.3` and never reads `get_config()`:

```python
content = await llm_config.call(
    messages=messages, scope="bank_mission", temperature=0.3, max_completion_tokens=8192
)
```

So setting `HINDSIGHT_API_LLM_TEMPERATURE=none` (your documented fix for Azure gpt-5.5) does **not** cover mission merging — the `0.3` is still sent, the call raises, the `try/except` in `_llm_merge_mission` swallows it, and the merge silently degrades to naive `"{current} {new_info}"` concatenation. With folder missions / mission-sandbox (#2455, #2254) actively shipping, this path is gaining users following the docs and still hitting a silent failure.

### Fix

Add `bank_mission` as a 5th per-operation temperature knob, mirroring the four introduced in #2469 (verification / retain / reflect / consolidation):

- `ENV_LLM_TEMPERATURE_BANK_MISSION` + `DEFAULT_LLM_TEMPERATURE_BANK_MISSION = 0.3` (preserves the historical value)
- `HindsightConfig.llm_temperature_bank_mission`, resolved via the existing `_resolve_operation_temperature` (per-op env → global `HINDSIGHT_API_LLM_TEMPERATURE` → default `0.3`)
- `bank_utils.py` now passes `temperature=get_config().llm_temperature_bank_mission`

The documented global override now genuinely covers mission merging, and `none` correctly omits the parameter there too. Default behavior is unchanged (still `0.3`).

### Docs / tests

- Documented the new knob in `configuration.md` and regenerated the CI-enforced skills mirror via `scripts/generate-docs-skill.sh` (diff is the single new row).
- `test_llm_temperature_env.py`: `bank_mission` added to `_OP_FIELDS`, so the default / global-override / global-`none` resolution cases now assert it too.
- `test_llm_temperature_pipeline.py`: two new tests drive `_llm_merge_mission` through the mock LLM and assert the `bank_mission` call receives `0.3` by default and `None` (omitted) under `HINDSIGHT_API_LLM_TEMPERATURE=none`.

`test_llm_temperature_env.py` passes locally (13 passed); the pipeline tests mirror the existing reflect/retain pipeline tests (they need the Postgres-backed `memory` fixture, which runs in CI).

Follow-up to merged #2469.
