### PR TITLE
Show full memory details in explore

### DIFF
--- a/hindsight-cli/src/commands/explore.rs
+++ b/hindsight-cli/src/commands/explore.rs
@@ -931,7 +931,8 @@ fn render_memories(f: &mut Frame, app: &mut App, area: Rect) {
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(7),  // Memory metadata
-                Constraint::Min(0),     // Full text content
+                Constraint::Percentage(45), // Full text content
+                Constraint::Percentage(55), // Complete JSON details
             ])
             .split(area);
 
@@ -969,6 +970,13 @@ fn render_memories(f: &mut Frame, app: &mut App, area: Rect) {
             .style(Style::default().fg(Color::White));
 
         f.render_widget(content_widget, chunks[1]);
+
+        let details_widget = Paragraph::new(format_memory_details_json(memory))
+            .block(Block::default().borders(Borders::ALL).title("Details JSON"))
+            .wrap(Wrap { trim: false })
+            .style(Style::default().fg(Color::White));
+
+        f.render_widget(details_widget, chunks[2]);
     } else {
         // Show memory list as table
         let mut items = vec![
@@ -1010,6 +1018,11 @@ fn render_memories(f: &mut Frame, app: &mut App, area: Rect) {
 
         f.render_stateful_widget(list, area, &mut app.memories_state);
     }
+}
+
+fn format_memory_details_json(memory: &Map<String, Value>) -> String {
+    serde_json::to_string_pretty(memory)
+        .unwrap_or_else(|_| "Unable to render memory details".to_string())
 }
 
 fn render_entities(f: &mut Frame, app: &mut App, area: Rect) {
@@ -1566,5 +1579,26 @@ mod tests {
 
         select_next_headered_row(&mut state, 0);
         assert_eq!(state.selected(), None);
+    }
+
+    #[test]
+    fn memory_details_json_includes_non_text_attributes() {
+        let memory = serde_json::json!({
+            "id": "mem_123",
+            "fact_type": "world",
+            "text": "Alice works at Google",
+            "entities": [
+                {"canonical_name": "Alice", "type": "person"}
+            ],
+            "metadata": {
+                "source": "import"
+            }
+        });
+
+        let details = format_memory_details_json(memory.as_object().unwrap());
+
+        assert!(details.contains("\"id\": \"mem_123\""));
+        assert!(details.contains("\"entities\""));
+        assert!(details.contains("\"metadata\""));
     }
 }


### PR DESCRIPTION
## Summary
- add a Details JSON panel when viewing a memory in `hindsight explore`
- keep the existing metadata and full-text panels while exposing fields such as id, entities, and metadata
- add a focused CLI unit test for non-text attributes in the details output

Fixes #2482

## Tests
- `cargo test --manifest-path hindsight-cli/Cargo.toml memory_details_json -- --nocapture`
- `git diff --check`

## Risk
Low. This only changes the memory detail view rendering and leaves list navigation/data loading untouched.