### PR TITLE
docs(eve): sync assistant reply default

### DIFF
--- a/hindsight-docs/docs-integrations/eve.md
+++ b/hindsight-docs/docs-integrations/eve.md
@@ -68,7 +68,7 @@ hindsightMemory({
   budget,      // "low" | "mid" | "high" — recall result budget (default "mid")
   maxTokens,   // recall token budget (default 1024)
   context,     // `context` tag written on retained items (default "eve")
-  includeAssistantReply, // also retain the assistant's reply (default false — user message only)
+  includeAssistantReply, // also retain the assistant's reply (default true)
   timeoutMs,   // HTTP timeout (default 15000)
   onError,     // (err, phase) => void — failures degrade silently (default console.warn)
 });


### PR DESCRIPTION
## Summary

Sync the Eve integration guide with the current auto-memory default from #2585: `includeAssistantReply` now defaults to `true`.

The package README and integration changelog already describe the default-on behavior, but the public guide still said the default was `false` / user-message-only.

## Checks

- Source-checked `hindsight-integrations/eve/src/config.ts`
- Compared the package README and Eve changelog
- Confirmed there is no `skills/hindsight-docs/references/docs-integrations/eve.md` mirror to regenerate
