### PR TITLE
fix(engine): consolidate duplicated engine definitions

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/causal_links.py
+++ b/hindsight-api-slim/hindsight_api/engine/causal_links.py
@@ -1,0 +1,13 @@
+"""Shared causal-link taxonomy.
+
+Retain writes only the canonical relationship.  Transfer import/export also
+preserves historical relationship types so existing banks keep their graph
+semantics without allowing new retain output to create those types.
+"""
+
+CANONICAL_CAUSAL_LINK_TYPE = "caused_by"
+LEGACY_CAUSAL_LINK_TYPE_NAMES = ("causes", "enables", "prevents")
+
+CANONICAL_CAUSAL_LINK_TYPES = frozenset({CANONICAL_CAUSAL_LINK_TYPE})
+LEGACY_CAUSAL_LINK_TYPES = frozenset(LEGACY_CAUSAL_LINK_TYPE_NAMES)
+CAUSAL_LINK_TYPES = (CANONICAL_CAUSAL_LINK_TYPE, *LEGACY_CAUSAL_LINK_TYPE_NAMES)

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -31,9 +31,6 @@ from ..config import (
 if TYPE_CHECKING:
     from .response_models import LLMToolCallResult
 
-# Seed applied to every Groq request for deterministic behavior.
-DEFAULT_LLM_SEED = 4242
-
 logger = logging.getLogger(__name__)
 
 # Disable httpx logging

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -7,6 +7,7 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from ..._vector_index import ann_search_tuning_settings, configured_vector_extension
+from ..causal_links import CANONICAL_CAUSAL_LINK_TYPES, LEGACY_CAUSAL_LINK_TYPES
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
@@ -16,8 +17,6 @@ logger = logging.getLogger(__name__)
 
 # Sentinel UUID used in the unique index to represent NULL entity_id
 _NIL_ENTITY_UUID = "00000000-0000-0000-0000-000000000000"
-_CANONICAL_CAUSAL_LINK_TYPES = frozenset({"caused_by"})
-_LEGACY_CAUSAL_LINK_TYPES = frozenset({"causes", "enables", "prevents"})
 
 # Maximum number of temporal links to keep per unit (from_unit_id).
 # Retrieval only reads top 10-20 per unit via LATERAL join, so keeping
@@ -792,7 +791,7 @@ async def create_causal_links_batch(
         bank_id,
         unit_ids,
         causal_relations_per_fact,
-        _CANONICAL_CAUSAL_LINK_TYPES,
+        CANONICAL_CAUSAL_LINK_TYPES,
         ops=ops,
     )
 
@@ -814,7 +813,7 @@ async def restore_legacy_causal_links_batch(
         bank_id,
         unit_ids,
         causal_relations_per_fact,
-        _LEGACY_CAUSAL_LINK_TYPES,
+        LEGACY_CAUSAL_LINK_TYPES,
         ops=ops,
     )
 

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -19,9 +19,12 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
+from ..causal_links import CAUSAL_LINK_TYPES
 from ..db_utils import acquire_with_retry
 from ..schema import fq_table
 from .schema import (
+    CARRIED_HISTORY_TABLES,
+    HISTORY_TABLES,
     SCHEMA_VERSION,
     TransferCausalRelation,
     TransferChunk,
@@ -71,9 +74,7 @@ _BANK_ROW_TABLES = ("banks", "mental_models", "directives", "webhooks")
 # keep their (id, bank_id) across export/import, so their refresh history can be
 # re-attached. The surrogate ``id`` is dropped on dump so the target reassigns it
 # (see _dump_history_rows); restored after its parent table (mental_models).
-_CARRIED_HISTORY_TABLES = ("mental_model_history",)
 # Operational history — only carried with include_history=True.
-_HISTORY_TABLES = ("audit_log", "llm_requests")
 # Intentionally never exported.
 _SKIP_TABLES = frozenset(
     {
@@ -128,8 +129,6 @@ class _LoadedExport:
 # Retain currently writes only ``caused_by``. The legacy types stay in archives
 # so importing a historical bank preserves its graph; temporal/semantic/entity
 # links are regenerated against the target bank.
-_CAUSAL_LINK_TYPES = ("caused_by", "causes", "enables", "prevents")
-
 # Facts of these types are exported; observations are derived and excluded.
 _EXPORTED_FACT_TYPES = ("world", "experience")
 
@@ -288,11 +287,11 @@ async def export_bank(conn: Any, bank_id: str, *, include_history: bool = False)
     observations = await _load_observations(conn, bank_id, loaded.unit_index)
 
     bank_rows = {table: await _dump_bank_rows(conn, table, bank_id) for table in _BANK_ROW_TABLES}
-    for table in _CARRIED_HISTORY_TABLES:
+    for table in CARRIED_HISTORY_TABLES:
         bank_rows[table] = await _dump_history_rows(conn, table, bank_id)
     history_rows: dict[str, list[dict]] = {}
     if include_history:
-        history_rows = {table: await _dump_bank_rows(conn, table, bank_id) for table in _HISTORY_TABLES}
+        history_rows = {table: await _dump_bank_rows(conn, table, bank_id) for table in HISTORY_TABLES}
 
     archive = io.BytesIO()
     fact_total = 0
@@ -544,7 +543,7 @@ async def _attach_causal_relations(conn: Any, loaded: _LoadedFacts) -> None:
           AND from_unit_id = ANY($2)
           AND to_unit_id = ANY($2)
         """,
-        list(_CAUSAL_LINK_TYPES),
+        list(CAUSAL_LINK_TYPES),
         list(loaded.unit_index.keys()),
     )
     for row in rows:

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from typing import Any, Literal
 
+from ..causal_links import CANONICAL_CAUSAL_LINK_TYPE, LEGACY_CAUSAL_LINK_TYPES
 from ..db_utils import acquire_with_retry
 from ..retain import bank_utils, chunk_storage, embedding_processing, fact_storage, link_utils, orchestrator
 from ..retain.types import (
@@ -29,6 +30,8 @@ from ..retain.types import (
 )
 from ..schema import fq_table
 from .schema import (
+    CARRIED_HISTORY_TABLES,
+    HISTORY_TABLES,
     SCHEMA_VERSION,
     TransferDocument,
     TransferFact,
@@ -40,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 OnConflict = Literal["skip", "replace", "new-id"]
 _VALID_CONFLICT_MODES: tuple[OnConflict, ...] = ("skip", "replace", "new-id")
-_LEGACY_CAUSAL_LINK_TYPES = frozenset({"causes", "enables", "prevents"})
 
 
 @dataclass
@@ -222,8 +224,6 @@ _BANK_CHILD_TABLES = ("mental_models", "directives", "webhooks")
 # Child-history carried verbatim; restored after its parent (mental_models) so the
 # foreign key resolves. Surrogate ids were dropped on export (the target reassigns
 # them), so these restore via fresh IDENTITY values.
-_CARRIED_HISTORY_TABLES = ("mental_model_history",)
-_HISTORY_TABLES = ("audit_log", "llm_requests")
 
 
 @dataclass
@@ -264,11 +264,11 @@ def parse_bank_archive(archive_bytes: bytes) -> ParsedBankArchive:
                 f"Not a whole-bank archive (archive_type={manifest.archive_type!r}); use import_documents instead"
             )
         bank_rows: dict[str, list[dict]] = {}
-        for table in ("banks", *_BANK_CHILD_TABLES, *_CARRIED_HISTORY_TABLES):
+        for table in ("banks", *_BANK_CHILD_TABLES, *CARRIED_HISTORY_TABLES):
             fname = f"{table}.json"
             bank_rows[table] = json.loads(zf.read(fname)) if fname in names else []
         history_rows: dict[str, list[dict]] = {}
-        for table in _HISTORY_TABLES:
+        for table in HISTORY_TABLES:
             fname = f"history/{table}.json"
             if fname in names:
                 history_rows[table] = json.loads(zf.read(fname))
@@ -409,7 +409,7 @@ async def import_bank(
         result.directives_imported = await _restore_rows(conn, "directives", parsed.bank_rows.get("directives", []))
         result.webhooks_imported = await _restore_rows(conn, "webhooks", parsed.bank_rows.get("webhooks", []))
         if include_history:
-            for table in _HISTORY_TABLES:
+            for table in HISTORY_TABLES:
                 result.history_rows_imported += await _restore_rows(conn, table, parsed.history_rows.get(table, []))
 
     logger.info(
@@ -719,7 +719,7 @@ def _to_extracted_fact(fact: TransferFact) -> ExtractedFact:
         causal_relations=[
             CausalRelation(relation_type=rel.relation_type, target_fact_index=rel.target_fact_index)
             for rel in fact.causal_relations
-            if rel.relation_type == "caused_by"
+            if rel.relation_type == CANONICAL_CAUSAL_LINK_TYPE
         ],
         content_index=0,
         chunk_index=fact.chunk_index,
@@ -741,7 +741,7 @@ def _legacy_causal_relations(document: TransferDocument) -> list[list[CausalRela
         [
             CausalRelation(relation_type=relation.relation_type, target_fact_index=relation.target_fact_index)
             for relation in fact.causal_relations
-            if relation.relation_type in _LEGACY_CAUSAL_LINK_TYPES
+            if relation.relation_type in LEGACY_CAUSAL_LINK_TYPES
         ]
         for fact in document.facts
     ]

--- a/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/schema.py
@@ -22,6 +22,12 @@ from pydantic import BaseModel, Field
 # Bump when the archive layout changes in a backward-incompatible way.
 SCHEMA_VERSION = 1
 
+# Whole-bank transfer table classifications shared by export and import.
+# Child history is always carried after its mental-model parent; operational
+# history is optional and included only when the caller requests it.
+CARRIED_HISTORY_TABLES = ("mental_model_history",)
+HISTORY_TABLES = ("audit_log", "llm_requests")
+
 ObservationScopes = Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]]
 
 

--- a/hindsight-api-slim/tests/test_causal_link_taxonomy.py
+++ b/hindsight-api-slim/tests/test_causal_link_taxonomy.py
@@ -3,6 +3,12 @@
 import pytest
 from pydantic import ValidationError
 
+from hindsight_api.engine.causal_links import (
+    CANONICAL_CAUSAL_LINK_TYPE,
+    CANONICAL_CAUSAL_LINK_TYPES,
+    CAUSAL_LINK_TYPES,
+    LEGACY_CAUSAL_LINK_TYPES,
+)
 from hindsight_api.engine.retain.fact_extraction import CausalRelation, FactCausalRelation
 
 
@@ -20,3 +26,9 @@ def test_retain_causal_models_accept_caused_by() -> None:
     """The canonical causal relationship remains valid in both extraction schemas."""
     assert CausalRelation(target_fact_index=0, relation_type="caused_by").relation_type == "caused_by"
     assert FactCausalRelation(target_index=0, relation_type="caused_by").relation_type == "caused_by"
+
+
+def test_causal_link_taxonomy_keeps_canonical_and_legacy_types_separate() -> None:
+    assert CANONICAL_CAUSAL_LINK_TYPES == {CANONICAL_CAUSAL_LINK_TYPE}
+    assert LEGACY_CAUSAL_LINK_TYPES == {"causes", "enables", "prevents"}
+    assert CAUSAL_LINK_TYPES == (CANONICAL_CAUSAL_LINK_TYPE, "causes", "enables", "prevents")

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -95,19 +95,14 @@ def test_export_bank_covers_schema():
     """Every bank-scoped table must be classified by export_bank — logical, carried,
     history, or explicitly skipped — so a future migration can't silently drop one."""
     from hindsight_api.admin.cli import BACKUP_TABLES
-    from hindsight_api.engine.transfer.export import (
-        _BANK_ROW_TABLES,
-        _CARRIED_HISTORY_TABLES,
-        _HISTORY_TABLES,
-        _REPLAYED_TABLES,
-        _SKIP_TABLES,
-    )
+    from hindsight_api.engine.transfer.export import _BANK_ROW_TABLES, _REPLAYED_TABLES, _SKIP_TABLES
+    from hindsight_api.engine.transfer.schema import CARRIED_HISTORY_TABLES, HISTORY_TABLES
 
     buckets = [
         set(_REPLAYED_TABLES),
         set(_BANK_ROW_TABLES),
-        set(_CARRIED_HISTORY_TABLES),
-        set(_HISTORY_TABLES),
+        set(CARRIED_HISTORY_TABLES),
+        set(HISTORY_TABLES),
         set(_SKIP_TABLES),
     ]
     classified = set().union(*buckets)


### PR DESCRIPTION
## Summary

- Centralize causal link taxonomy used by retain and transfer.
- Share transfer history table classifications between export and import.
- Use the shared canonical type in importer filtering.
- Remove the unused wrapper-level Groq seed constant.

## Root cause

Several engine modules independently defined the same causal and transfer
metadata. Import also hard-coded the canonical causal type, so a taxonomy
change could silently cause canonical links to be discarded.

## Validation

- `ruff format --check hindsight_api/engine/transfer/importer.py`
- `ruff check hindsight_api/engine/transfer/importer.py`
- `pytest -q -n0 tests/test_causal_link_taxonomy.py`
- `pytest -q -n0 tests/test_document_transfer.py::test_export_bank_covers_schema`