### PR TITLE
fix(claude-code): isolate MCP server cwd

### DIFF
--- a/hindsight-integrations/claude-code/scripts/mcp_server.py
+++ b/hindsight-integrations/claude-code/scripts/mcp_server.py
@@ -19,12 +19,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Launched via scripts/run_mcp.sh which execs the venv's interpreter, so
 # `mcp` and friends resolve from ${CLAUDE_PLUGIN_DATA}/venv/site-packages.
-from mcp.server.fastmcp import FastMCP
-
+from lib.bank import derive_bank_id
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.daemon import get_api_url
-from lib.bank import derive_bank_id
+from mcp.server.fastmcp import FastMCP
 
 # ── Server setup ────────────────────────────────────────
 
@@ -32,7 +31,11 @@ mcp = FastMCP("hindsight")
 
 # Resolve config at startup
 _config = load_config()
-_dbg = lambda *a: debug_log(_config, *a)
+
+
+def _dbg(*a):
+    debug_log(_config, *a)
+
 
 if not _config.get("enableKnowledgeTools"):
     # Knowledge tools are opt-out. When disabled we must NOT exit: the plugin
@@ -51,7 +54,8 @@ except Exception as e:
     print(f"[Hindsight MCP] Failed to resolve API URL: {e}", file=sys.stderr)
     sys.exit(1)
 
-_hook_input = {"cwd": os.getcwd(), "session_id": ""}
+_project_cwd = os.environ.get("HINDSIGHT_MCP_PROJECT_CWD", os.getcwd())
+_hook_input = {"cwd": _project_cwd, "session_id": ""}
 _default_bank_id = derive_bank_id(_hook_input, _config)
 _client = HindsightClient(
     _api_url,

--- a/hindsight-integrations/claude-code/scripts/run_mcp.sh
+++ b/hindsight-integrations/claude-code/scripts/run_mcp.sh
@@ -51,4 +51,12 @@ if [ ! -f "${REQ_CACHED}" ] \
   cp "${REQ_SRC}" "${REQ_CACHED}"
 fi
 
+# Claude Code launches MCP servers from the session project directory. If that
+# directory contains an unreadable .env, FastMCP's default settings loader can
+# fail before our config loads. Run from plugin-owned data instead, while
+# preserving the session project cwd for bank derivation.
+export HINDSIGHT_MCP_PROJECT_CWD="${PWD}"
+mkdir -p "${CLAUDE_PLUGIN_DATA}"
+cd "${CLAUDE_PLUGIN_DATA}"
+
 exec "${PY}" "${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"

--- a/hindsight-integrations/claude-code/tests/test_mcp_server.py
+++ b/hindsight-integrations/claude-code/tests/test_mcp_server.py
@@ -21,6 +21,16 @@ def _read_mcp_server_source() -> str:
     return open(os.path.join(SCRIPTS_DIR, "mcp_server.py"), encoding="utf-8").read()
 
 
+class TestDefaultBankUsesProjectCwd:
+    """The MCP server must derive its default bank from Claude's project cwd."""
+
+    def test_default_bank_prefers_launcher_project_cwd(self):
+        src = _read_mcp_server_source()
+        assert "HINDSIGHT_MCP_PROJECT_CWD" in src
+        assert 'os.environ.get("HINDSIGHT_MCP_PROJECT_CWD", os.getcwd())' in src
+        assert '_hook_input = {"cwd": _project_cwd, "session_id": ""}' in src
+
+
 class TestListPagesUsesMetadataProjection:
     """`agent_knowledge_list_pages` must request the API's metadata projection.
 

--- a/hindsight-integrations/claude-code/tests/test_run_mcp.py
+++ b/hindsight-integrations/claude-code/tests/test_run_mcp.py
@@ -18,6 +18,7 @@ fabricated venv tree and assert on the interpreter it selects.
 """
 
 import os
+import stat
 import subprocess
 import textwrap
 
@@ -62,6 +63,27 @@ def _make_executable(path: str) -> None:
     os.chmod(path, 0o755)
 
 
+def _run_tail_with_fake_exec(plugin_data: str, plugin_root: str) -> str:
+    """Run the launcher tail with a fake exec and return project/server cwd."""
+    driver = textwrap.dedent(
+        """
+        set -e
+        export CLAUDE_PLUGIN_DATA="$1"
+        export CLAUDE_PLUGIN_ROOT="$2"
+        PY=python
+        exec() { printf '%s\n%s' "$HINDSIGHT_MCP_PROJECT_CWD" "$(pwd)"; }
+        sed -n '/^export HINDSIGHT_MCP_PROJECT_CWD=/,$p' "$3" | source /dev/stdin
+        """
+    )
+    result = subprocess.run(
+        ["bash", "-c", driver, "bash", plugin_data, plugin_root, RUN_MCP_SH],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
 class TestResolvePyVenvLayouts:
     """`resolve_py` must find the interpreter in every supported venv layout."""
 
@@ -97,3 +119,28 @@ class TestResolvePyVenvLayouts:
             "resolve_py must still select <venv>/bin/python on POSIX; got: "
             + repr(resolved)
         )
+
+
+class TestMcpServerWorkingDirectory:
+    """The launcher must not run the server from Claude Code's project cwd."""
+
+    def test_exec_runs_from_plugin_data_dir_when_project_env_is_unreadable(self, tmp_path):
+        """FastMCP probes `.env` in cwd, so use the plugin-owned data dir."""
+        project = tmp_path / "project"
+        project.mkdir()
+        env_file = project / ".env"
+        env_file.write_text("SECRET=value\n")
+        env_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        plugin_data = tmp_path / "plugin-data"
+        plugin_root = tmp_path / "plugin-root"
+        plugin_root.mkdir()
+
+        previous = os.getcwd()
+        try:
+            os.chdir(project)
+            project_cwd, server_cwd = _run_tail_with_fake_exec(str(plugin_data), str(plugin_root)).splitlines()
+        finally:
+            os.chdir(previous)
+
+        assert project_cwd == str(project)
+        assert server_cwd == str(plugin_data)


### PR DESCRIPTION
Summary

Fixes #2634.

Claude Code starts the hindsight MCP stdio server from the active project directory. If that project contains an unreadable `.env`, FastMCP's settings initialization can fail before the plugin config loads.

This changes the launcher to:
- preserve the original Claude project cwd in `HINDSIGHT_MCP_PROJECT_CWD`
- switch to `CLAUDE_PLUGIN_DATA` before executing `mcp_server.py`
- derive the default bank from the preserved project cwd so `directoryBankMap` and project-based dynamic bank IDs keep working

Tests

- `uv run pytest tests/test_run_mcp.py tests/test_mcp_server.py -v`
- `uv run ruff check hindsight-integrations/claude-code/scripts/mcp_server.py hindsight-integrations/claude-code/tests/test_run_mcp.py hindsight-integrations/claude-code/tests/test_mcp_server.py`