### PR TITLE
fix(retain): honor configured LLM temperature in the batch fact-extraction path (#2469 follow-up)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1203,8 +1203,16 @@ def _build_request_body(llm_config, config, prompt: str, user_message: str, resp
     request_body = {
         "model": llm_config.model,
         "messages": [{"role": "system", "content": prompt}, {"role": "user", "content": user_message}],
-        "temperature": 0.1,
     }
+
+    # Honour the configured retain temperature. ``None`` omits the parameter
+    # entirely (for models like Azure GPT-5.5 that reject explicit temperatures),
+    # mirroring LLMProvider.call, which drops temperature when it is None. The
+    # batch path builds the request body directly instead of going through
+    # LLMProvider.call (#2469 only de-hardcoded the streaming path), so it must
+    # apply the same rule here.
+    if config.llm_temperature_retain is not None:
+        request_body["temperature"] = config.llm_temperature_retain
 
     # Add max_completion_tokens if configured
     if config.retain_max_completion_tokens:

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -217,3 +217,43 @@ async def test_none_event_date_with_valid_facts_no_crash():
 
     assert len(facts) == 1
     assert "Alice visited Paris" in facts[0].fact
+
+
+def _make_batch_temp_config(temperature):
+    """Minimal config for _build_request_body temperature tests."""
+    from hindsight_api.config import HindsightConfig
+
+    cfg = MagicMock(spec=HindsightConfig)
+    cfg.llm_temperature_retain = temperature
+    cfg.retain_max_completion_tokens = None
+    cfg.llm_strict_schema = False
+    return cfg
+
+
+def _make_batch_llm_config():
+    """Minimal LLMProvider mock for _build_request_body (non-openai skips service_tier)."""
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    llm = MagicMock(spec=LLMProvider)
+    llm.model = "gpt-test"
+    llm.provider = "mock"
+    return llm
+
+
+def test_build_request_body_forwards_configured_temperature():
+    """Batch retain path must send the configured retain temperature."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    body = _build_request_body(_make_batch_llm_config(), _make_batch_temp_config(0.7), "sys", "user", dict)
+    assert body["temperature"] == 0.7
+
+
+def test_build_request_body_omits_temperature_when_none():
+    """HINDSIGHT_API_LLM_TEMPERATURE=none must drop temperature from the batch
+    request body too (Azure GPT-5.5 rejects explicit temperatures). Follow-up to
+    #2469, which only de-hardcoded the streaming path and left the batch
+    _build_request_body hardcoding temperature=0.1."""
+    from hindsight_api.engine.retain.fact_extraction import _build_request_body
+
+    body = _build_request_body(_make_batch_llm_config(), _make_batch_temp_config(None), "sys", "user", dict)
+    assert "temperature" not in body


### PR DESCRIPTION
## Summary

#2469 (fixes #2459) made per-operation temperature configurable so models like Azure `gpt-5.5` — which reject *any* explicit `temperature` — work with `HINDSIGHT_API_LLM_TEMPERATURE=none`. It de-hardcoded the streaming fact-extraction call (`temperature=config.llm_temperature_retain` at `_extract_facts_from_chunk`), but the **batch** path was missed: `_build_request_body` still hardcodes `"temperature": 0.1`.

So on the batch retain path, `HINDSIGHT_API_LLM_TEMPERATURE=none` is silently ignored and Azure `gpt-5.5` keeps rejecting the request with `Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.` — the exact failure #2469 set out to fix.

## Change

`_build_request_body` now honours `config.llm_temperature_retain`, and **omits** the field entirely when it is `None`, mirroring `LLMProvider.call` (`if temperature is not None`). The `0.0` case is preserved via `is not None` (not a falsy check).

## Tests

- `test_build_request_body_forwards_configured_temperature` — configured value reaches the request body
- `test_build_request_body_omits_temperature_when_none` — `none` drops the field for temperature-rejecting models

Follow-up to merged #2469.
