### PR TITLE
fix(trace): skip pre-init LLM trace writes quietly instead of warning

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_trace.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_trace.py
@@ -517,6 +517,14 @@ class LLMTraceRecorder:
                     _safe_json(record.llm_info, self._max_chars) or "{}",
                     _safe_json(record.metadata, self._max_chars) or "{}",
                 )
+        except RuntimeError as e:
+            if "is not initialized" in str(e):
+                # Expected during startup: LLM calls (e.g. scope=verification) run in
+                # the init gather before the DB backend is initialized, so their
+                # traces cannot be persisted yet. Skip quietly, like pool-is-None.
+                logger.debug(f"LLM trace skipped for scope={record.scope}: backend not initialized yet")
+            else:
+                logger.warning(f"LLM trace write failed for scope={record.scope}: {e}")
         except Exception as e:
             logger.warning(f"LLM trace write failed for scope={record.scope}: {e}")
 

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -9,6 +9,7 @@ success/error paths, and the HTTP read API (list / stats / tokens).
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -799,3 +800,38 @@ async def test_real_llm_retain_and_consolidation_traced(memory_real_llm):
         assert by_op["consolidation"][0]["metadata"].get("source_memory_ids"), (
             "consolidation trace missing source_memory_ids"
         )
+
+
+# ── recorder: writes before backend init are an expected startup state ────────
+
+
+class _UninitializedBackend:
+    """Mimics a DB backend before initialize(): acquiring raises RuntimeError."""
+
+    def acquire(self):
+        raise RuntimeError("PostgreSQLBackend is not initialized. Call initialize() first.")
+
+
+@pytest.mark.asyncio
+async def test_safe_write_before_backend_init_logs_debug_not_warning(caplog):
+    """Startup LLM calls (e.g. scope=verification) run before the DB backend is
+    initialized by design — the trace writer must skip quietly, not warn (#startup-race)."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: _UninitializedBackend(),
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    record = LLMRequestRecord(
+        provider="openai",
+        model="glm-5",
+        scope="verification",
+        status="success",
+        started_at=datetime.now(timezone.utc),
+        ended_at=datetime.now(timezone.utc),
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._safe_write(record)
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, f"expected no warning for pre-init trace write, got: {[r.message for r in warnings]}"
+    assert any("not initialized" in r.message or "not available" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

Every deployment logs a spurious warning at boot:

```
WARNING - hindsight_api.engine.llm_trace - LLM trace write failed for scope=verification: PostgreSQLBackend is not initialized. Call initialize() first.
```

Root cause: `MemoryEngine.initialize()` runs `verify_llm()` inside the parallel init gather, which by design executes **before** the DB backend/pool is initialized (pg0 startup is in the same gather). The verification LLM call records a trace, and its write can therefore never succeed at boot — the writer's existing `pool is None` guard doesn't catch it because the pool getter returns a backend object that raises `RuntimeError` on acquire instead of returning `None`.

## Fix

Treat the backend's not-initialized `RuntimeError` in `_safe_write` the same way as the existing pool-is-None case: debug-level skip. All other write failures still warn. The not-initialized message shape is shared by both backends (`postgresql.py`, `oracle.py`).

Note: this matches on the exception message (`"is not initialized"`). If you'd prefer a typed exception on the backend interface instead, happy to rework — kept the change minimal here.

## Test

Regression test reproduces the exact production condition (recorder whose pool getter returns an uninitialized backend) and asserts the write skips at debug with no warning. Full `test_llm_trace.py` suite: 29 passed; ruff/format/ty clean.