### PR TITLE
fix(control-plane): forward document search q to dataplane

### DIFF
--- a/hindsight-control-plane/src/app/api/documents/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/route.ts
@@ -17,13 +17,14 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const q = searchParams.get("q") || undefined;
   const limit = searchParams.get("limit") ? Number(searchParams.get("limit")) : undefined;
   const offset = searchParams.get("offset") ? Number(searchParams.get("offset")) : undefined;
 
   const response = await sdk.listDocuments({
     client: lowLevelClient,
     path: { bank_id: bankId },
-    query: { limit, offset },
+    query: { q, limit, offset },
   });
   return respondWithSdk(response, "Failed to fetch documents", { request });
 }

--- a/hindsight-control-plane/tests/app/api/documents/route.test.ts
+++ b/hindsight-control-plane/tests/app/api/documents/route.test.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ListDocumentsArg = { query: Record<string, unknown> };
+
+const { listDocuments } = vi.hoisted(() => ({
+  listDocuments: vi.fn<(arg: ListDocumentsArg) => Promise<unknown>>(),
+}));
+
+vi.mock("@/lib/hindsight-client", () => ({
+  sdk: { listDocuments },
+  lowLevelClient: {},
+}));
+
+vi.mock("@/lib/sdk-response", () => ({
+  respondWithSdk: vi.fn(() => new Response(null, { status: 200 })),
+}));
+
+import { GET } from "@/app/api/documents/route";
+
+function makeRequest(url: string): NextRequest {
+  // The route only reads `request.nextUrl.searchParams`.
+  return { nextUrl: new URL(url) } as unknown as NextRequest;
+}
+
+describe("GET /api/documents", () => {
+  beforeEach(() => {
+    listDocuments.mockReset();
+    listDocuments.mockResolvedValue({ data: { items: [], total: 0 }, error: undefined });
+  });
+
+  it("forwards the `q` search term to the dataplane (search by document ID)", async () => {
+    await GET(makeRequest("http://localhost/api/documents?bank_id=b1&q=my-doc-id&limit=25&offset=0"));
+
+    expect(listDocuments).toHaveBeenCalledTimes(1);
+    expect(listDocuments.mock.calls[0][0].query).toMatchObject({ q: "my-doc-id" });
+  });
+
+  it("omits `q` when no search term is provided", async () => {
+    await GET(makeRequest("http://localhost/api/documents?bank_id=b1&limit=25&offset=0"));
+
+    expect(listDocuments.mock.calls[0][0].query.q).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2678.

Search-by-Document-ID on the Control Plane Documents page did nothing. The `/api/documents` proxy route read `bank_id`, `limit` and `offset` from the request but **never forwarded the `q` search parameter** — so the value (sent correctly by `client.listDocuments`, `src/lib/api.ts`) was silently dropped before reaching the dataplane, whose `q` is a case-insensitive substring filter on document ID (`GET /v1/default/banks/{bank_id}/documents`).

### Not Safari-specific
The issue was reported against Safari, but the root cause is browser-independent — the parameter is dropped server-side in the Next proxy route, so search-by-ID was broken in every browser. The reporter most likely only tested in Safari.

## Change

`src/app/api/documents/route.ts` — extract `q` from the query string and pass it through:

```ts
const q = searchParams.get("q") || undefined;
...
query: { q, limit, offset },
```

## Test

Adds `tests/app/api/documents/route.test.ts` (vitest) asserting the route forwards `q` to `sdk.listDocuments` when present and omits it otherwise. Verified it **fails on the pre-fix route** (forwarded query was `{ limit, offset }`) and passes after the change.

- `npx vitest run tests/app/api/documents/route.test.ts` → 2 passed
- `tsc --noEmit` clean, `eslint` clean on the changed files