### PR TITLE
feat(config): optional cap on planner parallelism for pool connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_READ_DATABASE_URL=  # Optional read-replica URL. When set, recall queries (semantic, BM25, graph, temporal) flow through a separate pool against this URL, offloading the primary. Typically points to a read-only endpoint (CNPG's <cluster>-ro service or Aurora reader endpoint).
 # HINDSIGHT_API_MIGRATION_DATABASE_URL=  # Direct PostgreSQL URL for migrations (bypasses PgBouncer). Falls back to DATABASE_URL.
 # HINDSIGHT_API_DATABASE_SCHEMA=public  # PostgreSQL schema name (default: public)
+# HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=  # Optional cap on Postgres planner parallelism for this process's pool connections. Unset leaves the server default; 0 makes background/bulk queries run serially (useful on worker processes sharing a primary with latency-sensitive traffic).
 # HINDSIGHT_API_MIGRATION_CONCURRENCY=1  # Tenant schemas to migrate concurrently (PG only, each in its own process; per-schema work stays sequential). Each worker has ~1-2s startup cost + uses ~3 DB connections, so it only pays off with many schemas (tens+) or slow migrations; keep concurrency*3 <= spare max_connections. Default: 1 (sequential).
 
 # Vector Extension (Optional - uses pgvector by default)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -584,6 +584,7 @@ ENV_DB_POOL_MAX_SIZE = "HINDSIGHT_API_DB_POOL_MAX_SIZE"
 ENV_DB_COMMAND_TIMEOUT = "HINDSIGHT_API_DB_COMMAND_TIMEOUT"
 ENV_DB_ACQUIRE_TIMEOUT = "HINDSIGHT_API_DB_ACQUIRE_TIMEOUT"
 ENV_DB_STATEMENT_TIMEOUT = "HINDSIGHT_API_DB_STATEMENT_TIMEOUT"
+ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER = "HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER"
 
 # Wall-clock cap on model/connection initialization at startup. If embeddings,
 # cross-encoder, or LLM verification hang (e.g. an offline HuggingFace download
@@ -1040,6 +1041,14 @@ DEFAULT_DB_POOL_MAX_SIZE = 100
 DEFAULT_DB_COMMAND_TIMEOUT = 60  # seconds
 DEFAULT_DB_ACQUIRE_TIMEOUT = 30  # seconds
 DEFAULT_DB_STATEMENT_TIMEOUT = 600  # seconds (Postgres statement_timeout applied on every pool connection; 0 disables)
+# Optional cap on Postgres planner parallelism for this process's pool
+# connections (SET max_parallel_workers_per_gather). None leaves the server
+# default untouched. Setting 0 on background-worker processes keeps bulk
+# maintenance queries (consolidation, graph upkeep) from fanning out across
+# cores that latency-sensitive foreground traffic is sharing — parallel
+# workers buy latency, which background work doesn't need, at the cost of
+# concurrent CPU footprint, which multi-tenant primaries do care about.
+DEFAULT_DB_MAX_PARALLEL_WORKERS_PER_GATHER: int | None = None
 DEFAULT_MODEL_INIT_TIMEOUT = 300  # seconds (cap on startup model/connection init; covers first-time downloads)
 
 # Worker configuration (distributed task processing)
@@ -1214,6 +1223,25 @@ def _parse_optional_positive_int(name: str, raw: str | None) -> int | None:
     if raw is None or raw == "":
         return None
     return _parse_positive_int(name, raw, 1)
+
+
+def _parse_optional_non_negative_int(name: str, raw: str | None) -> int | None:
+    """
+    Parse an optional env var that must be a non-negative integer when set.
+
+    Unlike ``_parse_optional_positive_int``, 0 is a meaningful value here —
+    e.g. ``max_parallel_workers_per_gather = 0`` disables planner parallelism
+    entirely. Unset/empty means "no opinion" (None).
+    """
+    if raw is None or raw == "":
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError as e:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from e
+    if parsed < 0:
+        raise ValueError(f"{name} must be >= 0, got {parsed}")
+    return parsed
 
 
 def _validate_retain_chunking_int(name: str, value: Any) -> int:
@@ -1896,6 +1924,7 @@ class HindsightConfig:
     db_command_timeout: int
     db_acquire_timeout: int
     db_statement_timeout: int
+    db_max_parallel_workers_per_gather: int | None
     model_init_timeout: float
 
     # Worker configuration (distributed task processing)
@@ -2902,6 +2931,10 @@ class HindsightConfig:
             db_command_timeout=int(os.getenv(ENV_DB_COMMAND_TIMEOUT, str(DEFAULT_DB_COMMAND_TIMEOUT))),
             db_acquire_timeout=int(os.getenv(ENV_DB_ACQUIRE_TIMEOUT, str(DEFAULT_DB_ACQUIRE_TIMEOUT))),
             db_statement_timeout=int(os.getenv(ENV_DB_STATEMENT_TIMEOUT, str(DEFAULT_DB_STATEMENT_TIMEOUT))),
+            db_max_parallel_workers_per_gather=_parse_optional_non_negative_int(
+                ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER,
+                os.getenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER),
+            ),
             model_init_timeout=float(os.getenv(ENV_MODEL_INIT_TIMEOUT, str(DEFAULT_MODEL_INIT_TIMEOUT))),
             # Worker configuration
             worker_enabled=os.getenv(ENV_WORKER_ENABLED, str(DEFAULT_WORKER_ENABLED)).lower() == "true",

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1028,6 +1028,7 @@ class MemoryEngine(MemoryEngineInterface):
         self._db_command_timeout = db_command_timeout if db_command_timeout is not None else config.db_command_timeout
         self._db_acquire_timeout = db_acquire_timeout if db_acquire_timeout is not None else config.db_acquire_timeout
         self._db_statement_timeout = config.db_statement_timeout
+        self._db_max_parallel_workers_per_gather = config.db_max_parallel_workers_per_gather
         self._run_migrations = run_migrations
         self._retain_entity_lookup = config.retain_entity_lookup
         self._retain_entity_resolution_batch_size = config.retain_entity_resolution_batch_size
@@ -2860,6 +2861,7 @@ class MemoryEngine(MemoryEngineInterface):
         self._dialect = create_sql_dialect(self._database_backend_type)
 
         stmt_timeout_s = self._db_statement_timeout
+        max_parallel_gather = self._db_max_parallel_workers_per_gather
         text_search_extension = get_config().text_search_extension
 
         # Per-connection initialization callback (PostgreSQL-specific for now)
@@ -2896,6 +2898,18 @@ class MemoryEngine(MemoryEngineInterface):
             # unaffected. 0 disables.
             if stmt_timeout_s > 0:
                 await conn.execute(f"SET statement_timeout = '{stmt_timeout_s}s'")
+
+            # Optional cap on planner parallelism for this process's
+            # connections. Deployments that run background workers against a
+            # database shared with latency-sensitive traffic can set this to 0
+            # on the worker process: bulk maintenance queries (consolidation,
+            # graph upkeep) then run serially instead of fanning out across
+            # parallel workers — parallelism buys latency, which background
+            # work doesn't need, at the cost of concurrent CPU footprint,
+            # which shared primaries do care about. None (default) leaves the
+            # server setting untouched.
+            if max_parallel_gather is not None:
+                await conn.execute(f"SET max_parallel_workers_per_gather = {max_parallel_gather}")
 
         await self._backend.initialize(
             self.db_url,

--- a/hindsight-api-slim/tests/test_db_parallel_workers_config.py
+++ b/hindsight-api-slim/tests/test_db_parallel_workers_config.py
@@ -1,0 +1,60 @@
+"""Config parsing for HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER.
+
+The flag is optional and static (server-level): unset means "leave the
+Postgres server default untouched"; 0 is a meaningful value (disable planner
+parallelism on this process's pool connections). These tests pin the parse
+semantics so a refactor can't silently turn "unset" into 0 or reject 0.
+"""
+
+import pytest
+
+from hindsight_api.config import (
+    ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER,
+    HindsightConfig,
+    _parse_optional_non_negative_int,
+)
+
+
+class TestParseOptionalNonNegativeInt:
+    def test_unset_returns_none(self):
+        assert _parse_optional_non_negative_int("X", None) is None
+
+    def test_empty_returns_none(self):
+        assert _parse_optional_non_negative_int("X", "") is None
+
+    def test_zero_is_valid(self):
+        # 0 = disable planner parallelism; must NOT be treated as unset.
+        assert _parse_optional_non_negative_int("X", "0") == 0
+
+    def test_positive_is_valid(self):
+        assert _parse_optional_non_negative_int("X", "2") == 2
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            _parse_optional_non_negative_int("X", "-1")
+
+    def test_non_integer_raises(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_optional_non_negative_int("X", "two")
+
+
+class TestFromEnv:
+    def test_default_is_none(self, monkeypatch):
+        monkeypatch.delenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER, raising=False)
+        config = HindsightConfig.from_env()
+        assert config.db_max_parallel_workers_per_gather is None
+
+    def test_env_zero(self, monkeypatch):
+        monkeypatch.setenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER, "0")
+        config = HindsightConfig.from_env()
+        assert config.db_max_parallel_workers_per_gather == 0
+
+    def test_env_positive(self, monkeypatch):
+        monkeypatch.setenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER, "1")
+        config = HindsightConfig.from_env()
+        assert config.db_max_parallel_workers_per_gather == 1
+
+    def test_env_invalid_fails_fast(self, monkeypatch):
+        monkeypatch.setenv(ENV_DB_MAX_PARALLEL_WORKERS_PER_GATHER, "-2")
+        with pytest.raises(ValueError):
+            HindsightConfig.from_env()

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -53,6 +53,7 @@ Migrations will automatically create the schema if it doesn't exist and create a
 | `HINDSIGHT_API_DB_COMMAND_TIMEOUT` | PostgreSQL command timeout in seconds (asyncpg client-side) | `60` |
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |
+| `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` | Optional Postgres `max_parallel_workers_per_gather` applied to every pool connection of this process. Unset leaves the server default. Set to `0` on background-worker processes so bulk maintenance queries (consolidation, graph upkeep) run serially instead of fanning out across CPU cores shared with latency-sensitive traffic. | unset |
 
 For high-concurrency workloads, increase `DB_POOL_MAX_SIZE`. Each concurrent recall/think operation can use 2-4 connections.
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -95,6 +95,7 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_READ_DATABASE_URL=  # Optional read-replica URL. When set, recall queries (semantic, BM25, graph, temporal) flow through a separate pool against this URL, offloading the primary. Typically points to a read-only endpoint (CNPG's <cluster>-ro service or Aurora reader endpoint).
 # HINDSIGHT_API_MIGRATION_DATABASE_URL=  # Direct PostgreSQL URL for migrations (bypasses PgBouncer). Falls back to DATABASE_URL.
 # HINDSIGHT_API_DATABASE_SCHEMA=public  # PostgreSQL schema name (default: public)
+# HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=  # Optional cap on Postgres planner parallelism for this process's pool connections. Unset leaves the server default; 0 makes background/bulk queries run serially (useful on worker processes sharing a primary with latency-sensitive traffic).
 # HINDSIGHT_API_MIGRATION_CONCURRENCY=1  # Tenant schemas to migrate concurrently (PG only, each in its own process; per-schema work stays sequential). Each worker has ~1-2s startup cost + uses ~3 DB connections, so it only pays off with many schemas (tens+) or slow migrations; keep concurrency*3 <= spare max_connections. Default: 1 (sequential).
 
 # Vector Extension (Optional - uses pgvector by default)


### PR DESCRIPTION
## Summary

Adds `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` — an optional, static (process-level) config. When set, every pool connection of the process runs `SET max_parallel_workers_per_gather = <n>` at init time, alongside the existing `statement_timeout` / ANN-tuning session setup. Unset (the default) leaves the server setting untouched, so existing deployments see no behavior change.

## Motivation

In multi-tenant deployments where background workers share a database with latency-sensitive foreground traffic, bulk maintenance queries (consolidation, graph upkeep) can fan out across Postgres parallel workers and occupy several cores each. Parallelism buys *latency* — which invisible background work doesn't need — at the cost of *concurrent CPU footprint*, which a shared primary very much cares about. Under load, with a multi-tenant workload where one tenant has a much larger dataset than the rest, a single tenant's background maintenance can monopolize the primary's cores and starve foreground queries.

Setting the cap to `0` on worker processes makes those queries run serially. Measured on a representative multi-million-row aggregate: serial execution cost ~29% more wall-clock but used **67% fewer concurrent cores** — and less total CPU, since parallel coordination isn't free.

## Design notes

- `0` is a meaningful value (disable parallelism), so the env parse distinguishes *unset* (None, no opinion) from *0* via a new `_parse_optional_non_negative_int` helper; negative/non-integer values fail fast at startup.
- Static field — deliberately not in `_CONFIGURABLE_FIELDS` (infrastructure tuning, not per-bank behavior).
- `.env.example` + bundled embed template + configuration docs updated per the config-flag checklist.

## Test plan

- 10 new unit tests (`test_db_parallel_workers_config.py`) pinning the parse semantics, incl. the 0-vs-unset distinction and fail-fast on invalid values
- `./scripts/hooks/lint.sh` clean; `ty check` clean
- Behavior validated against a real PostgreSQL: connections initialized by a worker process (through PgBouncer) observe the configured value, and heavy aggregates plan serially (`EXPLAIN ANALYZE` shows no Gather node)