### PR TITLE
fix(minimax): disable thinking by default

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -644,6 +644,11 @@ class OpenAICompatibleLLM(LLMInterface):
         # use the widely-supported max_tokens
         return "max_tokens"
 
+    def _apply_provider_extra_body_defaults(self, extra_body: dict[str, Any]) -> None:
+        """Apply provider-specific extra_body defaults while preserving user overrides."""
+        if self.provider == "minimax":
+            extra_body.setdefault("thinking", {"type": "disabled"})
+
     async def call(
         self,
         messages: list[dict[str, str]],
@@ -731,6 +736,7 @@ class OpenAICompatibleLLM(LLMInterface):
 
         # Provider-specific parameters
         extra_body: dict[str, Any] = {**self._config_extra_body}
+        self._apply_provider_extra_body_defaults(extra_body)
         if self.provider == "groq":
             call_params["seed"] = DEFAULT_LLM_SEED
             # Add service_tier if configured
@@ -1149,6 +1155,7 @@ class OpenAICompatibleLLM(LLMInterface):
 
         # Provider-specific parameters
         extra_body: dict[str, Any] = {**self._config_extra_body}
+        self._apply_provider_extra_body_defaults(extra_body)
         if self.provider == "groq":
             call_params["seed"] = DEFAULT_LLM_SEED
         if extra_body:

--- a/hindsight-api-slim/tests/test_minimax_thinking_body.py
+++ b/hindsight-api-slim/tests/test_minimax_thinking_body.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+def _make_minimax(extra_body=None) -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="minimax",
+        api_key="test-key",
+        base_url="",
+        model="MiniMax-M3",
+        extra_body=extra_body,
+    )
+
+
+def _text_response(content: str = "ok"):
+    return SimpleNamespace(
+        error=None,
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content=content, tool_calls=None, refusal=None),
+            )
+        ],
+    )
+
+
+def _tool_response():
+    tool_call = SimpleNamespace(
+        id="call_minimax_123",
+        function=SimpleNamespace(name="recall", arguments='{"query": "Project Rin"}'),
+    )
+    return SimpleNamespace(
+        error=None,
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(content=None, tool_calls=[tool_call], refusal=None),
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_minimax_call_disables_thinking_by_default():
+    llm = _make_minimax()
+    llm._client.chat.completions.create = AsyncMock(return_value=_text_response())
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+
+    assert llm._client.chat.completions.create.call_args.kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+@pytest.mark.asyncio
+async def test_minimax_call_preserves_configured_thinking_extra_body():
+    llm = _make_minimax(extra_body={"thinking": {"type": "enabled"}, "reasoning_split": True})
+    llm._client.chat.completions.create = AsyncMock(return_value=_text_response())
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+
+    assert llm._client.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "thinking": {"type": "enabled"},
+        "reasoning_split": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_minimax_tool_call_disables_thinking_by_default():
+    llm = _make_minimax()
+    llm._client.chat.completions.create = AsyncMock(return_value=_tool_response())
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "Search memory."}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "recall",
+                        "description": "Recall memories",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                        },
+                    },
+                }
+            ],
+            max_retries=0,
+        )
+
+    assert llm._client.chat.completions.create.call_args.kwargs["extra_body"] == {"thinking": {"type": "disabled"}}


### PR DESCRIPTION
Fixes #2555.

Summary:
- Add a MiniMax OpenAI-compatible extra_body default of `thinking: {type: disabled}`.
- Apply the same default to normal chat calls and tool-call requests.
- Preserve explicit `HINDSIGHT_API_LLM_EXTRA_BODY` overrides, including custom `thinking` or `reasoning_split` values.

Tests:
- `uv run --directory hindsight-api-slim ruff format hindsight_api/engine/providers/openai_compatible_llm.py tests/test_minimax_thinking_body.py`
- `uv run --directory hindsight-api-slim ruff check hindsight_api/engine/providers/openai_compatible_llm.py tests/test_minimax_thinking_body.py`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run --directory hindsight-api-slim pytest tests/test_minimax_thinking_body.py -q`
- `git diff --check`