### PR TITLE
feat(anthropic): implement the batch API interface via Message Batches (50% token discount)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -543,6 +543,211 @@ class AnthropicLLM(LLMInterface):
             raise last_exception
         raise RuntimeError("Anthropic tool call failed")
 
+    # ── Message Batches API (50% token discount) ─────────────────────────────
+
+    _BATCH_TOOL_NAME = "structured_response"
+
+    async def supports_batch_api(self) -> bool:
+        """Anthropic supports batch operations via the Message Batches API."""
+        return True
+
+    @staticmethod
+    def _map_batch_status(processing_status: str) -> str:
+        """Map Anthropic ``processing_status`` onto the OpenAI vocabulary.
+
+        The engine's poll loop breaks on "completed" and hard-fails on
+        "failed"/"expired"/"cancelled"; anything else keeps polling. Anthropic
+        batches only end as "ended" (per-request failures surface in the
+        results, mirroring OpenAI's "completed"-with-errors semantics), so
+        "ended" maps to "completed" and the non-terminal states pass through.
+        """
+        return "completed" if processing_status == "ended" else processing_status
+
+    def _translate_batch_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Translate one OpenAI-shaped request body into Messages API params.
+
+        Mirrors the conversion rules of ``call()``: system messages fold into
+        the ``system`` param; ``max_completion_tokens`` becomes ``max_tokens``
+        (default 4096); ``temperature`` is dropped (the sync path never sends
+        it either — current Claude models reject non-default sampling params);
+        an OpenAI ``response_format`` json_schema becomes a single forced
+        tool_use tool when strict (native constrained decoding, issue #1002),
+        else the schema is injected into the system prompt.
+        """
+        system_prompt: str | None = None
+        messages: list[dict[str, Any]] = []
+        for msg in body.get("messages", []):
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                system_prompt = (system_prompt + "\n\n" + content) if system_prompt else content
+            else:
+                messages.append({"role": role, "content": content})
+
+        params: dict[str, Any] = {
+            "model": body.get("model") or self.model,
+            "messages": messages,
+            "max_tokens": body.get("max_completion_tokens") or 4096,
+        }
+
+        json_schema = (body.get("response_format") or {}).get("json_schema") or {}
+        schema = json_schema.get("schema")
+        if schema is not None:
+            if json_schema.get("strict"):
+                params["tools"] = [
+                    {
+                        "name": self._BATCH_TOOL_NAME,
+                        "description": "Return the structured response.",
+                        "input_schema": schema,
+                    }
+                ]
+                params["tool_choice"] = {"type": "tool", "name": self._BATCH_TOOL_NAME}
+            else:
+                schema_msg = "\n\nYou must respond with valid JSON matching this schema:\n" + json.dumps(
+                    schema, indent=2, ensure_ascii=False
+                )
+                system_prompt = (system_prompt + schema_msg) if system_prompt else schema_msg
+
+        if system_prompt:
+            params["system"] = system_prompt
+
+        # Batch params ARE the raw Messages body, so operator-configured extra
+        # body params merge directly (the sync path routes them through the
+        # SDK's extra_body, which does the same merge server-side).
+        if self._extra_body:
+            params.update(self._extra_body)
+
+        return params
+
+    def _translate_batch_message(self, message: Any) -> dict[str, Any]:
+        """Render an Anthropic Message as the OpenAI response body the engine parses.
+
+        The engine reads ``choices[0].message.content`` (json.loads'ing it when
+        a schema was requested) and sums ``usage`` under the OpenAI key names.
+        Forced-tool responses carry their JSON in the tool_use block's input,
+        so that is re-serialized as the content string.
+        """
+        content = ""
+        tool_input = None
+        for block in message.content:
+            if block.type == "tool_use" and block.name == self._BATCH_TOOL_NAME:
+                tool_input = block.input or {}
+            elif block.type == "text":
+                content += block.text
+        if tool_input is not None:
+            content = json.dumps(tool_input, ensure_ascii=False)
+
+        usage = getattr(message, "usage", None)
+        input_tokens = (usage.input_tokens or 0) if usage else 0
+        output_tokens = (usage.output_tokens or 0) if usage else 0
+
+        return {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": getattr(message, "stop_reason", None),
+                }
+            ],
+            "usage": {
+                "prompt_tokens": input_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            },
+        }
+
+    async def submit_batch(
+        self,
+        requests: list[dict[str, Any]],
+        endpoint: str = "/v1/chat/completions",
+        completion_window: str = "24h",
+    ) -> dict[str, Any]:
+        """Submit a batch of requests to the Message Batches API.
+
+        Accepts the engine's OpenAI-JSONL-shaped entries. ``endpoint`` and
+        ``completion_window`` belong to that shared shape and have no Anthropic
+        equivalent (batches always resolve within 24 hours); both are ignored.
+        """
+        batch_requests = [
+            {
+                "custom_id": req["custom_id"],
+                "params": self._translate_batch_body(req.get("body") or {}),
+            }
+            for req in requests
+        ]
+
+        logger.info(f"Submitting Anthropic message batch with {len(batch_requests)} requests")
+        batch = await self._client.messages.batches.create(requests=batch_requests)
+        logger.info(f"Anthropic batch submitted: {batch.id}, status={batch.processing_status}")
+
+        return {
+            "batch_id": batch.id,
+            "status": self._map_batch_status(batch.processing_status),
+            "created_at": batch.created_at,
+            "request_count": len(batch_requests),
+        }
+
+    async def get_batch_status(self, batch_id: str) -> dict[str, Any]:
+        """Get batch status in the shape the engine's poll loop expects."""
+        batch = await self._client.messages.batches.retrieve(batch_id)
+
+        counts = batch.request_counts
+        processing = getattr(counts, "processing", 0) or 0
+        succeeded = getattr(counts, "succeeded", 0) or 0
+        errored = getattr(counts, "errored", 0) or 0
+        canceled = getattr(counts, "canceled", 0) or 0
+        expired = getattr(counts, "expired", 0) or 0
+        resolved = succeeded + errored + canceled + expired
+
+        result: dict[str, Any] = {
+            "batch_id": batch.id,
+            "status": self._map_batch_status(batch.processing_status),
+            "created_at": batch.created_at,
+            "request_counts": {
+                "total": processing + resolved,
+                "completed": resolved,
+                "failed": errored,
+            },
+        }
+
+        ended_at = getattr(batch, "ended_at", None)
+        if ended_at:
+            result["completed_at"] = ended_at
+
+        return result
+
+    async def retrieve_batch_results(self, batch_id: str) -> list[dict[str, Any]]:
+        """Retrieve completed batch results, translated to the OpenAI shape.
+
+        Succeeded entries become ``{"custom_id", "response": {"body": ...}}``;
+        errored/canceled/expired entries become ``{"custom_id", "error": ...}``
+        so the engine's per-result error handling applies unchanged.
+        """
+        batch = await self._client.messages.batches.retrieve(batch_id)
+        if batch.processing_status != "ended":
+            raise ValueError(f"Batch {batch_id} is not completed yet (status: {batch.processing_status})")
+
+        decoder = await self._client.messages.batches.results(batch_id)
+        results: list[dict[str, Any]] = []
+        async for entry in decoder:
+            outcome = entry.result
+            if outcome.type == "succeeded":
+                results.append(
+                    {
+                        "custom_id": entry.custom_id,
+                        "response": {"body": self._translate_batch_message(outcome.message)},
+                    }
+                )
+            else:
+                error = getattr(outcome, "error", None)
+                if error is not None:
+                    detail = f"{getattr(error, 'type', 'error')}: {getattr(error, 'message', error)}"
+                else:
+                    detail = f"batch request {outcome.type}"
+                results.append({"custom_id": entry.custom_id, "error": detail})
+
+        logger.info(f"Retrieved {len(results)} results for Anthropic batch {batch_id}")
+        return results
+
     async def cleanup(self) -> None:
         """Clean up resources (close Anthropic client connections)."""
         if hasattr(self, "_client") and self._client:

--- a/hindsight-api-slim/tests/test_anthropic_batch.py
+++ b/hindsight-api-slim/tests/test_anthropic_batch.py
@@ -1,0 +1,234 @@
+"""Anthropic Message Batches support for the provider batch interface.
+
+The engine's batch path (retain fact extraction, gated on
+``retain_batch_enabled``) speaks the OpenAI batch wire shape: JSONL entries
+with ``custom_id``/``method``/``url``/``body`` going in, and
+``response.body.choices[0].message.content`` (+ OpenAI-keyed ``usage``) coming
+out. ``AnthropicLLM`` translates both directions onto the Message Batches API,
+which bills all token usage at 50% of standard price.
+
+Translation rules mirror the provider's synchronous ``call()`` path:
+- system messages fold into the ``system`` param;
+- ``max_completion_tokens`` becomes ``max_tokens`` (default 4096);
+- ``temperature`` is dropped (the sync path never sends it either — current
+  Claude models reject non-default sampling params);
+- ``response_format`` with ``strict=True`` becomes a single forced tool_use
+  tool (native constrained decoding, issue #1002); non-strict injects the
+  schema into the system prompt and expects JSON text back.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_provider():
+    with patch("anthropic.AsyncAnthropic") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        from hindsight_api.engine.providers.anthropic_llm import AnthropicLLM
+
+        provider = AnthropicLLM(
+            provider="anthropic",
+            api_key="fake-key",
+            base_url="",
+            model="claude-sonnet-5",
+        )
+    provider._client = MagicMock()
+    return provider
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"facts": {"type": "array", "items": {"type": "string"}}},
+    "required": ["facts"],
+}
+
+
+def _openai_request(custom_id: str, *, strict: bool = True, temperature: float | None = 0.1) -> dict:
+    body = {
+        "model": "claude-sonnet-5",
+        "messages": [
+            {"role": "system", "content": "Extract facts."},
+            {"role": "user", "content": f"Text for {custom_id}"},
+        ],
+        "max_completion_tokens": 2000,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "facts", "schema": _SCHEMA, "strict": strict},
+        },
+    }
+    if temperature is not None:
+        body["temperature"] = temperature
+    return {"custom_id": custom_id, "method": "POST", "url": "/v1/chat/completions", "body": body}
+
+
+def _batch(status: str = "in_progress", **counts) -> SimpleNamespace:
+    defaults = {"processing": 0, "succeeded": 0, "errored": 0, "canceled": 0, "expired": 0}
+    defaults.update(counts)
+    return SimpleNamespace(
+        id="msgbatch_test1",
+        processing_status=status,
+        created_at="2026-07-08T00:00:00Z",
+        ended_at="2026-07-08T00:30:00Z" if status == "ended" else None,
+        request_counts=SimpleNamespace(**defaults),
+    )
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        self._iter = iter(self._items)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _succeeded_entry(custom_id: str, tool_input: dict) -> SimpleNamespace:
+    block = SimpleNamespace(type="tool_use", name="structured_response", input=tool_input, text=None)
+    message = SimpleNamespace(
+        content=[block],
+        usage=SimpleNamespace(input_tokens=100, output_tokens=40, cache_read_input_tokens=0),
+        stop_reason="tool_use",
+    )
+    return SimpleNamespace(custom_id=custom_id, result=SimpleNamespace(type="succeeded", message=message))
+
+
+def _errored_entry(custom_id: str) -> SimpleNamespace:
+    error = SimpleNamespace(type="invalid_request", message="bad request")
+    return SimpleNamespace(custom_id=custom_id, result=SimpleNamespace(type="errored", error=error))
+
+
+async def test_supports_batch_api():
+    provider = _make_provider()
+    assert await provider.supports_batch_api() is True
+
+
+async def test_submit_batch_translates_openai_requests():
+    provider = _make_provider()
+    provider._client.messages.batches.create = AsyncMock(return_value=_batch("in_progress", processing=2))
+
+    requests = [_openai_request("chunk_0"), _openai_request("chunk_1")]
+    metadata = await provider.submit_batch(requests)
+
+    provider._client.messages.batches.create.assert_awaited_once()
+    submitted = provider._client.messages.batches.create.await_args.kwargs["requests"]
+    assert [r["custom_id"] for r in submitted] == ["chunk_0", "chunk_1"]
+
+    params = submitted[0]["params"]
+    assert params["model"] == "claude-sonnet-5"
+    # System message folded into the system param, not left in messages.
+    assert "Extract facts." in params["system"]
+    assert all(m["role"] != "system" for m in params["messages"])
+    assert params["messages"] == [{"role": "user", "content": "Text for chunk_0"}]
+    assert params["max_tokens"] == 2000
+    # temperature is dropped, mirroring the sync call() path.
+    assert "temperature" not in params
+    # strict=True → forced tool_use (native constrained decoding).
+    assert params["tools"][0]["input_schema"] == _SCHEMA
+    assert params["tool_choice"] == {"type": "tool", "name": "structured_response"}
+
+    assert metadata["batch_id"] == "msgbatch_test1"
+    assert metadata["status"] == "in_progress"
+    assert metadata["request_count"] == 2
+
+
+async def test_submit_batch_non_strict_schema_injects_into_system():
+    provider = _make_provider()
+    provider._client.messages.batches.create = AsyncMock(return_value=_batch("in_progress", processing=1))
+
+    await provider.submit_batch([_openai_request("chunk_0", strict=False)])
+
+    params = provider._client.messages.batches.create.await_args.kwargs["requests"][0]["params"]
+    assert "tools" not in params
+    assert "tool_choice" not in params
+    # Schema is injected into the system prompt for JSON-text output.
+    assert "facts" in params["system"]
+    assert "valid JSON" in params["system"]
+
+
+async def test_get_batch_status_in_progress():
+    provider = _make_provider()
+    provider._client.messages.batches.retrieve = AsyncMock(
+        return_value=_batch("in_progress", processing=3, succeeded=1)
+    )
+
+    status = await provider.get_batch_status("msgbatch_test1")
+
+    assert status["batch_id"] == "msgbatch_test1"
+    assert status["status"] == "in_progress"
+    assert status["request_counts"]["total"] == 4
+    assert status["request_counts"]["completed"] == 1
+
+
+async def test_get_batch_status_ended_maps_to_completed():
+    """The engine's poll loop breaks on the OpenAI-vocabulary status 'completed'."""
+    provider = _make_provider()
+    provider._client.messages.batches.retrieve = AsyncMock(return_value=_batch("ended", succeeded=3, errored=1))
+
+    status = await provider.get_batch_status("msgbatch_test1")
+
+    assert status["status"] == "completed"
+    assert status["request_counts"]["total"] == 4
+    assert status["request_counts"]["completed"] == 4
+    assert status["request_counts"]["failed"] == 1
+    assert status["completed_at"] == "2026-07-08T00:30:00Z"
+
+
+async def test_retrieve_batch_results_translates_to_openai_shape():
+    provider = _make_provider()
+    provider._client.messages.batches.retrieve = AsyncMock(return_value=_batch("ended", succeeded=1, errored=1))
+    entries = [
+        _succeeded_entry("chunk_0", {"facts": ["Alice is an engineer."]}),
+        _errored_entry("chunk_1"),
+    ]
+    provider._client.messages.batches.results = AsyncMock(return_value=_AsyncIter(entries))
+
+    results = await provider.retrieve_batch_results("msgbatch_test1")
+
+    by_id = {r["custom_id"]: r for r in results}
+    ok = by_id["chunk_0"]
+    body = ok["response"]["body"]
+    # The engine reads choices[0].message.content and json.loads() it.
+    assert json.loads(body["choices"][0]["message"]["content"]) == {"facts": ["Alice is an engineer."]}
+    # Usage arrives under the OpenAI key names the engine sums.
+    assert body["usage"] == {"prompt_tokens": 100, "completion_tokens": 40, "total_tokens": 140}
+
+    failed = by_id["chunk_1"]
+    assert failed["error"]
+    assert "response" not in failed
+
+
+async def test_retrieve_batch_results_text_content_passthrough():
+    """Non-strict requests come back as text blocks; concatenate them as content."""
+    provider = _make_provider()
+    provider._client.messages.batches.retrieve = AsyncMock(return_value=_batch("ended", succeeded=1))
+    text_block = SimpleNamespace(type="text", text='{"facts": []}')
+    message = SimpleNamespace(
+        content=[text_block],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5, cache_read_input_tokens=0),
+        stop_reason="end_turn",
+    )
+    entry = SimpleNamespace(custom_id="chunk_0", result=SimpleNamespace(type="succeeded", message=message))
+    provider._client.messages.batches.results = AsyncMock(return_value=_AsyncIter([entry]))
+
+    results = await provider.retrieve_batch_results("msgbatch_test1")
+
+    assert results[0]["response"]["body"]["choices"][0]["message"]["content"] == '{"facts": []}'
+
+
+async def test_retrieve_batch_results_raises_when_not_ended():
+    provider = _make_provider()
+    provider._client.messages.batches.retrieve = AsyncMock(return_value=_batch("in_progress", processing=2))
+
+    with pytest.raises(ValueError, match="not completed"):
+        await provider.retrieve_batch_results("msgbatch_test1")


### PR DESCRIPTION
## What

Implements the `LLMInterface` batch methods (`supports_batch_api` / `submit_batch` / `get_batch_status` / `retrieve_batch_results`) in `AnthropicLLM` via Anthropic's [Message Batches API](https://platform.claude.com/docs/en/build-with-claude/batch-processing), which bills all token usage at 50% of standard price.

The engine's batch path (retain fact extraction, gated on `retain_batch_enabled`) has been available to the OpenAI-compatible and Gemini providers, but the gate hard-fails on Anthropic purely because the provider never implemented the interface. This fills that gap — no engine changes.

## How

The engine speaks the OpenAI batch wire shape (JSONL entries with `custom_id`/`body` in, `response.body.choices[0].message.content` + OpenAI-keyed `usage` out), so the provider translates both directions, mirroring the existing conversion rules of its own `call()` path:

- **submit**: system messages fold into `system`; `max_completion_tokens` → `max_tokens`; `temperature` is dropped (the sync path never sends it either — current Claude models reject non-default sampling params); `response_format` json_schema becomes a single forced `tool_use` tool when `strict` (native constrained decoding, same approach as #1002) or a system-prompt schema injection otherwise; operator `extra_body` params merge directly since batch params are the raw Messages body. Anthropic batches take requests inline — no file upload step.
- **status**: `processing_status` maps onto the vocabulary the engine's poll loop speaks — `"ended"` → `"completed"` (per-request failures surface in the results, matching OpenAI's completed-with-errors semantics); non-terminal states pass through; `request_counts` aggregate to `total`/`completed`/`failed`.
- **results**: succeeded messages render as `choices[0].message.content` (forced-tool JSON re-serialized as the content string) with `prompt_tokens`/`completion_tokens`/`total_tokens` usage; errored/canceled/expired entries become per-result `error` entries so the engine's existing error handling applies unchanged.

## Testing

- 8 new tests in `tests/test_anthropic_batch.py` (written first, watched fail): request translation (strict and non-strict), temperature dropping, status mapping both ways, result translation for tool-use and text content, and the not-ended guard.
- Existing suites pass unchanged: `test_batch_api.py`, `test_batch_api_validation.py`, `test_anthropic_structured_tool_use.py`, `test_llm_extra_body.py` (41 tests).
- `ruff check`, `ruff format --check`, `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
