### PR TITLE
fix(control-plane): tag/scope filter resets during consolidation polling in data view

### DIFF
--- a/hindsight-control-plane/src/components/data-view.tsx
+++ b/hindsight-control-plane/src/components/data-view.tsx
@@ -448,13 +448,23 @@ export function DataView({
   // restarts when consolidation starts/stops, not on every tick.
   const isConsolidating =
     factType === "observation" && (consolidationStatus?.pending_consolidation ?? 0) > 0;
+  // The tick goes through a ref so each fire sees the CURRENT filters; the
+  // interval itself still only restarts when consolidation starts/stops. Without
+  // this, the closure captures the filters from arming time, and a tag/scope
+  // selected mid-consolidation is clobbered ~4s later by a refetch using the
+  // stale (usually empty) filter — the same stale-closure guard as
+  // bank-profile-view's polling.
+  const pollTickRef = useRef<() => void>(() => {});
   useEffect(() => {
-    if (!isConsolidating || !currentBank) return;
-    const id = setInterval(() => {
+    pollTickRef.current = () => {
       const { tags, match } = resolveTagQuery();
       loadData(undefined, searchQuery || undefined, tags, match, true);
       loadScopes();
-    }, 4000);
+    };
+  });
+  useEffect(() => {
+    if (!isConsolidating || !currentBank) return;
+    const id = setInterval(() => pollTickRef.current(), 4000);
     return () => clearInterval(id);
   }, [isConsolidating, currentBank]);
 


### PR DESCRIPTION

## Symptom

In the memories data view, selecting a tag filter or observation scope while a bank
has `pending_consolidation > 0` shows the filtered subset briefly, then resets to the
unfiltered view within ~4 seconds. Easy to hit right after retaining documents —
exactly when users browse what was extracted.

## Cause

The consolidation-poll effect arms a `setInterval` whose closure captures
`resolveTagQuery` (and `searchQuery`) at arming time. Its dependency array is
deliberately `[isConsolidating, currentBank]` so the interval doesn't restart per
tick — but that means a filter selected *after* the poll starts is never seen by the
tick: the next silent `loadData` refetches with the stale (usually empty) filter and
overwrites the filtered graph data.

`bank-profile-view.tsx` already guards its polling against this same stale-closure
trap with a ref ("Use ref to get current value (avoids stale closure in
setInterval)"); the data view's poll predates that pattern.

## Fix

Route the tick through a ref that is refreshed every render, keeping the interval's
restart behavior unchanged (still only on consolidation start/stop):

- `pollTickRef.current` closes over the current `resolveTagQuery` / `searchQuery` /
  `loadData` / `loadScopes` each render;
- the interval calls `pollTickRef.current()`.

No behavior change other than the tick observing current filter state.

## Testing

- `tsc --noEmit` clean.
- Manual: bank with pending consolidation (retain a few docs) → data view →
  observations → select a scope/tag → filtered view now persists across poll ticks;
  badge/scopes keep refreshing live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
