### PR TITLE
fix(memory): return metadata from memory browse endpoints

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1433,6 +1433,7 @@ class ListMemoryUnitsResponse(BaseModel):
                         "date": "2024-01-15T10:30:00Z",
                         "type": "world",
                         "entities": "Alice (PERSON), Google (ORGANIZATION)",
+                        "metadata": {"source": "slack", "channel": "engineering"},
                     }
                 ],
                 "total": 150,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7466,7 +7466,7 @@ class MemoryEngine(MemoryEngineInterface):
                 f"""
                 SELECT id, text, event_date, context, fact_type, document_id,
                        mentioned_at, occurred_start, occurred_end, chunk_id, proof_count,
-                       tags, consolidated_at, consolidation_failed_at, edited_at, {curation_cols}
+                       tags, metadata, consolidated_at, consolidation_failed_at, edited_at, {curation_cols}
                 FROM {source_table}
                 {where_clause}
                 ORDER BY mentioned_at DESC NULLS LAST, created_at DESC
@@ -7521,6 +7521,7 @@ class MemoryEngine(MemoryEngineInterface):
                         "chunk_id": row["chunk_id"] if row["chunk_id"] else None,
                         "proof_count": row["proof_count"] if row["proof_count"] is not None else 1,
                         "tags": list(row["tags"]) if row["tags"] else [],
+                        "metadata": conn.parse_json(row["metadata"]) if row["metadata"] is not None else {},
                         "consolidated_at": row["consolidated_at"].isoformat() if row["consolidated_at"] else None,
                         "consolidation_failed_at": (
                             row["consolidation_failed_at"].isoformat() if row["consolidation_failed_at"] else None
@@ -7573,7 +7574,7 @@ class MemoryEngine(MemoryEngineInterface):
             # back to the archive (with its invalidation bookkeeping) on a miss.
             select_cols = (
                 "id, text, context, event_date, occurred_start, occurred_end, "
-                "mentioned_at, fact_type, document_id, chunk_id, tags, source_memory_ids, "
+                "mentioned_at, fact_type, document_id, chunk_id, tags, metadata, source_memory_ids, "
                 "observation_scopes, edited_at"
             )
             row = await conn.fetchrow(
@@ -7617,6 +7618,7 @@ class MemoryEngine(MemoryEngineInterface):
                 "document_id": row["document_id"] if row["document_id"] else None,
                 "chunk_id": str(row["chunk_id"]) if row["chunk_id"] else None,
                 "tags": row["tags"] if row["tags"] else [],
+                "metadata": conn.parse_json(row["metadata"]) if row["metadata"] is not None else {},
                 "observation_scopes": row["observation_scopes"] if row["observation_scopes"] else None,
                 "state": unit_state,
                 "invalidation_reason": row["invalidation_reason"],

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -6,6 +6,7 @@ These tests cover the move semantics, lossless revert (incl. entity
 associations), edit, the guards, listing, and recall exclusion.
 """
 
+import json
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -21,21 +22,29 @@ from hindsight_api.engine.retain import embedding_processing
 
 
 async def _insert_memory(
-    conn, memory: MemoryEngine, bank_id: str, text: str, fact_type: str = "experience"
+    conn,
+    memory: MemoryEngine,
+    bank_id: str,
+    text: str,
+    fact_type: str = "experience",
+    metadata: dict | None = None,
 ) -> uuid.UUID:
     """Insert a live memory unit with a real embedding, bypassing the LLM pipeline."""
     mem_id = uuid.uuid4()
     emb = await embedding_processing.generate_embeddings_batch(memory.embeddings, [text])
     await conn.execute(
         """
-        INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, event_date, created_at, updated_at, consolidated_at)
-        VALUES ($1, $2, $3, $4, $5::vector, NOW(), NOW(), NOW(), NOW())
+        INSERT INTO memory_units (
+            id, bank_id, text, fact_type, embedding, event_date, metadata, created_at, updated_at, consolidated_at
+        )
+        VALUES ($1, $2, $3, $4, $5::vector, NOW(), $6::jsonb, NOW(), NOW(), NOW())
         """,
         mem_id,
         bank_id,
         text,
         fact_type,
         str(emb[0]),
+        json.dumps(metadata or {}),
     )
     return mem_id
 
@@ -477,6 +486,47 @@ class TestGuardsAndListing:
         assert invalid[0]["id"] == str(m2)
         assert invalid[0]["state"] == "invalidated"
         assert invalid[0]["invalidation_reason"] == "dup"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_list_and_get_memory_units_include_metadata(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        bank_id = f"test-curation-metadata-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+        metadata = {"source": "slack", "channel": "engineering", "thread_id": "T123"}
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            mem_id = await _insert_memory(conn, memory, bank_id, "Fact with metadata.", metadata=metadata)
+
+        live = (await memory.list_memory_units(bank_id, request_context=request_context))["items"]
+        live_item = next(item for item in live if item["id"] == str(mem_id))
+        assert live_item["metadata"] == metadata
+
+        detail = await memory.get_memory_unit(bank_id, str(mem_id), request_context=request_context)
+        assert detail is not None
+        assert detail["metadata"] == metadata
+
+        with (
+            patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
+            patch.object(memory, "submit_async_graph_maintenance", new=AsyncMock()),
+        ):
+            await memory.update_memory_unit(
+                bank_id, str(mem_id), state="invalidated", reason="stale", request_context=request_context
+            )
+
+        invalid = (await memory.list_memory_units(bank_id, state="invalidated", request_context=request_context))[
+            "items"
+        ]
+        assert invalid[0]["id"] == str(mem_id)
+        assert invalid[0]["metadata"] == metadata
+
+        invalid_detail = await memory.get_memory_unit(bank_id, str(mem_id), request_context=request_context)
+        assert invalid_detail is not None
+        assert invalid_detail["state"] == "invalidated"
+        assert invalid_detail["metadata"] == metadata
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -6339,6 +6339,9 @@ components:
           date: 2024-01-15T10:30:00Z
           entities: "Alice (PERSON), Google (ORGANIZATION)"
           id: 550e8400-e29b-41d4-a716-446655440000
+          metadata:
+            channel: engineering
+            source: slack
           text: Alice works at Google on the AI team
           type: world
         limit: 100

--- a/hindsight-docs/docs/developer/api/memories.mdx
+++ b/hindsight-docs/docs/developer/api/memories.mdx
@@ -28,7 +28,7 @@ import memoriesGo from '!!raw-loader!@site/examples/api/memories.go';
 
 ## List memory units
 
-List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
+List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), metadata, entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
 
 <Tabs>
 <TabItem value="python" label="Python">
@@ -46,6 +46,8 @@ List the memory units in a bank. The response includes each unit's `fact_type` (
 </Tabs>
 
 ## Fetch a single memory unit
+
+Fetch a memory unit by ID, including its content, metadata, entities, timestamps, tags, and curation state.
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/examples/api/memories.go
+++ b/hindsight-docs/examples/api/memories.go
@@ -68,7 +68,7 @@ func main() {
 
 	if memoryID != "" {
 		// [docs:get-memory]
-		// Fetch a single memory unit (entities, dates, state).
+		// Fetch a single memory unit (metadata, entities, dates, state).
 		memory, _, _ := client.MemoryAPI.GetMemory(ctx, memBankID, memoryID).Execute()
 		fmt.Printf("Memory: %v\n", memory)
 		// [/docs:get-memory]

--- a/hindsight-docs/examples/api/memories.mjs
+++ b/hindsight-docs/examples/api/memories.mjs
@@ -51,7 +51,7 @@ if (!fact) {
 const memoryId = fact.id;
 
 // [docs:get-memory]
-// Fetch a single memory unit (entities, dates, state).
+// Fetch a single memory unit (metadata, entities, dates, state).
 const memory = await (
     await fetch(`${HINDSIGHT_URL}/v1/default/banks/${BANK_ID}/memories/${memoryId}`)
 ).json();

--- a/hindsight-docs/examples/api/memories.py
+++ b/hindsight-docs/examples/api/memories.py
@@ -84,7 +84,7 @@ async def main():
     memory_id = fact["id"]
 
     # [docs:get-memory]
-    # Fetch a single memory unit (includes entities, dates, and state).
+    # Fetch a single memory unit (includes metadata, entities, dates, and state).
     memory = await client.memory.get_memory(bank_id=BANK_ID, memory_id=memory_id)
 
     print(f"Text: {memory['text']}")

--- a/hindsight-docs/examples/api/memories.sh
+++ b/hindsight-docs/examples/api/memories.sh
@@ -32,7 +32,7 @@ MEMORY_ID=$(hindsight memory list "$BANK_ID" -o json | python3 -c "import sys,js
 
 if [ -n "$MEMORY_ID" ]; then
   # [docs:get-memory]
-  # Fetch a single memory unit (entities, dates, state)
+  # Fetch a single memory unit (metadata, entities, dates, state)
   curl -s "$HINDSIGHT_URL/v1/default/banks/$BANK_ID/memories/$MEMORY_ID"
   # [/docs:get-memory]
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -9551,6 +9551,10 @@
               "date": "2024-01-15T10:30:00Z",
               "entities": "Alice (PERSON), Google (ORGANIZATION)",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "metadata": {
+                "channel": "engineering",
+                "source": "slack"
+              },
               "text": "Alice works at Google on the AI team",
               "type": "world"
             }

--- a/hindsight-docs/versioned_docs/version-0.8/developer/api/memories.mdx
+++ b/hindsight-docs/versioned_docs/version-0.8/developer/api/memories.mdx
@@ -28,7 +28,7 @@ import memoriesGo from '!!raw-loader!@site/examples/api/memories.go';
 
 ## List memory units
 
-List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
+List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), metadata, entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
 
 <Tabs>
 <TabItem value="python" label="Python">
@@ -46,6 +46,8 @@ List the memory units in a bank. The response includes each unit's `fact_type` (
 </Tabs>
 
 ## Fetch a single memory unit
+
+Fetch a memory unit by ID, including its content, metadata, entities, timestamps, tags, and curation state.
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/skills/hindsight-docs/references/developer/api/memories.md
+++ b/skills/hindsight-docs/references/developer/api/memories.md
@@ -17,7 +17,7 @@ A **memory unit** is the atomic fact Hindsight extracts and stores. This page co
 
 ## List memory units
 
-List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
+List the memory units in a bank. The response includes each unit's `fact_type` (`world` | `experience` | `observation`), `state` (`valid` | `invalidated`), metadata, entities, occurred dates, and — for facts a user has edited — an `edited_at` timestamp. Invalidated rows are **included by default** so curation stays auditable; filter with `state=`.
 
 ### Python
 
@@ -57,6 +57,8 @@ curl -s "$HINDSIGHT_URL/v1/default/banks/$BANK_ID/memories/list?state=invalidate
 
 ## Fetch a single memory unit
 
+Fetch a memory unit by ID, including its content, metadata, entities, timestamps, tags, and curation state.
+
 ### Python
 
 ```python
@@ -66,7 +68,7 @@ curl -s "$HINDSIGHT_URL/v1/default/banks/$BANK_ID/memories/list?state=invalidate
 ### Node.js
 
 ```javascript
-// Fetch a single memory unit (entities, dates, state).
+// Fetch a single memory unit (metadata, entities, dates, state).
 const memory = await (
     await fetch(`${HINDSIGHT_URL}/v1/default/banks/${BANK_ID}/memories/${memoryId}`)
 ).json();

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -9551,6 +9551,10 @@
               "date": "2024-01-15T10:30:00Z",
               "entities": "Alice (PERSON), Google (ORGANIZATION)",
               "id": "550e8400-e29b-41d4-a716-446655440000",
+              "metadata": {
+                "channel": "engineering",
+                "source": "slack"
+              },
               "text": "Alice works at Google on the AI team",
               "type": "world"
             }


### PR DESCRIPTION
## Summary

Fixes #2582.

This updates the memory browse/detail read paths so stored memory-unit metadata is returned by `GET /memories/list` and `GET /memories/{id}`. Both live memory units and invalidated archive rows now select and serialize the `metadata` column.

## Root cause

Retain stores caller-provided metadata on each memory unit and recall already selects and returns it, but the list/get memory-unit queries omitted the `metadata` column. That made metadata invisible when users inspected memories directly, even when the database row had the expected value.

## Changes

- Select and return `metadata` from `list_memory_units()`.
- Select and return `metadata` from `get_memory_unit()` for live and invalidated memory units.
- Add a curation regression test covering list/get for both live and invalidated rows.
- Update API docs, examples, OpenAPI examples, and docs-skill references to mention metadata.

## Validation

- `cd hindsight-dev && uv run pytest tests/test_generate_openapi.py -q`
- `cd hindsight-api-slim && uv run pytest tests/test_base_path.py tests/test_memory_curation.py::TestGuardsAndListing::test_list_and_get_memory_units_include_metadata tests/test_http_api_integration.py::test_http_recall_preserves_metadata -q`
- `cd hindsight-docs && npm run build`
- `./scripts/hooks/lint.sh`
