### PR TITLE
deps(security): require LiteLLM 1.84.0

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "typer>=0.9.0",
     "cohere>=5.0.0",
-    "litellm>=1.83.14", # 1.82.7/1.82.8 had a supply chain compromise (yanked); 1.83.0+ also fixes GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789 / GHSA-pq44-5pcq-4r5g / GHSA-8cjq-wjmh-q42r
+    "litellm>=1.84.0", # 1.82.7/1.82.8 had a supply chain compromise (yanked); 1.83.0+ also fixes GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789 / GHSA-pq44-5pcq-4r5g / GHSA-8cjq-wjmh-q42r; 1.84.0 fixes GHSA-4xpc-pv4p-pm3w
     "markitdown[pdf,docx,pptx,xlsx,xls]>=0.1.4", # File to markdown conversion
     "obstore>=0.4.0", # S3/GCS/Azure object storage client (Rust-backed)
     "winloop>=0.1.0; sys_platform == 'win32'",

--- a/hindsight-integrations/litellm/pyproject.toml
+++ b/hindsight-integrations/litellm/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 dependencies = [
     "hindsight-client>=0.4.0",  # provides both hindsight_client and hindsight_client_api
-    "litellm>=1.83.14", # 1.82.7/1.82.8 supply-chain fix plus GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789 / GHSA-qrc4-49gv-mv9m / GHSA-wpfp-gwwc-vwq6
+    "litellm>=1.84.0", # 1.82.7/1.82.8 supply-chain fix plus GHSA-jjhc-v7c2-5hh6 / GHSA-53mr-6c8q-9789 / GHSA-qrc4-49gv-mv9m / GHSA-wpfp-gwwc-vwq6 / GHSA-4xpc-pv4p-pm3w
     # Transitive dependency security fixes
     "aiohttp>=3.13.3",  # Multiple DoS vulnerabilities
     "filelock>=3.20.3",  # TOCTOU race condition

--- a/hindsight-integrations/litellm/uv.lock
+++ b/hindsight-integrations/litellm/uv.lock
@@ -679,7 +679,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "hindsight-client", specifier = ">=0.4.0" },
-    { name = "litellm", specifier = ">=1.83.14" },
+    { name = "litellm", specifier = ">=1.84.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1826,7 +1826,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.2.22" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0" },
     { name = "langsmith", specifier = ">=0.8.18" },
-    { name = "litellm", specifier = ">=1.83.14" },
+    { name = "litellm", specifier = ">=1.84.0" },
     { name = "llama-cpp-python", extras = ["server"], marker = "extra == 'local-llm'", specifier = ">=0.3.0" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx", "xls"], specifier = ">=0.1.4" },
     { name = "mlx", marker = "sys_platform != 'win32' and extra == 'local-ml'", specifier = ">=0.31.0" },


### PR DESCRIPTION
## Summary

- raise the LiteLLM lower bound to 1.84.0 for the API-slim package and the LiteLLM integration
- sync the root and integration lockfile `requires-dist` metadata with that floor
- keep the resolved lockfile package at LiteLLM 1.87.0, which is already above the patched 1.84.0 floor

Refs GHSA-4xpc-pv4p-pm3w.

## Tests

- `git diff --check`
- `uv lock --check`
- `(cd hindsight-integrations/litellm && uv lock --check)`
