### PR TITLE
Fix _strip_code_fences truncating JSON when content contains inner backticks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -78,12 +78,24 @@ def _strip_code_fences(content: str) -> str:
     """
     if "```" not in content:
         return content
-    try:
-        if "```json" in content:
-            return content.split("```json")[1].split("```")[0].strip()
-        return content.split("```")[1].split("```")[0].strip()
-    except (IndexError, ValueError):
+    lines = content.split("\n")
+    # Find first line that starts a code fence (``` optionally followed by language)
+    fence_start = None
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            fence_start = i
+            break
+    if fence_start is None:
         return content
+    # Find matching closing fence (``` alone or with trailing whitespace)
+    fence_end = None
+    for j in range(fence_start + 1, len(lines)):
+        if lines[j].strip() == "```":
+            fence_end = j
+            break
+    if fence_end is None:
+        return content
+    return "\n".join(lines[fence_start + 1 : fence_end]).strip()
 
 
 # Reasoning/thinking tags emitted by extended-thinking models. Some providers

--- a/hindsight-api-slim/tests/test_strip_code_fences.py
+++ b/hindsight-api-slim/tests/test_strip_code_fences.py
@@ -36,6 +36,22 @@ class TestStripCodeFences:
         result = _strip_code_fences(content)
         assert '{"facts": []}' in result
 
+    def test_inner_backticks_preserved(self):
+        """Inner triple-backticks inside a JSON string value must not truncate the JSON.
+
+        Regression for the fact-extraction case where an extracted fact describes
+        code-fence behavior, so the JSON payload itself contains a literal
+        ```` ```json ```` — the old split-based stripper matched that inner
+        occurrence and cut the JSON mid-string.
+        """
+        import json
+
+        content = '```json\n{"facts": [{"what": "the model wraps output in ```json fences"}]}\n```'
+        result = _strip_code_fences(content)
+        assert result == '{"facts": [{"what": "the model wraps output in ```json fences"}]}'
+        parsed = json.loads(result)
+        assert parsed["facts"][0]["what"] == "the model wraps output in ```json fences"
+
     def test_no_fences_no_change(self):
         """Content without any backticks passes through."""
         content = "Just some text without fences"


### PR DESCRIPTION
The current implementation uses `content.split("```json")[1].split("```")[0]` to strip markdown code fences. This finds the **first** ` ``` ` after the opening fence — so when the extracted JSON itself contains literal triple-backtick characters, the split matches those inner backticks and truncates the JSON mid-string.

**When this bites:** Hindsight's fact-extraction LLM produces output wrapped in ` ```json ... ``` ` fences. If one of the extracted facts describes code fence behavior (e.g. "the model wraps output in ```json fences"), the JSON now contains ` ```json ` as a literal string value, and `split("```")` finds that inner occurrence. Result: truncated JSON → `json.loads` fails → retry loop (up to 4 retries per chunk).

**The fix** replaces string-splitting with line-based fence detection. Per the markdown spec, code fences must appear at the start of a line. Inner triple backticks inside JSON string values are preserved because they aren't at line boundaries.

**Before (broken):**
```python
_strip_code_fences('```json\n{"facts": [{"what": "uses ```json fences"}]}\n```')
# → '{"facts": [{"what": "uses '  (truncated!)
```

**After (fixed):**
```python
_strip_code_fences('```json\n{"facts": [{"what": "uses ```json fences"}]}\n```')
# → '{"facts": [{"what": "uses ```json fences"}]}'  (intact)
```

Edge cases: normal fences ✓, inner backticks preserved ✓, no fences no-op ✓, opening-only (truncated output) returned unchanged ✓, text around fence block handled correctly ✓.
