### PR TITLE
fix(retain): preserve memories when appending

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3448,19 +3448,23 @@ class MemoryEngine(MemoryEngineInterface):
             # worth of chunks/memories (issue #1888). Counting uses the same
             # bank-resolved, strategy-applied chunk size the orchestrator chunks
             # with, so the offsets match the chunk_index values it assigns.
-            from .retain import fact_extraction, fact_storage
+            from .retain import chunk_storage, fact_extraction
 
             chunking_config = await self._resolve_retain_chunking_config(bank_id, request_context, strategy)
             chunk_offsets: dict[str, int] = {}
 
-            # In update_mode="append", retain_batch prepends the existing document
-            # body to the FIRST sub-batch as an extra content item before chunking
-            # (see orchestrator.retain_batch), consuming chunks(existing_body)
-            # additional chunk_index slots ahead of that sub-batch's own content.
-            # Capture that chunk count per document up front — the first sub-batch
-            # overwrites documents.original_text when it commits, so it can't be
-            # read back afterwards — and fold it into the offset so later
-            # sub-batches continue past the prepended chunks instead of colliding.
+            # In update_mode="append" with the new preserve-units path
+            # (orchestrator.retain_batch >= PR #2666), the first sub-batch
+            # internally sets chunk_index_offset = existing_chunk_count (the
+            # orchestrator reads the DB and overrides whatever offset the caller
+            # passed).  memory_engine's chunk_offsets dict starts at 0, so after
+            # sub-batch 1 it would store chunk_offsets[doc] = 0+1 = 1 instead of
+            # existing_count+1.  Sub-batch 2 would then receive offset 1 and
+            # collide with existing chunk index 1.
+            #
+            # Fix: seed chunk_offsets with the current existing chunk count for
+            # every document that will be appended to, so the cursor starts in the
+            # right place and memory_engine's accounting tracks correctly.
             append_prepend_chunks: dict[str, int] = {}
             backend = await self._get_backend()
             append_doc_ids: set[str] = set()
@@ -3470,15 +3474,10 @@ class MemoryEngine(MemoryEngineInterface):
                     append_doc_ids.add(item_doc_id)
             for append_doc_id in append_doc_ids:
                 async with acquire_with_retry(backend) as conn:
-                    existing_text = await fact_storage.get_document_content(conn, bank_id, append_doc_id)
-                if existing_text:
-                    append_prepend_chunks[append_doc_id] = len(
-                        fact_extraction.chunk_text(
-                            existing_text,
-                            chunking_config.chunk_size,
-                            structured_chunk_size=chunking_config.structured_chunk_size,
-                        )
-                    )
+                    existing_chunks = await chunk_storage.load_existing_chunks(conn, bank_id, append_doc_id)
+                if existing_chunks:
+                    existing_count = max((c.chunk_index for c in existing_chunks), default=-1) + 1
+                    chunk_offsets[append_doc_id] = existing_count
 
             for i, (sub_batch, sub_origins) in enumerate(zip(sub_batches, origin_indices), 1):
                 # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -824,54 +824,37 @@ async def retain_batch(
     if update_mode == "append" and effective_doc_id and is_first_batch:
         async with acquire_with_retry(pool) as conn:
             existing_text = await fact_storage.get_document_content(conn, bank_id, effective_doc_id)
+            existing_chunks = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
         if existing_text:
-            # Prepend existing text as a new content item at the beginning
-            existing_content: RetainContentDict = {"content": existing_text}
-            # Copy context/tags from first item for consistency
-            first = contents_dicts[0]
-            if first.get("context"):
-                existing_content["context"] = first["context"]
-            if first.get("event_date"):
-                existing_content["event_date"] = first["event_date"]
-            if first.get("metadata"):
-                existing_content["metadata"] = first["metadata"]
-            if first.get("observation_scopes") is not None:
-                existing_content["observation_scopes"] = first["observation_scopes"]
-            if first.get("tags"):
-                existing_content["tags"] = first["tags"]
-            contents_dicts = [existing_content, *contents_dicts]
-            # Merge JSON arrays to keep original_text valid (#2409).
-            # Without this, combined_content joins items with "\n", producing
-            # "[...]\n[...]" which is not valid JSON. On the next append cycle
-            # chunk_text() fails to parse it and falls through to sentence-
-            # boundary text splitting, breaking speaker attribution.
+            incoming_text = (
+                document_body_override
+                if document_body_override is not None
+                else "\n".join([c.get("content", "") for c in contents_dicts])
+            )
+            appended_body = f"{existing_text}\n{incoming_text}"
+
+            # Keep stored original_text valid for JSON-array transcripts (#2409),
+            # but do not reprocess the old text. Append should accumulate memory:
+            # old chunks/memory_units remain attached to the document, and only
+            # this request's new content is extracted into additional chunks.
             try:
-                _merged = []
-                for _item in contents_dicts:
-                    _parsed = json.loads(_item.get("content", ""))
-                    if isinstance(_parsed, list) and all(isinstance(_e, dict) for _e in _parsed):
-                        _merged.extend(_parsed)
-                    else:
-                        _merged = None
-                        break
-                if _merged is not None:
-                    contents_dicts = [{"content": json.dumps(_merged, ensure_ascii=False)}]
-                    if first.get("context"):
-                        contents_dicts[0]["context"] = first["context"]
-                    if first.get("event_date"):
-                        contents_dicts[0]["event_date"] = first["event_date"]
-                    if first.get("metadata"):
-                        contents_dicts[0]["metadata"] = first["metadata"]
-                    if first.get("observation_scopes") is not None:
-                        contents_dicts[0]["observation_scopes"] = first["observation_scopes"]
-                    if first.get("tags"):
-                        contents_dicts[0]["tags"] = first["tags"]
+                existing_json = json.loads(existing_text)
+                incoming_json = json.loads(incoming_text)
+                if (
+                    isinstance(existing_json, list)
+                    and isinstance(incoming_json, list)
+                    and all(isinstance(entry, dict) for entry in existing_json)
+                    and all(isinstance(entry, dict) for entry in incoming_json)
+                ):
+                    appended_body = json.dumps([*existing_json, *incoming_json], ensure_ascii=False)
             except (json.JSONDecodeError, ValueError, TypeError):
                 pass
-            # Rebuild contents list to match
-            contents = _build_contents(contents_dicts, document_tags)
+
+            document_body_override = appended_body
+            chunk_index_offset = max((chunk.chunk_index for chunk in existing_chunks), default=-1) + 1
             log_buffer.append(
-                f"[append] Prepended {len(existing_text):,} chars from existing document {effective_doc_id}"
+                f"[append] Extending document {effective_doc_id}: preserving {len(existing_chunks)} existing chunks, "
+                f"appending {len(incoming_text):,} chars"
             )
 
     # --- Stale-request check (best-effort, before LLM extraction) ---
@@ -899,8 +882,13 @@ async def retain_batch(
             # billing cleanly instead of falling back to full-content billing.
             return [[] for _ in contents], TokenUsage(), 0
 
+    # Append mode should accumulate memory for the stable document_id. The retained
+    # document text is rewritten to the full appended body, but existing chunks and
+    # memory_units must stay in place while new chunks are added.
+    preserve_existing_document_units = update_mode == "append" and effective_doc_id is not None and is_first_batch
+
     # --- Delta retain: check if we can skip unchanged chunks ---
-    if is_first_batch:
+    if is_first_batch and update_mode != "append":
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -986,6 +974,7 @@ async def retain_batch(
         document_body_override=document_body_override,
         chunk_index_offset=chunk_index_offset,
         progress_callback=progress_callback,
+        preserve_existing_document_units=preserve_existing_document_units,
     )
 
 
@@ -1126,6 +1115,7 @@ async def _streaming_retain_batch(
     document_body_override: str | None = None,
     chunk_index_offset: int = 0,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
+    preserve_existing_document_units: bool = False,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -1426,7 +1416,7 @@ async def _streaming_retain_batch(
                             effective_doc_id,
                             bank_id,
                         )
-                        if is_recovery:
+                        if is_recovery or preserve_existing_document_units:
                             await fact_storage.upsert_document_metadata(
                                 conn,
                                 bank_id,
@@ -1528,7 +1518,7 @@ async def _streaming_retain_batch(
 
                     if not doc_tracking_done[0]:
                         # --- First batch: document tracking (atomic with chunk write) ---
-                        if is_recovery:
+                        if is_recovery or preserve_existing_document_units:
                             await fact_storage.upsert_document_metadata(
                                 conn,
                                 bank_id,
@@ -1537,9 +1527,10 @@ async def _streaming_retain_batch(
                                 retain_params,
                                 merged_tags,
                             )
+                            reason = "recovery" if is_recovery else "append"
                             log_buffer.append(
                                 f"[streaming] Document {effective_doc_id} updated "
-                                f"(recovery, preserving existing chunks)"
+                                f"({reason}, preserving existing chunks)"
                             )
                         else:
                             await fact_storage.handle_document_tracking(
@@ -1720,7 +1711,7 @@ async def _streaming_retain_batch(
                         effective_doc_id,
                         bank_id,
                     )
-                    if is_recovery:
+                    if is_recovery or preserve_existing_document_units:
                         await fact_storage.upsert_document_metadata(
                             conn,
                             bank_id,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -885,7 +885,12 @@ async def retain_batch(
     # Append mode should accumulate memory for the stable document_id. The retained
     # document text is rewritten to the full appended body, but existing chunks and
     # memory_units must stay in place while new chunks are added.
-    preserve_existing_document_units = update_mode == "append" and effective_doc_id is not None and is_first_batch
+    # For oversized appends that are split into multiple sub-batches by the caller
+    # (memory_engine), sub-batches 2..N arrive with is_first_batch=False but still
+    # carry update_mode="append" — they must also use upsert_document_metadata instead
+    # of handle_document_tracking to avoid cascade-deleting chunks committed by
+    # sub-batch 1.  Use update_mode directly here rather than the is_first_batch gate.
+    preserve_existing_document_units = update_mode == "append" and effective_doc_id is not None
 
     # --- Delta retain: check if we can skip unchanged chunks ---
     if is_first_batch and update_mode != "append":
@@ -1171,24 +1176,32 @@ async def _streaming_retain_batch(
     sanitized_content = ""
     is_recovery = False
 
-    try:
-        async with acquire_with_retry(pool) as conn:
-            doc_row = await conn.fetchrow(
-                f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
-                effective_doc_id,
-                bank_id,
-            )
-            if doc_row and doc_row["content_hash"] == new_content_hash:
-                existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
-                existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
-                if existing_chunk_hashes:
-                    is_recovery = True
-                    log_buffer.append(
-                        f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
-                        f"will skip matching and preserve existing data"
-                    )
-    except Exception:
-        pass  # If we can't load, just process all chunks
+    # In append mode the orchestrator already placed new chunks past existing
+    # ones (chunk_index_offset > 0).  If the content_hash matches an existing row
+    # — e.g. a later sub-batch whose document_body_override equals what sub-batch 1
+    # already wrote — triggering is_recovery would skip all new chunks instead of
+    # storing them, producing the "skipped N/N already-committed chunks" symptom.
+    # Recovery detection is only meaningful for the FIRST sub-batch of a fresh retain
+    # (chunk_index_offset == 0 AND not the preserve-existing append path).
+    if not preserve_existing_document_units and chunk_index_offset == 0:
+        try:
+            async with acquire_with_retry(pool) as conn:
+                doc_row = await conn.fetchrow(
+                    f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                    effective_doc_id,
+                    bank_id,
+                )
+                if doc_row and doc_row["content_hash"] == new_content_hash:
+                    existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
+                    existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
+                    if existing_chunk_hashes:
+                        is_recovery = True
+                        log_buffer.append(
+                            f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
+                            f"will skip matching and preserve existing data"
+                        )
+        except Exception:
+            pass  # If we can't load, just process all chunks
 
     # ---------------------------------------------------------------------------
     # Document tracking is DEFERRED to the first consumer batch TXN.

--- a/hindsight-api-slim/tests/test_delta_retain_duplicates.py
+++ b/hindsight-api-slim/tests/test_delta_retain_duplicates.py
@@ -270,6 +270,77 @@ async def memory_no_llm(pg0_db_url, embeddings, cross_encoder, query_analyzer):
 
 
 @pytest.mark.asyncio
+async def test_append_mode_preserves_existing_memory_units(memory_no_llm, request_context):
+    """Append mode extends a document without replacing its existing memories."""
+    bank_id = f"test_append_preserve_{_ts()}"
+    document_id = "append-preserve-doc"
+
+    try:
+        first_units = await memory_no_llm.retain_async(
+            bank_id=bank_id,
+            content="Alice prefers PostgreSQL for analytics.",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert first_units
+
+        pool = await memory_no_llm._get_pool()
+        async with pool.acquire() as conn:
+            before_rows = await conn.fetch(
+                "SELECT id, text FROM memory_units WHERE bank_id = $1 AND document_id = $2 ORDER BY created_at",
+                bank_id,
+                document_id,
+            )
+            before_chunk_count = await conn.fetchval(
+                "SELECT count(*) FROM chunks WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+        assert before_rows
+        before_ids = {row["id"] for row in before_rows}
+
+        append_units = await memory_no_llm.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Bob prefers Redis for caching.",
+                    "document_id": document_id,
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+        assert append_units and append_units[0]
+
+        async with pool.acquire() as conn:
+            after_rows = await conn.fetch(
+                "SELECT id, text FROM memory_units WHERE bank_id = $1 AND document_id = $2 ORDER BY created_at",
+                bank_id,
+                document_id,
+            )
+            after_chunk_count = await conn.fetchval(
+                "SELECT count(*) FROM chunks WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+            original_text = await conn.fetchval(
+                "SELECT original_text FROM documents WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                document_id,
+            )
+
+        after_ids = {row["id"] for row in after_rows}
+        assert before_ids <= after_ids
+        assert len(after_rows) > len(before_rows)
+        assert after_chunk_count > before_chunk_count
+        assert "Alice prefers PostgreSQL" in original_text
+        assert "Bob prefers Redis" in original_text
+
+    finally:
+        await memory_no_llm.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
 @pytest.mark.flaky(reruns=2, reruns_delay=2)
 async def test_concurrent_upserts_no_duplicates(memory_no_llm, request_context):
     """

--- a/hindsight-api-slim/tests/test_delta_retain_duplicates.py
+++ b/hindsight-api-slim/tests/test_delta_retain_duplicates.py
@@ -536,3 +536,76 @@ async def test_append_mode_preserves_document_metadata_projection(memory_no_llm,
 
     finally:
         await memory_no_llm.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.hs_llm_core
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
+async def test_append_mode_preserves_memory_units_with_real_llm(memory_real_llm, request_context):
+    """Append with a real LLM must preserve existing memory units.
+
+    This is the real-LLM companion to test_append_mode_preserves_existing_memory_units.
+    On main (before this fix), handle_document_tracking cascade-deletes all existing
+    memory_units on the first append retain, so the before_ids <= after_ids assertion
+    would fail.  On this branch, upsert_document_metadata is used instead and old
+    units survive.
+    """
+    bank_id = f"test_append_llm_{_ts()}"
+    document_id = "append-llm-doc"
+
+    try:
+        first_units = await memory_real_llm.retain_async(
+            bank_id=bank_id,
+            content="Sophia works as a machine learning engineer at a robotics company.",
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert first_units, "First retain should extract at least one memory unit"
+
+        pool = await memory_real_llm._get_pool()
+        async with pool.acquire() as conn:
+            before_rows = await conn.fetch(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+        assert before_rows, "There should be memory units after the first retain"
+        before_ids = {row["id"] for row in before_rows}
+
+        append_units = await memory_real_llm.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "Sophia recently published a paper on transformer-based motion planning.",
+                    "document_id": document_id,
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+        assert append_units and append_units[0], "Append retain should extract at least one memory unit"
+
+        async with pool.acquire() as conn:
+            after_rows = await conn.fetch(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND document_id = $2",
+                bank_id,
+                document_id,
+            )
+            original_text = await conn.fetchval(
+                "SELECT original_text FROM documents WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                document_id,
+            )
+
+        after_ids = {row["id"] for row in after_rows}
+
+        # All original memory unit IDs must still exist (not been cascade-deleted).
+        assert before_ids <= after_ids, f"Append deleted existing memory units: missing {before_ids - after_ids}"
+        # Append must have added at least one new unit from the new content.
+        assert len(after_rows) > len(before_rows), "Append should add new memory units, not just replace existing ones"
+        # The stored document body must contain both the original and new content.
+        assert "Sophia" in original_text
+        assert "motion planning" in original_text
+
+    finally:
+        await memory_real_llm.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Closes #2664

Fixes `update_mode="append"` so a retain with a stable `document_id` extends the existing document without deleting its existing chunks and memory units. The document's stored `original_text` is updated to the appended body, while only the new request content is extracted and stored as additional chunks.

## Changes

- Keep append mode out of the delta/full-replace path that treats old chunks as removed
- Update document metadata via `upsert_document_metadata` during append instead of `handle_document_tracking`
- Preserve existing chunks and memory units, and offset new chunk indexes after existing chunks
- Preserve valid JSON-array `original_text` when appending transcript-style JSON arrays
- Add a regression test proving append keeps existing memory unit IDs and adds new units/chunks

## Validation

```bash
uv run ruff check hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py hindsight-api-slim/tests/test_delta_retain_duplicates.py
./scripts/hooks/lint.sh