### PR TITLE
fix(graph-maintenance): retry cooccurrence sweep on deadlock

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -203,27 +203,43 @@ async def run_graph_maintenance_job(
 
     # --- Pass 2 & 3: entity / cooccurrence sweeps ---
     # Bank-wide single-statement deletes. Cheap when there's nothing to do.
+    #
+    # Unlike Pass 1's queue claim, these DELETEs aren't protected by any
+    # consistent lock-ordering guarantee: prune_stale_cooccurrences scans
+    # entity_cooccurrences via a join/NOT EXISTS plan, while retain's
+    # concurrent cooccurrence upserts (entity_resolver._flush_pending) lock
+    # the same rows in sorted (entity_id_1, entity_id_2) order. When a sweep
+    # and a concurrent upsert touch overlapping rows in opposite orders,
+    # Postgres detects a genuine circular wait and aborts one side with
+    # DeadlockDetectedError. Both prunes are idempotent bank-wide sweeps —
+    # rerunning only deletes what's still stale — so retrying the whole
+    # transaction on deadlock is safe.
+    from .db_utils import retry_with_backoff
     from .memory_engine import acquire_with_retry
 
-    async with acquire_with_retry(backend) as conn:
-        async with conn.transaction():
-            result.orphan_entities_pruned = await ops.prune_orphan_entities(
-                conn,
-                fq_table("entities"),
-                fq_table("unit_entities"),
-                bank_id,
-            )
-            # The orphan prune above cascades cooccurrences via FK. The
-            # explicit cooccurrence pass below catches the *stale-count*
-            # case: both entities still exist but no current unit witnesses
-            # them together.
-            result.stale_cooccurrences_pruned = await ops.prune_stale_cooccurrences(
-                conn,
-                fq_table("entity_cooccurrences"),
-                fq_table("unit_entities"),
-                fq_table("entities"),
-                bank_id,
-            )
+    async def _run_sweep() -> tuple[int, int]:
+        async with acquire_with_retry(backend) as conn:
+            async with conn.transaction():
+                orphan_pruned = await ops.prune_orphan_entities(
+                    conn,
+                    fq_table("entities"),
+                    fq_table("unit_entities"),
+                    bank_id,
+                )
+                # The orphan prune above cascades cooccurrences via FK. The
+                # explicit cooccurrence pass below catches the *stale-count*
+                # case: both entities still exist but no current unit
+                # witnesses them together.
+                stale_pruned = await ops.prune_stale_cooccurrences(
+                    conn,
+                    fq_table("entity_cooccurrences"),
+                    fq_table("unit_entities"),
+                    fq_table("entities"),
+                    bank_id,
+                )
+                return orphan_pruned, stale_pruned
+
+    result.orphan_entities_pruned, result.stale_cooccurrences_pruned = await retry_with_backoff(_run_sweep)
 
     elapsed = time.time() - job_start
     logger.info(

--- a/hindsight-api-slim/tests/test_graph_maintenance_deadlock.py
+++ b/hindsight-api-slim/tests/test_graph_maintenance_deadlock.py
@@ -1,6 +1,12 @@
 """Reproduces the concurrent-insert deadlock on ``graph_maintenance_queue``
 that PR #2353 targets, and demonstrates that a shared insertion order cures it.
 
+Also covers the ``entity_cooccurrences`` deadlock between the Pass 2/3 sweep
+(``prune_stale_cooccurrences``) and retain's concurrent cooccurrence upserts —
+the dominant ``DeadlockDetectedError`` cause in production logs (39 of 41
+occurrences in one week) — and the ``retry_with_backoff`` fix around that
+sweep in ``run_graph_maintenance_job``.
+
 A deadlock is a *database*-level phenomenon, so unlike the PR's own tests (which
 only assert that the Python list handed to ``conn.execute`` is sorted) these run
 against the real Postgres test DB and drive two genuinely-concurrent
@@ -24,10 +30,14 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 from asyncpg.exceptions import DeadlockDetectedError
 
+from hindsight_api import RequestContext
+from hindsight_api.engine.graph_maintenance import run_graph_maintenance_job
 from hindsight_api.engine.memory_engine import MemoryEngine
 
 # Two keys with an unambiguous sort order (low < high as UUIDs / as text).
@@ -82,6 +92,181 @@ async def test_unordered_concurrent_enqueue_deadlocks(memory: MemoryEngine):
 
     deadlocks = [r for r in results if isinstance(r, DeadlockDetectedError)]
     assert deadlocks, f"expected one transaction aborted with DeadlockDetectedError, got {results!r}"
+
+
+async def _insert_entity(conn, bank_id: str, entity_id: uuid.UUID, name: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO entities (id, bank_id, canonical_name, first_seen, last_seen, mention_count)
+        VALUES ($1, $2, $3, NOW(), NOW(), 1)
+        """,
+        entity_id,
+        bank_id,
+        name,
+    )
+
+
+async def _insert_cooccurrence(conn, entity_a: uuid.UUID, entity_b: uuid.UUID) -> None:
+    first, second = sorted([entity_a, entity_b])
+    await conn.execute(
+        """
+        INSERT INTO entity_cooccurrences (entity_id_1, entity_id_2, cooccurrence_count, last_cooccurred)
+        VALUES ($1, $2, 1, NOW())
+        """,
+        first,
+        second,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unordered_concurrent_sweep_and_upsert_deadlocks(memory: MemoryEngine):
+    """Reproduces the ``prune_stale_cooccurrences`` deadlock seen in production
+    (``asyncpg.exceptions.DeadlockDetectedError`` on ``entity_cooccurrences``,
+    39 of 41 deadlock occurrences in one week of logs).
+
+    ``prune_stale_cooccurrences`` (graph maintenance) scans/locks
+    ``entity_cooccurrences`` rows for a bank in whatever order its join/NOT
+    EXISTS plan visits them. Concurrently, retain's cooccurrence upserts
+    (``entity_resolver._flush_pending``) lock rows in sorted
+    ``(entity_id_1, entity_id_2)`` order — sorted specifically to avoid
+    deadlocking against *other* concurrent upserts, but that guarantee says
+    nothing about the maintenance sweep's scan order. Two transactions
+    touching the same two cooccurrence rows in opposite orders cycle, and
+    Postgres aborts one with ``DeadlockDetectedError``.
+
+    This models each side as a sequence of single-row statements with a
+    barrier between them (same technique as the queue-insert test above) so
+    the interleaving that produces the cycle is deterministic rather than
+    racy.
+    """
+    pool = await memory._get_pool()
+    bank_id = f"dl-sweep-{uuid.uuid4().hex[:8]}"
+
+    # Two cooccurrence rows. entity_cooccurrence_order_check pins each row's
+    # own (entity_id_1, entity_id_2) internally, but the two ROWS themselves
+    # sort as pair_low < pair_high by their first UUID.
+    pair_low = (uuid.UUID("00000000-0000-4000-8000-000000000001"), uuid.UUID("00000000-0000-4000-8000-000000000002"))
+    pair_high = (uuid.UUID("ffffffff-ffff-4fff-8fff-fffffffffffe"), uuid.UUID("ffffffff-ffff-4fff-8fff-ffffffffffff"))
+
+    async with pool.acquire() as conn:
+        for entity_id, name in [
+            (pair_low[0], "low-a"),
+            (pair_low[1], "low-b"),
+            (pair_high[0], "high-a"),
+            (pair_high[1], "high-b"),
+        ]:
+            await _insert_entity(conn, bank_id, entity_id, name)
+        await _insert_cooccurrence(conn, *pair_low)
+        await _insert_cooccurrence(conn, *pair_high)
+
+    barrier = asyncio.Barrier(2)
+
+    async def touch(conn, entity_a: uuid.UUID, entity_b: uuid.UUID) -> None:
+        first, second = sorted([entity_a, entity_b])
+        await conn.execute(
+            "UPDATE entity_cooccurrences SET cooccurrence_count = cooccurrence_count + 1 "
+            "WHERE entity_id_1 = $1 AND entity_id_2 = $2",
+            first,
+            second,
+        )
+
+    async def sweep_worker() -> None:
+        """Mimics the maintenance scan visiting pair_high before pair_low."""
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await touch(conn, *pair_high)
+                await barrier.wait()
+                await touch(conn, *pair_low)
+
+    async def upsert_worker() -> None:
+        """Mimics retain's sorted upsert — always ascending order."""
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await touch(conn, *pair_low)
+                await barrier.wait()
+                await touch(conn, *pair_high)
+
+    results = await asyncio.wait_for(
+        asyncio.gather(sweep_worker(), upsert_worker(), return_exceptions=True),
+        timeout=30,
+    )
+
+    deadlocks = [r for r in results if isinstance(r, DeadlockDetectedError)]
+    assert deadlocks, f"expected one transaction aborted with DeadlockDetectedError, got {results!r}"
+
+
+@pytest.mark.asyncio
+async def test_graph_maintenance_sweep_retries_on_deadlock(memory: MemoryEngine, request_context: RequestContext):
+    """``run_graph_maintenance_job``'s Pass 2/3 sweep must survive a deadlock.
+
+    Fix for the production bug reproduced above: the sweep
+    (``prune_orphan_entities`` + ``prune_stale_cooccurrences``) now runs
+    inside ``retry_with_backoff``, which already special-cases
+    ``DeadlockDetectedError``. Both prunes are idempotent bank-wide deletes,
+    so retrying the whole transaction after a deadlock is safe. Simulates the
+    deadlock via a mock (real two-connection reproduction is covered above;
+    this asserts the *application* behaviour — one transient
+    DeadlockDetectedError must not fail the job) and asserts the retry
+    actually happens and the job still returns correct prune counts.
+    """
+    bank_id = f"dl-fix-sweep-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    pool = await memory._get_pool()
+    ent_a = uuid.uuid4()
+    ent_b = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await _insert_entity(conn, bank_id, ent_a, "alice")
+        await _insert_entity(conn, bank_id, ent_b, "bob")
+        # Both entities are referenced by units (so prune_orphan_entities
+        # leaves them alone), but by DIFFERENT units — no unit references
+        # both, so the cooccurrence itself is stale and eligible for
+        # prune_stale_cooccurrences.
+        for entity_id, text in [(ent_a, "with_alice"), (ent_b, "with_bob")]:
+            unit_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, event_date, created_at, updated_at)
+                VALUES ($1, $2, $3, 'experience', NOW(), NOW(), NOW())
+                """,
+                unit_id,
+                bank_id,
+                text,
+            )
+            await conn.execute(
+                "INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)",
+                unit_id,
+                entity_id,
+            )
+        await conn.execute(
+            """
+            INSERT INTO entity_cooccurrences (entity_id_1, entity_id_2, cooccurrence_count, last_cooccurred)
+            VALUES ($1, $2, 1, $3)
+            """,
+            *sorted([ent_a, ent_b]),
+            datetime.now(UTC),
+        )
+
+    backend = await memory._get_backend()
+    real_prune = backend.ops.prune_stale_cooccurrences
+    call_count = 0
+
+    async def flaky_prune(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise DeadlockDetectedError("deadlock detected")
+        return await real_prune(*args, **kwargs)
+
+    backend.ops.prune_stale_cooccurrences = AsyncMock(side_effect=flaky_prune)
+    try:
+        result = await run_graph_maintenance_job(memory, bank_id, request_context)
+    finally:
+        backend.ops.prune_stale_cooccurrences = real_prune
+
+    assert call_count == 2, "expected exactly one deadlock retry"
+    assert result["orphan_entities_pruned"] == 0
+    assert result["stale_cooccurrences_pruned"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`run_graph_maintenance_job`'s Pass 2/3 sweep (`prune_orphan_entities` + `prune_stale_cooccurrences`) has no retry protection against `DeadlockDetectedError`, unlike other concurrency-sensitive paths in this codebase (e.g. #2353's sorted `graph_maintenance_queue` inserts, or `entity_resolver`'s sorted cooccurrence upserts).

- `prune_stale_cooccurrences` deletes `entity_cooccurrences` rows via a join/`NOT EXISTS` scan with no consistent lock-acquisition order.
- `entity_resolver._flush_pending`'s concurrent cooccurrence upserts lock the same rows in sorted `(entity_id_1, entity_id_2)` order — sorted specifically to avoid deadlocking against *other* concurrent upserts, but that guarantee says nothing about the maintenance sweep's scan order.
- When the sweep and a concurrent upsert touch overlapping rows in opposite orders, Postgres detects a genuine cycle and aborts one side with `DeadlockDetectedError`.
- `acquire_with_retry` explicitly does **not** retry exceptions raised inside the transaction body (only the acquire step — see its docstring / `test_db_utils.py`), so this deadlock previously propagated straight out of `execute_task` and dropped the maintenance pass for that invocation entirely.

Evidence: in a week of self-hosted production logs, this was **39 of 41** `DeadlockDetectedError` occurrences (the remaining 1 was in `claim_graph_maintenance_batch`, not addressed here to keep this PR focused — the queue-claim path is separately protected by submit-time per-bank dedup).

## Steps to reproduce

Both a raw DB-level reproduction and an application-level (pre-fix-fails / post-fix-passes) reproduction are included as tests, so this is fully reproducible without any external setup — the test suite uses an embedded Postgres (`pg0`), no Docker or manual DB needed.

**1. Raw two-connection deadlock** (no application code, exercises Postgres directly — same technique the existing `test_unordered_concurrent_enqueue_deadlocks` in this file already uses for the `graph_maintenance_queue` case, since a deadlock can't be forced deterministically inside a single un-pausable SQL statement):

```bash
cd hindsight-api-slim
uv run pytest tests/test_graph_maintenance_deadlock.py::test_unordered_concurrent_sweep_and_upsert_deadlocks -v
```

Two transactions touch the same two `entity_cooccurrences` rows in opposite orders (one mimicking the sweep's scan order, the other mimicking retain's sorted-upsert order via a barrier-synced interleaving) → Postgres raises `DeadlockDetectedError` on one of them, reproducing the exact exception class seen in production.

**2. Confirming the bug end-to-end (this test fails on `main`, passes with this fix):**

```bash
cd hindsight-api-slim
git stash  # or: check out this branch, then revert just graph_maintenance.py to main's version
uv run pytest tests/test_graph_maintenance_deadlock.py::test_graph_maintenance_sweep_retries_on_deadlock -v
```

On `main` (pre-fix), this fails with:

```
asyncpg.exceptions.DeadlockDetectedError: deadlock detected
```

propagating straight out of `run_graph_maintenance_job` — reproducing the exact "maintenance pass silently dropped" behavior seen in production logs. With this PR's fix applied, the same test passes (the deadlock is retried once and the sweep completes with correct prune counts). I verified this locally by reverting only `graph_maintenance.py` to its pre-PR state and re-running the test suite before submitting.

## Fix

Both `prune_orphan_entities` and `prune_stale_cooccurrences` are idempotent, bank-wide sweeps — rerunning only deletes what's still stale, no partial-completion hazard. Wrap the whole Pass 2/3 transaction in `retry_with_backoff`, which is already deadlock-aware (checks `DeadlockDetectedError` by name, exponential backoff) but was previously only used internally by `acquire_with_retry`'s legacy raw-pool path, not around any actual write transaction.

## Tests

Added to `test_graph_maintenance_deadlock.py` (extends the existing PR #2353 deadlock-test file):

- `test_unordered_concurrent_sweep_and_upsert_deadlocks` — raw two-connection reproduction of the exact production deadlock: two transactions touch the same two `entity_cooccurrences` rows in opposite orders (mimicking the sweep's scan order vs. retain's sorted-upsert order) and Postgres aborts one with `DeadlockDetectedError`. No application code involved — this documents the DB-level phenomenon directly, same technique the file already uses for the queue-insert case.
- `test_graph_maintenance_sweep_retries_on_deadlock` — injects one `DeadlockDetectedError` into `prune_stale_cooccurrences` via a mock and asserts `run_graph_maintenance_job` retries and still returns correct prune counts (`stale_cooccurrences_pruned == 1`, `orphan_entities_pruned == 0`).

```
cd hindsight-api-slim && uv run pytest tests/test_graph_maintenance_deadlock.py tests/test_graph_maintenance.py tests/test_db_utils.py -v
# 19 passed
```

Also ran `ruff check`, `ruff format --check`, and `ty check` on the changed files — all clean.

## Test plan

- [x] New deadlock reproduction test passes (`test_unordered_concurrent_sweep_and_upsert_deadlocks`)
- [x] New retry-behavior test passes (`test_graph_maintenance_sweep_retries_on_deadlock`)
- [x] Existing `test_graph_maintenance.py` (14 tests) and `test_db_utils.py` still pass
- [x] `ruff check` / `ruff format --check` / `ty check` clean on changed files

Made with [Cursor](https://cursor.com)
