### PR TITLE
fix(claude-code): skip primary + duplicate banks in recallAdditionalBanks

### DIFF
--- a/hindsight-integrations/claude-code/scripts/recall.py
+++ b/hindsight-integrations/claude-code/scripts/recall.py
@@ -201,9 +201,15 @@ def main():
 
     results = response.get("results", [])
 
-    # Also recall from any additional banks (e.g. shared user profile bank)
+    # Also recall from any additional banks (e.g. shared user profile bank).
+    # Skip the primary (already recalled above) and any repeated entry so
+    # bidirectional cross-bank setups don't re-recall a bank they already hit.
     additional_banks = config.get("recallAdditionalBanks", [])
+    seen_banks = {bank_id}
     for extra_bank_id in additional_banks:
+        if extra_bank_id in seen_banks:
+            continue
+        seen_banks.add(extra_bank_id)
         extra_filter = additional_bank_filters.get(extra_bank_id, {})
         extra_tags = extra_filter.get("recallTags", recall_tags) or None
         extra_tag_groups = extra_filter.get("recallTagGroups", tag_groups) or None

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -275,6 +275,34 @@ class TestRecallHook:
         assert captured[1]["tags"] == ["memory_type:rule"]
         assert captured[1]["tags_match"] == "all_strict"
 
+    def test_additional_banks_skip_primary_and_duplicates(self, monkeypatch, tmp_path):
+        """The primary bank (and repeated entries) must not be re-recalled."""
+        recalled_banks = []
+
+        def capture_and_respond(req, timeout=None):
+            if "/recall" in req.full_url:
+                recalled_banks.append(req.full_url)
+            return FakeHTTPResponse({"results": []})
+
+        hook_input = make_hook_input(prompt="anything")
+        _run_hook(
+            "recall",
+            hook_input,
+            monkeypatch,
+            tmp_path,
+            urlopen_side_effect=capture_and_respond,
+            extra_settings={
+                "bankId": "shared-bank",
+                # primary listed for bidirectional visibility, plus a dup + a real extra
+                "recallAdditionalBanks": ["shared-bank", "other-bank", "other-bank"],
+            },
+        )
+
+        # shared-bank recalled once (primary), other-bank once — 2 calls, not 4.
+        assert sum("shared-bank" in url for url in recalled_banks) == 1
+        assert sum("other-bank" in url for url in recalled_banks) == 1
+        assert len(recalled_banks) == 2
+
     def test_disabled_auto_recall_produces_no_output(self, monkeypatch, tmp_path):
         (tmp_path / "plugin_root").mkdir(exist_ok=True)
         (tmp_path / "plugin_data").mkdir(exist_ok=True)


### PR DESCRIPTION
Fixes #2604.

## Problem
The claude-code recall hook's `recallAdditionalBanks` loop recalled every entry with no dedup against the session's resolved primary bank. So a bidirectional cross-bank setup (each bank lists the other, so both must appear in `recallAdditionalBanks`) re-recalled the **primary** on every prompt — one wasted recall call (~0.4–0.65s) per user prompt, plus duplicate context.

## Fix
Guard the additional-banks loop with a `seen_banks` set seeded with the primary `bank_id` (already recalled above). This skips the primary and also de-dups repeated entries in the list.

```python
seen_banks = {bank_id}
for extra_bank_id in additional_banks:
    if extra_bank_id in seen_banks:
        continue
    seen_banks.add(extra_bank_id)
    ...
```

## Test
Adds `test_additional_banks_skip_primary_and_duplicates` — primary listed in `recallAdditionalBanks` plus a duplicated extra → asserts the primary is recalled once, the extra once, 2 calls total (not 4). Full `test_hooks.py` green (30 passed).

Thanks @hb-cam for the precise repro and the one-liner.