### PR TITLE
fix(auth): authorize bank writes before provisioning

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2488,25 +2488,43 @@ def validate_bank_template(manifest: "BankTemplateManifest") -> list[str]:
     return errors
 
 
+def load_default_bank_template_manifest() -> "BankTemplateManifest | None":
+    """Parse and semantically validate the configured default bank template."""
+    template_dict = get_config().default_bank_template
+    if not template_dict:
+        return None
+    manifest = BankTemplateManifest.model_validate(template_dict)
+    semantic_errors = validate_bank_template(manifest)
+    if semantic_errors:
+        raise ValueError("; ".join(semantic_errors))
+    return manifest
+
+
 async def apply_bank_template_manifest(
-    memory,
+    memory: MemoryEngine,
     bank_id: str,
     manifest: "BankTemplateManifest",
     request_context: "RequestContext",
+    *,
+    authorize_config_update: bool = True,
 ) -> "BankTemplateImportResponse":
     """Apply a validated BankTemplateManifest to an existing bank.
 
     Shared by the /import endpoint and the default-template-on-create hook
     driven by HINDSIGHT_API_DEFAULT_BANK_TEMPLATE. The bank MUST already
     exist; caller is responsible for validation (Pydantic + validate_bank_template).
+    ``authorize_config_update`` is false only for the server-owned default
+    template, which is not a client configuration update.
     """
     config_applied = False
     if manifest.bank:
         config_updates = manifest.bank.get_config_updates()
         if config_updates:
-            await memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
+            if authorize_config_update:
+                await memory.update_bank_config(bank_id, config_updates, request_context=request_context)
+            else:
+                await memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
             config_applied = True
-
     created_ids: list[str] = []
     updated_ids: list[str] = []
     operation_ids: list[str] = []
@@ -5781,28 +5799,15 @@ def _register_routes(app: FastAPI):
     ):
         """Create or update an agent with disposition and mission."""
         try:
-            # Ensure bank exists, validating create_bank only when this call
-            # actually creates a missing bank.
-            await app.state.memory._ensure_bank_exists(
-                bank_id,
-                request_context,
-            )
-
-            # Update name if provided (stored in DB for display only, deprecated)
-            if request.name is not None:
-                await app.state.memory.update_bank(
-                    bank_id,
-                    name=request.name,
-                    request_context=request_context,
-                )
-
-            # Apply all config overrides (includes reflect_mission, disposition, retain settings)
+            # The engine validates and authorizes all requested changes before
+            # creating a missing bank.
             config_updates = request.get_config_updates()
-            if config_updates:
-                await app.state.memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
-
-            # Get final profile
-            final_profile = await app.state.memory.get_bank_profile(bank_id, request_context=request_context)
+            final_profile = await app.state.memory.update_bank(
+                bank_id,
+                name=request.name,
+                config_updates=config_updates or None,
+                request_context=request_context,
+            )
             disposition_dict = (
                 final_profile["disposition"].model_dump()
                 if hasattr(final_profile["disposition"], "model_dump")
@@ -5818,6 +5823,8 @@ def _register_routes(app: FastAPI):
             )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except Exception as e:
@@ -5841,33 +5848,16 @@ def _register_routes(app: FastAPI):
     ):
         """Partially update an agent's profile (name, mission, disposition)."""
         try:
-            # PATCH is update-only; missing banks must not be created as a
-            # side effect of reading the profile.
-            existing_profile = await app.state.memory.get_bank_profile(
-                bank_id, request_context=request_context, create_if_missing=False
-            )
-            if existing_profile is None:
-                raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
-
-            # Update name if provided (stored in DB for display only, deprecated)
-            if request.name is not None:
-                await app.state.memory.update_bank(
-                    bank_id,
-                    name=request.name,
-                    request_context=request_context,
-                )
-
-            # Apply all config overrides (includes reflect_mission, disposition, retain settings)
+            # Update every requested field through one engine call so all
+            # authorization and validation completes before either write.
             config_updates = request.get_config_updates()
-            if config_updates:
-                await app.state.memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
-
-            # Get final profile
-            final_profile = await app.state.memory.get_bank_profile(
-                bank_id, request_context=request_context, create_if_missing=False
+            final_profile = await app.state.memory.update_bank(
+                bank_id,
+                name=request.name,
+                config_updates=config_updates or None,
+                create_if_missing=False,
+                request_context=request_context,
             )
-            if final_profile is None:
-                raise HTTPException(status_code=404, detail=f"Bank '{bank_id}' not found")
             disposition_dict = (
                 final_profile["disposition"].model_dump()
                 if hasattr(final_profile["disposition"], "model_dump")
@@ -5883,6 +5873,8 @@ def _register_routes(app: FastAPI):
             )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except (AuthenticationError, HTTPException):
             raise
         except Exception as e:
@@ -5978,12 +5970,12 @@ def _register_routes(app: FastAPI):
                     dry_run=True,
                 )
 
-            # Ensure bank exists, validating create_bank only when this import
-            # actually creates a missing target bank.
-            await app.state.memory._ensure_bank_exists(
-                bank_id,
-                request_context,
-            )
+            config_updates = body.bank.get_config_updates() if body.bank else {}
+            if not config_updates:
+                # Config-bearing imports create the bank through update_bank_config
+                # only after validation. Other imports retain the existing
+                # eager-create behavior needed by directive-only manifests.
+                await app.state.memory._ensure_bank_exists(bank_id, request_context)
 
             return await apply_bank_template_manifest(
                 memory=app.state.memory,
@@ -6359,25 +6351,8 @@ def _register_routes(app: FastAPI):
                 detail="Bank configuration API is disabled. Set HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true to re-enable.",
             )
         try:
-            # Authenticate and set schema context for multi-tenant DB queries
-            await app.state.memory._authenticate_tenant(request_context)
-            if app.state.memory._operation_validator:
-                from hindsight_api.extensions import BankReadContext, BankReadOperation
-
-                ctx = BankReadContext(
-                    bank_id=bank_id, operation=BankReadOperation.GET_BANK_CONFIG, request_context=request_context
-                )
-                await app.state.memory._validate_operation(
-                    app.state.memory._operation_validator.validate_bank_read(ctx)
-                )
-
-            # Get resolved config from config resolver
-            config_dict = await app.state.memory._config_resolver.get_bank_config(bank_id, request_context)
-
-            # Get bank-specific overrides only
-            bank_overrides = await app.state.memory._config_resolver._load_bank_config(bank_id)
-
-            return BankConfigResponse(bank_id=bank_id, config=config_dict, overrides=bank_overrides)
+            state = await app.state.memory.get_bank_config(bank_id, request_context=request_context)
+            return BankConfigResponse(bank_id=bank_id, config=state.config, overrides=state.overrides)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
@@ -6409,35 +6384,12 @@ def _register_routes(app: FastAPI):
                 detail="Bank configuration API is disabled. Set HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true to re-enable.",
             )
         try:
-            # Authenticate and set schema context for multi-tenant DB queries
-            await app.state.memory._authenticate_tenant(request_context)
-            if app.state.memory._operation_validator:
-                from hindsight_api.extensions import BankWriteContext, BankWriteOperation
-
-                ctx = BankWriteContext(
-                    bank_id=bank_id, operation=BankWriteOperation.UPDATE_BANK_CONFIG, request_context=request_context
-                )
-                await app.state.memory._validate_operation(
-                    app.state.memory._operation_validator.validate_bank_write(ctx)
-                )
-
-            # Validate Memory Defense policy shape before persisting.
-            if "memory_defense" in request.updates and request.updates["memory_defense"] is not None:
-                from hindsight_api.extensions.memory_defense import parse_policy
-
-                try:
-                    parse_policy(request.updates["memory_defense"])
-                except ValueError as exc:
-                    raise HTTPException(status_code=422, detail=f"invalid memory_defense policy: {exc}")
-
-            # Update config via config resolver (validates configurable fields and permissions)
-            await app.state.memory._config_resolver.update_bank_config(bank_id, request.updates, request_context)
-
-            # Return updated config
-            config_dict = await app.state.memory._config_resolver.get_bank_config(bank_id, request_context)
-            bank_overrides = await app.state.memory._config_resolver._load_bank_config(bank_id)
-
-            return BankConfigResponse(bank_id=bank_id, config=config_dict, overrides=bank_overrides)
+            state = await app.state.memory.update_bank_config(
+                bank_id,
+                request.updates,
+                request_context=request_context,
+            )
+            return BankConfigResponse(bank_id=bank_id, config=state.config, overrides=state.overrides)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except ValueError as e:
@@ -6470,26 +6422,8 @@ def _register_routes(app: FastAPI):
                 detail="Bank configuration API is disabled. Set HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true to re-enable.",
             )
         try:
-            # Authenticate and set schema context for multi-tenant DB queries
-            await app.state.memory._authenticate_tenant(request_context)
-            if app.state.memory._operation_validator:
-                from hindsight_api.extensions import BankWriteContext, BankWriteOperation
-
-                ctx = BankWriteContext(
-                    bank_id=bank_id, operation=BankWriteOperation.RESET_BANK_CONFIG, request_context=request_context
-                )
-                await app.state.memory._validate_operation(
-                    app.state.memory._operation_validator.validate_bank_write(ctx)
-                )
-
-            # Reset config via config resolver
-            await app.state.memory._config_resolver.reset_bank_config(bank_id)
-
-            # Return updated config (should match defaults now)
-            config_dict = await app.state.memory._config_resolver.get_bank_config(bank_id, request_context)
-            bank_overrides = await app.state.memory._config_resolver._load_bank_config(bank_id)
-
-            return BankConfigResponse(bank_id=bank_id, config=config_dict, overrides=bank_overrides)
+            state = await app.state.memory.reset_bank_config(bank_id, request_context=request_context)
+            return BankConfigResponse(bank_id=bank_id, config=state.config, overrides=state.overrides)
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -27,7 +27,7 @@ from hindsight_api.engine.audit import (
     AuditLogStatsResponse,
 )
 from hindsight_api.engine.llm_trace import LLMRequestListResponse, LLMRequestStatsResponse
-from hindsight_api.extensions import AuthenticationError, PrecheckOperation
+from hindsight_api.extensions import AuthenticationError, BankWriteOperation, PrecheckOperation
 
 
 def _parse_metadata(metadata: Any) -> dict[str, Any]:
@@ -149,6 +149,7 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
 
 
 from hindsight_api.config import get_config
+from hindsight_api.engine.interface import BankTemplateImportWrite
 from hindsight_api.engine.memory_engine import (
     Budget,
     RetainOperationConflictError,
@@ -2474,17 +2475,25 @@ def validate_bank_template(manifest: "BankTemplateManifest") -> list[str]:
         if bank.retain_custom_instructions and bank.retain_extraction_mode != "custom":
             errors.append("bank.retain_custom_instructions: requires retain_extraction_mode='custom'")
     if manifest.mental_models:
+        seen_mental_model_ids: set[str] = set()
         for i, mm in enumerate(manifest.mental_models):
             if not mm.name.strip():
                 errors.append(f"mental_models[{i}].name: must not be empty")
             if not mm.source_query.strip():
                 errors.append(f"mental_models[{i}].source_query: must not be empty")
+            if mm.id in seen_mental_model_ids:
+                errors.append(f"mental_models[{i}].id: duplicate id '{mm.id}'")
+            seen_mental_model_ids.add(mm.id)
     if manifest.directives:
+        seen_directive_names: set[str] = set()
         for i, d in enumerate(manifest.directives):
             if not d.name.strip():
                 errors.append(f"directives[{i}].name: must not be empty")
             if not d.content.strip():
                 errors.append(f"directives[{i}].content: must not be empty")
+            if d.name in seen_directive_names:
+                errors.append(f"directives[{i}].name: duplicate name '{d.name}'")
+            seen_directive_names.add(d.name)
     return errors
 
 
@@ -2505,37 +2514,183 @@ async def apply_bank_template_manifest(
     bank_id: str,
     manifest: "BankTemplateManifest",
     request_context: "RequestContext",
-    *,
-    authorize_config_update: bool = True,
 ) -> "BankTemplateImportResponse":
-    """Apply a validated BankTemplateManifest to an existing bank.
+    """Apply a client-provided BankTemplateManifest to a bank.
 
-    Shared by the /import endpoint and the default-template-on-create hook
-    driven by HINDSIGHT_API_DEFAULT_BANK_TEMPLATE. The bank MUST already
-    exist; caller is responsible for validation (Pydantic + validate_bank_template).
-    ``authorize_config_update`` is false only for the server-owned default
-    template, which is not a client configuration update.
+    The authorization context creates a missing bank after validating every
+    requested operation. The caller remains responsible for manifest validation
+    (Pydantic + validate_bank_template). Server-owned defaults use
+    ``apply_default_bank_template_resources`` instead, so this function always
+    owns persistence of its client-provided config.
     """
-    config_applied = False
-    if manifest.bank:
-        config_updates = manifest.bank.get_config_updates()
+    config_updates = manifest.bank.get_config_updates() if manifest.bank else {}
+    bank_exists = (
+        await memory.get_bank_profile(
+            bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        is not None
+    )
+
+    # A missing bank receives the server-owned default template during
+    # provisioning. Project those resources into the authorization decision so
+    # the client's import is authorized as an update when the default owns the
+    # same key, while still keeping every client check before bank creation.
+    default_manifest: BankTemplateManifest | None = None
+    if not bank_exists:
+        try:
+            default_manifest = load_default_bank_template_manifest()
+        except (ValueError, ValidationError):
+            # Provisioning owns error logging and the best-effort fallback for a
+            # malformed server template. Client authorization must not change it.
+            pass
+    imported_mental_model_ids = {item.id for item in manifest.mental_models or []}
+    imported_directive_names = {item.name for item in manifest.directives or []}
+    default_mental_models = (default_manifest.mental_models or []) if default_manifest else []
+    default_directives = (default_manifest.directives or []) if default_manifest else []
+    projected_mental_model_ids = {item.id for item in default_mental_models} & imported_mental_model_ids
+    projected_directive_names = {item.name for item in default_directives} & imported_directive_names
+
+    existing_by_id: dict[str, dict[str, Any]] = {}
+    if bank_exists and manifest.mental_models:
+        existing = await memory.list_mental_models(bank_id=bank_id, request_context=request_context)
+        existing_by_id = {m["id"]: m for m in existing}
+
+    existing_by_name: dict[str, dict[str, Any]] = {}
+    if bank_exists and manifest.directives:
+        existing_directives = await memory.list_directives(
+            bank_id=bank_id, active_only=False, request_context=request_context
+        )
+        existing_by_name = {d["name"]: d for d in existing_directives}
+
+    bank_writes: list[BankTemplateImportWrite] = []
+    if config_updates:
+        bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_BANK_CONFIG))
+    for mental_model in manifest.mental_models or []:
+        if mental_model.id in existing_by_id:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id))
+        elif mental_model.id in projected_mental_model_ids:
+            # Default-template application is best-effort. Authorize both
+            # outcomes before provisioning so a failed default create can
+            # safely fall back to the client's create operation.
+            bank_writes.extend(
+                [
+                    BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id),
+                    BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id),
+                ]
+            )
+        else:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id))
+    for directive in manifest.directives or []:
+        if directive.name in existing_by_name:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name))
+        elif directive.name in projected_directive_names:
+            bank_writes.extend(
+                [
+                    BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name),
+                    BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name),
+                ]
+            )
+        else:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name))
+
+    async with memory.bank_template_import_authorization(
+        bank_id,
+        config_updates=config_updates,
+        bank_writes=bank_writes,
+        mental_model_ids=[mental_model.id for mental_model in manifest.mental_models or []],
+        bank_exists=bank_exists,
+        request_context=request_context,
+    ):
+        if projected_mental_model_ids:
+            provisioned = await memory.list_mental_models(
+                bank_id=bank_id,
+                request_context=request_context,
+            )
+            provisioned_by_id = {item["id"]: item for item in provisioned}
+            existing_by_id.update(
+                {
+                    item_id: provisioned_by_id[item_id]
+                    for item_id in projected_mental_model_ids & provisioned_by_id.keys()
+                }
+            )
+
+        if projected_directive_names:
+            provisioned = await memory.list_directives(
+                bank_id=bank_id,
+                active_only=False,
+                request_context=request_context,
+            )
+            provisioned_by_name = {item["name"]: item for item in provisioned}
+            existing_by_name.update(
+                {name: provisioned_by_name[name] for name in projected_directive_names & provisioned_by_name.keys()}
+            )
+
         if config_updates:
-            if authorize_config_update:
-                await memory.update_bank_config(bank_id, config_updates, request_context=request_context)
-            else:
-                await memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
-            config_applied = True
+            await memory.update_bank_config(bank_id, config_updates, request_context=request_context)
+
+        return await _apply_bank_template_resources(
+            memory,
+            bank_id,
+            manifest,
+            existing_by_id,
+            existing_by_name,
+            request_context,
+            config_applied=bool(config_updates),
+        )
+
+
+async def apply_default_bank_template_resources(
+    memory: MemoryEngine,
+    bank_id: str,
+    manifest: "BankTemplateManifest",
+    request_context: "RequestContext",
+) -> None:
+    """Apply only the resources from a server-owned default template."""
+    existing_by_id: dict[str, dict[str, Any]] = {}
+    if manifest.mental_models:
+        existing = await memory.list_mental_models(bank_id=bank_id, request_context=request_context)
+        existing_by_id = {model["id"]: model for model in existing}
+
+    existing_by_name: dict[str, dict[str, Any]] = {}
+    if manifest.directives:
+        existing_directives = await memory.list_directives(
+            bank_id=bank_id,
+            active_only=False,
+            request_context=request_context,
+        )
+        existing_by_name = {directive["name"]: directive for directive in existing_directives}
+
+    await _apply_bank_template_resources(
+        memory,
+        bank_id,
+        manifest,
+        existing_by_id,
+        existing_by_name,
+        request_context,
+        config_applied=False,
+    )
+
+
+async def _apply_bank_template_resources(
+    memory: MemoryEngine,
+    bank_id: str,
+    manifest: "BankTemplateManifest",
+    existing_mental_models: dict[str, dict[str, Any]],
+    existing_directives: dict[str, dict[str, Any]],
+    request_context: "RequestContext",
+    *,
+    config_applied: bool,
+) -> "BankTemplateImportResponse":
+    """Apply template resources after the caller has handled config and access."""
     created_ids: list[str] = []
     updated_ids: list[str] = []
     operation_ids: list[str] = []
 
     if manifest.mental_models:
-        # Fetch existing mental models to decide create vs update
-        existing = await memory.list_mental_models(bank_id=bank_id, request_context=request_context)
-        existing_by_id = {m["id"]: m for m in existing}
-
         for mm in manifest.mental_models:
-            if mm.id in existing_by_id:
+            if mm.id in existing_mental_models:
                 await memory.update_mental_model(
                     bank_id=bank_id,
                     mental_model_id=mm.id,
@@ -2577,16 +2732,12 @@ async def apply_bank_template_manifest(
     directives_updated: list[str] = []
 
     if manifest.directives:
-        existing_directives = await memory.list_directives(
-            bank_id=bank_id, active_only=False, request_context=request_context
-        )
-        existing_by_name = {d["name"]: d for d in existing_directives}
-
         for directive in manifest.directives:
-            if directive.name in existing_by_name:
+            if directive.name in existing_directives:
                 await memory.update_directive(
                     bank_id=bank_id,
-                    directive_id=existing_by_name[directive.name]["id"],
+                    directive_id=existing_directives[directive.name]["id"],
+                    name=directive.name,
                     content=directive.content,
                     priority=directive.priority,
                     is_active=directive.is_active,
@@ -5969,13 +6120,6 @@ def _register_routes(app: FastAPI):
                     directives_created=[d.name for d in (body.directives or [])],
                     dry_run=True,
                 )
-
-            config_updates = body.bank.get_config_updates() if body.bank else {}
-            if not config_updates:
-                # Config-bearing imports create the bank through update_bank_config
-                # only after validation. Other imports retain the existing
-                # eager-create behavior needed by directive-only manifests.
-                await app.state.memory._ensure_bank_exists(bank_id, request_context)
 
             return await apply_bank_template_manifest(
                 memory=app.state.memory,

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -465,7 +465,11 @@ class ConfigResolver:
     async def update_bank_config(
         self, bank_id: str, updates: dict[str, Any], context: RequestContext | None = None
     ) -> None:
-        """Validate and persist bank configuration overrides for an existing bank."""
+        """Validate and persist bank configuration overrides for an existing bank.
+
+        Bank creation belongs to ``MemoryEngine``; this raises ``ValueError`` if
+        the bank does not exist rather than silently discarding the overrides.
+        """
         normalized_updates = await self.validate_bank_config_updates(bank_id, updates, context)
         await self._persist_bank_config(bank_id, normalized_updates)
 
@@ -475,7 +479,7 @@ class ConfigResolver:
         # before reaching this persistence step. COALESCE guards against a NULL
         # config column (NULL || jsonb is NULL), which would drop the override.
         async with self._backend.acquire() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 f"""
                 UPDATE {fq_table("banks")}
                 SET config = COALESCE(config, '{{}}'::jsonb) || $1::jsonb,
@@ -485,6 +489,14 @@ class ConfigResolver:
                 json.dumps(normalized_updates),
                 bank_id,
             )
+
+        # A missing bank row matches zero rows, which would otherwise persist
+        # nothing while reporting success. Fail loudly instead: reaching here
+        # without the row means a caller skipped the engine's provisioning step.
+        # (The Oracle wrapper reshapes rowcount into the same "UPDATE <n>" form.)
+        updated = int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
+        if updated == 0:
+            raise ValueError(f"Cannot update config for bank '{bank_id}': the bank does not exist")
 
         logger.info(f"Updated bank config for {bank_id}: {list(normalized_updates.keys())}")
 

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -331,11 +331,17 @@ class ConfigResolver:
             logger.error(f"Failed to bulk-load bank configs: {e}")
         return result
 
-    async def update_bank_config(
-        self, bank_id: str, updates: dict[str, Any], context: RequestContext | None = None
-    ) -> None:
+    async def validate_bank_config_updates(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        context: RequestContext | None = None,
+        *,
+        projected_bank_overrides: dict[str, Any] | None = None,
+        check_permissions: bool = True,
+    ) -> dict[str, Any]:
         """
-        Update bank configuration overrides (with permission checking).
+        Normalize and validate bank configuration overrides.
 
         Args:
             bank_id: Bank identifier
@@ -344,9 +350,16 @@ class ConfigResolver:
                     or Python field format (llm_provider).
                     Only configurable fields are allowed.
             context: Request context for permission checking
+            projected_bank_overrides: Bank overrides to use as the validation
+                base instead of loading the current bank row.
+            check_permissions: Whether client field permissions apply to these
+                updates. Server-owned projected values set this to false.
+
+        Returns:
+            Normalized updates ready to persist.
 
         Raises:
-            ValueError: If attempting to override invalid/disallowed fields
+            ValueError: If attempting to override invalid/disallowed fields.
         """
         # Normalize keys
         normalized_updates = normalize_config_dict(updates)
@@ -378,7 +391,7 @@ class ConfigResolver:
                 )
 
         # PERMISSIONS: Check tenant/bank permissions
-        if self.tenant_extension and context:
+        if check_permissions and self.tenant_extension and context:
             try:
                 allowed_fields = await self.tenant_extension.get_allowed_config_fields(context, bank_id)
                 if allowed_fields is not None:  # None means "allow all"
@@ -427,7 +440,11 @@ class ConfigResolver:
         )
         if chunking_fields_updated:
             config_dict = await self._resolve_parent_config_dict(bank_id, context)
-            active_bank_overrides = await self._load_bank_config(bank_id)
+            active_bank_overrides = (
+                await self._load_bank_config(bank_id)
+                if projected_bank_overrides is None
+                else dict(projected_bank_overrides)
+            )
             for key, value in normalized_updates.items():
                 if key not in self._configurable_fields:
                     continue
@@ -443,16 +460,21 @@ class ConfigResolver:
             )
             _validate_retain_strategy_chunking(base_config, base_config.retain_strategies)
 
-        # Persist the override. Banks are created lazily (on first retain), so a
-        # PATCH that precedes any ingestion would otherwise UPDATE zero rows and
-        # silently no-op while returning 200. Ensure the bank row exists first
-        # (this also creates its per-bank vector indexes), then merge defensively:
-        # COALESCE guards against a NULL config column (NULL || jsonb is NULL),
-        # which would drop the override even when a row is updated.
-        from .engine.retain.fact_storage import ensure_bank_exists
+        return normalized_updates
 
+    async def update_bank_config(
+        self, bank_id: str, updates: dict[str, Any], context: RequestContext | None = None
+    ) -> None:
+        """Validate and persist bank configuration overrides for an existing bank."""
+        normalized_updates = await self.validate_bank_config_updates(bank_id, updates, context)
+        await self._persist_bank_config(bank_id, normalized_updates)
+
+    async def _persist_bank_config(self, bank_id: str, normalized_updates: dict[str, Any]) -> None:
+        """Persist already-validated overrides without changing bank lifecycle state."""
+        # Bank lifecycle belongs to MemoryEngine. Callers must create the row
+        # before reaching this persistence step. COALESCE guards against a NULL
+        # config column (NULL || jsonb is NULL), which would drop the override.
         async with self._backend.acquire() as conn:
-            await ensure_bank_exists(conn, bank_id, ops=self._backend.ops)
             await conn.execute(
                 f"""
                 UPDATE {fq_table("banks")}

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from hindsight_api.engine.memory_engine import BankLlmHealthInfo, Budget
     from hindsight_api.engine.response_models import RecallResult, ReflectResult
     from hindsight_api.engine.search.tags import TagsMatch
+    from hindsight_api.extensions import BankWriteOperation
     from hindsight_api.models import RequestContext
 
 
@@ -23,6 +24,14 @@ class BankConfigState:
 
     config: dict[str, Any]
     overrides: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BankTemplateImportWrite:
+    """One bank-write decision reserved for a specific imported resource."""
+
+    operation: "BankWriteOperation"
+    target: str | None = None
 
 
 class MemoryEngineInterface(ABC):

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -6,6 +6,7 @@ authentication when a TenantExtension is configured.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,14 @@ if TYPE_CHECKING:
     from hindsight_api.engine.response_models import RecallResult, ReflectResult
     from hindsight_api.engine.search.tags import TagsMatch
     from hindsight_api.models import RequestContext
+
+
+@dataclass(frozen=True)
+class BankConfigState:
+    """Resolved bank configuration and its bank-level overrides."""
+
+    config: dict[str, Any]
+    overrides: dict[str, Any]
 
 
 class MemoryEngineInterface(ABC):
@@ -178,6 +187,37 @@ class MemoryEngineInterface(ABC):
             or None when create_if_missing=False and the bank does not
             exist.
         """
+        ...
+
+    @abstractmethod
+    async def get_bank_config(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Return resolved configuration after authenticating and authorizing the read."""
+        ...
+
+    @abstractmethod
+    async def update_bank_config(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Create a bank if needed and persist validated configuration overrides."""
+        ...
+
+    @abstractmethod
+    async def reset_bank_config(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Remove all bank configuration overrides after authorization."""
         ...
 
     @abstractmethod
@@ -600,6 +640,8 @@ class MemoryEngineInterface(ABC):
         *,
         name: str | None = None,
         mission: str | None = None,
+        config_updates: dict[str, Any] | None = None,
+        create_if_missing: bool = True,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """
@@ -609,6 +651,9 @@ class MemoryEngineInterface(ABC):
             bank_id: The memory bank ID.
             name: New bank name (optional).
             mission: New mission text (optional, replaces existing).
+            config_updates: Bank configuration overrides to apply with the profile update.
+            create_if_missing: Create a missing bank when True; otherwise raise
+                a 404 operation error.
             request_context: Request context for authentication.
 
         Returns:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast, overlo
 
 import asyncpg
 import httpx
+from pydantic import ValidationError
 
 from .._vector_index import ann_search_tuning_settings, configured_vector_extension
 from ..cancellation import OperationCancelledError
@@ -346,7 +347,7 @@ def validate_sql_schema(sql: str) -> None:
 
 from .cross_encoder import CrossEncoderModel
 from .embeddings import Embeddings, create_embeddings_from_env
-from .interface import MemoryEngineInterface
+from .interface import BankConfigState, MemoryEngineInterface
 
 if TYPE_CHECKING:
     from hindsight_api.extensions import OperationValidatorExtension, TenantExtension, ValidationResult
@@ -9161,6 +9162,20 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_BANK_PROFILE, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        return await self._get_bank_profile_authenticated(
+            bank_id,
+            request_context=request_context,
+            create_if_missing=create_if_missing,
+        )
+
+    async def _get_bank_profile_authenticated(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+        create_if_missing: bool,
+    ) -> dict[str, Any] | None:
+        """Load a profile after the caller has authenticated and authorized its read."""
         backend = await self._get_backend()
         if not create_if_missing:
             existing = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
@@ -9250,6 +9265,155 @@ class MemoryEngine(MemoryEngineInterface):
             await self._apply_default_bank_template(bank_id, request_context)
         return result.created
 
+    async def get_bank_config(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Return resolved bank configuration after read authorization."""
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            context = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.GET_BANK_CONFIG,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(context))
+        return await self._get_bank_config_authenticated(bank_id, request_context)
+
+    async def update_bank_config(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Create a bank if needed and persist validated configuration overrides."""
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.UPDATE_BANK_CONFIG,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+        await self._update_bank_config_authenticated(
+            bank_id,
+            updates,
+            request_context=request_context,
+        )
+        return await self._get_bank_config_authenticated(bank_id, request_context)
+
+    async def reset_bank_config(
+        self,
+        bank_id: str,
+        *,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Remove all bank configuration overrides after authorization."""
+        await self._authenticate_tenant(request_context)
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            context = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.RESET_BANK_CONFIG,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(context))
+        await self._config_resolver.reset_bank_config(bank_id)
+        return await self._get_bank_config_authenticated(bank_id, request_context)
+
+    async def _get_bank_config_authenticated(
+        self,
+        bank_id: str,
+        request_context: "RequestContext",
+    ) -> BankConfigState:
+        """Load config after the caller has established tenant and operation access."""
+        config = await self._config_resolver.get_bank_config(bank_id, request_context)
+        overrides = await self._config_resolver._load_bank_config(bank_id)
+        return BankConfigState(config=config, overrides=overrides)
+
+    async def _update_bank_config_authenticated(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        *,
+        request_context: "RequestContext",
+    ) -> None:
+        """Persist config after the caller has authenticated and authorized it."""
+        normalized_updates = await self._validate_bank_config_updates(
+            bank_id,
+            updates,
+            request_context=request_context,
+        )
+
+        # Validate before creating the bank so rejected updates do not leave behind
+        # an otherwise empty bank. Creation stays in the engine so every caller
+        # shares its lifecycle hooks.
+        await self._ensure_bank_exists(bank_id, request_context)
+        await self._config_resolver._persist_bank_config(bank_id, normalized_updates)
+
+    async def _validate_bank_config_updates(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        *,
+        request_context: "RequestContext",
+        bank_exists: bool | None = None,
+    ) -> dict[str, Any]:
+        """Validate and normalize config without creating a bank or persisting."""
+
+        # Keep API and MCP configuration updates consistent, including the
+        # endpoint-specific policy validation that existed before this method.
+        if "memory_defense" in updates and updates["memory_defense"] is not None:
+            from hindsight_api.extensions import OperationValidationError
+            from hindsight_api.extensions.memory_defense import parse_policy
+
+            try:
+                parse_policy(updates["memory_defense"])
+            except ValueError as exc:
+                raise OperationValidationError(f"invalid memory_defense policy: {exc}", status_code=422) from exc
+
+        if bank_exists is None:
+            backend = await self._get_backend()
+            bank_exists = bool(await bank_utils.get_bank_profile_if_exists(backend, bank_id))
+
+        projected_bank_overrides: dict[str, Any] | None = None
+        if not bank_exists:
+            from hindsight_api.api.http import load_default_bank_template_manifest
+
+            try:
+                default_manifest = load_default_bank_template_manifest()
+            except (ValueError, ValidationError):
+                default_manifest = None
+            default_updates = (
+                default_manifest.bank.get_config_updates() if default_manifest and default_manifest.bank else {}
+            )
+            if default_updates:
+                projected_bank_overrides = await self._config_resolver.validate_bank_config_updates(
+                    bank_id,
+                    default_updates,
+                    request_context,
+                    projected_bank_overrides={},
+                    # The default template is server-owned. Its values are
+                    # needed only as the base for validating the client update,
+                    # so client field permissions must not apply to them.
+                    check_permissions=False,
+                )
+
+        return await self._config_resolver.validate_bank_config_updates(
+            bank_id,
+            updates,
+            request_context,
+            projected_bank_overrides=projected_bank_overrides,
+        )
+
     async def _apply_default_bank_template(
         self,
         bank_id: str,
@@ -9262,23 +9426,14 @@ class MemoryEngine(MemoryEngineInterface):
         cannot wedge bank creation across all callers. Misconfiguration is
         still surfaced loudly via `logger.error`.
         """
-        from ..config import get_config
-
-        template_dict = get_config().default_bank_template
-        if not template_dict:
-            return
-
         # Lazy import to avoid a cycle (http.py imports memory_engine).
-        from pydantic import ValidationError
-
         from hindsight_api.api.http import (
-            BankTemplateManifest,
             apply_bank_template_manifest,
-            validate_bank_template,
+            load_default_bank_template_manifest,
         )
 
         try:
-            manifest = BankTemplateManifest.model_validate(template_dict)
+            manifest = load_default_bank_template_manifest()
         except ValidationError as e:
             errors = [f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}" for err in e.errors()]
             logger.error(
@@ -9286,13 +9441,13 @@ class MemoryEngine(MemoryEngineInterface):
                 f"and will be ignored for bank '{bank_id}': {'; '.join(errors)}"
             )
             return
-
-        semantic_errors = validate_bank_template(manifest)
-        if semantic_errors:
+        except ValueError as e:
             logger.error(
                 "HINDSIGHT_API_DEFAULT_BANK_TEMPLATE failed semantic validation "
-                f"and will be ignored for bank '{bank_id}': {'; '.join(semantic_errors)}"
+                f"and will be ignored for bank '{bank_id}': {e}"
             )
+            return
+        if manifest is None:
             return
 
         try:
@@ -9301,6 +9456,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id,
                 manifest=manifest,
                 request_context=request_context,
+                authorize_config_update=False,
             )
             logger.info(f"Applied HINDSIGHT_API_DEFAULT_BANK_TEMPLATE to newly-created bank '{bank_id}'")
         except Exception as e:
@@ -12709,44 +12865,106 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         name: str | None = None,
         mission: str | None = None,
+        config_updates: dict[str, Any] | None = None,
+        create_if_missing: bool = True,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
-        """Update bank name and/or mission."""
+        """Update bank profile and configuration with one tenant authentication."""
         await self._authenticate_tenant(request_context)
-        if self._operation_validator:
+
+        backend = None
+        if not create_if_missing:
+            if self._operation_validator:
+                from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+                ctx = BankReadContext(
+                    bank_id=bank_id,
+                    operation=BankReadOperation.GET_BANK_PROFILE,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                exists = await conn.fetchval(f"SELECT 1 FROM {fq_table('banks')} WHERE bank_id = $1", bank_id)
+            if exists is None:
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
+
+        if self._operation_validator and (name is not None or mission is not None):
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
             ctx = BankWriteContext(
                 bank_id=bank_id, operation=BankWriteOperation.UPDATE_BANK, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        backend = await self._get_backend()
 
-        async with acquire_with_retry(backend) as conn:
-            if name is not None:
+        if self._operation_validator and config_updates:
+            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+
+            ctx = BankWriteContext(
+                bank_id=bank_id,
+                operation=BankWriteOperation.UPDATE_BANK_CONFIG,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
+        normalized_config_updates = None
+        if config_updates:
+            normalized_config_updates = await self._validate_bank_config_updates(
+                bank_id,
+                config_updates,
+                request_context=request_context,
+                bank_exists=True if not create_if_missing else None,
+            )
+
+        if self._operation_validator and create_if_missing:
+            from hindsight_api.extensions import BankReadContext, BankReadOperation
+
+            ctx = BankReadContext(
+                bank_id=bank_id,
+                operation=BankReadOperation.GET_BANK_PROFILE,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+
+        # All validation is complete before any creation or write. PATCH-style
+        # callers skip creation so a concurrent delete cannot resurrect the bank.
+        if create_if_missing:
+            await self._ensure_bank_exists(bank_id, request_context)
+
+        if normalized_config_updates is not None:
+            await self._config_resolver._persist_bank_config(bank_id, normalized_config_updates)
+
+        if backend is None:
+            backend = await self._get_backend()
+
+        if name is not None or mission is not None:
+            async with acquire_with_retry(backend) as conn:
                 await conn.execute(
                     f"""
                     UPDATE {fq_table("banks")}
-                    SET name = $2, updated_at = NOW()
+                    SET name = COALESCE($2, name),
+                        mission = COALESCE($3, mission),
+                        updated_at = NOW()
                     WHERE bank_id = $1
                     """,
                     bank_id,
                     name,
-                )
-
-            if mission is not None:
-                await conn.execute(
-                    f"""
-                    UPDATE {fq_table("banks")}
-                    SET mission = $2, updated_at = NOW()
-                    WHERE bank_id = $1
-                    """,
-                    bank_id,
                     mission,
                 )
+        profile = await self._get_bank_profile_authenticated(
+            bank_id,
+            request_context=request_context,
+            create_if_missing=False,
+        )
+        if profile is None:
+            if not create_if_missing:
+                from hindsight_api.extensions import OperationValidationError
 
-        # Return updated profile
-        return await self.get_bank_profile(bank_id, request_context=request_context)
+                raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
+            raise RuntimeError(f"Bank '{bank_id}' was not found after updating it")
+        return profile
 
     # =========================================================================
     # Webhook configuration methods

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11,6 +11,7 @@ This implements a sophisticated memory architecture that combines:
 
 import asyncio
 import contextvars
+import copy
 import functools
 import inspect
 import json
@@ -18,7 +19,8 @@ import logging
 import sys
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast, overload
@@ -78,6 +80,26 @@ _current_schema: contextvars.ContextVar[str | None] = contextvars.ContextVar("cu
 # downstream provider calls can attribute spend per bank — e.g. tagging the OpenAI `user`
 # field for cost gateways. None outside a bank-scoped operation.
 _current_bank_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("current_bank_id", default=None)
+
+
+@dataclass
+class _BankTemplateImportAuthorizationState:
+    """Request-local import decisions consumed by the matching engine calls."""
+
+    engine: "MemoryEngine"
+    request_context: "RequestContext"
+    task: asyncio.Task[Any]
+    bank_id: str
+    requested_config_updates: dict[str, Any]
+    normalized_config_updates: dict[str, Any]
+    bank_write_remaining: dict["BankTemplateImportWrite", int]
+    mental_model_refresh_remaining: dict[str, int]
+    mental_model_get_remaining: dict[str, int]
+
+
+_bank_template_import_authorization: contextvars.ContextVar[_BankTemplateImportAuthorizationState | None] = (
+    contextvars.ContextVar("bank_template_import_authorization", default=None)
+)
 MENTAL_MODEL_PENDING_CONTENT = "Generating content..."
 
 
@@ -347,10 +369,15 @@ def validate_sql_schema(sql: str) -> None:
 
 from .cross_encoder import CrossEncoderModel
 from .embeddings import Embeddings, create_embeddings_from_env
-from .interface import BankConfigState, MemoryEngineInterface
+from .interface import BankConfigState, BankTemplateImportWrite, MemoryEngineInterface
 
 if TYPE_CHECKING:
-    from hindsight_api.extensions import OperationValidatorExtension, TenantExtension, ValidationResult
+    from hindsight_api.extensions import (
+        BankWriteOperation,
+        OperationValidatorExtension,
+        TenantExtension,
+        ValidationResult,
+    )
     from hindsight_api.models import RequestContext
 
     from .audit import AuditLogListResponse, AuditLogStatsResponse
@@ -9293,6 +9320,11 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> BankConfigState:
         """Create a bank if needed and persist validated configuration overrides."""
         await self._authenticate_tenant(request_context)
+        preauthorized_updates = self._consume_preauthorized_config_update(bank_id, updates, request_context)
+        if preauthorized_updates is not None:
+            await self._config_resolver._persist_bank_config(bank_id, preauthorized_updates)
+            return await self._get_bank_config_authenticated(bank_id, request_context)
+
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
@@ -9338,6 +9370,179 @@ class MemoryEngine(MemoryEngineInterface):
         config = await self._config_resolver.get_bank_config(bank_id, request_context)
         overrides = await self._config_resolver._load_bank_config(bank_id)
         return BankConfigState(config=config, overrides=overrides)
+
+    @asynccontextmanager
+    async def bank_template_import_authorization(
+        self,
+        bank_id: str,
+        *,
+        config_updates: dict[str, Any],
+        bank_writes: list[BankTemplateImportWrite],
+        mental_model_ids: list[str],
+        bank_exists: bool,
+        request_context: "RequestContext",
+    ) -> AsyncIterator[None]:
+        """Preauthorize an entire import, create the bank, and reuse each decision once.
+
+        Validators may reserve quota or make time-sensitive decisions, so the
+        subsequent engine calls consume these request-local decisions instead of
+        invoking the hooks a second time. The scope is installed only after bank
+        creation, keeping server-owned default-template work outside it.
+        """
+        await self._authenticate_tenant(request_context)
+        normalized_updates = (
+            await self._validate_bank_config_updates(
+                bank_id,
+                config_updates,
+                request_context=request_context,
+                bank_exists=bank_exists,
+            )
+            if config_updates
+            else {}
+        )
+
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext
+            from hindsight_api.extensions.operation_validator import MentalModelGetContext, MentalModelRefreshContext
+
+            for write in bank_writes:
+                context = BankWriteContext(
+                    bank_id=bank_id,
+                    operation=write.operation,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(context))
+
+            for mental_model_id in mental_model_ids:
+                refresh_context = MentalModelRefreshContext(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_mental_model_refresh(refresh_context))
+                get_context = MentalModelGetContext(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_mental_model_get(get_context))
+
+        if mental_model_ids:
+            self._raise_if_mental_model_refresh_unavailable()
+
+        # Create the bank only after every validation succeeds. Applying the default
+        # template before installing the scope prevents its operations from
+        # consuming permissions granted specifically for this import.
+        await self._ensure_bank_exists(bank_id, request_context)
+
+        bank_write_remaining: dict[BankTemplateImportWrite, int] = {}
+        for write in bank_writes:
+            bank_write_remaining[write] = bank_write_remaining.get(write, 0) + 1
+        refresh_remaining: dict[str, int] = {}
+        for mental_model_id in mental_model_ids:
+            refresh_remaining[mental_model_id] = refresh_remaining.get(mental_model_id, 0) + 1
+        task = asyncio.current_task()
+        assert task is not None
+        state = _BankTemplateImportAuthorizationState(
+            engine=self,
+            request_context=request_context,
+            task=task,
+            bank_id=bank_id,
+            requested_config_updates=copy.deepcopy(config_updates),
+            normalized_config_updates=normalized_updates,
+            bank_write_remaining=bank_write_remaining,
+            mental_model_refresh_remaining=dict(refresh_remaining),
+            mental_model_get_remaining=dict(refresh_remaining),
+        )
+        token = _bank_template_import_authorization.set(state)
+        try:
+            yield
+        finally:
+            _bank_template_import_authorization.reset(token)
+
+    def _consume_preauthorized_bank_write(
+        self,
+        bank_id: str,
+        operation: "BankWriteOperation",
+        request_context: "RequestContext",
+        *,
+        target: str | None = None,
+    ) -> bool:
+        """Consume the decision reserved for this operation and resource."""
+        state = self._get_bank_template_import_authorization_state(bank_id, request_context)
+        if state is None:
+            return False
+        write = BankTemplateImportWrite(operation=operation, target=target)
+        remaining = state.bank_write_remaining.get(write, 0)
+        if remaining <= 0:
+            raise RuntimeError(
+                f"Bank-template import write was not preauthorized or was already consumed: "
+                f"{operation.value} target={target!r}"
+            )
+        state.bank_write_remaining[write] = remaining - 1
+        return True
+
+    def _consume_preauthorized_mental_model_operation(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        *,
+        refresh: bool,
+        request_context: "RequestContext",
+    ) -> bool:
+        """Consume one matching mental-model refresh or get decision."""
+        state = self._get_bank_template_import_authorization_state(bank_id, request_context)
+        if state is None:
+            return False
+        remaining_by_id = state.mental_model_refresh_remaining if refresh else state.mental_model_get_remaining
+        remaining = remaining_by_id.get(mental_model_id, 0)
+        if remaining <= 0:
+            return False
+        remaining_by_id[mental_model_id] = remaining - 1
+        return True
+
+    def _consume_preauthorized_config_update(
+        self,
+        bank_id: str,
+        updates: dict[str, Any],
+        request_context: "RequestContext",
+    ) -> dict[str, Any] | None:
+        """Return prevalidated config when this is the authorized import write."""
+        state = self._get_bank_template_import_authorization_state(bank_id, request_context)
+        if state is None:
+            return None
+        if state.requested_config_updates != updates:
+            raise RuntimeError("Imported bank config changed after it was preauthorized")
+
+        from hindsight_api.extensions import BankWriteOperation
+
+        if not self._consume_preauthorized_bank_write(
+            bank_id,
+            BankWriteOperation.UPDATE_BANK_CONFIG,
+            request_context,
+        ):
+            raise RuntimeError("Imported bank config authorization scope disappeared")
+        return state.normalized_config_updates
+
+    def _get_bank_template_import_authorization_state(
+        self,
+        bank_id: str,
+        request_context: "RequestContext",
+    ) -> _BankTemplateImportAuthorizationState | None:
+        """Return the scope only to the task and objects that created it."""
+        state = _bank_template_import_authorization.get()
+        if (
+            state is None
+            or state.engine is not self
+            or state.request_context is not request_context
+            # Context variables propagate into child tasks. Requiring the
+            # originating task prevents a background task from spending the
+            # parent's mutable authorization counters.
+            or state.task is not asyncio.current_task()
+            or state.bank_id != bank_id
+        ):
+            return None
+        return state
 
     async def _update_bank_config_authenticated(
         self,
@@ -9428,7 +9633,7 @@ class MemoryEngine(MemoryEngineInterface):
         """
         # Lazy import to avoid a cycle (http.py imports memory_engine).
         from hindsight_api.api.http import (
-            apply_bank_template_manifest,
+            apply_default_bank_template_resources,
             load_default_bank_template_manifest,
         )
 
@@ -9451,12 +9656,17 @@ class MemoryEngine(MemoryEngineInterface):
             return
 
         try:
-            await apply_bank_template_manifest(
+            config_updates = manifest.bank.get_config_updates() if manifest.bank else {}
+            if config_updates:
+                # The bank was created before this server-owned hook runs, so
+                # bank creation and client UPDATE_BANK_CONFIG checks
+                # do not belong in this persistence step.
+                await self._config_resolver.update_bank_config(bank_id, config_updates, request_context)
+            await apply_default_bank_template_resources(
                 memory=self,
                 bank_id=bank_id,
                 manifest=manifest,
                 request_context=request_context,
-                authorize_config_update=False,
             )
             logger.info(f"Applied HINDSIGHT_API_DEFAULT_BANK_TEMPLATE to newly-created bank '{bank_id}'")
         except Exception as e:
@@ -10990,12 +11200,18 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions.operation_validator import MentalModelGetContext
 
-            ctx = MentalModelGetContext(
-                bank_id=bank_id,
-                mental_model_id=mental_model_id,
+            if not self._consume_preauthorized_mental_model_operation(
+                bank_id,
+                mental_model_id,
+                refresh=False,
                 request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_mental_model_get(ctx))
+            ):
+                ctx = MentalModelGetContext(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_mental_model_get(ctx))
 
         backend = await self._get_backend()
 
@@ -11122,10 +11338,16 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id, operation=BankWriteOperation.CREATE_MENTAL_MODEL, request_context=request_context
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if not self._consume_preauthorized_bank_write(
+                bank_id,
+                BankWriteOperation.CREATE_MENTAL_MODEL,
+                request_context,
+                target=mental_model_id,
+            ):
+                ctx = BankWriteContext(
+                    bank_id=bank_id, operation=BankWriteOperation.CREATE_MENTAL_MODEL, request_context=request_context
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
         # Generate embedding for the content
@@ -11682,10 +11904,16 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id, operation=BankWriteOperation.UPDATE_MENTAL_MODEL, request_context=request_context
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if not self._consume_preauthorized_bank_write(
+                bank_id,
+                BankWriteOperation.UPDATE_MENTAL_MODEL,
+                request_context,
+                target=mental_model_id,
+            ):
+                ctx = BankWriteContext(
+                    bank_id=bank_id, operation=BankWriteOperation.UPDATE_MENTAL_MODEL, request_context=request_context
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -12271,10 +12499,16 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id, operation=BankWriteOperation.CREATE_DIRECTIVE, request_context=request_context
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if not self._consume_preauthorized_bank_write(
+                bank_id,
+                BankWriteOperation.CREATE_DIRECTIVE,
+                request_context,
+                target=name,
+            ):
+                ctx = BankWriteContext(
+                    bank_id=bank_id, operation=BankWriteOperation.CREATE_DIRECTIVE, request_context=request_context
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -12327,10 +12561,16 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id, operation=BankWriteOperation.UPDATE_DIRECTIVE, request_context=request_context
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+            if not self._consume_preauthorized_bank_write(
+                bank_id,
+                BankWriteOperation.UPDATE_DIRECTIVE,
+                request_context,
+                target=name,
+            ):
+                ctx = BankWriteContext(
+                    bank_id=bank_id, operation=BankWriteOperation.UPDATE_DIRECTIVE, request_context=request_context
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
         # Build update query dynamically
@@ -13863,14 +14103,7 @@ class MemoryEngine(MemoryEngineInterface):
         Returns:
             Dict with operation_id
         """
-        # Block mental model refresh when LLM provider is "none"
-        if self._llm_config.provider == "none":
-            from .providers.none_llm import LLMNotAvailableError
-
-            raise LLMNotAvailableError(
-                "Mental model refresh requires an LLM provider. Current provider is set to 'none'. "
-                "Set HINDSIGHT_API_LLM_PROVIDER to a real provider (e.g., openai, anthropic, gemini)."
-            )
+        self._raise_if_mental_model_refresh_unavailable()
 
         await self._authenticate_tenant(request_context)
 
@@ -13878,12 +14111,18 @@ class MemoryEngine(MemoryEngineInterface):
         if self._operation_validator:
             from hindsight_api.extensions.operation_validator import MentalModelRefreshContext
 
-            ctx = MentalModelRefreshContext(
-                bank_id=bank_id,
-                mental_model_id=mental_model_id,
+            if not self._consume_preauthorized_mental_model_operation(
+                bank_id,
+                mental_model_id,
+                refresh=True,
                 request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_mental_model_refresh(ctx))
+            ):
+                ctx = MentalModelRefreshContext(
+                    bank_id=bank_id,
+                    mental_model_id=mental_model_id,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_mental_model_refresh(ctx))
 
         # Verify mental model exists
         mental_model = await self.get_mental_model(bank_id, mental_model_id, request_context=request_context)
@@ -13907,4 +14146,16 @@ class MemoryEngine(MemoryEngineInterface):
             task_payload=task_payload,
             result_metadata={"mental_model_id": mental_model_id, "name": mental_model["name"]},
             dedupe_by_bank=False,
+        )
+
+    def _raise_if_mental_model_refresh_unavailable(self) -> None:
+        """Reject refresh work before callers make any dependent writes."""
+        if self._llm_config.provider != "none":
+            return
+
+        from .providers.none_llm import LLMNotAvailableError
+
+        raise LLMNotAvailableError(
+            "Mental model refresh requires an LLM provider. Current provider is set to 'none'. "
+            "Set HINDSIGHT_API_LLM_PROVIDER to a real provider (e.g., openai, anthropic, gemini)."
         )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -13174,7 +13174,17 @@ class MemoryEngine(MemoryEngineInterface):
             await self._ensure_bank_exists(bank_id, request_context)
 
         if normalized_config_updates is not None:
-            await self._config_resolver._persist_bank_config(bank_id, normalized_config_updates)
+            try:
+                await self._config_resolver._persist_bank_config(bank_id, normalized_config_updates)
+            except ValueError:
+                # Update-only callers verified the bank above, so the row can only
+                # be gone if it was deleted concurrently. Surface that as the same
+                # 404 the final profile read below would produce, not a 400.
+                if create_if_missing:
+                    raise
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404) from None
 
         if backend is None:
             backend = await self._get_backend()

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -1235,20 +1235,16 @@ def _register_create_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsCo
         """
         try:
             request_context = _get_request_context(config)
-            # create_bank may auto-create the bank; validate that explicit
-            # creation permission before reading the resulting profile.
-            await memory._ensure_bank_exists(bank_id, request_context)
-            profile = await memory.get_bank_profile(bank_id, request_context=request_context)
-
-            # Update name/mission if provided
             if name is not None or mission is not None:
-                await memory.update_bank(
+                profile = await memory.update_bank(
                     bank_id,
                     name=name,
                     mission=mission,
                     request_context=request_context,
                 )
-                # Fetch updated profile
+            else:
+                # The public profile API owns bank creation and its lifecycle
+                # validation when no profile fields need updating.
                 profile = await memory.get_bank_profile(bank_id, request_context=request_context)
 
             # Serialize disposition if it's a Pydantic model

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -3290,28 +3290,21 @@ async def _do_update_bank(
     Args:
         name: Display name (stored in banks table).
         mission: Deprecated alias for reflect_mission — mapped into config_updates.
-        config_updates: Arbitrary config overrides passed to config_resolver.update_bank_config().
+        config_updates: Arbitrary config overrides passed to MemoryEngine.update_bank_config().
             Supports all configurable fields (retain_mission, disposition_*, etc.).
             The config resolver validates keys and rejects non-configurable/credential fields.
     """
-    # Update display name via engine (stored in DB banks table)
-    if name is not None:
-        await memory.update_bank(
-            target_bank,
-            name=name,
-            request_context=request_context,
-        )
-
     # Merge deprecated mission alias into config_updates as reflect_mission
     effective_config: dict[str, Any] = dict(config_updates) if config_updates else {}
     if mission is not None and "reflect_mission" not in effective_config:
         effective_config["reflect_mission"] = mission
 
-    if effective_config:
-        await memory._config_resolver.update_bank_config(target_bank, effective_config, request_context)
-
-    # Return updated profile
-    return await memory.get_bank_profile(target_bank, request_context=request_context)
+    return await memory.update_bank(
+        target_bank,
+        name=name,
+        config_updates=effective_config or None,
+        request_context=request_context,
+    )
 
 
 def _register_update_bank(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig) -> None:

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -1,11 +1,14 @@
 """Integration tests for bank template import/export endpoints."""
 
+from datetime import datetime
+
+import httpx
 import pytest
 import pytest_asyncio
-import httpx
-from datetime import datetime
+
 from hindsight_api.api import create_app
 from hindsight_api.api.http import BankTemplateManifest, validate_bank_template
+from hindsight_api.models import RequestContext
 
 
 @pytest_asyncio.fixture
@@ -681,6 +684,83 @@ class TestDefaultBankTemplateEnvVar:
         assert dir_resp.status_code == 200
         names = [d["name"] for d in dir_resp.json()["items"]]
         assert "Default Env Directive" in names
+
+    @pytest.mark.asyncio
+    async def test_import_updates_resources_provisioned_by_default_template(
+        self,
+        api_client,
+        bank_id,
+        _patched_default_template,
+    ):
+        """Import authorization projects default-template resources on a missing bank."""
+        response = await api_client.post(
+            f"/v1/default/banks/{bank_id}/import",
+            json={
+                "version": "1",
+                "mental_models": [
+                    {
+                        "id": "default-env-model",
+                        "name": "Imported Model",
+                        "source_query": "What did the import request?",
+                    }
+                ],
+                "directives": [
+                    {
+                        "name": "Default Env Directive",
+                        "content": "Follow the imported behavior.",
+                        "priority": 9,
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["mental_models_updated"] == ["default-env-model"]
+        assert body["mental_models_created"] == []
+        assert body["directives_updated"] == ["Default Env Directive"]
+        assert body["directives_created"] == []
+
+    @pytest.mark.asyncio
+    async def test_import_validates_config_against_projected_default_template(
+        self,
+        api_client,
+        memory,
+        bank_id,
+        monkeypatch,
+    ):
+        """A client config rejected against the projected defaults leaves no bank."""
+        from hindsight_api.config import _get_raw_config
+
+        raw = _get_raw_config()
+        monkeypatch.setattr(
+            raw,
+            "default_bank_template",
+            {
+                "version": "1",
+                "bank": {"retain_chunk_size": raw.retain_max_completion_tokens},
+            },
+        )
+
+        response = await api_client.post(
+            f"/v1/default/banks/{bank_id}/import",
+            json={
+                "version": "1",
+                "bank": {
+                    "retain_strategies": {
+                        "projected-default": {"retain_extraction_mode": "concise"},
+                    }
+                },
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        profile = await memory.get_bank_profile(
+            bank_id,
+            request_context=RequestContext(),
+            create_if_missing=False,
+        )
+        assert profile is None
 
     @pytest.mark.asyncio
     async def test_default_template_overrides_env_config_defaults(

--- a/hindsight-api-slim/tests/test_hierarchical_config.py
+++ b/hindsight-api-slim/tests/test_hierarchical_config.py
@@ -6,6 +6,7 @@ key normalization, API endpoints, validation, and caching.
 """
 
 import json
+import uuid
 
 import pytest
 
@@ -72,6 +73,9 @@ class FakeBankConfigConnection:
 
     async def execute(self, query, updates_json, bank_id):
         self.backend.config.update(json.loads(updates_json))
+        # Mirror the driver's "<CMD> <rowcount>" status: this fake stands in for
+        # a bank that already exists, so the UPDATE matches its single row.
+        return "UPDATE 1"
 
 
 @pytest.mark.asyncio
@@ -596,6 +600,24 @@ async def test_config_freshness_across_updates(memory, request_context):
 
     finally:
         await memory.delete_bank(bank1, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_update_bank_config_rejects_missing_bank(memory, request_context):
+    """The resolver must not report success while discarding the overrides.
+
+    Bank creation moved out of the resolver and into MemoryEngine, so a caller
+    that skips provisioning would otherwise UPDATE zero rows and silently no-op
+    while returning normally (the failure mode #1940 originally fixed).
+    """
+    bank_id = f"test-resolver-missing-bank-{uuid.uuid4().hex[:8]}"
+    resolver = ConfigResolver(backend=memory._backend)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        await resolver.update_bank_config(bank_id, {"enable_observations": False}, request_context)
+
+    profile = await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False)
+    assert profile is None
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1655,6 +1655,37 @@ async def test_patch_returns_404_when_bank_disappears_before_response_read(api_c
 
 
 @pytest.mark.asyncio
+async def test_patch_returns_404_when_bank_disappears_before_config_write(api_client, memory, monkeypatch):
+    """A delete racing the config write is not-found, not a validation error.
+
+    The resolver now raises when its UPDATE matches no rows, so an update-only
+    PATCH must map that to the same 404 as a missing bank rather than the 400
+    it uses for genuinely invalid config.
+    """
+    bank_id = f"patch_concurrent_delete_config_{datetime.now().timestamp()}"
+    response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+    assert response.status_code == 200, response.text
+    monkeypatch.setattr(
+        memory._config_resolver,
+        "_persist_bank_config",
+        AsyncMock(side_effect=ValueError(f"Cannot update config for bank '{bank_id}': the bank does not exist")),
+    )
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{bank_id}",
+        json={"name": "Changed", "reflect_mission": "Also changed"},
+    )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == f"Bank '{bank_id}' not found"
+
+    # The profile write must not have landed either — it runs after the config write.
+    profile = await api_client.get(f"/v1/default/banks/{bank_id}/profile")
+    assert profile.status_code == 200, profile.text
+    assert profile.json()["name"] == bank_id
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("reject_bank_write", "reject_refresh", "include_config"),
     [

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -4,6 +4,7 @@ Integration test for the complete Hindsight API.
 Tests all endpoints by starting a FastAPI server and making HTTP requests.
 """
 
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +13,7 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.engine.interface import BankTemplateImportWrite
 from hindsight_api.extensions import BankReadOperation, BankWriteOperation, OperationValidationError, ValidationResult
 from hindsight_api.models import RequestContext
 from tests.llm_judge import assert_meets_criteria
@@ -21,6 +23,7 @@ def _make_operation_validator(
     *,
     reject_bank_write: BankWriteOperation | None = None,
     reject_bank_read: BankReadOperation | None = None,
+    reject_mental_model_refresh: bool = False,
     reason: str = "operation is forbidden",
 ) -> MagicMock:
     """Build a complete async validator with one optional rejection."""
@@ -35,6 +38,12 @@ def _make_operation_validator(
             ValidationResult.reject(reason) if ctx.operation is reject_bank_read else ValidationResult.accept()
         )
     )
+    validator.validate_mental_model_refresh = AsyncMock(
+        return_value=ValidationResult.reject(reason) if reject_mental_model_refresh else ValidationResult.accept()
+    )
+    validator.validate_mental_model_get = AsyncMock(return_value=ValidationResult.accept())
+    validator.validate_create_bank = AsyncMock(return_value=ValidationResult.accept())
+    validator.on_mental_model_get_complete = AsyncMock()
     return validator
 
 
@@ -1643,6 +1652,309 @@ async def test_patch_returns_404_when_bank_disappears_before_response_read(api_c
 
     assert response.status_code == 404, response.text
     assert response.json()["detail"] == f"Bank '{bank_id}' not found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reject_bank_write", "reject_refresh", "include_config"),
+    [
+        (BankWriteOperation.CREATE_MENTAL_MODEL, False, True),
+        (None, True, False),
+    ],
+)
+async def test_import_authorization_rejection_does_not_create_bank(
+    api_client,
+    memory,
+    monkeypatch,
+    reject_bank_write,
+    reject_refresh,
+    include_config,
+):
+    """Every import authorization hook runs before bank creation."""
+    bank_id = f"import_authorization_rejection_{datetime.now().timestamp()}"
+    validator = _make_operation_validator(
+        reject_bank_write=reject_bank_write,
+        reject_mental_model_refresh=reject_refresh,
+        reason="mental model operation is forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    manifest = {
+        "version": "1",
+        "mental_models": [{"id": "import-model", "name": "Import", "source_query": "test"}],
+    }
+    if include_config:
+        manifest["bank"] = {"reflect_mission": "blocked"}
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json=manifest,
+    )
+    assert response.status_code == 403, response.text
+    await _assert_bank_missing(api_client, bank_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {
+            "version": "1",
+            "mental_models": [
+                {"id": "duplicate", "name": "First", "source_query": "first"},
+                {"id": "duplicate", "name": "Second", "source_query": "second"},
+            ],
+        },
+        {
+            "version": "1",
+            "directives": [
+                {"name": "duplicate", "content": "first"},
+                {"name": "duplicate", "content": "second"},
+            ],
+        },
+    ],
+)
+async def test_import_rejects_duplicate_items_before_bank_creation(api_client, manifest):
+    """Duplicate import keys fail semantic validation without creating a bank."""
+    bank_id = f"import_duplicate_{datetime.now().timestamp()}"
+    response = await api_client.post(f"/v1/default/banks/{bank_id}/import", json=manifest)
+    assert response.status_code == 400, response.text
+    assert "duplicate" in response.json()["detail"]
+
+    await _assert_bank_missing(api_client, bank_id)
+
+
+@pytest.mark.asyncio
+async def test_config_only_import_ensures_bank_once(api_client, memory, monkeypatch):
+    """The import context creates the bank before its config write."""
+    bank_id = f"import_single_bank_ensure_{datetime.now().timestamp()}"
+    ensure_bank_exists = AsyncMock(wraps=memory._ensure_bank_exists)
+    monkeypatch.setattr(memory, "_ensure_bank_exists", ensure_bank_exists)
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json={"version": "1", "bank": {"reflect_mission": "Import once"}},
+    )
+    assert response.status_code == 200, response.text
+    ensure_bank_exists.assert_awaited_once()
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_import_reuses_each_preauthorization_once(api_client, memory, monkeypatch):
+    """Import validators run once even though engine methods enforce them normally."""
+    bank_id = f"import_single_authorization_{datetime.now().timestamp()}"
+    validator = _make_operation_validator()
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(
+        memory,
+        "_submit_async_operation",
+        AsyncMock(return_value={"operation_id": "import-refresh"}),
+    )
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json={
+            "version": "1",
+            "bank": {"reflect_mission": "Import once"},
+            "mental_models": [{"id": "import-model", "name": "Import", "source_query": "test"}],
+            "directives": [{"name": "Be concise", "content": "Prefer short answers."}],
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
+        BankWriteOperation.UPDATE_BANK_CONFIG,
+        BankWriteOperation.CREATE_MENTAL_MODEL,
+        BankWriteOperation.CREATE_DIRECTIVE,
+    ]
+    validator.validate_mental_model_refresh.assert_awaited_once()
+    validator.validate_mental_model_get.assert_awaited_once()
+    validator.validate_create_bank.assert_awaited_once()
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_import_write_preauthorization_is_bound_to_resource_context_and_task(memory, monkeypatch):
+    """A cached grant can only be spent by its exact resource and task."""
+    bank_id = f"import_scoped_authorization_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    validator = _make_operation_validator()
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    write = BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, "allowed")
+
+    async with memory.bank_template_import_authorization(
+        bank_id,
+        config_updates={},
+        bank_writes=[write],
+        mental_model_ids=[],
+        bank_exists=True,
+        request_context=request_context,
+    ):
+        with pytest.raises(RuntimeError, match="not preauthorized"):
+            memory._consume_preauthorized_bank_write(
+                bank_id,
+                write.operation,
+                request_context,
+                target="different",
+            )
+        assert not memory._consume_preauthorized_bank_write(
+            bank_id,
+            write.operation,
+            RequestContext(),
+            target=write.target,
+        )
+
+        async def consume_in_child_task() -> bool:
+            return memory._consume_preauthorized_bank_write(
+                bank_id,
+                write.operation,
+                request_context,
+                target=write.target,
+            )
+
+        assert not await asyncio.create_task(consume_in_child_task())
+        assert memory._consume_preauthorized_bank_write(
+            bank_id,
+            write.operation,
+            request_context,
+            target=write.target,
+        )
+
+    validator.validate_bank_write.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_import_config_preauthorization_rejects_mismatch_and_reuse(memory, monkeypatch):
+    """Config drift or reuse cannot silently trigger a second validator call."""
+    bank_id = f"import_config_authorization_mismatch_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    validator = _make_operation_validator()
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    updates = {"reflect_mission": "Authorized"}
+
+    async with memory.bank_template_import_authorization(
+        bank_id,
+        config_updates=updates,
+        bank_writes=[BankTemplateImportWrite(BankWriteOperation.UPDATE_BANK_CONFIG)],
+        mental_model_ids=[],
+        bank_exists=True,
+        request_context=request_context,
+    ):
+        with pytest.raises(RuntimeError, match="changed after it was preauthorized"):
+            await memory.update_bank_config(
+                bank_id,
+                {"reflect_mission": "Different"},
+                request_context=request_context,
+            )
+        await memory.update_bank_config(bank_id, updates, request_context=request_context)
+        with pytest.raises(RuntimeError, match="already consumed"):
+            await memory.update_bank_config(bank_id, updates, request_context=request_context)
+
+    validator.validate_bank_write.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("default_template", "manifest", "create_operation", "created_field", "created_key"),
+    [
+        (
+            {
+                "version": "1",
+                "mental_models": [{"id": "shared-model", "name": "Default", "source_query": "default"}],
+            },
+            {
+                "version": "1",
+                "mental_models": [{"id": "shared-model", "name": "Imported", "source_query": "imported"}],
+            },
+            BankWriteOperation.CREATE_MENTAL_MODEL,
+            "mental_models_created",
+            "shared-model",
+        ),
+        (
+            {
+                "version": "1",
+                "directives": [{"name": "Shared directive", "content": "Default"}],
+            },
+            {
+                "version": "1",
+                "directives": [{"name": "Shared directive", "content": "Imported"}],
+            },
+            BankWriteOperation.CREATE_DIRECTIVE,
+            "directives_created",
+            "Shared directive",
+        ),
+    ],
+)
+async def test_import_falls_back_when_projected_default_resource_is_not_created(
+    api_client,
+    memory,
+    monkeypatch,
+    default_template,
+    manifest,
+    create_operation,
+    created_field,
+    created_key,
+):
+    """A failed best-effort default create uses the preauthorized client create."""
+    from hindsight_api.config import _get_raw_config
+
+    bank_id = f"import_default_fallback_{datetime.now().timestamp()}"
+    monkeypatch.setattr(_get_raw_config(), "default_bank_template", default_template)
+    validator = _make_operation_validator()
+    create_calls = 0
+
+    async def validate_bank_write(context):
+        nonlocal create_calls
+        if context.operation is create_operation:
+            create_calls += 1
+            if create_calls == 2:
+                return ValidationResult.reject("reject the server default")
+        return ValidationResult.accept()
+
+    validator.validate_bank_write = AsyncMock(side_effect=validate_bank_write)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(
+        memory,
+        "_submit_async_operation",
+        AsyncMock(return_value={"operation_id": "import-refresh"}),
+    )
+
+    response = await api_client.post(f"/v1/default/banks/{bank_id}/import", json=manifest)
+
+    assert response.status_code == 200, response.text
+    assert response.json()[created_field] == [created_key]
+    assert create_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_import_authorizes_projected_default_fallback_before_creating_bank(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """A denied fallback create leaves no bank behind."""
+    from hindsight_api.config import _get_raw_config
+
+    bank_id = f"import_default_fallback_rejection_{datetime.now().timestamp()}"
+    model = {"id": "shared-model", "name": "Shared", "source_query": "shared"}
+    monkeypatch.setattr(
+        _get_raw_config(),
+        "default_bank_template",
+        {"version": "1", "mental_models": [model]},
+    )
+    validator = _make_operation_validator(
+        reject_bank_write=BankWriteOperation.CREATE_MENTAL_MODEL,
+        reason="fallback create is forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json={"version": "1", "mental_models": [model]},
+    )
+
+    assert response.status_code == 403, response.text
+    await _assert_bank_missing(api_client, bank_id)
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -5,13 +5,42 @@ Tests all endpoints by starting a FastAPI server and making HTTP requests.
 """
 
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.extensions import BankReadOperation, BankWriteOperation, OperationValidationError, ValidationResult
+from hindsight_api.models import RequestContext
 from tests.llm_judge import assert_meets_criteria
+
+
+def _make_operation_validator(
+    *,
+    reject_bank_write: BankWriteOperation | None = None,
+    reject_bank_read: BankReadOperation | None = None,
+    reason: str = "operation is forbidden",
+) -> MagicMock:
+    """Build a complete async validator with one optional rejection."""
+    validator = MagicMock()
+    validator.validate_bank_write = AsyncMock(
+        side_effect=lambda ctx: (
+            ValidationResult.reject(reason) if ctx.operation is reject_bank_write else ValidationResult.accept()
+        )
+    )
+    validator.validate_bank_read = AsyncMock(
+        side_effect=lambda ctx: (
+            ValidationResult.reject(reason) if ctx.operation is reject_bank_read else ValidationResult.accept()
+        )
+    )
+    return validator
+
+
+async def _assert_bank_missing(api_client: httpx.AsyncClient, bank_id: str) -> None:
+    response = await api_client.get(f"/v1/default/banks/{bank_id}/profile")
+    assert response.status_code == 404, response.text
 
 
 @pytest_asyncio.fixture
@@ -1361,9 +1390,267 @@ async def test_patch_config_persists_override_for_uncreated_bank(api_client, fie
 
 
 @pytest.mark.asyncio
-async def test_patch_bank_does_not_create_missing_bank(api_client):
+async def test_patch_config_rejection_does_not_create_bank(api_client):
+    """Invalid config must fail before it creates a bank."""
+    test_bank_id = f"patch_invalid_config_{datetime.now().timestamp()}"
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{test_bank_id}/config",
+        json={"updates": {"database_url": "postgresql://invalid"}},
+    )
+    assert response.status_code == 400, response.text
+
+    await _assert_bank_missing(api_client, test_bank_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_config_does_not_apply_client_field_permissions_to_projected_defaults(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """Server-owned defaults are not checked against client field access."""
+    from hindsight_api.config import _get_raw_config
+
+    bank_id = f"patch_projected_default_permissions_{datetime.now().timestamp()}"
+    monkeypatch.setattr(
+        _get_raw_config(),
+        "default_bank_template",
+        {"version": "1", "bank": {"reflect_mission": "Server default"}},
+    )
+    tenant_extension = MagicMock()
+    tenant_extension.get_tenant_config = AsyncMock(return_value=None)
+    tenant_extension.get_allowed_config_fields = AsyncMock(return_value={"enable_observations"})
+    monkeypatch.setattr(memory._config_resolver, "tenant_extension", tenant_extension)
+    monkeypatch.setattr(memory, "_apply_default_bank_template", AsyncMock())
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{bank_id}/config",
+        json={"updates": {"enable_observations": True}},
+    )
+
+    assert response.status_code == 200, response.text
+    # The two lookups authorize the client update and filter the response.
+    # Projecting the server default must not add a third field-permission check.
+    assert tenant_extension.get_allowed_config_fields.await_count == 2
+    overrides = await memory._config_resolver._load_bank_config(bank_id)
+    assert overrides == {"enable_observations": True}
+
+
+@pytest.mark.asyncio
+async def test_reset_config_uses_engine_authorization(api_client, memory, monkeypatch):
+    """Config reset is rejected before deleting existing overrides."""
+    bank_id = f"reset_config_authorization_{datetime.now().timestamp()}"
+    response = await api_client.patch(
+        f"/v1/default/banks/{bank_id}/config",
+        json={"updates": {"enable_observations": False}},
+    )
+    assert response.status_code == 200, response.text
+
+    validator = _make_operation_validator(
+        reject_bank_write=BankWriteOperation.RESET_BANK_CONFIG,
+        reason="config reset is forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    response = await api_client.delete(f"/v1/default/banks/{bank_id}/config")
+    assert response.status_code == 403, response.text
+
+    response = await api_client.get(f"/v1/default/banks/{bank_id}/config")
+    assert response.status_code == 200, response.text
+    assert response.json()["overrides"]["enable_observations"] is False
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "suffix", "body"),
+    [
+        ("put", "", {"reflect_mission": "blocked"}),
+        ("patch", "", {"reflect_mission": "blocked"}),
+        ("post", "/import", {"version": "1", "bank": {"reflect_mission": "blocked"}}),
+    ],
+)
+async def test_bank_config_write_routes_require_config_permission(
+    api_client, memory, monkeypatch, method, suffix, body
+):
+    """Every external config write must enforce UPDATE_BANK_CONFIG."""
+    bank_id = f"config_permission_{method}_{datetime.now().timestamp()}"
+    if method == "patch":
+        response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+        assert response.status_code == 200, response.text
+
+    validator = _make_operation_validator(
+        reject_bank_write=BankWriteOperation.UPDATE_BANK_CONFIG,
+        reason="config updates are forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    response = await getattr(api_client, method)(f"/v1/default/banks/{bank_id}{suffix}", json=body)
+    assert response.status_code == 403, response.text
+    if method != "patch":
+        await _assert_bank_missing(api_client, bank_id)
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["put", "patch"])
+async def test_profile_config_validation_errors_return_400(api_client, method):
+    """Profile routes map config validation failures to client errors."""
+    bank_id = f"profile_invalid_config_{method}_{datetime.now().timestamp()}"
+    if method == "patch":
+        response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+        assert response.status_code == 200, response.text
+
+    response = await getattr(api_client, method)(
+        f"/v1/default/banks/{bank_id}",
+        json={"retain_chunk_size": 0},
+    )
+
+    assert response.status_code == 400, response.text
+    assert "retain_chunk_size must be >= 1" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_bank_combines_profile_and_config_with_one_authentication(memory, monkeypatch):
+    """Combined bank updates authenticate once but validate every requested operation."""
+    bank_id = f"combined_bank_update_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    validator = _make_operation_validator()
+    authenticate = AsyncMock(wraps=memory._authenticate_tenant)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_authenticate_tenant", authenticate)
+    profile = await memory.update_bank(
+        bank_id,
+        name="Combined update",
+        config_updates={"enable_observations": False},
+        request_context=request_context,
+    )
+
+    assert profile["name"] == "Combined update"
+    authenticate.assert_awaited_once()
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
+        BankWriteOperation.UPDATE_BANK,
+        BankWriteOperation.UPDATE_BANK_CONFIG,
+    ]
+    assert [call.args[0].operation for call in validator.validate_bank_read.await_args_list] == [
+        BankReadOperation.GET_BANK_PROFILE
+    ]
+    await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_put_name_only_preserves_name_for_new_bank(api_client):
+    """A name-only PUT creates the bank before updating its row."""
+    bank_id = f"name_only_put_{datetime.now().timestamp()}"
+
+    response = await api_client.put(f"/v1/default/banks/{bank_id}", json={"name": "Named bank"})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == "Named bank"
+
+
+@pytest.mark.asyncio
+async def test_update_bank_read_denial_has_no_side_effects(memory, monkeypatch):
+    """The response read check must run before bank creation or writes."""
+    bank_id = f"read_denied_update_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    validator = _make_operation_validator(
+        reject_bank_read=BankReadOperation.GET_BANK_PROFILE,
+        reason="profile reads are forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    with pytest.raises(OperationValidationError, match="profile reads are forbidden"):
+        await memory.update_bank(
+            bank_id,
+            config_updates={"enable_observations": False},
+            request_context=request_context,
+        )
+    monkeypatch.setattr(memory, "_operation_validator", None)
+    profile = await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False)
+    assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_update_bank_validates_against_projected_default_config(memory, monkeypatch):
+    """A missing bank's client config is checked against its pending defaults."""
+    from hindsight_api.config import _get_raw_config
+
+    bank_id = f"projected_default_config_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+    raw = _get_raw_config()
+    monkeypatch.setattr(
+        raw,
+        "default_bank_template",
+        {
+            "version": "1",
+            "bank": {"retain_chunk_size": raw.retain_max_completion_tokens},
+        },
+    )
+
+    with pytest.raises(ValueError, match="must be greater than"):
+        await memory.update_bank(
+            bank_id,
+            config_updates={
+                "retain_strategies": {
+                    "projected-default": {"retain_extraction_mode": "concise"},
+                }
+            },
+            request_context=request_context,
+        )
+
+    profile = await memory.get_bank_profile(
+        bank_id,
+        request_context=request_context,
+        create_if_missing=False,
+    )
+    assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_patch_rejection_does_not_partially_update_name(api_client, memory, monkeypatch):
+    """PATCH validates config access before changing the bank name."""
+    bank_id = f"patch_atomic_update_{datetime.now().timestamp()}"
+    response = await api_client.put(f"/v1/default/banks/{bank_id}", json={"name": "Original"})
+    assert response.status_code == 200, response.text
+
+    validator = _make_operation_validator(
+        reject_bank_write=BankWriteOperation.UPDATE_BANK_CONFIG,
+        reason="config updates are forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    response = await api_client.patch(
+        f"/v1/default/banks/{bank_id}",
+        json={"name": "Changed", "reflect_mission": "blocked"},
+    )
+    assert response.status_code == 403, response.text
+    profile = await api_client.get(f"/v1/default/banks/{bank_id}/profile")
+    assert profile.status_code == 200, profile.text
+    assert profile.json()["name"] == "Original"
+
+
+@pytest.mark.asyncio
+async def test_patch_returns_404_when_bank_disappears_before_response_read(api_client, memory, monkeypatch):
+    """A concurrent delete after the writes remains a not-found response."""
+    bank_id = f"patch_concurrent_delete_{datetime.now().timestamp()}"
+    response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+    assert response.status_code == 200, response.text
+    monkeypatch.setattr(memory, "_get_bank_profile_authenticated", AsyncMock(return_value=None))
+
+    response = await api_client.patch(
+        f"/v1/default/banks/{bank_id}",
+        json={"name": "Deleted concurrently"},
+    )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == f"Bank '{bank_id}' not found"
+
+
+@pytest.mark.asyncio
+async def test_patch_bank_does_not_create_missing_bank(api_client, memory, monkeypatch):
     """PATCH /banks/{bank_id} updates existing banks only."""
     test_bank_id = f"patch_missing_bank_{datetime.now().timestamp()}"
+    ensure_bank_exists = AsyncMock(wraps=memory._ensure_bank_exists)
+    monkeypatch.setattr(memory, "_ensure_bank_exists", ensure_bank_exists)
 
     response = await api_client.patch(
         f"/v1/default/banks/{test_bank_id}",
@@ -1371,6 +1658,7 @@ async def test_patch_bank_does_not_create_missing_bank(api_client):
     )
     assert response.status_code == 404, response.text
     assert response.json()["detail"] == f"Bank '{test_bank_id}' not found"
+    ensure_bank_exists.assert_not_awaited()
 
     profile = await api_client.get(f"/v1/default/banks/{test_bank_id}/profile")
     assert profile.status_code == 404, profile.text
@@ -1378,6 +1666,30 @@ async def test_patch_bank_does_not_create_missing_bank(api_client):
     banks = await api_client.get("/v1/default/banks")
     assert banks.status_code == 200, banks.text
     assert test_bank_id not in {bank["bank_id"] for bank in banks.json()["banks"]}
+
+
+@pytest.mark.asyncio
+async def test_patch_authorizes_and_reads_profile_once(api_client, memory, monkeypatch):
+    """PATCH delegates its update-only lifecycle to one engine call."""
+    bank_id = f"patch_single_profile_read_{datetime.now().timestamp()}"
+    response = await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+    assert response.status_code == 200, response.text
+
+    validator = _make_operation_validator()
+    authenticate = AsyncMock(wraps=memory._authenticate_tenant)
+    ensure_bank_exists = AsyncMock(wraps=memory._ensure_bank_exists)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(memory, "_authenticate_tenant", authenticate)
+    monkeypatch.setattr(memory, "_ensure_bank_exists", ensure_bank_exists)
+
+    response = await api_client.patch(f"/v1/default/banks/{bank_id}", json={"name": "Updated"})
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == "Updated"
+    authenticate.assert_awaited_once()
+    validator.validate_bank_read.assert_awaited_once()
+    assert validator.validate_bank_read.call_args.args[0].operation is BankReadOperation.GET_BANK_PROFILE
+    ensure_bank_exists.assert_not_awaited()
+    await memory.delete_bank(bank_id, request_context=RequestContext())
 
 
 @pytest.mark.hs_llm_core

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -195,9 +195,9 @@ def mock_memory():
     memory.get_bank_stats = AsyncMock(return_value={"nodes": 100, "links": 50})
     memory.delete_bank = AsyncMock(return_value={"deleted_memories": 10, "deleted_entities": 5})
 
-    # Config resolver (used by update_bank MCP tool for config fields)
+    # Only recall/reflect tools read from the resolver; update_bank now owns both
+    # the profile and the config write, so its assertions belong on that mock.
     memory._config_resolver = MagicMock()
-    memory._config_resolver.update_bank_config = AsyncMock()
 
     async def _update_bank(
         bank_id: str,
@@ -205,10 +205,9 @@ def mock_memory():
         name: str | None = None,
         mission: str | None = None,
         config_updates: dict[str, Any] | None = None,
+        create_if_missing: bool = True,
         request_context: RequestContext,
     ) -> dict[str, Any]:
-        if config_updates:
-            await memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
         return {"id": bank_id, "name": name or "Updated", "mission": mission or ""}
 
     memory.update_bank = AsyncMock(side_effect=_update_bank)
@@ -1600,14 +1599,13 @@ class TestTagsAndBankTools:
     async def test_update_bank(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         result = await _tools(mcp)["update_bank"].fn(name="New Name", mission="New Mission")
-        # name is updated via engine
-        call_kwargs = mock_memory.update_bank.call_args.kwargs
-        assert call_kwargs["name"] == "New Name"
-        # mission is routed to config resolver as reflect_mission
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        assert config_call.args[1] == {"reflect_mission": "New Mission"}
+        # name and config are applied by a single engine call
+        call = mock_memory.update_bank.call_args
+        assert call.kwargs["name"] == "New Name"
+        # mission is routed into config_updates as reflect_mission
+        assert call.kwargs["config_updates"] == {"reflect_mission": "New Mission"}
         # bank_id is the first positional arg
-        assert config_call.args[0] == "test-bank"
+        assert call.args[0] == "test-bank"
 
     async def test_delete_bank(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"delete_bank"}, include_bank_id=True)
@@ -1739,23 +1737,19 @@ class TestUpdateBankVariants:
         assert mock_memory.update_bank.call_args.args[0] == "test-bank"
         assert mock_memory.update_bank.call_args.kwargs["name"] is None
         assert mock_memory.update_bank.call_args.kwargs["config_updates"] == {"reflect_mission": "Guide reflect output"}
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        assert config_call.args[1] == {"reflect_mission": "Guide reflect output"}
         mock_memory.get_bank_profile.assert_not_called()
 
     async def test_update_bank_mission_maps_to_reflect_mission(self, mock_memory):
         """Deprecated mission param is mapped to reflect_mission in config."""
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         await _tools(mcp)["update_bank"].fn(mission="My mission")
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        assert config_call.args[1] == {"reflect_mission": "My mission"}
+        assert mock_memory.update_bank.call_args.kwargs["config_updates"] == {"reflect_mission": "My mission"}
 
     async def test_update_bank_config_reflect_mission_takes_precedence_over_mission(self, mock_memory):
         """When both mission and config_updates.reflect_mission are provided, config wins."""
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         await _tools(mcp)["update_bank"].fn(mission="old", config_updates={"reflect_mission": "new"})
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        assert config_call.args[1]["reflect_mission"] == "new"
+        assert mock_memory.update_bank.call_args.kwargs["config_updates"]["reflect_mission"] == "new"
 
     async def test_update_bank_multiple_config_fields(self, mock_memory):
         """Multiple config fields can be set in a single config_updates dict."""
@@ -1774,8 +1768,7 @@ class TestUpdateBankVariants:
                 "retain_structured_chunk_size": 5000,
             }
         )
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        updates = config_call.args[1]
+        updates = mock_memory.update_bank.call_args.kwargs["config_updates"]
         assert updates["retain_mission"] == "Extract technical decisions"
         assert updates["disposition_skepticism"] == 5
         assert updates["disposition_literalism"] == 1
@@ -1796,16 +1789,16 @@ class TestUpdateBankVariants:
         )
         mock_memory.update_bank.assert_awaited_once()
         assert mock_memory.update_bank.call_args.kwargs["name"] == "My Bank"
-        updates = mock_memory._config_resolver.update_bank_config.call_args.args[1]
+        updates = mock_memory.update_bank.call_args.kwargs["config_updates"]
         assert updates["reflect_mission"] == "Reflect guide"
         assert updates["retain_mission"] == "Retain guide"
 
     async def test_update_bank_no_config_call_when_only_name(self, mock_memory):
-        """When only name is provided, config resolver should not be called."""
+        """When only name is provided, no config update is requested."""
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         await _tools(mcp)["update_bank"].fn(name="Just Name")
         mock_memory.update_bank.assert_called_once()
-        mock_memory._config_resolver.update_bank_config.assert_not_called()
+        assert mock_memory.update_bank.call_args.kwargs["config_updates"] is None
 
     async def test_update_bank_config_updates_single_bank(self, mock_memory):
         """config_updates works in single-bank mode too."""
@@ -1814,8 +1807,7 @@ class TestUpdateBankVariants:
             config_updates={"retain_mission": "Extract everything", "disposition_empathy": 5}
         )
         assert isinstance(result, dict)
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        updates = config_call.args[1]
+        updates = mock_memory.update_bank.call_args.kwargs["config_updates"]
         assert updates["retain_mission"] == "Extract everything"
         assert updates["disposition_empathy"] == 5
 
@@ -1823,12 +1815,11 @@ class TestUpdateBankVariants:
         """bank_id override routes config update to the correct bank."""
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         await _tools(mcp)["update_bank"].fn(config_updates={"reflect_mission": "Test"}, bank_id="other-bank")
-        config_call = mock_memory._config_resolver.update_bank_config.call_args
-        assert config_call.args[0] == "other-bank"
+        assert mock_memory.update_bank.call_args.args[0] == "other-bank"
 
-    async def test_update_bank_config_resolver_validation_error(self, mock_memory):
-        """ValueError from config resolver (e.g. invalid field) is returned as error."""
-        mock_memory._config_resolver.update_bank_config.side_effect = ValueError(
+    async def test_update_bank_config_validation_error(self, mock_memory):
+        """ValueError from config validation (e.g. invalid field) is returned as error."""
+        mock_memory.update_bank.side_effect = ValueError(
             "Cannot override static (server-level) fields: ['database_url']"
         )
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
@@ -1846,7 +1837,7 @@ class TestUpdateBankVariants:
                 "entity_labels": ["PERSON", "ORG"],
             }
         )
-        updates = mock_memory._config_resolver.update_bank_config.call_args.args[1]
+        updates = mock_memory.update_bank.call_args.kwargs["config_updates"]
         assert updates["recall_budget_fixed_low"] == 100
         assert updates["consolidation_llm_batch_size"] == 8
         assert updates["entity_labels"] == ["PERSON", "ORG"]

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -1568,13 +1568,29 @@ class TestTagsAndBankTools:
         assert json.loads(result)["error"] == "Bank 'missing-bank' not found"
         assert mock_memory.get_bank_profile.call_args.kwargs["create_if_missing"] is False
 
-    async def test_create_bank_validates_creation(self, mock_memory):
+    async def test_create_bank_uses_public_profile_api(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"create_bank"}, include_bank_id=True)
         result = await _tools(mcp)["create_bank"].fn(bank_id="new-bank")
         assert '"test-bank"' in result or "test-bank" in result
-        call = mock_memory._ensure_bank_exists.call_args
-        assert call.args[0] == "new-bank"
-        assert "operation" not in call.kwargs
+        mock_memory.get_bank_profile.assert_awaited_once()
+        assert mock_memory.get_bank_profile.call_args.args[0] == "new-bank"
+        mock_memory.update_bank.assert_not_awaited()
+        mock_memory._ensure_bank_exists.assert_not_awaited()
+
+    async def test_create_bank_with_fields_uses_public_update_api(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"create_bank"}, include_bank_id=True)
+        result = await _tools(mcp)["create_bank"].fn(
+            bank_id="new-bank",
+            name="New Bank",
+            mission="Help the user",
+        )
+        assert json.loads(result)["name"] == "New Bank"
+        mock_memory.update_bank.assert_awaited_once()
+        assert mock_memory.update_bank.call_args.args[0] == "new-bank"
+        assert mock_memory.update_bank.call_args.kwargs["name"] == "New Bank"
+        assert mock_memory.update_bank.call_args.kwargs["mission"] == "Help the user"
+        mock_memory.get_bank_profile.assert_not_awaited()
+        mock_memory._ensure_bank_exists.assert_not_awaited()
 
     async def test_get_bank_stats(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"get_bank_stats"}, include_bank_id=True)

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,6 +14,7 @@ from hindsight_api.mcp_tools import (
     parse_timestamp,
     register_mcp_tools,
 )
+from hindsight_api.models import RequestContext
 
 
 class TestParseTimestamp:
@@ -191,12 +193,25 @@ def mock_memory():
     memory._ensure_bank_exists = AsyncMock(return_value=True)
     memory.get_bank_profile = AsyncMock(return_value={"id": "test-bank", "name": "Test Bank", "mission": "Testing"})
     memory.get_bank_stats = AsyncMock(return_value={"nodes": 100, "links": 50})
-    memory.update_bank = AsyncMock(return_value={"id": "test-bank", "name": "Updated"})
     memory.delete_bank = AsyncMock(return_value={"deleted_memories": 10, "deleted_entities": 5})
 
     # Config resolver (used by update_bank MCP tool for config fields)
     memory._config_resolver = MagicMock()
     memory._config_resolver.update_bank_config = AsyncMock()
+
+    async def _update_bank(
+        bank_id: str,
+        *,
+        name: str | None = None,
+        mission: str | None = None,
+        config_updates: dict[str, Any] | None = None,
+        request_context: RequestContext,
+    ) -> dict[str, Any]:
+        if config_updates:
+            await memory._config_resolver.update_bank_config(bank_id, config_updates, request_context)
+        return {"id": bank_id, "name": name or "Updated", "mission": mission or ""}
+
+    memory.update_bank = AsyncMock(side_effect=_update_bank)
     memory.list_banks = AsyncMock(return_value=[])
 
     return memory
@@ -1701,13 +1716,16 @@ class TestUpdateBankVariants:
         assert "error" in result
 
     async def test_update_bank_config_updates_dict(self, mock_memory):
-        """config_updates dict is passed directly to config resolver."""
+        """Config updates use the engine's bank-creating config path."""
         mcp = _make_mcp_server(mock_memory, {"update_bank"}, include_bank_id=True)
         await _tools(mcp)["update_bank"].fn(config_updates={"reflect_mission": "Guide reflect output"})
+        mock_memory.update_bank.assert_awaited_once()
+        assert mock_memory.update_bank.call_args.args[0] == "test-bank"
+        assert mock_memory.update_bank.call_args.kwargs["name"] is None
+        assert mock_memory.update_bank.call_args.kwargs["config_updates"] == {"reflect_mission": "Guide reflect output"}
         config_call = mock_memory._config_resolver.update_bank_config.call_args
         assert config_call.args[1] == {"reflect_mission": "Guide reflect output"}
-        # name should NOT be updated when not provided
-        mock_memory.update_bank.assert_not_called()
+        mock_memory.get_bank_profile.assert_not_called()
 
     async def test_update_bank_mission_maps_to_reflect_mission(self, mock_memory):
         """Deprecated mission param is mapped to reflect_mission in config."""
@@ -1760,6 +1778,7 @@ class TestUpdateBankVariants:
             name="My Bank",
             config_updates={"reflect_mission": "Reflect guide", "retain_mission": "Retain guide"},
         )
+        mock_memory.update_bank.assert_awaited_once()
         assert mock_memory.update_bank.call_args.kwargs["name"] == "My Bank"
         updates = mock_memory._config_resolver.update_bank_config.call_args.args[1]
         assert updates["reflect_mission"] == "Reflect guide"


### PR DESCRIPTION
## Summary

- Authorize client-owned bank writes before provisioning a missing bank.
- Preflight template imports and reuse each authorization decision exactly once.
- Route HTTP and MCP bank operations through the public `MemoryEngine` lifecycle APIs.

Fixes #2650

## Root cause

`ConfigResolver.update_bank_config()` previously combined validation, persistence, and implicit bank creation. Callers could therefore provision a bank before authorization completed, and multi-field requests could persist an earlier change before a later validation failure.

Template import had the same ordering problem across configuration, mental-model, directive, refresh, and read operations. Moving provisioning later also required accounting for resources supplied by the server-owned default template before selecting create or update semantics.

MCP bank creation additionally bypassed the public engine lifecycle by calling `_ensure_bank_exists()` directly.

## Changes

### Bank configuration and profile updates

- Add typed engine APIs for reading, updating, and resetting bank configuration.
- Split config validation and normalization from persistence.
- Validate profile and config changes together before creating a bank or persisting either change.
- Route PUT, PATCH, config PATCH/DELETE, and MCP config updates through engine-owned authentication and authorization.
- Preserve name-only creation and the existing `422` response for invalid memory-defense policies.
- Return HTTP `400` for invalid PUT/PATCH profile values and `404` if an update-only request loses the bank before its final read.

### Template import

- Project the server-owned default-template state before provisioning so import collisions use update semantics.
- Preauthorize the create fallback required when best-effort default resource creation fails.
- Preauthorize every import write, mental-model refresh, and required read before creating the bank.
- Re-read actual resources after provisioning and consume one-shot grants keyed by operation and resource target.
- Bind authorization state to the engine, request context, bank, and originating asyncio task.
- Reject duplicate mental-model IDs and directive names before provisioning.
- Reject mental-model imports without an available LLM before dependent writes.
- Keep default-template configuration server-owned, without applying client `UPDATE_BANK_CONFIG` field restrictions.

### MCP bank creation

- Delegate `create_bank` to public `MemoryEngine` profile and update APIs.
- Preserve default-template application while keeping lifecycle checks and authorization ordering inside the engine.
- Avoid the duplicate profile read previously performed by the MCP path.

## Impact

- Rejected config updates, template imports, and MCP operations no longer create empty banks or persist partial profile/config state before authorization completes.
- Template imports handle default-template resource collisions and fallback creation without duplicate hook calls.
- HTTP and MCP paths consistently use the engine-owned bank lifecycle.

## Validation

- `./scripts/hooks/lint.sh`
- `uv run ty check hindsight_api/engine/interface.py hindsight_api/engine/memory_engine.py hindsight_api/api/http.py`
- `uv run pytest tests/test_mcp_tools.py -q -n 0` — 192 passed
- `uv run pytest tests/test_bank_templates.py -q` — 36 passed
- Focused authorization, concurrency, and HTTP regression selection — 11 passed
- `git diff --check origin/main...HEAD`