### PR TITLE
test(retain): fix missing llm_temperature_retain in _build_request_body mock

### DIFF
--- a/hindsight-api-slim/tests/test_llm_strict_schema.py
+++ b/hindsight-api-slim/tests/test_llm_strict_schema.py
@@ -182,7 +182,7 @@ def test_batch_request_body_strict_follows_config(strict):
     from hindsight_api.engine.retain.fact_extraction import _build_request_body
 
     llm_config = SimpleNamespace(model="gpt-4o-mini", provider="openai", _provider_impl=SimpleNamespace())
-    config = SimpleNamespace(retain_max_completion_tokens=None, llm_strict_schema=strict)
+    config = SimpleNamespace(retain_max_completion_tokens=None, llm_strict_schema=strict, llm_temperature_retain=None)
     # provider != "openai" service-tier branch skipped via _provider_impl without attr
     llm_config._provider_impl.openai_service_tier = None
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing test failure surfaced by CI on hindsight-api-slim PRs:

```
FAILED tests/test_llm_strict_schema.py::test_batch_request_body_strict_follows_config[True]
  AttributeError: 'types.SimpleNamespace' object has no attribute 'llm_temperature_retain'
```

## Root cause

`_build_request_body` (`hindsight_api/engine/retain/fact_extraction.py`) reads `config.llm_temperature_retain` — added by the per-operation temperature work (#2459). But `test_batch_request_body_strict_follows_config` builds its `config` mock as a `SimpleNamespace` that never set that field, so the read raises `AttributeError`.

It goes unnoticed on `main` because path-filtering skips the `test-api` job for changes that don't touch `hindsight-api-slim`, but it fails deterministically on every PR that does touch it.

## Fix

Add `llm_temperature_retain=None` to the mock config. `None` means the temperature branch is skipped, so the test keeps asserting purely on the `strict` flag it targets (no behavior change).

## Test

```
tests/test_llm_strict_schema.py + tests/test_fact_extraction_retry.py — 18 passed
```
