### PR TITLE
fix(trace): skip LLM trace writes during daemon shutdown/pre-init races

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_trace.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_trace.py
@@ -477,6 +477,12 @@ class LLMTraceRecorder:
         if pool is None:
             logger.debug("LLM trace skipped: pool not available")
             return
+        # Guard against the backend existing but its internal asyncpg pool being
+        # None (during/after shutdown — close() calls backend.shutdown() which
+        # sets _pool=None before the backend object itself is dereferenced).
+        if getattr(pool, "_pool", "missing") is None:
+            logger.debug("LLM trace skipped: backend pool not initialized (shutdown in progress?)")
+            return
         try:
             schema = self._schema_getter()
             table = f"{schema}.llm_requests"
@@ -518,7 +524,13 @@ class LLMTraceRecorder:
                     _safe_json(record.metadata, self._max_chars) or "{}",
                 )
         except Exception as e:
-            logger.warning(f"LLM trace write failed for scope={record.scope}: {e}")
+            err_str = str(e)
+            # Downgrade known shutdown-related errors to DEBUG — these are
+            # expected races during daemon close()/restart and are not actionable.
+            if "pool is closing" in err_str or "not initialized" in err_str:
+                logger.debug("LLM trace write skipped (shutdown race) for scope=%s: %s", record.scope, e)
+            else:
+                logger.warning(f"LLM trace write failed for scope={record.scope}: {e}")
 
     async def _flush_pending(self, trace_id: str) -> None:
         """Await this trace's in-flight writes so its rows exist before an UPDATE."""
@@ -582,4 +594,8 @@ class LLMTraceRecorder:
                     json.dumps(patch),
                 )
         except Exception as e:
-            logger.warning(f"LLM trace memory_id attach failed for trace={trace_id}: {e}")
+            err_str = str(e)
+            if "pool is closing" in err_str or "not initialized" in err_str:
+                logger.debug("LLM trace memory_id attach skipped (shutdown race) for trace=%s: %s", trace_id, e)
+            else:
+                logger.warning(f"LLM trace memory_id attach failed for trace={trace_id}: {e}")

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -812,9 +812,7 @@ class _UninitializedBackend:
     _pool: object | None = None
 
     async def acquire(self):
-        raise RuntimeError(
-            "PostgreSQLBackend is not initialized. Call initialize() first."
-        )
+        raise RuntimeError("PostgreSQLBackend is not initialized. Call initialize() first.")
 
 
 class _ClosingBackend:
@@ -875,9 +873,7 @@ async def test_safe_write_backend_pool_none_skips_quietly(caplog):
     with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
         await recorder._safe_write(_make_record())
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert not warnings, (
-        f"expected no warning for backend._pool=None, got: {[r.message for r in warnings]}"
-    )
+    assert not warnings, f"expected no warning for backend._pool=None, got: {[r.message for r in warnings]}"
     assert any("not initialized" in r.message or "pool not" in r.message for r in caplog.records)
 
 
@@ -894,9 +890,7 @@ async def test_safe_write_pool_closing_downgrades_to_debug(caplog):
     with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
         await recorder._safe_write(_make_record())
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert not warnings, (
-        f"expected no warning for pool-is-closing, got: {[r.message for r in warnings]}"
-    )
+    assert not warnings, f"expected no warning for pool-is-closing, got: {[r.message for r in warnings]}"
     assert any("shutdown race" in r.message for r in caplog.records)
 
 
@@ -912,9 +906,7 @@ async def test_safe_write_unexpected_error_still_warns(caplog):
     with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
         await recorder._safe_write(_make_record())
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert len(warnings) == 1, (
-        f"expected exactly 1 warning for unexpected error, got: {[r.message for r in warnings]}"
-    )
+    assert len(warnings) == 1, f"expected exactly 1 warning for unexpected error, got: {[r.message for r in warnings]}"
 
 
 @pytest.mark.asyncio
@@ -933,6 +925,4 @@ async def test_attach_memory_ids_pool_none_skips_quietly(caplog):
             patch={"memory_ids": ["m1"]},
         )
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert not warnings, (
-        f"expected no warning for attach with _pool=None, got: {[r.message for r in warnings]}"
-    )
+    assert not warnings, f"expected no warning for attach with _pool=None, got: {[r.message for r in warnings]}"

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -9,6 +9,7 @@ success/error paths, and the HTTP read API (list / stats / tokens).
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -799,3 +800,139 @@ async def test_real_llm_retain_and_consolidation_traced(memory_real_llm):
         assert by_op["consolidation"][0]["metadata"].get("source_memory_ids"), (
             "consolidation trace missing source_memory_ids"
         )
+
+
+# ── recorder: shutdown / pre-init race conditions ─────────────────────────────
+
+
+class _UninitializedBackend:
+    """Mimics a DB backend before initialize() or after shutdown(): the object
+    exists but the internal asyncpg pool is None, so acquiring raises."""
+
+    _pool: object | None = None
+
+    async def acquire(self):
+        raise RuntimeError(
+            "PostgreSQLBackend is not initialized. Call initialize() first."
+        )
+
+
+class _ClosingBackend:
+    """Mimics a backend whose pool is mid-shutdown: the pool object exists but
+    asyncpg raises InterfaceError('pool is closing') on acquire."""
+
+    _pool = object()  # not None, passes the getattr guard
+
+    async def acquire(self):
+        raise Exception("pool is closing")
+
+
+class _UnexpectedErrorBackend:
+    """Mimics a backend with an unexpected (non-shutdown) error."""
+
+    _pool = object()
+
+    async def acquire(self):
+        raise RuntimeError("connection refused: some other error")
+
+
+def _make_record(scope: str = "verification") -> LLMRequestRecord:
+    return LLMRequestRecord(
+        provider="test",
+        model="test-model",
+        scope=scope,
+        status="success",
+        started_at=datetime.now(timezone.utc),
+        ended_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_safe_write_pool_none_skips_quietly(caplog):
+    """pool_getter returning None should skip at debug, never warn."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: None,
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._safe_write(_make_record())
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, f"expected no warning for pool=None, got: {[r.message for r in warnings]}"
+
+
+@pytest.mark.asyncio
+async def test_safe_write_backend_pool_none_skips_quietly(caplog):
+    """Backend exists but its internal _pool is None (post-shutdown) — should
+    skip at debug via the getattr guard, never warn."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: _UninitializedBackend(),
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._safe_write(_make_record())
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, (
+        f"expected no warning for backend._pool=None, got: {[r.message for r in warnings]}"
+    )
+    assert any("not initialized" in r.message or "pool not" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_safe_write_pool_closing_downgrades_to_debug(caplog):
+    """asyncpg InterfaceError('pool is closing') during acquire should be
+    downgraded to debug, not warned."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: _ClosingBackend(),
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._safe_write(_make_record())
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, (
+        f"expected no warning for pool-is-closing, got: {[r.message for r in warnings]}"
+    )
+    assert any("shutdown race" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_safe_write_unexpected_error_still_warns(caplog):
+    """Non-shutdown errors should still produce a WARNING."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: _UnexpectedErrorBackend(),
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._safe_write(_make_record())
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1, (
+        f"expected exactly 1 warning for unexpected error, got: {[r.message for r in warnings]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_attach_memory_ids_pool_none_skips_quietly(caplog):
+    """_attach_memory_ids with _pool=None should skip at debug, never warn."""
+    recorder = LLMTraceRecorder(
+        pool_getter=lambda: _UninitializedBackend(),
+        schema_getter=lambda: "public",
+        enabled=True,
+        allowed_scopes=[],
+    )
+    with caplog.at_level(logging.DEBUG, logger="hindsight_api.engine.llm_trace"):
+        await recorder._attach_memory_ids(
+            bank_id="test-bank",
+            trace_id="test-trace",
+            patch={"memory_ids": ["m1"]},
+        )
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, (
+        f"expected no warning for attach with _pool=None, got: {[r.message for r in warnings]}"
+    )


### PR DESCRIPTION
## Problem

`LLMTraceRecorder._safe_write` and `_attach_memory_ids` produce spurious WARNING logs during two race windows in the daemon lifecycle:

**1. Pre-init race:** `MemoryEngine.initialize()` runs `verify_llm()` inside the parallel init gather, which executes **before** the DB backend pool is ready. The `pool_getter` returns a backend object whose `_pool` is still `None`, so `acquire()` raises `RuntimeError("PostgreSQLBackend is not initialized")`.

**2. Shutdown race:** `MemoryEngine.close()` calls `backend.shutdown()` (sets `_pool=None`) before setting `self._backend=None`. Fire-and-forget trace tasks that are still in-flight see a non-None backend object, but its internal asyncpg pool is already closed — hitting either `RuntimeError("not initialized")` or `InterfaceError("pool is closing")`.

Both are expected lifecycle states, not actionable errors. Yet they produce repeated WARNING logs on every daemon restart:

```
WARNING - hindsight_api.engine.llm_trace - LLM trace write failed for scope=verification: PostgreSQLBackend is not initialized. Call initialize() first.
WARNING - hindsight_api.engine.llm_trace - LLM trace write failed for scope=verification: pool is closing
```

## Fix

Three changes in `llm_trace.py`:

1. **Pre-acquire guard** in `_safe_write`: check `getattr(pool, "_pool", "missing") is None` before attempting to acquire — catches the post-shutdown case where the backend object exists but its pool is gone.

2. **Error downgrade** in `_safe_write` except block: `"pool is closing"` and `"not initialized"` errors are downgraded to DEBUG (expected shutdown races). All other errors still WARN.

3. **Same downgrade** in `_attach_memory_ids` except block — covers the same race at the second write site.

## Relation to #2562

PR #2562 covered only the pre-init `RuntimeError("is not initialized")` path. This PR additionally covers:
- The shutdown `"pool is closing"` race (asyncpg `InterfaceError` — different exception type, not caught by #2562's `except RuntimeError`)
- The `_attach_memory_ids` write path (not touched by #2562 at all)

## Test

5 regression tests in `test_llm_trace.py`:

| Test | Scenario | Asserts |
|------|----------|---------|
| `test_safe_write_pool_none_skips_quietly` | `pool_getter` returns `None` | No WARNING |
| `test_safe_write_backend_pool_none_skips_quietly` | Backend exists, `_pool=None` | No WARNING, DEBUG msg present |
| `test_safe_write_pool_closing_downgrades_to_debug` | `acquire()` raises `"pool is closing"` | No WARNING, "shutdown race" in DEBUG |
| `test_safe_write_unexpected_error_still_warns` | `acquire()` raises unrelated error | WARNING preserved |
| `test_attach_memory_ids_pool_none_skips_quietly` | `_attach_memory_ids` with `_pool=None` | No WARNING |

Full `test_llm_trace.py` suite: **32 passed, 1 deselected** (real-LLM test needing API key).