### PR TITLE
Preserve document metadata during append retains

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -831,6 +831,12 @@ async def retain_batch(
             first = contents_dicts[0]
             if first.get("context"):
                 existing_content["context"] = first["context"]
+            if first.get("event_date"):
+                existing_content["event_date"] = first["event_date"]
+            if first.get("metadata"):
+                existing_content["metadata"] = first["metadata"]
+            if first.get("observation_scopes") is not None:
+                existing_content["observation_scopes"] = first["observation_scopes"]
             if first.get("tags"):
                 existing_content["tags"] = first["tags"]
             contents_dicts = [existing_content, *contents_dicts]
@@ -852,6 +858,12 @@ async def retain_batch(
                     contents_dicts = [{"content": json.dumps(_merged, ensure_ascii=False)}]
                     if first.get("context"):
                         contents_dicts[0]["context"] = first["context"]
+                    if first.get("event_date"):
+                        contents_dicts[0]["event_date"] = first["event_date"]
+                    if first.get("metadata"):
+                        contents_dicts[0]["metadata"] = first["metadata"]
+                    if first.get("observation_scopes") is not None:
+                        contents_dicts[0]["observation_scopes"] = first["observation_scopes"]
                     if first.get("tags"):
                         contents_dicts[0]["tags"] = first["tags"]
             except (json.JSONDecodeError, ValueError, TypeError):

--- a/hindsight-api-slim/tests/test_delta_retain_duplicates.py
+++ b/hindsight-api-slim/tests/test_delta_retain_duplicates.py
@@ -10,13 +10,11 @@ Verifies that:
 
 import asyncio
 import logging
-import os
 from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
 
-from hindsight_api import RequestContext
 from hindsight_api.engine.task_backend import SyncTaskBackend
 
 logger = logging.getLogger(__name__)
@@ -393,6 +391,77 @@ async def test_concurrent_upserts_no_duplicates(memory_no_llm, request_context):
         logger.info(
             f"Concurrent test passed: version {winning_version} won with {len(unit_texts)} memory units, no duplicates"
         )
+
+    finally:
+        await memory_no_llm.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_append_mode_preserves_document_metadata_projection(memory_no_llm, request_context):
+    """Append retains should keep item metadata visible through document APIs."""
+    bank_id = f"test_append_metadata_{_ts()}"
+    document_id = "append-metadata-doc"
+
+    try:
+        await memory_no_llm.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "first turn from the agent session",
+                    "context": "agent conversation",
+                    "document_id": document_id,
+                    "metadata": {
+                        "source": "hermes",
+                        "platform": "weixin",
+                        "session_id": document_id,
+                        "turn_index": "1",
+                    },
+                    "tags": ["source:hermes", "scope:local-agent", f"session:{document_id}"],
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+
+        await memory_no_llm.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": "second turn from the agent session",
+                    "context": "agent conversation",
+                    "document_id": document_id,
+                    "metadata": {
+                        "source": "hermes",
+                        "platform": "weixin",
+                        "session_id": document_id,
+                        "turn_index": "2",
+                    },
+                    "tags": ["source:hermes", "scope:local-agent", f"session:{document_id}"],
+                    "update_mode": "append",
+                }
+            ],
+            request_context=request_context,
+        )
+
+        doc = await memory_no_llm.get_document(document_id, bank_id, request_context=request_context)
+        assert doc is not None
+        assert doc["document_metadata"] == {
+            "source": "hermes",
+            "platform": "weixin",
+            "session_id": document_id,
+            "turn_index": "2",
+        }
+        assert doc["retain_params"]["metadata"] == doc["document_metadata"]
+        assert doc["retain_params"]["context"] == "agent conversation"
+
+        listed = await memory_no_llm.list_documents(
+            bank_id,
+            tags=["source:hermes"],
+            request_context=request_context,
+        )
+        listed_doc = next(item for item in listed["items"] if item["id"] == document_id)
+        assert listed_doc["document_metadata"] == doc["document_metadata"]
+        assert listed_doc["retain_params"]["metadata"] == doc["document_metadata"]
 
     finally:
         await memory_no_llm.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

Closes #2682.

When `update_mode=append` prepends the existing document body, the synthetic existing-content item kept context/tags but dropped item-level retain params such as `metadata`. Since document APIs project `document_metadata` from `documents.retain_params.metadata`, appended session documents could lose their document-level metadata even though the new retain item supplied it.

This carries the current append item's metadata/event_date/observation_scopes onto the synthetic/merged append document body so the document row keeps the latest retain params.

## Validation

```bash
uv run ruff check hindsight_api/engine/retain/orchestrator.py tests/test_delta_retain_duplicates.py
uv run python -m py_compile hindsight_api/engine/retain/orchestrator.py tests/test_delta_retain_duplicates.py
git diff --check
```

I also added a DB-backed regression test for the `GET /documents/{document_id}` and list-documents metadata projection. Local execution did not reach the test body because the shared embeddings fixture timed out while initializing/downloading `BAAI/bge-small-en-v1.5`; the failure was in setup, before the new assertions ran.