### PR TITLE
Fix Claude Code full-session retain growth

### DIFF
--- a/hindsight-integrations/claude-code/scripts/lib/state.py
+++ b/hindsight-integrations/claude-code/scripts/lib/state.py
@@ -194,3 +194,52 @@ def track_retention(session_id: str, message_count: int) -> tuple:
         return data, (chunk, compacted)
 
     return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)
+
+
+def plan_delta_retention(session_id: str, message_count: int) -> tuple:
+    """Plan the next full-session retain without mutating state.
+
+    Returns:
+        (start_index, document_index, compacted)
+
+    ``start_index`` is the first transcript message that has not been
+    successfully retained yet. ``document_index`` is used by the caller to build
+    the document_id: 0 maps to the plain session_id, then 1 maps to
+    ``session_id-c1``, and so on.
+    """
+    data = read_state("retention_tracking.json", {})
+    entry = data.get(session_id, {"message_count": 0, "next_chunk": 0})
+    last_count = int(entry.get("message_count", 0))
+
+    if "next_chunk" in entry:
+        document_index = int(entry.get("next_chunk", 0))
+    else:
+        # Backward compatibility with the old compaction-only state shape:
+        # if a session had already retained content, the next delta must not
+        # reuse the plain session_id document and overwrite it.
+        document_index = int(entry.get("chunk", 0)) + (1 if last_count > 0 else 0)
+
+    if message_count < last_count:
+        return 0, document_index, True
+
+    return min(last_count, message_count), document_index, False
+
+
+def commit_delta_retention(session_id: str, message_count: int, document_index: int):
+    """Commit a full-session retain checkpoint after the API call succeeds."""
+
+    def _update(data):
+        data[session_id] = {
+            "message_count": message_count,
+            "chunk": document_index,
+            "next_chunk": document_index + 1,
+        }
+
+        if len(data) > 10000:
+            sorted_keys = sorted(data.keys())
+            for k in sorted_keys[: len(sorted_keys) // 2]:
+                del data[k]
+
+        return data, None
+
+    return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)

--- a/hindsight-integrations/claude-code/scripts/retain.py
+++ b/hindsight-integrations/claude-code/scripts/retain.py
@@ -32,7 +32,7 @@ from lib.content import (
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
-from lib.state import increment_turn_count, track_retention
+from lib.state import commit_delta_retention, increment_turn_count, plan_delta_retention
 
 
 def read_transcript(transcript_path: str) -> list:
@@ -94,6 +94,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     retain_every_n = max(1, config.get("retainEveryNTurns", 1))
     retain_full_window = False
     messages_to_retain = all_messages
+    full_session_delta = None
 
     # Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
     if retain_every_n > 1 and not force:
@@ -114,9 +115,27 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             f"Chunked retain firing (window: {window_turns} turns, {len(messages_to_retain)} messages)",
         )
     else:
-        # Full session mode: retain all messages, always as full window
+        # Full session mode keeps the full conversation across documents, but
+        # only sends messages that were not retained by a successful prior call.
+        start_index, document_index, compacted = plan_delta_retention(session_id, len(all_messages))
+        if start_index >= len(all_messages):
+            debug_log(config, f"Full session retain: no new messages for session {session_id}, skipping retain")
+            return
+        messages_to_retain = all_messages[start_index:]
         retain_full_window = True
-        debug_log(config, f"Full session retain: {len(all_messages)} messages")
+        full_session_delta = (document_index, len(all_messages))
+        if compacted:
+            debug_log(
+                config,
+                f"Compaction detected for session {session_id}: transcript shrank, "
+                f"retaining {len(messages_to_retain)} messages as chunk {document_index}",
+            )
+        else:
+            debug_log(
+                config,
+                f"Full session delta retain: {len(messages_to_retain)} new messages "
+                f"of {len(all_messages)} total",
+            )
 
     # Format transcript
     retain_roles = config.get("retainRoles", ["user", "assistant"])
@@ -156,23 +175,14 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
 
     # Document ID strategy:
     # - Chunked mode: each chunk gets a timestamped document_id.
-    # - Full-session mode: uses session_id as base, but tracks message count
-    #   to detect compaction.  When Claude Code compacts the conversation the
-    #   transcript shrinks — if we kept the same document_id we'd overwrite the
-    #   pre-compaction document with a shorter one, losing context.  Instead we
-    #   increment a chunk counter so the old document is preserved.
+    # - Full-session mode: first retain uses session_id for compatibility, then
+    #   later deltas use session_id-cN so Hindsight accumulates the session
+    #   without overwriting the previous document on each Stop hook.
     if retain_mode == "chunked" and retain_every_n > 1:
         document_id = f"{session_id}-{int(time.time() * 1000)}"
     else:
-        chunk_index, compacted = track_retention(session_id, len(all_messages))
-        if compacted:
-            debug_log(
-                config,
-                f"Compaction detected for session {session_id}: transcript shrank, "
-                f"advancing to chunk {chunk_index} to preserve prior document",
-            )
-        # chunk 0 → plain session_id (backwards compatible with existing docs)
-        document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
+        document_index = full_session_delta[0] if full_session_delta else 0
+        document_id = session_id if document_index == 0 else f"{session_id}-c{document_index}"
 
     # Resolve template variables in tags and metadata.
     # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}
@@ -231,6 +241,8 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
             tags=tags,
             timeout=15,
         )
+        if full_session_delta:
+            commit_delta_retention(session_id, full_session_delta[1], full_session_delta[0])
         debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
     except Exception as e:
         print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)

--- a/hindsight-integrations/claude-code/tests/test_hooks.py
+++ b/hindsight-integrations/claude-code/tests/test_hooks.py
@@ -614,8 +614,8 @@ class TestRetainHook:
         assert captured_calls[1]["items"][0]["document_id"] == "sess-compact-test-c1"
         assert "third question" in captured_calls[1]["items"][0]["content"]
 
-    def test_full_session_same_document_when_growing(self, monkeypatch, tmp_path):
-        """When transcript grows (no compaction), retain should keep the same document_id."""
+    def test_full_session_delta_document_when_growing(self, monkeypatch, tmp_path):
+        """When transcript grows, retain should send only new messages to the next document."""
         messages_2 = [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "world"},
@@ -642,9 +642,37 @@ class TestRetainHook:
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
 
         assert len(captured_calls) == 2
-        # Both should use the same plain session_id
         assert captured_calls[0]["items"][0]["document_id"] == "sess-grow-test"
-        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test"
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test-c1"
+        second_content = captured_calls[1]["items"][0]["content"]
+        assert "hello" not in second_content
+        assert "more stuff" in second_content
+
+    def test_full_session_failure_does_not_advance_delta_checkpoint(self, monkeypatch, tmp_path):
+        """A failed retain should retry the same transcript slice on the next hook."""
+        messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-retry-test")
+        captured_calls = []
+
+        def fail_first_then_capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                body = json.loads(req.data.decode())
+                captured_calls.append(body)
+                if len(captured_calls) == 1:
+                    raise OSError("connection dropped")
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=fail_first_then_capture)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=fail_first_then_capture)
+
+        assert len(captured_calls) == 2
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-retry-test"
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-retry-test"
+        assert "first question" in captured_calls[1]["items"][0]["content"]
 
     def test_full_session_respects_retain_every_n_turns(self, monkeypatch, tmp_path):
         """In full-session mode, retainEveryNTurns should still gate when retain fires."""

--- a/hindsight-integrations/claude-code/tests/test_state.py
+++ b/hindsight-integrations/claude-code/tests/test_state.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from lib.state import read_state, track_retention, write_state
+from lib.state import commit_delta_retention, plan_delta_retention, read_state, track_retention, write_state
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +103,42 @@ class TestTrackRetention:
         chunk, compacted = track_retention("sess-1", 9)
         assert chunk == 1
         assert compacted is True
+
+
+class TestDeltaRetention:
+    def test_first_plan_starts_at_zero_with_plain_document(self):
+        start, document_index, compacted = plan_delta_retention("sess-1", 4)
+        assert start == 0
+        assert document_index == 0
+        assert compacted is False
+
+    def test_successful_commit_advances_start_and_document_index(self):
+        commit_delta_retention("sess-1", 4, 0)
+        start, document_index, compacted = plan_delta_retention("sess-1", 7)
+        assert start == 4
+        assert document_index == 1
+        assert compacted is False
+
+    def test_plan_does_not_commit_on_its_own(self):
+        plan_delta_retention("sess-1", 4)
+        start, document_index, compacted = plan_delta_retention("sess-1", 4)
+        assert start == 0
+        assert document_index == 0
+        assert compacted is False
+
+    def test_compaction_resets_start_but_keeps_next_document(self):
+        commit_delta_retention("sess-1", 10, 2)
+        start, document_index, compacted = plan_delta_retention("sess-1", 3)
+        assert start == 0
+        assert document_index == 3
+        assert compacted is True
+
+    def test_old_compaction_state_shape_does_not_reuse_plain_document(self):
+        write_state("retention_tracking.json", {"sess-1": {"message_count": 5, "chunk": 0}})
+        start, document_index, compacted = plan_delta_retention("sess-1", 8)
+        assert start == 5
+        assert document_index == 1
+        assert compacted is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the Claude Code plugin full-session retain path so repeated Stop hooks stop resending the entire cumulative transcript.

- first full-session retain keeps the existing plain `session_id` document id
- later full-session retains send only messages after the last successful checkpoint to `session_id-cN`
- checkpoints advance only after the retain API call succeeds, so failed calls retry the same slice
- transcript compaction resets the slice to the compacted transcript while still using the next chunk document id
- old compaction-only state files are treated as already having used the plain `session_id` document, so they do not overwrite it on upgrade

This targets #2644.

## Tests

- `uv run pytest tests/test_state.py tests/test_hooks.py -q` -> `49 passed`
- `uv run pytest -q -k 'not test_exec_runs_from_plugin_data_dir_when_project_env_is_unreadable'` -> `202 passed, 1 deselected`
- `python3 -m py_compile hindsight-integrations/claude-code/scripts/retain.py hindsight-integrations/claude-code/scripts/lib/state.py`
- `git diff --check`
- pre-commit hook on commit passed, including `lint.sh`

One unrelated local test still fails for me unchanged: `tests/test_run_mcp.py::TestMcpServerWorkingDirectory::test_exec_runs_from_plugin_data_dir_when_project_env_is_unreadable` returns no output from the fake `exec` shell probe. I left that path untouched.
