### PR TITLE
fix(cli): set default User-Agent header

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -10,6 +10,26 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 
+const DEFAULT_CLI_USER_AGENT: &str = concat!("hindsight-cli/", env!("CARGO_PKG_VERSION"));
+
+fn default_headers(api_key: Option<&str>) -> Result<reqwest::header::HeaderMap> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        reqwest::header::HeaderValue::from_static(DEFAULT_CLI_USER_AGENT),
+    );
+
+    if let Some(key) = api_key {
+        let auth_value = format!("Bearer {}", key);
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_str(&auth_value)?,
+        );
+    }
+
+    Ok(headers)
+}
+
 /// Convert a progenitor client error into an anyhow error that includes the
 /// HTTP response body. Without this, errors render as
 /// "Unexpected Response: Response { ... }" with no body, hiding validation
@@ -112,15 +132,7 @@ impl ApiClient {
         let mut client_builder =
             reqwest::Client::builder().timeout(std::time::Duration::from_secs(120));
 
-        if let Some(key) = api_key {
-            let mut headers = reqwest::header::HeaderMap::new();
-            let auth_value = format!("Bearer {}", key);
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&auth_value)?,
-            );
-            client_builder = client_builder.default_headers(headers);
-        }
+        client_builder = client_builder.default_headers(default_headers(api_key.as_deref())?);
 
         let http_client = client_builder.build()?;
 
@@ -1308,6 +1320,31 @@ pub use types::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_headers_set_cli_user_agent_without_api_key() {
+        let headers = default_headers(None).unwrap();
+
+        assert_eq!(
+            headers.get(reqwest::header::USER_AGENT).unwrap(),
+            DEFAULT_CLI_USER_AGENT,
+        );
+        assert!(!headers.contains_key(reqwest::header::AUTHORIZATION));
+    }
+
+    #[test]
+    fn default_headers_keep_authorization_with_cli_user_agent() {
+        let headers = default_headers(Some("hsk_test")).unwrap();
+
+        assert_eq!(
+            headers.get(reqwest::header::USER_AGENT).unwrap(),
+            DEFAULT_CLI_USER_AGENT,
+        );
+        assert_eq!(
+            headers.get(reqwest::header::AUTHORIZATION).unwrap(),
+            "Bearer hsk_test",
+        );
+    }
 
     #[test]
     fn test_operation_deserialize() {


### PR DESCRIPTION
## Summary
- set a default `User-Agent` for the CLI reqwest client
- keep the existing bearer auth default header behavior
- add unit coverage for CLI default headers with and without an API key

Fixes #2538.

## Tests
- `rustfmt --edition 2021 --check hindsight-cli/src/api.rs`
- `cargo test --manifest-path hindsight-cli/Cargo.toml api::tests::default_headers -- --nocapture`
- `cargo test --manifest-path hindsight-cli/Cargo.toml api::tests -- --nocapture`

Note: full `cargo fmt --manifest-path hindsight-cli/Cargo.toml --check` is currently blocked by pre-existing formatting diffs in other CLI files outside this patch.