### PR TITLE
feat(recall): add raw reranker min score filter

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -318,10 +318,10 @@ class RecallRequest(BaseModel):
         default=None,
         description="Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are "
         "retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for "
-        "this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left "
-        "unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use "
-        "with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match "
-        "may score ~0.001 even though it is ranked first).",
+        "this request); `reranker`, `reranker_raw`, and `final` are post-ranking filters on the scored results. "
+        "Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score "
+        "filtering. Use with care — the reranker's absolute scores are not calibrated across queries "
+        "(a clearly-relevant match may score ~0.001 even though it is ranked first).",
     )
 
     @field_validator("query")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -369,7 +369,7 @@ from .response_models import (
 from .response_models import RecallResult as RecallResultModel
 from .retain import bank_utils, embedding_utils
 from .retain.types import RetainContentDict
-from .search.reranking import CrossEncoderReranker, apply_combined_scoring
+from .search.reranking import CrossEncoderReranker, apply_combined_scoring, filter_scored_results_by_min_scores
 from .search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
 from .search.types import ScoredResult
 from .task_backend import TaskBackend
@@ -4840,7 +4840,7 @@ class MemoryEngine(MemoryEngineInterface):
                 if strategy_boosts:
                     log_buffer.append(f"  [4.7] Strategy boosts applied: {strategy_boosts}")
 
-            # Step 4.9: post-query min_scores filters (reranker + final). The
+            # Step 4.9: post-query min_scores filters (reranker + raw + final). The
             # semantic/text floors are applied earlier inside the SQL arms (see
             # retrieve_semantic_bm25_combined); here we apply the post-rank floors on
             # the scored results, after the final sort and before truncation, so every
@@ -4850,17 +4850,19 @@ class MemoryEngine(MemoryEngineInterface):
             # cross-encoder's absolute scores are not calibrated for a fixed cutoff
             # (a clearly-relevant match can score ~0.001 while its *ranking* is right).
             min_reranker = min_scores.reranker if min_scores else None
+            min_reranker_raw = min_scores.reranker_raw if min_scores else None
             min_final = min_scores.final if min_scores else None
-            if (min_reranker is not None or min_final is not None) and scored_results:
+            if (min_reranker is not None or min_reranker_raw is not None or min_final is not None) and scored_results:
                 before_min_score = len(scored_results)
-                scored_results = [
-                    sr
-                    for sr in scored_results
-                    if (min_reranker is None or sr.cross_encoder_score_normalized >= min_reranker)
-                    and (min_final is None or sr.weight >= min_final)
-                ]
+                scored_results = filter_scored_results_by_min_scores(
+                    scored_results,
+                    min_reranker=min_reranker,
+                    min_reranker_raw=min_reranker_raw,
+                    min_final=min_final,
+                )
                 log_buffer.append(
-                    f"  [4.9] min_scores(reranker={min_reranker}, final={min_final}): "
+                    f"  [4.9] min_scores(reranker={min_reranker}, "
+                    f"reranker_raw={min_reranker_raw}, final={min_final}): "
                     f"{before_min_score}->{len(scored_results)} results"
                 )
 
@@ -5288,6 +5290,7 @@ class MemoryEngine(MemoryEngineInterface):
                 sr.id: RecallScores(
                     final=sr.weight,
                     reranker=None if reranker_passthrough else sr.cross_encoder_score_normalized,
+                    reranker_raw=None if reranker_passthrough else sr.cross_encoder_score,
                     semantic=sr.candidate.arm_scores.semantic,
                     keyword=sr.candidate.arm_scores.keyword,
                 )

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -179,13 +179,18 @@ class RecallScores(BaseModel):
     can be filtered on via the recall ``min_scores`` request parameter. ``semantic``
     and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that
     strategy did not surface this result); ``reranker`` is the cross-encoder's
-    normalized relevance.
+    normalized relevance and ``reranker_raw`` is the provider's raw score before
+    normalization.
     """
 
     final: float = Field(description="Final ranking score (combined reranker + recency/temporal/proof boosts)")
     reranker: float | None = Field(
         default=None,
         description="Cross-encoder relevance, normalized 0-1. None when the reranker is a passthrough (rrf/interleave modes).",
+    )
+    reranker_raw: float | None = Field(
+        default=None,
+        description="Raw cross-encoder/reranker score before normalization. None when the reranker is a passthrough.",
     )
     semantic: float | None = Field(
         default=None, description="Vector cosine similarity (0-1). None if this result was not surfaced semantically."
@@ -201,15 +206,18 @@ class MinScores(BaseModel):
 
     ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
     arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
-    config for this request), so they prune weak matches before fusion. ``reranker``
-    and ``final`` are **post-query** filters applied to the scored results after
-    reranking. Any field left None imposes no floor; all-None (the default) means
-    no score filtering.
+    config for this request), so they prune weak matches before fusion. ``reranker``,
+    ``reranker_raw``, and ``final`` are **post-query** filters applied to the scored
+    results after reranking. ``reranker`` uses the normalized reranker score;
+    ``reranker_raw`` uses the provider's raw reranker score before normalization.
+    Any field left None imposes no floor; all-None (the default) means no score
+    filtering.
     """
 
     semantic: float | None = Field(default=None, description="Retrieval-level: minimum vector similarity (0-1).")
     keyword: float | None = Field(default=None, description="Retrieval-level: minimum keyword/full-text (BM25) score.")
     reranker: float | None = Field(default=None, description="Post-query: minimum normalized reranker score (0-1).")
+    reranker_raw: float | None = Field(default=None, description="Post-query: minimum raw reranker score.")
     final: float | None = Field(default=None, description="Post-query: minimum final ranking score.")
 
 

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -192,6 +192,30 @@ def apply_combined_scoring(
         sr.weight = sr.combined_score
 
 
+def filter_scored_results_by_min_scores(
+    scored_results: list[ScoredResult],
+    *,
+    min_reranker: float | None = None,
+    min_reranker_raw: float | None = None,
+    min_final: float | None = None,
+) -> list[ScoredResult]:
+    """Apply post-query recall min_scores filters to scored results.
+
+    Retrieval-level floors (semantic/keyword) are applied earlier by the SQL arms;
+    this helper only handles floors that need reranked/final scores.
+    """
+    if min_reranker is None and min_reranker_raw is None and min_final is None:
+        return scored_results
+
+    return [
+        sr
+        for sr in scored_results
+        if (min_reranker is None or sr.cross_encoder_score_normalized >= min_reranker)
+        and (min_reranker_raw is None or sr.cross_encoder_score >= min_reranker_raw)
+        and (min_final is None or sr.weight >= min_final)
+    ]
+
+
 class CrossEncoderReranker:
     """
     Neural reranking using a cross-encoder model.

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -860,7 +860,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
                     Anchors relative temporal expressions and recency scoring.
                 min_scores: Optional per-stage score floors as an object with any of: "semantic", "keyword"
-                    (retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"reranker": 0.5}.
+                    (retrieval-level cutoffs), "reranker", "reranker_raw", "final" (post-ranking).
+                    E.g. {"reranker": 0.5}.
                     All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.
@@ -945,7 +946,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
                     Anchors relative temporal expressions and recency scoring.
                 min_scores: Optional per-stage score floors as an object with any of: "semantic", "keyword"
-                    (retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"reranker": 0.5}.
+                    (retrieval-level cutoffs), "reranker", "reranker_raw", "final" (post-ranking).
+                    E.g. {"reranker": 0.5}.
                     All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.

--- a/hindsight-api-slim/tests/test_min_score_filters.py
+++ b/hindsight-api-slim/tests/test_min_score_filters.py
@@ -1,0 +1,62 @@
+"""Unit tests for post-query recall min_scores filters."""
+
+from hindsight_api.engine.response_models import MinScores, RecallScores
+from hindsight_api.engine.search.reranking import filter_scored_results_by_min_scores
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult, ScoredResult
+
+
+def _scored_result(
+    result_id: str,
+    *,
+    raw: float,
+    normalized: float,
+    final: float,
+) -> ScoredResult:
+    return ScoredResult(
+        candidate=MergedCandidate(
+            retrieval=RetrievalResult(id=result_id, text=result_id, fact_type="world"),
+            rrf_score=1.0,
+        ),
+        cross_encoder_score=raw,
+        cross_encoder_score_normalized=normalized,
+        combined_score=final,
+        weight=final,
+    )
+
+
+def test_min_scores_models_accept_reranker_raw() -> None:
+    assert MinScores(reranker_raw=0.05).reranker_raw == 0.05
+    assert RecallScores(final=0.9, reranker=0.8, reranker_raw=0.05).reranker_raw == 0.05
+
+
+def test_reranker_raw_floor_uses_raw_score_not_normalized() -> None:
+    low_raw_high_norm = _scored_result("low-raw-high-norm", raw=0.01, normalized=0.95, final=0.9)
+    high_raw_low_norm = _scored_result("high-raw-low-norm", raw=0.2, normalized=0.2, final=0.8)
+
+    filtered = filter_scored_results_by_min_scores(
+        [low_raw_high_norm, high_raw_low_norm],
+        min_reranker_raw=0.1,
+    )
+
+    assert [result.id for result in filtered] == ["high-raw-low-norm"]
+
+
+def test_reranker_floor_still_uses_normalized_score() -> None:
+    low_raw_high_norm = _scored_result("low-raw-high-norm", raw=0.01, normalized=0.95, final=0.9)
+    high_raw_low_norm = _scored_result("high-raw-low-norm", raw=0.2, normalized=0.2, final=0.8)
+
+    filtered = filter_scored_results_by_min_scores(
+        [low_raw_high_norm, high_raw_low_norm],
+        min_reranker=0.9,
+    )
+
+    assert [result.id for result in filtered] == ["low-raw-high-norm"]
+
+
+def test_final_floor_still_uses_final_weight() -> None:
+    low_final = _scored_result("low-final", raw=0.2, normalized=0.9, final=0.4)
+    high_final = _scored_result("high-final", raw=0.1, normalized=0.5, final=0.8)
+
+    filtered = filter_scored_results_by_min_scores([low_final, high_final], min_final=0.5)
+
+    assert [result.id for result in filtered] == ["high-final"]

--- a/hindsight-api-slim/tests/test_recall_min_score.py
+++ b/hindsight-api-slim/tests/test_recall_min_score.py
@@ -2,7 +2,7 @@
 
 Inserts memory_units with known content + real embeddings directly via SQL, then
 verifies that recall_async:
-  - returns a `scores` object (final/reranker/semantic/keyword) on every result,
+  - returns a `scores` object (final/reranker/reranker_raw/semantic/keyword) on every result,
   - applies the post-query floors (`reranker`, `final`) to the scored results,
   - applies the retrieval-level floors (`semantic`, `keyword`) inside the SQL arms,
   - is unchanged by the default (`min_scores=None`).
@@ -101,6 +101,8 @@ class TestRecallScores:
         for r in result.results:
             assert r.scores is not None, f"result {r.id} is missing scores"
             assert isinstance(r.scores.final, float)
+            if r.scores.reranker is not None:
+                assert r.scores.reranker_raw is not None
             # semantic surfaced these (vector arm) — should be populated and 0..1
             assert r.scores.semantic is not None
             assert 0.0 <= r.scores.semantic <= 1.0

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -6907,10 +6907,12 @@ components:
 
         ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
         arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
-        config for this request), so they prune weak matches before fusion. ``reranker``
-        and ``final`` are **post-query** filters applied to the scored results after
-        reranking. Any field left None imposes no floor; all-None (the default) means
-        no score filtering.
+        config for this request), so they prune weak matches before fusion. ``reranker``,
+        ``reranker_raw``, and ``final`` are **post-query** filters applied to the scored
+        results after reranking. ``reranker`` uses the normalized reranker score;
+        ``reranker_raw`` uses the provider's raw reranker score before normalization.
+        Any field left None imposes no floor; all-None (the default) means no score
+        filtering.
       properties:
         semantic:
           nullable: true
@@ -6919,6 +6921,9 @@ components:
           nullable: true
           type: number
         reranker:
+          nullable: true
+          type: number
+        reranker_raw:
           nullable: true
           type: number
         final:
@@ -7363,7 +7368,8 @@ components:
         can be filtered on via the recall ``min_scores`` request parameter. ``semantic``
         and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that
         strategy did not surface this result); ``reranker`` is the cross-encoder's
-        normalized relevance.
+        normalized relevance and ``reranker_raw`` is the provider's raw score before
+        normalization.
       properties:
         final:
           description: Final ranking score (combined reranker + recency/temporal/proof
@@ -7371,6 +7377,9 @@ components:
           title: Final
           type: number
         reranker:
+          nullable: true
+          type: number
+        reranker_raw:
           nullable: true
           type: number
         semantic:

--- a/hindsight-clients/go/model_min_scores.go
+++ b/hindsight-clients/go/model_min_scores.go
@@ -17,11 +17,12 @@ import (
 // checks if the MinScores type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &MinScores{}
 
-// MinScores Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker`` and ``final`` are **post-query** filters applied to the scored results after reranking. Any field left None imposes no floor; all-None (the default) means no score filtering.
+// MinScores Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker``, ``reranker_raw``, and ``final`` are **post-query** filters applied to the scored results after reranking. ``reranker`` uses the normalized reranker score; ``reranker_raw`` uses the provider's raw reranker score before normalization. Any field left None imposes no floor; all-None (the default) means no score filtering.
 type MinScores struct {
 	Semantic NullableFloat32 `json:"semantic,omitempty"`
 	Keyword NullableFloat32 `json:"keyword,omitempty"`
 	Reranker NullableFloat32 `json:"reranker,omitempty"`
+	RerankerRaw NullableFloat32 `json:"reranker_raw,omitempty"`
 	Final NullableFloat32 `json:"final,omitempty"`
 }
 
@@ -168,6 +169,48 @@ func (o *MinScores) UnsetReranker() {
 	o.Reranker.Unset()
 }
 
+// GetRerankerRaw returns the RerankerRaw field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MinScores) GetRerankerRaw() float32 {
+	if o == nil || IsNil(o.RerankerRaw.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.RerankerRaw.Get()
+}
+
+// GetRerankerRawOk returns a tuple with the RerankerRaw field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MinScores) GetRerankerRawOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RerankerRaw.Get(), o.RerankerRaw.IsSet()
+}
+
+// HasRerankerRaw returns a boolean if a field has been set.
+func (o *MinScores) HasRerankerRaw() bool {
+	if o != nil && o.RerankerRaw.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRerankerRaw gets a reference to the given NullableFloat32 and assigns it to the RerankerRaw field.
+func (o *MinScores) SetRerankerRaw(v float32) {
+	o.RerankerRaw.Set(&v)
+}
+// SetRerankerRawNil sets the value for RerankerRaw to be an explicit nil
+func (o *MinScores) SetRerankerRawNil() {
+	o.RerankerRaw.Set(nil)
+}
+
+// UnsetRerankerRaw ensures that no value is present for RerankerRaw, not even an explicit nil
+func (o *MinScores) UnsetRerankerRaw() {
+	o.RerankerRaw.Unset()
+}
+
 // GetFinal returns the Final field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MinScores) GetFinal() float32 {
 	if o == nil || IsNil(o.Final.Get()) {
@@ -228,6 +271,9 @@ func (o MinScores) ToMap() (map[string]interface{}, error) {
 	}
 	if o.Reranker.IsSet() {
 		toSerialize["reranker"] = o.Reranker.Get()
+	}
+	if o.RerankerRaw.IsSet() {
+		toSerialize["reranker_raw"] = o.RerankerRaw.Get()
 	}
 	if o.Final.IsSet() {
 		toSerialize["final"] = o.Final.Get()

--- a/hindsight-clients/go/model_recall_scores.go
+++ b/hindsight-clients/go/model_recall_scores.go
@@ -19,11 +19,12 @@ import (
 // checks if the RecallScores type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &RecallScores{}
 
-// RecallScores Per-result recall scores from different stages of the pipeline.  ``final`` is the value results are ranked by. The others are diagnostic and can be filtered on via the recall ``min_scores`` request parameter. ``semantic`` and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that strategy did not surface this result); ``reranker`` is the cross-encoder's normalized relevance.
+// RecallScores Per-result recall scores from different stages of the pipeline.  ``final`` is the value results are ranked by. The others are diagnostic and can be filtered on via the recall ``min_scores`` request parameter. ``semantic`` and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that strategy did not surface this result); ``reranker`` is the cross-encoder's normalized relevance and ``reranker_raw`` is the provider's raw score before normalization.
 type RecallScores struct {
 	// Final ranking score (combined reranker + recency/temporal/proof boosts)
 	Final float32 `json:"final"`
 	Reranker NullableFloat32 `json:"reranker,omitempty"`
+	RerankerRaw NullableFloat32 `json:"reranker_raw,omitempty"`
 	Semantic NullableFloat32 `json:"semantic,omitempty"`
 	Keyword NullableFloat32 `json:"keyword,omitempty"`
 }
@@ -112,6 +113,48 @@ func (o *RecallScores) SetRerankerNil() {
 // UnsetReranker ensures that no value is present for Reranker, not even an explicit nil
 func (o *RecallScores) UnsetReranker() {
 	o.Reranker.Unset()
+}
+
+// GetRerankerRaw returns the RerankerRaw field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *RecallScores) GetRerankerRaw() float32 {
+	if o == nil || IsNil(o.RerankerRaw.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.RerankerRaw.Get()
+}
+
+// GetRerankerRawOk returns a tuple with the RerankerRaw field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RecallScores) GetRerankerRawOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.RerankerRaw.Get(), o.RerankerRaw.IsSet()
+}
+
+// HasRerankerRaw returns a boolean if a field has been set.
+func (o *RecallScores) HasRerankerRaw() bool {
+	if o != nil && o.RerankerRaw.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetRerankerRaw gets a reference to the given NullableFloat32 and assigns it to the RerankerRaw field.
+func (o *RecallScores) SetRerankerRaw(v float32) {
+	o.RerankerRaw.Set(&v)
+}
+// SetRerankerRawNil sets the value for RerankerRaw to be an explicit nil
+func (o *RecallScores) SetRerankerRawNil() {
+	o.RerankerRaw.Set(nil)
+}
+
+// UnsetRerankerRaw ensures that no value is present for RerankerRaw, not even an explicit nil
+func (o *RecallScores) UnsetRerankerRaw() {
+	o.RerankerRaw.Unset()
 }
 
 // GetSemantic returns the Semantic field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -211,6 +254,9 @@ func (o RecallScores) ToMap() (map[string]interface{}, error) {
 	toSerialize["final"] = o.Final
 	if o.Reranker.IsSet() {
 		toSerialize["reranker"] = o.Reranker.Get()
+	}
+	if o.RerankerRaw.IsSet() {
+		toSerialize["reranker_raw"] = o.RerankerRaw.Get()
 	}
 	if o.Semantic.IsSet() {
 		toSerialize["semantic"] = o.Semantic.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/min_scores.py
+++ b/hindsight-clients/python/hindsight_client_api/models/min_scores.py
@@ -24,13 +24,14 @@ from typing_extensions import Self
 
 class MinScores(BaseModel):
     """
-    Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker`` and ``final`` are **post-query** filters applied to the scored results after reranking. Any field left None imposes no floor; all-None (the default) means no score filtering.
+    Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker``, ``reranker_raw``, and ``final`` are **post-query** filters applied to the scored results after reranking. ``reranker`` uses the normalized reranker score; ``reranker_raw`` uses the provider's raw reranker score before normalization. Any field left None imposes no floor; all-None (the default) means no score filtering.
     """ # noqa: E501
     semantic: Optional[Union[StrictFloat, StrictInt]] = None
     keyword: Optional[Union[StrictFloat, StrictInt]] = None
     reranker: Optional[Union[StrictFloat, StrictInt]] = None
+    reranker_raw: Optional[Union[StrictFloat, StrictInt]] = None
     final: Optional[Union[StrictFloat, StrictInt]] = None
-    __properties: ClassVar[List[str]] = ["semantic", "keyword", "reranker", "final"]
+    __properties: ClassVar[List[str]] = ["semantic", "keyword", "reranker", "reranker_raw", "final"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -86,6 +87,11 @@ class MinScores(BaseModel):
         if self.reranker is None and "reranker" in self.model_fields_set:
             _dict['reranker'] = None
 
+        # set to None if reranker_raw (nullable) is None
+        # and model_fields_set contains the field
+        if self.reranker_raw is None and "reranker_raw" in self.model_fields_set:
+            _dict['reranker_raw'] = None
+
         # set to None if final (nullable) is None
         # and model_fields_set contains the field
         if self.final is None and "final" in self.model_fields_set:
@@ -106,6 +112,7 @@ class MinScores(BaseModel):
             "semantic": obj.get("semantic"),
             "keyword": obj.get("keyword"),
             "reranker": obj.get("reranker"),
+            "reranker_raw": obj.get("reranker_raw"),
             "final": obj.get("final")
         })
         return _obj

--- a/hindsight-clients/python/hindsight_client_api/models/recall_scores.py
+++ b/hindsight-clients/python/hindsight_client_api/models/recall_scores.py
@@ -24,13 +24,14 @@ from typing_extensions import Self
 
 class RecallScores(BaseModel):
     """
-    Per-result recall scores from different stages of the pipeline.  ``final`` is the value results are ranked by. The others are diagnostic and can be filtered on via the recall ``min_scores`` request parameter. ``semantic`` and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that strategy did not surface this result); ``reranker`` is the cross-encoder's normalized relevance.
+    Per-result recall scores from different stages of the pipeline.  ``final`` is the value results are ranked by. The others are diagnostic and can be filtered on via the recall ``min_scores`` request parameter. ``semantic`` and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that strategy did not surface this result); ``reranker`` is the cross-encoder's normalized relevance and ``reranker_raw`` is the provider's raw score before normalization.
     """ # noqa: E501
     final: Union[StrictFloat, StrictInt] = Field(description="Final ranking score (combined reranker + recency/temporal/proof boosts)")
     reranker: Optional[Union[StrictFloat, StrictInt]] = None
+    reranker_raw: Optional[Union[StrictFloat, StrictInt]] = None
     semantic: Optional[Union[StrictFloat, StrictInt]] = None
     keyword: Optional[Union[StrictFloat, StrictInt]] = None
-    __properties: ClassVar[List[str]] = ["final", "reranker", "semantic", "keyword"]
+    __properties: ClassVar[List[str]] = ["final", "reranker", "reranker_raw", "semantic", "keyword"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -76,6 +77,11 @@ class RecallScores(BaseModel):
         if self.reranker is None and "reranker" in self.model_fields_set:
             _dict['reranker'] = None
 
+        # set to None if reranker_raw (nullable) is None
+        # and model_fields_set contains the field
+        if self.reranker_raw is None and "reranker_raw" in self.model_fields_set:
+            _dict['reranker_raw'] = None
+
         # set to None if semantic (nullable) is None
         # and model_fields_set contains the field
         if self.semantic is None and "semantic" in self.model_fields_set:
@@ -100,6 +106,7 @@ class RecallScores(BaseModel):
         _obj = cls.model_validate({
             "final": obj.get("final"),
             "reranker": obj.get("reranker"),
+            "reranker_raw": obj.get("reranker_raw"),
             "semantic": obj.get("semantic"),
             "keyword": obj.get("keyword")
         })

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2660,10 +2660,12 @@ export type MentalModelTriggerOutput = {
  *
  * ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
  * arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
- * config for this request), so they prune weak matches before fusion. ``reranker``
- * and ``final`` are **post-query** filters applied to the scored results after
- * reranking. Any field left None imposes no floor; all-None (the default) means
- * no score filtering.
+ * config for this request), so they prune weak matches before fusion. ``reranker``,
+ * ``reranker_raw``, and ``final`` are **post-query** filters applied to the scored
+ * results after reranking. ``reranker`` uses the normalized reranker score;
+ * ``reranker_raw`` uses the provider's raw reranker score before normalization.
+ * Any field left None imposes no floor; all-None (the default) means no score
+ * filtering.
  */
 export type MinScores = {
   /**
@@ -2684,6 +2686,12 @@ export type MinScores = {
    * Post-query: minimum normalized reranker score (0-1).
    */
   reranker?: number | null;
+  /**
+   * Reranker Raw
+   *
+   * Post-query: minimum raw reranker score.
+   */
+  reranker_raw?: number | null;
   /**
    * Final
    *
@@ -2998,7 +3006,7 @@ export type RecallRequest = {
    */
   tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
   /**
-   * Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first).
+   * Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker`, `reranker_raw`, and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first).
    */
   min_scores?: MinScores | null;
 };
@@ -3117,7 +3125,8 @@ export type RecallResult = {
  * can be filtered on via the recall ``min_scores`` request parameter. ``semantic``
  * and ``keyword`` are the raw per-strategy retrieval scores (``None`` when that
  * strategy did not surface this result); ``reranker`` is the cross-encoder's
- * normalized relevance.
+ * normalized relevance and ``reranker_raw`` is the provider's raw score before
+ * normalization.
  */
 export type RecallScores = {
   /**
@@ -3132,6 +3141,12 @@ export type RecallScores = {
    * Cross-encoder relevance, normalized 0-1. None when the reranker is a passthrough (rrf/interleave modes).
    */
   reranker?: number | null;
+  /**
+   * Reranker Raw
+   *
+   * Raw cross-encoder/reranker score before normalization. None when the reranker is a passthrough.
+   */
+  reranker_raw?: number | null;
   /**
    * Semantic
    *

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -360,20 +360,21 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The five fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
 | `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
 | `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
 | `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
+| `reranker_raw` | post-query | minimum raw cross-encoder score before normalization, applied to the ranked results |
 | `final` | post-query | minimum final ranking score, applied to the ranked results |
 
 ```json
 { "query": "...", "min_scores": { "reranker": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`reranker_raw`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 
@@ -445,6 +446,7 @@ An object of the per-stage scores for this result. `null` for `source_facts` ent
 
 - **`final`** — the score this fact was ranked by (cross-encoder relevance × recency/temporal/evidence boosts). `results` is ordered by it descending. A relative signal, not a calibrated probability (see the note above).
 - **`reranker`** — the cross-encoder's normalized relevance (`0`–`1`). `null` when the deployment uses a passthrough reranker (RRF/interleave modes).
+- **`reranker_raw`** — the cross-encoder provider's raw score before normalization. `null` when the deployment uses a passthrough reranker.
 - **`semantic`** — the raw vector cosine similarity (`0`–`1`). `null` if this result was not surfaced by semantic search.
 - **`keyword`** — the raw keyword/full-text (BM25) score (`≥ 0`, unbounded). `null` if this result was not surfaced by keyword search.
 

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -204,7 +204,7 @@ Search memories to provide personalized responses.
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`reranker_raw`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
 **Example:**
 ```json

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10406,6 +10406,18 @@
             "title": "Reranker",
             "description": "Post-query: minimum normalized reranker score (0-1)."
           },
+          "reranker_raw": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reranker Raw",
+            "description": "Post-query: minimum raw reranker score."
+          },
           "final": {
             "anyOf": [
               {
@@ -10421,7 +10433,7 @@
         },
         "type": "object",
         "title": "MinScores",
-        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``\nand ``final`` are **post-query** filters applied to the scored results after\nreranking. Any field left None imposes no floor; all-None (the default) means\nno score filtering."
+        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``,\n``reranker_raw``, and ``final`` are **post-query** filters applied to the scored\nresults after reranking. ``reranker`` uses the normalized reranker score;\n``reranker_raw`` uses the provider's raw reranker score before normalization.\nAny field left None imposes no floor; all-None (the default) means no score\nfiltering."
       },
       "ObservationScope": {
         "properties": {
@@ -11010,7 +11022,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
+            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker`, `reranker_raw`, and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
           }
         },
         "type": "object",
@@ -11358,6 +11370,18 @@
             "title": "Reranker",
             "description": "Cross-encoder relevance, normalized 0-1. None when the reranker is a passthrough (rrf/interleave modes)."
           },
+          "reranker_raw": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reranker Raw",
+            "description": "Raw cross-encoder/reranker score before normalization. None when the reranker is a passthrough."
+          },
           "semantic": {
             "anyOf": [
               {
@@ -11388,7 +11412,7 @@
           "final"
         ],
         "title": "RecallScores",
-        "description": "Per-result recall scores from different stages of the pipeline.\n\n``final`` is the value results are ranked by. The others are diagnostic and\ncan be filtered on via the recall ``min_scores`` request parameter. ``semantic``\nand ``keyword`` are the raw per-strategy retrieval scores (``None`` when that\nstrategy did not surface this result); ``reranker`` is the cross-encoder's\nnormalized relevance."
+        "description": "Per-result recall scores from different stages of the pipeline.\n\n``final`` is the value results are ranked by. The others are diagnostic and\ncan be filtered on via the recall ``min_scores`` request parameter. ``semantic``\nand ``keyword`` are the raw per-strategy retrieval scores (``None`` when that\nstrategy did not surface this result); ``reranker`` is the cross-encoder's\nnormalized relevance and ``reranker_raw`` is the provider's raw score before\nnormalization."
       },
       "RecoverConsolidationResponse": {
         "properties": {

--- a/hindsight-docs/versioned_docs/version-0.8/developer/api/recall.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/api/recall.mdx
@@ -360,20 +360,21 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The five fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
 | `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
 | `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
 | `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
+| `reranker_raw` | post-query | minimum raw cross-encoder score before normalization, applied to the ranked results |
 | `final` | post-query | minimum final ranking score, applied to the ranked results |
 
 ```json
 { "query": "...", "min_scores": { "reranker": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`reranker_raw`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 
@@ -445,6 +446,7 @@ An object of the per-stage scores for this result. `null` for `source_facts` ent
 
 - **`final`** — the score this fact was ranked by (cross-encoder relevance × recency/temporal/evidence boosts). `results` is ordered by it descending. A relative signal, not a calibrated probability (see the note above).
 - **`reranker`** — the cross-encoder's normalized relevance (`0`–`1`). `null` when the deployment uses a passthrough reranker (RRF/interleave modes).
+- **`reranker_raw`** — the cross-encoder provider's raw score before normalization. `null` when the deployment uses a passthrough reranker.
 - **`semantic`** — the raw vector cosine similarity (`0`–`1`). `null` if this result was not surfaced by semantic search.
 - **`keyword`** — the raw keyword/full-text (BM25) score (`≥ 0`, unbounded). `null` if this result was not surfaced by keyword search.
 

--- a/hindsight-docs/versioned_docs/version-0.8/developer/mcp-server.md
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/mcp-server.md
@@ -204,7 +204,7 @@ Search memories to provide personalized responses.
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`reranker_raw`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
 **Example:**
 ```json

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -605,20 +605,21 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The five fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
 | `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
 | `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
 | `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
+| `reranker_raw` | post-query | minimum raw cross-encoder score before normalization, applied to the ranked results |
 | `final` | post-query | minimum final ranking score, applied to the ranked results |
 
 ```json
 { "query": "...", "min_scores": { "reranker": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`reranker_raw`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 
@@ -690,6 +691,7 @@ An object of the per-stage scores for this result. `null` for `source_facts` ent
 
 - **`final`** — the score this fact was ranked by (cross-encoder relevance × recency/temporal/evidence boosts). `results` is ordered by it descending. A relative signal, not a calibrated probability (see the note above).
 - **`reranker`** — the cross-encoder's normalized relevance (`0`–`1`). `null` when the deployment uses a passthrough reranker (RRF/interleave modes).
+- **`reranker_raw`** — the cross-encoder provider's raw score before normalization. `null` when the deployment uses a passthrough reranker.
 - **`semantic`** — the raw vector cosine similarity (`0`–`1`). `null` if this result was not surfaced by semantic search.
 - **`keyword`** — the raw keyword/full-text (BM25) score (`≥ 0`, unbounded). `null` if this result was not surfaced by keyword search.
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -204,7 +204,7 @@ Search memories to provide personalized responses.
 | `tags` | list[string] | No | Filter memories by tags |
 | `tags_match` | string | No | Tag matching mode: `any` (default) or `all` |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`reranker_raw`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 
 **Example:**
 ```json

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10406,6 +10406,18 @@
             "title": "Reranker",
             "description": "Post-query: minimum normalized reranker score (0-1)."
           },
+          "reranker_raw": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reranker Raw",
+            "description": "Post-query: minimum raw reranker score."
+          },
           "final": {
             "anyOf": [
               {
@@ -10421,7 +10433,7 @@
         },
         "type": "object",
         "title": "MinScores",
-        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``\nand ``final`` are **post-query** filters applied to the scored results after\nreranking. Any field left None imposes no floor; all-None (the default) means\nno score filtering."
+        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``,\n``reranker_raw``, and ``final`` are **post-query** filters applied to the scored\nresults after reranking. ``reranker`` uses the normalized reranker score;\n``reranker_raw`` uses the provider's raw reranker score before normalization.\nAny field left None imposes no floor; all-None (the default) means no score\nfiltering."
       },
       "ObservationScope": {
         "properties": {
@@ -11010,7 +11022,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
+            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker`, `reranker_raw`, and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
           }
         },
         "type": "object",
@@ -11358,6 +11370,18 @@
             "title": "Reranker",
             "description": "Cross-encoder relevance, normalized 0-1. None when the reranker is a passthrough (rrf/interleave modes)."
           },
+          "reranker_raw": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reranker Raw",
+            "description": "Raw cross-encoder/reranker score before normalization. None when the reranker is a passthrough."
+          },
           "semantic": {
             "anyOf": [
               {
@@ -11388,7 +11412,7 @@
           "final"
         ],
         "title": "RecallScores",
-        "description": "Per-result recall scores from different stages of the pipeline.\n\n``final`` is the value results are ranked by. The others are diagnostic and\ncan be filtered on via the recall ``min_scores`` request parameter. ``semantic``\nand ``keyword`` are the raw per-strategy retrieval scores (``None`` when that\nstrategy did not surface this result); ``reranker`` is the cross-encoder's\nnormalized relevance."
+        "description": "Per-result recall scores from different stages of the pipeline.\n\n``final`` is the value results are ranked by. The others are diagnostic and\ncan be filtered on via the recall ``min_scores`` request parameter. ``semantic``\nand ``keyword`` are the raw per-strategy retrieval scores (``None`` when that\nstrategy did not surface this result); ``reranker`` is the cross-encoder's\nnormalized relevance and ``reranker_raw`` is the provider's raw score before\nnormalization."
       },
       "RecoverConsolidationResponse": {
         "properties": {


### PR DESCRIPTION
## Summary
- add min_scores.reranker_raw for filtering on the raw cross-encoder score before normalization
- expose scores.reranker_raw so callers can inspect and calibrate raw thresholds
- update recall/MCP docs and generated OpenAPI references

## Tests
- uv run --frozen --project hindsight-api-slim --with pytest python -m pytest hindsight-api-slim/tests/test_min_score_filters.py hindsight-api-slim/tests/test_recall_min_score.py::TestRecallRequestDefault::test_http_request_defaults_to_none -q
- uv run --frozen --project hindsight-api-slim ruff check hindsight-api-slim/hindsight_api/api/http.py hindsight-api-slim/hindsight_api/engine/memory_engine.py hindsight-api-slim/hindsight_api/engine/response_models.py hindsight-api-slim/hindsight_api/engine/search/reranking.py hindsight-api-slim/hindsight_api/mcp_tools.py hindsight-api-slim/tests/test_min_score_filters.py hindsight-api-slim/tests/test_recall_min_score.py
- uv run --frozen generate-openapi