### PR TITLE
fix(api): accept verbatim extraction mode in bank manifests

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -52,6 +52,7 @@ from fastapi.routing import APIRoute
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from hindsight_api import MemoryEngine
+from hindsight_api.config import RETAIN_EXTRACTION_MODES
 
 
 def _annotation_is_nullable(annotation: Any) -> bool:
@@ -1245,7 +1246,7 @@ class CreateBankRequest(BaseModel):
     )
     retain_extraction_mode: str | None = Field(
         default=None,
-        description="Fact extraction mode: 'concise' (default), 'verbose', or 'custom'.",
+        description="Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'.",
     )
     retain_custom_instructions: str | None = Field(
         default=None,
@@ -2203,7 +2204,8 @@ class BankTemplateConfig(BaseModel):
     reflect_mission: str | None = Field(default=None, description="Mission/context for Reflect operations")
     retain_mission: str | None = Field(default=None, description="Steers what gets extracted during retain")
     retain_extraction_mode: str | None = Field(
-        default=None, description="Fact extraction mode: 'concise' (default), 'verbose', or 'custom'"
+        default=None,
+        description="Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'",
     )
     retain_custom_instructions: str | None = Field(
         default=None, description="Custom extraction prompt (when mode='custom')"
@@ -2429,10 +2431,10 @@ def validate_bank_template(manifest: "BankTemplateManifest") -> list[str]:
     if manifest.bank:
         bank = manifest.bank
         if bank.retain_extraction_mode is not None:
-            valid_modes = ("concise", "verbose", "custom", "chunks")
-            if bank.retain_extraction_mode not in valid_modes:
+            if bank.retain_extraction_mode not in RETAIN_EXTRACTION_MODES:
                 errors.append(
-                    f"bank.retain_extraction_mode: must be one of {valid_modes}, got '{bank.retain_extraction_mode}'"
+                    "bank.retain_extraction_mode: "
+                    f"must be one of {RETAIN_EXTRACTION_MODES}, got '{bank.retain_extraction_mode}'"
                 )
         if bank.retain_custom_instructions and bank.retain_extraction_mode != "custom":
             errors.append("bank.retain_custom_instructions: requires retain_extraction_mode='custom'")

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -5,6 +5,7 @@ import pytest_asyncio
 import httpx
 from datetime import datetime
 from hindsight_api.api import create_app
+from hindsight_api.api.http import BankTemplateManifest, validate_bank_template
 
 
 @pytest_asyncio.fixture
@@ -80,6 +81,17 @@ class TestImportValidation:
         assert data["config_applied"] is True
         assert set(data["mental_models_created"]) == {"test-model-one", "test-model-two"}
         assert set(data["directives_created"]) == {"Be concise", "Use examples"}
+
+    def test_verbatim_extraction_mode_is_valid(self):
+        """verbatim is a valid retain extraction mode in bank manifests."""
+        manifest = BankTemplateManifest.model_validate(
+            {
+                "version": "1",
+                "bank": {"retain_extraction_mode": "verbatim"},
+            }
+        )
+
+        assert validate_bank_template(manifest) == []
 
     @pytest.mark.asyncio
     async def test_import_invalid_version(self, api_client, bank_id):

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -592,7 +592,7 @@ class Hindsight:
             disposition_empathy: Deprecated. Use update_bank_config(disposition_empathy=...) instead.
             disposition: Deprecated. Use update_bank_config(disposition_skepticism=...) instead.
             retain_mission: Steers what gets extracted during retain(). Injected alongside built-in rules.
-            retain_extraction_mode: Fact extraction mode: 'concise' (default), 'verbose', or 'custom'.
+            retain_extraction_mode: Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'.
             retain_custom_instructions: Custom extraction prompt (only active when mode is 'custom').
             retain_chunk_size: Target maximum characters for each content chunk during retain.
             retain_structured_chunk_size: Maximum characters for a single JSONL line or conversation
@@ -731,7 +731,7 @@ class Hindsight:
             disposition_empathy: Deprecated. Use update_bank_config(disposition_empathy=...) instead.
             disposition: Deprecated. Use update_bank_config(disposition_skepticism=...) instead.
             retain_mission: Steers what gets extracted during retain(). Injected alongside built-in rules.
-            retain_extraction_mode: Fact extraction mode: 'concise' (default), 'verbose', or 'custom'.
+            retain_extraction_mode: Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'.
             retain_custom_instructions: Custom extraction prompt (only active when mode is 'custom').
             retain_chunk_size: Target maximum characters for each content chunk during retain.
             retain_structured_chunk_size: Maximum characters for a single JSONL line or conversation

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -453,7 +453,7 @@ export type BankTemplateConfig = {
   /**
    * Retain Extraction Mode
    *
-   * Fact extraction mode: 'concise' (default), 'verbose', or 'custom'
+   * Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'
    */
   retain_extraction_mode?: string | null;
   /**
@@ -1080,7 +1080,7 @@ export type CreateBankRequest = {
   /**
    * Retain Extraction Mode
    *
-   * Fact extraction mode: 'concise' (default), 'verbose', or 'custom'.
+   * Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'.
    */
   retain_extraction_mode?: string | null;
   /**

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -500,7 +500,7 @@ export class HindsightClient {
       dispositionEmpathy?: number;
       /** Steers what gets extracted during retain(). Injected alongside built-in rules. */
       retainMission?: string;
-      /** Fact extraction mode: 'concise' (default), 'verbose', or 'custom'. */
+      /** Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'. */
       retainExtractionMode?: string;
       /** Custom extraction prompt (only active when retainExtractionMode is 'custom'). */
       retainCustomInstructions?: string;

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -39,7 +39,7 @@
             }
           ],
           "default": null,
-          "description": "Fact extraction mode: 'concise' (default), 'verbose', or 'custom'",
+          "description": "Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'",
           "title": "Retain Extraction Mode"
         },
         "retain_custom_instructions": {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -6592,7 +6592,7 @@
               }
             ],
             "title": "Retain Extraction Mode",
-            "description": "Fact extraction mode: 'concise' (default), 'verbose', or 'custom'"
+            "description": "Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'"
           },
           "retain_custom_instructions": {
             "anyOf": [
@@ -7631,7 +7631,7 @@
               }
             ],
             "title": "Retain Extraction Mode",
-            "description": "Fact extraction mode: 'concise' (default), 'verbose', or 'custom'."
+            "description": "Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'."
           },
           "retain_custom_instructions": {
             "anyOf": [

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -6592,7 +6592,7 @@
               }
             ],
             "title": "Retain Extraction Mode",
-            "description": "Fact extraction mode: 'concise' (default), 'verbose', or 'custom'"
+            "description": "Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'"
           },
           "retain_custom_instructions": {
             "anyOf": [
@@ -7631,7 +7631,7 @@
               }
             ],
             "title": "Retain Extraction Mode",
-            "description": "Fact extraction mode: 'concise' (default), 'verbose', or 'custom'."
+            "description": "Fact extraction mode: 'concise' (default), 'verbose', 'custom', 'verbatim', or 'chunks'."
           },
           "retain_custom_instructions": {
             "anyOf": [


### PR DESCRIPTION
## Problem

The engine accepts `retain_extraction_mode=verbatim` through environment/config resolution, but bank-template manifest import rejected the same mode because the validator had a re-typed mode tuple that omitted it. This surfaced during a verbatim-mode data migration.

## Solution

Use the canonical `RETAIN_EXTRACTION_MODES` tuple for bank-template validation so future extraction modes cannot drift, and update the related API schema descriptions to include `verbatim` and `chunks`.

## Testing

- `uv run --directory hindsight-api-slim pytest tests/test_bank_templates.py::TestImportValidation::test_verbatim_extraction_mode_is_valid`
- `uv run --directory hindsight-api-slim python -m py_compile hindsight_api/api/http.py`
- `scripts/generate-bank-template-schema.sh`
- `scripts/generate-docs-skill.sh`
