### PR TITLE
fix(reflect): tolerate null-like tool integer limits

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -1386,22 +1386,35 @@ async def _execute_tool(
         query = args.get("query")
         if not query:
             return {"error": "search_mental_models requires a query parameter"}
-        max_results = int(args.get("max_results") or 5)
+        max_results, error = _parse_tool_int_arg_or_error(args, "max_results", default=5)
+        if error:
+            return {"error": error}
         return await search_mental_models_fn(query, max_results)
 
     elif tool_name == "search_observations":
         query = args.get("query")
         if not query:
             return {"error": "search_observations requires a query parameter"}
-        max_tokens = max(int(args.get("max_tokens") or 5000), 1000)  # Default 5000, min 1000
+        max_tokens, error = _parse_tool_int_arg_or_error(args, "max_tokens", default=5000, minimum=1000)
+        if error:
+            return {"error": error}
         return await search_observations_fn(query, max_tokens)
 
     elif tool_name == "recall":
         query = args.get("query")
         if not query:
             return {"error": "recall requires a query parameter"}
-        max_tokens = max(int(args.get("max_tokens") or 2048), 1000)  # Default 2048, min 1000
-        max_chunk_tokens = max(int(args.get("max_chunk_tokens") or 1000), 1000)  # Always enabled, min 1000
+        max_tokens, error = _parse_tool_int_arg_or_error(args, "max_tokens", default=2048, minimum=1000)
+        if error:
+            return {"error": error}
+        max_chunk_tokens, error = _parse_tool_int_arg_or_error(
+            args,
+            "max_chunk_tokens",
+            default=1000,
+            minimum=1000,
+        )
+        if error:
+            return {"error": error}
         return await recall_fn(query, max_tokens, max_chunk_tokens)
 
     elif tool_name == "expand":
@@ -1415,23 +1428,63 @@ async def _execute_tool(
         return {"error": f"Unknown tool: {tool_name}"}
 
 
+_NULLISH_TOOL_INT_STRINGS = {"", "none", "null"}
+
+
+def _parse_tool_int_arg(args: dict[str, Any], key: str, *, default: int, minimum: int | None = None) -> int:
+    raw_value = args.get(key)
+    if not raw_value:
+        value = default
+    elif isinstance(raw_value, str) and raw_value.strip().lower() in _NULLISH_TOOL_INT_STRINGS:
+        value = default
+    else:
+        value = int(raw_value)
+    if minimum is None:
+        return value
+    return max(value, minimum)
+
+
+def _parse_tool_int_arg_or_error(
+    args: dict[str, Any],
+    key: str,
+    *,
+    default: int,
+    minimum: int | None = None,
+) -> tuple[int, str | None]:
+    try:
+        return _parse_tool_int_arg(args, key, default=default, minimum=minimum), None
+    except (OverflowError, TypeError, ValueError):
+        return default, f"{key} must be an integer or null-like value"
+
+
+def _summarize_tool_int_arg(args: dict[str, Any], key: str, *, default: int, minimum: int | None = None) -> str:
+    try:
+        return str(_parse_tool_int_arg(args, key, default=default, minimum=minimum))
+    except (OverflowError, TypeError, ValueError):
+        return f"invalid:{args.get(key)!r}"
+
+
+def _summarize_tool_query(args: dict[str, Any]) -> str:
+    query = args.get("query") or ""
+    if not isinstance(query, str):
+        query = str(query)
+    return f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
+
+
 def _summarize_input(tool_name: str, args: dict[str, Any]) -> str:
     """Create a summary of tool input for logging, showing all params."""
     if tool_name == "search_mental_models":
-        query = args.get("query", "")
-        query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
-        max_results = int(args.get("max_results") or 5)
+        query_preview = _summarize_tool_query(args)
+        max_results = _summarize_tool_int_arg(args, "max_results", default=5)
         return f"(query={query_preview}, max_results={max_results})"
     elif tool_name == "search_observations":
-        query = args.get("query", "")
-        query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
-        max_tokens = max(int(args.get("max_tokens") or 5000), 1000)
+        query_preview = _summarize_tool_query(args)
+        max_tokens = _summarize_tool_int_arg(args, "max_tokens", default=5000, minimum=1000)
         return f"(query={query_preview}, max_tokens={max_tokens})"
     elif tool_name == "recall":
-        query = args.get("query", "")
-        query_preview = f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
-        max_tokens = max(int(args.get("max_tokens") or 2048), 1000)
-        max_chunk_tokens = max(int(args.get("max_chunk_tokens") or 1000), 1000)
+        query_preview = _summarize_tool_query(args)
+        max_tokens = _summarize_tool_int_arg(args, "max_tokens", default=2048, minimum=1000)
+        max_chunk_tokens = _summarize_tool_int_arg(args, "max_chunk_tokens", default=1000, minimum=1000)
         return f"(query={query_preview}, max_tokens={max_tokens}, max_chunk_tokens={max_chunk_tokens})"
     elif tool_name == "expand":
         memory_ids = args.get("memory_ids", [])

--- a/hindsight-api-slim/tests/test_reflect_tools.py
+++ b/hindsight-api-slim/tests/test_reflect_tools.py
@@ -5,6 +5,7 @@ import uuid
 
 import pytest
 
+from hindsight_api.engine.reflect.agent import _execute_tool, _summarize_input
 from hindsight_api.engine.reflect.tools import _document_metadata_from_retain_params, tool_expand
 
 
@@ -118,3 +119,203 @@ def test_document_metadata_from_retain_params_accepts_json_strings() -> None:
 def test_document_metadata_from_retain_params_ignores_invalid_values(retain_params) -> None:
     """Malformed retain_params should not break reflect expansion."""
     assert _document_metadata_from_retain_params(retain_params) is None
+
+
+async def _unexpected_tool_call(*_args):
+    raise AssertionError("unexpected tool callback")
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_treats_string_none_max_tokens_as_default() -> None:
+    """Some providers emit JSON null as the string "None" in tool calls."""
+    captured: dict[str, object] = {}
+
+    async def search_observations(query: str, max_tokens: int) -> dict[str, object]:
+        captured["query"] = query
+        captured["max_tokens"] = max_tokens
+        return {"observations": []}
+
+    result = await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": "None"},
+        _unexpected_tool_call,
+        search_observations,
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+    )
+
+    assert result == {"observations": []}
+    assert captured == {"query": "deployment failures", "max_tokens": 5000}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_limit", ["bogus", float("inf")])
+async def test_execute_tool_returns_error_for_invalid_integer_limit(bad_limit) -> None:
+    """Malformed integer limits should be a tool error, not an exception."""
+    result = await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": bad_limit},
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+    )
+
+    assert result == {"error": "max_tokens must be an integer or null-like value"}
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_preserves_search_mental_models_max_results_values() -> None:
+    """Only token limits have minimums; max_results keeps the prior pass-through behavior."""
+    captured: dict[str, object] = {}
+
+    async def search_mental_models(query: str, max_results: int) -> dict[str, object]:
+        captured["query"] = query
+        captured["max_results"] = max_results
+        return {"mental_models": []}
+
+    result = await _execute_tool(
+        "search_mental_models",
+        {"query": "deployment failures", "max_results": -1},
+        search_mental_models,
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+    )
+
+    assert result == {"mental_models": []}
+    assert captured == {"query": "deployment failures", "max_results": -1}
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_preserves_falsey_values_as_default_sentinel() -> None:
+    """The old `or default` behavior treated falsey limit values as omitted."""
+    captured: dict[str, object] = {}
+
+    async def search_mental_models(query: str, max_results: int) -> dict[str, object]:
+        captured["mental_model_max_results"] = max_results
+        return {"mental_models": []}
+
+    async def search_observations(query: str, max_tokens: int) -> dict[str, object]:
+        captured["observation_max_tokens"] = max_tokens
+        return {"observations": []}
+
+    async def recall(query: str, max_tokens: int, max_chunk_tokens: int) -> dict[str, object]:
+        captured["recall_max_tokens"] = max_tokens
+        captured["recall_max_chunk_tokens"] = max_chunk_tokens
+        return {"memories": []}
+
+    await _execute_tool(
+        "search_mental_models",
+        {"query": "deployment failures", "max_results": 0},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+    await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": 0},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+    await _execute_tool(
+        "recall",
+        {"query": "deployment failures", "max_tokens": 0, "max_chunk_tokens": 0},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+    await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": False},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+    await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": []},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+    await _execute_tool(
+        "search_observations",
+        {"query": "deployment failures", "max_tokens": {}},
+        search_mental_models,
+        search_observations,
+        recall,
+        _unexpected_tool_call,
+    )
+
+    assert captured == {
+        "mental_model_max_results": 5,
+        "observation_max_tokens": 5000,
+        "recall_max_tokens": 2048,
+        "recall_max_chunk_tokens": 1000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_treats_null_like_recall_limits_as_defaults() -> None:
+    """Null-like string limits should not crash reflect tool execution."""
+    captured: dict[str, object] = {}
+
+    async def recall(query: str, max_tokens: int, max_chunk_tokens: int) -> dict[str, object]:
+        captured["query"] = query
+        captured["max_tokens"] = max_tokens
+        captured["max_chunk_tokens"] = max_chunk_tokens
+        return {"memories": []}
+
+    result = await _execute_tool(
+        "recall",
+        {"query": "incident notes", "max_tokens": "null", "max_chunk_tokens": ""},
+        _unexpected_tool_call,
+        _unexpected_tool_call,
+        recall,
+        _unexpected_tool_call,
+    )
+
+    assert result == {"memories": []}
+    assert captured == {"query": "incident notes", "max_tokens": 2048, "max_chunk_tokens": 1000}
+
+
+def test_summarize_input_never_raises_for_invalid_tool_limit_strings() -> None:
+    """Trace logging must not turn a recoverable tool error into HTTP 500."""
+    assert (
+        _summarize_input(
+            "search_observations",
+            {"query": "deployment failures", "max_tokens": "None"},
+        )
+        == "(query='deployment failures', max_tokens=5000)"
+    )
+
+    assert (
+        _summarize_input(
+            "recall",
+            {"query": "deployment failures", "max_tokens": "bogus", "max_chunk_tokens": "null"},
+        )
+        == "(query='deployment failures', max_tokens=invalid:'bogus', max_chunk_tokens=1000)"
+    )
+
+    assert (
+        _summarize_input(
+            "search_observations",
+            {"query": "deployment failures", "max_tokens": float("inf")},
+        )
+        == "(query='deployment failures', max_tokens=invalid:inf)"
+    )
+
+    assert (
+        _summarize_input(
+            "search_observations",
+            {"query": None, "max_tokens": "None"},
+        )
+        == "(query='', max_tokens=5000)"
+    )


### PR DESCRIPTION
## Summary

Fixes #2637 by making reflect tool integer limits tolerate provider-emitted null-like strings such as `"None"`, `"null"`, and `""`.

This covers both paths that were involved in the reported 500:
- tool execution for `search_observations`, `recall`, and `search_mental_models`
- trace/input summarization after a tool returns an error

I kept the old `args.get(...) or default` compatibility for falsy omitted-style values like `0`, `false`, `[]`, and `{}`. Non-falsy malformed limits such as `"bogus"` or non-finite floats now become a structured tool error instead of escaping through trace logging.

## Validation

- `uv run --frozen pytest hindsight-api-slim/tests/test_reflect_tools.py -q` — 14 passed
- `python3 -m py_compile hindsight-api-slim/hindsight_api/engine/reflect/agent.py hindsight-api-slim/tests/test_reflect_tools.py`
- `uv run --frozen ruff format --check hindsight-api-slim/hindsight_api/engine/reflect/agent.py hindsight-api-slim/tests/test_reflect_tools.py`
- `uv run --frozen ruff check hindsight-api-slim/hindsight_api/engine/reflect/agent.py hindsight-api-slim/tests/test_reflect_tools.py`

Codex adversarial review forced rework around max_results compatibility, malformed integer errors, non-finite floats, and safe query summarization. Final patch preserves the legacy falsy-default behavior while adding the null-like string handling needed for #2637.
