### PR TITLE
fix(engine): clarify causal link compatibility

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_creation.py
@@ -74,7 +74,9 @@ async def create_causal_links_batch(
     """
     Create causal links between facts.
 
-    Links facts that have causal relationships (causes, enables, prevents).
+    Retain writes the canonical ``caused_by`` relationship only. The database and
+    retrieval paths also recognize historical causal types so imported and
+    pre-existing memories remain traversable.
 
     Args:
         conn: Database connection
@@ -90,22 +92,7 @@ async def create_causal_links_batch(
     if len(unit_ids) != len(facts):
         raise ValueError(f"Mismatch between unit_ids ({len(unit_ids)}) and facts ({len(facts)})")
 
-    # Extract causal relations in the format expected by link_utils
-    # Format: List of lists, where each inner list is the causal relations for that fact
-    causal_relations_per_fact = []
-    for fact in facts:
-        if fact.causal_relations:
-            # Convert CausalRelation objects to dicts
-            relations_dicts = [
-                {
-                    "relation_type": rel.relation_type,
-                    "target_fact_index": rel.target_fact_index,
-                }
-                for rel in fact.causal_relations
-            ]
-            causal_relations_per_fact.append(relations_dicts)
-        else:
-            causal_relations_per_fact.append([])
+    causal_relations_per_fact = [fact.causal_relations or [] for fact in facts]
 
     link_count = await link_utils.create_causal_links_batch(conn, bank_id, unit_ids, causal_relations_per_fact, ops=ops)
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -7,12 +7,17 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
+from ..db.base import DatabaseConnection
+from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
+from .types import CausalRelation
 
 logger = logging.getLogger(__name__)
 
 # Sentinel UUID used in the unique index to represent NULL entity_id
 _NIL_ENTITY_UUID = "00000000-0000-0000-0000-000000000000"
+_CANONICAL_CAUSAL_LINK_TYPES = frozenset({"caused_by"})
+_LEGACY_CAUSAL_LINK_TYPES = frozenset({"causes", "enables", "prevents"})
 
 # Maximum number of temporal links to keep per unit (from_unit_id).
 # Retrieval only reads top 10-20 per unit via LATERAL join, so keeping
@@ -771,28 +776,61 @@ async def create_semantic_links_batch(
 
 
 async def create_causal_links_batch(
-    conn,
+    conn: DatabaseConnection,
     bank_id: str,
     unit_ids: list[str],
-    causal_relations_per_fact: list[list[dict]],
-    ops=None,
+    causal_relations_per_fact: list[list[CausalRelation]],
+    ops: DataAccessOps | None = None,
 ) -> int:
-    """
-    Create causal links between facts based on LLM-extracted causal relationships.
+    """Create canonical causal links for the retain pipeline.
 
-    Args:
-        conn: Database connection
-        unit_ids: List of unit IDs (in same order as causal_relations_per_fact)
-        causal_relations_per_fact: List of causal relations for each fact.
-            Each element is a list of dicts with:
-            - target_fact_index: Index into unit_ids for the target fact
-            - relation_type: "caused_by"
+    Retain must only create the backward-looking ``caused_by`` form. Historical
+    types are restored exclusively through ``restore_legacy_causal_links_batch``.
+    """
+    return await _write_causal_links_batch(
+        conn,
+        bank_id,
+        unit_ids,
+        causal_relations_per_fact,
+        _CANONICAL_CAUSAL_LINK_TYPES,
+        ops=ops,
+    )
+
+
+async def restore_legacy_causal_links_batch(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_ids: list[str],
+    causal_relations_per_fact: list[list[CausalRelation]],
+    ops: DataAccessOps | None = None,
+) -> int:
+    """Restore historical causal links while importing a transfer archive.
+
+    This is deliberately separate from the retain writer: retrieval continues
+    reading historical types, but only transfer import may create them.
+    """
+    return await _write_causal_links_batch(
+        conn,
+        bank_id,
+        unit_ids,
+        causal_relations_per_fact,
+        _LEGACY_CAUSAL_LINK_TYPES,
+        ops=ops,
+    )
+
+
+async def _write_causal_links_batch(
+    conn: DatabaseConnection,
+    bank_id: str,
+    unit_ids: list[str],
+    causal_relations_per_fact: list[list[CausalRelation]],
+    allowed_relation_types: frozenset[str],
+    ops: DataAccessOps | None = None,
+) -> int:
+    """Write causal links after the caller has selected its allowed taxonomy.
 
     Returns:
         Number of causal links created
-
-    Causal link type:
-    - "caused_by": This fact was caused by the target fact
     """
     if not unit_ids or not causal_relations_per_fact:
         return 0
@@ -809,15 +847,13 @@ async def create_causal_links_batch(
             from_unit_id = unit_ids[fact_idx]
 
             for relation in causal_relations:
-                target_idx = relation["target_fact_index"]
-                relation_type = relation["relation_type"]
+                target_idx = relation.target_fact_index
+                relation_type = relation.relation_type
 
-                # Validate relation_type - only "caused_by" is supported (DB constraint)
-                valid_types = {"caused_by"}
-                if relation_type not in valid_types:
+                if relation_type not in allowed_relation_types:
                     logger.error(
                         f"Invalid relation_type '{relation_type}' (type: {type(relation_type).__name__}) "
-                        f"from fact {fact_idx}. Must be one of: {valid_types}. "
+                        f"from fact {fact_idx}. Must be one of: {allowed_relation_types}. "
                         f"Relation data: {relation}"
                     )
                     continue

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -96,10 +96,12 @@ class CausalRelation:
     """
     Causal relationship between facts.
 
-    Represents how one fact was caused by another.
+    Retain emits only the backward-looking ``caused_by`` form. Transfer import
+    reuses this structure to restore historical causal types without allowing
+    normal retain writes to create them.
     """
 
-    relation_type: str  # "caused_by"
+    relation_type: str  # ``caused_by`` for retain; legacy types for transfer restore
     target_fact_index: int  # Index of the target fact in the batch
 
 

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -125,8 +125,9 @@ class _LoadedExport:
     unit_index: dict[Any, _UnitLocation] = field(default_factory=dict)
 
 
-# Causal link types that retain persists between facts. Only these travel in the
-# archive; temporal/semantic/entity links are regenerated against the target bank.
+# Retain currently writes only ``caused_by``. The legacy types stay in archives
+# so importing a historical bank preserves its graph; temporal/semantic/entity
+# links are regenerated against the target bank.
 _CAUSAL_LINK_TYPES = ("caused_by", "causes", "enables", "prevents")
 
 # Facts of these types are exported; observations are derived and excluded.

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -19,7 +19,7 @@ from datetime import UTC, date, datetime
 from typing import Any, Literal
 
 from ..db_utils import acquire_with_retry
-from ..retain import bank_utils, chunk_storage, embedding_processing, fact_storage, orchestrator
+from ..retain import bank_utils, chunk_storage, embedding_processing, fact_storage, link_utils, orchestrator
 from ..retain.types import (
     CausalRelation,
     ChunkMetadata,
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 OnConflict = Literal["skip", "replace", "new-id"]
 _VALID_CONFLICT_MODES: tuple[OnConflict, ...] = ("skip", "replace", "new-id")
+_LEGACY_CAUSAL_LINK_TYPES = frozenset({"causes", "enables", "prevents"})
 
 
 @dataclass
@@ -474,6 +475,7 @@ async def _import_one_document(
     )
 
     extracted_facts = [_to_extracted_fact(fact) for fact in document.facts]
+    legacy_causal_relations = _legacy_causal_relations(document)
 
     processed_facts: list[ProcessedFact] = []
     if extracted_facts:
@@ -544,6 +546,18 @@ async def _import_one_document(
                 outbox_callback=outbox_callback,
                 ops=ops,
             )
+
+            # Retain writes only ``caused_by``. Restore legacy archive edges
+            # separately so their distinct direction and semantics survive a
+            # transfer without broadening the normal retain write contract.
+            if result_unit_ids and legacy_causal_relations:
+                await link_utils.restore_legacy_causal_links_batch(
+                    conn,
+                    bank_id,
+                    result_unit_ids[0],
+                    legacy_causal_relations,
+                    ops=ops,
+                )
 
         try:
             await entity_resolver.flush_pending_stats()
@@ -705,6 +719,7 @@ def _to_extracted_fact(fact: TransferFact) -> ExtractedFact:
         causal_relations=[
             CausalRelation(relation_type=rel.relation_type, target_fact_index=rel.target_fact_index)
             for rel in fact.causal_relations
+            if rel.relation_type == "caused_by"
         ],
         content_index=0,
         chunk_index=fact.chunk_index,
@@ -714,3 +729,19 @@ def _to_extracted_fact(fact: TransferFact) -> ExtractedFact:
         tags=list(fact.tags),
         observation_scopes=fact.observation_scopes,
     )
+
+
+def _legacy_causal_relations(document: TransferDocument) -> list[list[CausalRelation]]:
+    """Return legacy archive edges for transfer-only restoration.
+
+    Invalid archive values are excluded. The write helper repeats the explicit
+    compatibility allowlist as a persistence boundary.
+    """
+    return [
+        [
+            CausalRelation(relation_type=relation.relation_type, target_fact_index=relation.target_fact_index)
+            for relation in fact.causal_relations
+            if relation.relation_type in _LEGACY_CAUSAL_LINK_TYPES
+        ]
+        for fact in document.facts
+    ]

--- a/hindsight-api-slim/hindsight_api/models.py
+++ b/hindsight-api-slim/hindsight_api/models.py
@@ -284,6 +284,8 @@ class MemoryLink(Base):
     entity = relationship("Entity", back_populates="memory_links")
 
     __table_args__ = (
+        # Retain writes ``caused_by`` only. Keep the historical causal values
+        # valid so existing rows and transfer archives remain queryable.
         CheckConstraint(
             "link_type IN ('temporal', 'semantic', 'entity', 'causes', 'caused_by', 'enables', 'prevents')",
             name="memory_links_link_type_check",

--- a/hindsight-api-slim/tests/test_causal_link_taxonomy.py
+++ b/hindsight-api-slim/tests/test_causal_link_taxonomy.py
@@ -1,0 +1,22 @@
+"""Regression tests for the causal link taxonomy used by retain."""
+
+import pytest
+from pydantic import ValidationError
+
+from hindsight_api.engine.retain.fact_extraction import CausalRelation, FactCausalRelation
+
+
+@pytest.mark.parametrize("relation_type", ["causes", "enables", "prevents"])
+def test_retain_causal_models_reject_legacy_relation_types(relation_type: str) -> None:
+    """New retain output is canonical even though storage reads legacy links."""
+    with pytest.raises(ValidationError):
+        CausalRelation(target_fact_index=0, relation_type=relation_type)
+
+    with pytest.raises(ValidationError):
+        FactCausalRelation(target_index=0, relation_type=relation_type)
+
+
+def test_retain_causal_models_accept_caused_by() -> None:
+    """The canonical causal relationship remains valid in both extraction schemas."""
+    assert CausalRelation(target_fact_index=0, relation_type="caused_by").relation_type == "caused_by"
+    assert FactCausalRelation(target_index=0, relation_type="caused_by").relation_type == "caused_by"

--- a/hindsight-api-slim/tests/test_causal_relations.py
+++ b/hindsight-api-slim/tests/test_causal_relations.py
@@ -63,9 +63,7 @@ class TestCausalRelationsValidation:
                     assert rel.target_fact_index >= 0, (
                         f"Fact {i} has negative causal relation index: {rel.target_fact_index}"
                     )
-                    assert rel.relation_type in ["caused_by", "enabled_by", "prevented_by"], (
-                        f"Invalid relation_type: {rel.relation_type}"
-                    )
+                    assert rel.relation_type == "caused_by", f"Invalid relation_type: {rel.relation_type}"
 
     @pytest.mark.asyncio
     async def test_first_fact_has_no_causal_relations(self):
@@ -196,10 +194,10 @@ class TestCausalRelationsValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_relation_types_are_backward_looking(self):
+    async def test_relation_types_use_the_canonical_form(self):
         """
-        Test that all relation types describe how the current fact
-        relates to a previous fact (caused_by, enabled_by, prevented_by).
+        Test that all extracted relation types use the canonical backward-looking
+        ``caused_by`` form.
         """
         text = """
         Alice learned Python programming.
@@ -220,12 +218,9 @@ class TestCausalRelationsValidation:
             config=_get_raw_config(),
         )
 
-        # Verify relation types are all backward-looking
-        valid_types = {"caused_by", "enabled_by", "prevented_by"}
-
         for i, fact in enumerate(facts):
             if fact.causal_relations:
                 for rel in fact.causal_relations:
-                    assert rel.relation_type in valid_types, (
-                        f"Invalid relation_type '{rel.relation_type}'. Must be one of: {valid_types}"
+                    assert rel.relation_type == "caused_by", (
+                        f"Invalid relation_type '{rel.relation_type}'. Must be 'caused_by'"
                     )

--- a/hindsight-api-slim/tests/test_causal_relationships.py
+++ b/hindsight-api-slim/tests/test_causal_relationships.py
@@ -85,11 +85,10 @@ After searching for weeks, I finally found a cheaper apartment in Brooklyn.
             f"Got {len(all_causal_relations)}: {all_causal_relations}"
         )
 
-        # Verify relation types are valid (passive only - facts reference PREVIOUS facts)
-        valid_types = {"caused_by", "enabled_by", "prevented_by"}
+        # Retain writes the single canonical passive form for previous facts.
         for rel in all_causal_relations:
-            assert rel["relation_type"] in valid_types, (
-                f"Invalid relation_type '{rel['relation_type']}'. Must be one of {valid_types}"
+            assert rel["relation_type"] == "caused_by", (
+                f"Invalid relation_type '{rel['relation_type']}'. Must be 'caused_by'"
             )
 
     @pytest.mark.asyncio
@@ -165,10 +164,9 @@ Machine learning fascinated me so much that I changed my career to data science.
                     )
 
     @pytest.mark.asyncio
-    async def test_bidirectional_causal_relationships(self):
+    async def test_causal_relationships_use_backward_references(self):
         """
-        Test that bidirectional causal relationships (causes and caused_by)
-        are handled correctly.
+        Test that causal relationships are represented as backward references.
         """
         text = """
 My promotion at work caused me to move to New York.

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -568,6 +568,57 @@ async def test_full_roundtrip_integrity(memory, request_context):
 
 
 @pytest.mark.asyncio
+async def test_transfer_preserves_legacy_causal_links(memory, request_context):
+    """Legacy causal edges survive export/import without becoming retain inputs."""
+    src = _unique_bank("transfer_legacy_causal_src")
+    dst = _unique_bank("transfer_legacy_causal_dst")
+    legacy_types = ("causes", "enables", "prevents")
+    try:
+        await _retain(
+            memory,
+            src,
+            "Alice completed the design. Bob began implementation after the design.",
+            request_context,
+            "doc-legacy-causal",
+        )
+        units = await memory.list_memory_units(src, fact_type="world", request_context=request_context)
+        assert len(units["items"]) >= 2
+        from_unit_id = uuid.UUID(str(units["items"][0]["id"]))
+        to_unit_id = uuid.UUID(str(units["items"][1]["id"]))
+        from_text = units["items"][0]["text"]
+        to_text = units["items"][1]["text"]
+
+        backend = await memory._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            await conn.executemany(
+                f"INSERT INTO {fq_table('memory_links')} "
+                "(from_unit_id, to_unit_id, link_type, entity_id, bank_id, weight) "
+                "VALUES ($1, $2, $3, NULL, $4, 1.0)",
+                [(from_unit_id, to_unit_id, link_type, src) for link_type in legacy_types],
+            )
+
+        archive = await memory.export_documents_async(src, request_context)
+        await _import(memory, dst, archive, request_context)
+
+        async with acquire_with_retry(backend) as conn:
+            imported_types = await conn.fetch(
+                f"SELECT ml.link_type, source.text AS source_text, target.text AS target_text "
+                f"FROM {fq_table('memory_links')} ml "
+                f"JOIN {fq_table('memory_units')} source ON source.id = ml.from_unit_id "
+                f"JOIN {fq_table('memory_units')} target ON target.id = ml.to_unit_id "
+                "WHERE ml.bank_id = $1 AND ml.link_type = ANY($2)",
+                dst,
+                list(legacy_types),
+            )
+        assert {(row["link_type"], row["source_text"], row["target_text"]) for row in imported_types} == {
+            (link_type, from_text, to_text) for link_type in legacy_types
+        }
+    finally:
+        await memory.delete_bank(src, request_context=request_context)
+        await memory.delete_bank(dst, request_context=request_context)
+
+
+@pytest.mark.asyncio
 async def test_export_import_observations(memory, request_context):
     """With include_observations, observations transfer and their sources re-link."""
     src = _unique_bank("transfer_obs_src")

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -1923,7 +1923,7 @@ async def test_causal_links_creation(memory, request_context):
     """
     Test that causal links are created between facts with causal relationships.
 
-    Causal links connect facts where one causes, enables, or prevents another.
+    Retain represents causal links with the canonical ``caused_by`` type.
     Note: This depends on LLM extracting causal relationships, which may be non-deterministic.
     """
     bank_id = f"test_causal_links_{datetime.now(timezone.utc).timestamp()}"
@@ -1955,7 +1955,7 @@ async def test_causal_links_creation(memory, request_context):
                 SELECT from_unit_id, to_unit_id, link_type, weight
                 FROM memory_links
                 WHERE from_unit_id::text = ANY($1)
-                  AND link_type IN ('causes', 'caused_by', 'enables', 'prevents')
+                  AND link_type = 'caused_by'
                 ORDER BY link_type, weight DESC
                 """,
                 unit_ids,
@@ -1974,9 +1974,7 @@ async def test_causal_links_creation(memory, request_context):
                     logger.info(
                         f"  Link: {from_id[:8]}... -> {to_id[:8]}... ({link_type}, weight: {link['weight']:.2f})"
                     )
-                    assert link["link_type"] in ["causes", "caused_by", "enables", "prevents"], (
-                        f"Causal link type must be valid, got '{link['link_type']}'"
-                    )
+                    assert link["link_type"] == "caused_by"
                     assert 0.0 <= link["weight"] <= 1.0, "Weight should be between 0 and 1"
 
                 logger.info("Causal links created successfully:")


### PR DESCRIPTION
## Summary

Fixes #2590.

This PR makes the causal-link taxonomy explicit: normal retain writes only the canonical backward-looking `caused_by` relationship. Existing `causes`, `enables`, and `prevents` links remain supported as historical data: the database accepts them, recall continues to traverse them, and transfer archives preserve them.

## Root cause

The write path, schema, retrieval code, and transfer code described different causal taxonomies. In particular, export correctly serialized all four causal link types, but import replayed every archived relationship through the normal retain writer. That writer intentionally accepts only `caused_by`, so valid legacy links were logged as invalid and omitted from the imported graph while the import operation still succeeded.

## What changed

- Document the canonical-write versus historical-compatibility boundary in retain, schema, and transfer code.
- Keep normal retain restricted to `caused_by`; it cannot create legacy causal link types.
- Split the link helpers into a canonical retain writer and a transfer-only legacy restore writer.
- Restore `causes`, `enables`, and `prevents` only while importing a transfer archive, preserving each edge type and its source and target facts.
- Keep recall and other existing read paths compatible with all historical causal types.
- Update stale causal taxonomy assertions and add deterministic coverage for the retain schema boundary.

## Compatibility

This does not change the database constraint, migration behavior, or recall scoring. It only restores transfer compatibility for valid historical causal links already supported by those read paths. Cross-document causal links remain outside the existing archive format and are unchanged by this PR.

## Validation

- `uv run pytest -n 0 -q -p no:logging tests/test_causal_link_taxonomy.py tests/test_document_transfer.py::test_transfer_preserves_legacy_causal_links` — 5 passed.
- The new transfer round-trip test inserts all three legacy link types, exports the document, imports it into a new bank, and verifies the imported type, source text, and target text for every edge.
- `uv run ruff format --check` and `uv run ruff check` on changed files.
- `uv run ty check hindsight_api`.

