### PR TITLE
fix(embeddings): cap LiteLLM SDK inputs over the model token limit (#2501)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -1226,6 +1226,10 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self.encoding_format = encoding_format or None
         self._litellm = None  # Will be set during initialization
         self._dimension: int | None = None
+        # Max per-input tokens accepted by the embedding model, resolved at
+        # initialize(). None means "unknown" -> inputs are sent unchanged
+        # (preserves prior behavior for models we have no limit for).
+        self._max_input_tokens: int | None = None
 
     @property
     def provider_name(self) -> str:
@@ -1282,7 +1286,79 @@ class LiteLLMSDKEmbeddings(Embeddings):
         except Exception as e:
             raise RuntimeError(f"Failed to initialize LiteLLM SDK embeddings: {e}")
 
+        self._max_input_tokens = self._resolve_max_input_tokens()
+        if self._max_input_tokens is not None:
+            logger.info(
+                f"Embeddings: LiteLLM SDK max input tokens for {self.model} = {self._max_input_tokens} "
+                "(oversized inputs will be truncated before embedding)"
+            )
+
         logger.info(f"Embeddings: LiteLLM SDK provider initialized (model: {self.model}, dim: {self._dimension})")
+
+    def _resolve_max_input_tokens(self) -> int | None:
+        """Best-effort per-input token limit for the embedding model.
+
+        Returns None when unknown, in which case encode() sends inputs
+        unchanged. Checks a small table of known embedding-model limits first
+        (substring match on the model name), then falls back to LiteLLM's model
+        metadata. Any lookup failure degrades to None rather than raising.
+        """
+        model_lower = self.model.lower()
+        for marker, limit in _EMBEDDING_MODEL_MAX_INPUT_TOKENS.items():
+            if marker in model_lower:
+                return limit
+        try:
+            info = self._litellm.get_model_info(self.model)
+        except Exception:  # noqa: BLE001 - metadata lookup is best-effort
+            return None
+        if isinstance(info, dict):
+            limit = info.get("max_input_tokens")
+            if isinstance(limit, int) and limit > 0:
+                return limit
+        return None
+
+    def _truncate_to_max_input_tokens(self, text: str) -> str:
+        """Truncate a single input so it fits the model's input token limit.
+
+        Uses LiteLLM's tokenizer for the model when available; falls back to a
+        conservative character estimate if tokenization is unavailable. A safety
+        ratio leaves headroom because a provider's server-side tokenizer (e.g.
+        Amazon Titan) may count differently from the local tokenizer. When no
+        limit is known the text is returned unchanged.
+        """
+        limit = self._max_input_tokens
+        if limit is None:
+            return text
+        budget = max(1, int(limit * _EMBEDDING_INPUT_TOKEN_SAFETY_RATIO))
+        try:
+            tokens = self._litellm.encode(model=self.model, text=text)
+        except Exception:  # noqa: BLE001 - tokenizer may be unavailable
+            tokens = None
+        if tokens is not None:
+            token_count = len(tokens)
+            if token_count <= budget:
+                return text
+            # Input is known-oversized. Prefer an exact token-boundary
+            # truncation via decode; if decode is unavailable or yields an
+            # empty string, cut characters *proportionally* to the token
+            # overflow (robust for scripts where chars-per-token differs from
+            # the 4x estimate, e.g. CJK). Never return the oversized text —
+            # that is exactly the permanent-failure loop #2501 is fixing.
+            try:
+                truncated = self._litellm.decode(model=self.model, tokens=tokens[:budget])
+                if truncated:
+                    return truncated
+            except Exception:  # noqa: BLE001 - decode is best-effort
+                pass
+            proportional_chars = max(1, int(len(text) * budget / token_count))
+            return text[:proportional_chars]
+        # Tokenization unavailable: only shorten inputs that are obviously
+        # oversized by a conservative character estimate (~4 chars/token);
+        # leave smaller inputs untouched.
+        max_chars = budget * 4
+        if len(text) > max_chars:
+            return text[:max_chars]
+        return text
 
     def encode(self, texts: list[str]) -> list[list[float]]:
         """
@@ -1305,6 +1381,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
         # Process in batches
         for i in range(0, len(texts), self.batch_size):
             batch = texts[i : i + self.batch_size]
+            if self._max_input_tokens is not None:
+                batch = [self._truncate_to_max_input_tokens(text) for text in batch]
 
             try:
                 # Build kwargs for embedding call
@@ -1351,6 +1429,24 @@ class LiteLLMSDKEmbeddings(Embeddings):
 # names (e.g. "gemini-embedding-2-preview", "gemini-embedding-2"), with or
 # without a "google/" or "models/" prefix.
 _GEMINI_AGGREGATING_MODEL_MARKER = "gemini-embedding-2"
+
+# Known per-input token limits for embedding models, matched as a substring of
+# the (lowercased) model name. Sending an input longer than the provider's
+# limit fails the whole embedding call; for delta-refreshed mental models this
+# can pin a model in a permanent refresh-failure loop (see issue #2501). LiteLLM
+# model metadata is consulted as a fallback for anything not listed here.
+_EMBEDDING_MODEL_MAX_INPUT_TOKENS: dict[str, int] = {
+    "amazon.titan-embed-text-v2": 8192,
+    "amazon.titan-embed-text-v1": 8192,
+    "text-embedding-3-small": 8191,
+    "text-embedding-3-large": 8191,
+    "text-embedding-ada-002": 8191,
+}
+
+# Fraction of the model's input token limit to target when truncating. Leaves
+# headroom because a provider's server-side tokenizer may count more tokens
+# than the local tokenizer used for truncation.
+_EMBEDDING_INPUT_TOKEN_SAFETY_RATIO = 0.95
 
 
 def _gemini_model_aggregates_inputs(model: str) -> bool:

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -13,7 +13,6 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from hindsight_api.engine.embeddings import LiteLLMSDKEmbeddings, create_embeddings_from_env
 
 
@@ -495,7 +494,6 @@ class TestLiteLLMSDKEmbeddings:
             ):
                 await emb.initialize()
 
-
     async def test_resolve_max_input_tokens_from_known_table(self, mock_litellm):
         """Known embedding models resolve their input-token limit from the table."""
         with patch(
@@ -585,6 +583,7 @@ class TestLiteLLMSDKEmbeddings:
 
     async def test_encode_preserves_input_order_and_count_in_mixed_batch(self, mock_litellm):
         """A mixed-size batch keeps 1:1 input->vector alignment; only oversized inputs change."""
+
         # index 0 oversized, index 1 small, index 2 oversized.
         def fake_encode(model, text):
             return list(range(9000)) if text.startswith("BIG") else list(range(5))
@@ -608,9 +607,9 @@ class TestLiteLLMSDKEmbeddings:
 
         assert len(result) == 3  # 1:1 alignment preserved
         sent = mock_litellm.embedding.call_args.kwargs["input"]
-        assert sent[0] == "CUT"       # oversized truncated
-        assert sent[1] == "small-b"   # small untouched, position preserved
-        assert sent[2] == "CUT"       # oversized truncated
+        assert sent[0] == "CUT"  # oversized truncated
+        assert sent[1] == "small-b"  # small untouched, position preserved
+        assert sent[2] == "CUT"  # oversized truncated
 
     async def test_encode_does_not_truncate_within_budget(self, mock_litellm):
         """Inputs already under the token budget are sent unchanged (no decode)."""

--- a/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_embeddings.py
@@ -496,6 +496,158 @@ class TestLiteLLMSDKEmbeddings:
                 await emb.initialize()
 
 
+    async def test_resolve_max_input_tokens_from_known_table(self, mock_litellm):
+        """Known embedding models resolve their input-token limit from the table."""
+        with patch(
+            "builtins.__import__",
+            side_effect=lambda name, *args: mock_litellm if name == "litellm" else __import__(name, *args),
+        ):
+            emb = LiteLLMSDKEmbeddings(model="bedrock/amazon.titan-embed-text-v2:0")
+            await emb.initialize()
+
+            assert emb._max_input_tokens == 8192
+            mock_litellm.get_model_info.assert_not_called()
+
+    async def test_resolve_max_input_tokens_falls_back_to_litellm_metadata(self, mock_litellm):
+        """Unknown models fall back to litellm.get_model_info()['max_input_tokens']."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 2048}
+        with patch(
+            "builtins.__import__",
+            side_effect=lambda name, *args: mock_litellm if name == "litellm" else __import__(name, *args),
+        ):
+            emb = LiteLLMSDKEmbeddings(model="some-provider/mystery-embed")
+            await emb.initialize()
+
+            assert emb._max_input_tokens == 2048
+            mock_litellm.get_model_info.assert_called_once_with("some-provider/mystery-embed")
+
+    async def test_resolve_max_input_tokens_unknown_is_none(self, mock_litellm):
+        """When neither the table nor litellm metadata yields a limit, it stays None."""
+        mock_litellm.get_model_info.side_effect = Exception("no metadata")
+        with patch(
+            "builtins.__import__",
+            side_effect=lambda name, *args: mock_litellm if name == "litellm" else __import__(name, *args),
+        ):
+            emb = LiteLLMSDKEmbeddings(model="some-provider/mystery-embed")
+            await emb.initialize()
+
+            assert emb._max_input_tokens is None
+
+    async def test_encode_truncates_oversized_input(self, mock_litellm):
+        """Oversized single input is shortened to the model's token budget before embedding."""
+        oversized_tokens = list(range(9000))
+        mock_litellm.encode.return_value = oversized_tokens
+        mock_litellm.decode.return_value = "truncated-content"
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
+
+        emb = LiteLLMSDKEmbeddings(model="bedrock/amazon.titan-embed-text-v2:0")
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        emb._max_input_tokens = 8192
+
+        result = emb.encode(["x" * 100000])
+
+        assert len(result) == 1
+        decode_kwargs = mock_litellm.decode.call_args.kwargs
+        assert len(decode_kwargs["tokens"]) == int(8192 * 0.95)
+        embed_kwargs = mock_litellm.embedding.call_args.kwargs
+        assert embed_kwargs["input"] == ["truncated-content"]
+
+    async def test_encode_oversized_falls_back_to_char_cut_when_decode_empty(self, mock_litellm):
+        """If decode() yields an empty string, an oversized input is still cut (never sent whole).
+
+        Regression guard: a decode that returns "" must not let the original
+        oversized text through — that is the exact #2501 failure mode.
+        """
+        mock_litellm.encode.return_value = list(range(9000))
+        mock_litellm.decode.return_value = ""  # decode unavailable / empty
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
+
+        emb = LiteLLMSDKEmbeddings(model="bedrock/amazon.titan-embed-text-v2:0")
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        emb._max_input_tokens = 8192
+
+        budget = int(8192 * 0.95)
+        # Dense text where char count ~ token count (each "char" is one token
+        # in this mock: encode returns 9000 tokens for a 9000-char string), so a
+        # fixed budget*4 char cut would wrongly pass it through. The proportional
+        # fallback must cut to ~budget chars here.
+        dense = "d" * 9000
+        result = emb.encode([dense])
+
+        assert len(result) == 1
+        sent = mock_litellm.embedding.call_args.kwargs["input"][0]
+        # proportional cut: len(text) * budget / token_count = 9000 * budget / 9000 = budget
+        expected = int(9000 * budget / 9000)
+        assert sent == "d" * expected
+        assert len(sent) < len(dense)
+
+    async def test_encode_preserves_input_order_and_count_in_mixed_batch(self, mock_litellm):
+        """A mixed-size batch keeps 1:1 input->vector alignment; only oversized inputs change."""
+        # index 0 oversized, index 1 small, index 2 oversized.
+        def fake_encode(model, text):
+            return list(range(9000)) if text.startswith("BIG") else list(range(5))
+
+        mock_litellm.encode.side_effect = fake_encode
+        mock_litellm.decode.return_value = "CUT"
+
+        def fake_embedding(model, input, **kwargs):
+            resp = MagicMock()
+            resp.data = [{"embedding": [float(i)] * 768, "index": i} for i in range(len(input))]
+            return resp
+
+        mock_litellm.embedding.side_effect = fake_embedding
+
+        emb = LiteLLMSDKEmbeddings(model="bedrock/amazon.titan-embed-text-v2:0", batch_size=100)
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        emb._max_input_tokens = 8192
+
+        result = emb.encode(["BIG-a", "small-b", "BIG-c"])
+
+        assert len(result) == 3  # 1:1 alignment preserved
+        sent = mock_litellm.embedding.call_args.kwargs["input"]
+        assert sent[0] == "CUT"       # oversized truncated
+        assert sent[1] == "small-b"   # small untouched, position preserved
+        assert sent[2] == "CUT"       # oversized truncated
+
+    async def test_encode_does_not_truncate_within_budget(self, mock_litellm):
+        """Inputs already under the token budget are sent unchanged (no decode)."""
+        mock_litellm.encode.return_value = list(range(10))
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
+
+        emb = LiteLLMSDKEmbeddings(model="bedrock/amazon.titan-embed-text-v2:0")
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        emb._max_input_tokens = 8192
+
+        result = emb.encode(["short text"])
+
+        assert len(result) == 1
+        mock_litellm.decode.assert_not_called()
+        embed_kwargs = mock_litellm.embedding.call_args.kwargs
+        assert embed_kwargs["input"] == ["short text"]
+
+    async def test_encode_skips_truncation_when_limit_unknown(self, mock_litellm):
+        """When no input-token limit is known, inputs are sent unchanged (prior behavior)."""
+        mock_litellm.embedding.return_value.data = [{"embedding": [0.1] * 768, "index": 0}]
+
+        emb = LiteLLMSDKEmbeddings(model="some-provider/mystery-embed")
+        emb._litellm = mock_litellm
+        emb._dimension = 768
+        emb._max_input_tokens = None
+
+        big_text = "x" * 100000
+        result = emb.encode([big_text])
+
+        assert len(result) == 1
+        mock_litellm.encode.assert_not_called()
+        mock_litellm.decode.assert_not_called()
+        embed_kwargs = mock_litellm.embedding.call_args.kwargs
+        assert embed_kwargs["input"] == [big_text]
+
+
 class TestLiteLLMSDKEmbeddingsFactory:
     """Test the factory function for creating LiteLLM SDK embeddings."""
 


### PR DESCRIPTION
## Summary

Fixes #2501. A delta-refreshed mental model can grow past the embedding model's input token limit (e.g. Bedrock `amazon.titan-embed-text-v2:0` = 8192 tokens). Once it does, every scheduled refresh re-sends the same oversized input to `litellm.embedding`, which the provider rejects — so the model is pinned in a permanent refresh-failure loop until manually cleared.

## Change

`LiteLLMSDKEmbeddings`:
- Resolves the model's max input tokens at `initialize()` — a small known-model table (substring match) first, then `litellm.get_model_info(model)["max_input_tokens"]` as a fallback. Unknown ⇒ `None`.
- In `encode()`, truncates any oversized input **before** the embedding call, using `litellm.encode`/`litellm.decode` with a 0.95 safety ratio (leaving headroom for server-side tokenizer differences), and a proportional character-cut fallback when tokenization/decode is unavailable.
- When no limit is known (`None`), inputs are sent unchanged — **no behavior change** for models without a known limit.

This is a focused runtime guard; it does not redesign the delta-refresh document pipeline.

## Tests

Adds regression tests in `test_litellm_sdk_embeddings.py`:
- limit resolution: known-table / `get_model_info` fallback / unknown-is-None
- oversized single input truncated to the token budget
- empty-`decode()` still cuts an oversized input (never sends it whole — the exact #2501 failure mode)
- mixed-size batch preserves 1:1 input→vector alignment and ordering (only oversized inputs change)
- within-budget input is a no-op (no `decode` call)
- unknown-limit input is a no-op (no tokenization)

All existing `LiteLLMSDKEmbeddings` tests continue to pass.
