### PR TITLE
fix(claude-code): seed bank missions only when unset; never overwrite existing (#2492)

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -22,6 +22,18 @@
   `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
   such tags were sent as-is. Tags without `:` are unaffected.
 
+### Fixed
+
+- Bank mission seeding no longer overwrites per-bank `reflect_mission` /
+  `retain_mission` that were authored out-of-band (control plane UI or
+  `PATCH /banks/{id}/config`). `ensure_bank_mission` now reads the bank's
+  existing overrides first and only fills mission fields that are not already
+  set, so shared banks keep their configured missions. Correctness no longer
+  depends on the local `bank_missions.json` state file (which reset per machine
+  and re-triggered the clobber). Also fixes an issue where `retainMission`
+  could not be seeded unless `bankMission` was also configured. Fixes #2492
+  (Claude Code counterpart of #1270 / #1473).
+
 ## [0.1.0] - 2025-03-23
 
 ### Added

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -205,8 +205,8 @@ A **bank** is an isolated memory store — like a separate "brain." These settin
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
 | `bankId` | `HINDSIGHT_BANK_ID` | `"claude_code"` | The bank ID to use when `dynamicBankId` is `false`. All sessions share this single bank. |
-| `bankMission` | `HINDSIGHT_BANK_MISSION` | generic assistant prompt | A short description of the agent's identity and purpose. Sent to Hindsight when creating or updating the bank, and used during recall to contextualize results. |
-| `retainMission` | — | extraction prompt | Instructions for the fact extraction LLM — tells it *what* to extract from conversations (e.g. "Extract technical decisions and user preferences"). |
+| `bankMission` | `HINDSIGHT_BANK_MISSION` | generic assistant prompt | A short description of the agent's identity and purpose (the bank's reflect mission). Seeded onto the bank on first use **only if the bank has no reflect mission yet** — an existing per-bank mission (set via the control plane or API) is never overwritten. |
+| `retainMission` | — | extraction prompt | Instructions for the fact extraction LLM — tells it *what* to extract from conversations (e.g. "Extract technical decisions and user preferences"). Seeded onto the bank on first use only if no retain mission is set yet; never overwrites an existing one. |
 | `dynamicBankId` | `HINDSIGHT_DYNAMIC_BANK_ID` | `false` | When `true`, the plugin derives a unique bank ID from context fields (see `dynamicBankGranularity`), giving each combination its own isolated memory. |
 | `dynamicBankGranularity` | — | `["agent", "project"]` | Which context fields to combine when building a dynamic bank ID. Available fields: `agent` (agent name), `project` (working directory), `session` (session ID), `channel` (channel ID), `user` (user ID). |
 | `bankIdPrefix` | — | `""` | A string prepended to all bank IDs — both static and dynamic. Useful for namespacing (e.g. `"prod"` or `"staging"`). |

--- a/hindsight-integrations/claude-code/scripts/lib/bank.py
+++ b/hindsight-integrations/claude-code/scripts/lib/bank.py
@@ -143,37 +143,83 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
     return f"{prefix}-{base_bank_id}" if prefix else base_bank_id
 
 
-def ensure_bank_mission(client, bank_id: str, config: dict, debug_fn=None):
-    """Set bank mission on first use, skip if already set.
+def _mark_bank_reconciled(bank_id: str) -> None:
+    """Record that we've reconciled missions for a bank (local perf cache).
 
-    Port of: banksWithMissionSet Set tracking in index.js
-
-    Uses a state file to persist which banks have had their mission set
-    across ephemeral hook invocations.
+    This is only an optimization to avoid a GET on every hook invocation — it
+    is NOT the correctness boundary. Correctness comes from checking the
+    server's per-bank overrides before writing (see ensure_bank_mission).
     """
-    mission = config.get("bankMission", "")
-    if not mission or not mission.strip():
+    missions_set = read_state("bank_missions.json", {})
+    missions_set[bank_id] = True
+    # Cap tracked banks (mirrors Openclaw's MAX_TRACKED_BANK_CLIENTS)
+    if len(missions_set) > 10000:
+        keys = sorted(missions_set.keys())
+        for k in keys[: len(keys) // 2]:
+            del missions_set[k]
+    write_state("bank_missions.json", missions_set)
+
+
+def ensure_bank_mission(client, bank_id: str, config: dict, debug_fn=None):
+    """Seed configured missions onto a bank, filling only fields not already set.
+
+    Intent: guarantee a bank has reflect/retain missions before its first use,
+    using the plugin's configured defaults. But a bank shared by multiple
+    parties may already have missions authored out-of-band (control plane UI or
+    `PATCH /banks/{id}/config`). Those must win — the plugin only fills the
+    gaps, it never overwrites an existing per-bank mission.
+
+    To decide what is "already set" we inspect the bank's *overrides* (the
+    bank-specific config), not the fully-resolved config, so a global/tenant
+    default doesn't suppress seeding a brand-new bank.
+
+    A local state file caches which banks we've reconciled to avoid a GET on
+    every hook, but it is only an optimization: correctness is enforced by the
+    server-side check, so a wiped state file (fresh machine, cleared cache)
+    can no longer cause a clobber the way the old unconditional PATCH did.
+    """
+    reflect_mission = (config.get("bankMission") or "").strip()
+    retain_mission = (config.get("retainMission") or "").strip()
+    if not reflect_mission and not retain_mission:
+        # Nothing configured → explicit opt-out; manage missions out-of-band.
         return
 
-    # Check if we've already set mission for this bank
-    missions_set = read_state("bank_missions.json", {})
-    if bank_id in missions_set:
+    # Fast path: already reconciled this bank in a previous hook invocation.
+    if bank_id in read_state("bank_missions.json", {}):
         return
 
     try:
-        retain_mission = config.get("retainMission")
-        client.set_bank_mission(bank_id, mission, retain_mission=retain_mission, timeout=10)
-        missions_set[bank_id] = True
-        # Cap tracked banks (mirrors Openclaw's MAX_TRACKED_BANK_CLIENTS)
-        if len(missions_set) > 10000:
-            keys = sorted(missions_set.keys())
-            for k in keys[: len(keys) // 2]:
-                del missions_set[k]
-        write_state("bank_missions.json", missions_set)
-        if debug_fn:
-            debug_fn(f"Set mission for bank: {bank_id}")
+        existing = client.get_bank_config(bank_id, timeout=10)
+        overrides = existing.get("overrides") or {}
+        server_reflect = (overrides.get("reflect_mission") or "").strip()
+        server_retain = (overrides.get("retain_mission") or "").strip()
+
+        # Only send a mission field the bank doesn't already have set.
+        reflect_update = reflect_mission if (reflect_mission and not server_reflect) else None
+        retain_update = retain_mission if (retain_mission and not server_retain) else None
+
+        if reflect_update is not None or retain_update is not None:
+            client.set_bank_mission(
+                bank_id,
+                reflect_mission=reflect_update,
+                retain_mission=retain_update,
+                timeout=10,
+            )
+            if debug_fn:
+                fields = [
+                    name
+                    for name, val in (("reflect", reflect_update), ("retain", retain_update))
+                    if val is not None
+                ]
+                debug_fn(f"Seeded {', '.join(fields)} mission(s) for bank: {bank_id}")
+        elif debug_fn:
+            debug_fn(f"Bank {bank_id} already has missions set; leaving them unchanged")
+
+        # Mark reconciled either way so we don't re-GET on every hook.
+        _mark_bank_reconciled(bank_id)
     except Exception as e:
-        # Don't fail if mission set fails — bank might not exist yet,
-        # will be created on first retain (mirrors Openclaw behavior)
+        # Don't fail if reconciliation fails — bank might not exist yet, or the
+        # config API may be disabled. We deliberately do NOT mark the bank
+        # reconciled here, so a transient failure is retried on the next hook.
         if debug_fn:
-            debug_fn(f"Could not set bank mission for {bank_id}: {e}")
+            debug_fn(f"Could not reconcile bank missions for {bank_id}: {e}")

--- a/hindsight-integrations/claude-code/scripts/lib/client.py
+++ b/hindsight-integrations/claude-code/scripts/lib/client.py
@@ -169,16 +169,46 @@ class HindsightClient:
         }
         return self.request("POST", path, body, timeout=timeout)
 
-    def set_bank_mission(
-        self, bank_id: str, mission: str, retain_mission: Optional[str] = None, timeout: int = 15
-    ) -> dict:
-        """Set the mission/persona for a bank.
+    def get_bank_config(self, bank_id: str, timeout: int = 10) -> dict:
+        """Fetch a bank's configuration.
 
-        Uses PATCH /banks/{id}/config with reflect_mission and retain_mission.
-        The old PUT /banks/{id} with 'mission' field is deprecated in v0.4.19.
+        Returns the raw GET /banks/{id}/config response, which contains both
+        the fully-resolved `config` (global → tenant → bank) and the
+        bank-specific `overrides`. Banks are created lazily on first retain, so
+        a bank that has never been touched yields HTTP 404 — treated here as
+        "no config yet" and returned as an empty dict rather than raising.
         """
         path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/config"
-        updates = {"reflect_mission": mission}
-        if retain_mission:
+        try:
+            resp = self.request("GET", path, timeout=timeout)
+        except RuntimeError as e:
+            if "HTTP 404" in str(e):
+                return {}
+            raise
+        return resp if isinstance(resp, dict) else {}
+
+    def set_bank_mission(
+        self,
+        bank_id: str,
+        reflect_mission: Optional[str] = None,
+        retain_mission: Optional[str] = None,
+        timeout: int = 15,
+    ) -> dict:
+        """Set the mission(s)/persona for a bank.
+
+        Uses PATCH /banks/{id}/config. Only the mission fields passed as
+        non-None are sent, so callers can update reflect and retain missions
+        independently without clobbering the other. Returns an empty dict
+        (no request issued) when neither mission is provided.
+
+        The old PUT /banks/{id} with 'mission' field is deprecated in v0.4.19.
+        """
+        updates: dict = {}
+        if reflect_mission is not None:
+            updates["reflect_mission"] = reflect_mission
+        if retain_mission is not None:
             updates["retain_mission"] = retain_mission
+        if not updates:
+            return {}
+        path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/config"
         return self.request("PATCH", path, {"updates": updates}, timeout=timeout)

--- a/hindsight-integrations/claude-code/tests/test_bank.py
+++ b/hindsight-integrations/claude-code/tests/test_bank.py
@@ -254,44 +254,88 @@ class TestDirectoryBankMap:
 
 
 class TestEnsureBankMission:
-    def test_sets_mission_on_first_call(self, state_dir):
+    def _client(self, overrides=None):
+        """MagicMock client whose bank has the given config overrides.
+
+        `overrides=None` simulates a bank that doesn't exist yet (GET 404 →
+        empty dict from get_bank_config).
+        """
         client = MagicMock()
+        client.get_bank_config.return_value = {"overrides": overrides} if overrides is not None else {}
+        return client
+
+    def test_seeds_reflect_mission_on_new_bank(self, state_dir):
+        client = self._client()
         cfg = _cfg(bankMission="You are a helpful assistant.", bankId="test-bank")
         ensure_bank_mission(client, "test-bank", cfg)
+        client.get_bank_config.assert_called_once_with("test-bank", timeout=10)
         client.set_bank_mission.assert_called_once_with(
-            "test-bank", "You are a helpful assistant.", retain_mission=None, timeout=10
+            "test-bank", reflect_mission="You are a helpful assistant.", retain_mission=None, timeout=10
         )
 
-    def test_skips_if_already_set(self, state_dir):
-        client = MagicMock()
-        cfg = _cfg(bankMission="mission text")
-        ensure_bank_mission(client, "bank-a", cfg)
-        ensure_bank_mission(client, "bank-a", cfg)  # second call
-        assert client.set_bank_mission.call_count == 1
-
-    def test_skips_if_mission_empty(self, state_dir):
-        client = MagicMock()
-        cfg = _cfg(bankMission="")
-        ensure_bank_mission(client, "bank-b", cfg)
-        client.set_bank_mission.assert_not_called()
-
-    def test_includes_retain_mission_if_set(self, state_dir):
-        client = MagicMock()
+    def test_seeds_both_missions_on_new_bank(self, state_dir):
+        client = self._client()
         cfg = _cfg(bankMission="reflect mission", retainMission="retain mission")
         ensure_bank_mission(client, "bank-c", cfg)
         client.set_bank_mission.assert_called_once_with(
-            "bank-c", "reflect mission", retain_mission="retain mission", timeout=10
+            "bank-c", reflect_mission="reflect mission", retain_mission="retain mission", timeout=10
         )
 
-    def test_graceful_on_api_error(self, state_dir):
-        client = MagicMock()
-        client.set_bank_mission.side_effect = RuntimeError("server down")
-        cfg = _cfg(bankMission="mission")
-        # Should not raise
-        ensure_bank_mission(client, "bank-d", cfg)
+    def test_does_not_overwrite_existing_server_missions(self, state_dir):
+        # Bank already has both missions authored out-of-band (control plane).
+        client = self._client(
+            overrides={"reflect_mission": "You are an artist", "retain_mission": "Extract paintings"}
+        )
+        cfg = _cfg(bankMission="Claude Code default", retainMission="tech default")
+        ensure_bank_mission(client, "bank-existing", cfg)
+        client.set_bank_mission.assert_not_called()
 
-    def test_different_banks_each_set_once(self, state_dir):
+    def test_fills_only_the_unset_field(self, state_dir):
+        # Bank has a reflect mission but no retain mission; plugin fills the gap.
+        client = self._client(overrides={"reflect_mission": "You are an artist"})
+        cfg = _cfg(bankMission="Claude Code default", retainMission="tech default")
+        ensure_bank_mission(client, "bank-partial", cfg)
+        client.set_bank_mission.assert_called_once_with(
+            "bank-partial", reflect_mission=None, retain_mission="tech default", timeout=10
+        )
+
+    def test_retain_only_config_seeds_retain(self, state_dir):
+        # bankMission empty but retainMission set — must still seed retain.
+        client = self._client()
+        cfg = _cfg(bankMission="", retainMission="retain only")
+        ensure_bank_mission(client, "bank-retain", cfg)
+        client.set_bank_mission.assert_called_once_with(
+            "bank-retain", reflect_mission=None, retain_mission="retain only", timeout=10
+        )
+
+    def test_skips_if_already_reconciled_locally(self, state_dir):
+        client = self._client()
+        cfg = _cfg(bankMission="mission text")
+        ensure_bank_mission(client, "bank-a", cfg)
+        ensure_bank_mission(client, "bank-a", cfg)  # second call → fast path
+        assert client.get_bank_config.call_count == 1
+        assert client.set_bank_mission.call_count == 1
+
+    def test_skips_if_no_missions_configured(self, state_dir):
+        client = self._client()
+        cfg = _cfg(bankMission="", retainMission=None)
+        ensure_bank_mission(client, "bank-b", cfg)
+        client.get_bank_config.assert_not_called()
+        client.set_bank_mission.assert_not_called()
+
+    def test_graceful_on_api_error_and_retries(self, state_dir):
         client = MagicMock()
+        client.get_bank_config.side_effect = RuntimeError("server down")
+        cfg = _cfg(bankMission="mission")
+        # Should not raise, and must not mark the bank reconciled (so it retries).
+        ensure_bank_mission(client, "bank-d", cfg)
+        client.get_bank_config.side_effect = None
+        client.get_bank_config.return_value = {}
+        ensure_bank_mission(client, "bank-d", cfg)
+        client.set_bank_mission.assert_called_once()
+
+    def test_different_banks_each_seeded_once(self, state_dir):
+        client = self._client()
         cfg = _cfg(bankMission="mission")
         ensure_bank_mission(client, "bank-x", cfg)
         ensure_bank_mission(client, "bank-y", cfg)

--- a/hindsight-integrations/claude-code/tests/test_client.py
+++ b/hindsight-integrations/claude-code/tests/test_client.py
@@ -331,9 +331,80 @@ class TestHindsightClientSetBankMission:
             return FakeResp({})
 
         with patch("urllib.request.urlopen", side_effect=fake_open):
-            c.set_bank_mission("my-bank", "I am Claude", retain_mission="Extract facts")
+            c.set_bank_mission("my-bank", reflect_mission="I am Claude", retain_mission="Extract facts")
 
         assert captured["method"] == "PATCH"
         assert "my-bank" in captured["url"]
         assert captured["body"]["updates"]["reflect_mission"] == "I am Claude"
         assert captured["body"]["updates"]["retain_mission"] == "Extract facts"
+
+    def test_sends_only_reflect_when_retain_omitted(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.set_bank_mission("my-bank", reflect_mission="I am Claude")
+
+        assert captured["body"]["updates"] == {"reflect_mission": "I am Claude"}
+
+    def test_sends_only_retain_when_reflect_omitted(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.set_bank_mission("my-bank", retain_mission="Extract facts")
+
+        assert captured["body"]["updates"] == {"retain_mission": "Extract facts"}
+
+    def test_no_request_when_nothing_provided(self):
+        c = HindsightClient("http://localhost:9077")
+        with patch("urllib.request.urlopen") as mock_open:
+            result = c.set_bank_mission("my-bank")
+        assert result == {}
+        mock_open.assert_not_called()
+
+
+class TestHindsightClientGetBankConfig:
+    def test_returns_response_dict(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+        payload = {"bank_id": "my-bank", "config": {"reflect_mission": "x"}, "overrides": {"reflect_mission": "x"}}
+
+        def fake_open(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["method"] = req.method
+            return FakeResp(payload)
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            result = c.get_bank_config("my-bank")
+
+        assert captured["method"] == "GET"
+        assert "my-bank" in captured["url"]
+        assert result["overrides"]["reflect_mission"] == "x"
+
+    def test_returns_empty_dict_on_404(self):
+        c = HindsightClient("http://localhost:9077")
+
+        def fake_open(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, BytesIO(b"missing"))
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            assert c.get_bank_config("ghost-bank") == {}
+
+    def test_reraises_non_404_errors(self):
+        c = HindsightClient("http://localhost:9077")
+
+        def fake_open(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 500, "Server Error", {}, BytesIO(b"boom"))
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                c.get_bank_config("my-bank")


### PR DESCRIPTION
## Summary

Fixes #2492 — the Claude Code plugin overwrites per-bank missions authored out-of-band (control plane UI or `PATCH /banks/{id}/config`) the first time it touches a bank. This is the Claude Code counterpart of the OpenClaw bug #1270 (fixed by #1473), which was never ported here even though `scripts/lib/bank.py` documents itself as a port of OpenClaw's `banksWithMissionSet` logic.

## The bug

`ensure_bank_mission` unconditionally PATCHed `reflect_mission` + `retain_mission` from the plugin's configured `bankMission`/`retainMission`, guarded only by a **local** state file (`bank_missions.json`) tracking "have *I* pushed a mission" — never "does the bank already have one server-side". Consequences:

- A bank configured elsewhere (control plane, API, another machine) is treated as "unset" and gets stomped.
- The clobber re-fires whenever the local state is lost (fresh machine, cleared cache).
- It runs on both recall (`UserPromptSubmit`) and retain (session end), so it can fire on the very first prompt.
- The server-side PATCH is a blind JSONB merge (`config || $1`), so whatever the plugin sends wins.

A straight port of #1473 was insufficient: that fix only stops stamping when the config field is *empty*, but the Claude Code `settings.json` ships **non-empty** mission defaults, so it would still clobber a differing per-bank mission.

## The fix

`ensure_bank_mission` is now **server-aware**: it reads the bank's existing overrides and only fills mission fields that are not already set — user-authored missions always win, the plugin merely seeds gaps.

- **`client.py`**
  - New `get_bank_config(bank_id)` → returns the bank's config; a `404` (bank not created yet — banks are lazily created on first retain) is treated as "empty" so brand-new banks are still seeded.
  - `set_bank_mission(...)` now takes `reflect_mission=` / `retain_mission=` and sends **only the fields provided** (no-ops if none). This also fixes a pre-existing quirk where `retainMission` could not be seeded unless `bankMission` was also configured.
- **`bank.py`** — `ensure_bank_mission` GETs `overrides`, computes per-field gaps, and PATCHes only the missing ones. The local `bank_missions.json` is demoted to a **perf cache** (avoids a GET on every hook); correctness now comes from the server check, so a wiped state file can no longer re-trigger a clobber.
- Transient failures (unreachable server, timeout, non-404 HTTP errors) skip cleanly **without** marking the bank reconciled, so they retry on the next hook rather than seeding or clobbering.

## Behaviour matrix

| Server state (bank overrides) | Plugin configured | Result |
|---|---|---|
| both missions set | both | no PATCH (missions preserved) |
| reflect set, retain empty | both | PATCH retain only |
| both empty / bank 404 | both | seed both |
| both empty | retain only | seed retain only |
| unreachable / timeout / 5xx | any | skip, retry next hook (no write) |

## Edge cases intentionally left as-is

- **Non-default retain strategies.** The "already set?" check inspects only the *root* `overrides.retain_mission`. But the server auto-applies `retain_default_strategy` when a retain call sends no strategy (`memory_engine.py`), and `apply_strategy` overlays that strategy's `retain_mission` over the root (`config_resolver.py`). So if the root retain mission is empty but a default strategy carries its own, the plugin still PATCHes a root retain mission. **Impact is non-functional** — the default strategy's mission still wins at retain time, so this only writes an otherwise-masked root value (semantic pollution, not a behaviour clobber). Fully resolving this would couple the client to server strategy-resolution internals (which also have global defaults), so it was deliberately deferred.
- **404 is overloaded.** The server returns `404` both when a bank doesn't exist *and* when the bank-config API is disabled (`HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false`). In the disabled case the plugin does a harmless GET+PATCH that both 404, never marks reconciled, and retries each hook — no clobber, just mildly chatty at debug level.
- **Server-side hardening not included.** The PATCH endpoint still has no "set-if-absent" semantics for mission fields; this PR fixes the client behaviour only. A server-side guard could be a separate change.

## Scope

This PR is **Patch 1 only** (the behavioural fix). Blanking the shipped `settings.json` mission defaults is a separate, independently-adoptable change and will come as its own PR.

## Tests

`tests/test_bank.py` and `tests/test_client.py` updated/extended: new-bank seeding, existing-mission preservation, partial (gap-only) fill, retain-only config, local fast-path, opt-out, graceful-error-then-retry, plus `get_bank_config` (200 / 404 / non-404) and independent-field `set_bank_mission`. Full plugin suite: 201 passing.
