### PR TITLE
chore(claude-code): drop opinionated bankMission/retainMission defaults (#2492)

### DIFF
--- a/hindsight-integrations/claude-code/CHANGELOG.md
+++ b/hindsight-integrations/claude-code/CHANGELOG.md
@@ -21,6 +21,11 @@
 - Tags that resolve to an empty namespace content (e.g. `"user:"` when
   `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
   such tags were sent as-is. Tags without `:` are unaffected.
+- The bundled `settings.json` no longer ships opinionated `bankMission` /
+  `retainMission` defaults; both are now empty (matching the internal config
+  defaults). The plugin only seeds missions you explicitly configure, so a
+  default install never stamps a generic persona onto a bank. Set these
+  fields to opt into seeding. See #2492.
 
 ## [0.1.0] - 2025-03-23
 

--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -205,8 +205,8 @@ A **bank** is an isolated memory store — like a separate "brain." These settin
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
 | `bankId` | `HINDSIGHT_BANK_ID` | `"claude_code"` | The bank ID to use when `dynamicBankId` is `false`. All sessions share this single bank. |
-| `bankMission` | `HINDSIGHT_BANK_MISSION` | generic assistant prompt | A short description of the agent's identity and purpose. Sent to Hindsight when creating or updating the bank, and used during recall to contextualize results. |
-| `retainMission` | — | extraction prompt | Instructions for the fact extraction LLM — tells it *what* to extract from conversations (e.g. "Extract technical decisions and user preferences"). |
+| `bankMission` | `HINDSIGHT_BANK_MISSION` | `""` (unset) | A short description of the agent's identity and purpose (the bank's reflect mission). Empty by default so the plugin does not stamp a generic persona; set it to seed a mission onto the bank. |
+| `retainMission` | — | `null` (unset) | Instructions for the fact extraction LLM — tells it *what* to extract from conversations (e.g. "Extract technical decisions and user preferences"). Empty by default; set it to seed a retain mission onto the bank. |
 | `dynamicBankId` | `HINDSIGHT_DYNAMIC_BANK_ID` | `false` | When `true`, the plugin derives a unique bank ID from context fields (see `dynamicBankGranularity`), giving each combination its own isolated memory. |
 | `dynamicBankGranularity` | — | `["agent", "project"]` | Which context fields to combine when building a dynamic bank ID. Available fields: `agent` (agent name), `project` (working directory), `session` (session ID), `channel` (channel ID), `user` (user ID). |
 | `bankIdPrefix` | — | `""` | A string prepended to all bank IDs — both static and dynamic. Useful for namespacing (e.g. `"prod"` or `"staging"`). |

--- a/hindsight-integrations/claude-code/settings.json
+++ b/hindsight-integrations/claude-code/settings.json
@@ -1,8 +1,8 @@
 {
   "hindsightApiUrl": "",
   "bankId": "claude_code",
-  "bankMission": "You are a Claude Code AI assistant. Focus on technical discussions, decisions, and context relevant to the user's projects.",
-  "retainMission": "Extract technical decisions, architectural choices, user preferences, project context, and people/tool relationships. Ignore routine greetings and transient operational details.",
+  "bankMission": "",
+  "retainMission": null,
   "autoRecall": true,
   "autoRetain": true,
   "retainMode": "full-session",


### PR DESCRIPTION
## Summary

Part of #2492. Removes the opinionated `bankMission` / `retainMission` defaults shipped in the Claude Code plugin's `settings.json`, which are what triggered the mission-clobber for default installs.

The bundled `settings.json` shipped:

```json
"bankMission":   "You are a Claude Code AI assistant. Focus on technical discussions, decisions, and context relevant to the user's projects.",
"retainMission": "Extract technical decisions, architectural choices, user preferences, project context, and people/tool relationships. Ignore routine greetings and transient operational details.",
```

So any default install stamped a generic persona onto a bank the first time the plugin touched it — overwriting per-bank missions authored via the control plane / API. This blanks both to match the plugin's own internal defaults (`config.py`: `bankMission=""`, `retainMission=None`), so the plugin only seeds missions the user explicitly configures.

## Changes

- **`settings.json`** — `bankMission: ""`, `retainMission: null`.
- **`README.md`** — config table default column updated to `""` / `null` (unset), documenting opt-in seeding.
- **`CHANGELOG.md`** — `Changed` entry.

## Behaviour

No behavioural change when the fields are empty: `bank.py` already treats an empty/`None` mission as an opt-out and sends nothing. `""` vs `null` is a typing convention only (`bankMission` is a `str`, `retainMission` is `Optional[str]`) — both are falsy and indistinguishable to the code.

## Relationship to the other PR

This is the **defaults-removal half** of #2492, deliberately kept separate from the server-aware seeding fix (#2493) so each can be adopted independently:

- #2493 — makes `ensure_bank_mission` server-aware (never overwrites an existing per-bank mission). Fixes the clobber even for users who keep non-empty missions configured.
- **This PR** — stops default installs from seeding a generic persona at all.

Note: #2493 and this PR touch adjacent regions of `README.md` / `CHANGELOG.md`; depending on merge order a trivial conflict may need resolving.

## Tests

Full Claude Code plugin suite passes (192 tests); `settings.json` validated as JSON.
