### PR TITLE
fix(oracle): don't await the synchronous cursor.close() in _set_session_schema

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/oracle.py
@@ -1297,7 +1297,10 @@ class OracleBackend(DatabaseBackend):
         if schema and schema != "public":
             cursor = conn.cursor()
             await cursor.execute(f'ALTER SESSION SET CURRENT_SCHEMA = "{schema}"')
-            await cursor.close()
+            # oracledb's AsyncCursor.close() is synchronous (not a coroutine);
+            # awaiting it raises "object NoneType can't be used in 'await'
+            # expression" and aborts every acquire() under a non-public schema.
+            cursor.close()
 
     @asynccontextmanager
     async def acquire(self) -> AsyncIterator[OracleConnection]:

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -847,3 +847,68 @@ class TestNormalizeSchema:
         assert backend.normalize_schema("public") is None
         assert backend.normalize_schema("tenant_abc") == "tenant_abc"
         assert backend.normalize_schema(None) is None
+
+
+# ---------------------------------------------------------------------------
+# OracleBackend._set_session_schema regression
+# ---------------------------------------------------------------------------
+
+
+class TestOracleSetSessionSchema:
+    """Regression coverage for _set_session_schema (no live Oracle required)."""
+
+    @pytest.mark.asyncio
+    async def test_does_not_await_synchronous_cursor_close(self):
+        """A non-public schema is applied without awaiting the sync cursor.close().
+
+        oracledb's AsyncCursor.close() is synchronous (returns None), so
+        ``await cursor.close()`` raised "object NoneType can't be used in
+        'await' expression" on every acquire() under a non-public schema —
+        breaking the DB health check and all memory operations on Oracle.
+        Reproduced with a fake cursor whose close() is synchronous, exactly
+        like oracledb: this test fails (TypeError) against the buggy code and
+        passes once the erroneous await is removed.
+        """
+        from hindsight_api.engine import memory_engine
+        from hindsight_api.engine.db.oracle import OracleBackend
+
+        executed: list[str] = []
+        closed = {"count": 0}
+
+        class _FakeAsyncCursor:
+            async def execute(self, sql: str) -> None:
+                executed.append(sql)
+
+            def close(self) -> None:  # synchronous, like oracledb.AsyncCursor.close
+                closed["count"] += 1
+
+        class _FakeConn:
+            def cursor(self) -> "_FakeAsyncCursor":
+                return _FakeAsyncCursor()
+
+        backend = OracleBackend()
+        token = memory_engine._current_schema.set("TENANT_X")
+        try:
+            await backend._set_session_schema(_FakeConn())
+        finally:
+            memory_engine._current_schema.reset(token)
+
+        assert closed["count"] == 1
+        assert any('ALTER SESSION SET CURRENT_SCHEMA = "TENANT_X"' in s for s in executed)
+
+    @pytest.mark.asyncio
+    async def test_public_schema_is_a_noop(self):
+        """The default ``public`` schema does no session work on Oracle."""
+        from hindsight_api.engine import memory_engine
+        from hindsight_api.engine.db.oracle import OracleBackend
+
+        class _FakeConn:
+            def cursor(self):
+                raise AssertionError("cursor() must not be called for the public schema")
+
+        backend = OracleBackend()
+        token = memory_engine._current_schema.set("public")
+        try:
+            await backend._set_session_schema(_FakeConn())
+        finally:
+            memory_engine._current_schema.reset(token)


### PR DESCRIPTION
## Fix: Oracle backend crashes on every connection acquire under a non-public schema

### The bug

`OracleBackend._set_session_schema()` awaits `oracledb`'s **synchronous** `AsyncCursor.close()`:

```python
cursor = conn.cursor()
await cursor.execute(f'ALTER SESSION SET CURRENT_SCHEMA = "{schema}"')
await cursor.close()          # ← close() returns None; awaiting it raises TypeError
```

`AsyncCursor.close` is not a coroutine (`inspect.iscoroutinefunction(...) is False`), so this raises:

```
TypeError: object NoneType can't be used in 'await' expression
```

It fires inside `acquire()` — the entry point for **every** database operation — whenever the active schema is non-`public`. The effect is that the Oracle backend is unusable in that configuration: `/health` reports `{"status":"unhealthy","database":"error"}` and every retain/recall/reflect call fails.

On Oracle a "schema" is a user, and the default `HINDSIGHT_API_DATABASE_SCHEMA=public` isn't a real user — so any working Oracle deployment sets the schema to the connecting user, which is exactly the condition that triggers the crash.

### The fix

Drop the erroneous `await` (one line):

```python
cursor.close()
```

### Tests

Adds two unit tests in `tests/test_db_abstraction.py` (`TestOracleSetSessionSchema`) that drive `_set_session_schema` with a fake connection whose cursor's `close()` is synchronous — exactly like `oracledb`. No live Oracle required, so they run in the standard `test-api` job:

- `test_does_not_await_synchronous_cursor_close` — activates a non-`public` schema and asserts the `ALTER SESSION` is issued and the cursor is closed without raising. **Fails against the buggy code** (reproduces the `TypeError`), passes with the fix.
- `test_public_schema_is_a_noop` — asserts the `public` default touches no cursor.

### Why it wasn't caught

The existing `OracleBackend` acquire tests run without an active schema, so `get_current_schema()` returns the `public` default and the buggy branch (`schema != "public"`) is never entered.

### Verification

Beyond the unit tests, this was validated end-to-end against a local Oracle Database Free 23ai with the fix applied: `/health` returns `{"status":"healthy","database":"connected"}`, migrations run, and retain → recall → reflect all succeed. Without the fix, `/health` is `unhealthy` and the same calls fail with the `TypeError` above.

### Note: the label-gated `test-api-oracle` job is separately broken

While validating this I found the `oracle-tests`-gated CI job (`test-api-oracle`) is already failing on `main`, unrelated to this change: the shared `oracle_db_url` fixture (`tests/conftest.py:328`) connects as the value of `ORACLE_TEST_DSN` — which the workflow sets to the **non-privileged** `hindsight_test` user — and runs `CREATE USER`, so every test using that fixture errors with `ORA-01031: insufficient privileges` during setup. That's a test-infrastructure issue (the fixture needs a privileged/`SYSTEM` DSN, or should tolerate the user already existing) and is out of scope here; happy to file it separately.
