### PR TITLE
feat(eve): retain the assistant reply by default

### DIFF
--- a/hindsight-integrations/eve/README.md
+++ b/hindsight-integrations/eve/README.md
@@ -82,7 +82,7 @@ hindsightMemory({
   budget, // "low" | "mid" | "high" — recall result budget (default "mid")
   maxTokens, // number  — recall token budget (default 1024)
   context, // string  — `context` tag written on retained items (default "eve")
-  includeAssistantReply, // boolean — also retain the assistant's reply (default false)
+  includeAssistantReply, // boolean — also retain the assistant's reply (default true)
   timeoutMs, // number  — HTTP timeout (default 15000)
   onError, // (err, phase) => void — failures degrade silently via this (default console.warn)
 });
@@ -101,8 +101,9 @@ specific retrieval inherently needs a tool the model calls; that's out of scope 
 
 - Memory is scoped to a **bank** (one isolated store, e.g. per user). Point both files at the
   same `HINDSIGHT_BANK_ID`.
-- By default only the **user's** message is retained (the durable signal) — set
-  `includeAssistantReply: true` to also store the assistant's reply.
+- By default **both** the user's message and the assistant's reply are retained — the
+  reply is usually where the answer lives. Set `includeAssistantReply: false` to store
+  only the user's message.
 - Retains run asynchronously and never block a turn; failures degrade via `onError`.
 - The recall block injected into context is fenced with a sentinel so recalled facts are never
   re-retained.

--- a/hindsight-integrations/eve/src/auto-memory.test.ts
+++ b/hindsight-integrations/eve/src/auto-memory.test.ts
@@ -23,7 +23,7 @@ const handlers = (def: { events: unknown }): any => def.events;
 afterEach(() => vi.unstubAllGlobals());
 
 describe("hindsightRetainHook", () => {
-  it("retains the user's message on turn.completed (user-only by default)", async () => {
+  it("retains both the user message and assistant reply on turn.completed (both by default)", async () => {
     const fetchFn = mockFetch();
     const ev = handlers(hindsightRetainHook(OPTS));
 
@@ -36,20 +36,18 @@ describe("hindsightRetainHook", () => {
     expect(url).toBe("http://test/v1/default/banks/b/memories");
     const body = JSON.parse(init.body);
     expect(body.async).toBe(true);
-    expect(body.items[0].content).toBe("User: I prefer tabs");
+    expect(body.items[0].content).toBe("User: I prefer tabs\n\nAssistant: Got it.");
     expect(body.items[0].context).toBe("eve");
     expect(body.items[0].metadata).toMatchObject({ sessionId: "s1", turnId: "t1", channel: "web" });
   });
 
-  it("includes the assistant reply when includeAssistantReply is set", async () => {
+  it("stores only the user message when includeAssistantReply is false", async () => {
     const fetchFn = mockFetch();
-    const ev = handlers(hindsightRetainHook({ ...OPTS, includeAssistantReply: true }));
+    const ev = handlers(hindsightRetainHook({ ...OPTS, includeAssistantReply: false }));
     ev["message.received"]({ data: { turnId: "t1", message: "I prefer tabs" } });
     ev["message.completed"]({ data: { turnId: "t1", message: "Got it.", finishReason: "stop" } });
     await ev["turn.completed"]({ data: { turnId: "t1" } }, CTX);
-    expect(JSON.parse(fetchFn.mock.calls[0][1].body).items[0].content).toBe(
-      "User: I prefer tabs\n\nAssistant: Got it."
-    );
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).items[0].content).toBe("User: I prefer tabs");
   });
 
   it("ignores non-terminal assistant steps (finishReason !== 'stop')", async () => {

--- a/hindsight-integrations/eve/src/config.test.ts
+++ b/hindsight-integrations/eve/src/config.test.ts
@@ -60,22 +60,20 @@ describe("resolveAutoMemory", () => {
 });
 
 describe("turn pairing buffer", () => {
-  it("stores only the user message by default (drops the assistant reply)", () => {
+  it("stores both the user message and assistant reply by default", () => {
     const buf: TurnBuffer = new Map();
     recordUserMessage(buf, "t1", "I prefer tabs");
     recordAssistantMessage(buf, "t1", "Noted.");
     const pair = takeTurn(buf, "t1");
     expect(buf.has("t1")).toBe(false); // taken
-    expect(buildRetainContent(pair)).toBe("User: I prefer tabs");
+    expect(buildRetainContent(pair)).toBe("User: I prefer tabs\n\nAssistant: Noted.");
   });
 
-  it("appends the assistant reply when includeAssistant is set", () => {
+  it("drops the assistant reply when includeAssistant is false", () => {
     const buf: TurnBuffer = new Map();
     recordUserMessage(buf, "t1", "I prefer tabs");
     recordAssistantMessage(buf, "t1", "Noted.");
-    expect(buildRetainContent(takeTurn(buf, "t1"), true)).toBe(
-      "User: I prefer tabs\n\nAssistant: Noted."
-    );
+    expect(buildRetainContent(takeTurn(buf, "t1"), false)).toBe("User: I prefer tabs");
   });
 
   it("skips a turn with no user text", () => {

--- a/hindsight-integrations/eve/src/config.ts
+++ b/hindsight-integrations/eve/src/config.ts
@@ -33,9 +33,10 @@ export interface AutoMemoryOptions {
   /** `context` tag written on retained items. Defaults to `"eve"`. */
   context?: string;
   /**
-   * Also store the assistant's reply (not just the user's message). Off by
-   * default — retaining only what the user says keeps banks clean and avoids
-   * re-storing the agent's own acknowledgments/chatter.
+   * Also store the assistant's reply, not just the user's message. On by
+   * default — the assistant's reply is usually where the answer lives (the
+   * decision, the solution, the code it wrote), so both halves of the turn are
+   * worth remembering. Set to `false` to retain only the user's message.
    */
   includeAssistantReply?: boolean;
   /** HTTP timeout in ms. Defaults to `15000`. */
@@ -105,7 +106,7 @@ export function resolveAutoMemory(
     budget: options.budget ?? "mid",
     maxTokens: options.maxTokens ?? 1024,
     context: options.context ?? "eve",
-    includeAssistantReply: options.includeAssistantReply ?? false,
+    includeAssistantReply: options.includeAssistantReply ?? true,
     timeoutMs: options.timeoutMs ?? 15_000,
     // eslint-disable-next-line no-console
     onError: options.onError ?? ((error) => console.warn("[hindsight-eve] memory error:", error)),
@@ -152,13 +153,14 @@ export function takeTurn(buffer: TurnBuffer, turnId: string): TurnPair | undefin
 
 /**
  * Build the retain `content` for a turn, or `null` to skip. Skips turns with no
- * user text. By default stores only the user's message (the durable signal);
- * with `includeAssistant`, appends the assistant reply with any injected
- * recalled-context block stripped out so recalled facts are never re-retained.
+ * user text. By default appends the assistant reply (that is usually where the
+ * answer lives) with any injected recalled-context block stripped out so
+ * recalled facts are never re-retained; pass `includeAssistant: false` to store
+ * only the user's message.
  */
 export function buildRetainContent(
   pair: TurnPair | undefined,
-  includeAssistant = false
+  includeAssistant = true
 ): string | null {
   const user = (pair?.user ?? "").trim();
   if (!user) return null;


### PR DESCRIPTION
## Summary
Flip `includeAssistantReply` to default **`true`** in the `hindsight-eve` auto-retain hook, so a completed turn retains **both** the user's message and the assistant's reply — not just the user's message.

The assistant's reply is usually where the answer lives: the decision reached, the solution described, the code written. Retaining only the user's message captures the question but loses the answer.

## Why: consistency with every other auto-retain integration
This came out of blog review (#2584). I checked how the comparable integrations handle it. Every Hindsight integration that does **automatic** retain already stores the assistant side by default:

| Integration | Auto-retain pattern | Default |
|---|---|---|
| **agent-framework** (Microsoft) | `ContextProvider.after_run` — *same pattern as eve* | `include_input=True` + `include_response=True` (hardcoded) |
| **opencode** | `session.idle` hook | `retainMode: "full-session"` — user + assistant |
| **claude-code** | Stop hook | `retainRoles: ["user", "assistant"]` |

(ai-sdk and openhands are tool-only — the model decides what to save — so they don't set an auto-retain default.)

eve was the **only** auto-retain integration defaulting to user-only. This aligns it with the rest.

## Changes
- `src/config.ts`: `resolveAutoMemory` default `includeAssistantReply` → `true`; `buildRetainContent` param default → `true`; updated JSDoc.
- `README.md`: options table + Notes updated to describe the new default (also resolves an existing contradiction — the "How it works" section already claimed it retained the assistant's answer).
- Tests: repurposed the two "user-only by default" cases to assert the new default (both), with the opt-out (`includeAssistantReply: false`) still covered. `27 passed`.

## Opt-out
Set `includeAssistantReply: false` to keep the old user-only behavior.

## Notes
- This is a behavior change; it may warrant a version bump on the next `hindsight-eve` release — leaving that to maintainers.
- Local `test` + `build` (incl. DTS) pass. The repo-wide pre-commit lint hook couldn't run in my worktree (unrelated `hindsight-control-plane` deps not installed); CI runs the full lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)