### PR TITLE
fix(codex): send client identity headers for GPT-5.6

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -53,6 +53,12 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+# Newer Codex models are gated on the first-party client identity; the previous
+# browser-shaped User-Agent returned "Model not found" for Luna (#2643).
+# Use a neutral version because Hindsight must not claim a specific Codex release.
+_CODEX_ORIGINATOR = "codex_cli_rs"
+_CODEX_USER_AGENT = "codex_cli_rs/0.0.0 (Hindsight)"
+
 # Name of the single forced function tool used to carry structured output when
 # strict_schema is on. The Codex backend speaks the OpenAI Responses API, so a
 # forced function call gives us constrained decoding straight into the response
@@ -186,6 +192,18 @@ class CodexLLM(LLMInterface):
     @property
     def account_id(self) -> str:
         return self._auth_manager.account_id
+
+    def _build_request_headers(self) -> httpx.Headers:
+        return httpx.Headers(
+            {
+                "Authorization": f"Bearer {self.access_token}",
+                "Content-Type": "application/json",
+                "OpenAI-Account-ID": self.account_id,
+                "User-Agent": _CODEX_USER_AGENT,
+                "Origin": "https://chatgpt.com",
+                "originator": _CODEX_ORIGINATOR,
+            }
+        )
 
     @property
     def refresh_token(self) -> str | None:
@@ -475,13 +493,7 @@ class CodexLLM(LLMInterface):
             payload["tool_choice"] = {"type": "function", "name": _STRUCTURED_TOOL_NAME}
             payload["parallel_tool_calls"] = False
 
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-            "OpenAI-Account-ID": self.account_id,
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-            "Origin": "https://chatgpt.com",
-        }
+        headers = self._build_request_headers()
 
         url = f"{self.base_url}/codex/responses"
 
@@ -843,13 +855,7 @@ class CodexLLM(LLMInterface):
             "prompt_cache_key": str(uuid.uuid4()),
         }
 
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-            "OpenAI-Account-ID": self.account_id,
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-            "Origin": "https://chatgpt.com",
-        }
+        headers = self._build_request_headers()
 
         url = f"{self.base_url}/codex/responses"
 

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import os
 import stat
 import sys
 import time
@@ -422,6 +421,7 @@ async def test_call_reactively_refreshes_on_401_and_retries(tmp_path: Path):
     refresh_resp = _refresh_response(200, {"access_token": new_access, "refresh_token": "rt-new"})
 
     call_count = {"refresh": 0, "post": 0}
+    sent_headers: list[httpx.Headers] = []
 
     # Sync mock for the auth manager's HTTP client (used for token refresh).
     def fake_refresh_post(*args, **kwargs):
@@ -431,6 +431,7 @@ async def test_call_reactively_refreshes_on_401_and_retries(tmp_path: Path):
     # Async mock for the LLM's HTTP client (used for backend calls).
     async def fake_backend_post(url, **kwargs):
         call_count["post"] += 1
+        sent_headers.append(httpx.Headers(kwargs["headers"]))
         if call_count["post"] == 1:
             raise httpx.HTTPStatusError("401", request=MagicMock(), response=fail_response)
         return success_resp
@@ -451,6 +452,10 @@ async def test_call_reactively_refreshes_on_401_and_retries(tmp_path: Path):
     assert call_count["refresh"] == 1
     assert call_count["post"] == 2  # one 401, one success after refresh
     assert llm.access_token == new_access
+    assert sent_headers[0]["Authorization"] == f"Bearer {fresh}"
+    assert sent_headers[1]["Authorization"] == f"Bearer {new_access}"
+    for header_name in ("Content-Type", "OpenAI-Account-ID", "User-Agent", "Origin", "originator"):
+        assert sent_headers[1][header_name] == sent_headers[0][header_name]
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_codex_request_headers.py
+++ b/hindsight-api-slim/tests/test_codex_request_headers.py
@@ -1,0 +1,63 @@
+"""Regression tests for Codex request identity headers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from hindsight_api.engine.providers.codex_llm import CodexLLM
+
+
+def build_llm() -> CodexLLM:
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=None),
+    ):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.6-luna",
+        )
+
+
+def assert_codex_request_identity(headers: httpx.Headers) -> None:
+    assert headers["originator"] == "codex_cli_rs"
+    assert headers["User-Agent"] == "codex_cli_rs/0.0.0 (Hindsight)"
+
+
+@pytest.mark.asyncio
+async def test_call_sends_codex_request_identity() -> None:
+    llm = build_llm()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
+    ):
+        mock_post.return_value = response
+        await llm.call(messages=[{"role": "user", "content": "hello"}], max_retries=0)
+
+    assert_codex_request_identity(mock_post.call_args.kwargs["headers"])
+
+
+@pytest.mark.asyncio
+async def test_call_with_tools_sends_codex_request_identity() -> None:
+    llm = build_llm()
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    with (
+        patch.object(llm._client, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock, return_value=(None, [])),
+    ):
+        mock_post.return_value = response
+        await llm.call_with_tools(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            max_retries=0,
+        )
+
+    assert_codex_request_identity(mock_post.call_args.kwargs["headers"])

--- a/hindsight-api-slim/tests/test_codex_strict_schema.py
+++ b/hindsight-api-slim/tests/test_codex_strict_schema.py
@@ -100,12 +100,15 @@ async def test_strict_schema_uses_forced_function_tool():
                 max_retries=0,
             )
         sent_payload = mock_post.call_args.kwargs["json"]
+        sent_headers = mock_post.call_args.kwargs["headers"]
 
     # Forced tool wired into the request payload.
     assert sent_payload["tool_choice"] == {"type": "function", "name": "structured_response"}
     assert len(sent_payload["tools"]) == 1
     assert sent_payload["tools"][0]["name"] == "structured_response"
     assert sent_payload["parallel_tool_calls"] is False
+    assert sent_headers["originator"] == "codex_cli_rs"
+    assert sent_headers["User-Agent"] == "codex_cli_rs/0.0.0 (Hindsight)"
     # No prompt-injected schema in the instructions.
     assert "You must respond with valid JSON" not in sent_payload["instructions"]
 

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -261,7 +261,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4-mini
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.6-luna  # defaults to gpt-5.4-mini
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -321,7 +321,7 @@ Use your ChatGPT Plus or Pro subscription for Hindsight without separate OpenAI 
 4. **Configure Hindsight:**
    ```bash
    export HINDSIGHT_API_LLM_PROVIDER=openai-codex
-   # export HINDSIGHT_API_LLM_MODEL=gpt-5.3-codex  # defaults to gpt-5.4-mini
+   # export HINDSIGHT_API_LLM_MODEL=gpt-5.6-luna  # defaults to gpt-5.4-mini
    # No API key needed - reads from ~/.codex/auth.json automatically
    ```
 


### PR DESCRIPTION
## Summary

- send Codex client identity headers through one shared request-header helper
- cover normal, strict structured-output, tool-call, and OAuth-refresh paths
- document explicit `gpt-5.6-luna` selection without changing the default model

The production change is confined to `codex_llm.py`. The remaining files add regression coverage and update one documentation example plus its generated mirror.

Fixes #2643.

## Testing

- focused Codex suite: 46 passed
- `npm run build --workspace=hindsight-docs`
- isolated Codex OAuth: Sol, Terra, Luna, and `gpt-5.4-mini` passed plain text, strict structured output, and tool calling

Full local suite: 3,795 passed; 7 failures and 7 errors require unavailable external credentials/services or test fixtures and are unrelated to this patch.
