### PR TITLE
fix(control-plane): show all mental models instead of capping at 100

### DIFF
--- a/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/mental-models/route.ts
@@ -8,6 +8,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     const { searchParams } = new URL(request.url);
     const tags = searchParams.getAll("tags");
     const tagsMatch = searchParams.get("tags_match");
+    const limit = searchParams.get("limit");
+    const offset = searchParams.get("offset");
 
     if (!bankId) {
       return NextResponse.json(
@@ -25,6 +27,12 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
     }
     if (tagsMatch) {
       queryParams.append("tags_match", tagsMatch);
+    }
+    if (limit) {
+      queryParams.append("limit", limit);
+    }
+    if (offset) {
+      queryParams.append("offset", offset);
     }
 
     const url = dataplaneBankUrl(

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -154,12 +154,23 @@ export function MentalModelsView() {
 
     setLoading(true);
     try {
-      const mentalModelsData = await client.listMentalModels(
-        currentBank,
-        selectedTags.length > 0 ? selectedTags : undefined,
-        selectedTags.length > 0 ? tagsMatch : undefined
-      );
-      setMentalModels(mentalModelsData.items || []);
+      // The API caps each response at PAGE_SIZE, so page through until a short
+      // page is returned to load every mental model for this bank.
+      const PAGE_SIZE = 1000;
+      const all: MentalModel[] = [];
+      for (let offset = 0; ; offset += PAGE_SIZE) {
+        const page = await client.listMentalModels(
+          currentBank,
+          selectedTags.length > 0 ? selectedTags : undefined,
+          selectedTags.length > 0 ? tagsMatch : undefined,
+          PAGE_SIZE,
+          offset
+        );
+        const items = page.items || [];
+        all.push(...items);
+        if (items.length < PAGE_SIZE) break;
+      }
+      setMentalModels(all);
     } catch (error) {
       console.error("Error loading mental models:", error);
     } finally {

--- a/hindsight-control-plane/src/components/mental-models-view.tsx
+++ b/hindsight-control-plane/src/components/mental-models-view.tsx
@@ -156,7 +156,7 @@ export function MentalModelsView() {
     try {
       // The API caps each response at PAGE_SIZE, so page through until a short
       // page is returned to load every mental model for this bank.
-      const PAGE_SIZE = 1000;
+      const PAGE_SIZE = 100;
       const all: MentalModel[] = [];
       for (let offset = 0; ; offset += PAGE_SIZE) {
         const page = await client.listMentalModels(

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1205,13 +1205,25 @@ export class ControlPlaneClient {
   /**
    * List mental models for a bank
    */
-  async listMentalModels(bankId: string, tags?: string[], tagsMatch?: string) {
+  async listMentalModels(
+    bankId: string,
+    tags?: string[],
+    tagsMatch?: string,
+    limit?: number,
+    offset?: number
+  ) {
     const params = new URLSearchParams();
     if (tags && tags.length > 0) {
       tags.forEach((t) => params.append("tags", t));
     }
     if (tagsMatch) {
       params.append("tags_match", tagsMatch);
+    }
+    if (limit !== undefined) {
+      params.append("limit", String(limit));
+    }
+    if (offset !== undefined) {
+      params.append("offset", String(offset));
     }
     const query = params.toString();
     return this.fetchApi<{


### PR DESCRIPTION
## Problem

A user reported the control plane only shows up to **100 mental models**.

It's true. The mental models view called `listMentalModels` **without a `limit`**, so the dataplane fell back to its default cap of 100 (`GET /v1/default/banks/{bank_id}/mental-models` → `limit: int = Query(100, ge=1, le=1000)`). Any bank with more than 100 mental models silently hid the rest:

- The **files view** (the default) lists everything it has loaded and has no pagination controls.
- The **dashboard view**'s pagination and the search box both operate over the full in-memory list.

So nothing past the first 100 was reachable in either view.

## Fix

Page through the API and load every mental model for the bank, preserving all existing behavior (client-side search across all models, both views, the dashboard's existing pagination controls):

- `lib/api.ts` — `listMentalModels()` accepts optional `limit`/`offset` and forwards them.
- `api/banks/[bankId]/mental-models/route.ts` — the proxy route forwards `limit`/`offset` to the dataplane.
- `components/mental-models-view.tsx` — `loadData()` loops in pages of 1000 (the dataplane's max), accumulating until a short page is returned.

No dataplane, OpenAPI, or SDK changes — the endpoint already supported `limit`/`offset`.

## Note

This loads all models with full detail, matching the prior semantics (it already loaded "everything," just capped at 100). Fine for typical bank sizes (hundreds → low thousands). If a bank ever holds tens of thousands of models, true server-side pagination (paged fetch + server-side search) would be the follow-up.

## Testing

- `./scripts/hooks/lint.sh` → all lints passed
- `tsc --noEmit` clean for the changed files (one pre-existing unrelated error in `recall/route.ts`)