### PR TITLE
fix(opencode): install plugin SDK at runtime

### DIFF
--- a/hindsight-integrations/opencode/package-lock.json
+++ b/hindsight-integrations/opencode/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
+        "@opencode-ai/plugin": "^1.3.13",
         "@vectorize-io/hindsight-client": "^0.4.19"
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.3.13",
         "@types/node": "^22.0.0",
         "tsup": "^8.5.1",
         "typescript": "^5.7.0",
@@ -20,9 +20,6 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "@opencode-ai/plugin": ">=1.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -563,7 +560,6 @@
       "version": "1.3.13",
       "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.13.tgz",
       "integrity": "sha512-zHgtWfdDz8Wu8srE8f8HUtPT9i6c3jTmgQKoFZUZ+RR5CMQF1kAlb1cxeEe9Xm2DRNFVJog9Cv/G1iUHYgXSUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/sdk": "1.3.13",
@@ -586,7 +582,6 @@
       "version": "1.3.13",
       "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.13.tgz",
       "integrity": "sha512-/M6HlNnba+xf1EId6qFb2tG0cvq0db3PCQDug1glrf8wYOU57LYNF8WvHX9zoDKPTMv0F+O4pcP/8J+WvDaxHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
@@ -2675,7 +2670,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/hindsight-integrations/opencode/package.json
+++ b/hindsight-integrations/opencode/package.json
@@ -41,14 +41,11 @@
     "test:e2e": "HINDSIGHT_LIVE_E2E=1 vitest run",
     "prepublishOnly": "npm run clean && npm run build"
   },
-  "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.0.0"
-  },
   "dependencies": {
+    "@opencode-ai/plugin": "^1.3.13",
     "@vectorize-io/hindsight-client": "^0.4.19"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "^1.3.13",
     "@types/node": "^22.0.0",
     "tsup": "^8.5.1",
     "typescript": "^5.7.0",


### PR DESCRIPTION
## Summary

Move `@opencode-ai/plugin` into the OpenCode integration's runtime dependencies and remove the peer-only declaration. The built plugin entrypoint imports `@opencode-ai/plugin/tool`, so OpenCode needs that package available in its isolated plugin cache when loading the integration.

`@vectorize-io/hindsight-client` remains a runtime dependency, and the lockfile is updated to reflect the new dependency classification.

Fixes #2573

## Verification

- `npm run build`
- `npm pack --json`
- Installed the generated tarball with `opencode plugin ...@file:` in a fresh temporary project
- Confirmed the OpenCode cache contained both runtime dependencies
- Confirmed direct import of the built plugin entrypoint succeeded