### PR TITLE
fix(control-plane) fix json viewer unicode output display

### DIFF
--- a/hindsight-control-plane/src/components/ui/json-viewer.tsx
+++ b/hindsight-control-plane/src/components/ui/json-viewer.tsx
@@ -14,7 +14,19 @@ interface JsonViewerProps {
   className?: string;
 }
 
+function parseJsonString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
 function toDisplayText(value: unknown): string {
+  value = typeof value === "string" ? parseJsonString(value) : value;
   if (typeof value === "string") return value;
   // Unescape newlines inside string values so multi-line content (e.g. prompts)
   // renders as real line breaks under `whitespace-pre-wrap` instead of literal "\n".


### PR DESCRIPTION
## Summary

Fix JSON viewer display for JSON payloads stored as strings.

When trace output is stored as a JSON string, escaped Unicode characters such as `\u5927\u5446` were rendered directly. This change parses string values that are valid JSON objects/arrays before pretty-printing them, so non-ASCII text displays normally.


## Before
<img width="639" height="407" alt="image" src="https://github.com/user-attachments/assets/f6a48b26-c2a4-4dec-ac9e-3af11f733294" />

## After
<img width="614" height="715" alt="image" src="https://github.com/user-attachments/assets/4ecb54f2-d4d4-4270-ae33-6432fee8cf78" />


## Test

- Verified locally in the LLM trace output panel
- Pre-commit hooks passed
