### PR TITLE
Disable MiniMax M3 thinking by default

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -644,6 +644,18 @@ class OpenAICompatibleLLM(LLMInterface):
         # use the widely-supported max_tokens
         return "max_tokens"
 
+    def _apply_minimax_defaults(self, extra_body: dict[str, Any]) -> None:
+        """Apply MiniMax request defaults while preserving explicit config."""
+        if self.provider != "minimax":
+            return
+
+        # MiniMax-M3 enables thinking by default. Hindsight's LLM calls expect
+        # direct answers unless callers opt into provider-specific behavior.
+        # MiniMax documents that M2.x accepts this parameter but cannot disable
+        # thinking, so keep the default scoped to M3.
+        if self.model.lower() == "minimax-m3":
+            extra_body.setdefault("thinking", {"type": "disabled"})
+
     async def call(
         self,
         messages: list[dict[str, str]],
@@ -731,6 +743,7 @@ class OpenAICompatibleLLM(LLMInterface):
 
         # Provider-specific parameters
         extra_body: dict[str, Any] = {**self._config_extra_body}
+        self._apply_minimax_defaults(extra_body)
         if self.provider == "groq":
             call_params["seed"] = DEFAULT_LLM_SEED
             # Add service_tier if configured
@@ -1149,6 +1162,7 @@ class OpenAICompatibleLLM(LLMInterface):
 
         # Provider-specific parameters
         extra_body: dict[str, Any] = {**self._config_extra_body}
+        self._apply_minimax_defaults(extra_body)
         if self.provider == "groq":
             call_params["seed"] = DEFAULT_LLM_SEED
         if extra_body:

--- a/hindsight-api-slim/tests/test_minimax_thinking_defaults.py
+++ b/hindsight-api-slim/tests/test_minimax_thinking_defaults.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+@pytest.fixture(autouse=True)
+def clear_proxy_env(monkeypatch):
+    for key in ("ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY", "all_proxy", "http_proxy", "https_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_minimax_llm(model: str = "MiniMax-M3", extra_body: dict | None = None) -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="minimax",
+        api_key="test-key",
+        base_url=None,
+        model=model,
+        extra_body=extra_body,
+    )
+
+
+def _chat_response(content: str = "ok"):
+    choice = SimpleNamespace(
+        finish_reason="stop",
+        message=SimpleNamespace(content=content, tool_calls=None, refusal=None),
+    )
+    return SimpleNamespace(choices=[choice], usage=None, error=None)
+
+
+def _tool_response():
+    choice = SimpleNamespace(
+        finish_reason="stop",
+        message=SimpleNamespace(content="done", tool_calls=None, refusal=None, reasoning_content=None),
+    )
+    return SimpleNamespace(choices=[choice], usage=None, error=None)
+
+
+async def _capture_call_kwargs(llm: OpenAICompatibleLLM) -> dict:
+    create = AsyncMock(return_value=_chat_response())
+    llm._client.chat.completions.create = create
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await llm.call(
+            messages=[{"role": "user", "content": "ping"}],
+            max_retries=0,
+        )
+    return create.call_args.kwargs
+
+
+async def _capture_tool_call_kwargs(llm: OpenAICompatibleLLM) -> dict:
+    create = AsyncMock(return_value=_tool_response())
+    llm._client.chat.completions.create = create
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[{"type": "function", "function": {"name": "noop", "parameters": {}}}],
+            max_retries=0,
+        )
+    return create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_minimax_m3_disables_thinking_by_default():
+    sent = await _capture_call_kwargs(_make_minimax_llm())
+
+    assert sent["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_minimax_m3_preserves_explicit_thinking_config():
+    sent = await _capture_call_kwargs(_make_minimax_llm(extra_body={"thinking": {"type": "adaptive"}}))
+
+    assert sent["extra_body"]["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.asyncio
+async def test_minimax_m3_tool_calls_disable_thinking_by_default():
+    sent = await _capture_tool_call_kwargs(_make_minimax_llm())
+
+    assert sent["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_minimax_m2_does_not_claim_thinking_can_be_disabled():
+    sent = await _capture_call_kwargs(_make_minimax_llm(model="MiniMax-M2.7"))
+
+    assert "extra_body" not in sent


### PR DESCRIPTION
## Summary
- set MiniMax-M3 OpenAI-compatible calls to send `extra_body.thinking={"type": "disabled"}` by default
- preserve explicit `HINDSIGHT_API_LLM_EXTRA_BODY` / provider `extra_body` overrides via `setdefault`
- cover both normal `call()` and `call_with_tools()` paths

## Notes
MiniMax's OpenAI-compatible docs state that MiniMax-M3 enables thinking by default, that `thinking: {"type": "disabled"}` skips thinking, and that `reasoning_split` only controls response field splitting. The same docs also say M2.x cannot disable thinking, so this change is intentionally scoped to MiniMax-M3 rather than claiming to fix M2.x.

Closes #2555 for the MiniMax-M3 default-thinking case.

## Tests
- `uv run pytest tests/test_minimax_thinking_defaults.py`
- `uv run ruff check hindsight_api/engine/providers/openai_compatible_llm.py tests/test_minimax_thinking_defaults.py`
- `uv run ruff format --check hindsight_api/engine/providers/openai_compatible_llm.py tests/test_minimax_thinking_defaults.py`