### PR TITLE
fix(recall): remove unused graph seed inputs

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/graph_retrieval.py
@@ -40,8 +40,6 @@ class GraphRetriever(ABC):
         fact_type: str,
         budget: int,
         query_text: str | None = None,
-        semantic_seeds: list[RetrievalResult] | None = None,
-        temporal_seeds: list[RetrievalResult] | None = None,
         adjacency=None,  # TypedAdjacency, optional pre-loaded graph
         tags: list[str] | None = None,  # Visibility scope tags for filtering
         tags_match: TagsMatch = "any",  # How to match tags: 'any' (OR) or 'all' (AND)
@@ -59,8 +57,6 @@ class GraphRetriever(ABC):
             fact_type: Fact type to filter ('world', 'experience', 'observation')
             budget: Maximum number of nodes to explore/return
             query_text: Original query text (optional, for some strategies)
-            semantic_seeds: Pre-computed semantic entry points (from semantic retrieval)
-            temporal_seeds: Pre-computed temporal entry points (from temporal retrieval)
             adjacency: Pre-loaded typed adjacency graph (optional)
             tags: Optional list of tags for visibility filtering (OR matching)
 

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -1,8 +1,8 @@
 """
 Link Expansion graph retrieval.
 
-Expands from semantic/temporal seeds through three parallel, first-class signals
-stored in memory_links:
+Selects bounded semantic seeds, then expands through three parallel,
+first-class signals stored in memory_links:
 
 1. Entity links  — query-time self-join through unit_entities. Score = number of distinct
                    shared entities between the seed set and each candidate, computed via
@@ -127,8 +127,6 @@ class LinkExpansionRetriever(GraphRetriever):
         fact_type: str,
         budget: int,
         query_text: str | None = None,
-        semantic_seeds: list[RetrievalResult] | None = None,
-        temporal_seeds: list[RetrievalResult] | None = None,
         adjacency=None,
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
@@ -146,8 +144,6 @@ class LinkExpansionRetriever(GraphRetriever):
             fact_type: Fact type to filter
             budget: Maximum results to return
             query_text: Original query text (unused)
-            semantic_seeds: Pre-computed semantic entry points
-            temporal_seeds: Pre-computed temporal entry points
             adjacency: Unused, kept for interface compatibility
             tags: Optional list of tags for visibility filtering
 
@@ -158,32 +154,28 @@ class LinkExpansionRetriever(GraphRetriever):
         timings = GraphRetrievalTimings(fact_type=fact_type)
 
         async with acquire_with_retry(pool) as conn:
-            # Find seeds if not provided
-            if semantic_seeds:
-                all_seeds = list(semantic_seeds)
-            else:
-                seeds_start = time.time()
-                all_seeds = await _find_semantic_seeds(
-                    conn,
-                    query_embedding_str,
-                    bank_id,
-                    fact_type,
-                    limit=20,
-                    threshold=0.3,
-                    tags=tags,
-                    tags_match=tags_match,
-                    tag_groups=tag_groups,
-                    created_after=created_after,
-                    created_before=created_before,
-                )
-                timings.seeds_time = time.time() - seeds_start
-                logger.debug(
-                    f"[LinkExpansion] Found {len(all_seeds)} semantic seeds for fact_type={fact_type} "
-                    f"(tags={tags}, tags_match={tags_match})"
-                )
-
-            if temporal_seeds:
-                all_seeds.extend(temporal_seeds)
+            # Graph traversal deliberately chooses its own bounded seeds. The semantic and temporal
+            # retrieval arms have independent candidate limits and thresholds, so reusing their
+            # results would silently change graph-retrieval recall behavior.
+            seeds_start = time.time()
+            all_seeds = await _find_semantic_seeds(
+                conn,
+                query_embedding_str,
+                bank_id,
+                fact_type,
+                limit=20,
+                threshold=0.3,
+                tags=tags,
+                tags_match=tags_match,
+                tag_groups=tag_groups,
+                created_after=created_after,
+                created_before=created_before,
+            )
+            timings.seeds_time = time.time() - seeds_start
+            logger.debug(
+                f"[LinkExpansion] Found {len(all_seeds)} semantic seeds for fact_type={fact_type} "
+                f"(tags={tags}, tags_match={tags_match})"
+            )
 
             if not all_seeds:
                 return [], timings

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -822,8 +822,6 @@ async def retrieve_all_fact_types_parallel(
             fact_type=ft,
             budget=thinking_budget,
             query_text=query_text,
-            semantic_seeds=None,
-            temporal_seeds=None,
             tags=tags,
             tags_match=tags_match,
             tag_groups=tag_groups,

--- a/hindsight-api-slim/hindsight_api/engine/search/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/types.py
@@ -22,7 +22,7 @@ class GraphRetrievalTimings:
     pattern_count: int = 0  # Number of patterns executed
     fusion: float = 0.0  # Time for RRF fusion
     fetch: float = 0.0  # Time to fetch memory unit details
-    seeds_time: float = 0.0  # Time to find semantic seeds (if fallback used)
+    seeds_time: float = 0.0  # Time spent selecting semantic graph seeds
     result_count: int = 0  # Number of results returned
     # Detailed per-hop timing: list of {hop, exec_time, uncached, load_time, edges_loaded, total_time}
     hop_details: list[dict] = field(default_factory=list)

--- a/hindsight-api-slim/tests/test_temporal_recall_selection.py
+++ b/hindsight-api-slim/tests/test_temporal_recall_selection.py
@@ -177,6 +177,7 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
     start = datetime(2025, 1, 1, tzinfo=UTC)
     end = datetime(2025, 2, 1, tzinfo=UTC)
     temporal_thresholds: list[float] = []
+    graph_call_kwargs: list[set[str]] = []
 
     @asynccontextmanager
     async def fake_acquire_with_retry(pool):
@@ -191,6 +192,7 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
 
     class FakeGraphRetriever:
         async def retrieve(self, **kwargs):
+            graph_call_kwargs.append(set(kwargs))
             return [], None
 
     monkeypatch.setattr(retrieval_module, "acquire_with_retry", fake_acquire_with_retry)
@@ -213,3 +215,18 @@ async def test_min_semantic_does_not_tighten_temporal_seed_threshold(monkeypatch
     )
 
     assert temporal_thresholds == [0.1]
+    assert graph_call_kwargs == [
+        {
+            "pool",
+            "query_embedding_str",
+            "bank_id",
+            "fact_type",
+            "budget",
+            "query_text",
+            "tags",
+            "tags_match",
+            "tag_groups",
+            "created_after",
+            "created_before",
+        }
+    ]


### PR DESCRIPTION
## Summary

Closes #2593.

Graph retrieval does not reuse semantic or temporal results from the other recall arms. It deliberately selects its own bounded semantic seed set before expanding memory links. This PR removes an unused internal interface that incorrectly implied callers could provide those seed sets.

## Root cause

`GraphRetriever.retrieve()` and `LinkExpansionRetriever.retrieve()` accepted `semantic_seeds` and `temporal_seeds`, but the only production caller always supplied `None`. `LinkExpansionRetriever` consequently always ran its own semantic seed query. The stale parameters and comments made the implementation look incomplete and raised the question in #2593 of whether recall was failing to reuse already-fetched semantic and temporal candidates.

## Changes

- Remove `semantic_seeds` and `temporal_seeds` from the internal graph-retriever interface and link-expansion implementation.
- Stop passing placeholder `None` values from the recall orchestrator.
- Document the intentional independent-seed design: the semantic and temporal arms use different candidate limits and thresholds, so reusing their outputs would silently change graph-retrieval behavior.
- Update timing and module comments to match the implementation.
- Add a regression assertion that graph retrieval is not called with the removed inputs.

## Validation

- `uv run pytest tests/test_temporal_recall_selection.py -v`
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run ty check ...`
- `./scripts/hooks/lint.sh`
- `git diff --check`