### PR TITLE
fix(consolidation): request JSON dedup decisions

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -115,15 +115,38 @@ class _DedupDecision(BaseModel):
         return "keep"
 
 
+def _dedup_decision_from_response(raw: Any) -> _DedupDecision:
+    try:
+        if isinstance(raw, _DedupDecision):
+            return raw
+        if isinstance(raw, str):
+            return _DedupDecision.model_validate_json(raw)
+        return _DedupDecision.model_validate(raw)
+    except ValueError as exc:
+        logger.warning("Invalid consolidation dedup response %r; defaulting to keep: %s", raw, exc)
+        return _DedupDecision(action="keep", reason="invalid structured response")
+
+
 _DEDUP_PROMPT = """You reconcile long-term memory observations. A NEW observation is about to be \
 stored, and it is highly similar to an EXISTING one:
 
 [NEW] {new}
 [EXISTING] {existing}
 
-If they assert the SAME fact (wording aside), respond action="merge" and provide `text`: a single \
-observation that preserves EVERY detail from both. If they differ in ANY important detail — a \
-number/quantity, a named entity or language, a negation, or a condition — respond action="keep"."""
+Respond with ONLY one valid JSON object matching one of these shapes:
+
+For duplicate facts:
+{{"action": "merge", "text": "...", "reason": "..."}}
+
+For distinct facts:
+{{"action": "keep", "text": "", "reason": "..."}}
+
+Do NOT use key=value lines, markdown fences, or any text outside the JSON object.
+
+If they assert the SAME fact (wording aside), set "action" to "merge" and provide "text": a \
+single observation that preserves EVERY detail from both. If they differ in ANY important detail \
+— a number/quantity, a named entity or language, a negation, or a condition — set "action" to \
+"keep" and "text" to an empty string."""
 
 
 def _dedup_active(config: Any) -> bool:
@@ -201,10 +224,12 @@ async def _dedup_adjudicate(
     if best_id is None:
         return _DedupOutcome(best_id=None, merged_text="", should_merge=False)
 
-    decision: _DedupDecision = await dedup_llm_config.call(
-        messages=[{"role": "user", "content": _DEDUP_PROMPT.format(new=anchor_text, existing=best_text)}],
-        response_format=_DedupDecision,
-        scope="consolidation_dedup",
+    decision = _dedup_decision_from_response(
+        await dedup_llm_config.call(
+            messages=[{"role": "user", "content": _DEDUP_PROMPT.format(new=anchor_text, existing=best_text)}],
+            response_format=_DedupDecision,
+            scope="consolidation_dedup",
+        )
     )
     if decision.action != "merge":
         return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False)

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -14,7 +14,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from hindsight_api.engine.consolidation.consolidator import (
+    _DEDUP_PROMPT,
     _dedup_active,
+    _dedup_decision_from_response,
     _dedup_reconcile_create,
     _dedup_reconcile_update,
     _DedupDecision,
@@ -127,7 +129,7 @@ async def test_dedup_no_twin_above_threshold_returns_none() -> None:
 
 async def test_dedup_llm_keep_does_not_merge() -> None:
     kwargs, conn, llm = _ctx()
-    llm.call.return_value = _DedupDecision(action="keep", reason="different language")
+    llm.call.return_value = '{"action": "keep", "text": "", "reason": "different language"}'
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
@@ -190,10 +192,46 @@ def test_dedup_decision_non_scalar_action_defaults_to_keep(caplog) -> None:
     assert "defaulting to keep" in caplog.text
 
 
+def test_dedup_decision_accepts_raw_json_and_dict_responses() -> None:
+    raw_merge = '{"action": "merge", "text": "Merged observation.", "reason": "same fact"}'
+    raw_keep = {"action": "keep", "text": "", "reason": "different fact"}
+
+    merge_decision = _dedup_decision_from_response(raw_merge)
+    keep_decision = _dedup_decision_from_response(raw_keep)
+
+    assert merge_decision.action == "merge"
+    assert merge_decision.text == "Merged observation."
+    assert keep_decision.action == "keep"
+    assert keep_decision.text == ""
+
+
+def test_dedup_decision_legacy_raw_text_defaults_to_keep(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        decision = _dedup_decision_from_response('action="merge" text="Merged observation."')
+
+    assert decision.action == "keep"
+    assert decision.reason == "invalid structured response"
+    assert "Invalid consolidation dedup response" in caplog.text
+
+
+def test_dedup_prompt_contract_requests_json_not_key_value() -> None:
+    prompt = _DEDUP_PROMPT.format(new="The agent checked health at 14:07.", existing="Health was checked.")
+
+    assert '{"action": "merge", "text": "...", "reason": "..."}' in prompt
+    assert '{"action": "keep", "text": "", "reason": "..."}' in prompt
+    assert '"text" to an empty string' in prompt
+    assert "Do NOT use key=value" in prompt
+    assert 'respond action="merge"' not in prompt
+    assert "{new}" not in prompt
+    assert "{existing}" not in prompt
+
+
 async def test_dedup_llm_merge_folds_into_twin() -> None:
     kwargs, conn, llm = _ctx()
     kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
-    llm.call.return_value = _DedupDecision(action="merge", text="Uzbek content on YouTube is very rich.")
+    llm.call.return_value = (
+        '{"action": "merge", "text": "Uzbek content on YouTube is very rich.", "reason": "same fact"}'
+    )
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]):
         result = await _dedup_reconcile_create(**kwargs)
     assert result == _TWIN_ID  # merged into the twin; caller skips the CREATE


### PR DESCRIPTION
Fixes #2658.

## Summary

- change the consolidation dedup prompt from the old `action="merge"` key/value wording to explicit JSON shapes for both merge and keep decisions
- tolerate parsed Pydantic decisions, raw JSON strings, and raw dicts from the LLM layer before applying the dedup decision
- default malformed or legacy raw text responses to `keep` so a non-compliant model does not abort consolidation
- add regression coverage for JSON prompt formatting, raw JSON/dict response coercion, legacy raw text fallback, and the create-path merge/keep behavior with raw JSON responses

## Verification

- `ruff format --check hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py hindsight-api-slim/tests/test_consolidation_dedup.py`
- `ruff check hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py hindsight-api-slim/tests/test_consolidation_dedup.py`
- `git diff --check`
- `python3 -m compileall -q hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py hindsight-api-slim/tests/test_consolidation_dedup.py`
- isolated prompt-contract harness
- isolated raw decision coercion harness

`PYTHONPATH=hindsight-api-slim python3 -m pytest -o addopts='' hindsight-api-slim/tests/test_consolidation_dedup.py` could not run in this sparse cron environment because `asyncpg` is not installed. Earlier `uv run --frozen pytest ...` attempts were also blocked by unavailable locked platform wheels for this Python/platform combination.
