### PR TITLE
fix(control-plane): build local client before production build

### DIFF
--- a/hindsight-control-plane/package.json
+++ b/hindsight-control-plane/package.json
@@ -11,6 +11,7 @@
     "public"
   ],
   "scripts": {
+    "prebuild": "npm run build -w @vectorize-io/hindsight-client",
     "dev": "next dev --turbopack -p ${PORT:-9999}",
     "build": "NODE_ENV=production next build && npm run build:standalone",
     "build:standalone": "rm -rf standalone && SERVER_JS=$(find .next/standalone -path '*/node_modules' -prune -o -name 'server.js' -print | head -1) && test -n \"$SERVER_JS\" || (echo 'Error: server.js not found in .next/standalone - standalone build failed' && exit 1) && STANDALONE_ROOT=$(dirname \"$SERVER_JS\") && cp -r \"$STANDALONE_ROOT\" standalone && cp -r .next/standalone/node_modules standalone/node_modules && mkdir -p standalone/.next && cp -r .next/static standalone/.next/static && mkdir -p standalone/public && (cp -r public/* standalone/public/ 2>/dev/null || true)",


### PR DESCRIPTION
Fixes #2561.

Problem:
- The control plane depends on the local TypeScript client via `file:../hindsight-clients/typescript`.
- A clean checkout can run `npm run build` in the control plane before the client `dist` files exist or match current source.

Fix:
- Add a `prebuild` step for the control plane that builds `@vectorize-io/hindsight-client` first.

Validation:
- `npm run prebuild --workspace=hindsight-control-plane`
- `npm run build --workspace=hindsight-control-plane`

Risk:
- Low. This uses the existing client build script and only changes the control-plane build order.