### PR TITLE
fix(worker): reclaim expired processing task leases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Unset uses HINDSIGHT_API_RETAIN_CHUNK_SIZE as the structured-chunk limit.
 # HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE=
 
+# Worker task lease. Processing tasks whose heartbeat is older than this are
+# returned to pending so another worker can pick them up. 0 disables reaping.
+# HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS=3600
+
 # Dry-run extraction preview endpoint (POST /memories/dry-run-extract). Enabled by default; it makes
 # a real LLM call but stores nothing. Set to false to remove the endpoint (returns 404).
 # HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT=true

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3139,6 +3139,7 @@ def create_app(
                 max_slots=config.worker_max_slots,
                 slot_reservations=config.worker_slot_reservations,
                 consolidation_bank_priority=config.worker_consolidation_bank_priority or None,
+                task_lease_seconds=config.worker_task_lease_seconds,
             )
             poller_task = asyncio.create_task(poller.run())
             logging.info(f"Worker poller started (worker_id={worker_id})")

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -596,6 +596,7 @@ ENV_WORKER_ID = "HINDSIGHT_API_WORKER_ID"
 ENV_WORKER_POLL_INTERVAL_MS = "HINDSIGHT_API_WORKER_POLL_INTERVAL_MS"
 ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
 ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS = "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS"
+ENV_WORKER_TASK_LEASE_SECONDS = "HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
 
@@ -1048,6 +1049,7 @@ DEFAULT_WORKER_ID = None  # Will use hostname if not specified
 DEFAULT_WORKER_POLL_INTERVAL_MS = 500  # Poll database every 500ms
 DEFAULT_WORKER_MAX_RETRIES = 3  # Max retries before marking task failed
 DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS = 60  # Seconds between retries on transient task failure
+DEFAULT_WORKER_TASK_LEASE_SECONDS = 3600  # Reclaim processing tasks whose heartbeat is stale for this long
 DEFAULT_WORKER_HTTP_PORT = 8889  # HTTP port for worker metrics/health
 DEFAULT_WORKER_MAX_SLOTS = 10  # Total concurrent tasks per worker
 DEFAULT_RETAIN_MAX_CONCURRENT = 4  # Max concurrent retain DB phases (HNSW reads + writes). Limits I/O contention.
@@ -1904,6 +1906,7 @@ class HindsightConfig:
     worker_poll_interval_ms: int
     worker_max_retries: int
     worker_task_retry_backoff_seconds: int
+    worker_task_lease_seconds: int
     worker_http_port: int
     worker_max_slots: int
     worker_slot_reservations: dict[str, int]
@@ -2267,6 +2270,8 @@ class HindsightConfig:
                 f"exceeds worker_max_slots ({self.worker_max_slots}). "
                 f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."
             )
+        if self.worker_task_lease_seconds < 0:
+            raise ValueError("worker_task_lease_seconds must be >= 0")
 
     @classmethod
     def from_env(cls) -> "HindsightConfig":
@@ -2913,6 +2918,9 @@ class HindsightConfig:
                     ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS,
                     str(DEFAULT_WORKER_TASK_RETRY_BACKOFF_SECONDS),
                 )
+            ),
+            worker_task_lease_seconds=int(
+                os.getenv(ENV_WORKER_TASK_LEASE_SECONDS, str(DEFAULT_WORKER_TASK_LEASE_SECONDS))
             ),
             worker_http_port=int(os.getenv(ENV_WORKER_HTTP_PORT, str(DEFAULT_WORKER_HTTP_PORT))),
             worker_max_slots=int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS))),

--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -264,6 +264,7 @@ def main():
             max_slots=config.worker_max_slots,
             slot_reservations=config.worker_slot_reservations,
             consolidation_bank_priority=config.worker_consolidation_bank_priority or None,
+            task_lease_seconds=config.worker_task_lease_seconds,
         )
 
         # Create the HTTP app for metrics/health

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -14,6 +14,7 @@ import json
 import logging
 import time
 import traceback
+import uuid
 from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 # Progress logging interval in seconds
 PROGRESS_LOG_INTERVAL = 30
+LEASE_REAPER_INTERVAL = 60
 
 # Stuck-task stack-dump thresholds (seconds). Each task gets one stack dump
 # per threshold it crosses (5min, 10min, 20min, 40min, 80min...).
@@ -148,6 +150,7 @@ class WorkerPoller:
         max_slots: int = 10,
         slot_reservations: dict[str, int] | None = None,
         consolidation_bank_priority: dict[str, int] | None = None,
+        task_lease_seconds: int = 3600,
     ):
         """
         Initialize the worker poller.
@@ -170,6 +173,8 @@ class WorkerPoller:
                 Patterns support ``*`` as wildcard. A bare ``*`` key is the catch-all default.
                 When set, consolidation tasks are claimed in priority tiers rather than
                 pure created_at order. None or empty dict preserves current behavior.
+            task_lease_seconds: Reset ``processing`` rows whose ``updated_at`` heartbeat
+                is older than this many seconds. Set to 0 to disable the lease reaper.
         """
         self._backend = backend
         self._worker_id = worker_id
@@ -191,6 +196,10 @@ class WorkerPoller:
         self._consolidation_bank_priority: dict[str, int] | None = (
             consolidation_bank_priority if consolidation_bank_priority else None
         )
+        if task_lease_seconds < 0:
+            raise ValueError("task_lease_seconds must be >= 0")
+        self._task_lease_seconds = task_lease_seconds
+        self._last_lease_reap = 0.0
         # Cache of which optional PG routines are installed on the server
         # (probed once, memoised for the life of the poller).
         from ..engine.db.optional_routines import OptionalRoutines
@@ -821,6 +830,79 @@ class WorkerPoller:
             logger.info(f"Worker {self._worker_id} recovered {total_count} stale tasks from previous run")
         return total_count
 
+    async def reap_expired_leases(self) -> int:
+        """Reset stale ``processing`` rows owned by dead or unreachable workers.
+
+        ``recover_own_tasks`` only clears rows for this worker id at startup. That
+        does not help when another worker dies permanently, or when a container
+        restarts with a different hostname. The lease reaper uses the operation
+        heartbeat (`updated_at`, refreshed by progress writes and task state
+        transitions) as the ownership signal and returns expired rows to the
+        pending queue without incrementing retry_count.
+        """
+        if self._task_lease_seconds <= 0:
+            return 0
+
+        schemas = await self._get_schemas()
+        total_count = 0
+
+        async with self._in_flight_lock:
+            active_operation_ids = [uuid.UUID(op_id) for op_id in self._active_tasks]
+
+        for schema in schemas:
+            table = fq_table("async_operations", schema)
+            try:
+                async with self._backend.acquire() as conn:
+                    if active_operation_ids:
+                        result = await conn.execute(
+                            f"""
+                            UPDATE {table}
+                            SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                            WHERE status = 'processing'
+                              AND task_payload IS NOT NULL
+                              AND updated_at < now() - ($1::int * interval '1 second')
+                              AND operation_id != ALL($2::uuid[])
+                            """,
+                            self._task_lease_seconds,
+                            active_operation_ids,
+                        )
+                    else:
+                        result = await conn.execute(
+                            f"""
+                            UPDATE {table}
+                            SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
+                            WHERE status = 'processing'
+                              AND task_payload IS NOT NULL
+                              AND updated_at < now() - ($1::int * interval '1 second')
+                            """,
+                            self._task_lease_seconds,
+                        )
+
+                count = int(result.split()[-1]) if result else 0
+                total_count += count
+            except Exception as e:
+                schema_display = f'"{schema}"' if schema else str(schema)
+                logger.warning(
+                    f"Worker {self._worker_id} failed to reap expired leases for schema {schema_display}: {e}"
+                )
+
+        if total_count > 0:
+            logger.warning(
+                f"Worker {self._worker_id} reaped {total_count} expired task lease(s) "
+                f"older than {self._task_lease_seconds}s"
+            )
+        return total_count
+
+    async def _reap_expired_leases_if_due(self) -> None:
+        """Throttle lease reaping so the hot poll loop does not query every 500ms."""
+        if self._task_lease_seconds <= 0:
+            return
+        now = time.monotonic()
+        if now - self._last_lease_reap < LEASE_REAPER_INTERVAL:
+            return
+        self._last_lease_reap = now
+        await self.reap_expired_leases()
+
     async def _recover_batch_operations(self, schema: str | None) -> int:
         """
         Recover batch API operations that were in-flight when worker crashed.
@@ -898,6 +980,9 @@ class WorkerPoller:
         and immediately continues polling (up to slot limits).
         """
         await self.recover_own_tasks()
+        await self.reap_expired_leases()
+        if self._task_lease_seconds > 0:
+            self._last_lease_reap = time.monotonic()
 
         reservations_str = (
             ", ".join(f"{k}={v}" for k, v in self._slot_reservations.items()) if self._slot_reservations else "none"
@@ -910,6 +995,8 @@ class WorkerPoller:
 
         while not self._shutdown.is_set():
             try:
+                await self._reap_expired_leases_if_due()
+
                 # Claim a batch of tasks (respecting slot limits)
                 tasks = await self.claim_batch()
 

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -92,9 +92,9 @@ class TestWorkerOperationMetrics:
 
         poller = WorkerPoller(backend=MagicMock(), worker_id="w-test", executor=executor)
         # Stub terminal-state handlers so _execute_task_inner never touches the DB.
-        poller._mark_failed = AsyncMock()
-        poller._defer_operation = AsyncMock()
-        poller._schedule_retry = AsyncMock()
+        poller._mark_failed = AsyncMock()  # type: ignore[assignment]
+        poller._defer_operation = AsyncMock()  # type: ignore[assignment]
+        poller._schedule_retry = AsyncMock()  # type: ignore[assignment]
         return poller
 
     async def _run(self, executor, task_type="batch_retain"):
@@ -1434,6 +1434,194 @@ class TestWorkerDecommission:
         assert len(worker2_rows) == 3
         for row in worker2_rows:
             assert row["status"] == "processing"
+
+
+class TestWorkerLeaseReaper:
+    """Tests for reclaiming processing tasks whose worker lease expired."""
+
+    @pytest.mark.asyncio
+    async def test_reap_expired_leases_releases_stale_processing_tasks(self, pool, backend, clean_operations):
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        stale_op_id = uuid.uuid4()
+        fresh_op_id = uuid.uuid4()
+        parent_op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, worker_id,
+                 claimed_at, updated_at, retry_count)
+            VALUES
+                ($1, $2, 'test', 'processing', $3::jsonb, 'dead-worker',
+                 now() - interval '2 hours', now() - interval '2 hours', 4),
+                ($4, $2, 'test', 'processing', $3::jsonb, 'live-worker',
+                 now(), now(), 0),
+                ($5, $2, 'batch_retain', 'processing', NULL, 'dead-worker',
+                 now() - interval '2 hours', now() - interval '2 hours', 0)
+            """,
+            stale_op_id,
+            bank_id,
+            payload,
+            fresh_op_id,
+            parent_op_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="new-worker",
+            executor=lambda x: None,
+            task_lease_seconds=60,
+        )
+
+        reaped = await poller.reap_expired_leases()
+
+        assert reaped == 1
+        rows = await pool.fetch(
+            "SELECT operation_id, status, worker_id, claimed_at, retry_count FROM async_operations WHERE bank_id = $1",
+            bank_id,
+        )
+        by_id = {row["operation_id"]: row for row in rows}
+
+        stale = by_id[stale_op_id]
+        assert stale["status"] == "pending"
+        assert stale["worker_id"] is None
+        assert stale["claimed_at"] is None
+        assert stale["retry_count"] == 4, "lease reaping must not count as a task retry"
+
+        fresh = by_id[fresh_op_id]
+        assert fresh["status"] == "processing"
+        assert fresh["worker_id"] == "live-worker"
+
+        parent = by_id[parent_op_id]
+        assert parent["status"] == "processing", "payload-less parent rows are not worker-claimable leases"
+        assert parent["worker_id"] == "dead-worker"
+
+    @pytest.mark.asyncio
+    async def test_reap_expired_leases_uses_database_clock(self):
+        from hindsight_api.worker import WorkerPoller
+
+        class FakeTenant:
+            schema = None
+
+        class FakeTenantExtension:
+            async def list_tenants(self):
+                return [FakeTenant()]
+
+        class FakeConnection:
+            def __init__(self):
+                self.calls = []
+
+            async def execute(self, query, *args):
+                self.calls.append((query, args))
+                return "UPDATE 0"
+
+        class FakeAcquire:
+            def __init__(self, conn):
+                self.conn = conn
+
+            async def __aenter__(self):
+                return self.conn
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeBackend:
+            def __init__(self):
+                self.conn = FakeConnection()
+
+            def acquire(self):
+                return FakeAcquire(self.conn)
+
+        backend = FakeBackend()
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="new-worker",
+            executor=lambda x: None,
+            tenant_extension=FakeTenantExtension(),
+            task_lease_seconds=60,
+        )
+
+        assert await poller.reap_expired_leases() == 0
+
+        assert len(backend.conn.calls) == 1
+        query, args = backend.conn.calls[0]
+        assert "updated_at < now() - ($1::int * interval '1 second')" in query
+        assert args == (60,)
+
+    @pytest.mark.asyncio
+    async def test_run_does_not_reap_leases_twice_on_startup(self):
+        from hindsight_api.worker import WorkerPoller
+
+        async def executor(_task_dict):
+            return None
+
+        poller = WorkerPoller(
+            backend=MagicMock(),
+            worker_id="new-worker",
+            executor=executor,
+            task_lease_seconds=60,
+        )
+        reap_calls = 0
+
+        async def recover_own_tasks():
+            return 0
+
+        async def reap_expired_leases():
+            nonlocal reap_calls
+            reap_calls += 1
+            return 0
+
+        async def claim_batch():
+            poller._shutdown.set()
+            return []
+
+        async def log_progress_if_due():
+            return None
+
+        poller.recover_own_tasks = recover_own_tasks  # type: ignore[method-assign]
+        poller.reap_expired_leases = reap_expired_leases  # type: ignore[method-assign]
+        poller.claim_batch = claim_batch  # type: ignore[method-assign]
+        poller._log_progress_if_due = log_progress_if_due  # type: ignore[method-assign]
+
+        await poller.run()
+
+        assert reap_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_reap_expired_leases_disabled_when_zero(self, pool, backend, clean_operations):
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload, worker_id, claimed_at, updated_at)
+            VALUES ($1, $2, 'test', 'processing', $3::jsonb, 'dead-worker',
+                    now() - interval '2 hours', now() - interval '2 hours')
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id="new-worker",
+            executor=lambda x: None,
+            task_lease_seconds=0,
+        )
+
+        assert await poller.reap_expired_leases() == 0
+        row = await pool.fetchrow("SELECT status, worker_id FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "processing"
+        assert row["worker_id"] == "dead-worker"
 
 
 class TestSyncTaskBackend:

--- a/hindsight-api-slim/tests/test_worker_retry_knobs.py
+++ b/hindsight-api-slim/tests/test_worker_retry_knobs.py
@@ -71,6 +71,25 @@ async def _cleanup(pool, bank_id: str, operation_id: uuid.UUID) -> None:
     await pool.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
 
 
+def test_worker_task_lease_seconds_env_var() -> None:
+    from hindsight_api.config import HindsightConfig
+
+    with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS": "120"}):
+        clear_config_cache()
+        config = HindsightConfig.from_env()
+
+    assert config.worker_task_lease_seconds == 120
+
+
+def test_worker_task_lease_seconds_rejects_negative() -> None:
+    from hindsight_api.config import HindsightConfig
+
+    with patch.dict(os.environ, {"HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS": "-1"}):
+        clear_config_cache()
+        with pytest.raises(ValueError, match="worker_task_lease_seconds"):
+            HindsightConfig.from_env()
+
+
 @pytest.mark.asyncio
 async def test_retry_count_cap_honors_env_var(memory):
     """When HINDSIGHT_API_WORKER_MAX_RETRIES=5, retry_count=4 must still retry (4 < 5)."""

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1623,6 +1623,7 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_POLL_INTERVAL_MS` | Database polling interval in milliseconds | `500` |
 | `HINDSIGHT_API_WORKER_MAX_RETRIES` | Max retries before marking task failed | `3` |
 | `HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS` | Seconds between retries on transient task failure | `60` |
+| `HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS` | Reclaim `processing` tasks whose heartbeat (`updated_at`) is older than this many seconds. Returns them to `pending` without incrementing retry count. Set `0` to disable. | `3600` |
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` | Reserved slots for consolidation tasks within `WORKER_MAX_SLOTS` (bank-serialization preserved) | `2` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -80,6 +80,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Unset uses HINDSIGHT_API_RETAIN_CHUNK_SIZE as the structured-chunk limit.
 # HINDSIGHT_API_RETAIN_STRUCTURED_CHUNK_SIZE=
 
+# Worker task lease. Processing tasks whose heartbeat is older than this are
+# returned to pending so another worker can pick them up. 0 disables reaping.
+# HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS=3600
+
 # Dry-run extraction preview endpoint (POST /memories/dry-run-extract). Enabled by default; it makes
 # a real LLM call but stores nothing. Set to false to remove the endpoint (returns 404).
 # HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT=true


### PR DESCRIPTION
## Summary
- add HINDSIGHT_API_WORKER_TASK_LEASE_SECONDS with nonnegative validation
- let workers periodically reset stale processing rows from dead workers back to pending
- keep payload-less parent rows and locally active tasks untouched

## Verification
- uv run pytest tests/test_worker.py::TestWorkerLeaseReaper tests/test_worker_retry_knobs.py::test_worker_task_lease_seconds_env_var tests/test_worker_retry_knobs.py::test_worker_task_lease_seconds_rejects_negative -q
- uv run ruff check hindsight_api/worker/poller.py hindsight_api/config.py hindsight_api/api/http.py hindsight_api/worker/main.py tests/test_worker.py tests/test_worker_retry_knobs.py
- uv run ty check hindsight_api/worker/poller.py hindsight_api/config.py hindsight_api/api/http.py hindsight_api/worker/main.py tests/test_worker.py tests/test_worker_retry_knobs.py
- ./scripts/hooks/lint.sh
- git diff --check