### PR TITLE
fix: coerce non-string metadata values to strings in MemoryFact.parse_metadata

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -255,13 +255,20 @@ class MemoryFact(BaseModel):
     @field_validator("metadata", mode="before")
     @classmethod
     def parse_metadata(cls, v: Any) -> dict[str, str] | None:
-        """Parse metadata from JSON string if needed (asyncpg may return JSONB as str)."""
+        """Parse metadata from JSON string if needed (asyncpg may return JSONB as str).
+
+        Also coerces non-string dict values (e.g., integer IDs stored in JSONB)
+        to strings, preventing ValidationError when consolidation encounters
+        metadata like {"original_id": 348} instead of {"original_id": "348"}.
+        """
         if v is None:
             return None
         if isinstance(v, str):
             import json
 
-            return json.loads(v)
+            v = json.loads(v)
+        if isinstance(v, dict):
+            return {str(k): str(val) for k, val in v.items()}
         return v
 
     chunk_id: str | None = Field(

--- a/hindsight-api-slim/tests/test_response_models.py
+++ b/hindsight-api-slim/tests/test_response_models.py
@@ -1,0 +1,31 @@
+"""Tests for MemoryFact response-model validation."""
+
+from hindsight_api.engine.response_models import MemoryFact
+
+_BASE = {"id": "u1", "text": "hi", "fact_type": "observation"}
+
+
+class TestMemoryFactMetadataCoercion:
+    """metadata values may arrive as non-strings from JSONB; they must coerce to str.
+
+    Regression for #2622: an integer ``original_id`` stored in ``metadata`` raised
+    ``ValidationError`` (``string_type``) and blocked consolidation, because
+    ``metadata`` is typed ``dict[str, str]`` and the raw dict passed straight
+    through to Pydantic.
+    """
+
+    def test_integer_value_is_coerced_to_string(self):
+        fact = MemoryFact(**_BASE, metadata={"original_id": 12345})
+        assert fact.metadata == {"original_id": "12345"}
+
+    def test_jsonb_string_with_integer_value_is_coerced(self):
+        # asyncpg may hand back JSONB as a raw string; ints inside must still coerce.
+        fact = MemoryFact(**_BASE, metadata='{"original_id": 12345, "n": 3}')
+        assert fact.metadata == {"original_id": "12345", "n": "3"}
+
+    def test_string_values_pass_through_unchanged(self):
+        fact = MemoryFact(**_BASE, metadata={"source": "slack", "channel": "eng"})
+        assert fact.metadata == {"source": "slack", "channel": "eng"}
+
+    def test_none_metadata_stays_none(self):
+        assert MemoryFact(**_BASE, metadata=None).metadata is None


### PR DESCRIPTION
## Summary
Fix consolidation blocker caused by non-string metadata values in MemoryFact.

## Problem
When `memory_units` contain metadata with non-string values (e.g., `{"original_id": 348}` from observation bookmarks), the consolidation worker fails with:
```
ValidationError: metadata.original_id — Input should be a valid string [type=string_type]
```

This happens because `MemoryFact.metadata` is typed as `dict[str, str]` but the `parse_metadata` validator doesn't coerce non-string dict values.

## Root Cause
In `engine/response_models.py:253`, `metadata: dict[str, str]`. The `@field_validator("metadata")` method only handles `str → dict` coercion (for asyncpg JSONB serialization), not `int/other → str` coercion for individual values.

## Fix
Added value coercion in `parse_metadata`: after JSON parsing (or on raw dict input), iterate all key-value pairs and convert both to strings with `{str(k): str(val) for k, val in v.items()}`. This safely handles integer, float, bool, and None values.

## Impact
- 394 out of 10,741 memory_units affected (3.7%) in a production bank
- Consolidation was completely blocked with 6,321 pending items
- 71 consecutive consolidation failures before workaround applied

## Testing
- Existing tests pass (no behavior change for already-string metadata)
- Verified on bank with 10,741 MUs — consolidation resumed immediately after fix + workaround cleanup
- Backward compatible: string values pass through unchanged

Closes #2622