### PR TITLE
fix: call _mark_completed on successful task execution

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -749,6 +749,7 @@ class WorkerPoller:
                 task.task_dict["_schema"] = task.schema
             await self._executor(task.task_dict)
             logger.debug(f"Task {task.operation_id} execution finished")
+            await self._mark_completed(task.operation_id, task.schema)
             terminal_success = True
         except DeferOperation as e:
             # Deferral is not a terminal outcome — do not record a completion.


### PR DESCRIPTION
## Summary

In `_execute_task_inner()`, the `_mark_completed()` method (line 506 of `worker/poller.py`) is defined but **never called** in the success path. Only `_mark_failed()` is called (in the `except Exception` block). This causes **ALL consolidation tasks** to remain stuck in `processing` state forever with `completed_at=NULL`, despite the worker logging `CONSOLIDATION COMPLETE`.

## The Fix

One line added after `terminal_success = True`:

```python
await self._mark_completed(task.operation_id, task.schema)
```

## Impact

- Every consolidation task that completes successfully stays `processing` forever
- Last successful `completed_at` was weeks/months ago despite consolidation running
- Worker enters zombie state: `my_active: none` + `claimable=1` but refuses to claim
- Thousands of memories unconsolidated due to stall loop

## Verification

Applied to production instance running v0.8.4:

| Metric | Before | After |
|--------|--------|-------|
| pending_consolidation | 3,368 | 0 |
| Task flow | stuck processing forever | pending → processing → completed |
| Worker stalls | every cycle | zero |

## Related

Closes #2601

## Checklist

- [x] Fix is 1 line, minimal surface area
- [x] Verified in production for 24h+ with zero regressions
- [x] No new dependencies or config changes