### PR TITLE
fix(consolidation): default invalid dedup actions to keep

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -102,6 +102,15 @@ class _DedupDecision(BaseModel):
     text: str = ""  # the synthesized merged observation (when action == "merge")
     reason: str = ""
 
+    @field_validator("action", mode="before")
+    @classmethod
+    def _normalize_action(cls, value: object) -> str:
+        if isinstance(value, str) and value in {"merge", "keep"}:
+            return value
+
+        logger.warning("Invalid consolidation dedup action %r; defaulting to keep", value)
+        return "keep"
+
 
 _DEDUP_PROMPT = """You reconcile long-term memory observations. A NEW observation is about to be \
 stored, and it is highly similar to an EXISTING one:

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -5,6 +5,7 @@ guard the fix in CI — unlike the real-LLM integration test, which only trigger
 the path stochastically.
 """
 
+import logging
 import types
 import uuid
 from dataclasses import dataclass
@@ -140,6 +141,38 @@ async def test_dedup_llm_missing_action_defaults_to_keep() -> None:
     assert result is None
     llm.call.assert_awaited_once()
     conn.execute.assert_not_called()  # missing action is a conservative no-merge
+
+
+def test_dedup_decision_accepts_exact_valid_actions() -> None:
+    assert _DedupDecision(action="merge").action == "merge"
+    assert _DedupDecision(action="keep").action == "keep"
+
+
+def test_dedup_decision_invalid_action_defaults_to_keep(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        decision = _DedupDecision(action="need_input", reason="model asked for more context")
+
+    assert decision.action == "keep"
+    assert "need_input" in caplog.text
+    assert "defaulting to keep" in caplog.text
+
+
+def test_dedup_decision_near_miss_merge_defaults_to_keep(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        decision = _DedupDecision(action="Merge")
+
+    assert decision.action == "keep"
+    assert "Merge" in caplog.text
+
+
+def test_dedup_decision_non_scalar_action_defaults_to_keep(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        list_decision = _DedupDecision(action=[])
+        dict_decision = _DedupDecision(action={"value": "merge"})
+
+    assert list_decision.action == "keep"
+    assert dict_decision.action == "keep"
+    assert "defaulting to keep" in caplog.text
 
 
 async def test_dedup_llm_merge_folds_into_twin() -> None:


### PR DESCRIPTION
## Summary

Fixes #2545.

Consolidation dedup already defaulted a missing structured `action` to `keep`, but near-miss or malformed action values from a lax structured-output model could still fail Pydantic validation before the conservative no-merge path ran.

This adds a `mode="before"` validator on `_DedupDecision.action` that:

- preserves exact `"merge"` / `"keep"` decisions
- logs invalid action values
- defaults every other scalar or non-scalar shape to `"keep"`

That keeps malformed dedup verdicts from accidentally merging observations or requeueing the consolidation job.

## Tests

- `ruff check hindsight_api/engine/consolidation/consolidator.py tests/test_consolidation_dedup.py`
- `ruff format --check hindsight_api/engine/consolidation/consolidator.py tests/test_consolidation_dedup.py`
- `python3 -m py_compile hindsight_api/engine/consolidation/consolidator.py tests/test_consolidation_dedup.py`
- local validator smoke check for exact valid actions, unknown string actions, near-miss `Merge`, list/dict values, and missing action

I could not run `pytest tests/test_consolidation_dedup.py` in this macOS arm64 environment: `uv run` resolves `onnxruntime==1.27.0`, which has no wheel for the current Python/platform combo, and direct `PYTHONPATH=. pytest ... -o addopts=''` cannot collect without the project runtime deps such as `asyncpg` installed.

Codex review noted a low-confidence import concern about `field_validator`; the module already imports it from Pydantic and `py_compile` passed.
