### PR TITLE
fix(claude-code): don't retain Claude Code injected/synthetic context

### DIFF
--- a/hindsight-integrations/claude-code/.gitattributes
+++ b/hindsight-integrations/claude-code/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must always check out with LF endings. On Windows, a global
+# core.autocrlf=true otherwise rewrites them to CRLF, which breaks the `\`
+# line-continuations and the shebang when the hooks run under Git Bash.
+*.sh text eol=lf

--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -56,9 +56,13 @@ def strip_injected_context(content: str) -> str:
     wrappers (``<system-reminder>``, ``<command-*>``, ...). These were never
     sent by the user, so drop them before retention to keep memories limited to
     the messages actually exchanged.
+
+    The opening-tag pattern (``<tag\b[^>]*>``) tolerates attributes, mirroring
+    ``strip_channel_envelope`` — so a future ``<system-reminder priority="x">``
+    still matches instead of silently slipping through.
     """
     for tag in INJECTED_CONTEXT_TAGS:
-        content = re.sub(rf"<{tag}>[\s\S]*?</{tag}>", "", content)
+        content = re.sub(rf"<{tag}\b[^>]*>[\s\S]*?</{tag}>", "", content)
     return content
 
 
@@ -66,15 +70,26 @@ def strip_memory_tags(content: str) -> str:
     """Remove <hindsight_memories> and <relevant_memories> blocks.
 
     Prevents retain feedback loop — these were injected during recall and
-    should not be re-stored. Also drops Claude Code harness-injected context
-    (see strip_injected_context) so behind-the-scenes turns are not retained.
+    should not be re-stored. Single-responsibility: harness-injected context is
+    handled separately by strip_injected_context; use sanitize_content when both
+    concerns apply.
 
     Port of: stripMemoryTags() in index.js
     """
-    content = re.sub(r"<hindsight_memories>[\s\S]*?</hindsight_memories>", "", content)
-    content = re.sub(r"<relevant_memories>[\s\S]*?</relevant_memories>", "", content)
-    content = strip_injected_context(content)
+    content = re.sub(r"<hindsight_memories\b[^>]*>[\s\S]*?</hindsight_memories>", "", content)
+    content = re.sub(r"<relevant_memories\b[^>]*>[\s\S]*?</relevant_memories>", "", content)
     return content
+
+
+def sanitize_content(content: str) -> str:
+    """Strip everything the user/assistant did not actually author.
+
+    Composes the two independent stripping concerns so call sites get a fully
+    cleaned message from one place while each underlying function stays focused:
+      - strip_memory_tags: recall-injected memory blocks (feedback-loop guard)
+      - strip_injected_context: Claude Code harness-injected synthetic turns
+    """
+    return strip_injected_context(strip_memory_tags(content))
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +132,7 @@ def compose_recall_query(
 
         content = _extract_text_content(msg.get("content", ""), role=role)
         content = strip_channel_envelope(content)
-        content = strip_memory_tags(content).strip()
+        content = sanitize_content(content).strip()
         if not content:
             continue
 
@@ -273,7 +288,7 @@ def _extract_message_blocks(content, role: str = "") -> list:
       - Channel message tool_use blocks get their text extracted inline.
     """
     if isinstance(content, str):
-        cleaned = strip_channel_envelope(strip_memory_tags(content)).strip()
+        cleaned = strip_channel_envelope(sanitize_content(content)).strip()
         return [{"type": "text", "text": cleaned}] if cleaned else []
 
     if not isinstance(content, list):
@@ -286,7 +301,7 @@ def _extract_message_blocks(content, role: str = "") -> list:
         block_type = block.get("type", "")
 
         if block_type == "text":
-            text = strip_channel_envelope(strip_memory_tags(block.get("text", ""))).strip()
+            text = strip_channel_envelope(sanitize_content(block.get("text", ""))).strip()
             if text:
                 blocks.append({"type": "text", "text": text})
 
@@ -413,7 +428,7 @@ def _prepare_text_transcript(messages: list, allowed_roles: set) -> tuple:
 
         content = _extract_text_content(msg.get("content", ""), role=role)
         content = strip_channel_envelope(content)
-        content = strip_memory_tags(content).strip()
+        content = sanitize_content(content).strip()
 
         if not content:
             continue

--- a/hindsight-integrations/claude-code/scripts/lib/content.py
+++ b/hindsight-integrations/claude-code/scripts/lib/content.py
@@ -35,16 +35,45 @@ def strip_channel_envelope(content: str) -> str:
     return content
 
 
+# Claude Code injects harness context into transcript turns using these XML
+# wrappers. The text inside was never authored by the user or assistant (skill
+# reminders, task notifications, local command output, slash-command metadata),
+# so it should not be retained as memory.
+INJECTED_CONTEXT_TAGS = (
+    "system-reminder",
+    "task-notification",
+    "local-command-stdout",
+    "command-name",
+    "command-message",
+    "command-args",
+)
+
+
+def strip_injected_context(content: str) -> str:
+    """Remove Claude Code harness-injected context wrappers.
+
+    Claude Code rides synthetic context inside otherwise-real turns using XML
+    wrappers (``<system-reminder>``, ``<command-*>``, ...). These were never
+    sent by the user, so drop them before retention to keep memories limited to
+    the messages actually exchanged.
+    """
+    for tag in INJECTED_CONTEXT_TAGS:
+        content = re.sub(rf"<{tag}>[\s\S]*?</{tag}>", "", content)
+    return content
+
+
 def strip_memory_tags(content: str) -> str:
     """Remove <hindsight_memories> and <relevant_memories> blocks.
 
     Prevents retain feedback loop — these were injected during recall and
-    should not be re-stored.
+    should not be re-stored. Also drops Claude Code harness-injected context
+    (see strip_injected_context) so behind-the-scenes turns are not retained.
 
     Port of: stripMemoryTags() in index.js
     """
     content = re.sub(r"<hindsight_memories>[\s\S]*?</hindsight_memories>", "", content)
     content = re.sub(r"<relevant_memories>[\s\S]*?</relevant_memories>", "", content)
+    content = strip_injected_context(content)
     return content
 
 

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -54,6 +54,12 @@ def read_transcript(transcript_path: str) -> list:
                     continue
                 try:
                     entry = json.loads(line)
+                    # Claude Code marks injected/synthetic turns (skill docs,
+                    # settings schemas, slash-command expansions) with isMeta.
+                    # These were never authored by the user or assistant, so
+                    # skip them to avoid retaining behind-the-scenes context.
+                    if entry.get("isMeta"):
+                        continue
                     # Claude Code nested format: {type: "user", message: {role, content}}
                     if entry.get("type") in ("user", "assistant"):
                         msg = entry.get("message", {})

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -11,6 +11,7 @@ from lib.content import (
     format_current_time,
     format_memories,
     prepare_retention_transcript,
+    sanitize_content,
     slice_last_turns_by_user_boundary,
     strip_channel_envelope,
     strip_injected_context,
@@ -67,12 +68,42 @@ class TestStripMemoryTags:
         raw = "<hindsight_memories>\n- mem1\n- mem2\n</hindsight_memories>"
         assert strip_memory_tags(raw).strip() == ""
 
-    def test_also_strips_injected_context(self):
+    def test_strips_memory_block_with_attributes(self):
+        raw = 'before <hindsight_memories count="3">secret</hindsight_memories> after'
+        result = strip_memory_tags(raw)
+        assert "hindsight_memories" not in result
+        assert "secret" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_leaves_injected_context_alone(self):
+        # strip_memory_tags is single-responsibility: harness-injected context
+        # is sanitize_content's job, not this function's.
         raw = "real question <system-reminder>harness noise</system-reminder>"
         result = strip_memory_tags(raw)
-        assert "system-reminder" not in result
+        assert "harness noise" in result
+
+
+# ---------------------------------------------------------------------------
+# sanitize_content
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeContent:
+    def test_strips_both_memory_tags_and_injected_context(self):
+        raw = (
+            "real question "
+            "<hindsight_memories>recalled</hindsight_memories> "
+            "<system-reminder>harness noise</system-reminder>"
+        )
+        result = sanitize_content(raw)
+        assert "recalled" not in result
         assert "harness noise" not in result
         assert "real question" in result
+
+    def test_passthrough_clean_text(self):
+        raw = "an ordinary user message"
+        assert sanitize_content(raw) == raw
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +138,16 @@ class TestStripInjectedContext:
     def test_strips_local_command_stdout(self):
         raw = "q <local-command-stdout>output</local-command-stdout>"
         assert "output" not in strip_injected_context(raw)
+
+    def test_strips_tag_with_attributes(self):
+        # The opening-tag pattern tolerates attributes so a future
+        # <system-reminder priority="high"> still gets stripped.
+        raw = 'keep <system-reminder priority="high">injected</system-reminder> me'
+        result = strip_injected_context(raw)
+        assert "injected" not in result
+        assert "system-reminder" not in result
+        assert "keep" in result
+        assert "me" in result
 
     def test_passthrough_clean_text(self):
         raw = "an ordinary user message"

--- a/hindsight-integrations/claude-code/tests/test_content.py
+++ b/hindsight-integrations/claude-code/tests/test_content.py
@@ -13,6 +13,7 @@ from lib.content import (
     prepare_retention_transcript,
     slice_last_turns_by_user_boundary,
     strip_channel_envelope,
+    strip_injected_context,
     strip_memory_tags,
     truncate_recall_query,
 )
@@ -65,6 +66,51 @@ class TestStripMemoryTags:
     def test_strips_multiline_block(self):
         raw = "<hindsight_memories>\n- mem1\n- mem2\n</hindsight_memories>"
         assert strip_memory_tags(raw).strip() == ""
+
+    def test_also_strips_injected_context(self):
+        raw = "real question <system-reminder>harness noise</system-reminder>"
+        result = strip_memory_tags(raw)
+        assert "system-reminder" not in result
+        assert "harness noise" not in result
+        assert "real question" in result
+
+
+# ---------------------------------------------------------------------------
+# strip_injected_context
+# ---------------------------------------------------------------------------
+
+
+class TestStripInjectedContext:
+    def test_strips_system_reminder(self):
+        raw = "keep me <system-reminder>injected</system-reminder> too"
+        result = strip_injected_context(raw)
+        assert "injected" not in result
+        assert "keep me" in result
+        assert "too" in result
+
+    def test_strips_command_wrappers(self):
+        raw = (
+            "<command-name>/foo</command-name>"
+            "<command-message>msg</command-message>"
+            "<command-args>bar</command-args>"
+        )
+        assert strip_injected_context(raw).strip() == ""
+
+    def test_strips_multiline_task_notification(self):
+        raw = "before\n<task-notification>\nline1\nline2\n</task-notification>\nafter"
+        result = strip_injected_context(raw)
+        assert "task-notification" not in result
+        assert "line1" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_strips_local_command_stdout(self):
+        raw = "q <local-command-stdout>output</local-command-stdout>"
+        assert "output" not in strip_injected_context(raw)
+
+    def test_passthrough_clean_text(self):
+        raw = "an ordinary user message"
+        assert strip_injected_context(raw) == raw
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -754,3 +754,62 @@ class TestRetainHook:
             mod.main()
 
         assert "called" not in captured
+
+
+# ---------------------------------------------------------------------------
+# read_transcript — nested-format parsing and isMeta filtering
+# ---------------------------------------------------------------------------
+
+
+def _load_read_transcript():
+    """Import read_transcript from the retain hook script."""
+    scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+    spec = importlib.util.spec_from_file_location("retain_read_transcript", os.path.join(scripts_dir, "retain.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.read_transcript
+
+
+def _write_jsonl(tmp_path, entries):
+    """Write raw transcript entries (Claude Code nested format) as JSONL."""
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("\n".join(json.dumps(e) for e in entries))
+    return str(f)
+
+
+class TestReadTranscript:
+    def test_skips_isMeta_entries(self, tmp_path):
+        """isMeta turns (skill docs, schemas, slash-command expansions) are dropped."""
+        read_transcript = _load_read_transcript()
+        entries = [
+            {"type": "user", "message": {"role": "user", "content": "real question"}},
+            {"type": "user", "message": {"role": "user", "content": "injected skill doc"}, "isMeta": True},
+            {"type": "assistant", "message": {"role": "assistant", "content": "real answer"}},
+        ]
+        messages = read_transcript(_write_jsonl(tmp_path, entries))
+        contents = [m["content"] for m in messages]
+        assert "real question" in contents
+        assert "real answer" in contents
+        assert "injected skill doc" not in contents
+        assert len(messages) == 2
+
+    def test_keeps_non_meta_entries(self, tmp_path):
+        """A missing or falsey isMeta flag leaves the turn intact."""
+        read_transcript = _load_read_transcript()
+        entries = [
+            {"type": "user", "message": {"role": "user", "content": "hello"}, "isMeta": False},
+            {"type": "assistant", "message": {"role": "assistant", "content": "hi"}},
+        ]
+        messages = read_transcript(_write_jsonl(tmp_path, entries))
+        assert [m["content"] for m in messages] == ["hello", "hi"]
+
+    def test_unwraps_nested_message_format(self, tmp_path):
+        """Claude Code's {type, message:{role, content}} nesting is flattened."""
+        read_transcript = _load_read_transcript()
+        entries = [{"type": "user", "message": {"role": "user", "content": "nested"}}]
+        messages = read_transcript(_write_jsonl(tmp_path, entries))
+        assert messages == [{"role": "user", "content": "nested"}]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        read_transcript = _load_read_transcript()
+        assert read_transcript(str(tmp_path / "nope.jsonl")) == []


### PR DESCRIPTION
## Problem

The Claude Code auto-retain hook stores a lot of behind-the-scenes context that the user never actually sent, polluting the memory bank with harness noise (skill docs, settings schemas, slash-command expansions, system reminders, command output). In practice this drowns real project/preference facts under injected-context memories.

Two root causes, plus a Windows packaging papercut:

1. **`read_transcript()` ignores `isMeta`.** Claude Code marks injected/synthetic transcript turns with `isMeta: true` (skill documentation, settings-schema dumps, slash-command expansions). These were being retained as if the user authored them.

2. **Harness context rides inside real turns.** Genuine user/assistant turns can embed harness-injected context in XML wrappers — `<system-reminder>`, `<task-notification>`, `<local-command-stdout>`, and `<command-name>/<command-message>/<command-args>`. None of that was sent by the user, but it was being retained verbatim.

3. **Shell hooks get CRLF on Windows.** With the Git-for-Windows default `core.autocrlf=true`, `scripts/*.sh` check out with CRLF endings, which breaks their `\` line-continuations and shebang under Git Bash.

## Changes

- `scripts/retain.py`: skip transcript entries where `isMeta` is set.
- `scripts/lib/content.py`: add `strip_injected_context()` (removes the Claude Code harness wrappers) and call it from `strip_memory_tags()`, so every existing retention/recall call site benefits.
- `hindsight-integrations/claude-code/.gitattributes`: pin `*.sh text eol=lf`.
- `tests/test_content.py`: unit tests for `strip_injected_context()` and the `strip_memory_tags()` path.

## Testing

`PYTHONPATH=scripts python -m pytest tests/test_content.py` → all pass (63). Full-suite failures on my Windows box are pre-existing and unrelated (path-separator/symlink assertions in `test_run_mcp.py`, `test_config.py`, `test_bank.py`) — they fail identically on a pristine checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
