### PR TITLE
feat(anthropic): prompt caching via inline cache_control markers

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -34,6 +34,43 @@ def _usage_from_anthropic_response(response: Any) -> LLMResponseUsage:
     )
 
 
+_EPHEMERAL_CACHE = {"type": "ephemeral"}
+
+
+def _cached_system_blocks(system_prompt: str) -> list[dict[str, Any]]:
+    """Render the system prompt as a block list with a cache_control marker.
+
+    Anthropic prompt caching is a prefix match: marking the (single) system
+    block caches tools + system together. The system prompt is stable per
+    scope — fact extraction reuses it across every chunk, reflect and
+    consolidation keep their stable instructions there — so repeat calls read
+    it at ~10% of the base input price. Markers below the model's minimum
+    cacheable prefix are silently ignored (no write premium), so marking is
+    safe unconditionally. This is the "inline-marker provider" strategy that
+    ``LLMInterface.get_or_create_cached_prefix`` documents for Anthropic.
+    """
+    return [{"type": "text", "text": system_prompt, "cache_control": _EPHEMERAL_CACHE}]
+
+
+def _mark_last_message_for_caching(messages: list[dict[str, Any]]) -> None:
+    """Add a cache_control marker to the final content block, in place.
+
+    Used on the multi-turn (tool-calling) path: the reflect agent loop resends
+    the entire growing conversation each iteration, so this request's
+    end-marker becomes the next iteration's cache read point. Together with
+    the system marker this uses 2 of the 4 allowed breakpoints.
+    """
+    if not messages:
+        return
+    last = messages[-1]
+    content = last.get("content")
+    if isinstance(content, str):
+        if content.strip():  # the API rejects empty text blocks
+            last["content"] = [{"type": "text", "text": content, "cache_control": _EPHEMERAL_CACHE}]
+    elif isinstance(content, list) and content and isinstance(content[-1], dict):
+        content[-1]["cache_control"] = _EPHEMERAL_CACHE
+
+
 class AnthropicLLM(LLMInterface):
     """
     LLM provider using Anthropic's Claude models.
@@ -206,7 +243,9 @@ class AnthropicLLM(LLMInterface):
         }
 
         if system_prompt:
-            call_params["system"] = system_prompt
+            # One-shot calls share only the system prompt with each other, so
+            # that is the sole cache breakpoint on this path.
+            call_params["system"] = _cached_system_blocks(system_prompt)
 
         if use_forced_tool:
             # Single tool whose input_schema IS the response schema; force the model to
@@ -450,6 +489,11 @@ class AnthropicLLM(LLMInterface):
             else:
                 anthropic_messages.append({"role": role, "content": content})
 
+        # Multi-turn tool loop: cache the stable prefix (tools + system) via
+        # the system marker, and the growing conversation via an end-marker
+        # that the next iteration reads back.
+        _mark_last_message_for_caching(anthropic_messages)
+
         call_params: dict[str, Any] = {
             "model": self.model,
             "messages": anthropic_messages,
@@ -457,7 +501,7 @@ class AnthropicLLM(LLMInterface):
             "max_tokens": max_completion_tokens or 4096,
         }
         if system_prompt:
-            call_params["system"] = system_prompt
+            call_params["system"] = _cached_system_blocks(system_prompt)
 
         if self._extra_body:
             call_params["extra_body"] = self._extra_body

--- a/hindsight-api-slim/tests/test_anthropic_prompt_caching.py
+++ b/hindsight-api-slim/tests/test_anthropic_prompt_caching.py
@@ -1,0 +1,181 @@
+"""Anthropic prompt caching via inline cache_control markers.
+
+``LLMInterface.get_or_create_cached_prefix`` documents Anthropic as an
+"inline-marker provider": rather than returning an explicit cache handle, the
+provider marks the reusable prefix inside ``call`` / ``call_with_tools`` with
+``cache_control`` breakpoints. Cache reads bill at ~10% of the base input
+price; a marker below the model's minimum cacheable prefix is silently
+ignored by the API (no premium), so marking is safe unconditionally.
+
+Two breakpoints (of the 4 allowed):
+- the system prompt, in both entry points — it is stable per scope (fact
+  extraction reuses it across every chunk; reflect/consolidation put their
+  stable instructions there), so tools+system cache across calls;
+- the last message content block, in ``call_with_tools`` only — the reflect
+  agent loop resends the whole growing conversation each iteration, so each
+  request's end-marker becomes the next iteration's cache read point.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+pytestmark = pytest.mark.asyncio
+
+EPHEMERAL = {"type": "ephemeral"}
+
+
+def _make_provider():
+    with patch("anthropic.AsyncAnthropic") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        from hindsight_api.engine.providers.anthropic_llm import AnthropicLLM
+
+        provider = AnthropicLLM(
+            provider="anthropic",
+            api_key="fake-key",
+            base_url="",
+            model="claude-sonnet-5",
+        )
+    provider._client = MagicMock()
+    return provider
+
+
+def _text_response(text: str = "ok"):
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    resp = MagicMock()
+    resp.content = [block]
+    resp.usage = MagicMock(input_tokens=10, output_tokens=2, cache_read_input_tokens=0)
+    resp.stop_reason = "end_turn"
+    return resp
+
+
+def _tool_response():
+    resp = MagicMock()
+    resp.content = []
+    resp.usage = MagicMock(input_tokens=10, output_tokens=2, cache_read_input_tokens=0)
+    resp.stop_reason = "end_turn"
+    return resp
+
+
+class _Out(BaseModel):
+    facts: list[str]
+
+
+async def test_call_marks_system_prompt_for_caching():
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_text_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Stable extraction instructions."},
+                {"role": "user", "content": "Chunk text."},
+            ],
+            scope="test",
+            max_retries=0,
+        )
+
+    params = provider._client.messages.create.await_args.kwargs
+    assert params["system"] == [{"type": "text", "text": "Stable extraction instructions.", "cache_control": EPHEMERAL}]
+    # User messages are untouched in call() — one-shot calls share no
+    # conversation prefix with each other, only the system prompt.
+    assert params["messages"] == [{"role": "user", "content": "Chunk text."}]
+
+
+async def test_call_non_strict_schema_lands_inside_cached_system_block():
+    """Schema injection happens before marking, so the marked block includes it."""
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_text_response('{"facts": []}'))
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Extract."},
+                {"role": "user", "content": "Text."},
+            ],
+            response_format=_Out,
+            scope="test",
+            max_retries=0,
+        )
+
+    params = provider._client.messages.create.await_args.kwargs
+    assert len(params["system"]) == 1
+    system_block = params["system"][0]
+    assert system_block["cache_control"] == EPHEMERAL
+    assert "Extract." in system_block["text"]
+    assert "valid JSON" in system_block["text"]
+
+
+async def test_call_without_system_prompt_sends_no_system_param():
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_text_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            scope="test",
+            max_retries=0,
+        )
+
+    assert "system" not in provider._client.messages.create.await_args.kwargs
+
+
+async def test_call_with_tools_marks_system_and_last_message():
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_tool_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call_with_tools(
+            messages=[
+                {"role": "system", "content": "Reflect agent instructions."},
+                {"role": "user", "content": "Question?"},
+                {"role": "assistant", "content": "Working on it."},
+                {"role": "user", "content": "Latest turn."},
+            ],
+            tools=[{"function": {"name": "recall", "description": "d", "parameters": {"type": "object"}}}],
+            max_retries=0,
+        )
+
+    params = provider._client.messages.create.await_args.kwargs
+    assert params["system"] == [{"type": "text", "text": "Reflect agent instructions.", "cache_control": EPHEMERAL}]
+
+    messages = params["messages"]
+    # Earlier messages carry no markers — only the final block gets one, so
+    # the next iteration of the agent loop reads the whole prefix from cache.
+    assert messages[0] == {"role": "user", "content": "Question?"}
+    assert messages[1] == {"role": "assistant", "content": "Working on it."}
+    assert messages[2]["content"] == [{"type": "text", "text": "Latest turn.", "cache_control": EPHEMERAL}]
+
+
+async def test_call_with_tools_marks_last_block_of_tool_result_message():
+    """Tool-result turns arrive as block lists; the marker goes on the last block."""
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_tool_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call_with_tools(
+            messages=[
+                {"role": "user", "content": "Question?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "t1", "function": {"name": "recall", "arguments": "{}"}},
+                        {"id": "t2", "function": {"name": "recall", "arguments": "{}"}},
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "t1", "content": "result one"},
+                {"role": "tool", "tool_call_id": "t2", "content": "result two"},
+            ],
+            tools=[{"function": {"name": "recall", "description": "d", "parameters": {"type": "object"}}}],
+            max_retries=0,
+        )
+
+    messages = provider._client.messages.create.await_args.kwargs["messages"]
+    last_blocks = messages[-1]["content"]
+    assert last_blocks[-1]["type"] == "tool_result"
+    assert last_blocks[-1]["cache_control"] == EPHEMERAL
+    # The earlier tool-result message is unmarked.
+    assert all("cache_control" not in block for block in messages[-2]["content"])

--- a/hindsight-api-slim/tests/test_anthropic_structured_tool_use.py
+++ b/hindsight-api-slim/tests/test_anthropic_structured_tool_use.py
@@ -107,5 +107,8 @@ async def test_non_strict_keeps_text_injection_fallback():
         )
     kwargs = provider._client.messages.create.call_args.kwargs
     assert "tools" not in kwargs  # no forced tool when not strict
-    assert "valid JSON matching this schema" in (kwargs.get("system") or "")
+    # system is a cache_control-marked block list; the schema text-injection
+    # lands inside the (single) block.
+    system_text = "".join(block["text"] for block in (kwargs.get("system") or []))
+    assert "valid JSON matching this schema" in system_text
     assert isinstance(result, _Decision)


### PR DESCRIPTION
## What

Adds Anthropic prompt caching to `AnthropicLLM` via inline `cache_control` markers — the "inline-marker provider" strategy that `LLMInterface.get_or_create_cached_prefix`'s docstring already describes for Anthropic. No engine changes, no new config.

Today the provider sends no `cache_control` at all, so every call pays full input price on content the engine resends verbatim:

- fact extraction reuses the same system prompt across every chunk;
- the reflect agent loop resends the entire growing conversation on each of its iterations (up to `HINDSIGHT_API_REFLECT_MAX_ITERATIONS`), re-paying the full prefix each time.

Anthropic cache reads bill at ~10% of the base input price, so on reflect-heavy workloads (mental-model refresh) this is a large input-cost reduction with no latency penalty.

## How

Two breakpoints (of the four Anthropic allows):

1. **System prompt, both entry points** — rendered as a block list with `cache_control: {type: "ephemeral"}`. Caching is a prefix match, so this caches tools + system together. Schema text-injection (the non-strict `response_format` path) happens before marking and lands inside the cached block.
2. **Final message content block, `call_with_tools()` only** — each agent-loop request's end-marker becomes the next iteration's cache read point. String content converts to a text block (skipped for empty strings, which the API rejects); block-list content (tool results) gets the marker on its last block.

Marking is safe unconditionally: below the model's minimum cacheable prefix the marker is silently ignored — no write premium, no error. `cache_read_input_tokens` already flows through `_usage_from_anthropic_response` into metrics/tracing, so cache effectiveness is observable immediately via `cached_tokens`.

## Testing

- 5 new tests in `tests/test_anthropic_prompt_caching.py` (written first, watched fail): marker placement on both entry points, schema-injection landing inside the cached block, tool-result block-list handling, and the no-system passthrough.
- One existing assertion updated for the representation change: `test_non_strict_keeps_text_injection_fallback` checked a substring on `system` as a plain string; the schema-in-prompt behavior itself is unchanged and still covered.
- `test_anthropic_structured_tool_use.py`, `test_llm_extra_body.py`, and `test_mental_model_delta.py` pass; `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
