### PR TITLE
fix(agent-sdk): release recall token fix as 0.1.1

### DIFF
--- a/hindsight-tools/hindsight-agent-sdk/package-lock.json
+++ b/hindsight-tools/hindsight-agent-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectorize-io/hindsight-agent-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectorize-io/hindsight-agent-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@vectorize-io/hindsight-client": "^0.6.2"

--- a/hindsight-tools/hindsight-agent-sdk/package.json
+++ b/hindsight-tools/hindsight-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectorize-io/hindsight-agent-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agent knowledge tools powered by Hindsight — harness-agnostic SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@vectorize-io/hindsight-agent-sdk` from `0.1.0` to `0.1.1`
- keep `package-lock.json` in sync for the SDK package

## Why

The source fix from #1552 is already on main: `agent_knowledge_recall` now exposes `max_tokens` and no longer maps `max_results` to the Hindsight `maxTokens` budget.

However, npm still only has `@vectorize-io/hindsight-agent-sdk@0.1.0`, which predates #1552. The follow-up on #2591 points at that published behavior: installs can still get `maxTokens=10` from the stale tarball even though the repository source has been fixed.

This PR is intentionally only the patch-release metadata change; `prepublishOnly` still builds `dist` at publish time.

## Checks

- `npm ci --ignore-scripts --workspaces=false`
- `npm test`
- `npm run build`
- `npm pack --dry-run --workspaces=false`

Codex review note: the review broker returned an empty final response twice during this run, so this was recorded as `DEGRADED`; the diff is limited to package metadata and the SDK test/build/package dry run passed.
