### PR TITLE
fix(api): let PATCH /memories clear occurred dates with null

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1667,8 +1667,8 @@ class UpdateMemoryRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_an_edit(self) -> "UpdateMemoryRequest":
-        if all(
-            v is None
+        has_value_edit = any(
+            v is not None
             for v in (
                 self.text,
                 self.context,
@@ -1678,7 +1678,9 @@ class UpdateMemoryRequest(BaseModel):
                 self.entities,
                 self.state,
             )
-        ):
+        )
+        has_date_clear = bool({"occurred_start", "occurred_end"} & self.model_fields_set)
+        if not has_value_edit and not has_date_clear:
             raise ValueError("Provide at least one field to update.")
         if self.state is not None and self.state not in ("valid", "invalidated"):
             raise ValueError("state must be 'valid' or 'invalidated'.")
@@ -3751,13 +3753,23 @@ def _register_routes(app: FastAPI):
     ):
         """Curate a single memory unit (edit text / invalidate / revert)."""
         try:
+            occurred_start = (
+                ""
+                if "occurred_start" in request.model_fields_set and request.occurred_start is None
+                else request.occurred_start
+            )
+            occurred_end = (
+                ""
+                if "occurred_end" in request.model_fields_set and request.occurred_end is None
+                else request.occurred_end
+            )
             data = await app.state.memory.update_memory_unit(
                 bank_id=bank_id,
                 memory_id=memory_id,
                 text=request.text,
                 context=request.context,
-                occurred_start=request.occurred_start,
-                occurred_end=request.occurred_end,
+                occurred_start=occurred_start,
+                occurred_end=occurred_end,
                 new_fact_type=request.fact_type,
                 entities=request.entities,
                 state=request.state,

--- a/hindsight-api-slim/tests/test_curation_http.py
+++ b/hindsight-api-slim/tests/test_curation_http.py
@@ -79,6 +79,39 @@ async def test_patch_invalidate_and_revert_over_http(api_client, memory):
 
 
 @pytest.mark.asyncio
+async def test_patch_clears_occurred_dates_with_explicit_null(api_client, memory):
+    bank_id = f"curation-http-clear-dates-{uuid.uuid4().hex[:8]}"
+    mem_id = await _insert_fact(memory, bank_id, "Release v1.2 happened on Monday.")
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE memory_units
+            SET occurred_start = '2024-01-15T10:30:00Z',
+                occurred_end = '2024-01-15T11:00:00Z'
+            WHERE id = $1
+            """,
+            uuid.UUID(mem_id),
+        )
+
+    resp = await api_client.patch(
+        f"/v1/default/banks/{bank_id}/memories/{mem_id}",
+        json={"occurred_start": None, "occurred_end": None},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["occurred_start"] is None
+    assert resp.json()["occurred_end"] is None
+
+    resp = await api_client.get(f"/v1/default/banks/{bank_id}/memories/{mem_id}")
+    assert resp.status_code == 200
+    assert resp.json()["occurred_start"] is None
+    assert resp.json()["occurred_end"] is None
+
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
 async def test_patch_not_found_returns_404(api_client, memory):
     bank_id = f"curation-http-404-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())


### PR DESCRIPTION
Fixes #2603.

`PATCH /memories/{id}` currently treats explicit JSON `null` for `occurred_start` / `occurred_end` the same as an omitted field, so a request that only clears those dates is rejected as an empty update.

This keeps the existing engine contract (`None` = unchanged, `""` = clear) and does the translation at the HTTP boundary only when the client explicitly supplied the field as `null`. Omitted occurred fields still leave dates unchanged.

Verification:
- `uvx ruff@0.14.9 format --check hindsight-api-slim/hindsight_api/api/http.py hindsight-api-slim/tests/test_curation_http.py`
- `uvx ruff@0.14.9 check --select F hindsight-api-slim/hindsight_api/api/http.py hindsight-api-slim/tests/test_curation_http.py`
- `python3 -m py_compile hindsight-api-slim/hindsight_api/api/http.py hindsight-api-slim/tests/test_curation_http.py`

I could not run the targeted pytest in this macOS Python 3.14 environment because dependency sync stops on `onnxruntime==1.20.1` having no compatible wheel/source distribution for this platform.
