### PR TITLE
fix(claude-code): retain session deltas

### DIFF
--- a/hindsight-integrations/claude-code/README.md
+++ b/hindsight-integrations/claude-code/README.md
@@ -243,7 +243,7 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 | Setting | Env Var | Default | Description |
 |---------|---------|---------|-------------|
 | `autoRetain` | `HINDSIGHT_AUTO_RETAIN` | `true` | Master switch for auto-retain. Set to `false` to disable memory storage entirely. |
-| `retainMode` | `HINDSIGHT_RETAIN_MODE` | `"full-session"` | Retention strategy. `"full-session"` sends the full conversation transcript (with chunking). |
+| `retainMode` | `HINDSIGHT_RETAIN_MODE` | `"full-session"` | Retention strategy. `"full-session"` sends the initial transcript once, then only new messages in chunk documents; compaction starts a fresh chunk. |
 | `retainEveryNTurns` | — | `10` | How often to retain. `1` = every turn; `10` = every 10th turn. Higher values reduce API calls but delay memory capture. Values > 1 enable **chunked retention** with a sliding window. |
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |

--- a/hindsight-integrations/claude-code/scripts/lib/state.py
+++ b/hindsight-integrations/claude-code/scripts/lib/state.py
@@ -167,6 +167,55 @@ def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
     return result
 
 
+def plan_retention(session_id: str, message_count: int) -> RetentionProgress:
+    """Plan retention state without writing the checkpoint.
+
+    The caller must only commit the returned progress after the retain request
+    succeeds; otherwise a transient API failure would skip unsent messages on the
+    next hook run.
+    """
+    data = read_state("retention_tracking.json", {})
+    entry = data.get(session_id, {"message_count": 0, "chunk": 0})
+    last_count = entry["message_count"]
+    chunk = entry["chunk"]
+    compacted = False
+    start_index = last_count
+
+    if message_count < last_count:
+        # Transcript shrank — compaction happened. The compacted transcript is
+        # new canonical content, so send it as a fresh chunk rather than trying
+        # to diff it against the pre-compaction transcript.
+        chunk += 1
+        compacted = True
+        start_index = 0
+    elif message_count > last_count and last_count > 0:
+        # The transcript grew normally. Store only the new suffix in its own
+        # document so repeated Stop hooks grow linearly instead of resending
+        # the whole session under a replacement document_id.
+        chunk += 1
+    elif message_count == last_count:
+        start_index = message_count
+
+    return RetentionProgress(chunk_index=chunk, compacted=compacted, start_index=start_index)
+
+
+def commit_retention(session_id: str, message_count: int, chunk_index: int) -> None:
+    """Persist the checkpoint for a successful retain."""
+
+    def _update(data):
+        data[session_id] = {"message_count": message_count, "chunk": chunk_index}
+
+        # Cap tracked sessions
+        if len(data) > 10000:
+            sorted_keys = sorted(data.keys())
+            for k in sorted_keys[: len(sorted_keys) // 2]:
+                del data[k]
+
+        return data, None
+
+    _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)
+
+
 def track_retention(session_id: str, message_count: int) -> RetentionProgress:
     """Track retention state, compaction, and the next unsent message offset.
 
@@ -181,39 +230,6 @@ def track_retention(session_id: str, message_count: int) -> RetentionProgress:
         compaction was detected, and the first message index to retain from the
         current transcript.
     """
-
-    def _update(data):
-        entry = data.get(session_id, {"message_count": 0, "chunk": 0})
-        last_count = entry["message_count"]
-        chunk = entry["chunk"]
-        compacted = False
-        start_index = last_count
-
-        if message_count < last_count:
-            # Transcript shrank — compaction happened. The compacted transcript is
-            # new canonical content, so send it as a fresh chunk rather than trying
-            # to diff it against the pre-compaction transcript.
-            chunk += 1
-            compacted = True
-            start_index = 0
-        elif message_count > last_count and last_count > 0:
-            # The transcript grew normally. Store only the new suffix in its own
-            # document so repeated Stop hooks grow linearly instead of resending
-            # the whole session under a replacement document_id.
-            chunk += 1
-        elif message_count == last_count:
-            start_index = message_count
-
-        entry["message_count"] = message_count
-        entry["chunk"] = chunk
-        data[session_id] = entry
-
-        # Cap tracked sessions
-        if len(data) > 10000:
-            sorted_keys = sorted(data.keys())
-            for k in sorted_keys[: len(sorted_keys) // 2]:
-                del data[k]
-
-        return data, RetentionProgress(chunk_index=chunk, compacted=compacted, start_index=start_index)
-
-    return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)
+    progress = plan_retention(session_id, message_count)
+    commit_retention(session_id, message_count, progress.chunk_index)
+    return progress

--- a/hindsight-integrations/claude-code/scripts/lib/state.py
+++ b/hindsight-integrations/claude-code/scripts/lib/state.py
@@ -8,12 +8,22 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 
 # fcntl is Unix-only; import conditionally so the module loads on Windows
 if sys.platform != "win32":
     import fcntl
 else:
     fcntl = None
+
+
+@dataclass(frozen=True)
+class RetentionProgress:
+    """State transition for a full-session retain attempt."""
+
+    chunk_index: int
+    compacted: bool
+    start_index: int
 
 
 def _state_dir() -> str:
@@ -157,17 +167,19 @@ def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
     return result
 
 
-def track_retention(session_id: str, message_count: int) -> tuple:
-    """Track retention state and detect compaction.
+def track_retention(session_id: str, message_count: int) -> RetentionProgress:
+    """Track retention state, compaction, and the next unsent message offset.
 
-    Compares the current message count against the last retained count for this
-    session.  When the transcript shrinks (compaction), increments a chunk counter
-    so the caller can use a distinct document_id, preserving the pre-compaction
-    document.
+    Full-session mode reads Claude Code's cumulative transcript, but each retain
+    should only send messages added since the previous successful hook run. Reusing
+    a document_id replaces that document on the server, so incremental payloads use
+    a monotonically increasing chunk id. When the transcript shrinks, Claude Code
+    compacted the session; the new compacted transcript starts a fresh chunk.
 
     Returns:
-        (chunk_index, compacted) — chunk_index for building document_id,
-        compacted is True if compaction was detected this call.
+        RetentionProgress with the chunk_index for building document_id, whether
+        compaction was detected, and the first message index to retain from the
+        current transcript.
     """
 
     def _update(data):
@@ -175,11 +187,22 @@ def track_retention(session_id: str, message_count: int) -> tuple:
         last_count = entry["message_count"]
         chunk = entry["chunk"]
         compacted = False
+        start_index = last_count
 
         if message_count < last_count:
-            # Transcript shrank — compaction happened
+            # Transcript shrank — compaction happened. The compacted transcript is
+            # new canonical content, so send it as a fresh chunk rather than trying
+            # to diff it against the pre-compaction transcript.
             chunk += 1
             compacted = True
+            start_index = 0
+        elif message_count > last_count and last_count > 0:
+            # The transcript grew normally. Store only the new suffix in its own
+            # document so repeated Stop hooks grow linearly instead of resending
+            # the whole session under a replacement document_id.
+            chunk += 1
+        elif message_count == last_count:
+            start_index = message_count
 
         entry["message_count"] = message_count
         entry["chunk"] = chunk
@@ -191,6 +214,6 @@ def track_retention(session_id: str, message_count: int) -> tuple:
             for k in sorted_keys[: len(sorted_keys) // 2]:
                 del data[k]
 
-        return data, (chunk, compacted)
+        return data, RetentionProgress(chunk_index=chunk, compacted=compacted, start_index=start_index)
 
     return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -32,7 +32,7 @@ from lib.content import (
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
-from lib.state import increment_turn_count, track_retention
+from lib.state import commit_retention, increment_turn_count, plan_retention
 
 
 def read_transcript(transcript_path: str) -> list:
@@ -95,6 +95,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     retain_full_window = False
     messages_to_retain = all_messages
     document_id = session_id
+    retention_progress = None
 
     # Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
     if retain_every_n > 1 and not force:
@@ -124,23 +125,23 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             f"Chunked retain firing (window: {window_turns} turns, {len(messages_to_retain)} messages)",
         )
     else:
-        progress = track_retention(session_id, len(all_messages))
-        if progress.start_index >= len(all_messages):
+        retention_progress = plan_retention(session_id, len(all_messages))
+        if retention_progress.start_index >= len(all_messages):
             debug_log(config, f"No new messages for session {session_id}, skipping retain")
             return
-        messages_to_retain = all_messages[progress.start_index :]
-        retain_full_window = progress.start_index == 0
-        if progress.compacted:
+        messages_to_retain = all_messages[retention_progress.start_index :]
+        retain_full_window = retention_progress.start_index == 0
+        if retention_progress.compacted:
             debug_log(
                 config,
                 f"Compaction detected for session {session_id}: transcript shrank, "
-                f"retaining compacted transcript as chunk {progress.chunk_index}",
+                f"retaining compacted transcript as chunk {retention_progress.chunk_index}",
             )
-        document_id = session_id if progress.chunk_index == 0 else f"{session_id}-c{progress.chunk_index}"
+        document_id = session_id if retention_progress.chunk_index == 0 else f"{session_id}-c{retention_progress.chunk_index}"
         debug_log(
             config,
             f"Full session retain: {len(messages_to_retain)} new messages "
-            f"from {len(all_messages)} total into chunk {progress.chunk_index}",
+            f"from {len(all_messages)} total into chunk {retention_progress.chunk_index}",
         )
 
     # Format transcript
@@ -151,6 +152,8 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     )
 
     if not transcript:
+        if retention_progress is not None:
+            commit_retention(session_id, len(all_messages), retention_progress.chunk_index)
         debug_log(config, "Empty transcript after formatting, skipping retain")
         return
 
@@ -236,6 +239,8 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             tags=tags,
             timeout=15,
         )
+        if retention_progress is not None:
+            commit_retention(session_id, len(all_messages), retention_progress.chunk_index)
         debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
     except Exception as e:
         print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -94,6 +94,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     retain_every_n = max(1, config.get("retainEveryNTurns", 1))
     retain_full_window = False
     messages_to_retain = all_messages
+    document_id = session_id
 
     # Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
     if retain_every_n > 1 and not force:
@@ -103,20 +104,44 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             debug_log(config, f"Turn {turn_count}/{retain_every_n}, skipping retain (next at turn {next_at})")
             return
 
+    # Document ID strategy:
+    # - Chunked mode: each sliding-window chunk gets a timestamped document_id.
+    # - Full-session mode: the transcript file is cumulative, but each retain only
+    #   sends messages not retained by a previous Stop hook. Each suffix uses a new
+    #   chunk document_id because reusing a document_id replaces the server-side
+    #   document instead of appending to it. Chunk 0 keeps the plain session_id for
+    #   backwards compatibility; later chunks use session_id-cN. If Claude Code
+    #   compacts the transcript, the compacted transcript starts a fresh chunk.
     if retain_mode == "chunked" and retain_every_n > 1:
         # Sliding window: N turns + configured overlap
         overlap_turns = config.get("retainOverlapTurns", 0)
         window_turns = retain_every_n + overlap_turns
         messages_to_retain = slice_last_turns_by_user_boundary(all_messages, window_turns)
         retain_full_window = True
+        document_id = f"{session_id}-{int(time.time() * 1000)}"
         debug_log(
             config,
             f"Chunked retain firing (window: {window_turns} turns, {len(messages_to_retain)} messages)",
         )
     else:
-        # Full session mode: retain all messages, always as full window
-        retain_full_window = True
-        debug_log(config, f"Full session retain: {len(all_messages)} messages")
+        progress = track_retention(session_id, len(all_messages))
+        if progress.start_index >= len(all_messages):
+            debug_log(config, f"No new messages for session {session_id}, skipping retain")
+            return
+        messages_to_retain = all_messages[progress.start_index :]
+        retain_full_window = progress.start_index == 0
+        if progress.compacted:
+            debug_log(
+                config,
+                f"Compaction detected for session {session_id}: transcript shrank, "
+                f"retaining compacted transcript as chunk {progress.chunk_index}",
+            )
+        document_id = session_id if progress.chunk_index == 0 else f"{session_id}-c{progress.chunk_index}"
+        debug_log(
+            config,
+            f"Full session retain: {len(messages_to_retain)} new messages "
+            f"from {len(all_messages)} total into chunk {progress.chunk_index}",
+        )
 
     # Format transcript
     retain_roles = config.get("retainRoles", ["user", "assistant"])
@@ -153,26 +178,6 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     # Derive bank ID and ensure mission
     bank_id = derive_bank_id(hook_input, config)
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
-
-    # Document ID strategy:
-    # - Chunked mode: each chunk gets a timestamped document_id.
-    # - Full-session mode: uses session_id as base, but tracks message count
-    #   to detect compaction.  When Claude Code compacts the conversation the
-    #   transcript shrinks — if we kept the same document_id we'd overwrite the
-    #   pre-compaction document with a shorter one, losing context.  Instead we
-    #   increment a chunk counter so the old document is preserved.
-    if retain_mode == "chunked" and retain_every_n > 1:
-        document_id = f"{session_id}-{int(time.time() * 1000)}"
-    else:
-        chunk_index, compacted = track_retention(session_id, len(all_messages))
-        if compacted:
-            debug_log(
-                config,
-                f"Compaction detected for session {session_id}: transcript shrank, "
-                f"advancing to chunk {chunk_index} to preserve prior document",
-            )
-        # chunk 0 → plain session_id (backwards compatible with existing docs)
-        document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
 
     # Resolve template variables in tags and metadata.
     # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -668,6 +668,33 @@ class TestRetainHook:
         assert len(captured_calls) == 1
         assert captured_calls[0]["items"][0]["document_id"] == "sess-no-new"
 
+    def test_full_session_retry_keeps_checkpoint_on_retain_failure(self, monkeypatch, tmp_path):
+        messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-retry-test")
+        captured_calls = []
+        attempts = {"count": 0}
+
+        def fail_first_then_capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                attempts["count"] += 1
+                if attempts["count"] == 1:
+                    raise OSError("temporary retain failure")
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=fail_first_then_capture)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=fail_first_then_capture)
+
+        assert attempts["count"] == 2
+        assert len(captured_calls) == 1
+        item = captured_calls[0]["items"][0]
+        assert item["document_id"] == "sess-retry-test"
+        assert "first question" in item["content"]
+
     def test_full_session_respects_retain_every_n_turns(self, monkeypatch, tmp_path):
         """In full-session mode, retainEveryNTurns should still gate when retain fires."""
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -614,8 +614,8 @@ class TestRetainHook:
         assert captured_calls[1]["items"][0]["document_id"] == "sess-compact-test-c1"
         assert "third question" in captured_calls[1]["items"][0]["content"]
 
-    def test_full_session_same_document_when_growing(self, monkeypatch, tmp_path):
-        """When transcript grows (no compaction), retain should keep the same document_id."""
+    def test_full_session_uses_delta_document_when_growing(self, monkeypatch, tmp_path):
+        """When transcript grows, retain should send only new messages in a new document chunk."""
         messages_2 = [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "world"},
@@ -642,9 +642,31 @@ class TestRetainHook:
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
 
         assert len(captured_calls) == 2
-        # Both should use the same plain session_id
         assert captured_calls[0]["items"][0]["document_id"] == "sess-grow-test"
-        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test"
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test-c1"
+        assert "hello" in captured_calls[0]["items"][0]["content"]
+        assert "more stuff" in captured_calls[1]["items"][0]["content"]
+        assert "hello" not in captured_calls[1]["items"][0]["content"]
+
+    def test_full_session_skips_when_transcript_has_no_new_messages(self, monkeypatch, tmp_path):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-no-new")
+        captured_calls = []
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 1
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-no-new"
 
     def test_full_session_respects_retain_every_n_turns(self, monkeypatch, tmp_path):
         """In full-session mode, retainEveryNTurns should still gate when retain fires."""

--- a/hindsight-integrations/claude-code/tests/test_state.py
+++ b/hindsight-integrations/claude-code/tests/test_state.py
@@ -3,7 +3,6 @@
 import json
 
 import pytest
-
 from lib.state import read_state, track_retention, write_state
 
 
@@ -20,63 +19,72 @@ def _isolated_state(monkeypatch, tmp_path):
 
 class TestTrackRetention:
     def test_first_call_returns_chunk_zero(self):
-        chunk, compacted = track_retention("sess-1", 10)
-        assert chunk == 0
-        assert compacted is False
+        progress = track_retention("sess-1", 10)
+        assert progress.chunk_index == 0
+        assert progress.compacted is False
+        assert progress.start_index == 0
 
-    def test_growing_transcript_keeps_same_chunk(self):
+    def test_growing_transcript_advances_chunk_and_starts_at_last_count(self):
         track_retention("sess-1", 4)
-        chunk, compacted = track_retention("sess-1", 8)
-        assert chunk == 0
-        assert compacted is False
+        progress = track_retention("sess-1", 8)
+        assert progress.chunk_index == 1
+        assert progress.compacted is False
+        assert progress.start_index == 4
 
-    def test_equal_count_keeps_same_chunk(self):
+    def test_equal_count_keeps_same_chunk_and_skips_all_messages(self):
         track_retention("sess-1", 5)
-        chunk, compacted = track_retention("sess-1", 5)
-        assert chunk == 0
-        assert compacted is False
+        progress = track_retention("sess-1", 5)
+        assert progress.chunk_index == 0
+        assert progress.compacted is False
+        assert progress.start_index == 5
 
     def test_shrinking_transcript_triggers_compaction(self):
         track_retention("sess-1", 10)
-        chunk, compacted = track_retention("sess-1", 3)
-        assert chunk == 1
-        assert compacted is True
+        progress = track_retention("sess-1", 3)
+        assert progress.chunk_index == 1
+        assert progress.compacted is True
+        assert progress.start_index == 0
 
     def test_multiple_compactions_increment_chunk(self):
         track_retention("sess-1", 10)
 
-        chunk, compacted = track_retention("sess-1", 3)
-        assert chunk == 1
-        assert compacted is True
+        progress = track_retention("sess-1", 3)
+        assert progress.chunk_index == 1
+        assert progress.compacted is True
+        assert progress.start_index == 0
 
         # Grow again after compaction
         track_retention("sess-1", 8)
 
         # Second compaction
-        chunk, compacted = track_retention("sess-1", 2)
-        assert chunk == 2
-        assert compacted is True
+        progress = track_retention("sess-1", 2)
+        assert progress.chunk_index == 3
+        assert progress.compacted is True
+        assert progress.start_index == 0
 
-    def test_growth_after_compaction_stays_on_same_chunk(self):
+    def test_growth_after_compaction_advances_to_next_delta_chunk(self):
         track_retention("sess-1", 10)
-        track_retention("sess-1", 3)  # compaction → chunk 1
+        track_retention("sess-1", 3)  # compaction -> chunk 1
 
-        chunk, compacted = track_retention("sess-1", 6)
-        assert chunk == 1
-        assert compacted is False
+        progress = track_retention("sess-1", 6)
+        assert progress.chunk_index == 2
+        assert progress.compacted is False
+        assert progress.start_index == 3
 
     def test_sessions_are_independent(self):
         track_retention("sess-a", 10)
         track_retention("sess-b", 20)
 
         # Compaction on sess-a only
-        chunk_a, compacted_a = track_retention("sess-a", 3)
-        chunk_b, compacted_b = track_retention("sess-b", 25)
+        progress_a = track_retention("sess-a", 3)
+        progress_b = track_retention("sess-b", 25)
 
-        assert chunk_a == 1
-        assert compacted_a is True
-        assert chunk_b == 0
-        assert compacted_b is False
+        assert progress_a.chunk_index == 1
+        assert progress_a.compacted is True
+        assert progress_a.start_index == 0
+        assert progress_b.chunk_index == 1
+        assert progress_b.compacted is False
+        assert progress_b.start_index == 20
 
     def test_persists_across_calls(self, tmp_path):
         """State file is written to disk and survives between calls."""
@@ -93,16 +101,18 @@ class TestTrackRetention:
     def test_compaction_from_one_message(self):
         """Edge case: transcript shrinks to a single message."""
         track_retention("sess-1", 50)
-        chunk, compacted = track_retention("sess-1", 1)
-        assert chunk == 1
-        assert compacted is True
+        progress = track_retention("sess-1", 1)
+        assert progress.chunk_index == 1
+        assert progress.compacted is True
+        assert progress.start_index == 0
 
     def test_shrink_by_one_triggers_compaction(self):
         """Even shrinking by a single message counts as compaction."""
         track_retention("sess-1", 10)
-        chunk, compacted = track_retention("sess-1", 9)
-        assert chunk == 1
-        assert compacted is True
+        progress = track_retention("sess-1", 9)
+        assert progress.chunk_index == 1
+        assert progress.compacted is True
+        assert progress.start_index == 0
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-integrations/claude-code/tests/test_state.py
+++ b/hindsight-integrations/claude-code/tests/test_state.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from lib.state import read_state, track_retention, write_state
+from lib.state import commit_retention, plan_retention, read_state, track_retention, write_state
 
 
 @pytest.fixture(autouse=True)
@@ -113,6 +113,22 @@ class TestTrackRetention:
         assert progress.chunk_index == 1
         assert progress.compacted is True
         assert progress.start_index == 0
+
+
+class TestPlanCommitRetention:
+    def test_plan_does_not_persist_checkpoint(self):
+        progress = plan_retention("sess-1", 4)
+        assert progress.chunk_index == 0
+        assert progress.compacted is False
+        assert progress.start_index == 0
+        assert read_state("retention_tracking.json", {}) == {}
+
+    def test_commit_advances_next_plan(self):
+        commit_retention("sess-1", 4, 0)
+        progress = plan_retention("sess-1", 7)
+        assert progress.chunk_index == 1
+        assert progress.compacted is False
+        assert progress.start_index == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2644

Fixes the Claude Code integration Stop hook so full-session retain no longer resends the entire cumulative transcript on every retain call. The first retain keeps the existing `session_id` document_id behavior, while later normal growth sends only new messages under `session_id-cN` chunk documents. If Claude Code compacts the transcript, the compacted transcript starts a fresh chunk instead of overwriting the pre-compaction document.

## Changes

- Track full-session retain progress with a typed `RetentionProgress` dataclass
- Retain only messages after the last committed transcript count for normal growth
- Skip retain when the transcript has no new messages
- Preserve compaction protection by starting a fresh chunk after transcript shrink
- Update Claude Code README to describe delta chunk behavior
- Add/update regression tests for growth, duplicate Stop hooks, and compaction

## Validation

```bash
uv run pytest hindsight-integrations/claude-code/tests/test_state.py hindsight-integrations/claude-code/tests/test_hooks.py -q
uv run ruff check hindsight-integrations/claude-code/scripts/retain.py hindsight-integrations/claude-code/scripts/lib/state.py hindsight-integrations/claude-code/tests/test_state.py hindsight-integrations/claude-code/tests/test_hooks.py
./scripts/hooks/lint.sh