### PR TITLE
docs(cli): describe explore memory detail view

### DIFF
--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -381,6 +381,7 @@ The explorer provides an interactive terminal interface to:
 
 - **Browse memory banks** — View all banks and their statistics
 - **Search memories** — Run recall queries with real-time results
+- **Inspect memory details** — Open a memory to view its text, metadata, entities, and full JSON fields
 - **Inspect entities** — Explore the knowledge graph and entity relationships
 - **View facts** — Browse world facts, experiences, and observations
 - **Navigate documents** — See source documents and their extracted memories
@@ -390,7 +391,7 @@ The explorer provides an interactive terminal interface to:
 | Key | Action |
 |-----|--------|
 | `↑/↓` | Navigate items |
-| `Enter` | Select / Expand |
+| `Enter` | Select item / view details |
 | `Tab` | Switch panels |
 | `/` | Search |
 | `q` | Quit |

--- a/hindsight-docs/versioned_docs/version-0.8/sdks/cli.md
+++ b/hindsight-docs/versioned_docs/version-0.8/sdks/cli.md
@@ -381,6 +381,7 @@ The explorer provides an interactive terminal interface to:
 
 - **Browse memory banks** — View all banks and their statistics
 - **Search memories** — Run recall queries with real-time results
+- **Inspect memory details** — Open a memory to view its text, metadata, entities, and full JSON fields
 - **Inspect entities** — Explore the knowledge graph and entity relationships
 - **View facts** — Browse world facts, experiences, and observations
 - **Navigate documents** — See source documents and their extracted memories
@@ -390,7 +391,7 @@ The explorer provides an interactive terminal interface to:
 | Key | Action |
 |-----|--------|
 | `↑/↓` | Navigate items |
-| `Enter` | Select / Expand |
+| `Enter` | Select item / view details |
 | `Tab` | Switch panels |
 | `/` | Search |
 | `q` | Quit |

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "0.8.3"
+    "version": "0.8.4"
   },
   "paths": {
     "/health": {

--- a/skills/hindsight-docs/references/sdks/cli.md
+++ b/skills/hindsight-docs/references/sdks/cli.md
@@ -381,6 +381,7 @@ The explorer provides an interactive terminal interface to:
 
 - **Browse memory banks** — View all banks and their statistics
 - **Search memories** — Run recall queries with real-time results
+- **Inspect memory details** — Open a memory to view its text, metadata, entities, and full JSON fields
 - **Inspect entities** — Explore the knowledge graph and entity relationships
 - **View facts** — Browse world facts, experiences, and observations
 - **Navigate documents** — See source documents and their extracted memories
@@ -390,7 +391,7 @@ The explorer provides an interactive terminal interface to:
 | Key | Action |
 |-----|--------|
 | `↑/↓` | Navigate items |
-| `Enter` | Select / Expand |
+| `Enter` | Select item / view details |
 | `Tab` | Switch panels |
 | `/` | Search |
 | `q` | Quit |


### PR DESCRIPTION
## Summary
- document that `hindsight explore` can open a memory detail view with text, metadata, entities, and full JSON fields
- clarify the Enter shortcut now selects an item or opens details
- sync the generated docs skill reference

## Tests
- `git diff --check`
- pre-commit hooks via `git commit`
- `npm run build` in `hindsight-docs` (passes; existing Docusaurus broken-anchor warning remains for `/blog/2026/04/28/version-0-5-5`)
