### PR TITLE
docs: document CODEX_HOME isolation for long-running Codex services

### DIFF
--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -258,6 +258,10 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
 export HINDSIGHT_API_LLM_MODEL=gpt-5.4-mini
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
+# For long-running services, set CODEX_HOME to a dedicated auth directory so
+# Hindsight doesn't share (and lose) its refresh token with another Codex process.
+# See Models docs → "Isolating Codex auth for long-running services".
+# export CODEX_HOME=/var/lib/hindsight/codex
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=claude-code

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -278,6 +278,54 @@ You can use any model supported by OpenAI Codex CLI
 - Usage is billed to your ChatGPT subscription (not separate API costs)
 - For personal development use only (see ChatGPT Terms of Service)
 
+#### Isolating Codex auth for long-running services
+
+By default Hindsight reads Codex credentials from `~/.codex/auth.json` — the
+same file the `@openai/codex` CLI, editor plugins, and other agent runtimes use.
+This is convenient for local development but can cause a subtle failure mode when
+Hindsight runs as a **long-lived service** (systemd unit, container, background
+daemon) alongside another Codex process:
+
+- Codex refresh tokens are single-use and rotate on refresh.
+- If another process refreshes the shared token, Hindsight's long-running
+  process is left holding a stale refresh token.
+- Recall and `/health` keep working (the database and API are fine), but
+  `/reflect` fails with an error such as:
+  ```text
+  Codex refresh_token is permanently invalid (error.code=refresh_token_reused).
+  Run 'codex auth login' to re-authenticate.
+  ```
+
+To avoid this, give the Hindsight service its **own dedicated Codex auth home**
+via the `CODEX_HOME` environment variable. Hindsight honors `CODEX_HOME` exactly
+like the `@openai/codex` CLI: when set, it reads `$CODEX_HOME/auth.json` instead
+of `~/.codex/auth.json`.
+
+```bash
+# Dedicated credentials directory for the Hindsight service
+export CODEX_HOME=/var/lib/hindsight/codex
+
+# One-time login into that isolated home (opens a browser / device-code flow)
+codex auth login   # writes $CODEX_HOME/auth.json
+
+export HINDSIGHT_API_LLM_PROVIDER=openai-codex
+hindsight-api
+```
+
+For a systemd unit, set it in the service definition so it never shares auth
+with an interactive Codex session:
+
+```ini
+[Service]
+Environment=CODEX_HOME=/var/lib/hindsight/codex
+```
+
+After a fresh login into the dedicated home and restarting only the Hindsight
+service, `/reflect` uses its own token that other Codex processes will not
+rotate out from under it.
+
+`CODEX_HOME` is also honored by the `openai-codex` embeddings provider.
+
 ---
 
 ### Nous Portal Setup (Hermes)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -258,6 +258,10 @@ export HINDSIGHT_API_LLM_MODEL=your-model-name
 export HINDSIGHT_API_LLM_PROVIDER=openai-codex
 export HINDSIGHT_API_LLM_MODEL=gpt-5.4-mini
 # No API key needed - uses OAuth tokens from ~/.codex/auth.json
+# For long-running services, set CODEX_HOME to a dedicated auth directory so
+# Hindsight doesn't share (and lose) its refresh token with another Codex process.
+# See Models docs → "Isolating Codex auth for long-running services".
+# export CODEX_HOME=/var/lib/hindsight/codex
 
 # Claude Code (Claude Pro/Max subscription - uses OAuth, no API key needed)
 export HINDSIGHT_API_LLM_PROVIDER=claude-code

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -338,6 +338,54 @@ You can use any model supported by OpenAI Codex CLI
 - Usage is billed to your ChatGPT subscription (not separate API costs)
 - For personal development use only (see ChatGPT Terms of Service)
 
+#### Isolating Codex auth for long-running services
+
+By default Hindsight reads Codex credentials from `~/.codex/auth.json` — the
+same file the `@openai/codex` CLI, editor plugins, and other agent runtimes use.
+This is convenient for local development but can cause a subtle failure mode when
+Hindsight runs as a **long-lived service** (systemd unit, container, background
+daemon) alongside another Codex process:
+
+- Codex refresh tokens are single-use and rotate on refresh.
+- If another process refreshes the shared token, Hindsight's long-running
+  process is left holding a stale refresh token.
+- Recall and `/health` keep working (the database and API are fine), but
+  `/reflect` fails with an error such as:
+  ```text
+  Codex refresh_token is permanently invalid (error.code=refresh_token_reused).
+  Run 'codex auth login' to re-authenticate.
+  ```
+
+To avoid this, give the Hindsight service its **own dedicated Codex auth home**
+via the `CODEX_HOME` environment variable. Hindsight honors `CODEX_HOME` exactly
+like the `@openai/codex` CLI: when set, it reads `$CODEX_HOME/auth.json` instead
+of `~/.codex/auth.json`.
+
+```bash
+# Dedicated credentials directory for the Hindsight service
+export CODEX_HOME=/var/lib/hindsight/codex
+
+# One-time login into that isolated home (opens a browser / device-code flow)
+codex auth login   # writes $CODEX_HOME/auth.json
+
+export HINDSIGHT_API_LLM_PROVIDER=openai-codex
+hindsight-api
+```
+
+For a systemd unit, set it in the service definition so it never shares auth
+with an interactive Codex session:
+
+```ini
+[Service]
+Environment=CODEX_HOME=/var/lib/hindsight/codex
+```
+
+After a fresh login into the dedicated home and restarting only the Hindsight
+service, `/reflect` uses its own token that other Codex processes will not
+rotate out from under it.
+
+`CODEX_HOME` is also honored by the `openai-codex` embeddings provider.
+
 ---
 
 ### Nous Portal Setup (Hermes)


### PR DESCRIPTION
## What

Documents how to isolate Codex OAuth credentials for long-running Hindsight
services by setting a dedicated `CODEX_HOME`.

Closes #2476 (the `CODEX_HOME` / Codex OAuth isolation part).

## Why

Hindsight already honors `CODEX_HOME` for both the `openai-codex` LLM provider
and embeddings (`engine/providers/codex_auth.py` → `default_codex_auth_file()`),
but this was only surfaced in the 0.8.3 changelog — never in the user-facing
Models or Configuration docs.

As reported in #2476, when Hindsight runs as a long-lived service and shares
`~/.codex/auth.json` with another Codex process, the single-use refresh token
can be rotated out from under it. The symptom is confusing: `/health` stays
green and recall works, but `/reflect` fails with
`refresh_token_reused`. The operational fix is a dedicated `CODEX_HOME` for the
service.

## Changes

- **`models.mdx`** — new subsection "Isolating Codex auth for long-running
  services" under the OpenAI Codex setup: explains the shared-token failure
  mode, the `/health`-green-but-`/reflect`-broken symptom, and shows shell +
  systemd `CODEX_HOME` setup.
- **`configuration.md`** — pointer comment next to the `openai-codex` LLM
  snippet with a commented `CODEX_HOME` example.
- Regenerated `skills/hindsight-docs/` mirror (docs-skill generator).

Docs-only; no code changes.

## Out of scope

This issue also proposed a separate reflect/LLM health endpoint, a
client/server version-drift diagnostic, and provenance-tagging best practices.
Those are larger feature asks and are intentionally not addressed here — this PR
covers the documentation gap only.
