### PR TITLE
Record refresh mental model outcome metadata

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -60,6 +60,7 @@ from .llm_trace import (
 from .operation_metadata import (
     BatchRetainChildMetadata,
     BatchRetainParentMetadata,
+    RefreshMentalModelOutcomeMetadata,
     RetainExtractionErrors,
     RetainOutcomeAggregate,
     RetainOutcomeMetadata,
@@ -1827,6 +1828,7 @@ class MemoryEngine(MemoryEngineInterface):
         )
         if refreshed is None:
             raise ValueError(f"Mental model {mental_model_id} not found in bank {bank_id}")
+        await self._write_refresh_mental_model_outcome_metadata(task_dict.get("operation_id"), refreshed)
 
         # Compute facts/mental_models counts for the post-op validator hook.
         # refresh_mental_model already persisted everything; the hook only needs
@@ -2437,6 +2439,39 @@ class MemoryEngine(MemoryEngineInterface):
             # give clients a reliable success/silent-failure signal, so a missing
             # write silently regresses them to the ambiguous pre-fix behaviour.
             logger.warning(f"Failed to write retain outcome metadata for {operation_id}: {e}")
+
+    async def _write_refresh_mental_model_outcome_metadata(
+        self, operation_id: str | None, refreshed: dict[str, Any]
+    ) -> None:
+        """Persist completed mental-model refresh outcome fields before completion."""
+        if not operation_id:
+            return
+
+        content = refreshed.get("content") or ""
+        reflect_response = refreshed.get("reflect_response") or {}
+        based_on = reflect_response.get("based_on") or {}
+        based_on_counts = {fact_type: len(facts) for fact_type, facts in based_on.items() if isinstance(facts, list)}
+        outcome = RefreshMentalModelOutcomeMetadata(
+            content_len=len(content),
+            populated_content=bool(content.strip()),
+            based_on_counts=based_on_counts,
+        )
+
+        try:
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                await conn.execute(
+                    f"""
+                    UPDATE {fq_table("async_operations")}
+                    SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb,
+                        updated_at = now()
+                    WHERE operation_id = $1
+                    """,
+                    uuid.UUID(operation_id),
+                    json.dumps(outcome.to_dict()),
+                )
+        except Exception as e:
+            logger.warning(f"Failed to write refresh mental model outcome metadata for {operation_id}: {e}")
 
     async def _mark_operation_completed_and_fire_webhook(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -142,3 +142,20 @@ class RefreshMentalModelMetadata:
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for JSON serialization."""
         return asdict(self)
+
+
+@dataclass
+class RefreshMentalModelOutcomeMetadata:
+    """Machine-readable outcome metadata for a completed mental model refresh."""
+
+    content_len: int
+    populated_content: bool
+    based_on_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict for JSON serialization."""
+        return {
+            "content_len": self.content_len,
+            "populated_content": self.populated_content,
+            "based_on_counts": self.based_on_counts,
+        }

--- a/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_scheduled_refresh.py
@@ -159,6 +159,58 @@ async def test_due_but_not_stale_model_is_skipped(memory: MemoryEngine, request_
 
 
 @pytest.mark.asyncio
+async def test_async_refresh_writes_outcome_metadata(memory: MemoryEngine, request_context, monkeypatch):
+    """Async refresh completion records semantic outcome fields in result_metadata."""
+    bank = await _make_bank(memory, request_context)
+    operation_id = uuid.uuid4()
+    mm_id = f"mm-{uuid.uuid4().hex}"
+
+    async with memory._pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, result_metadata)
+            VALUES ($1, $2, 'refresh_mental_model', 'processing', $3::jsonb, $4::jsonb)
+            """,
+            operation_id,
+            bank,
+            json.dumps({"type": "refresh_mental_model", "bank_id": bank, "mental_model_id": mm_id}),
+            json.dumps({"mental_model_id": mm_id, "name": "sched model"}),
+        )
+
+    async def _refresh(*, bank_id, mental_model_id, request_context):
+        return {
+            "id": mental_model_id,
+            "source_query": "what changed",
+            "content": "Useful refreshed content.",
+            "reflect_response": {
+                "based_on": {
+                    "experience": [{"id": "fact-1"}],
+                    "observation": [{"id": "obs-1"}, {"id": "obs-2"}],
+                    "mental-models": [{"id": "mm-source"}],
+                }
+            },
+        }
+
+    monkeypatch.setattr(memory, "refresh_mental_model", _refresh)
+
+    await memory._handle_refresh_mental_model(
+        {"type": "refresh_mental_model", "operation_id": str(operation_id), "bank_id": bank, "mental_model_id": mm_id}
+    )
+
+    async with memory._pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT result_metadata FROM async_operations WHERE operation_id = $1", operation_id)
+
+    metadata = row["result_metadata"]
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+    assert metadata["mental_model_id"] == mm_id
+    assert metadata["name"] == "sched model"
+    assert metadata["content_len"] == len("Useful refreshed content.")
+    assert metadata["populated_content"] is True
+    assert metadata["based_on_counts"] == {"experience": 1, "observation": 2, "mental-models": 1}
+
+
+@pytest.mark.asyncio
 async def test_not_due_model_is_skipped_even_when_stale(memory: MemoryEngine, request_context, monkeypatch):
     """A model whose cron has not elapsed since the last refresh is not refreshed,
     even when new memories exist — the cron gate, not just staleness, must hold."""


### PR DESCRIPTION
## Summary
- add outcome metadata for completed async mental-model refresh operations
- record content length, populated-content signal, and based_on counts by fact type
- keep submit-time metadata such as mental_model_id/name intact

Closes #2605

## Test
- uv run --with socksio pytest tests/test_mental_model_scheduled_refresh.py::test_async_refresh_writes_outcome_metadata -q -n0
- uv run ruff format --check hindsight_api/engine/memory_engine.py hindsight_api/engine/operation_metadata.py tests/test_mental_model_scheduled_refresh.py
- uv run ruff check hindsight_api/engine/memory_engine.py hindsight_api/engine/operation_metadata.py tests/test_mental_model_scheduled_refresh.py
- git diff --check