### PR TITLE
fix(parsers): coerce non-bytes buffers before the UTF-8 charset probe in markitdown

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
+++ b/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
@@ -186,7 +186,11 @@ class MarkitdownParser(FileParser):
         if Path(filename).suffix.lower() not in _TEXT_EXTENSIONS:
             return None
         try:
-            file_data.decode("utf-8")
+            # file_data may arrive as a non-``bytes`` buffer (e.g. a memoryview or
+            # a native/Rust-backed buffer object) that has no ``.decode``; coerce
+            # through the buffer protocol before the UTF-8 probe. The ``tmp.write``
+            # in the caller already relies only on the same buffer protocol.
+            bytes(file_data).decode("utf-8")
         except UnicodeDecodeError:
             return None
         from markitdown import StreamInfo

--- a/hindsight-api-slim/tests/test_markitdown_parser.py
+++ b/hindsight-api-slim/tests/test_markitdown_parser.py
@@ -63,3 +63,26 @@ def test_utf8_stream_info_skips_non_utf8_text():
     latin1 = "café".encode("latin-1")  # 0xe9, invalid as standalone UTF-8
 
     assert MarkitdownParser._utf8_stream_info(latin1, "a.txt") is None
+
+
+def test_utf8_stream_info_accepts_non_bytes_buffer():
+    """file_data may arrive as a buffer-protocol object that is not a Python
+    ``bytes`` (e.g. a memoryview or a native/Rust-backed buffer) and therefore
+    has no ``.decode``. The UTF-8 probe must coerce via ``bytes()`` instead of
+    assuming concrete ``bytes``, else every text file fails to parse with
+    ``'...' object has no attribute 'decode'``.
+    """
+
+    class _BufferOnly:
+        """A buffer-protocol object without a ``.decode`` method."""
+
+        def __init__(self, data: bytes) -> None:
+            self._mv = memoryview(data)
+
+        def __buffer__(self, flags):  # PEP 688 buffer protocol
+            return self._mv.__buffer__(flags)
+
+    info = MarkitdownParser._utf8_stream_info(_BufferOnly("über".encode("utf-8")), "a.txt")
+
+    assert info is not None
+    assert info.charset == "utf-8"

--- a/hindsight-api-slim/tests/test_markitdown_parser.py
+++ b/hindsight-api-slim/tests/test_markitdown_parser.py
@@ -72,17 +72,14 @@ def test_utf8_stream_info_accepts_non_bytes_buffer():
     assuming concrete ``bytes``, else every text file fails to parse with
     ``'...' object has no attribute 'decode'``.
     """
+    # memoryview is a buffer-protocol object with no ``.decode`` and, unlike a
+    # PEP 688 ``__buffer__`` class, ``bytes(memoryview)`` works on every
+    # supported Python version — a portable stand-in for the native buffer the
+    # storage layer returns.
+    buf = memoryview("über".encode("utf-8"))
+    assert not hasattr(buf, "decode")  # precondition: would hit the original AttributeError
 
-    class _BufferOnly:
-        """A buffer-protocol object without a ``.decode`` method."""
-
-        def __init__(self, data: bytes) -> None:
-            self._mv = memoryview(data)
-
-        def __buffer__(self, flags):  # PEP 688 buffer protocol
-            return self._mv.__buffer__(flags)
-
-    info = MarkitdownParser._utf8_stream_info(_BufferOnly("über".encode("utf-8")), "a.txt")
+    info = MarkitdownParser._utf8_stream_info(buf, "a.txt")
 
     assert info is not None
     assert info.charset == "utf-8"


### PR DESCRIPTION
## Problem

`MarkitdownParser._utf8_stream_info()` is type-hinted `file_data: bytes` and calls `file_data.decode("utf-8")` to check whether a text file is valid UTF-8 before handing markitdown an explicit charset hint (the hint added to work around markitdown's sample-based charset mis-detection on UTF-8 text).

But the value that flows into the parser is not always a concrete `bytes`. Callers can pass any buffer-protocol object — a `memoryview`, or a native/Rust-backed buffer (e.g. a PyO3 `Bytes`). Those support the buffer protocol but have **no `.decode` method**, so the probe raises:

```
AttributeError: '...Bytes' object has no attribute 'decode'
```

and **every text-file parse fails** (`.txt`, `.json`, `.jsonl`, `.ipynb`, `.md`, `.csv`, `.html`, ...) with `Failed to parse '<file>'`.

This wasn't caught by the existing parser tests because they pass `bytes` literals (`b"..."`, `"...".encode()`), for which `.decode()` works — the failure only appears when the upstream read path yields a non-`bytes` buffer.

## Fix

Coerce through the buffer protocol before the probe:

```python
bytes(file_data).decode("utf-8")
```

`bytes()` accepts any buffer-protocol object (the same protocol `tempfile.write(file_data)` a few lines up already relies on), and is a no-op copy for a real `bytes`. No behavior change for the `bytes` path; the non-`bytes` path now works instead of raising.

## Test

Adds `test_utf8_stream_info_accepts_non_bytes_buffer`, which passes a buffer-only object (implements the buffer protocol, has no `.decode`) and asserts the UTF-8 hint is still produced. Fails before the fix, passes after. Full `test_markitdown_parser.py` is green (6/6).