### PR TITLE
fix(codex): implement strict_schema via forced tool call + repair invalid \escape (#2504)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -53,6 +53,53 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+# Name of the single forced function tool used to carry structured output when
+# strict_schema is on. The Codex backend speaks the OpenAI Responses API, so a
+# forced function call gives us constrained decoding straight into the response
+# schema — no prompt-injected schema, no raw json.loads on free-form model text,
+# no invalid-\escape retry storm (issue #2504, same class as #1002 / #2339).
+_STRUCTURED_TOOL_NAME = "structured_response"
+
+# Valid JSON string escape characters (the char that may follow a backslash).
+_VALID_JSON_ESCAPE_CHARS = set('"\\/bfnrtu')
+
+
+def _repair_invalid_json_escapes(text: str) -> str:
+    """Best-effort repair of invalid ``\\escape`` sequences in a JSON string.
+
+    Escape-heavy content (code, serial/CLI commands, Windows paths, regexes)
+    makes weaker models emit backslashes that aren't valid JSON escapes (e.g.
+    ``\\d``, ``\\s``, ``C:\\Users``), so ``json.loads`` fails deterministically
+    and every retry re-fails the same way (issue #2504). This doubles any
+    backslash that isn't part of a valid escape so the payload parses. It is a
+    lenient fallback only — the strict_schema forced-tool path is the real fix.
+    """
+    result: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt in _VALID_JSON_ESCAPE_CHARS:
+                # Preserve the valid escape (both chars) verbatim.
+                result.append(ch)
+                result.append(nxt)
+                i += 2
+                continue
+            # Invalid escape: escape the lone backslash so JSON parses.
+            result.append("\\\\")
+            i += 1
+            continue
+        if ch == "\\" and i + 1 == n:
+            # Trailing lone backslash — escape it.
+            result.append("\\\\")
+            i += 1
+            continue
+        result.append(ch)
+        i += 1
+    return "".join(result)
+
 
 class CodexLLM(LLMInterface):
     """
@@ -336,7 +383,18 @@ class CodexLLM(LLMInterface):
         strict_schema: bool = False,
         return_usage: bool = False,
     ) -> Any:
-        """Make API call to Codex backend with SSE streaming."""
+        """Make API call to Codex backend with SSE streaming.
+
+        Args:
+            strict_schema: Route structured output through a single forced
+                function tool (constrained decoding) instead of prompt-injecting
+                the schema and parsing free-form text. The Codex backend speaks
+                the OpenAI Responses API, so the forced function call emits the
+                response schema directly as tool arguments — eliminating the
+                invalid-``\\escape`` retry storm (issue #2504). When False, falls
+                back to schema-in-prompt + JSON parse, now hardened with a lenient
+                invalid-escape repair before giving up.
+        """
         start_time = time.time()
 
         # Proactively refresh the OAuth access_token if it's near expiry.
@@ -361,11 +419,22 @@ class CodexLLM(LLMInterface):
             else:
                 user_messages.append(msg)
 
-        # Add JSON schema instruction if response_format is provided
+        # Structured output: prefer a single forced function tool (constrained
+        # decoding) over text-injecting the schema and parsing the reply. The
+        # forced tool guarantees schema-shaped JSON in the tool arguments,
+        # eliminating the invalid-\escape retry storm (issue #2504). When
+        # strict_schema is off we keep the schema-in-prompt + json.loads
+        # fallback (now hardened with a lenient escape repair) for callers that
+        # can't force tools.
+        schema = None
+        use_forced_tool = False
         if response_format is not None and hasattr(response_format, "model_json_schema"):
             schema = response_format.model_json_schema()
-            schema_msg = f"\n\nYou must respond with valid JSON matching this schema:\n{json.dumps(schema, indent=2, ensure_ascii=False)}"
-            system_instruction += schema_msg
+            if strict_schema:
+                use_forced_tool = True
+            else:
+                schema_msg = f"\n\nYou must respond with valid JSON matching this schema:\n{json.dumps(schema, indent=2, ensure_ascii=False)}"
+                system_instruction += schema_msg
 
         # gpt-5.2-codex only supports "detailed" reasoning summary
         reasoning_summary = "detailed" if "5.2" in self.model else self.reasoning_summary
@@ -392,6 +461,20 @@ class CodexLLM(LLMInterface):
             "prompt_cache_key": str(uuid.uuid4()),
         }
 
+        if use_forced_tool and schema is not None:
+            # Single function tool whose parameters ARE the response schema;
+            # force it via tool_choice so the backend does constrained decoding.
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "name": _STRUCTURED_TOOL_NAME,
+                    "description": "Return the structured response.",
+                    "parameters": schema,
+                }
+            ]
+            payload["tool_choice"] = {"type": "function", "name": _STRUCTURED_TOOL_NAME}
+            payload["parallel_tool_calls"] = False
+
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
@@ -412,8 +495,15 @@ class CodexLLM(LLMInterface):
                 response = await self._client.post(url, json=payload, headers=headers, timeout=120.0)
                 response.raise_for_status()
 
-                # Parse SSE stream
-                content = await self._parse_sse_stream(response)
+                # Forced-tool path: read structured output from the function-call
+                # arguments (already a JSON string in a dedicated channel) rather
+                # than from free-form assistant text.
+                if use_forced_tool:
+                    text_content, tool_calls = await self._parse_sse_tool_stream(response)
+                    content = text_content or ""
+                else:
+                    tool_calls = []
+                    content = await self._parse_sse_stream(response)
 
                 # Codex SSE carries no usage block; stash the same char/4 estimate
                 # the success path traces so a later parse/validate failure records
@@ -426,7 +516,28 @@ class CodexLLM(LLMInterface):
                 )
 
                 # Handle structured output
-                if response_format is not None:
+                if use_forced_tool:
+                    tool_input = None
+                    for tc in tool_calls:
+                        if tc.name == _STRUCTURED_TOOL_NAME:
+                            tool_input = tc.arguments if isinstance(tc.arguments, dict) else None
+                            break
+                    if tool_input is None:
+                        # Model ignored the forced tool (rare — e.g. a gateway that
+                        # drops tool_choice). Retry so we don't hard-fail.
+                        logger.warning(
+                            f"Codex forced structured tool missing from response "
+                            f"(attempt {attempt + 1}/{max_retries + 1})"
+                        )
+                        if attempt < max_retries:
+                            backoff = min(initial_backoff * (2**attempt), max_backoff)
+                            await asyncio.sleep(backoff)
+                            attempt += 1
+                            continue
+                        raise RuntimeError("Codex did not return the forced structured_response tool call")
+                    content = json.dumps(tool_input)
+                    result = tool_input if skip_validation else response_format.model_validate(tool_input)
+                elif response_format is not None:
                     # Models may wrap JSON in markdown
                     clean_content = content
                     if "```json" in content:
@@ -437,13 +548,20 @@ class CodexLLM(LLMInterface):
                     try:
                         json_data = json.loads(clean_content)
                     except json.JSONDecodeError as e:
-                        logger.warning(f"Codex JSON parse error (attempt {attempt + 1}/{max_retries + 1}): {e}")
-                        if attempt < max_retries:
-                            backoff = min(initial_backoff * (2**attempt), max_backoff)
-                            await asyncio.sleep(backoff)
-                            attempt += 1
-                            continue
-                        raise
+                        # Escape-heavy content deterministically re-fails every
+                        # retry (issue #2504). Try a lenient invalid-escape repair
+                        # before burning a retry / re-raising.
+                        try:
+                            json_data = json.loads(_repair_invalid_json_escapes(clean_content))
+                            logger.info("Codex JSON parsed after repairing invalid escape sequences")
+                        except json.JSONDecodeError:
+                            logger.warning(f"Codex JSON parse error (attempt {attempt + 1}/{max_retries + 1}): {e}")
+                            if attempt < max_retries:
+                                backoff = min(initial_backoff * (2**attempt), max_backoff)
+                                await asyncio.sleep(backoff)
+                                attempt += 1
+                                continue
+                            raise
 
                     if skip_validation:
                         result = json_data
@@ -872,8 +990,13 @@ class CodexLLM(LLMInterface):
                             try:
                                 arguments = json.loads(arguments_str)
                             except json.JSONDecodeError:
-                                logger.warning(f"Failed to parse tool arguments: {arguments_str}")
-                                arguments = {}
+                                # Escape-heavy content can emit invalid \escape
+                                # sequences (issue #2504); repair before giving up.
+                                try:
+                                    arguments = json.loads(_repair_invalid_json_escapes(arguments_str))
+                                except json.JSONDecodeError:
+                                    logger.warning(f"Failed to parse tool arguments: {arguments_str}")
+                                    arguments = {}
 
                             tool_calls.append(
                                 LLMToolCall(

--- a/hindsight-api-slim/tests/test_codex_strict_schema.py
+++ b/hindsight-api-slim/tests/test_codex_strict_schema.py
@@ -1,0 +1,185 @@
+"""
+Regression tests for Codex structured output (issue #2504).
+
+Before the fix, ``CodexLLM.call(strict_schema=True)`` was a dead no-op: structured
+output always went through prompt-injected schema + raw ``json.loads`` on the
+model's free-form text. Escape-heavy content (code, serial/CLI commands, Windows
+paths, regexes) makes weaker models emit invalid ``\\escape`` sequences, so every
+parse attempt fails and retain/consolidation burn all retries and fail.
+
+The fix:
+- ``strict_schema=True`` routes structured output through a single forced function
+  tool (constrained decoding into the response schema).
+- The non-strict fallback now repairs invalid ``\\escape`` sequences before giving up.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.providers.codex_llm import (
+    CodexLLM,
+    _repair_invalid_json_escapes,
+)
+from hindsight_api.engine.response_models import LLMToolCall
+
+
+class _Fact(BaseModel):
+    fact: str
+
+
+def build_llm() -> CodexLLM:
+    with patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.4-mini",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _repair_invalid_json_escapes — pure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_repair_fixes_invalid_escape_in_json():
+    # `\d` and `\s` are not valid JSON escapes; raw json.loads fails.
+    broken = r'{"fact": "regex \d+\s matches digits"}'
+    import json
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(broken)
+    repaired = _repair_invalid_json_escapes(broken)
+    assert json.loads(repaired) == {"fact": r"regex \d+\s matches digits"}
+
+
+def test_repair_preserves_valid_escapes():
+    import json
+
+    valid = r'{"fact": "line1\nline2\ttab \"quoted\" \\backslash é"}'
+    # Already valid — repair must not corrupt it.
+    assert json.loads(_repair_invalid_json_escapes(valid)) == json.loads(valid)
+
+
+def test_repair_handles_windows_paths():
+    import json
+
+    # Uses path segments whose first char isn't a valid JSON escape letter
+    # (b/f/n/r/t/u), where the repair is unambiguous.
+    broken = r'{"path": "C:\Windows\System32\app.exe"}'
+    assert json.loads(_repair_invalid_json_escapes(broken)) == {"path": r"C:\Windows\System32\app.exe"}
+
+
+def test_repair_handles_trailing_backslash():
+    # A lone trailing backslash must be escaped, not dropped.
+    assert _repair_invalid_json_escapes("abc\\") == "abc\\\\"
+
+
+# ---------------------------------------------------------------------------
+# strict_schema forced-tool path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_uses_forced_function_tool():
+    llm = build_llm()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    tool_call = LLMToolCall(id="call-1", name="structured_response", arguments={"fact": "the sky is blue"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = response
+        with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
+            mock_parse.return_value = (None, [tool_call])
+            result = await llm.call(
+                messages=[{"role": "user", "content": "The sky is blue"}],
+                response_format=_Fact,
+                strict_schema=True,
+                max_retries=0,
+            )
+        sent_payload = mock_post.call_args.kwargs["json"]
+
+    # Forced tool wired into the request payload.
+    assert sent_payload["tool_choice"] == {"type": "function", "name": "structured_response"}
+    assert len(sent_payload["tools"]) == 1
+    assert sent_payload["tools"][0]["name"] == "structured_response"
+    assert sent_payload["parallel_tool_calls"] is False
+    # No prompt-injected schema in the instructions.
+    assert "You must respond with valid JSON" not in sent_payload["instructions"]
+
+    assert isinstance(result, _Fact)
+    assert result.fact == "the sky is blue"
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_skip_validation_returns_dict():
+    llm = build_llm()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    tool_call = LLMToolCall(id="c", name="structured_response", arguments={"fact": "x"})
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = response
+        with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
+            mock_parse.return_value = (None, [tool_call])
+            result = await llm.call(
+                messages=[{"role": "user", "content": "hi"}],
+                response_format=_Fact,
+                strict_schema=True,
+                skip_validation=True,
+                max_retries=0,
+            )
+
+    assert result == {"fact": "x"}
+
+
+@pytest.mark.asyncio
+async def test_strict_schema_retries_when_forced_tool_missing():
+    llm = build_llm()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = response
+        # Model returns no tool call at all — should raise after retries exhausted.
+        with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
+            mock_parse.return_value = ("some prose", [])
+            with pytest.raises(RuntimeError, match="structured_response"):
+                await llm.call(
+                    messages=[{"role": "user", "content": "hi"}],
+                    response_format=_Fact,
+                    strict_schema=True,
+                    max_retries=0,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Non-strict fallback: escape repair keeps the retry storm from happening
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_strict_repairs_invalid_escapes_without_retrying():
+    llm = build_llm()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    # Escape-heavy content the model would emit as invalid JSON.
+    escape_heavy = r'{"fact": "run rig-control \d serial \s command"}'
+
+    with patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = response
+        with patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock) as mock_parse:
+            mock_parse.return_value = escape_heavy
+            result = await llm.call(
+                messages=[{"role": "user", "content": "coding transcript"}],
+                response_format=_Fact,
+                strict_schema=False,
+                max_retries=3,
+            )
+
+    # Parsed on the first attempt (no retry storm): the SSE stream was read once.
+    assert mock_post.await_count == 1
+    assert isinstance(result, _Fact)
+    assert result.fact == r"run rig-control \d serial \s command"


### PR DESCRIPTION
## Summary

Fixes #2504. `codex_llm.py` accepted `strict_schema` but never used it — structured output always went through prompt-injected schema + raw `json.loads` on the model's free-form text. Escape-heavy content (code, serial/CLI commands, Windows paths, regexes) makes weaker models emit invalid `\escape` sequences, so every parse attempt fails and retain/consolidation burn all retries and fail deterministically (same class as #1002 / #2339).

## Changes

**Primary — forced tool call.** `strict_schema=True` now routes structured output through a single forced function tool (`structured_response`) whose parameters *are* the response schema, with `tool_choice` pinned to it and `parallel_tool_calls=False`. The Codex backend speaks the OpenAI Responses API, so the model emits schema-shaped JSON as tool arguments in a dedicated channel instead of free-form prose — mirroring the Anthropic forced-`tool_use` fix from #2339. Falls back to a retry if the model ignores the forced tool.

**Secondary — lenient escape repair.** `_repair_invalid_json_escapes()` doubles any backslash that isn't part of a valid JSON escape. It's applied both in the non-strict `call()` fallback and in tool-argument parsing (`_parse_sse_tool_stream`, which also serves `call_with_tools`), so the deterministic retry storm stops even in the default config. Documented as best-effort (the `\r`/`\t`/etc. collision is inherently ambiguous).

## Tests

`tests/test_codex_strict_schema.py` (8 new):
- forced-tool wiring + no prompt injection
- `skip_validation` dict return
- retry-then-raise when the forced tool is missing
- no-retry-storm escape repair in the non-strict path
- pure unit tests for the repair helper (valid-escape preservation, Windows paths, trailing backslash)

This is structured-output plumbing (not LLM-interpretation behaviour), so deterministic unit tests are the right coverage. Lint, ruff, and `ty` all pass.
