### PR TITLE
feat(extensions): OIDC + GitHub tenant extensions; fix(worker): drain scan-only schemas (follow-up to #1555)

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/__init__.py
+++ b/hindsight-api-slim/hindsight_api/extensions/__init__.py
@@ -18,7 +18,10 @@ with the system (e.g., running migrations for tenant schemas).
 from hindsight_api.extensions.base import Extension
 from hindsight_api.extensions.builtin import (
     ApiKeyTenantExtension,
+    GitHubRoleOperationValidator,
+    GitHubTenantExtension,
     MemoryDefenseRegexExtension,
+    OidcTenantExtension,
     SupabaseTenantExtension,
 )
 from hindsight_api.extensions.context import DefaultExtensionContext, ExtensionContext
@@ -118,6 +121,9 @@ __all__ = [
     # Tenant/Auth
     "ApiKeyTenantExtension",
     "SupabaseTenantExtension",
+    "OidcTenantExtension",
+    "GitHubTenantExtension",
+    "GitHubRoleOperationValidator",
     "AuthenticationError",
     "RequestContext",
     "Tenant",

--- a/hindsight-api-slim/hindsight_api/extensions/builtin/__init__.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/__init__.py
@@ -7,18 +7,29 @@ They can be used directly or serve as examples for custom implementations.
 Available built-in extensions:
     - ApiKeyTenantExtension: Simple API key validation with public schema
     - SupabaseTenantExtension: Supabase JWT validation with per-user schema isolation
+    - OidcTenantExtension: Generic OIDC/OAuth (JWKS) auth with per-user schema isolation
+    - GitHubTenantExtension: GitHub OAuth with team-based roles and per-user schema isolation
+    - GitHubRoleOperationValidator: Gates retain/recall/reflect by GitHub team-derived role
 
 Example usage:
     HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.tenant:ApiKeyTenantExtension
     HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.supabase_tenant:SupabaseTenantExtension
+    HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.oidc_tenant:OidcTenantExtension
+    HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.github_tenant:GitHubTenantExtension
 """
 
+from hindsight_api.extensions.builtin.github_role_validator import GitHubRoleOperationValidator
+from hindsight_api.extensions.builtin.github_tenant import GitHubTenantExtension
 from hindsight_api.extensions.builtin.memory_defense_regex import MemoryDefenseRegexExtension
+from hindsight_api.extensions.builtin.oidc_tenant import OidcTenantExtension
 from hindsight_api.extensions.builtin.supabase_tenant import SupabaseTenantExtension
 from hindsight_api.extensions.builtin.tenant import ApiKeyTenantExtension
 
 __all__ = [
     "ApiKeyTenantExtension",
+    "GitHubRoleOperationValidator",
+    "GitHubTenantExtension",
     "MemoryDefenseRegexExtension",
+    "OidcTenantExtension",
     "SupabaseTenantExtension",
 ]

--- a/hindsight-api-slim/hindsight_api/extensions/builtin/github_role_validator.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/github_role_validator.py
@@ -1,0 +1,71 @@
+"""
+GitHub role-based OperationValidator for Hindsight.
+
+Companion to
+:class:`hindsight_api.extensions.builtin.github_tenant.GitHubTenantExtension`.
+
+The tenant extension resolves the user's GitHub team-based role and encodes it
+into ``RequestContext.tenant_id`` as ``gh_<id>:<role>``. This validator reads
+that role and gates the core memory operations accordingly:
+
+    - ``admin``  : all operations allowed.
+    - ``member`` : all operations allowed (read/write).
+    - ``viewer`` : recall allowed; retain and reflect rejected (read-only).
+    - unknown    : fail closed — retain/reflect rejected.
+
+The role is read directly from ``tenant_id`` (no additional GitHub API call),
+so this validator stays cheap and stateless.
+
+Enable alongside the GitHub tenant extension:
+    HINDSIGHT_API_OPERATION_VALIDATOR_EXTENSION=hindsight_api.extensions.builtin.github_role_validator:GitHubRoleOperationValidator
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hindsight_api.extensions.builtin.github_tenant import (
+    ROLE_ADMIN,
+    ROLE_MEMBER,
+    parse_role_from_tenant_id,
+)
+from hindsight_api.extensions.operation_validator import (
+    OperationValidatorExtension,
+    RecallContext,
+    ReflectContext,
+    RetainContext,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GitHubRoleOperationValidator"]
+
+# Roles permitted to perform write/compute operations (retain, reflect).
+_WRITE_ROLES = {ROLE_ADMIN, ROLE_MEMBER}
+
+
+class GitHubRoleOperationValidator(OperationValidatorExtension):
+    """Gate retain/recall/reflect based on the GitHub team-derived role."""
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        super().__init__(config or {})
+
+    def _can_write(self, tenant_id: str | None) -> bool:
+        return parse_role_from_tenant_id(tenant_id) in _WRITE_ROLES
+
+    async def validate_retain(self, ctx: RetainContext) -> ValidationResult:
+        if self._can_write(ctx.request_context.tenant_id):
+            return ValidationResult.accept()
+        return ValidationResult.reject("Read-only role: retain is not permitted", status_code=403)
+
+    async def validate_reflect(self, ctx: ReflectContext) -> ValidationResult:
+        if self._can_write(ctx.request_context.tenant_id):
+            return ValidationResult.accept()
+        return ValidationResult.reject("Read-only role: reflect is not permitted", status_code=403)
+
+    async def validate_recall(self, ctx: RecallContext) -> ValidationResult:
+        # All roles (including viewer) may read.
+        return ValidationResult.accept()

--- a/hindsight-api-slim/hindsight_api/extensions/builtin/github_tenant.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/github_tenant.py
@@ -1,0 +1,319 @@
+"""
+GitHub OAuth Tenant Extension for Hindsight.
+
+A purpose-built configuration of :class:`OidcTenantExtension` for GitHub OAuth.
+
+GitHub OAuth user access tokens are **opaque** (not JWTs), so this variant does
+not use JWKS verification. Instead it validates tokens against the GitHub REST
+API and resolves the user's identity and team/organization membership.
+
+Two things this extension provides:
+
+1. **Per-user schema isolation** — identical to the generic OIDC extension. Each
+   GitHub user gets their own PostgreSQL schema ``{prefix}_{github_user_id}``
+   (the numeric, immutable user id), so multiple users share one Hindsight
+   instance with complete data separation.
+
+2. **Team-based roles** — a user's GitHub team membership in a configured org is
+   mapped to a Hindsight role (``admin`` / ``member`` / ``viewer``). The role
+   **gates capabilities** (it does not change the schema):
+       - ``admin``  : full access, may modify all bank config fields.
+       - ``member`` : read/write memory, may modify a limited set of config fields.
+       - ``viewer`` : read-only (recall allowed; retain/reflect rejected).
+
+   Capability enforcement is split across two hooks:
+       - bank-config write permissions via :meth:`get_allowed_config_fields`
+         (handled here in the tenant extension), and
+       - retain/recall/reflect gating via
+         :class:`hindsight_api.extensions.builtin.github_role_validator.GitHubRoleOperationValidator`
+         (a companion OperationValidator). The role is propagated to the
+         validator through ``RequestContext.tenant_id`` encoded as
+         ``gh_<id>:<role>`` so no second GitHub call is needed.
+
+Configuration via environment variables:
+    HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.github_tenant:GitHubTenantExtension
+    HINDSIGHT_API_TENANT_GITHUB_ORG=my-org
+
+    # Team slugs (comma-separated) mapped to each role
+    HINDSIGHT_API_TENANT_GITHUB_ADMIN_TEAMS=platform-admins
+    HINDSIGHT_API_TENANT_GITHUB_MEMBER_TEAMS=engineering,data
+    HINDSIGHT_API_TENANT_GITHUB_VIEWER_TEAMS=analysts
+
+    # Optional
+    HINDSIGHT_API_TENANT_GITHUB_DEFAULT_ROLE=viewer   # role for org members in no mapped team; empty = deny
+    HINDSIGHT_API_TENANT_GITHUB_API_URL=https://api.github.com  # set for GHES
+    HINDSIGHT_API_TENANT_GITHUB_ROLE_CACHE_TTL=300    # seconds
+    HINDSIGHT_API_TENANT_SCHEMA_PREFIX=user
+
+Companion validator (recommended) for read/write gating:
+    HINDSIGHT_API_OPERATION_VALIDATOR_EXTENSION=hindsight_api.extensions.builtin.github_role_validator:GitHubRoleOperationValidator
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+
+import httpx
+
+from hindsight_api.extensions.builtin.oidc_tenant import (
+    REQUEST_TIMEOUT_SECONDS,
+    Identity,
+    OidcTenantExtension,
+)
+from hindsight_api.extensions.tenant import AuthenticationError
+from hindsight_api.models import RequestContext
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ROLE_ADMIN",
+    "ROLE_MEMBER",
+    "ROLE_VIEWER",
+    "GitHubTenantExtension",
+    "encode_tenant_id",
+    "parse_role_from_tenant_id",
+]
+
+ROLE_ADMIN = "admin"
+ROLE_MEMBER = "member"
+ROLE_VIEWER = "viewer"
+
+# Role precedence: a user in multiple mapped teams gets the strongest role.
+_ROLE_RANK = {ROLE_VIEWER: 0, ROLE_MEMBER: 1, ROLE_ADMIN: 2}
+
+# Config fields that the "member" role is allowed to modify on a bank.
+# Subset of HindsightConfig.get_configurable_fields(); kept conservative.
+_MEMBER_ALLOWED_FIELDS: set[str] = {
+    "retain_chunk_size",
+    "retain_custom_instructions",
+    "recall_default_budget",
+}
+
+_TENANT_ID_SEP = ":"
+
+
+def encode_tenant_id(github_id: str, role: str) -> str:
+    """Encode the GitHub id and resolved role into a RequestContext.tenant_id."""
+    return f"gh_{github_id}{_TENANT_ID_SEP}{role}"
+
+
+def parse_role_from_tenant_id(tenant_id: str | None) -> str | None:
+    """Extract the role from a tenant_id encoded by :func:`encode_tenant_id`."""
+    if not tenant_id or _TENANT_ID_SEP not in tenant_id:
+        return None
+    return tenant_id.split(_TENANT_ID_SEP, 1)[1] or None
+
+
+class GitHubTenantExtension(OidcTenantExtension):
+    """OIDC tenant extension specialized for GitHub OAuth with team-based roles."""
+
+    def __init__(self, config: dict[str, str]) -> None:
+        # GitHub uses opaque tokens validated via the API, not JWKS/discovery.
+        # Pre-fill config so the base validator does not require an OIDC issuer.
+        config = dict(config)
+        self.github_api_url = (config.get("github_api_url") or "https://api.github.com").rstrip("/")
+        # Mark issuer present (logical) so base _validate_config passes; we never
+        # actually perform OIDC discovery or JWKS for GitHub.
+        config.setdefault("oidc_issuer", self.github_api_url)
+
+        super().__init__(config)
+
+        self.github_org = (config.get("github_org") or "").strip()
+        if not self.github_org:
+            raise ValueError("HINDSIGHT_API_TENANT_GITHUB_ORG is required when using GitHubTenantExtension")
+
+        self.admin_teams = self._parse_teams(config.get("github_admin_teams"))
+        self.member_teams = self._parse_teams(config.get("github_member_teams"))
+        self.viewer_teams = self._parse_teams(config.get("github_viewer_teams"))
+
+        # Role for org members not in any mapped team. Empty string = deny.
+        self.default_role = (config.get("github_default_role", ROLE_VIEWER) or "").strip().lower()
+        if self.default_role and self.default_role not in _ROLE_RANK:
+            raise ValueError(
+                f"Invalid github_default_role '{self.default_role}'. "
+                f"Must be one of: {', '.join(_ROLE_RANK)} (or empty to deny)."
+            )
+
+        try:
+            self.role_cache_ttl = float(config.get("github_role_cache_ttl", "300"))
+        except ValueError:
+            raise ValueError("HINDSIGHT_API_TENANT_GITHUB_ROLE_CACHE_TTL must be a number (seconds)")
+
+        # token-hash -> (expires_at, role). Avoids a GitHub round-trip per request.
+        self._role_cache: dict[str, tuple[float, str]] = {}
+
+    @staticmethod
+    def _parse_teams(raw: str | None) -> set[str]:
+        if not raw:
+            return set()
+        return {t.strip().lower() for t in raw.split(",") if t.strip()}
+
+    def _validate_config(self) -> None:
+        # GitHub does not use schema_prefix-only validation differently, but we
+        # do not require an OIDC issuer (the base would). schema_prefix is still
+        # validated by the base via the regex check below.
+        from hindsight_api.extensions.builtin.oidc_tenant import _SCHEMA_PREFIX_RE
+
+        if not _SCHEMA_PREFIX_RE.match(self.schema_prefix):
+            raise ValueError(
+                f"Invalid schema_prefix '{self.schema_prefix}'. "
+                "Must be a valid Postgres identifier (letters, digits, underscores, "
+                "starting with a letter or underscore)."
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle (no OIDC discovery / JWKS for GitHub)
+    # ------------------------------------------------------------------
+
+    async def on_startup(self) -> None:
+        logger.info("Initializing GitHub tenant extension (org=%s)", self.github_org)
+        logger.info("Schema prefix: %s_", self.schema_prefix)
+        self._http_client = httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS)
+
+    # ------------------------------------------------------------------
+    # Identity (GitHub REST API instead of JWKS)
+    # ------------------------------------------------------------------
+
+    def _headers(self, token: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    async def _resolve_identity(self, token: str) -> Identity:
+        """Validate the opaque token via GET /user and return the GitHub identity."""
+        if self._http_client is None:
+            raise AuthenticationError("Extension not initialized")
+        try:
+            response = await self._http_client.get(f"{self.github_api_url}/user", headers=self._headers(token))
+        except httpx.TimeoutException:
+            raise AuthenticationError("GitHub authentication timeout - please retry")
+        except httpx.RequestError as e:
+            raise AuthenticationError(f"GitHub connection error: {e!s}")
+
+        if response.status_code == 401:
+            raise AuthenticationError("Invalid or expired GitHub token")
+        if response.status_code != 200:
+            raise AuthenticationError(f"GitHub authentication failed: {response.status_code}")
+
+        user = response.json()
+        user_id = user.get("id")
+        login = user.get("login")
+        if user_id is None:
+            raise AuthenticationError("GitHub token valid but no user id returned")
+        # Use the immutable numeric id as the subject (login can change).
+        return Identity(subject=str(user_id), claims={"login": login, "id": user_id})
+
+    def _schema_for_subject(self, subject: str) -> str:
+        """Per-user schema based on the immutable GitHub numeric id."""
+        return f"{self.schema_prefix}_{subject}"
+
+    # ------------------------------------------------------------------
+    # Role resolution + propagation
+    # ------------------------------------------------------------------
+
+    async def _load_roles(self, token: str, identity: Identity, context: RequestContext) -> None:
+        """Resolve the user's role from team membership and propagate it.
+
+        The role is stored on ``identity.roles`` and encoded into
+        ``context.tenant_id`` (``gh_<id>:<role>``) so the companion
+        OperationValidator can read it without another GitHub call.
+        """
+        role = await self._resolve_role(token, identity)
+        if role is None:
+            raise AuthenticationError(f"User is not a member of any authorized team in org '{self.github_org}'")
+        identity.roles = [role]
+        context.tenant_id = encode_tenant_id(identity.subject, role)
+
+    async def _resolve_role(self, token: str, identity: Identity) -> str | None:
+        """Return the strongest mapped role for the user, or the default role."""
+        cache_key = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        now = time.monotonic()
+        cached = self._role_cache.get(cache_key)
+        if cached and cached[0] > now:
+            return cached[1] or None
+
+        teams = await self._fetch_user_team_slugs(token)
+
+        role: str | None = None
+        for team in teams:
+            if team in self.admin_teams:
+                role = self._stronger(role, ROLE_ADMIN)
+            elif team in self.member_teams:
+                role = self._stronger(role, ROLE_MEMBER)
+            elif team in self.viewer_teams:
+                role = self._stronger(role, ROLE_VIEWER)
+
+        if role is None:
+            role = self.default_role or None
+
+        self._role_cache[cache_key] = (now + self.role_cache_ttl, role or "")
+        return role
+
+    @staticmethod
+    def _stronger(current: str | None, candidate: str) -> str:
+        if current is None:
+            return candidate
+        return current if _ROLE_RANK[current] >= _ROLE_RANK[candidate] else candidate
+
+    async def _fetch_user_team_slugs(self, token: str) -> set[str]:
+        """Return the set of team slugs (in the configured org) the user belongs to."""
+        if self._http_client is None:
+            raise AuthenticationError("Extension not initialized")
+
+        slugs: set[str] = set()
+        page = 1
+        while True:
+            try:
+                response = await self._http_client.get(
+                    f"{self.github_api_url}/user/teams",
+                    headers=self._headers(token),
+                    params={"per_page": 100, "page": page},
+                )
+            except httpx.TimeoutException:
+                raise AuthenticationError("GitHub authentication timeout - please retry")
+            except httpx.RequestError as e:
+                raise AuthenticationError(f"GitHub connection error: {e!s}")
+
+            if response.status_code != 200:
+                raise AuthenticationError(f"Failed to read GitHub teams: {response.status_code}")
+
+            batch = response.json()
+            if not isinstance(batch, list) or not batch:
+                break
+            for team in batch:
+                org_login = ((team.get("organization") or {}).get("login") or "").lower()
+                if org_login == self.github_org.lower():
+                    slug = (team.get("slug") or "").lower()
+                    if slug:
+                        slugs.add(slug)
+            if len(batch) < 100:
+                break
+            page += 1
+
+        return slugs
+
+    # ------------------------------------------------------------------
+    # Capability gating: bank-config write permissions per role
+    # ------------------------------------------------------------------
+
+    async def get_allowed_config_fields(self, context: RequestContext, bank_id: str) -> set[str] | None:
+        """Restrict which bank-config fields a role may modify.
+
+        - admin  -> None (all configurable fields)
+        - member -> a curated subset
+        - viewer -> empty set (read-only)
+        - unknown -> empty set (fail closed)
+        """
+        role = parse_role_from_tenant_id(context.tenant_id)
+        if role == ROLE_ADMIN:
+            return None
+        if role == ROLE_MEMBER:
+            return set(_MEMBER_ALLOWED_FIELDS)
+        # viewer or unknown -> no config writes
+        return set()

--- a/hindsight-api-slim/hindsight_api/extensions/builtin/oidc_tenant.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/oidc_tenant.py
@@ -1,0 +1,346 @@
+"""
+Generic OIDC / OAuth Tenant Extension for Hindsight.
+
+Validates OIDC ID tokens / JWT access tokens from any standard OpenID Connect
+provider (Auth0, Okta, Keycloak, Microsoft Entra ID, Google, ...) and maps each
+authenticated user to an isolated PostgreSQL schema.
+
+Each authenticated user gets their own schema (``{prefix}_{subject}``), ensuring
+complete data isolation between users sharing one Hindsight instance.
+
+Verification strategy:
+    Tokens are verified locally using public keys discovered from the provider's
+    OIDC discovery document (``{issuer}/.well-known/openid-configuration`` ->
+    ``jwks_uri``). This requires no network call per request once JWKS is cached
+    and matches the approach used by :class:`SupabaseTenantExtension`.
+
+Extensibility:
+    This class is intentionally written so provider-specific variants can be
+    built as thin subclasses. The verification + identity extraction step is
+    isolated in :meth:`_resolve_identity`, schema naming in
+    :meth:`_schema_for_subject`, and role loading in :meth:`_load_roles`. The
+    GitHub variant (:class:`hindsight_api.extensions.builtin.github_tenant.GitHubTenantExtension`)
+    overrides these without reusing JWKS, because GitHub OAuth user tokens are
+    opaque (not JWTs).
+
+Configuration via environment variables:
+    HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.oidc_tenant:OidcTenantExtension
+    HINDSIGHT_API_TENANT_OIDC_ISSUER=https://your-tenant.auth0.com/
+
+    # Optional
+    HINDSIGHT_API_TENANT_OIDC_AUDIENCE=your-api-audience      # expected `aud`
+    HINDSIGHT_API_TENANT_OIDC_JWKS_URI=https://.../jwks.json  # skip discovery
+    HINDSIGHT_API_TENANT_SUBJECT_CLAIM=sub                    # claim -> schema
+    HINDSIGHT_API_TENANT_SCHEMA_PREFIX=user                   # schema prefix
+    HINDSIGHT_API_TENANT_ALGORITHMS=RS256,ES256               # allowed algs
+
+Usage:
+    curl -H "Authorization: Bearer <id_or_access_token>" \\
+        https://your-hindsight-server/v1/default/banks/my-bank/memories/recall
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+
+import httpx
+import jwt as pyjwt
+from jwt import PyJWK
+
+from hindsight_api.extensions.tenant import AuthenticationError, Tenant, TenantContext, TenantExtension
+from hindsight_api.models import RequestContext
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Identity", "OidcTenantExtension"]
+
+# Minimum expected token length (JWTs are typically 100+ characters).
+MIN_TOKEN_LENGTH = 20
+
+# Timeout for provider HTTP calls (discovery, JWKS, userinfo).
+REQUEST_TIMEOUT_SECONDS = 10.0
+
+# JWKS cache TTL.
+JWKS_CACHE_TTL_SECONDS = 600
+
+# Minimum interval between JWKS refreshes to avoid hammering the endpoint.
+JWKS_MIN_REFRESH_INTERVAL_SECONDS = 30
+
+# Default asymmetric algorithms supported for JWT signing.
+DEFAULT_ALGORITHMS = ["RS256", "ES256"]
+
+# Schema prefix must be a valid Postgres identifier component.
+_SCHEMA_PREFIX_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+# Postgres identifier maximum length (bytes). Schema names must fit.
+_MAX_IDENTIFIER_LENGTH = 63
+
+# Characters allowed verbatim in a sanitized subject component.
+_SAFE_SUBJECT_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+@dataclass
+class Identity:
+    """Resolved identity for an authenticated request.
+
+    Attributes:
+        subject: Stable unique identifier for the user (used to derive schema).
+        claims: Raw claims/attributes resolved from the token or provider.
+        roles: Optional resolved role names (populated by role-aware subclasses).
+    """
+
+    subject: str
+    claims: dict = field(default_factory=dict)
+    roles: list[str] = field(default_factory=list)
+
+
+class OidcTenantExtension(TenantExtension):
+    """TenantExtension that validates OIDC/JWT tokens for multi-tenant isolation.
+
+    Each authenticated user gets their own PostgreSQL schema derived from a
+    configurable subject claim, ensuring complete memory isolation between users
+    on a shared Hindsight instance.
+    """
+
+    def __init__(self, config: dict[str, str]) -> None:
+        super().__init__(config)
+
+        self.issuer = (config.get("oidc_issuer") or "").rstrip("/")
+        self.audience = config.get("oidc_audience") or None
+        self.jwks_uri = config.get("oidc_jwks_uri") or None
+        self.userinfo_endpoint = config.get("oidc_userinfo_endpoint") or None
+        self.subject_claim = config.get("subject_claim", "sub")
+        self.schema_prefix = config.get("schema_prefix", "user")
+
+        algorithms_raw = config.get("algorithms", "")
+        self.algorithms = (
+            [a.strip() for a in algorithms_raw.split(",") if a.strip()] if algorithms_raw else list(DEFAULT_ALGORITHMS)
+        )
+
+        # Track initialized schemas to avoid redundant migrations.
+        self._initialized_schemas: set[str] = set()
+
+        # Reusable HTTP client (created on startup).
+        self._http_client: httpx.AsyncClient | None = None
+
+        # JWKS state.
+        self._jwks_keys: dict[str, PyJWK] = {}
+        self._jwks_last_fetched: float = 0.0
+
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        """Validate configuration. Subclasses may relax issuer/JWKS requirements."""
+        if not self.issuer and not self.jwks_uri:
+            raise ValueError(
+                "HINDSIGHT_API_TENANT_OIDC_ISSUER is required. "
+                "Set it to your OIDC provider issuer URL (e.g. https://tenant.auth0.com/)."
+            )
+        if not _SCHEMA_PREFIX_RE.match(self.schema_prefix):
+            raise ValueError(
+                f"Invalid schema_prefix '{self.schema_prefix}'. "
+                "Must be a valid Postgres identifier (letters, digits, underscores, "
+                "starting with a letter or underscore)."
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def on_startup(self) -> None:
+        logger.info("Initializing OIDC tenant extension")
+        if self.issuer:
+            logger.info("OIDC issuer: %s", self.issuer)
+        logger.info("Schema prefix: %s_", self.schema_prefix)
+
+        self._http_client = httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS)
+
+        # Discover JWKS URI if not explicitly provided.
+        if not self.jwks_uri and self.issuer:
+            await self._discover()
+
+        if self.jwks_uri:
+            try:
+                await self._fetch_jwks()
+                logger.info("JWKS loaded — using local JWT verification with %d key(s)", len(self._jwks_keys))
+            except Exception as e:  # noqa: BLE001 - best-effort warm-up
+                logger.warning("Could not pre-fetch JWKS (%s); will retry on first request.", e)
+
+    async def on_shutdown(self) -> None:
+        logger.info("Shutting down OIDC tenant extension")
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    # ------------------------------------------------------------------
+    # OIDC discovery + JWKS management
+    # ------------------------------------------------------------------
+
+    async def _discover(self) -> None:
+        """Fetch the OIDC discovery document and cache endpoints."""
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+        url = f"{self.issuer}/.well-known/openid-configuration"
+        try:
+            response = await self._http_client.get(url)
+            response.raise_for_status()
+            doc = response.json()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("OIDC discovery failed at %s (%s)", url, e)
+            return
+        self.jwks_uri = self.jwks_uri or doc.get("jwks_uri")
+        self.userinfo_endpoint = self.userinfo_endpoint or doc.get("userinfo_endpoint")
+        # Prefer the issuer the provider reports, if present.
+        self.issuer = (doc.get("issuer") or self.issuer).rstrip("/")
+
+    async def _fetch_jwks(self) -> None:
+        """Fetch public signing keys from the provider's JWKS endpoint."""
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+        if not self.jwks_uri:
+            raise AuthenticationError("No JWKS URI configured or discovered")
+
+        response = await self._http_client.get(self.jwks_uri)
+        response.raise_for_status()
+
+        jwks_data = response.json()
+        keys: dict[str, PyJWK] = {}
+        for key_data in jwks_data.get("keys", []):
+            kid = key_data.get("kid")
+            if kid:
+                keys[kid] = PyJWK(key_data)
+
+        self._jwks_keys = keys
+        self._jwks_last_fetched = time.monotonic()
+
+    async def _get_signing_key(self, token: str) -> PyJWK:
+        """Resolve the signing key for a token, refreshing JWKS on key rotation."""
+        try:
+            header = pyjwt.get_unverified_header(token)
+        except pyjwt.DecodeError:
+            raise AuthenticationError("Invalid token header")
+        kid = header.get("kid")
+        if not kid:
+            raise AuthenticationError("Token missing key ID (kid) header")
+
+        now = time.monotonic()
+        if not self._jwks_keys or now - self._jwks_last_fetched > JWKS_CACHE_TTL_SECONDS:
+            await self._fetch_jwks()
+
+        if kid in self._jwks_keys:
+            return self._jwks_keys[kid]
+
+        if time.monotonic() - self._jwks_last_fetched > JWKS_MIN_REFRESH_INTERVAL_SECONDS:
+            logger.info("Signing key %s not cached, refreshing JWKS for possible rotation", kid)
+            await self._fetch_jwks()
+            if kid in self._jwks_keys:
+                return self._jwks_keys[kid]
+
+        raise AuthenticationError("Unable to find signing key for token")
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    async def authenticate(self, context: RequestContext) -> TenantContext:
+        """Validate a token and return tenant context with an isolated schema."""
+        token = context.api_key
+        if not token:
+            raise AuthenticationError(
+                "Missing Authorization header. Expected: Bearer <token>",
+                headers={"WWW-Authenticate": 'Bearer realm="hindsight"'},
+            )
+        if len(token) < MIN_TOKEN_LENGTH:
+            raise AuthenticationError("Invalid token format")
+        if self._http_client is None:
+            raise AuthenticationError("Extension not initialized")
+
+        identity = await self._resolve_identity(token)
+        if not identity.subject:
+            raise AuthenticationError("Token valid but missing subject")
+
+        # Load roles (no-op in the base class) and let subclasses stash state.
+        await self._load_roles(token, identity, context)
+
+        schema_name = self._schema_for_subject(identity.subject)
+
+        if schema_name not in self._initialized_schemas:
+            await self._initialize_schema(schema_name)
+
+        return TenantContext(schema_name=schema_name)
+
+    async def _resolve_identity(self, token: str) -> Identity:
+        """Verify the token and resolve the user identity.
+
+        Default implementation performs local JWKS-based JWT verification.
+        Provider-specific subclasses (e.g. GitHub) override this.
+        """
+        try:
+            signing_key = await self._get_signing_key(token)
+            options = {}
+            decode_kwargs: dict = {"algorithms": self.algorithms}
+            if self.audience:
+                decode_kwargs["audience"] = self.audience
+            else:
+                options["verify_aud"] = False
+            if self.issuer:
+                decode_kwargs["issuer"] = self.issuer
+            decode_kwargs["options"] = options
+            payload = pyjwt.decode(token, signing_key.key, **decode_kwargs)
+        except pyjwt.ExpiredSignatureError:
+            raise AuthenticationError("Token has expired")
+        except pyjwt.InvalidAudienceError:
+            raise AuthenticationError("Invalid token audience")
+        except pyjwt.InvalidIssuerError:
+            raise AuthenticationError("Invalid token issuer")
+        except pyjwt.DecodeError:
+            raise AuthenticationError("Invalid token")
+        except AuthenticationError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            raise AuthenticationError(f"Token verification failed: {e!s}")
+
+        subject = payload.get(self.subject_claim)
+        if not subject:
+            raise AuthenticationError(f"Token missing subject claim '{self.subject_claim}'")
+        return Identity(subject=str(subject), claims=payload)
+
+    async def _load_roles(self, token: str, identity: Identity, context: RequestContext) -> None:
+        """Hook for role-aware subclasses. No-op in the generic extension."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Schema management
+    # ------------------------------------------------------------------
+
+    def _schema_for_subject(self, subject: str) -> str:
+        """Derive a safe, isolated Postgres schema name for a subject."""
+        safe = _SAFE_SUBJECT_RE.sub("_", subject)
+        schema = f"{self.schema_prefix}_{safe}"
+        if len(schema) > _MAX_IDENTIFIER_LENGTH:
+            # Hash long/opaque subjects to stay within the identifier limit while
+            # remaining stable and collision-resistant.
+            digest = hashlib.sha256(subject.encode("utf-8")).hexdigest()[:32]
+            schema = f"{self.schema_prefix}_{digest}"
+        return schema
+
+    async def _initialize_schema(self, schema_name: str) -> None:
+        """Run migrations for a new tenant schema and cache the result."""
+        logger.info("Initializing schema: %s", schema_name)
+        try:
+            await self.context.run_migration(schema_name)
+            self._initialized_schemas.add(schema_name)
+            logger.info("Schema ready: %s", schema_name)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Schema initialization failed for %s: %s", schema_name, e)
+            raise AuthenticationError(f"Failed to initialize tenant: {e!s}")
+
+    async def list_tenants(self) -> list[Tenant]:
+        """Return all tenant schemas that have been initialized."""
+        return [Tenant(schema=schema) for schema in self._initialized_schemas]

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -362,25 +362,46 @@ class WorkerPoller:
             return []
 
         schemas = await self._get_schemas()
-        if not schemas:
-            return []
 
         # Scan: find which schemas have pending work using a lightweight
         # EXISTS check (no locks). Then only claim from those schemas
         # using the expensive FOR UPDATE SKIP LOCKED query.
+        #
+        # On the server-side routine path, _scan_active_schemas() is the
+        # authority on where claimable work lives and is independent of
+        # _get_schemas(): the routine probes pg_namespace directly, so it
+        # returns tenant schemas this process never initialized in memory.
+        # That matters because list_tenants() (the source of _get_schemas())
+        # only knows about schemas THIS process created during an
+        # authenticated request — a worker process serves no user requests,
+        # so its in-memory tenant set is empty. We must therefore derive the
+        # claimable schema universe from the scan result UNIONed with
+        # _get_schemas(), never gate claiming on _get_schemas() alone.
         active_schemas = await self._scan_active_schemas(schemas)
 
         if not active_schemas:
-            self._next_schema_idx = (self._next_schema_idx + 1) % len(schemas)
+            if schemas:
+                self._next_schema_idx = (self._next_schema_idx + 1) % len(schemas)
             return []
+
+        # Union the configured tenant list with any schemas the scan
+        # discovered (the routine may surface schemas absent from the
+        # in-memory tenant list). Preserve _get_schemas() ordering first for
+        # stable rotation, then append scan-only schemas deterministically.
+        ordered_schemas: list[str | None] = list(schemas)
+        seen = set(ordered_schemas)
+        for s in sorted(active_schemas, key=lambda x: (x is not None, x or "")):
+            if s not in seen:
+                ordered_schemas.append(s)
+                seen.add(s)
 
         # Build rotation list from active schemas only, preserving their
         # original positions for correct offset advancement.
-        all_indexed = list(enumerate(schemas))
+        all_indexed = list(enumerate(ordered_schemas))
         active_indexed = [(i, s) for i, s in all_indexed if s in active_schemas]
 
         # Rotate so no tenant is always first.
-        start = self._next_schema_idx % len(schemas)
+        start = self._next_schema_idx % len(ordered_schemas)
         rotated = [x for x in active_indexed if x[0] >= start] + [x for x in active_indexed if x[0] < start]
 
         all_tasks: list[ClaimedTask] = []
@@ -440,9 +461,9 @@ class WorkerPoller:
         # Advance offset past the last schema we serviced, or by 1 if
         # nothing was claimed (so we don't keep re-hitting an empty head).
         if last_serviced_idx is not None:
-            self._next_schema_idx = (last_serviced_idx + 1) % len(schemas)
+            self._next_schema_idx = (last_serviced_idx + 1) % len(ordered_schemas)
         else:
-            self._next_schema_idx = (start + 1) % len(schemas)
+            self._next_schema_idx = (start + 1) % len(ordered_schemas)
 
         return all_tasks
 

--- a/hindsight-api-slim/tests/test_github_role_validator.py
+++ b/hindsight-api-slim/tests/test_github_role_validator.py
@@ -1,0 +1,66 @@
+"""Tests for the GitHub role-based OperationValidator."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api.extensions.builtin.github_role_validator import GitHubRoleOperationValidator
+from hindsight_api.extensions.builtin.github_tenant import (
+    ROLE_ADMIN,
+    ROLE_MEMBER,
+    ROLE_VIEWER,
+    encode_tenant_id,
+)
+from hindsight_api.models import RequestContext
+
+
+def _ctx(role: str | None):
+    tenant_id = encode_tenant_id("1", role) if role else None
+    c = MagicMock()
+    c.request_context = RequestContext(api_key="x", tenant_id=tenant_id)
+    return c
+
+
+@pytest.fixture
+def validator():
+    return GitHubRoleOperationValidator({})
+
+
+class TestRetain:
+    @pytest.mark.asyncio
+    async def test_admin_allowed(self, validator):
+        assert (await validator.validate_retain(_ctx(ROLE_ADMIN))).allowed
+
+    @pytest.mark.asyncio
+    async def test_member_allowed(self, validator):
+        assert (await validator.validate_retain(_ctx(ROLE_MEMBER))).allowed
+
+    @pytest.mark.asyncio
+    async def test_viewer_rejected(self, validator):
+        result = await validator.validate_retain(_ctx(ROLE_VIEWER))
+        assert not result.allowed
+
+    @pytest.mark.asyncio
+    async def test_unknown_rejected(self, validator):
+        assert not (await validator.validate_retain(_ctx(None))).allowed
+
+
+class TestReflect:
+    @pytest.mark.asyncio
+    async def test_viewer_rejected(self, validator):
+        assert not (await validator.validate_reflect(_ctx(ROLE_VIEWER))).allowed
+
+    @pytest.mark.asyncio
+    async def test_member_allowed(self, validator):
+        assert (await validator.validate_reflect(_ctx(ROLE_MEMBER))).allowed
+
+
+class TestRecall:
+    @pytest.mark.asyncio
+    async def test_viewer_allowed(self, validator):
+        assert (await validator.validate_recall(_ctx(ROLE_VIEWER))).allowed
+
+    @pytest.mark.asyncio
+    async def test_unknown_allowed_to_read(self, validator):
+        # Recall is permitted for everyone, including unmapped tenants.
+        assert (await validator.validate_recall(_ctx(None))).allowed

--- a/hindsight-api-slim/tests/test_github_tenant.py
+++ b/hindsight-api-slim/tests/test_github_tenant.py
@@ -1,0 +1,232 @@
+"""Tests for the GitHub OAuth Tenant Extension."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from hindsight_api.extensions.builtin.github_tenant import (
+    ROLE_ADMIN,
+    ROLE_MEMBER,
+    ROLE_VIEWER,
+    GitHubTenantExtension,
+    encode_tenant_id,
+    parse_role_from_tenant_id,
+)
+from hindsight_api.extensions.tenant import AuthenticationError, TenantContext, TenantExtension
+from hindsight_api.models import RequestContext
+
+
+def _make_extension(**overrides) -> GitHubTenantExtension:
+    config = {
+        "github_org": "acme",
+        "github_admin_teams": "platform-admins",
+        "github_member_teams": "engineering, data",
+        "github_viewer_teams": "analysts",
+    }
+    config.update(overrides)
+    return GitHubTenantExtension(config)
+
+
+def _resp(status_code=200, json_data=None):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.json.return_value = json_data if json_data is not None else {}
+    return r
+
+
+def _user_resp(user_id=12345678, login="octocat"):
+    return _resp(200, {"id": user_id, "login": login})
+
+
+def _teams_resp(slugs, org="acme"):
+    return _resp(200, [{"slug": s, "organization": {"login": org}} for s in slugs])
+
+
+class TestInit:
+    def test_requires_org(self):
+        with pytest.raises(ValueError, match="GITHUB_ORG is required"):
+            GitHubTenantExtension({})
+
+    def test_is_tenant_extension(self):
+        assert isinstance(_make_extension(), TenantExtension)
+
+    def test_parses_team_config(self):
+        ext = _make_extension()
+        assert ext.admin_teams == {"platform-admins"}
+        assert ext.member_teams == {"engineering", "data"}
+        assert ext.viewer_teams == {"analysts"}
+
+    def test_default_role(self):
+        assert _make_extension().default_role == ROLE_VIEWER
+        assert _make_extension(github_default_role="").default_role == ""
+
+    def test_rejects_bad_default_role(self):
+        with pytest.raises(ValueError, match="Invalid github_default_role"):
+            _make_extension(github_default_role="superuser")
+
+    def test_does_not_require_oidc_issuer(self):
+        # GitHub uses opaque tokens; no issuer needed.
+        ext = _make_extension()
+        assert ext.github_api_url == "https://api.github.com"
+
+    def test_ghes_api_url(self):
+        ext = _make_extension(github_api_url="https://ghe.acme.com/api/v3/")
+        assert ext.github_api_url == "https://ghe.acme.com/api/v3"
+
+
+class TestTenantIdEncoding:
+    def test_round_trip(self):
+        tid = encode_tenant_id("12345678", ROLE_ADMIN)
+        assert tid == "gh_12345678:admin"
+        assert parse_role_from_tenant_id(tid) == ROLE_ADMIN
+
+    def test_parse_none(self):
+        assert parse_role_from_tenant_id(None) is None
+        assert parse_role_from_tenant_id("gh_123") is None
+
+
+class TestIdentityAndSchema:
+    @pytest.mark.asyncio
+    async def test_resolve_identity_uses_numeric_id(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _user_resp(user_id=42, login="alice")
+        identity = await ext._resolve_identity("tok")
+        assert identity.subject == "42"
+        assert identity.claims["login"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_resolve_identity_401(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _resp(401)
+        with pytest.raises(AuthenticationError, match="Invalid or expired GitHub token"):
+            await ext._resolve_identity("tok")
+
+    def test_schema_per_user(self):
+        ext = _make_extension()
+        assert ext._schema_for_subject("42") == "user_42"
+
+
+class TestRoleResolution:
+    @pytest.mark.asyncio
+    async def test_admin_team_wins(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["platform-admins", "engineering"])
+        role = await ext._resolve_role("tok", MagicMock())
+        assert role == ROLE_ADMIN
+
+    @pytest.mark.asyncio
+    async def test_member_role(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["engineering"])
+        assert await ext._resolve_role("tok", MagicMock()) == ROLE_MEMBER
+
+    @pytest.mark.asyncio
+    async def test_viewer_role(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["analysts"])
+        assert await ext._resolve_role("tok", MagicMock()) == ROLE_VIEWER
+
+    @pytest.mark.asyncio
+    async def test_default_role_when_no_mapped_team(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["random-team"])
+        assert await ext._resolve_role("tok", MagicMock()) == ROLE_VIEWER
+
+    @pytest.mark.asyncio
+    async def test_deny_when_default_empty(self):
+        ext = _make_extension(github_default_role="")
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["random-team"])
+        assert await ext._resolve_role("tok", MagicMock()) is None
+
+    @pytest.mark.asyncio
+    async def test_other_org_teams_ignored(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["platform-admins"], org="other-org")
+        # Team belongs to a different org -> falls back to default role.
+        assert await ext._resolve_role("tok", MagicMock()) == ROLE_VIEWER
+
+    @pytest.mark.asyncio
+    async def test_role_is_cached(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._http_client.get.return_value = _teams_resp(["engineering"])
+        await ext._resolve_role("tok", MagicMock())
+        await ext._resolve_role("tok", MagicMock())
+        # Only one teams fetch despite two resolutions.
+        assert ext._http_client.get.await_count == 1
+
+
+class TestAuthenticateEndToEnd:
+    @pytest.mark.asyncio
+    async def test_authenticate_sets_schema_and_role(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+
+        def get(url, **kwargs):
+            if url.endswith("/user"):
+                return _user_resp(user_id=999, login="bob")
+            return _teams_resp(["platform-admins"])
+
+        ext._http_client.get.side_effect = get
+        mock_ctx = MagicMock()
+        mock_ctx.run_migration = AsyncMock()
+        ext.set_context(mock_ctx)
+
+        req = RequestContext(api_key="a" * 40)
+        result = await ext.authenticate(req)
+        assert isinstance(result, TenantContext)
+        assert result.schema_name == "user_999"
+        assert req.tenant_id == "gh_999:admin"
+        mock_ctx.run_migration.assert_awaited_once_with("user_999")
+
+    @pytest.mark.asyncio
+    async def test_authenticate_denies_unauthorized_user(self):
+        ext = _make_extension(github_default_role="")
+        ext._http_client = AsyncMock()
+
+        def get(url, **kwargs):
+            if url.endswith("/user"):
+                return _user_resp(user_id=7, login="nobody")
+            return _teams_resp(["unrelated"])
+
+        ext._http_client.get.side_effect = get
+        ext.set_context(MagicMock())
+
+        with pytest.raises(AuthenticationError, match="not a member of any authorized team"):
+            await ext.authenticate(RequestContext(api_key="a" * 40))
+
+
+class TestAllowedConfigFields:
+    @pytest.mark.asyncio
+    async def test_admin_all_fields(self):
+        ext = _make_extension()
+        ctx = RequestContext(api_key="x", tenant_id=encode_tenant_id("1", ROLE_ADMIN))
+        assert await ext.get_allowed_config_fields(ctx, "bank") is None
+
+    @pytest.mark.asyncio
+    async def test_member_subset(self):
+        ext = _make_extension()
+        ctx = RequestContext(api_key="x", tenant_id=encode_tenant_id("1", ROLE_MEMBER))
+        fields = await ext.get_allowed_config_fields(ctx, "bank")
+        assert isinstance(fields, set) and fields
+
+    @pytest.mark.asyncio
+    async def test_viewer_readonly(self):
+        ext = _make_extension()
+        ctx = RequestContext(api_key="x", tenant_id=encode_tenant_id("1", ROLE_VIEWER))
+        assert await ext.get_allowed_config_fields(ctx, "bank") == set()
+
+    @pytest.mark.asyncio
+    async def test_unknown_fails_closed(self):
+        ext = _make_extension()
+        ctx = RequestContext(api_key="x", tenant_id=None)
+        assert await ext.get_allowed_config_fields(ctx, "bank") == set()

--- a/hindsight-api-slim/tests/test_oidc_tenant.py
+++ b/hindsight-api-slim/tests/test_oidc_tenant.py
@@ -1,0 +1,171 @@
+"""Tests for the generic OIDC Tenant Extension."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt import PyJWK
+
+from hindsight_api.extensions.builtin.oidc_tenant import (
+    _MAX_IDENTIFIER_LENGTH,
+    Identity,
+    OidcTenantExtension,
+)
+from hindsight_api.extensions.tenant import AuthenticationError, Tenant, TenantContext, TenantExtension
+from hindsight_api.models import RequestContext
+
+
+def _make_extension(**overrides) -> OidcTenantExtension:
+    config = {"oidc_issuer": "https://issuer.example.com"}
+    config.update(overrides)
+    return OidcTenantExtension(config)
+
+
+class TestInit:
+    def test_init_valid(self):
+        ext = _make_extension()
+        assert ext.issuer == "https://issuer.example.com"
+        assert ext.subject_claim == "sub"
+        assert ext.schema_prefix == "user"
+        assert ext.algorithms == ["RS256", "ES256"]
+
+    def test_strips_trailing_slash(self):
+        ext = _make_extension(oidc_issuer="https://issuer.example.com/")
+        assert ext.issuer == "https://issuer.example.com"
+
+    def test_requires_issuer_or_jwks(self):
+        with pytest.raises(ValueError, match="HINDSIGHT_API_TENANT_OIDC_ISSUER is required"):
+            OidcTenantExtension({})
+
+    def test_jwks_uri_alone_is_enough(self):
+        ext = OidcTenantExtension({"oidc_jwks_uri": "https://issuer.example.com/jwks"})
+        assert ext.jwks_uri == "https://issuer.example.com/jwks"
+
+    def test_custom_algorithms(self):
+        ext = _make_extension(algorithms="RS256, HS256")
+        assert ext.algorithms == ["RS256", "HS256"]
+
+    def test_rejects_bad_schema_prefix(self):
+        with pytest.raises(ValueError, match="Invalid schema_prefix"):
+            _make_extension(schema_prefix='"; DROP TABLE')
+
+    def test_is_tenant_extension(self):
+        assert isinstance(_make_extension(), TenantExtension)
+
+
+class TestSchemaDerivation:
+    def test_simple_subject(self):
+        ext = _make_extension()
+        assert ext._schema_for_subject("abc123") == "user_abc123"
+
+    def test_sanitizes_unsafe_chars(self):
+        ext = _make_extension()
+        # UUID-style hyphens and provider "|" separators become underscores.
+        assert ext._schema_for_subject("auth0|a1b2-c3") == "user_auth0_a1b2_c3"
+
+    def test_custom_prefix(self):
+        ext = _make_extension(schema_prefix="tenant")
+        assert ext._schema_for_subject("xyz") == "tenant_xyz"
+
+    def test_long_subject_is_hashed_within_identifier_limit(self):
+        ext = _make_extension()
+        schema = ext._schema_for_subject("x" * 200)
+        assert len(schema) <= _MAX_IDENTIFIER_LENGTH
+        assert schema.startswith("user_")
+        # Deterministic.
+        assert schema == ext._schema_for_subject("x" * 200)
+
+
+class TestAuthenticate:
+    @pytest.mark.asyncio
+    async def test_missing_token_raises_with_www_authenticate(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        with pytest.raises(AuthenticationError) as exc:
+            await ext.authenticate(RequestContext(api_key=None))
+        assert "WWW-Authenticate" in exc.value.headers
+
+    @pytest.mark.asyncio
+    async def test_short_token_rejected(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        with pytest.raises(AuthenticationError, match="Invalid token format"):
+            await ext.authenticate(RequestContext(api_key="short"))
+
+    @pytest.mark.asyncio
+    async def test_authenticate_provisions_schema_once(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._resolve_identity = AsyncMock(return_value=Identity(subject="user-42"))
+        mock_ctx = MagicMock()
+        mock_ctx.run_migration = AsyncMock()
+        ext.set_context(mock_ctx)
+
+        token = "a" * 40
+        result = await ext.authenticate(RequestContext(api_key=token))
+        assert isinstance(result, TenantContext)
+        assert result.schema_name == "user_user_42"
+        mock_ctx.run_migration.assert_awaited_once_with("user_user_42")
+
+        # Second call must not re-run migration.
+        await ext.authenticate(RequestContext(api_key=token))
+        assert mock_ctx.run_migration.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_jwks_jwt_verification_end_to_end(self):
+        """Real RSA-signed JWT is verified locally and yields the subject schema."""
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = pyjwt.encode(
+            {"sub": "user-77", "iss": "https://issuer.example.com", "aud": "my-api"},
+            private_key,
+            algorithm="RS256",
+            headers={"kid": "kid-1"},
+        )
+        jwk = PyJWK.from_json(pyjwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+
+        ext = _make_extension(oidc_audience="my-api")
+        ext._http_client = AsyncMock()
+        ext._jwks_keys = {"kid-1": jwk}
+        import time as _t
+
+        ext._jwks_last_fetched = _t.monotonic()
+        mock_ctx = MagicMock()
+        mock_ctx.run_migration = AsyncMock()
+        ext.set_context(mock_ctx)
+
+        result = await ext.authenticate(RequestContext(api_key=token))
+        assert result.schema_name == "user_user_77"
+
+    @pytest.mark.asyncio
+    async def test_expired_jwt_rejected(self):
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = pyjwt.encode(
+            {"sub": "u", "iss": "https://issuer.example.com", "exp": 1},
+            private_key,
+            algorithm="RS256",
+            headers={"kid": "kid-1"},
+        )
+        jwk = PyJWK.from_json(pyjwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._jwks_keys = {"kid-1": jwk}
+        import time as _t
+
+        ext._jwks_last_fetched = _t.monotonic()
+        ext.set_context(MagicMock())
+        with pytest.raises(AuthenticationError, match="expired"):
+            await ext.authenticate(RequestContext(api_key=token))
+
+    @pytest.mark.asyncio
+    async def test_list_tenants_reflects_initialized(self):
+        ext = _make_extension()
+        ext._http_client = AsyncMock()
+        ext._resolve_identity = AsyncMock(return_value=Identity(subject="u1"))
+        mock_ctx = MagicMock()
+        mock_ctx.run_migration = AsyncMock()
+        ext.set_context(mock_ctx)
+
+        await ext.authenticate(RequestContext(api_key="a" * 40))
+        tenants = await ext.list_tenants()
+        assert tenants == [Tenant(schema="user_u1")]

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3146,6 +3146,77 @@ class TestClaimBatchRotation:
             f"Claim called on {len(schemas_claimed)} schemas — should only visit schemas the scan identified as active"
         )
 
+    @pytest.mark.asyncio
+    async def test_claim_batch_claims_scan_only_schema_when_list_tenants_empty(self, pool, backend, clean_operations):
+        """Regression for the worker-side blind spot in self-registering
+        tenant extensions (OIDC/GitHub).
+
+        ``list_tenants()`` for those extensions only returns schemas the
+        *current process* initialized in memory during an authenticated
+        request. A worker process serves no user requests, so its
+        ``list_tenants()`` is permanently empty — but the per-user tenant
+        schemas (and their pending async_operations) very much exist in the
+        database. The server-side ``schemas_with_pending_work()`` routine
+        surfaces them, so ``claim_batch`` must claim from the scan result
+        even when it is wholly disjoint from ``_get_schemas()``.
+
+        Before the fix, ``claim_batch`` bailed at ``if not schemas: return []``
+        (empty ``_get_schemas()``) and never reached the scan, so claimable
+        rows sat pending forever (worker logs: ``queried=0/0 schemas:`` /
+        ``claimable=N`` with ``slots=0``).
+        """
+        from hindsight_api.extensions.tenant import Tenant
+        from hindsight_api.worker import WorkerPoller
+
+        class _EmptyTenantExtension:
+            """Mimics a worker's view of a self-registering extension:
+            authenticate() is never called here, so no schema is ever
+            registered and list_tenants() stays empty."""
+
+            async def list_tenants(self) -> list[Tenant]:
+                return []
+
+        bank_id = f"test-scan-only-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        op_id = uuid.uuid4()
+        await pool.execute(
+            """INSERT INTO async_operations
+               (operation_id, bank_id, operation_type, status, task_payload)
+               VALUES ($1, $2, 'test', 'pending', $3::jsonb)""",
+            op_id,
+            bank_id,
+            json.dumps({"type": "test", "bank_id": bank_id}),
+        )
+
+        # Routine reports 'public' has work; _get_schemas() (empty extension)
+        # returns []. The two sets are disjoint after normalization only by
+        # the empty-vs-{None} gap — claim_batch must still service 'public'.
+        await pool.execute(
+            "CREATE OR REPLACE FUNCTION public.schemas_with_pending_work() "
+            "RETURNS SETOF text AS $$ "
+            "BEGIN RETURN QUERY SELECT 'public'::text; END "
+            "$$ LANGUAGE plpgsql STABLE"
+        )
+        try:
+            poller = WorkerPoller(
+                backend=backend,
+                worker_id="test-scan-only",
+                executor=lambda x: None,
+                tenant_extension=_EmptyTenantExtension(),  # type: ignore[arg-type]
+            )
+
+            claimed = await poller.claim_batch()
+
+            my_claims = [c for c in claimed if c.task_dict.get("bank_id") == bank_id]
+            assert len(my_claims) == 1, (
+                "claim_batch must claim work the routine discovered even when "
+                f"list_tenants() is empty; got {len(my_claims)} claims for our bank"
+            )
+        finally:
+            await pool.execute("DROP FUNCTION IF EXISTS public.schemas_with_pending_work()")
+            await pool.execute("DELETE FROM async_operations WHERE operation_id = $1", op_id)
+
 
 class TestDecommissionAllWorkers:
     """Tests for decommission-workers (all workers) functionality."""

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/audit-logs${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/audit-logs/stats/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/audit-logs/stats${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/config/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/config/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getDataplaneClient, sdk } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { bankId } = await params;
   const response = await sdk.getBankConfig({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to fetch bank config", { request });
@@ -35,7 +35,7 @@ export async function PATCH(
   const { updates } = body;
 
   const response = await sdk.updateBankConfig({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: { updates },
   });
@@ -48,7 +48,7 @@ export async function DELETE(
 ) {
   const { bankId } = await params;
   const response = await sdk.resetBankConfig({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to reset bank config", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/consolidate/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/consolidate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -17,7 +17,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   }
 
   const response = await sdk.triggerConsolidation({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to trigger consolidation", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/consolidation-recover/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/consolidation-recover/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -17,7 +17,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   }
 
   const response = await sdk.recoverConsolidation({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to recover consolidation", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/[directiveId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {
@@ -73,7 +73,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -123,7 +123,7 @@ export async function DELETE(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/directives/${encodeURIComponent(directiveId)}`),
-      { method: "DELETE", headers: getDataplaneHeaders() }
+      { method: "DELETE", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/directives/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       bankId,
       `/directives${queryParams.toString() ? `?${queryParams}` : ""}`
     );
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders(request) });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -77,7 +77,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const response = await fetch(dataplaneBankUrl(bankId, "/directives"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/export/route.ts
@@ -11,7 +11,7 @@ export async function GET(
 
     const url = dataplaneBankUrl(bankId, "/export");
     const response = await fetch(url, {
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/health/llm/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/health/llm/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getDataplaneClient, sdk } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(
@@ -8,7 +8,7 @@ export async function POST(
 ) {
   const { bankId } = await params;
   const response = await sdk.testBankLlm({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to test bank LLM connectivity", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/import/route.ts
@@ -15,7 +15,7 @@ export async function POST(
     const url = dataplaneBankUrl(bankId, `/import${dryRun ? "?dry_run=true" : ""}`);
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/llm-requests${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/stats/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/llm-requests/stats/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const url = dataplaneBankUrl(bankId, `/llm-requests/stats${query ? `?${query}` : ""}`);
     const response = await fetch(url, {
       method: "GET",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/clear/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/clear/route.ts
@@ -21,7 +21,7 @@ export async function POST(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/clear`),
-      { method: "POST", headers: getDataplaneHeaders() }
+      { method: "POST", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/history/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/refresh/route.ts
@@ -21,7 +21,7 @@ export async function POST(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/refresh`),
-      { method: "POST", headers: getDataplaneHeaders() }
+      { method: "POST", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/[mentalModelId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {
@@ -73,7 +73,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -123,7 +123,7 @@ export async function DELETE(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}`),
-      { method: "DELETE", headers: getDataplaneHeaders() }
+      { method: "DELETE", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       bankId,
       `/mental-models${queryParams.toString() ? `?${queryParams}` : ""}`
     );
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders(request) });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -77,7 +77,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
 
     const response = await fetch(dataplaneBankUrl(bankId, "/mental-models"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       body: JSON.stringify(body),
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/[modelId]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
 
     const response = await fetch(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(modelId)}`),
-      { method: "GET", headers: getDataplaneHeaders() }
+      { method: "GET", headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -18,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
 
     // Note: tags filtering is not supported by the list_memories API endpoint
     const response = await sdk.listMemories({
-      client: lowLevelClient,
+      client: getDataplaneClient(request),
       path: { bank_id: bankId },
       query: {
         type: "observation",
@@ -82,7 +82,7 @@ export async function DELETE(
     }
 
     const response = await sdk.clearObservations({
-      client: lowLevelClient,
+      client: getDataplaneClient(request),
       path: { bank_id: bankId },
     });
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
 
     const response = await fetch(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/observations/scopes`,
-      { headers: getDataplaneHeaders() }
+      { headers: getDataplaneHeaders(request) }
     );
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/operations/[operationId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -33,7 +33,7 @@ export async function GET(
   const includePayload = url.searchParams.get("include_payload") === "true";
 
   const response = await sdk.getOperationStatus({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId, operation_id: operationId },
     query: includePayload ? { include_payload: true } : undefined,
   });
@@ -70,7 +70,7 @@ export async function POST(
     const url = dataplaneBankUrl(bankId, `/operations/${encodeURIComponent(operationId)}/retry`);
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
     });
 
     const data = await response.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function PUT(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
@@ -29,7 +29,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ bank
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: {
       name: body.name,
@@ -66,7 +66,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ ba
   }
 
   const response = await sdk.updateBank({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: {
       name: body.name,
@@ -94,7 +94,7 @@ export async function DELETE(
   }
 
   const response = await sdk.deleteBank({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to delete bank", { request });

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/tags/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     if (offset) queryParams.append("offset", offset);
 
     const url = dataplaneBankUrl(bankId, `/tags${queryParams.toString() ? `?${queryParams}` : ""}`);
-    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders() });
+    const response = await fetch(url, { method: "GET", headers: getDataplaneHeaders(request) });
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/deliveries/route.ts
@@ -15,7 +15,7 @@ export async function GET(
   const res = await fetch(
     dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}/deliveries?${qs}`),
     {
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
     }
   );
   const data = await res.json();

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/[webhookId]/route.ts
@@ -10,7 +10,7 @@ export async function PATCH(
   const body = await request.json();
   const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "PATCH",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
     body: JSON.stringify(body),
   });
   const data = await res.json();
@@ -32,7 +32,7 @@ export async function DELETE(
   const { bankId, webhookId } = await params;
   const res = await fetch(dataplaneBankUrl(bankId, `/webhooks/${encodeURIComponent(webhookId)}`), {
     method: "DELETE",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
   });
   const data = await res.json();
   if (!res.ok)

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
@@ -5,7 +5,7 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   const { bankId } = await params;
   const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
   });
   const data = await res.json();
   if (!res.ok)
@@ -24,7 +24,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ ban
   const body = await request.json();
   const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
     method: "POST",
-    headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+    headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
     body: JSON.stringify(body),
   });
   const data = await res.json();

--- a/hindsight-control-plane/src/app/api/banks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 const HTTP_CREATED = 201;
 
 export async function GET(request: Request) {
-  const response = await sdk.listBanks({ client: lowLevelClient });
+  const response = await sdk.listBanks({ client: getDataplaneClient(request) });
   return respondWithSdk(response, "Failed to fetch banks", { request });
 }
 
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id },
     body: {},
   });

--- a/hindsight-control-plane/src/app/api/chunks/[chunkId]/route.ts
+++ b/hindsight-control-plane/src/app/api/chunks/[chunkId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { chunkId } = await params;
   const response = await sdk.getChunk({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { chunk_id: chunkId },
   });
   return respondWithSdk(response, "Failed to fetch chunk", { request });

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     const response = await fetch(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/chunks?limit=${limit}&offset=${offset}`,
       {
-        headers: getDataplaneHeaders(),
+        headers: getDataplaneHeaders(request),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
@@ -25,7 +25,7 @@ export async function POST(
       `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/reprocess`,
       {
         method: "POST",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient, dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -22,7 +22,7 @@ export async function GET(
   }
 
   const response = await sdk.getDocument({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId, document_id: documentId },
   });
   return respondWithSdk(response, "Failed to fetch document", { request });
@@ -52,7 +52,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/documents/${encodeURIComponent(documentId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       }
     );
@@ -95,7 +95,7 @@ export async function DELETE(
   }
 
   const response = await sdk.deleteDocument({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId, document_id: documentId },
   });
   return respondWithSdk(response, "Failed to delete document", { request });

--- a/hindsight-control-plane/src/app/api/documents/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(request: NextRequest) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
   const offset = searchParams.get("offset") ? Number(searchParams.get("offset")) : undefined;
 
   const response = await sdk.listDocuments({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     query: { limit, offset },
   });

--- a/hindsight-control-plane/src/app/api/documents/transfer/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/transfer/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     const suffix = `/document-transfer${qs.toString() ? `?${qs.toString()}` : ""}`;
 
     const response = await fetch(dataplaneBankUrl(bankId, suffix), {
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
     const suffix = `/document-transfer?on_conflict=${encodeURIComponent(onConflict)}`;
     const response = await fetch(dataplaneBankUrl(bankId, suffix), {
       method: "POST",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
       body: outForm,
     });
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/entities/[entityId]/regenerate/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/[entityId]/regenerate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(
@@ -24,7 +24,7 @@ export async function POST(
   const decodedEntityId = decodeURIComponent(entityId);
 
   const response = await sdk.regenerateEntityObservations({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: {
       bank_id: bankId,
       entity_id: decodedEntityId,

--- a/hindsight-control-plane/src/app/api/entities/[entityId]/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/[entityId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -25,7 +25,7 @@ export async function GET(
   const decodedEntityId = decodeURIComponent(entityId);
 
   const response = await sdk.getEntity({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: {
       bank_id: bankId,
       entity_id: decodedEntityId,

--- a/hindsight-control-plane/src/app/api/entities/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/graph/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(request: NextRequest) {
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     : undefined;
 
   const response = await sdk.getEntityGraph({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     query: { limit, min_count: minCount },
   });

--- a/hindsight-control-plane/src/app/api/entities/route.ts
+++ b/hindsight-control-plane/src/app/api/entities/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(request: NextRequest) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
   const offset = searchParams.get("offset") ? Number(searchParams.get("offset")) : undefined;
 
   const response = await sdk.listEntities({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     query: { limit, offset },
   });

--- a/hindsight-control-plane/src/app/api/extract/route.ts
+++ b/hindsight-control-plane/src/app/api/extract/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     const res = await fetch(dataplaneBankUrl(bankId, "/memories/dry-run-extract"), {
       method: "POST",
-      headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+      headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       body: JSON.stringify({
         content,
         retain_mission,

--- a/hindsight-control-plane/src/app/api/files/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/files/retain/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     // Forward the form data to the dataplane
     const response = await fetch(url, {
       method: "POST",
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
       body: formData,
       // Don't set Content-Type - let fetch handle multipart boundary
     });

--- a/hindsight-control-plane/src/app/api/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/graph/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     if (chunkId) params.append("chunk_id", chunkId);
 
     const response = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/graph?${params}`, {
-      headers: getDataplaneHeaders(),
+      headers: getDataplaneHeaders(request),
     });
 
     if (!response.ok) {

--- a/hindsight-control-plane/src/app/api/list/route.ts
+++ b/hindsight-control-plane/src/app/api/list/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { hindsightClient } from "@/lib/hindsight-client";
+import { getDataplaneHindsightClient } from "@/lib/hindsight-client";
 
 export async function GET(request: NextRequest) {
   try {
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
     const state = stateParam === "valid" || stateParam === "invalidated" ? stateParam : undefined;
     const documentId = searchParams.get("document_id") || undefined;
 
-    const response = await hindsightClient.listMemories(bankId, {
+    const response = await getDataplaneHindsightClient(request).listMemories(bankId, {
       limit,
       offset,
       type,

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/history/route.ts
@@ -25,7 +25,7 @@ export async function GET(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}/history`),
       {
         method: "GET",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       }
     );
 

--- a/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/[memoryId]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
       {
         method: "GET",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
       }
     );
 
@@ -83,7 +83,7 @@ export async function PATCH(
       dataplaneBankUrl(bankId, `/memories/${encodeURIComponent(memoryId)}`),
       {
         method: "PATCH",
-        headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
+        headers: getDataplaneHeaders(request, { "Content-Type": "application/json" }),
         body: JSON.stringify({
           text,
           context,

--- a/hindsight-control-plane/src/app/api/memories/retain/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/retain/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { hindsightClient } from "@/lib/hindsight-client";
+import { getDataplaneHindsightClient } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
         }))
       : items;
 
-    const response = await hindsightClient.retainBatch(bankId, mappedItems, {
+    const response = await getDataplaneHindsightClient(request).retainBatch(bankId, mappedItems, {
       documentId: document_id,
       documentTags: document_tags,
     });

--- a/hindsight-control-plane/src/app/api/memories/retain_async/route.ts
+++ b/hindsight-control-plane/src/app/api/memories/retain_async/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: NextRequest) {
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
   const { items } = body;
 
   const response = await sdk.retainMemories({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: { items, async: true },
   });

--- a/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/operations/[agentId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -16,7 +16,7 @@ export async function GET(
   const excludeParents = searchParams.get("exclude_parents") === "true" ? true : undefined;
 
   const response = await sdk.listOperations({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: agentId },
     query: { status, type, limit, offset, exclude_parents: excludeParents },
   });
@@ -42,7 +42,7 @@ export async function DELETE(
   }
 
   const response = await sdk.cancelOperation({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: agentId, operation_id: operationId },
   });
   return respondWithSdk(response, "Failed to cancel operation", { request });

--- a/hindsight-control-plane/src/app/api/profile/[bankId]/route.ts
+++ b/hindsight-control-plane/src/app/api/profile/[bankId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { bankId } = await params;
   const response = await sdk.getBankProfile({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
   });
   return respondWithSdk(response, "Failed to fetch bank profile", { request });
@@ -34,7 +34,7 @@ export async function PUT(
   }
 
   const response = await sdk.createOrUpdateBank({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: body,
   });

--- a/hindsight-control-plane/src/app/api/recall/route.ts
+++ b/hindsight-control-plane/src/app/api/recall/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { lowLevelClient, sdk } from "@/lib/hindsight-client";
+import { getDataplaneClient, sdk } from "@/lib/hindsight-client";
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     } = body;
 
     const response = await sdk.recallMemories({
-      client: lowLevelClient,
+      client: getDataplaneClient(request),
       path: { bank_id: bankId },
       body: {
         query,

--- a/hindsight-control-plane/src/app/api/reflect/route.ts
+++ b/hindsight-control-plane/src/app/api/reflect/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function POST(request: NextRequest) {
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
   }
 
   const response = await sdk.reflect({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: bankId },
     body: requestBody,
   });

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/memories-timeseries/route.ts
@@ -14,7 +14,7 @@ export async function GET(
       agentId,
       `/stats/memories-timeseries?period=${encodeURIComponent(period)}&time_field=${encodeURIComponent(timeField)}`
     );
-    const upstream = await fetch(url, { headers: getDataplaneHeaders() });
+    const upstream = await fetch(url, { headers: getDataplaneHeaders(request) });
     const body = await upstream.json();
     return NextResponse.json(body, { status: upstream.status });
   } catch (error) {

--- a/hindsight-control-plane/src/app/api/stats/[agentId]/route.ts
+++ b/hindsight-control-plane/src/app/api/stats/[agentId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { sdk, lowLevelClient } from "@/lib/hindsight-client";
+import { sdk, getDataplaneClient } from "@/lib/hindsight-client";
 import { respondWithSdk } from "@/lib/sdk-response";
 
 export async function GET(
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { agentId } = await params;
   const response = await sdk.getAgentStats({
-    client: lowLevelClient,
+    client: getDataplaneClient(request),
     path: { bank_id: agentId },
   });
   return respondWithSdk(response, "Failed to fetch stats", { request });

--- a/hindsight-control-plane/src/app/api/version/route.ts
+++ b/hindsight-control-plane/src/app/api/version/route.ts
@@ -4,6 +4,9 @@ import { sdk, lowLevelClient } from "@/lib/hindsight-client";
 
 export async function GET(request: Request) {
   try {
+    // Version is fetched from unauthenticated contexts (e.g. the login page) to
+    // advertise feature flags, so it intentionally uses the shared client /
+    // static key rather than a per-user token.
     const response = await sdk.getVersion({
       client: lowLevelClient,
     });

--- a/hindsight-control-plane/src/lib/auth/dataplane-auth.ts
+++ b/hindsight-control-plane/src/lib/auth/dataplane-auth.ts
@@ -1,0 +1,107 @@
+/**
+ * Request-scoped dataplane authentication resolution.
+ *
+ * The Control Plane is a backend-for-frontend (BFF): browser requests hit
+ * Next.js route handlers, which in turn call the dataplane API. How those
+ * downstream calls authenticate depends on how the deployment is fronted.
+ *
+ * Auth-mode cascade (highest priority first):
+ *
+ *   1. Forwarded `Authorization` header — when the Control Plane runs behind a
+ *      reverse proxy / identity-aware proxy that authenticates the end user and
+ *      forwards their bearer token (e.g. oauth2-proxy with
+ *      `--pass-access-token`, an API gateway, or a direct API caller), we
+ *      forward that exact token to the dataplane. This preserves per-user
+ *      identity end-to-end, so the dataplane can enforce per-user tenant
+ *      isolation. The Control Plane stays auth-agnostic: it trusts whatever
+ *      `Authorization` the upstream proxy injected.
+ *
+ *   2. Static dataplane API key — `HINDSIGHT_CP_DATAPLANE_API_KEY`. A single
+ *      shared credential for all Control Plane traffic. This is the historical
+ *      behavior for self-hosted single-tenant deployments.
+ *
+ *   3. No auth — the dataplane is reachable without credentials (local dev or
+ *      an internally-trusted network).
+ *
+ * Keeping this generic (we forward an opaque `Authorization` header rather than
+ * hard-coding any specific provider) means the same code path works for GitHub
+ * OAuth, OIDC, API gateways, or static keys, and is safe to merge upstream
+ * without coupling the Control Plane to any particular IdP.
+ */
+
+const STATIC_DATAPLANE_API_KEY = process.env.HINDSIGHT_CP_DATAPLANE_API_KEY || "";
+
+/**
+ * Additional inbound headers that identity-aware proxies use to carry the
+ * end-user's access token. Checked only when a raw `Authorization` header is
+ * not already present. Order is significant (first match wins).
+ */
+const FORWARDED_TOKEN_HEADERS = [
+  "x-forwarded-access-token",
+  "x-auth-request-access-token",
+] as const;
+
+/**
+ * Resolve the `Authorization` header value the dataplane call should use for a
+ * given inbound request, following the cascade documented above.
+ *
+ * @returns the full header value (e.g. `"Bearer abc123"`) or `undefined` when
+ *          no credential applies (open dataplane).
+ */
+export function resolveDataplaneAuthHeader(
+  request: { headers: Headers | { get(name: string): string | null } }
+): string | undefined {
+  const get = (name: string) => request.headers.get(name);
+
+  // 1. Pass through an Authorization header injected upstream / by the caller.
+  const inboundAuth = get("authorization");
+  if (inboundAuth && inboundAuth.trim().length > 0) {
+    return inboundAuth;
+  }
+
+  // 1b. Some proxies forward only the raw token in a side header.
+  for (const headerName of FORWARDED_TOKEN_HEADERS) {
+    const token = get(headerName);
+    if (token && token.trim().length > 0) {
+      return `Bearer ${token.trim()}`;
+    }
+  }
+
+  // 2. Fall back to the static shared dataplane key, if configured.
+  if (STATIC_DATAPLANE_API_KEY) {
+    return `Bearer ${STATIC_DATAPLANE_API_KEY}`;
+  }
+
+  // 3. No credential — open dataplane.
+  return undefined;
+}
+
+/**
+ * Build a header object for direct `fetch` calls to the dataplane, merging the
+ * resolved `Authorization` header with any caller-provided extras.
+ */
+export function dataplaneHeadersFor(
+  request: { headers: Headers | { get(name: string): string | null } },
+  extra?: Record<string, string>
+): Record<string, string> {
+  const headers: Record<string, string> = { ...extra };
+  const auth = resolveDataplaneAuthHeader(request);
+  if (auth) {
+    headers["Authorization"] = auth;
+  }
+  return headers;
+}
+
+/**
+ * True when this deployment is fronted by an identity-aware proxy that has
+ * already authenticated the end user (i.e. a usable forwarded credential is
+ * present on the request). Used by the UI auth gate to decide whether the
+ * Control Plane's own login is required.
+ */
+export function hasForwardedIdentity(
+  request: { headers: Headers | { get(name: string): string | null } }
+): boolean {
+  const get = (name: string) => request.headers.get(name);
+  if ((get("authorization") || "").trim().length > 0) return true;
+  return FORWARDED_TOKEN_HEADERS.some((h) => (get(h) || "").trim().length > 0);
+}

--- a/hindsight-control-plane/src/lib/hindsight-client.ts
+++ b/hindsight-control-plane/src/lib/hindsight-client.ts
@@ -11,18 +11,78 @@ import {
   sdk,
 } from "@vectorize-io/hindsight-client";
 
+import {
+  dataplaneHeadersFor,
+  resolveDataplaneAuthHeader,
+} from "@/lib/auth/dataplane-auth";
+
 export const DATAPLANE_URL = process.env.HINDSIGHT_CP_DATAPLANE_API_URL || "http://localhost:8888";
 const DATAPLANE_API_KEY = process.env.HINDSIGHT_CP_DATAPLANE_API_KEY || "";
 
 /**
- * Auth headers for direct fetch calls to the dataplane API.
+ * Minimal shape of an inbound request needed to resolve auth — anything with a
+ * header getter (Next.js `Request` / `NextRequest` both satisfy this).
  */
-export function getDataplaneHeaders(extra?: Record<string, string>): Record<string, string> {
+type InboundRequest = { headers: Headers | { get(name: string): string | null } };
+
+/**
+ * Auth headers for direct fetch calls to the dataplane API.
+ *
+ * When an inbound `request` is supplied, auth is resolved per-request via the
+ * cascade in {@link dataplaneHeadersFor} (forwarded user token > static key >
+ * none) — this is what route handlers acting on behalf of a user should pass.
+ *
+ * When `request` is omitted (or `null`), it falls back to the static key only —
+ * for server-side contexts with no end user (health checks, background tasks).
+ */
+export function getDataplaneHeaders(
+  request?: InboundRequest | null,
+  extra?: Record<string, string>
+): Record<string, string> {
+  if (request) {
+    return dataplaneHeadersFor(request, extra);
+  }
   const headers: Record<string, string> = { ...extra };
   if (DATAPLANE_API_KEY) {
     headers["Authorization"] = `Bearer ${DATAPLANE_API_KEY}`;
   }
   return headers;
+}
+
+/**
+ * Build a request-scoped low-level SDK client whose `Authorization` header is
+ * resolved from the inbound request (forwarded user token > static key > none).
+ *
+ * Route handlers that act on behalf of an end user should use this instead of
+ * the shared {@link lowLevelClient} singleton, so the user's identity is
+ * carried through to the dataplane.
+ */
+export function getDataplaneClient(request: InboundRequest) {
+  const auth = resolveDataplaneAuthHeader(request);
+  return createClient(
+    createConfig({
+      baseUrl: DATAPLANE_URL,
+      headers: auth ? { Authorization: auth } : undefined,
+    })
+  );
+}
+
+/**
+ * Build a request-scoped high-level {@link HindsightClient} whose auth is
+ * resolved from the inbound request (forwarded user token > static key > none).
+ *
+ * Use this instead of the shared {@link hindsightClient} singleton in route
+ * handlers that act on behalf of an end user.
+ */
+export function getDataplaneHindsightClient(request: InboundRequest): HindsightClient {
+  const auth = resolveDataplaneAuthHeader(request);
+  // HindsightClient takes an apiKey and prefixes it with "Bearer ". Strip a
+  // leading "Bearer " from the resolved header so we don't double-prefix.
+  const apiKey = auth?.replace(/^Bearer\s+/i, "") || undefined;
+  return new HindsightClient({
+    baseUrl: DATAPLANE_URL,
+    apiKey,
+  });
 }
 
 /**

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -4,6 +4,7 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 import createIntlMiddleware from "next-intl/middleware";
 
 import { ACCESS_KEY_COOKIE, verifySessionToken } from "@/lib/auth/session";
+import { hasForwardedIdentity } from "@/lib/auth/dataplane-auth";
 import { stripBasePath, withBasePath } from "@/lib/base-path";
 import { routing } from "@/i18n/routing";
 
@@ -27,9 +28,19 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const appPathname = stripBasePath(pathname);
 
+  // UI auth-gate cascade:
+  //   1. If an identity-aware proxy in front of the Control Plane already
+  //      authenticated the user (forwarded Authorization / access-token
+  //      header), trust it and skip the Control Plane's own login entirely.
+  //   2. Else, if HINDSIGHT_CP_ACCESS_KEY is set, require the access-key login.
+  //   3. Else, no auth — open UI.
+  // This keeps single-tenant self-hosted behavior unchanged while letting a
+  // reverse proxy own authentication without a second login prompt.
+  const proxyAuthenticated = hasForwardedIdentity(request);
+
   // API routes are not locale-prefixed — handle auth directly without i18n routing.
   if (appPathname.startsWith("/api/")) {
-    if (!accessKey) {
+    if (!accessKey || proxyAuthenticated) {
       return NextResponse.next();
     }
 
@@ -57,7 +68,7 @@ export async function middleware(request: NextRequest) {
   // Page routes: enforce auth first, then delegate to the i18n middleware for
   // locale negotiation and rewriting. With localePrefix "never" the locale is
   // never in the path, so appPathname is already the canonical route.
-  if (accessKey) {
+  if (accessKey && !proxyAuthenticated) {
     const isPublic = PUBLIC_PATTERNS.some((pattern) => appPathname.startsWith(pattern));
 
     if (!isPublic) {

--- a/hindsight-docs/docs/developer/extensions.md
+++ b/hindsight-docs/docs/developer/extensions.md
@@ -32,6 +32,57 @@ HINDSIGHT_API_TENANT_SUPABASE_SERVICE_KEY=your-service-role-key
 
 See the [source code](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/extensions/builtin/supabase_tenant.py) for complete configuration options and implementation details.
 
+**Built-in: OidcTenantExtension**
+
+Generic OpenID Connect / OAuth multi-tenancy for any standard OIDC provider (Auth0, Okta, Keycloak, Microsoft Entra ID, Google, ...). Each authenticated user gets their own PostgreSQL schema (`{prefix}_{subject}`), ensuring complete data separation. Tokens are verified locally using JWKS discovered from the provider's `/.well-known/openid-configuration` document (no network call per request).
+
+```bash
+HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.oidc_tenant:OidcTenantExtension
+HINDSIGHT_API_TENANT_OIDC_ISSUER=https://your-tenant.auth0.com/
+
+# Optional
+HINDSIGHT_API_TENANT_OIDC_AUDIENCE=your-api-audience        # expected `aud` claim
+HINDSIGHT_API_TENANT_OIDC_JWKS_URI=https://.../jwks.json    # skip discovery
+HINDSIGHT_API_TENANT_SUBJECT_CLAIM=sub                      # claim used to derive the schema
+HINDSIGHT_API_TENANT_SCHEMA_PREFIX=user                     # schema prefix (default "user")
+HINDSIGHT_API_TENANT_ALGORITHMS=RS256,ES256                 # allowed signing algorithms
+```
+
+The subject claim is sanitized into a valid Postgres identifier; long/opaque subjects are hashed to stay within the identifier length limit. See the [source code](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/extensions/builtin/oidc_tenant.py) for details.
+
+**Built-in: GitHubTenantExtension**
+
+A purpose-built configuration of `OidcTenantExtension` for **GitHub OAuth** that adds **team-based role assignment**. GitHub OAuth user access tokens are opaque (not JWTs), so this variant validates them against the GitHub REST API instead of JWKS.
+
+Like the other tenant extensions, **each GitHub user gets their own isolated schema** — `{prefix}_{github_user_id}`, keyed on the immutable numeric user id. In addition, the user's GitHub **team membership** in a configured org is mapped to a Hindsight role that **gates capabilities** (the schema stays per-user):
+
+| Role | Memory operations | Bank config |
+| --- | --- | --- |
+| `admin` | retain / recall / reflect | all configurable fields |
+| `member` | retain / recall / reflect | a curated subset of fields |
+| `viewer` | recall only (read-only) | none (read-only) |
+
+```bash
+HINDSIGHT_API_TENANT_EXTENSION=hindsight_api.extensions.builtin.github_tenant:GitHubTenantExtension
+HINDSIGHT_API_TENANT_GITHUB_ORG=my-org
+
+# Team slugs (comma-separated) mapped to each role
+HINDSIGHT_API_TENANT_GITHUB_ADMIN_TEAMS=platform-admins
+HINDSIGHT_API_TENANT_GITHUB_MEMBER_TEAMS=engineering,data
+HINDSIGHT_API_TENANT_GITHUB_VIEWER_TEAMS=analysts
+
+# Optional
+HINDSIGHT_API_TENANT_GITHUB_DEFAULT_ROLE=viewer             # role for org members in no mapped team; empty = deny
+HINDSIGHT_API_TENANT_GITHUB_API_URL=https://api.github.com  # set for GitHub Enterprise Server
+HINDSIGHT_API_TENANT_GITHUB_ROLE_CACHE_TTL=300              # seconds to cache resolved roles
+HINDSIGHT_API_TENANT_SCHEMA_PREFIX=user
+
+# Companion validator that enforces read/write gating on retain/recall/reflect
+HINDSIGHT_API_OPERATION_VALIDATOR_EXTENSION=hindsight_api.extensions.builtin.github_role_validator:GitHubRoleOperationValidator
+```
+
+Role enforcement is split across two hooks: bank-config write permissions are enforced by the tenant extension's `get_allowed_config_fields`, while retain/recall/reflect gating is enforced by the companion `GitHubRoleOperationValidator`. The resolved role is propagated to the validator through `RequestContext.tenant_id` (encoded as `gh_<id>:<role>`), so no extra GitHub API call is made per operation. See the [source code](https://github.com/vectorize-io/hindsight/blob/main/hindsight-api-slim/hindsight_api/extensions/builtin/github_tenant.py) for details.
+
 For other multi-tenant setups with separate schemas per tenant (e.g., custom JWT-based auth), implement a custom `TenantExtension`.
 
 ---


### PR DESCRIPTION
## Summary

Two related changes that enable multi-user, self-hosted Hindsight deployments with per-user tenant isolation behind a generic identity layer:

1. **New built-in tenant extensions** (`feat`) — OIDC and GitHub, plus a GitHub role-based operation validator.
2. **Worker poller follow-up fix** (`fix`) — drains pending work even when the in-memory tenant list is empty (the scenario self-registering extensions create). Follow-up to #1555.

Both changes are additive and backward-compatible: behavior is unchanged unless the new extensions are explicitly selected via environment variables.

## Tenant extensions

Adds two built-in `TenantExtension` implementations alongside the existing `ApiKeyTenantExtension` / `SupabaseTenantExtension`:

- **`OidcTenantExtension`** — generic OIDC/OAuth bearer-token auth via JWKS, with per-user schema isolation. Works with any standards-compliant IdP.
- **`GitHubTenantExtension`** — GitHub OAuth: validates the token via `GET /user` and `GET /user/teams`, derives a per-user schema and team-based roles.
- **`GitHubRoleOperationValidator`** — gates `retain`/`recall`/`reflect` by the GitHub team-derived role.

Activated only when `HINDSIGHT_API_TENANT_EXTENSION` points at them — no default behavior change.

### Control Plane (BFF) auth made provider-agnostic

The Control Plane now resolves the downstream dataplane `Authorization` header through a new `resolveDataplaneAuthHeader()` cascade:

1. Forward an inbound `Authorization` / `X-Forwarded-Access-Token` header when present (identity-aware proxy or direct caller) — preserves end-to-end per-user identity for tenant isolation.
2. Else fall back to the static `HINDSIGHT_CP_DATAPLANE_API_KEY` (historical single-tenant behavior).
3. Else no auth (local dev / internally-trusted network).

This forwards an opaque `Authorization` header rather than hard-coding any IdP, so the same path works for GitHub OAuth, OIDC, API gateways, or static keys — **no coupling to oauth2-proxy or any specific provider**.

## Worker fix (follow-up to #1555)

#1555 fixed the `'public'` vs `None` normalization mismatch in `_scan_active_schemas()`. While integrating self-registering tenant extensions I hit two remaining blind spots in `claim_batch()` in the same code path:

1. `if not schemas: return []` early-exits whenever `_get_schemas()` (the in-memory tenant list from `list_tenants()`) is empty. A worker process serves no authenticated user requests, so extensions that only learn about a schema during a request leave the worker's tenant list empty — and the worker never even scans for work.
2. Claiming is built from the tenant list rather than the scan results, so a schema discovered **only** by `public.schemas_with_pending_work()` is never claimed.

Fix: drop the early-exit and union scan-discovered schemas with the in-memory tenant list before claiming (preserving `_get_schemas()` ordering for stable rotation). Pending work now drains regardless of whether the tenant list is populated.

## Tests

- New unit tests: `test_oidc_tenant.py`, `test_github_tenant.py`, `test_github_role_validator.py`.
- New worker regression test `test_claim_batch_claims_scan_only_schema_when_list_tenants_empty` covering the empty-tenant-list path.
- `ruff check` and `ruff format --check` pass on all changed Python.

## Notes

- Docs added under `docs/developer/extensions.md`.
- No new dependencies (no `pyproject.toml` / lockfile changes).
