### PR TITLE
Avoid slim embedded daemon startup without local ML deps

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 import sysconfig
 import time
+from collections.abc import Mapping
+from importlib.util import find_spec
 from pathlib import Path
 from typing import IO, Optional
 
@@ -202,7 +204,30 @@ class DaemonEmbedManager(EmbedManager):
         override = self._profile_manager.load_profile_config(profile).get(env_key)
         return override or os.getenv(env_key) or __version__
 
-    def _find_api_command(self, api_version: str) -> list[str]:
+    @staticmethod
+    def _needs_local_sentence_transformers(env: Mapping[str, str] | None = None) -> bool:
+        """Return True when the daemon config will load the local ST providers."""
+        env = env or os.environ
+        embeddings_provider = env.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "local")
+        reranker_provider = env.get("HINDSIGHT_API_RERANKER_PROVIDER", "local")
+        return embeddings_provider == "local" or reranker_provider == "local"
+
+    @staticmethod
+    def _can_use_installed_api_binary(env: Mapping[str, str] | None = None) -> bool:
+        """Avoid slim sibling binaries when default local ML deps are unavailable."""
+        if not DaemonEmbedManager._needs_local_sentence_transformers(env):
+            return True
+        if find_spec("sentence_transformers") is not None:
+            return True
+        logger.warning(
+            "Installed hindsight-api binary is missing local ML dependencies; "
+            "falling back to uvx hindsight-api for the local daemon. Set "
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER and HINDSIGHT_API_RERANKER_PROVIDER "
+            "to non-local providers to use a slim install."
+        )
+        return False
+
+    def _find_api_command(self, api_version: str, env: Mapping[str, str] | None = None) -> list[str]:
         """Find the command to run hindsight-api (api_version used only for the uvx fallback)."""
         # Check if we're in development mode
         dev_command = self._dev_api_command()
@@ -221,7 +246,7 @@ class DaemonEmbedManager(EmbedManager):
 
         scripts_dir = Path(sysconfig.get_path("scripts"))
         candidate = scripts_dir / binary_name
-        if candidate.exists():
+        if candidate.exists() and self._can_use_installed_api_binary(env):
             # The console exe lives in sys.executable's scripts dir, so
             # hindsight_api is importable by the GUI interpreter; prefer it on
             # Windows to avoid ConPTY popping a terminal tab (issue #1885).
@@ -237,7 +262,7 @@ class DaemonEmbedManager(EmbedManager):
         package_root = Path(__file__).parent.parent
         for bin_dir in ("bin", "Scripts"):
             candidate = package_root / bin_dir / binary_name
-            if candidate.exists():
+            if candidate.exists() and self._can_use_installed_api_binary(env):
                 return [str(candidate)]
 
         # Fall back to uvx for the installed version (resolved by the caller).
@@ -499,7 +524,7 @@ class DaemonEmbedManager(EmbedManager):
         env["HINDSIGHT_API_DAEMON_LOG"] = str(daemon_log)
 
         # Build command
-        cmd = self._find_api_command(self._component_version(profile, "HINDSIGHT_EMBED_API_VERSION")) + [
+        cmd = self._find_api_command(self._component_version(profile, "HINDSIGHT_EMBED_API_VERSION"), env=env) + [
             "--daemon",
             "--idle-timeout",
             str(idle_timeout),

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -6,6 +6,10 @@ from hindsight_embed import get_embed_manager
 from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
 
 
+def _mock_sentence_transformers_present(monkeypatch):
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.find_spec", lambda name: object())
+
+
 def test_sanitize_profile_name_via_db_url():
     """Test profile name sanitization through database URL generation."""
     manager = get_embed_manager()
@@ -144,6 +148,7 @@ def test_find_api_command_prefers_installed_binary_over_uvx(tmp_path, monkeypatc
     )
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(api_binary)]
 
@@ -216,6 +221,7 @@ def test_find_api_command_target_install_uses_file_relative_fallback(tmp_path, m
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(fake_module))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(venv_scripts))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(sibling_bin)]
 
@@ -261,6 +267,7 @@ def test_find_api_command_windows_uses_exe_suffix(tmp_path, monkeypatch):
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(interp_dir / "python.exe"))
+    _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(api_binary)]
 
@@ -288,6 +295,7 @@ def test_find_api_command_windows_prefers_gui_interpreter(tmp_path, monkeypatch)
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(scripts_dir / "python.exe"))
+    _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(pythonw), "-m", "hindsight_api.main"]
 
@@ -312,6 +320,7 @@ def test_find_api_command_windows_prefers_scripts_dir_pythonw_for_wrappers(tmp_p
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Windows")
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sys.executable", str(wrapper_dir / "hindsight-embed.exe"))
+    _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(pythonw), "-m", "hindsight_api.main"]
 

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -148,6 +148,50 @@ def test_find_api_command_prefers_installed_binary_over_uvx(tmp_path, monkeypatc
     assert manager._find_api_command("0.0.0") == [str(api_binary)]
 
 
+def test_find_api_command_skips_slim_binary_without_local_ml(tmp_path, monkeypatch):
+    """Default local embeddings/reranker need sentence-transformers.
+
+    A slim sibling hindsight-api binary can exist without local ML extras
+    installed. In that case, use the uvx full-package fallback instead of
+    starting a daemon that immediately fails during local provider init.
+    """
+    scripts_dir = tmp_path / "bin"
+    scripts_dir.mkdir()
+    (scripts_dir / "hindsight-api").touch()
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py")
+    )
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.find_spec", lambda name: None)
+
+    assert manager._find_api_command("1.2.3", env={}) == ["uvx", "hindsight-api@1.2.3"]
+
+
+def test_find_api_command_allows_slim_binary_with_external_providers(tmp_path, monkeypatch):
+    """Slim installs are valid when both embeddings and reranker are external."""
+    scripts_dir = tmp_path / "bin"
+    scripts_dir.mkdir()
+    api_binary = scripts_dir / "hindsight-api"
+    api_binary.touch()
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr(
+        "hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py")
+    )
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.find_spec", lambda name: None)
+
+    env = {
+        "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "cohere",
+        "HINDSIGHT_API_RERANKER_PROVIDER": "cohere",
+    }
+    assert manager._find_api_command("1.2.3", env=env) == [str(api_binary)]
+
+
 def test_find_api_command_target_install_uses_file_relative_fallback(tmp_path, monkeypatch):
     """
     When installed with `pip install --target`, sysconfig still points at the


### PR DESCRIPTION
## Summary
- skip installed/sibling `hindsight-api` binaries for the embedded daemon when default local embeddings or reranker need `sentence_transformers` but it is not importable
- fall back to `uvx hindsight-api@<version>` in that case, preserving the existing slim binary path for external embedding/reranker providers
- add regression coverage for both the default local and external-provider paths

Fixes #2671

## Tests
- `uv run pytest tests/test_embed_manager.py -v`
- `uv run ruff check hindsight_embed`
- `uv run ty check hindsight_embed`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy NO_PROXY="*" uv run pytest tests -v`