### PR TITLE
fix(recall): preserve combined graph activation scores

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -243,12 +243,16 @@ class LinkExpansionRetriever(GraphRetriever):
         }
 
         sorted_ids = sorted(score_map.keys(), key=lambda x: score_map[x], reverse=True)[:budget]
-        rows = [row_map[fact_id] for fact_id in sorted_ids]
 
         results = []
-        for row in rows:
+        for fact_id in sorted_ids:
+            row = row_map[fact_id]
             result = RetrievalResult.from_db_row(dict(row))
-            result.activation = row["score"]
+            # ``activation`` is used to re-sort graph results after fact types are
+            # combined. It must retain the final additive score rather than the
+            # raw score from one signal, which would otherwise discard the other
+            # signals and make the cross-fact-type order disagree with this order.
+            result.activation = score_map[fact_id]
             results.append(result)
 
         # filter_results_by_tags is a no-op when no filter applies (tags falsy and not

--- a/hindsight-api-slim/tests/test_link_expansion_scoring.py
+++ b/hindsight-api-slim/tests/test_link_expansion_scoring.py
@@ -1,0 +1,61 @@
+"""Regression tests for Link Expansion's final graph score."""
+
+from contextlib import asynccontextmanager
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from hindsight_api.engine.search import link_expansion_retrieval
+from hindsight_api.engine.search.link_expansion_retrieval import LinkExpansionRetriever
+from hindsight_api.engine.search.types import RetrievalResult
+
+
+def _row(fact_id: str, score: float, fact_type: str) -> dict[str, str | float]:
+    """Create the subset of an expansion query row needed by RetrievalResult."""
+    return {"id": fact_id, "text": fact_id, "fact_type": fact_type, "score": score}
+
+
+@pytest.mark.asyncio
+async def test_activation_preserves_additive_score_across_fact_types(monkeypatch):
+    """Graph merge order must match Link Expansion's additive per-type score."""
+    retriever = LinkExpansionRetriever()
+
+    @asynccontextmanager
+    async def fake_acquire_with_retry(_pool):
+        yield object()
+
+    async def fake_expand_combined(_conn, _seed_ids, fact_type, _budget, *, ops):
+        if fact_type == "world":
+            # Convergent semantic and causal signals make this fact's total
+            # score higher, despite its raw entity count being only 1.
+            return [_row("a", 1.0, fact_type)], [_row("a", 0.9, fact_type)], [_row("a", 0.3, fact_type)]
+        return [_row("b", 2.0, fact_type)], [_row("b", 0.7, fact_type)], []
+
+    monkeypatch.setattr(link_expansion_retrieval, "acquire_with_retry", fake_acquire_with_retry)
+    monkeypatch.setattr(retriever, "_expand_combined", fake_expand_combined)
+    pool = SimpleNamespace(ops=object())
+
+    world_results, _ = await retriever.retrieve(
+        pool,
+        query_embedding_str="unused",
+        bank_id="bank",
+        fact_type="world",
+        budget=2,
+        semantic_seeds=[RetrievalResult(id="seed-world", text="seed", fact_type="world")],
+    )
+    experience_results, _ = await retriever.retrieve(
+        pool,
+        query_embedding_str="unused",
+        bank_id="bank",
+        fact_type="experience",
+        budget=2,
+        semantic_seeds=[RetrievalResult(id="seed-experience", text="seed", fact_type="experience")],
+    )
+
+    combined = world_results + experience_results
+    combined.sort(key=lambda result: result.activation or 0.0, reverse=True)
+
+    assert [result.id for result in combined] == ["a", "b"]
+    assert world_results[0].activation == pytest.approx(math.tanh(0.5) + 0.9 + 0.3)
+    assert experience_results[0].activation == pytest.approx(math.tanh(1.0) + 0.7)


### PR DESCRIPTION
## Summary

Link Expansion gathers graph candidates from three signals: shared entities, semantic links, and causal links. Within each fact type it computes an additive final score:

- entity score: tanh(shared entity count x 0.5)
- semantic score: the strongest semantic-link weight
- causal score: the strongest causal-link weight

Candidates are correctly ranked and limited by that combined score within a fact type. The bug was in the result conversion step: it stored the original score from one database row in activation instead of the final combined score.

For candidates found through entity expansion, activation was normally the untransformed shared-entity count. For semantic-only or causal-only candidates, it was that individual link weight. As a result, activation could omit the other signals and did not necessarily match the score that selected the candidate.

## Ranking reversal example

| Candidate | Raw shared entities | Entity score | Semantic score | Causal score | Correct combined score | Old activation | Correct rank | Old merged rank |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| A | 1 | 0.462 | 0.900 | 0.300 | 1.662 | 1 | 1 | 2 |
| B | 2 | 0.762 | 0.700 | 0.000 | 1.462 | 2 | 2 | 1 |

```mermaid
flowchart LR
    A[Candidate A: entity 1 plus semantic 0.9 plus causal 0.3] --> AS[combined score: 1.662]
    B[Candidate B: entity 2 plus semantic 0.7] --> BS[combined score: 1.462]
    AS --> IR[Per-fact-type ranking: A before B]
    BS --> IR
    A --> AO[old activation: 1]
    B --> BO[old activation: 2]
    AO --> MR[Old cross-type merge: B before A]
    BO --> MR
    IR --> FIX[Fixed activation uses combined score]
    FIX --> CR[Cross-type merge: A before B]
```

Recall combines graph results from all requested fact types and sorts them by activation before applying the per-source cap and Reciprocal Rank Fusion. The old merge could therefore reverse the graph ranking above, allowing B to receive a better graph rank even though Link Expansion had selected A as more relevant.

## Fix

Store the computed additive score map value in activation. The cross-fact-type graph ordering, source cap, RRF input rank, and trace score now use the same final graph score as the per-fact-type candidate selection.

## Regression coverage

Add a small deterministic unit test with the ranking-reversal example above. It verifies that the candidate with the higher combined score remains ahead after results from two fact types are merged. Reverting activation to a raw row score makes this test fail.

## Validation

- uv run pytest tests/test_link_expansion_scoring.py -q
- ./scripts/hooks/lint.sh
- uv run ty check hindsight_api/
- git diff --check