### PR TITLE
Use strict schema for consolidation output

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -2298,6 +2298,7 @@ async def _consolidate_batch_with_llm(
                 ],
                 "response_format": response_model,
                 "scope": "consolidation",
+                "strict_schema": True,
             }
             # Only request an explicit output budget when configured. Left unset by default the key is
             # omitted, so each provider keeps its implicit default (backwards compatible). Operators on

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -10,6 +10,7 @@ from hindsight_api.engine.consolidation.consolidator import _consolidate_batch_w
 @pytest.fixture
 def mock_llm_config():
     llm = AsyncMock()
+    llm._provider_impl = None
     response = MagicMock()
     response.creates = []
     response.updates = []
@@ -68,6 +69,18 @@ class TestConsolidationRetryBudget:
             config=mock_config,
         )
         assert mock_llm_config.call.call_args.kwargs.get("max_retries") == 3
+
+    @pytest.mark.asyncio
+    async def test_strict_schema_threaded_to_call(self, mock_llm_config, mock_config):
+        """Consolidation uses provider-native structured output when available."""
+        await _consolidate_batch_with_llm(
+            llm_config=mock_llm_config,
+            memories=[{"id": "m1", "text": "test"}],
+            union_observations=[],
+            union_source_facts={},
+            config=mock_config,
+        )
+        assert mock_llm_config.call.call_args.kwargs.get("strict_schema") is True
 
     @pytest.mark.asyncio
     async def test_max_completion_tokens_threaded_to_call(self, mock_llm_config, mock_config):


### PR DESCRIPTION
## Summary
- request provider-native structured output for consolidation batch responses
- keeps the existing consolidation output budget behavior unchanged
- adds a regression check that `strict_schema` is threaded into the LLM call

This narrows one raw-JSON failure mode related to #2668, but it is not a complete fix for truncation at the output budget. The remaining design question is whether consolidation should be strict-by-default, matching extraction/reflect, given the retry tradeoff for smaller local models.

## Tests
- `uv run pytest tests/test_consolidation_retry_budget.py tests/test_anthropic_structured_tool_use.py -q`
- `git diff --check`