### PR TITLE
chore(search): remove HINDSIGHT_API_LAZY_RERANKER flag (eager reranker init)

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -573,7 +573,6 @@ ENV_LLAMACPP_EXTRA_ARGS = "HINDSIGHT_API_LLAMACPP_EXTRA_ARGS"
 
 # Optimization flags
 ENV_SKIP_LLM_VERIFICATION = "HINDSIGHT_API_SKIP_LLM_VERIFICATION"
-ENV_LAZY_RERANKER = "HINDSIGHT_API_LAZY_RERANKER"
 
 # Database migrations
 ENV_RUN_MIGRATIONS_ON_STARTUP = "HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP"
@@ -1886,7 +1885,6 @@ class HindsightConfig:
 
     # Optimization flags
     skip_llm_verification: bool
-    lazy_reranker: bool
 
     # Database migrations
     run_migrations_on_startup: bool
@@ -2730,7 +2728,6 @@ class HindsightConfig:
             ),
             # Optimization flags
             skip_llm_verification=os.getenv(ENV_SKIP_LLM_VERIFICATION, "false").lower() == "true",
-            lazy_reranker=os.getenv(ENV_LAZY_RERANKER, "false").lower() == "true",
             # Retain settings
             retain_max_completion_tokens=int(
                 os.getenv(ENV_RETAIN_MAX_COMPLETION_TOKENS, str(DEFAULT_RETAIN_MAX_COMPLETION_TOKENS))

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -917,7 +917,6 @@ class MemoryEngine(MemoryEngineInterface):
         operation_validator: "OperationValidatorExtension | None" = None,
         tenant_extension: "TenantExtension | None" = None,
         skip_llm_verification: bool | None = None,
-        lazy_reranker: bool | None = None,
     ):
         """
         Initialize the temporal + semantic memory system.
@@ -959,9 +958,6 @@ class MemoryEngine(MemoryEngineInterface):
                              If provided, operations require a RequestContext for authentication.
             skip_llm_verification: Skip LLM connection verification during initialization.
                                   Defaults to HINDSIGHT_API_SKIP_LLM_VERIFICATION env var or False.
-            lazy_reranker: Delay reranker initialization until first use. Useful for retain-only
-                          operations that don't need the cross-encoder. Defaults to
-                          HINDSIGHT_API_LAZY_RERANKER env var or False.
         """
         # Load config from environment for any missing parameters
         from ..config import _get_raw_config, get_config
@@ -978,7 +974,6 @@ class MemoryEngine(MemoryEngineInterface):
         self._skip_llm_verification = (
             skip_llm_verification if skip_llm_verification is not None else config.skip_llm_verification
         )
-        self._lazy_reranker = lazy_reranker if lazy_reranker is not None else config.lazy_reranker
 
         # Apply defaults from config
         db_url = db_url or config.database_url
@@ -2748,16 +2743,16 @@ class MemoryEngine(MemoryEngineInterface):
                             f"set HINDSIGHT_API_RETAIN_BATCH_ENABLED=false."
                         )
 
-        # Build list of initialization tasks
+        # Build list of initialization tasks. The cross-encoder is initialized
+        # eagerly here (single-threaded, before any request is served) so that
+        # the per-request ensure_initialized() guard always short-circuits and
+        # concurrent cold-start recalls can never double-load the model.
         init_tasks = [
             start_pg0(),
             init_embeddings(),
             init_query_analyzer(),
+            init_cross_encoder(),
         ]
-
-        # Only init cross-encoder eagerly if not using lazy initialization
-        if not self._lazy_reranker:
-            init_tasks.append(init_cross_encoder())
 
         # Only verify LLM if not skipping
         if not self._skip_llm_verification:

--- a/hindsight-api-slim/tests/test_llm_timeout_propagation.py
+++ b/hindsight-api-slim/tests/test_llm_timeout_propagation.py
@@ -64,7 +64,6 @@ def _clean_timeout_env(monkeypatch):
     from hindsight_api.config import clear_config_cache
 
     monkeypatch.setenv("HINDSIGHT_API_SKIP_LLM_VERIFICATION", "true")
-    monkeypatch.setenv("HINDSIGHT_API_LAZY_RERANKER", "true")
     monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "mock")
     monkeypatch.setenv("HINDSIGHT_API_LLM_MODEL", "default-model")
     for op in ("LLM", "RETAIN_LLM", "REFLECT_LLM", "CONSOLIDATION_LLM"):
@@ -123,7 +122,7 @@ def test_memory_engine_threads_per_operation_timeout(monkeypatch, _clean_timeout
     # reflect intentionally unset -> inherits the global 100
     clear_config_cache()
 
-    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+    engine = MemoryEngine(skip_llm_verification=True)
 
     assert engine._llm_config.timeout == 100.0
     assert engine._retain_llm_config.timeout == 300.0
@@ -144,7 +143,7 @@ def test_memory_engine_threads_per_operation_retry_policy(monkeypatch, _clean_ti
     monkeypatch.setenv("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF", "99")
     clear_config_cache()
 
-    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+    engine = MemoryEngine(skip_llm_verification=True)
 
     # Global applies everywhere unless overridden.
     assert engine._llm_config.max_retries == 4
@@ -166,7 +165,7 @@ def test_memory_engine_per_op_defaults_to_global_default(_clean_timeout_env):
         DEFAULT_LLM_MAX_RETRIES,
     )
 
-    engine = MemoryEngine(skip_llm_verification=True, lazy_reranker=True)
+    engine = MemoryEngine(skip_llm_verification=True)
 
     for cfg in (
         engine._llm_config,

--- a/hindsight-api-slim/tests/test_model_init_timeout.py
+++ b/hindsight-api-slim/tests/test_model_init_timeout.py
@@ -1,5 +1,5 @@
 """
-Startup/lazy model-init must fail fast instead of hanging forever.
+Startup model-init must fail fast instead of hanging forever.
 
 Covers issue #1897: if a model load blocks (e.g. an offline HuggingFace
 download or an unreachable provider), initialization is capped by a wall-clock
@@ -68,7 +68,7 @@ def test_default_model_init_timeout_is_300s():
 
 
 @pytest.mark.asyncio
-async def test_lazy_reranker_init_fails_fast_on_hang():
+async def test_reranker_ensure_initialized_fails_fast_on_hang():
     """A stuck cross-encoder load raises RuntimeError within the timeout, not forever."""
     reranker = CrossEncoderReranker(cross_encoder=_HangingCrossEncoder())
     config = _make_config(model_init_timeout=0.1)
@@ -81,7 +81,7 @@ async def test_lazy_reranker_init_fails_fast_on_hang():
 
 
 @pytest.mark.asyncio
-async def test_lazy_reranker_init_succeeds_within_timeout():
+async def test_reranker_ensure_initialized_succeeds_within_timeout():
     """A fast init completes normally and marks the reranker initialized."""
     encoder = _FastCrossEncoder()
     reranker = CrossEncoderReranker(cross_encoder=encoder)

--- a/hindsight-api-slim/tests/test_model_load_default_dtype.py
+++ b/hindsight-api-slim/tests/test_model_load_default_dtype.py
@@ -70,7 +70,6 @@ async def test_global_default_dtype_restored_to_float32_after_init():
             query_analyzer=_NoopQueryAnalyzer(),
             run_migrations=False,
             skip_llm_verification=True,
-            lazy_reranker=False,  # load the cross-encoder eagerly, in the gather
             task_backend=SyncTaskBackend(),
         )
 

--- a/hindsight-api-slim/tests/test_per_operation_llm_config.py
+++ b/hindsight-api-slim/tests/test_per_operation_llm_config.py
@@ -17,7 +17,6 @@ def setup_test_env():
     # Save original environment values
     env_vars_to_set = {
         "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true",
-        "HINDSIGHT_API_LAZY_RERANKER": "true",
         "HINDSIGHT_API_LLM_PROVIDER": "mock",
         "HINDSIGHT_API_LLM_MODEL": "default-model",
         "HINDSIGHT_API_RETAIN_LLM_PROVIDER": "mock",
@@ -76,7 +75,6 @@ class TestPerOperationLLMConfig:
 
         engine = MemoryEngine(
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         # Verify default config
@@ -105,7 +103,6 @@ class TestPerOperationLLMConfig:
 
         engine = MemoryEngine(
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         for cfg in (
@@ -131,7 +128,6 @@ class TestPerOperationLLMConfig:
             reflect_llm_provider="mock",
             reflect_llm_model="explicit-reflect",
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         assert engine._llm_config.model == "explicit-default"
@@ -154,7 +150,6 @@ class TestPerOperationLLMConfig:
 
             engine = MemoryEngine(
                 skip_llm_verification=True,
-                lazy_reranker=True,
             )
 
             # All should fall back to default
@@ -268,7 +263,6 @@ class TestRetainUsesRetainLLMConfig:
             reflect_llm_provider="mock",
             reflect_llm_model="reflect-specific-model",
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         # Verify the retain LLM config is set correctly
@@ -294,7 +288,6 @@ class TestReflectUsesReflectLLMConfig:
             reflect_llm_provider="mock",
             reflect_llm_model="reflect-specific-model",
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         # Verify the reflect LLM config is set correctly
@@ -320,7 +313,6 @@ class TestReflectUsesReflectLLMConfig:
             reflect_llm_provider="mock",
             reflect_llm_model="reflect-specific-model",
             skip_llm_verification=True,
-            lazy_reranker=True,
         )
 
         engine._authenticate_tenant = AsyncMock()  # type: ignore[method-assign]

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1025,7 +1025,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LOG_FORMAT` | Log format: `text` or `json` (structured logging for cloud platforms) | `text` |
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
 | `HINDSIGHT_API_MCP_ENABLED` | Enable MCP server at `/mcp/{bank_id}/` | `true` |
-| `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Also applies to lazy reranker init on the first request. Increase if a legitimate first-time model download needs more time. | `300` |
+| `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Increase if a legitimate first-time model download needs more time. | `300` |
 
 ### Retrieval
 
@@ -1653,7 +1653,6 @@ This ensures `shadow-*` banks are always consolidated before others, even if the
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_SKIP_LLM_VERIFICATION` | Skip LLM connection check on startup | `false` |
-| `HINDSIGHT_API_LAZY_RERANKER` | Lazy-load reranker model (faster startup) | `false` |
 
 #### Bank stats cache
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1025,7 +1025,7 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_LOG_FORMAT` | Log format: `text` or `json` (structured logging for cloud platforms) | `text` |
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
 | `HINDSIGHT_API_MCP_ENABLED` | Enable MCP server at `/mcp/{bank_id}/` | `true` |
-| `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Also applies to lazy reranker init on the first request. Increase if a legitimate first-time model download needs more time. | `300` |
+| `HINDSIGHT_API_MODEL_INIT_TIMEOUT` | Wall-clock cap (seconds) on startup model/connection initialization. If embeddings, the cross-encoder, or LLM verification block (e.g. an offline model download or an unreachable provider), the server fails fast with a clear error instead of hanging forever. Increase if a legitimate first-time model download needs more time. | `300` |
 
 ### Retrieval
 
@@ -1653,7 +1653,6 @@ This ensures `shadow-*` banks are always consolidated before others, even if the
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_SKIP_LLM_VERIFICATION` | Skip LLM connection check on startup | `false` |
-| `HINDSIGHT_API_LAZY_RERANKER` | Lazy-load reranker model (faster startup) | `false` |
 
 #### Bank stats cache
 


### PR DESCRIPTION
## Summary

Removes the `HINDSIGHT_API_LAZY_RERANKER` flag entirely. The cross-encoder reranker is now always initialized **eagerly at startup**.

## Why

This came out of the discussion on #2445. The reported race in `CrossEncoderReranker.ensure_initialized()` — two concurrent cold recalls both passing the `_initialized=False` check across the `await` and double-loading the model — is real, **but only reachable in lazy mode**. In the default eager path, `init_cross_encoder()` runs during `MemoryEngine.initialize()` (single-threaded, before any request is served) and sets `_initialized=True`, so the per-request guard always short-circuits and the window never opens.

Rather than guard the lazy path with a lock (#2445's approach), the cleaner fix is to drop the flag:

- **Eliminates the race by construction** — there's no longer a path where the first request triggers a cold model load.
- **Removes the first-recall latency cliff** — the ~2–10s model load no longer lands on a user request.
- The only thing the flag bought was skipping an ~80MB cross-encoder load for **retain-only deployments** — not worth the extra config surface and the concurrency footgun.

`ensure_initialized()` is kept as a cheap idempotent guard on the recall path (it now always short-circuits).

## Changes

- `config.py`: drop `ENV_LAZY_RERANKER`, the `lazy_reranker` field, and `from_env()` wiring
- `memory_engine.py`: drop the `lazy_reranker` constructor param/docstring; always append `init_cross_encoder()` to the startup task list
- Tests: drop the now-dead `lazy_reranker` kwarg / env var; rename the `ensure_initialized` timeout tests (they exercise the still-present guard, not the removed flag)
- Docs: remove the `HINDSIGHT_API_LAZY_RERANKER` row + the stale "lazy reranker init" mention in `MODEL_INIT_TIMEOUT`; regenerate the docs-skill mirror. Versioned docs (0.6/0.7/0.8) left untouched — the flag existed in those releases.

## Note for reviewers

This is a behavior change for **retain-only deployments**: they now load the cross-encoder at startup even though they never rerank (~80MB RAM + a couple seconds). If anyone is relying on `HINDSIGHT_API_LAZY_RERANKER=true` in production, flag it.

## Tests

- `tests/test_per_operation_llm_config.py`, `tests/test_llm_timeout_propagation.py`, `tests/test_model_init_timeout.py`, `tests/test_model_load_default_dtype.py`, `tests/test_config_validation.py` — all pass locally
- `ty check` clean; lint hook clean
