### PR TITLE
fix(consolidation): normalize dedup action case/whitespace before validation

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -105,8 +105,10 @@ class _DedupDecision(BaseModel):
     @field_validator("action", mode="before")
     @classmethod
     def _normalize_action(cls, value: object) -> str:
-        if isinstance(value, str) and value in {"merge", "keep"}:
-            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"merge", "keep"}:
+                return normalized
 
         logger.warning("Invalid consolidation dedup action %r; defaulting to keep", value)
         return "keep"

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -11,6 +11,8 @@ import uuid
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from hindsight_api.engine.consolidation.consolidator import (
     _dedup_active,
     _dedup_reconcile_create,
@@ -157,12 +159,25 @@ def test_dedup_decision_invalid_action_defaults_to_keep(caplog) -> None:
     assert "defaulting to keep" in caplog.text
 
 
-def test_dedup_decision_near_miss_merge_defaults_to_keep(caplog) -> None:
-    with caplog.at_level(logging.WARNING):
-        decision = _DedupDecision(action="Merge")
-
-    assert decision.action == "keep"
-    assert "Merge" in caplog.text
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Case / whitespace variants of the CORRECT verdict are recovered via
+        # normalize, not discarded — a genuine merge must not become a missed merge.
+        ("Merge", "merge"),
+        (" MERGE ", "merge"),
+        ("keep\n", "keep"),
+        ("KEEP", "keep"),
+        # Unrecognized / non-str values still degrade to keep (unchanged fail-safe;
+        # the warning path is covered by the dedicated tests below).
+        ("await", "keep"),
+        ("unknown", "keep"),
+        (None, "keep"),
+        (123, "keep"),
+    ],
+)
+def test_dedup_decision_normalizes_action_case_and_whitespace(raw: object, expected: str) -> None:
+    assert _DedupDecision(action=raw).action == expected
 
 
 def test_dedup_decision_non_scalar_action_defaults_to_keep(caplog) -> None:


### PR DESCRIPTION
## Summary
Follow-up to #2565 (fixes #2545). #2565 correctly degrades invalid dedup `action` values to `keep`, but the check is case-sensitive with no whitespace trimming (`value in {"merge", "keep"}`). The `_DEDUP_PROMPT` requests lowercase `action="merge"` / `action="keep"`; lax-JSON models (e.g. gpt-oss-120b) intermittently emit case/whitespace variants of the *correct* verdict — `"Merge"`, `" MERGE "`, `"keep\n"` — which are discarded to `keep`, turning a genuine merge into a missed merge → duplicate near-identical observations that should have been folded.

## Change
Normalize `str` inputs with `.strip().lower()` before the membership check. Non-str / unrecognized values still degrade to `keep` (unchanged). Case is not semantic, so this only ever recovers the intended verdict — it can never produce a wrong `merge`.

## Tests
- `test_consolidation_dedup.py`: case/whitespace variants (`Merge`, ` MERGE `, `keep\n`) normalize to the correct verdict; unknown / `None` / non-str still degrade to `keep`.
- **Note — one pre-existing test intentionally changed:** `test_dedup_decision_near_miss_merge_defaults_to_keep` asserted `"Merge" → "keep"`, i.e. it encoded exactly the behavior this PR changes. It is replaced by the parametrized test above (which subsumes it). The sibling degradation tests (`test_dedup_decision_invalid_action_defaults_to_keep` for `"need_input"`, `test_dedup_decision_non_scalar_action_defaults_to_keep` for `[]`/`{}`) are unchanged and still cover the warning + fail-safe path.
- Verified locally: `ruff check` + `ruff format --check` clean on both files; `pytest tests/test_consolidation_dedup.py` → 29 passed.
