### PR TITLE
feat(audit): optional per-bank gate for audit logging

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2991,10 +2991,14 @@ def _make_audited_http(audit_logger_getter: Callable[[], AuditLogger | None]):
             @wraps(func)
             async def wrapper(*args, **kwargs):
                 al = audit_logger_getter()
-                if al is None or not al.is_enabled(action):
+                bank_id = kwargs.get("bank_id")
+                # should_log applies the global env/action gate AND the
+                # optional per-bank predicate; when no predicate is set it is
+                # equivalent to is_enabled(action), so default deployments are
+                # unaffected.
+                if al is None or not await al.should_log(action, bank_id):
                     return await func(*args, **kwargs)
 
-                bank_id = kwargs.get("bank_id")
                 started_at = _dt.now(_tz.utc)
 
                 req_data = None

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1104,11 +1104,13 @@ DEFAULT_METRICS_BACKLOG_ENABLED = False  # Disabled by default: runs periodic pe
 DEFAULT_AUDIT_LOG_ENABLED = False  # Disabled by default
 DEFAULT_AUDIT_LOG_ACTIONS = ""  # Empty = audit all eligible actions
 DEFAULT_AUDIT_LOG_RETENTION_DAYS = -1  # -1 = keep forever
-# Per-bank audit toggle default. True so that when a per-bank gate IS wired,
-# a bank with no explicit setting participates in auditing (opt-out), which
-# preserves "audit everything" once the deployment-wide switch is on. Inert
-# unless a gate consults it.
-DEFAULT_AUDIT_ENABLED = True
+# Per-bank audit toggle default. FALSE — a bank with no explicit setting is
+# NOT audited (opt-in): auditing must be turned on deliberately per bank. This
+# default surfaces through the resolved bank config, so UIs reading it show a
+# new bank as off. Inert in deployments that don't wire a per-bank gate (the
+# master audit_log_enabled switch governs there), so OSS behavior is unchanged
+# either way; opt-in is the safe default for the field's actual consumers.
+DEFAULT_AUDIT_ENABLED = False
 
 # LLM request tracing defaults
 DEFAULT_LLM_TRACE_ENABLED = True  # Enabled by default

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -661,6 +661,13 @@ ENV_RECENCY_DECAY_HALFLIFE_DAYS = "HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS"
 ENV_AUDIT_LOG_ENABLED = "HINDSIGHT_API_AUDIT_LOG_ENABLED"
 ENV_AUDIT_LOG_ACTIONS = "HINDSIGHT_API_AUDIT_LOG_ACTIONS"
 ENV_AUDIT_LOG_RETENTION_DAYS = "HINDSIGHT_API_AUDIT_LOG_RETENTION_DAYS"
+# Per-bank audit toggle (configurable, overridable per bank). DISTINCT from
+# AUDIT_LOG_ENABLED above: that is the static, deployment-wide master switch
+# ("can this server audit at all"); this is a per-bank field that a per-bank
+# audit gate (AuditLogger.set_bank_gate) can consult to enable auditing for
+# some banks and not others. With no gate wired (the default), nothing reads
+# this field, so behavior is unchanged.
+ENV_AUDIT_ENABLED = "HINDSIGHT_API_AUDIT_ENABLED"
 
 # LLM request tracing settings
 ENV_LLM_TRACE_ENABLED = "HINDSIGHT_API_LLM_TRACE_ENABLED"
@@ -1097,6 +1104,11 @@ DEFAULT_METRICS_BACKLOG_ENABLED = False  # Disabled by default: runs periodic pe
 DEFAULT_AUDIT_LOG_ENABLED = False  # Disabled by default
 DEFAULT_AUDIT_LOG_ACTIONS = ""  # Empty = audit all eligible actions
 DEFAULT_AUDIT_LOG_RETENTION_DAYS = -1  # -1 = keep forever
+# Per-bank audit toggle default. True so that when a per-bank gate IS wired,
+# a bank with no explicit setting participates in auditing (opt-out), which
+# preserves "audit everything" once the deployment-wide switch is on. Inert
+# unless a gate consults it.
+DEFAULT_AUDIT_ENABLED = True
 
 # LLM request tracing defaults
 DEFAULT_LLM_TRACE_ENABLED = True  # Enabled by default
@@ -1942,9 +1954,10 @@ class HindsightConfig:
     metrics_backlog_enabled: bool
 
     # Audit log configuration (static - server-level only)
-    audit_log_enabled: bool  # Master switch for audit logging
+    audit_log_enabled: bool  # Master switch for audit logging (static, server-level)
     audit_log_actions: list[str]  # Allowlist of action types (empty = all)
     audit_log_retention_days: int  # -1 = keep forever, >0 = delete after N days
+    audit_enabled: bool  # Per-bank audit toggle (configurable; consulted by a per-bank gate)
 
     # LLM request tracing configuration (static - server-level only)
     llm_trace_enabled: bool  # Master switch for per-bank LLM request tracing
@@ -2066,6 +2079,8 @@ class HindsightConfig:
         # Entity labels (controlled vocabulary for entity classification)
         "entity_labels",
         "entities_allow_free_form",
+        # Per-bank audit toggle (consulted by an optional per-bank audit gate)
+        "audit_enabled",
         # Consolidation settings
         "enable_observations",
         "enable_auto_consolidation",
@@ -3015,6 +3030,8 @@ class HindsightConfig:
             audit_log_retention_days=int(
                 os.getenv(ENV_AUDIT_LOG_RETENTION_DAYS, str(DEFAULT_AUDIT_LOG_RETENTION_DAYS))
             ),
+            # Per-bank audit toggle (configurable; overridable per bank)
+            audit_enabled=os.getenv(ENV_AUDIT_ENABLED, str(DEFAULT_AUDIT_ENABLED)).lower() == "true",
             # LLM request tracing configuration (static, server-level only)
             llm_trace_enabled=os.getenv(ENV_LLM_TRACE_ENABLED, str(DEFAULT_LLM_TRACE_ENABLED)).lower() == "true",
             llm_trace_scopes=[

--- a/hindsight-api-slim/hindsight_api/engine/audit.py
+++ b/hindsight-api-slim/hindsight_api/engine/audit.py
@@ -230,7 +230,11 @@ async def audit_context(
             result = await do_work()
             entry.response = result_dict
     """
-    if audit_logger is None or not audit_logger.is_enabled(action):
+    # Full decision incl. the optional per-bank gate — otherwise this
+    # write path (e.g. the retain engine's audit_context) would bypass the
+    # per-bank predicate that the HTTP/MCP wrappers honor, and a bank gated
+    # off would still get audit rows.
+    if audit_logger is None or not await audit_logger.should_log(action, bank_id):
         entry = AuditEntry(action=action, transport=transport, bank_id=bank_id)
         yield entry
         return

--- a/hindsight-api-slim/hindsight_api/engine/audit.py
+++ b/hindsight-api-slim/hindsight_api/engine/audit.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -124,14 +124,54 @@ class AuditLogger:
         self._schema_getter = schema_getter
         self._enabled = enabled
         self._allowed_actions: frozenset[str] | None = frozenset(allowed_actions) if allowed_actions else None
+        # Optional per-bank predicate. When set, an action that passes the
+        # global env/action check is ALSO gated on this async callback, so an
+        # embedder can enable auditing for some banks and not others without
+        # touching the global switch. None (the default) means "no per-bank
+        # gating" — every bank that passes is_enabled() is logged, i.e. the
+        # original behavior is preserved exactly. The callback should be cheap
+        # (e.g. cache-backed): it's awaited on the request path for every
+        # otherwise-auditable action.
+        self._bank_gate: Callable[[str | None], Awaitable[bool]] | None = None
+
+    def set_bank_gate(self, gate: Callable[[str | None], Awaitable[bool]] | None) -> None:
+        """Attach (or clear) the optional per-bank audit predicate.
+
+        Intended for embedders that store per-bank audit settings out of band
+        (e.g. a control plane). Passing None restores the default all-banks
+        behavior.
+        """
+        self._bank_gate = gate
 
     def is_enabled(self, action: str) -> bool:
-        """Check if audit logging is enabled for this action."""
+        """Global env/action gate. Cheap and synchronous.
+
+        Does NOT consult the per-bank predicate — callers on the hot path use
+        this as a fast pre-filter, then ``should_log`` for the full decision.
+        """
         if not self._enabled:
             return False
         if self._allowed_actions is not None:
             return action in self._allowed_actions
         return True
+
+    async def should_log(self, action: str, bank_id: str | None) -> bool:
+        """Full audit decision: global gate AND (optional) per-bank predicate.
+
+        Falls back to ``is_enabled(action)`` when no per-bank gate is set, so
+        deployments that don't use per-bank gating pay nothing extra.
+        """
+        if not self.is_enabled(action):
+            return False
+        if self._bank_gate is None:
+            return True
+        try:
+            return await self._bank_gate(bank_id)
+        except Exception as e:
+            # A misbehaving gate must never break the request or silently
+            # enable auditing for a bank meant to be off — fail closed.
+            logger.warning(f"Audit bank gate failed for bank={bank_id}: {e}; skipping audit")
+            return False
 
     def log_fire_and_forget(self, entry: AuditEntry) -> None:
         """Schedule an audit write as a background task."""

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -512,6 +512,7 @@ def _apply_audit_logging(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
         """Create an audited wrapper for a tool's run method."""
 
         async def _audited_run(arguments, _name=tool_name, _orig=original_run):
+            # Cheap env/action pre-filter before resolving bank_id.
             if not audit_logger.is_enabled(_name):
                 return await _orig(arguments)
 
@@ -520,6 +521,11 @@ def _apply_audit_logging(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
                 bank_id = arguments.get("bank_id") or (config.bank_id_resolver() if config.bank_id_resolver else None)
             elif hasattr(arguments, "get"):
                 bank_id = arguments.get("bank_id")
+
+            # Full decision incl. the optional per-bank predicate (no-op when
+            # unset). Resolved after bank_id so the predicate can see it.
+            if not await audit_logger.should_log(_name, bank_id):
+                return await _orig(arguments)
 
             entry = AuditEntry(
                 action=_name,

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -564,6 +564,7 @@ def _apply_audit_logging(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
         if original_call_tool:
 
             async def _audited_call_tool(name, arguments=None, **kwargs):
+                # Cheap env/action pre-filter before resolving bank_id.
                 if name not in _AUDITABLE_MCP_TOOLS or not audit_logger.is_enabled(name):
                     return await original_call_tool(name, arguments, **kwargs)
 
@@ -572,6 +573,11 @@ def _apply_audit_logging(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCon
                     bank_id = arguments.get("bank_id") or (
                         config.bank_id_resolver() if config.bank_id_resolver else None
                     )
+
+                # Full decision incl. the optional per-bank predicate (no-op
+                # when unset). Resolved after bank_id so the predicate sees it.
+                if not await audit_logger.should_log(name, bank_id):
+                    return await original_call_tool(name, arguments, **kwargs)
 
                 entry = AuditEntry(
                     action=name,

--- a/hindsight-api-slim/tests/test_audit_bank_gate.py
+++ b/hindsight-api-slim/tests/test_audit_bank_gate.py
@@ -6,10 +6,12 @@ gate set, behavior equals the original ``is_enabled(action)`` — and the
 new per-bank behavior when a gate IS set.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from hindsight_api.config import HindsightConfig
-from hindsight_api.engine.audit import AuditLogger
+from hindsight_api.engine.audit import AuditLogger, audit_context
 
 
 class TestAuditEnabledIsConfigurable:
@@ -109,3 +111,42 @@ class TestWithBankGate:
         assert await al.should_log("retain", "bank-a") is False
         al.set_bank_gate(None)
         assert await al.should_log("retain", "bank-a") is True
+
+
+class TestAuditContextHonorsGate:
+    """audit_context is a separate write path (used by the retain engine). It
+    must honor the per-bank gate too, or a gated-off bank leaks audit rows."""
+
+    @pytest.mark.asyncio
+    async def test_gated_off_bank_does_not_log(self):
+        al = _logger(enabled=True)
+
+        async def gate(bank_id):
+            return False
+
+        al.set_bank_gate(gate)
+        with patch.object(al, "log_fire_and_forget") as write:
+            async with audit_context(al, "retain", "http", bank_id="bank-off") as entry:
+                entry.response = {"ok": True}
+        write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gated_on_bank_logs(self):
+        al = _logger(enabled=True)
+
+        async def gate(bank_id):
+            return True
+
+        al.set_bank_gate(gate)
+        with patch.object(al, "log_fire_and_forget") as write:
+            async with audit_context(al, "retain", "http", bank_id="bank-on") as entry:
+                entry.response = {"ok": True}
+        write.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_gate_logs_as_before(self):
+        al = _logger(enabled=True)
+        with patch.object(al, "log_fire_and_forget") as write:
+            async with audit_context(al, "retain", "http", bank_id="bank-a") as entry:
+                entry.response = {"ok": True}
+        write.assert_called_once()

--- a/hindsight-api-slim/tests/test_audit_bank_gate.py
+++ b/hindsight-api-slim/tests/test_audit_bank_gate.py
@@ -21,8 +21,9 @@ class TestAuditEnabledIsConfigurable:
     def test_audit_enabled_in_configurable_fields(self):
         assert "audit_enabled" in HindsightConfig.get_configurable_fields()
 
-    def test_default_true(self):
-        assert HindsightConfig.from_env().audit_enabled is True
+    def test_default_false_opt_in(self):
+        # Opt-in: a bank with no explicit setting is not audited.
+        assert HindsightConfig.from_env().audit_enabled is False
 
 
 def _logger(enabled: bool, allowed_actions=None) -> AuditLogger:

--- a/hindsight-api-slim/tests/test_audit_bank_gate.py
+++ b/hindsight-api-slim/tests/test_audit_bank_gate.py
@@ -1,0 +1,111 @@
+"""Unit tests for AuditLogger's optional per-bank gate.
+
+These are pure (no DB): they exercise the decision logic in ``should_log``
+directly. The point is to pin the backward-compatibility contract — with no
+gate set, behavior equals the original ``is_enabled(action)`` — and the
+new per-bank behavior when a gate IS set.
+"""
+
+import pytest
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.audit import AuditLogger
+
+
+class TestAuditEnabledIsConfigurable:
+    """The per-bank ``audit_enabled`` field must be overridable per bank so
+    the bank-config API accepts it (unknown fields are rejected)."""
+
+    def test_audit_enabled_in_configurable_fields(self):
+        assert "audit_enabled" in HindsightConfig.get_configurable_fields()
+
+    def test_default_true(self):
+        assert HindsightConfig.from_env().audit_enabled is True
+
+
+def _logger(enabled: bool, allowed_actions=None) -> AuditLogger:
+    return AuditLogger(
+        pool_getter=lambda: None,
+        schema_getter=lambda: "public",
+        enabled=enabled,
+        allowed_actions=allowed_actions or [],
+    )
+
+
+class TestNoGateBackwardCompat:
+    """No bank gate set → should_log == is_enabled (the original behavior)."""
+
+    @pytest.mark.asyncio
+    async def test_enabled_no_gate_logs_all_banks(self):
+        al = _logger(enabled=True)
+        assert al.is_enabled("retain") is True
+        assert await al.should_log("retain", "bank-a") is True
+        assert await al.should_log("retain", "bank-b") is True
+        # bank_id is irrelevant without a gate — even None logs.
+        assert await al.should_log("retain", None) is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_gate_logs_nothing(self):
+        al = _logger(enabled=False)
+        assert await al.should_log("retain", "bank-a") is False
+
+    @pytest.mark.asyncio
+    async def test_action_allowlist_still_applies(self):
+        al = _logger(enabled=True, allowed_actions=["retain"])
+        assert await al.should_log("retain", "bank-a") is True
+        assert await al.should_log("recall", "bank-a") is False
+
+
+class TestWithBankGate:
+    """A gate is set → global gate AND the per-bank predicate."""
+
+    @pytest.mark.asyncio
+    async def test_gate_selects_specific_banks(self):
+        al = _logger(enabled=True)
+        allowed = {"bank-on"}
+
+        async def gate(bank_id):
+            return bank_id in allowed
+
+        al.set_bank_gate(gate)
+        assert await al.should_log("retain", "bank-on") is True
+        assert await al.should_log("retain", "bank-off") is False
+
+    @pytest.mark.asyncio
+    async def test_global_off_short_circuits_gate(self):
+        al = _logger(enabled=False)
+        called = False
+
+        async def gate(bank_id):
+            nonlocal called
+            called = True
+            return True
+
+        al.set_bank_gate(gate)
+        # Global gate is off, so the (potentially expensive) per-bank gate is
+        # never awaited.
+        assert await al.should_log("retain", "bank-on") is False
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_gate_failure_fails_closed(self):
+        al = _logger(enabled=True)
+
+        async def gate(bank_id):
+            raise RuntimeError("control plane unreachable")
+
+        al.set_bank_gate(gate)
+        # A broken gate must not enable auditing for a bank meant to be off.
+        assert await al.should_log("retain", "bank-x") is False
+
+    @pytest.mark.asyncio
+    async def test_clearing_gate_restores_all_banks(self):
+        al = _logger(enabled=True)
+
+        async def gate(bank_id):
+            return False
+
+        al.set_bank_gate(gate)
+        assert await al.should_log("retain", "bank-a") is False
+        al.set_bank_gate(None)
+        assert await al.should_log("retain", "bank-a") is True

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1707,6 +1707,7 @@ Audit logging captures mutating operations (retain, recall, reflect, bank config
 | `HINDSIGHT_API_AUDIT_LOG_ENABLED` | Master switch for audit logging. Must be `true` for any audit events to be written. | `false` |
 | `HINDSIGHT_API_AUDIT_LOG_ACTIONS` | Comma-separated allowlist of action types to audit (empty = all eligible actions) | `""` |
 | `HINDSIGHT_API_AUDIT_LOG_RETENTION_DAYS` | Number of days to retain audit log entries. `-1` = keep forever. | `-1` |
+| `HINDSIGHT_API_AUDIT_ENABLED` | Per-bank audit toggle (hierarchical — overridable per bank). Distinct from the master switch above: this lets a deployment enable auditing for some banks and not others when a per-bank audit gate is wired via `AuditLogger.set_bank_gate(...)`. With no gate wired (the default), this field is inert and every bank that passes the master switch is audited. | `true` |
 
 ### LLM Request Tracing
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1707,7 +1707,7 @@ Audit logging captures mutating operations (retain, recall, reflect, bank config
 | `HINDSIGHT_API_AUDIT_LOG_ENABLED` | Master switch for audit logging. Must be `true` for any audit events to be written. | `false` |
 | `HINDSIGHT_API_AUDIT_LOG_ACTIONS` | Comma-separated allowlist of action types to audit (empty = all eligible actions) | `""` |
 | `HINDSIGHT_API_AUDIT_LOG_RETENTION_DAYS` | Number of days to retain audit log entries. `-1` = keep forever. | `-1` |
-| `HINDSIGHT_API_AUDIT_ENABLED` | Per-bank audit toggle (hierarchical — overridable per bank). Distinct from the master switch above: this lets a deployment enable auditing for some banks and not others when a per-bank audit gate is wired via `AuditLogger.set_bank_gate(...)`. With no gate wired (the default), this field is inert and every bank that passes the master switch is audited. | `true` |
+| `HINDSIGHT_API_AUDIT_ENABLED` | Per-bank audit toggle (hierarchical — overridable per bank). Distinct from the master switch above: this lets a deployment enable auditing for some banks and not others when a per-bank audit gate is wired via `AuditLogger.set_bank_gate(...)`. **Opt-in — defaults to `false`**, so a bank is audited only when explicitly turned on. Inert when no gate is wired (the master switch governs there). | `false` |
 
 ### LLM Request Tracing
 


### PR DESCRIPTION
## Summary

Lets an embedder enable audit logging for some banks and not others, without changing the deployment-wide master switch. Additive and off by default — with no gate wired, behavior is unchanged.

### AuditLogger per-bank gate
- `AuditLogger.set_bank_gate(gate)` attaches an optional async `Callable[[bank_id], bool]`.
- `should_log(action, bank_id)` applies the global env/action gate first (cheap, sync `is_enabled`) and only then awaits the predicate.
- Default is `None` → `should_log` is equivalent to `is_enabled(action)`, so deployments that don't use per-bank gating pay nothing and behave exactly as before.
- Global-off short-circuits before the predicate; a raising predicate **fails closed** (not logged) so a broken gate can't silently enable auditing for a bank meant to be off.
- All four audit-write paths honor it: the HTTP `@audited` decorator, both MCP tool wrappers, and `audit_context` (the retain engine path).

### Configurable per-bank field
- New `audit_enabled` bank config field (hierarchical, overridable per bank), added to `_CONFIGURABLE_FIELDS` so the bank-config API accepts it. **Opt-in — defaults to `false`.**
- Distinct from the static `audit_log_enabled` master switch. Inert unless a per-bank gate consults it.

## Test plan
- New `tests/test_audit_bank_gate.py` (12 cases): no-gate backward-compat contract, gated selection, global-off short-circuit, fail-closed, `audit_context` honors the gate, gate clearing, and the `audit_enabled` field is configurable + defaults false.
- `ruff` + `ty` clean; configurable-field round-trip suite passes.
- Docs updated (`configuration.md`).