### PR TITLE
feat(anthropic): carry the prompt-cache marker on batch system prompts

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -617,6 +617,12 @@ class AnthropicLLM(LLMInterface):
         an OpenAI ``response_format`` json_schema becomes a single forced
         tool_use tool when strict (native constrained decoding, issue #1002),
         else the schema is injected into the system prompt.
+
+        The system prompt carries the same cache_control marker as the sync
+        one-shot path (its sole breakpoint): every request in a retain batch
+        shares the fact-extraction system prompt, so the first item's cache
+        write serves the remaining items as best-effort reads — and the
+        cache-read discount stacks with the 50% batch discount.
         """
         system_prompt: str | None = None
         messages: list[dict[str, Any]] = []
@@ -653,7 +659,7 @@ class AnthropicLLM(LLMInterface):
                 system_prompt = (system_prompt + schema_msg) if system_prompt else schema_msg
 
         if system_prompt:
-            params["system"] = system_prompt
+            params["system"] = _cached_system_blocks(system_prompt)
 
         # Batch params ARE the raw Messages body, so operator-configured extra
         # body params merge directly (the sync path routes them through the

--- a/hindsight-api-slim/tests/test_anthropic_batch.py
+++ b/hindsight-api-slim/tests/test_anthropic_batch.py
@@ -126,8 +126,9 @@ async def test_submit_batch_translates_openai_requests():
 
     params = submitted[0]["params"]
     assert params["model"] == "claude-sonnet-5"
-    # System message folded into the system param, not left in messages.
-    assert "Extract facts." in params["system"]
+    # System message folded into the system param (as the cached block list
+    # the sync call() path sends), not left in messages.
+    assert "Extract facts." in params["system"][0]["text"]
     assert all(m["role"] != "system" for m in params["messages"])
     assert params["messages"] == [{"role": "user", "content": "Text for chunk_0"}]
     assert params["max_tokens"] == 2000
@@ -151,9 +152,47 @@ async def test_submit_batch_non_strict_schema_injects_into_system():
     params = provider._client.messages.batches.create.await_args.kwargs["requests"][0]["params"]
     assert "tools" not in params
     assert "tool_choice" not in params
-    # Schema is injected into the system prompt for JSON-text output.
-    assert "facts" in params["system"]
-    assert "valid JSON" in params["system"]
+    # Schema is injected into the system prompt for JSON-text output —
+    # inside the cached block, so the injection is part of the cached prefix.
+    assert "facts" in params["system"][0]["text"]
+    assert "valid JSON" in params["system"][0]["text"]
+
+
+async def test_submit_batch_system_carries_cache_control_marker():
+    """Batch items share their system prompt, so it gets the cache marker.
+
+    Mirrors the sync ``call()`` one-shot rule: system is the sole cache
+    breakpoint. Within a Message Batch every request carries the same fact-
+    extraction system prompt, so the first request's cache write serves the
+    rest as best-effort reads (and stacks with the 50% batch discount).
+    """
+    provider = _make_provider()
+    provider._client.messages.batches.create = AsyncMock(return_value=_batch("in_progress", processing=1))
+
+    await provider.submit_batch([_openai_request("chunk_0")])
+
+    params = provider._client.messages.batches.create.await_args.kwargs["requests"][0]["params"]
+    assert params["system"] == [{"type": "text", "text": "Extract facts.", "cache_control": {"type": "ephemeral"}}]
+    # One-shot items: no end-marker on messages (that breakpoint only pays
+    # off on the sync tool loop, where the next iteration reads it back).
+    assert "cache_control" not in json.dumps(params["messages"])
+
+
+async def test_submit_batch_without_system_message_sends_no_system_param():
+    provider = _make_provider()
+    provider._client.messages.batches.create = AsyncMock(return_value=_batch("in_progress", processing=1))
+
+    body = {
+        "model": "claude-sonnet-5",
+        "messages": [{"role": "user", "content": "no system here"}],
+        "max_completion_tokens": 1000,
+    }
+    request = {"custom_id": "chunk_0", "method": "POST", "url": "/v1/chat/completions", "body": body}
+    await provider.submit_batch([request])
+
+    params = provider._client.messages.batches.create.await_args.kwargs["requests"][0]["params"]
+    assert "system" not in params
+    assert "cache_control" not in json.dumps(params["messages"])
 
 
 async def test_get_batch_status_in_progress():


### PR DESCRIPTION
Follow-up to #2628 + #2629 (thanks for the quick reviews and merges on both).

## What

`_translate_batch_body` sent `system` as a plain string, so batch requests never participated in prompt caching. This renders it through the same `_cached_system_blocks` helper the sync path uses — batch items are one-shots, so it applies `call()`'s one-shot rule exactly: **system is the sole cache breakpoint**.

Deliberately **no end-marker on batch messages**: that second breakpoint only pays off on the sync tool loop, where the next iteration reads the growing prefix back. Batch items are independent one-shots — marking each item's final message would be pure cache-write premium with nothing ever reading it.

## Why it pays

Every request in a retain batch shares the fact-extraction system prompt, so the first item's cache write serves the remaining items as best-effort reads within the batch — and the cache-read discount stacks with the 50% batch discount. Marking below the model's minimum cacheable prefix is silently ignored (no write premium), so this is safe unconditionally — same reasoning as the `_cached_system_blocks` docstring.

## Tests

TDD, mirroring the existing batch-suite style:
- cached-block wire shape: marker present on system, `messages` unmarked (`cache_control` nowhere in them)
- non-strict schema injection lands **inside** the cached block (part of the cached prefix)
- requests without a system message are unchanged (no `system` param, no markers)
- existing shape assertions updated from string to block list

`test_anthropic_batch.py` + `test_anthropic_prompt_caching.py` + `test_anthropic_structured_tool_use.py` + `test_llm_extra_body.py`: **46 pass** locally. (`test_llm_provider.py`'s 2 failures reproduce on clean `main` in my env — pre-existing/environmental, not from this diff.) `ruff check` + `ruff format --check` clean on both touched files.

Since `cache_read_input_tokens` already flows into metrics (#2629), batch cache effectiveness is observable immediately.
