### PR TITLE
feat(api): enrich refresh_mental_model result_metadata with semantic outcome

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -60,6 +60,7 @@ from .llm_trace import (
 from .operation_metadata import (
     BatchRetainChildMetadata,
     BatchRetainParentMetadata,
+    RefreshMentalModelOutcomeMetadata,
     RetainExtractionErrors,
     RetainOutcomeAggregate,
     RetainOutcomeMetadata,
@@ -1828,6 +1829,10 @@ class MemoryEngine(MemoryEngineInterface):
         if refreshed is None:
             raise ValueError(f"Mental model {mental_model_id} not found in bank {bank_id}")
 
+        # Enrich the submit-time result_metadata with the semantic outcome
+        # before the worker marks the operation completed (#2605).
+        await self._write_refresh_outcome_metadata(task_dict.get("operation_id"), refreshed)
+
         # Compute facts/mental_models counts for the post-op validator hook.
         # refresh_mental_model already persisted everything; the hook only needs
         # tallies that derive from the stored reflect_response payload.
@@ -2437,6 +2442,47 @@ class MemoryEngine(MemoryEngineInterface):
             # give clients a reliable success/silent-failure signal, so a missing
             # write silently regresses them to the ambiguous pre-fix behaviour.
             logger.warning(f"Failed to write retain outcome metadata for {operation_id}: {e}")
+
+    async def _write_refresh_outcome_metadata(self, operation_id: str | None, refreshed: dict[str, Any]) -> None:
+        """Persist completed refresh outcome fields before the operation is marked completed.
+
+        Refresh parity with ``_write_retain_outcome_metadata`` (#2605): merges the
+        outcome into the submit-time ``{mental_model_id, name}`` metadata rather
+        than replacing it, so consumers joining on those keys keep working.
+        """
+        if not operation_id:
+            return
+
+        from .reflect.agent import NO_ANSWER_TEXT
+
+        content = refreshed.get("content") or ""
+        stripped = content.strip()
+        based_on = (refreshed.get("reflect_response") or {}).get("based_on") or {}
+        outcome = RefreshMentalModelOutcomeMetadata(
+            content_len=len(content),
+            # The no-answer stub and the pending placeholder complete
+            # wire-successful but carry no real synthesis — a length check
+            # alone would read them as populated.
+            populated_content=bool(stripped) and stripped not in (MENTAL_MODEL_PENDING_CONTENT, NO_ANSWER_TEXT),
+            based_on_counts={fact_type: len(facts or []) for fact_type, facts in based_on.items()},
+        )
+        try:
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                await conn.execute(
+                    f"""
+                    UPDATE {fq_table("async_operations")}
+                    SET result_metadata = COALESCE(result_metadata, '{{}}'::jsonb) || $2::jsonb,
+                        updated_at = now()
+                    WHERE operation_id = $1
+                    """,
+                    uuid.UUID(operation_id),
+                    json.dumps(outcome.to_dict()),
+                )
+        except Exception as e:
+            # Best-effort, but log loudly: a missing write regresses clients to
+            # fetch-and-measure health checks (the pre-#2605 behaviour).
+            logger.warning(f"Failed to write refresh outcome metadata for {operation_id}: {e}")
 
     async def _mark_operation_completed_and_fire_webhook(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -142,3 +142,21 @@ class RefreshMentalModelMetadata:
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for JSON serialization."""
         return asdict(self)
+
+
+@dataclass
+class RefreshMentalModelOutcomeMetadata:
+    """Machine-readable outcome metadata for a completed refresh_mental_model operation.
+
+    Refresh parity with RetainOutcomeMetadata (#2605): lets a monitoring layer
+    distinguish "refreshed with real content" from "refreshed empty" by reading
+    result_metadata alone, without a follow-up content fetch.
+    """
+
+    content_len: int
+    populated_content: bool
+    based_on_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict for JSON serialization."""
+        return asdict(self)

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -49,6 +49,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_ITERATIONS = 10
 
+# Fallback answer when the LLM returns nothing usable. Consumers that need to
+# tell a real answer from this placeholder (e.g. refresh outcome metadata's
+# populated_content) compare against this constant rather than the literal.
+NO_ANSWER_TEXT = "No answer provided."
+
 
 def _normalize_tool_name(name: str) -> str:
     """Normalize tool name from various LLM output formats.
@@ -1252,7 +1257,7 @@ async def _process_done_tool(
     raw_answer = args.get("answer", "").strip()
     answer = _clean_done_answer(raw_answer) if raw_answer else ""
     if not answer:
-        answer = "No answer provided."
+        answer = NO_ANSWER_TEXT
 
     # Validate IDs (only include IDs that were actually retrieved)
     used_memory_ids = [mid for mid in (args.get("memory_ids") or []) if mid in available_memory_ids]

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -1,0 +1,117 @@
+"""Refresh operations expose semantic outcome fields in result_metadata (#2605).
+
+Retain operations have carried machine-readable outcome metadata since 0.8.x
+(``unit_ids_count`` etc.). These tests pin the refresh-side parity: a completed
+refresh_mental_model operation must let a monitoring layer distinguish
+"refreshed with real content" from "refreshed empty" by reading
+``result_metadata`` alone, without a follow-up content fetch.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+# The reflect agent's fallback answer when the LLM returns nothing usable
+# (hindsight_api/engine/reflect/agent.py). Non-empty, so it survives the
+# empty-content guard in refresh_mental_model and completes wire-successful —
+# exactly the case populated_content must expose.
+NO_ANSWER_STUB = "No answer provided."
+
+
+@pytest.fixture
+async def bank_with_model(memory: MemoryEngine, request_context):
+    """Bank with one mental model, unique per test for xdist safety."""
+    bank_id = f"test-refresh-meta-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    mm = await memory.create_mental_model(
+        bank_id=bank_id,
+        name="Outcome Meta Model",
+        source_query="What outcome fields does refresh expose?",
+        content="Original content",
+        request_context=request_context,
+    )
+    yield memory, bank_id, mm
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+def _fake_refreshed(content: str, based_on: dict) -> dict:
+    """Shape of refresh_mental_model's return value as consumed by the handler."""
+    return {
+        "content": content,
+        "reflect_response": {"text": content, "based_on": based_on, "mental_models": []},
+        "source_query": "What outcome fields does refresh expose?",
+    }
+
+
+async def _submit_with_fake_refresh(memory, monkeypatch, bank_id, mm, request_context, refreshed):
+    """Submit an async refresh whose reflect outcome is stubbed to `refreshed`.
+
+    The patch must land before submission: the test task backend executes the
+    queued task synchronously on submit, so this exercises the real path
+    (execute_task -> _handle_refresh_mental_model -> metadata write).
+    """
+
+    async def fake_refresh(bank_id, mental_model_id, *, request_context):
+        return refreshed
+
+    monkeypatch.setattr(memory, "refresh_mental_model", fake_refresh)
+    result = await memory.submit_async_refresh_mental_model(
+        bank_id=bank_id,
+        mental_model_id=mm["id"],
+        request_context=request_context,
+    )
+    await asyncio.sleep(0.1)
+    return result["operation_id"]
+
+
+@pytest.mark.asyncio
+async def test_completed_refresh_enriches_result_metadata(bank_with_model, request_context, monkeypatch):
+    """A completed refresh writes content_len / populated_content / based_on_counts."""
+    memory, bank_id, mm = bank_with_model
+    content = "x" * 120
+    based_on = {
+        "world": [{"id": "f1"}, {"id": "f2"}, {"id": "f3"}],
+        "mental-models": [{"id": "m1"}],
+    }
+
+    operation_id = await _submit_with_fake_refresh(
+        memory, monkeypatch, bank_id, mm, request_context, _fake_refreshed(content, based_on)
+    )
+
+    status = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=operation_id, request_context=request_context
+    )
+    assert status["status"] == "completed"
+    meta = status["result_metadata"]
+
+    # Submit-time keys are merged with, not replaced by, the outcome fields:
+    # existing consumers join on mental_model_id/name.
+    assert meta["mental_model_id"] == mm["id"]
+    assert meta["name"] == "Outcome Meta Model"
+
+    assert meta["content_len"] == 120
+    assert meta["populated_content"] is True
+    assert meta["based_on_counts"] == {"world": 3, "mental-models": 1}
+
+
+@pytest.mark.asyncio
+async def test_no_answer_stub_reads_as_unpopulated(bank_with_model, request_context, monkeypatch):
+    """The historical 19-char stub completes wire-successful but must not read as populated."""
+    memory, bank_id, mm = bank_with_model
+
+    operation_id = await _submit_with_fake_refresh(
+        memory, monkeypatch, bank_id, mm, request_context, _fake_refreshed(NO_ANSWER_STUB, {})
+    )
+
+    status = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=operation_id, request_context=request_context
+    )
+    assert status["status"] == "completed"
+    meta = status["result_metadata"]
+
+    assert meta["content_len"] == len(NO_ANSWER_STUB)
+    assert meta["populated_content"] is False
+    assert meta["based_on_counts"] == {}


### PR DESCRIPTION
Fixes #2605.

## What

`refresh_mental_model` operations completed with `result_metadata` carrying only the submit-time `{mental_model_id, name}` stub (set in `submit_async_refresh_mental_model` before the op runs, never enriched). This PR mirrors the retain enrichment pattern (`operation_metadata.py` + completion-time metadata write) as suggested in the issue thread: the worker handler now merges the semantic outcome into `result_metadata` at completion.

New fields on completed refresh ops:

- `content_len` — length of the final stored content
- `populated_content` — `true` only for real synthesis: the reflect agent's `"No answer provided."` fallback and the `"Generating content..."` placeholder complete wire-successful but read as `false` (a bare length check would report the 19-char stub as populated)
- `based_on_counts` — per-fact-type grounding counts from the reflect response

## How

- `RefreshMentalModelOutcomeMetadata` dataclass alongside `RetainOutcomeMetadata` in `operation_metadata.py`
- `_write_refresh_outcome_metadata` in the engine, mirroring `_write_retain_outcome_metadata`: jsonb merge (`COALESCE(result_metadata, '{}'::jsonb) || …`) so the submit-time keys consumers join on are **preserved, not replaced**; best-effort with a loud warning on failure
- Called from `_handle_refresh_mental_model` after a successful refresh, before the worker marks the operation completed (same ordering as retain)
- The reflect agent's fallback literal is promoted to a `NO_ANSWER_TEXT` constant so the populated judgment compares against the constant rather than a copied string

No endpoint or request model changes — `result_metadata` is already a free-form dict in the operation status response, so no OpenAPI/client regeneration is needed.

## Testing

- New `tests/test_refresh_outcome_metadata.py` (2 tests, written first and watched fail): a completed refresh exposes all three fields with the submit-time keys intact; the no-answer stub completes but reads `populated_content: false`
- Tests exercise the real path (submit → task backend → handler → metadata write → `get_operation_status`) against the embedded pg0 database with only the LLM-bound `refresh_mental_model` stubbed
- Neighboring suites pass: `test_mental_model_scheduled_refresh.py`, `test_mental_model_delta.py`, `test_mental_model_hooks.py` (24 passed, 4 skipped), `test_async_batch_retain.py` (22 passed)
- `ruff check`, `ruff format --check`, `ty check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
