### PR TITLE
fix(claude-code): skip duplicate recall banks

### DIFF
--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -72,6 +72,18 @@ def filter_by_min_scores(results: list[dict], min_scores: dict, config: dict) ->
     return filtered
 
 
+def unique_additional_banks(additional_banks: list, primary_bank_id: str) -> list[str]:
+    """Return configured extra banks without repeating the primary bank."""
+    seen = {primary_bank_id}
+    unique = []
+    for extra_bank_id in additional_banks:
+        if not isinstance(extra_bank_id, str) or not extra_bank_id or extra_bank_id in seen:
+            continue
+        seen.add(extra_bank_id)
+        unique.append(extra_bank_id)
+    return unique
+
+
 def read_transcript_messages(transcript_path: str) -> list:
     """Read messages from a JSONL transcript file for multi-turn context.
 
@@ -202,7 +214,7 @@ def main():
     results = response.get("results", [])
 
     # Also recall from any additional banks (e.g. shared user profile bank)
-    additional_banks = config.get("recallAdditionalBanks", [])
+    additional_banks = unique_additional_banks(config.get("recallAdditionalBanks", []), bank_id)
     for extra_bank_id in additional_banks:
         extra_filter = additional_bank_filters.get(extra_bank_id, {})
         extra_tags = extra_filter.get("recallTags", recall_tags) or None

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -275,6 +275,31 @@ class TestRecallHook:
         assert captured[1]["tags"] == ["memory_type:rule"]
         assert captured[1]["tags_match"] == "all_strict"
 
+    def test_additional_banks_skip_primary_and_duplicates(self, monkeypatch, tmp_path):
+        captured_urls = []
+
+        def capture_and_respond(req, timeout=None):
+            if "/recall" in req.full_url:
+                captured_urls.append(req.full_url)
+            return FakeHTTPResponse({"results": []})
+
+        hook_input = make_hook_input(prompt="What project rules apply here?")
+        _run_hook(
+            "recall",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture_and_respond,
+            extra_settings={
+                "bankId": "project-bank",
+                "recallAdditionalBanks": ["project-bank", "normative-bank", "normative-bank"],
+            },
+        )
+
+        assert len(captured_urls) == 2
+        assert "/banks/project-bank/memories/recall" in captured_urls[0]
+        assert "/banks/normative-bank/memories/recall" in captured_urls[1]
+
     def test_disabled_auto_recall_produces_no_output(self, monkeypatch, tmp_path):
         (tmp_path / "plugin_root").mkdir(exist_ok=True)
         (tmp_path / "plugin_data").mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- skip recallAdditionalBanks entries that repeat the primary Claude Code memory bank
- de-duplicate repeated additional bank IDs while preserving order
- add a regression test for primary-bank and repeated extra-bank entries

Closes #2604

## Test
- uv run pytest hindsight-integrations/claude-code/tests/test_hooks.py::TestRecallHook::test_additional_banks_skip_primary_and_duplicates -q
- uv run pytest hindsight-integrations/claude-code/tests/test_hooks.py -q
- uv run ruff format --check hindsight-integrations/claude-code/scripts/recall.py hindsight-integrations/claude-code/tests/test_hooks.py
- uv run ruff check hindsight-integrations/claude-code/scripts/recall.py hindsight-integrations/claude-code/tests/test_hooks.py
- git diff --check