### PR TITLE
feat(devin-desktop): two-tier bank scoping + visible memory use (v0.2.0)

### DIFF
--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -54,9 +54,14 @@ hindsight-devin-desktop init --api-token YOUR_HINDSIGHT_API_KEY
 `init` (run inside a repo) derives the project bank from your git remote and
 wires **both agents**: the MCP server entries, the per-project rules (**commit
 `./.devin/rules/hindsight.md` and `./AGENTS.md`** so teammates share the project
-bank), and the global rules. Then **open Devin Desktop and press Refresh in the
-MCP panel** (editing config doesn't hot-reload) — the `hindsight` tools then load
-for whichever agent you use.
+bank), and the global rules. Then **activate the server** in whichever agent you
+use (config isn't hot-reloaded):
+
+- **Cascade** — open the MCP panel and press **Refresh**.
+- **Devin Local** — open the **Devin MCP Marketplace**, find `hindsight` under
+  **Installed**, and click **Connect**.
+
+The `hindsight` tools then load and are used automatically.
 
 Use a [Hindsight Cloud](https://hindsight.vectorize.io) key, or a self-hosted
 server with `--api-url http://localhost:8888` (no token needed for an open local

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -22,10 +22,21 @@ each:
 | Tool approval | automatic | pre-seeded allow-rule (`mcp__hindsight__*`) so tools don't prompt |
 | Per-project rule | `.devin/rules/hindsight.md` | repo-root `AGENTS.md` |
 | Global rule | `~/.codeium/windsurf/memories/global_rules.md` | `~/.config/devin/AGENTS.md` |
+| Auto-recall | — (rule-driven) | **`SessionStart` hook** injects memory deterministically |
 
 Configuring one agent does **not** surface the server in the other, so the
 integration writes both. All the file edits are surgical — dedicated files, or a
 fenced managed block inside shared files (`AGENTS.md`, `global_rules.md`).
+
+### Deterministic auto-recall (Devin Local)
+
+The MCP tools + rules are *model-driven* — the agent recalls because the rule
+tells it to. For Devin Local, `init` also adds a **`SessionStart` hook** that
+recalls project + global memory and injects it into the agent's context at the
+start of every session — so relevant memory is loaded **even if the model
+forgets to call `recall`**. (Cascade can't do this — its hooks can't inject
+context.) The hook fails silently if Hindsight is unreachable and never blocks a
+session. Opt out with `hindsight-devin-desktop init --no-hooks`.
 
 ## Two-tier memory: global + per-project
 

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -70,6 +70,14 @@ and the always-on rule tells the agent which `bank_id` to use — recall both ba
 at task start, retain project facts to the project bank and user facts to the
 global bank. An `X-Bank-Id` header names the global bank as the default.
 
+### Opting out of the shared layer (`--no-global-bank`)
+
+If you'd rather your preferences *not* follow you across repos, pass
+`--no-global-bank` (local-only mode): everything — project facts **and** your
+preferences — stays in that repo's project bank, nothing is shared, and the
+global rule files aren't written. Good for keeping work and personal machines
+separate, or when a shared profile isn't wanted.
+
 ## Install
 
 ```bash

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -3,16 +3,29 @@
 Long-term memory for **Devin Desktop** (the editor formerly known as Windsurf / Codeium), powered by [Hindsight](https://github.com/vectorize-io/hindsight).
 
 `hindsight-devin-desktop init` wires the Hindsight **MCP server** into Devin
-Desktop's global `mcp_config.json` and writes always-on memory rules, so Devin
-has `recall` / `retain` / `reflect` tools and — guided by the rules — recalls
-relevant memory at the start of a task and retains durable facts as it works.
+Desktop and adds always-on recall/retain rules, so the agent has `recall` /
+`retain` / `reflect` tools and — guided by the rules — recalls relevant memory at
+the start of a task and retains durable facts as it works.
 
-> **Note:** Cognition rebranded Windsurf to Devin Desktop (June 2026). The MCP
-> config still lives under `~/.codeium/` (unchanged by the rebrand); Devin's own
-> docs disagree on the exact path, so `init` writes **both**
-> `~/.codeium/windsurf/mcp_config.json` and `~/.codeium/mcp_config.json`. The
-> workspace rule lives under `.devin/rules/` (with `.windsurf/rules/` as a legacy
-> fallback).
+> **Note:** Cognition rebranded Windsurf to Devin Desktop (June 2026). This
+> integration configures **both agents Devin Desktop ships** (see below), so
+> memory works whichever one you use.
+
+## Two agents, both covered
+
+Devin Desktop runs two agents with **separate** configuration, so `init` wires
+each:
+
+| | **Cascade** (legacy Windsurf agent) | **Devin Local** (the successor agent) |
+| --- | --- | --- |
+| MCP server | `~/.codeium/windsurf/mcp_config.json` (`serverUrl`) | `~/.config/devin/config.json` (`url` + `transport` + `headers`) |
+| Tool approval | automatic | pre-seeded allow-rule (`mcp__hindsight__*`) so tools don't prompt |
+| Per-project rule | `.devin/rules/hindsight.md` | repo-root `AGENTS.md` |
+| Global rule | `~/.codeium/windsurf/memories/global_rules.md` | `~/.config/devin/AGENTS.md` |
+
+Configuring one agent does **not** surface the server in the other, so the
+integration writes both. All the file edits are surgical — dedicated files, or a
+fenced managed block inside shared files (`AGENTS.md`, `global_rules.md`).
 
 ## Two-tier memory: global + per-project
 
@@ -22,42 +35,13 @@ on one repo never bleeds into another:
 - **Global bank** (`devin-desktop`) — your cross-project memory: preferences,
   coding style, who you are. Shared across every project.
 - **Project bank** (`devin-desktop-<slug>`) — this repository's memory:
-  architecture, decisions, conventions, bugs. The `<slug>` is derived from the
-  repo's **git remote**, so it's stable across machines and identical for
-  teammates who clone the same repo.
+  architecture, decisions, conventions. The `<slug>` is derived from the repo's
+  **git remote**, so it's stable across machines and identical for teammates.
 
-The MCP server runs in **multi-bank mode** (a single `serverUrl` ending in
-`/mcp/`), and the committed per-project rule tells the agent which `bank_id` to
-use — recall both banks at task start, retain project facts to the project bank
-and user facts to the global bank.
-
-## How it works
-
-Devin Desktop supports two things this integration uses:
-
-- **MCP servers** in the global `mcp_config.json` under `mcpServers`, including
-  **remote servers** via `serverUrl` with headers — so the Hindsight MCP endpoint
-  connects directly, in multi-bank mode:
-
-  ```json
-  {
-    "mcpServers": {
-      "hindsight": {
-        "serverUrl": "https://api.hindsight.vectorize.io/mcp/",
-        "headers": {
-          "Authorization": "Bearer hsk_...",
-          "X-Bank-Id": "devin-desktop"
-        }
-      }
-    }
-  }
-  ```
-
-  (`X-Bank-Id` is the fallback bank for any call that omits `bank_id`.)
-
-- **Workspace rules** in `.devin/rules/` (per-project, committed) plus the global
-  `~/.codeium/windsurf/memories/global_rules.md`. A rule with `trigger: always_on`
-  is applied to every request — that's where the recall/retain routing lives.
+The MCP server runs in **multi-bank mode** (a single endpoint ending in `/mcp/`),
+and the always-on rule tells the agent which `bank_id` to use — recall both banks
+at task start, retain project facts to the project bank and user facts to the
+global bank. An `X-Bank-Id` header names the global bank as the default.
 
 ## Install
 
@@ -67,26 +51,27 @@ cd your-project
 hindsight-devin-desktop init --api-token YOUR_HINDSIGHT_API_KEY
 ```
 
-`init` (run inside a repo) derives the project bank from your git remote, merges
-the `mcpServers` entry into Devin's config, writes `./.devin/rules/hindsight.md`
-(**commit this** so teammates share the project bank), and adds a managed block
-to your global rules. Then **open Devin Desktop and press Refresh in the MCP
-panel** (editing the config doesn't hot-reload) — the `hindsight` tools then load.
+`init` (run inside a repo) derives the project bank from your git remote and
+wires **both agents**: the MCP server entries, the per-project rules (**commit
+`./.devin/rules/hindsight.md` and `./AGENTS.md`** so teammates share the project
+bank), and the global rules. Then **open Devin Desktop and press Refresh in the
+MCP panel** (editing config doesn't hot-reload) — the `hindsight` tools then load
+for whichever agent you use.
 
 Use a [Hindsight Cloud](https://hindsight.vectorize.io) key, or a self-hosted
 server with `--api-url http://localhost:8888` (no token needed for an open local
-server). Pass `--bank-id <id>` to set the project bank explicitly instead of
-deriving it, or `--global-bank <id>` to change the cross-project bank. If
-`mcp_config.json` isn't plain JSON, `init` prints the snippet to paste instead of
-touching the file — or run `hindsight-devin-desktop init --print-only` anytime.
+server). Pass `--bank-id <id>` to set the project bank explicitly, or
+`--global-bank <id>` to change the cross-project bank. Run
+`hindsight-devin-desktop init --print-only` to see everything it would write
+without touching a file.
 
 ## Commands
 
 | Command | Description |
 | --- | --- |
-| `hindsight-devin-desktop init` | Add the MCP server + memory rules (derives the project bank) |
-| `hindsight-devin-desktop status` | Show resolved banks + whether the server/rules are configured |
-| `hindsight-devin-desktop uninstall` | Remove the MCP server + memory rules |
+| `hindsight-devin-desktop init` | Wire both agents' MCP server + memory rules (derives the project bank) |
+| `hindsight-devin-desktop status` | Show resolved banks + whether each agent is configured |
+| `hindsight-devin-desktop uninstall` | Remove the MCP server + memory rules from both agents |
 
 ## Configuration
 

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -23,20 +23,36 @@ each:
 | Per-project rule | `.devin/rules/hindsight.md` | repo-root `AGENTS.md` |
 | Global rule | `~/.codeium/windsurf/memories/global_rules.md` | `~/.config/devin/AGENTS.md` |
 | Auto-recall | — (rule-driven) | **`SessionStart` hook** injects memory deterministically |
+| Retain nudge | — | **`Stop` hook** forces a retain pass before the session ends |
+| Visibility | **`post_mcp_tool_use` banner** (`hooks.json`) | native tool cards + rule narration |
 
 Configuring one agent does **not** surface the server in the other, so the
 integration writes both. All the file edits are surgical — dedicated files, or a
-fenced managed block inside shared files (`AGENTS.md`, `global_rules.md`).
+fenced managed block inside shared files (`AGENTS.md`, `global_rules.md`,
+`hooks.json`).
 
-### Deterministic auto-recall (Devin Local)
+### Hooks (Devin Local) — deterministic memory, always visible
 
-The MCP tools + rules are *model-driven* — the agent recalls because the rule
-tells it to. For Devin Local, `init` also adds a **`SessionStart` hook** that
-recalls project + global memory and injects it into the agent's context at the
-start of every session — so relevant memory is loaded **even if the model
-forgets to call `recall`**. (Cascade can't do this — its hooks can't inject
-context.) The hook fails silently if Hindsight is unreachable and never blocks a
-session. Opt out with `hindsight-devin-desktop init --no-hooks`.
+The MCP tools + rules are *model-driven* — the agent recalls/retains because the
+rule tells it to. For Devin Local, `init` also adds two hooks (opt out of both
+with `--no-hooks`):
+
+- **`SessionStart` auto-recall** — recalls project + global memory and injects it
+  into the agent's context at the start of every session, so relevant memory
+  loads **even if the model forgets to call `recall`**. It **always reports
+  status** (loaded N / empty / unavailable) so memory use is never silent, and
+  never blocks a session.
+- **`Stop` retain-nudge** — before the agent stops, it forces one retain pass
+  (the model decides *what* is durable and calls `retain`). Loop-guarded. Costs
+  one extra turn per session; opt out with `--no-retain-hook`.
+
+**Why not fully-automatic retain?** Devin's hooks can't hand a script the
+conversation transcript, so a hook can't summarize-and-retain on its own — the
+nudge is the closest deterministic option (guaranteed *trigger*, model authors
+the content). Cascade can't do either hook (its hooks can't inject context), so
+recall/retain there stay model-driven — but `init` adds a `post_mcp_tool_use`
+banner (`show_output`) so Cascade **visibly shows** every `🧠 Hindsight: <tool>
+used`.
 
 ## Two-tier memory: global + per-project
 

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -2,66 +2,91 @@
 
 Long-term memory for **Devin Desktop** (the editor formerly known as Windsurf / Codeium), powered by [Hindsight](https://github.com/vectorize-io/hindsight).
 
-`hindsight-devin-desktop init` wires the Hindsight **MCP server** into Devin Desktop's
-`~/.codeium/windsurf/mcp_config.json` and adds an always-on recall/retain rule to
-`.devin/rules/hindsight.md`. Devin then has `recall` / `retain` / `reflect`
-tools and — guided by the rule — recalls relevant memory at the start of a task
-and retains durable facts as it works.
+`hindsight-devin-desktop init` wires the Hindsight **MCP server** into Devin
+Desktop's global `mcp_config.json` and writes always-on memory rules, so Devin
+has `recall` / `retain` / `reflect` tools and — guided by the rules — recalls
+relevant memory at the start of a task and retains durable facts as it works.
 
 > **Note:** Cognition rebranded Windsurf to Devin Desktop (June 2026). The MCP
-> config path still lives under `~/.codeium/windsurf/` — that's Devin Desktop's
-> on-disk data directory and is unchanged by the rebrand. The workspace rule now
-> lives under `.devin/rules/` (with `.windsurf/rules/` kept as a legacy fallback).
+> config still lives under `~/.codeium/` (unchanged by the rebrand); Devin's own
+> docs disagree on the exact path, so `init` writes **both**
+> `~/.codeium/windsurf/mcp_config.json` and `~/.codeium/mcp_config.json`. The
+> workspace rule lives under `.devin/rules/` (with `.windsurf/rules/` as a legacy
+> fallback).
+
+## Two-tier memory: global + per-project
+
+Memory is split across two Hindsight **banks** (isolated memory scopes), so work
+on one repo never bleeds into another:
+
+- **Global bank** (`devin-desktop`) — your cross-project memory: preferences,
+  coding style, who you are. Shared across every project.
+- **Project bank** (`devin-desktop-<slug>`) — this repository's memory:
+  architecture, decisions, conventions, bugs. The `<slug>` is derived from the
+  repo's **git remote**, so it's stable across machines and identical for
+  teammates who clone the same repo.
+
+The MCP server runs in **multi-bank mode** (a single `serverUrl` ending in
+`/mcp/`), and the committed per-project rule tells the agent which `bank_id` to
+use — recall both banks at task start, retain project facts to the project bank
+and user facts to the global bank.
 
 ## How it works
 
 Devin Desktop supports two things this integration uses:
 
-- **MCP servers** in `~/.codeium/windsurf/mcp_config.json` under `mcpServers`,
-  including **remote servers** via `serverUrl` with headers — so the Hindsight
-  MCP endpoint connects directly:
+- **MCP servers** in the global `mcp_config.json` under `mcpServers`, including
+  **remote servers** via `serverUrl` with headers — so the Hindsight MCP endpoint
+  connects directly, in multi-bank mode:
 
   ```json
   {
     "mcpServers": {
       "hindsight": {
-        "serverUrl": "https://api.hindsight.vectorize.io/mcp/my-project/",
-        "headers": { "Authorization": "Bearer hsk_..." }
+        "serverUrl": "https://api.hindsight.vectorize.io/mcp/",
+        "headers": {
+          "Authorization": "Bearer hsk_...",
+          "X-Bank-Id": "devin-desktop"
+        }
       }
     }
   }
   ```
 
-- **Workspace rules** in `.devin/rules/`. A rule file with `trigger: always_on`
-  frontmatter is applied to every Devin request in the workspace — that's where
-  the recall/retain rule lives.
+  (`X-Bank-Id` is the fallback bank for any call that omits `bank_id`.)
+
+- **Workspace rules** in `.devin/rules/` (per-project, committed) plus the global
+  `~/.codeium/windsurf/memories/global_rules.md`. A rule with `trigger: always_on`
+  is applied to every request — that's where the recall/retain routing lives.
 
 ## Install
 
 ```bash
 pip install hindsight-devin-desktop
 cd your-project
-hindsight-devin-desktop init --api-token YOUR_HINDSIGHT_API_KEY --bank-id my-project
+hindsight-devin-desktop init --api-token YOUR_HINDSIGHT_API_KEY
 ```
 
-`init` merges the `mcpServers` entry into `~/.codeium/windsurf/mcp_config.json`
-(Devin Desktop's single global MCP config) and writes the rule into
-`./.devin/rules/hindsight.md`. Reload Devin Desktop (or refresh MCP servers) and
-the `hindsight` tools are available.
+`init` (run inside a repo) derives the project bank from your git remote, merges
+the `mcpServers` entry into Devin's config, writes `./.devin/rules/hindsight.md`
+(**commit this** so teammates share the project bank), and adds a managed block
+to your global rules. Then **open Devin Desktop and press Refresh in the MCP
+panel** (editing the config doesn't hot-reload) — the `hindsight` tools then load.
 
 Use a [Hindsight Cloud](https://hindsight.vectorize.io) key, or a self-hosted
 server with `--api-url http://localhost:8888` (no token needed for an open local
-server). If `mcp_config.json` isn't plain JSON, `init` prints the snippet to
-paste instead of touching the file — or run `hindsight-devin-desktop init --print-only`
-anytime.
+server). Pass `--bank-id <id>` to set the project bank explicitly instead of
+deriving it, or `--global-bank <id>` to change the cross-project bank. If
+`mcp_config.json` isn't plain JSON, `init` prints the snippet to paste instead of
+touching the file — or run `hindsight-devin-desktop init --print-only` anytime.
 
 ## Commands
 
 | Command | Description |
 | --- | --- |
-| `hindsight-devin-desktop init` | Add the MCP server + recall/retain rule |
-| `hindsight-devin-desktop status` | Show whether the server + rule are configured |
-| `hindsight-devin-desktop uninstall` | Remove the server + rule |
+| `hindsight-devin-desktop init` | Add the MCP server + memory rules (derives the project bank) |
+| `hindsight-devin-desktop status` | Show resolved banks + whether the server/rules are configured |
+| `hindsight-devin-desktop uninstall` | Remove the MCP server + memory rules |
 
 ## Configuration
 
@@ -69,7 +94,8 @@ anytime.
 | --- | --- | --- |
 | API URL | `HINDSIGHT_API_URL` | `https://api.hindsight.vectorize.io` |
 | API token | `HINDSIGHT_API_TOKEN` | _(none; required for Cloud)_ |
-| Bank id | `HINDSIGHT_DEVIN_DESKTOP_BANK_ID` | `devin-desktop` |
+| Global bank | `HINDSIGHT_DEVIN_DESKTOP_GLOBAL_BANK` | `devin-desktop` |
+| Project bank | `HINDSIGHT_DEVIN_DESKTOP_BANK_ID` | _(derived from git remote)_ |
 
 ## Development
 

--- a/hindsight-integrations/devin-desktop/README.md
+++ b/hindsight-integrations/devin-desktop/README.md
@@ -29,7 +29,8 @@ each:
 Configuring one agent does **not** surface the server in the other, so the
 integration writes both. All the file edits are surgical — dedicated files, or a
 fenced managed block inside shared files (`AGENTS.md`, `global_rules.md`,
-`hooks.json`).
+`hooks.json`). Paths above are macOS/Linux; on Windows the Devin Local config
+lives under `%APPDATA%\devin\` (Cascade stays under `~/.codeium/windsurf\`).
 
 ### Hooks (Devin Local) — deterministic memory, always visible
 
@@ -96,7 +97,21 @@ use (config isn't hot-reloaded):
 - **Devin Local** — open the **Devin MCP Marketplace**, find `hindsight` under
   **Installed**, and click **Connect**.
 
-The `hindsight` tools then load and are used automatically.
+The `hindsight` tools then load and are used automatically. (Not sure which agent
+you're on? Check the **agent selector** in the bottom-right of Devin Desktop.)
+
+### Verify it's working
+
+Start a session and you'll *see* memory is on — nothing is silent:
+
+- **Devin Local** — the reply opens with a status line like
+  `🧠 Hindsight preloaded 3 memories for this session` (or `no memory yet`, or
+  `⚠️ memory unavailable this session`). Every hook run is also logged to
+  `~/.hindsight/devin-hook.log`, so you can confirm the recall/retain hooks fired.
+- **Cascade** — each `recall`/`retain` shows as a tool card, and expanding the
+  `post-tool hooks` line reveals the `🧠 Hindsight: <tool> used` banner.
+- `hindsight-devin-desktop status` lists every component as installed for both
+  agents, and the banks it resolved.
 
 Use a [Hindsight Cloud](https://hindsight.vectorize.io) key, or a self-hosted
 server with `--api-url http://localhost:8888` (no token needed for an open local

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/__init__.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/__init__.py
@@ -1,10 +1,10 @@
 """Hindsight memory integration for Devin Desktop (formerly Windsurf / Codeium).
 
-Wires the Hindsight MCP server (multi-bank mode) into Devin Desktop's global
-``mcp_config.json`` and writes always-on memory rules — a per-project rule naming
-this repo's bank plus a global rule for cross-project memory — so Devin has
-``recall``/``retain``/``reflect`` tools and uses them automatically, scoped per
-project.
+Wires the Hindsight MCP server (multi-bank mode) into **both** agents Devin
+Desktop ships — Cascade and Devin Local — and writes always-on memory rules for
+each: a per-project rule naming this repo's bank plus a global rule for
+cross-project memory. Both agents then have ``recall``/``retain``/``reflect``
+tools and use them automatically, scoped per project.
 
 CLI::
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/__init__.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/__init__.py
@@ -1,12 +1,15 @@
 """Hindsight memory integration for Devin Desktop (formerly Windsurf / Codeium).
 
-Wires the Hindsight MCP server into Devin Desktop's ``~/.codeium/windsurf/mcp_config.json``
-and writes an always-on recall/retain rule into ``.devin/rules/hindsight.md``,
-so Devin has ``recall``/``retain``/``reflect`` tools and uses them automatically.
+Wires the Hindsight MCP server (multi-bank mode) into Devin Desktop's global
+``mcp_config.json`` and writes always-on memory rules — a per-project rule naming
+this repo's bank plus a global rule for cross-project memory — so Devin has
+``recall``/``retain``/``reflect`` tools and uses them automatically, scoped per
+project.
 
 CLI::
 
-    hindsight-devin-desktop init --api-token hsk_... --bank-id my-project
+    cd your-project
+    hindsight-devin-desktop init --api-token hsk_...
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cascade_hooks.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cascade_hooks.py
@@ -1,0 +1,120 @@
+"""Cascade visibility banner via a ``post_mcp_tool_use`` hook.
+
+Cascade renders a hook's stdout in its UI when ``show_output: true``. We register
+a ``post_mcp_tool_use`` command hook that prints ``🧠 Hindsight: <tool> used`` so
+every recall/retain is visibly obvious. Cascade has no per-hook matcher, so the
+hook fires for all MCP tools and filters to the hindsight server in-script (see
+:func:`hindsight_devin_desktop.hook.cmd_banner`).
+
+Hooks live in ``~/.codeium/windsurf/hooks.json`` (same path on every OS for the
+Devin Desktop / ex-Windsurf user tier). The file is shared with the user's own
+hooks, so we manage only our single entry — identified by our command marker —
+and never clobber theirs. We only rewrite the file when it parses as strict JSON.
+
+(Devin Local uses a different, richer hook system — see
+:mod:`hindsight_devin_desktop.devin_local`.)
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+EVENT = "post_mcp_tool_use"
+HOOK_MODULE = "hindsight_devin_desktop.hook"
+_MARKER = f"{HOOK_MODULE} banner"
+
+
+def default_hooks_path() -> Path:
+    """Cascade's user hooks file (``~/.codeium/windsurf/hooks.json``)."""
+    return Path.home() / ".codeium" / "windsurf" / "hooks.json"
+
+
+def banner_command() -> str:
+    return f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} banner"
+
+
+def _our_entry() -> dict[str, Any]:
+    cmd = banner_command()
+    # `command` = bash (macOS/Linux), `powershell` = Windows; same invocation works in both.
+    return {"command": cmd, "powershell": cmd, "show_output": True}
+
+
+def _is_ours(entry: Any) -> bool:
+    return isinstance(entry, dict) and _MARKER in (entry.get("command", "") + entry.get("powershell", ""))
+
+
+@dataclass
+class BannerResult:
+    action: str  # created / merged / unchanged / removed / manual
+    path: Path
+
+
+def _load_strict(path: Path) -> Optional[dict[str, Any]]:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def apply_banner(path: Path) -> BannerResult:
+    """Add our ``post_mcp_tool_use`` banner hook to ``hooks.json`` (idempotent)."""
+    if not path.is_file():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"hooks": {EVENT: [_our_entry()]}}, indent=2) + "\n", encoding="utf-8")
+        return BannerResult("created", path)
+
+    data = _load_strict(path)
+    if data is None:
+        return BannerResult("manual", path)
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = {}
+    entries = hooks.get(EVENT)
+    if not isinstance(entries, list):
+        entries = []
+    if any(_is_ours(e) for e in entries):
+        return BannerResult("unchanged", path)
+    entries.append(_our_entry())
+    hooks[EVENT] = entries
+    data["hooks"] = hooks
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return BannerResult("merged", path)
+
+
+def remove_banner(path: Path) -> BannerResult:
+    """Remove our banner hook from ``hooks.json``, preserving the user's own."""
+    data = _load_strict(path)
+    if data is None:
+        return BannerResult("manual" if path.is_file() else "unchanged", path)
+
+    hooks = data.get("hooks")
+    entries = hooks.get(EVENT) if isinstance(hooks, dict) else None
+    if not isinstance(entries, list) or not any(_is_ours(e) for e in entries):
+        return BannerResult("unchanged", path)
+
+    kept = [e for e in entries if not _is_ours(e)]
+    if kept:
+        hooks[EVENT] = kept
+    else:
+        hooks.pop(EVENT, None)
+    if not hooks:
+        data.pop("hooks", None)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return BannerResult("removed", path)
+
+
+def is_installed(path: Path) -> bool:
+    """Whether our banner hook is present in ``hooks.json``."""
+    data = _load_strict(path)
+    hooks = data.get("hooks") if data else None
+    entries = hooks.get(EVENT) if isinstance(hooks, dict) else None
+    return isinstance(entries, list) and any(_is_ours(e) for e in entries)

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -82,7 +82,7 @@ class InstallOutcome:
     devin_project_path: Path
 
 
-def build_install(resolved: Resolved, paths: Paths) -> InstallOutcome:
+def build_install(resolved: Resolved, paths: Paths, with_hook: bool = True) -> InstallOutcome:
     """Wire both agents (the testable core)."""
     # Cascade
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
@@ -92,7 +92,7 @@ def build_install(resolved: Resolved, paths: Paths) -> InstallOutcome:
 
     # Devin Local
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
-    devin_config = devin_local.apply_to_config(paths.devin_config, dl_server)
+    devin_config = devin_local.apply_to_config(paths.devin_config, dl_server, with_hook=with_hook)
     dl_global = devin_local.write_global_agents(paths.devin_global_agents, resolved.global_bank)
     dl_project = devin_local.write_project_agents(
         paths.devin_project_agents, resolved.project_bank, resolved.global_bank
@@ -178,7 +178,7 @@ def _scaffold_user_config(resolved: Resolved, path: Path) -> None:
 _VERB = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in", "removed": "Removed"}
 
 
-def _print_only(resolved: Resolved, server: dict, dl_server: dict) -> None:
+def _print_only(resolved: Resolved, server: dict, dl_server: dict, with_hook: bool) -> None:
     print("# Cascade agent\nAdd this to ~/.codeium/windsurf/mcp_config.json:\n")
     print(render_snippet(server))
     print(f"\nSave this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
@@ -186,7 +186,7 @@ def _print_only(resolved: Resolved, server: dict, dl_server: dict) -> None:
     print("Add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
     print(render_block(resolved.global_bank))
     print("\n# Devin Local agent\nMerge this into ~/.config/devin/config.json:\n")
-    print(devin_local.render_snippet(dl_server))
+    print(devin_local.render_snippet(dl_server, with_hook=with_hook))
     print("\nAdd this to AGENTS.md (repo root) and ~/.config/devin/AGENTS.md:\n")
     print(render_rule_text(resolved.project_bank, resolved.global_bank))
 
@@ -194,11 +194,12 @@ def _print_only(resolved: Resolved, server: dict, dl_server: dict) -> None:
 def cmd_init(args: argparse.Namespace) -> None:
     resolved = _resolve(args)
     paths = _paths(args)
+    with_hook = not getattr(args, "no_hooks", False)
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
 
     if args.print_only:
-        _print_only(resolved, server, dl_server)
+        _print_only(resolved, server, dl_server, with_hook)
         return
 
     print("Setting up Hindsight for Devin Desktop ...")
@@ -206,7 +207,7 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"  Project bank: {resolved.project_bank}")
     print(f"      from {resolved.project_source}")
     _scaffold_user_config(resolved, _user_config_path(args))
-    outcome = build_install(resolved, paths)
+    outcome = build_install(resolved, paths, with_hook=with_hook)
 
     print("\n  Cascade agent:")
     for result in outcome.mcp:
@@ -232,6 +233,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         f"    {outcome.devin_project_action.capitalize()} project rule in {outcome.devin_project_path}  (commit this)"
     )
     print(f"    {outcome.devin_global_action.capitalize()} global rule in {outcome.devin_global_path}")
+    if with_hook and dc.action != "manual":
+        print("    Added a SessionStart auto-recall hook (memory is injected even if the model forgets to recall)")
 
     print("\nActivate the server in whichever agent you use (config isn't hot-reloaded):")
     print("  - Cascade:     open the MCP panel and press Refresh.")
@@ -262,6 +265,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     print(
         f"  Global rule in {paths.devin_global_agents}: {mark(devin_local.agents_installed(paths.devin_global_agents))}"
     )
+    print(f"  Auto-recall hook in {paths.devin_config}: {mark(devin_local.hook_installed(paths.devin_config))}")
 
 
 def cmd_uninstall(args: argparse.Namespace) -> None:
@@ -320,6 +324,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     init_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
     init_p.add_argument("--global-bank", default=None, help="Cross-project bank (default: devin-desktop)")
     init_p.add_argument("--print-only", action="store_true", help="Print the config to add manually; write nothing")
+    init_p.add_argument("--no-hooks", action="store_true", help="Skip the Devin Local SessionStart auto-recall hook")
     _add_overrides(init_p)
     init_p.set_defaults(func=cmd_init)
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -1,12 +1,14 @@
 """CLI for the Hindsight Devin Desktop integration.
 
 ``hindsight-devin-desktop init`` wires the Hindsight MCP server (multi-bank mode)
-into Devin Desktop's global ``mcp_config.json`` and writes always-on memory rules:
+into **both** agents Devin Desktop ships:
 
-* a per-project ``.devin/rules/hindsight.md`` (committed) naming this repo's
-  project bank plus the user's global bank, and
-* a managed block in ``~/.codeium/windsurf/memories/global_rules.md`` naming the
-  global bank so it's active in every workspace.
+* **Cascade** — MCP in ``~/.codeium/windsurf/mcp_config.json`` (``serverUrl``),
+  always-on rules in ``.devin/rules/hindsight.md`` (per-project) +
+  ``~/.codeium/windsurf/memories/global_rules.md`` (global).
+* **Devin Local** — MCP in ``~/.config/devin/config.json`` (``url``/``transport``/
+  ``headers``, plus an auto-approve permission), always-on rules in ``AGENTS.md``
+  (repo root, per-project) + ``~/.config/devin/AGENTS.md`` (global).
 
 The project bank is derived from the repo's git remote so each project keeps its
 own isolated memory while the global bank carries cross-project preferences.
@@ -21,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-from . import __version__
+from . import __version__, devin_local
 from .config import USER_CONFIG_FILE, load_config
 from .global_rules import (
     GlobalRuleResult,
@@ -41,7 +43,7 @@ from .mcp_config import (
 )
 from .mcp_config import is_installed as server_installed
 from .project import project_bank_id
-from .rules import clear_rule, default_rules_path, render_rule, write_rule
+from .rules import clear_rule, default_rules_path, render_rule, render_rule_text, write_rule
 from .rules import is_installed as rule_installed
 
 
@@ -57,37 +59,77 @@ class Resolved:
 
 
 @dataclass
+class Paths:
+    """Every file the integration manages, across both agents."""
+
+    mcp: List[Path]  # Cascade mcp_config.json (both documented locations)
+    rules: Path  # Cascade per-project rule (.devin/rules/hindsight.md)
+    global_rules: Path  # Cascade global rule (global_rules.md)
+    devin_config: Path  # Devin Local config.json (MCP + permissions)
+    devin_global_agents: Path  # Devin Local global AGENTS.md
+    devin_project_agents: Path  # Devin Local per-project AGENTS.md (repo root)
+
+
+@dataclass
 class InstallOutcome:
     mcp: List[McpResult]
     rules_path: Path
     global_rule: GlobalRuleResult
+    devin_config: devin_local.ConfigResult
+    devin_global_action: str
+    devin_global_path: Path
+    devin_project_action: str
+    devin_project_path: Path
 
 
-def build_install(
-    resolved: Resolved, mcp_paths: List[Path], rules_path: Path, global_rules_path: Path
-) -> InstallOutcome:
-    """Apply the MCP server entry (to each path) and both rule files (testable core)."""
+def build_install(resolved: Resolved, paths: Paths) -> InstallOutcome:
+    """Wire both agents (the testable core)."""
+    # Cascade
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
-    mcp = [apply_to_mcp(path, server) for path in mcp_paths]
-    write_rule(rules_path, resolved.project_bank, resolved.global_bank)
-    global_rule = write_global_rule(global_rules_path, resolved.global_bank)
-    return InstallOutcome(mcp=mcp, rules_path=rules_path, global_rule=global_rule)
+    mcp = [apply_to_mcp(path, server) for path in paths.mcp]
+    write_rule(paths.rules, resolved.project_bank, resolved.global_bank)
+    global_rule = write_global_rule(paths.global_rules, resolved.global_bank)
+
+    # Devin Local
+    dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
+    devin_config = devin_local.apply_to_config(paths.devin_config, dl_server)
+    dl_global = devin_local.write_global_agents(paths.devin_global_agents, resolved.global_bank)
+    dl_project = devin_local.write_project_agents(
+        paths.devin_project_agents, resolved.project_bank, resolved.global_bank
+    )
+
+    return InstallOutcome(
+        mcp=mcp,
+        rules_path=paths.rules,
+        global_rule=global_rule,
+        devin_config=devin_config,
+        devin_global_action=dl_global,
+        devin_global_path=paths.devin_global_agents,
+        devin_project_action=dl_project,
+        devin_project_path=paths.devin_project_agents,
+    )
 
 
 def _user_config_path(args: argparse.Namespace) -> Path:
     return Path(args.user_config_path) if args.user_config_path else USER_CONFIG_FILE
 
 
-def _mcp_paths(args: argparse.Namespace) -> List[Path]:
-    return [Path(args.mcp_path)] if args.mcp_path else default_mcp_paths()
-
-
-def _rules_path(args: argparse.Namespace) -> Path:
-    return Path(args.rules_path) if args.rules_path else default_rules_path()
-
-
-def _global_rules_path(args: argparse.Namespace) -> Path:
-    return Path(args.global_rules_path) if args.global_rules_path else default_global_rules_path()
+def _paths(args: argparse.Namespace) -> Paths:
+    mcp = [Path(args.mcp_path)] if args.mcp_path else default_mcp_paths()
+    return Paths(
+        mcp=mcp,
+        rules=Path(args.rules_path) if args.rules_path else default_rules_path(),
+        global_rules=Path(args.global_rules_path) if args.global_rules_path else default_global_rules_path(),
+        devin_config=Path(args.devin_config_path) if args.devin_config_path else devin_local.default_config_path(),
+        devin_global_agents=(
+            Path(args.devin_global_agents_path)
+            if args.devin_global_agents_path
+            else devin_local.default_global_agents_path()
+        ),
+        devin_project_agents=(
+            Path(args.project_agents_path) if args.project_agents_path else devin_local.default_project_agents_path()
+        ),
+    )
 
 
 def _resolve(args: argparse.Namespace) -> Resolved:
@@ -133,20 +175,30 @@ def _scaffold_user_config(resolved: Resolved, path: Path) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+_VERB = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in", "removed": "Removed"}
+
+
+def _print_only(resolved: Resolved, server: dict, dl_server: dict) -> None:
+    print("# Cascade agent\nAdd this to ~/.codeium/windsurf/mcp_config.json:\n")
+    print(render_snippet(server))
+    print(f"\nSave this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
+    print(render_rule(resolved.project_bank, resolved.global_bank))
+    print("Add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
+    print(render_block(resolved.global_bank))
+    print("\n# Devin Local agent\nMerge this into ~/.config/devin/config.json:\n")
+    print(devin_local.render_snippet(dl_server))
+    print("\nAdd this to AGENTS.md (repo root) and ~/.config/devin/AGENTS.md:\n")
+    print(render_rule_text(resolved.project_bank, resolved.global_bank))
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     resolved = _resolve(args)
-    mcp_paths = _mcp_paths(args)
-    rules_path = _rules_path(args)
-    global_rules_path = _global_rules_path(args)
+    paths = _paths(args)
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
+    dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
 
     if args.print_only:
-        print("Add this to your Devin Desktop mcp_config.json:\n")
-        print(render_snippet(server))
-        print(f"\nAnd save this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
-        print(render_rule(resolved.project_bank, resolved.global_bank))
-        print("And add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
-        print(render_block(resolved.global_bank))
+        _print_only(resolved, server, dl_server)
         return
 
     print("Setting up Hindsight for Devin Desktop ...")
@@ -154,62 +206,101 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"  Project bank: {resolved.project_bank}")
     print(f"      from {resolved.project_source}")
     _scaffold_user_config(resolved, _user_config_path(args))
-    outcome = build_install(resolved, mcp_paths, rules_path, global_rules_path)
+    outcome = build_install(resolved, paths)
 
+    print("\n  Cascade agent:")
     for result in outcome.mcp:
         if result.action == "manual":
-            print(f"  Your {result.path} isn't plain JSON, so I won't rewrite it.")
-            print("  Add this `mcpServers` entry yourself:\n")
+            print(f"    {result.path} isn't plain JSON — add the `mcpServers` entry yourself:\n")
             print(render_snippet(server))
         else:
-            verb = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in"}[result.action]
-            print(f"  {verb} {result.path} (hindsight MCP, multi-bank)")
-    print(f"  Wrote project memory rule to {outcome.rules_path}  (commit this)")
+            print(f"    {_VERB[result.action]} {result.path} (hindsight MCP, multi-bank)")
+    print(f"    Wrote project rule to {outcome.rules_path}  (commit this)")
     g = outcome.global_rule
-    print(f"  {g.action.capitalize()} global memory rule in {g.path}")
+    print(f"    {g.action.capitalize()} global rule in {g.path}")
     if g.over_cap:
-        print(f"  warning: {g.path} is now {g.over_cap} chars (Devin's cap is 6000); trim it so nothing is dropped.")
+        print(f"    warning: {g.path} is now {g.over_cap} chars (Cascade's cap is 6000); trim it.")
+
+    print("\n  Devin Local agent:")
+    dc = outcome.devin_config
+    if dc.action == "manual":
+        print(f"    {dc.path} isn't plain JSON — merge this yourself:\n")
+        print(devin_local.render_snippet(dl_server))
+    else:
+        print(f"    {_VERB[dc.action]} {dc.path} (hindsight MCP + auto-approve)")
+    print(
+        f"    {outcome.devin_project_action.capitalize()} project rule in {outcome.devin_project_path}  (commit this)"
+    )
+    print(f"    {outcome.devin_global_action.capitalize()} global rule in {outcome.devin_global_path}")
 
     print("\nNow open Devin Desktop and press Refresh in the MCP panel (or restart) —")
-    print("editing mcp_config.json does not hot-reload. The hindsight tools")
-    print("(recall/retain/reflect) then load and are used automatically.")
+    print("editing config does not hot-reload. Memory then loads for whichever agent")
+    print("you use (Cascade or Devin Local) and is used automatically.")
 
 
 def cmd_status(args: argparse.Namespace) -> None:
     resolved = _resolve(args)
+    paths = _paths(args)
     print(f"Global bank:  {resolved.global_bank}")
     print(f"Project bank: {resolved.project_bank}  ({resolved.project_source})")
-    for path in _mcp_paths(args):
-        print(f"MCP server in {path}: {'installed' if server_installed(path) else 'not installed'}")
-    rules_path = _rules_path(args)
-    print(f"Project rule in {rules_path}: {'installed' if rule_installed(rules_path) else 'not installed'}")
-    global_rules_path = _global_rules_path(args)
+
+    def mark(ok: bool) -> str:
+        return "installed" if ok else "not installed"
+
+    print("Cascade:")
+    for path in paths.mcp:
+        print(f"  MCP server in {path}: {mark(server_installed(path))}")
+    print(f"  Project rule in {paths.rules}: {mark(rule_installed(paths.rules))}")
+    print(f"  Global rule in {paths.global_rules}: {mark(global_rule_installed(paths.global_rules))}")
+    print("Devin Local:")
+    print(f"  MCP server in {paths.devin_config}: {mark(devin_local.is_installed(paths.devin_config))}")
     print(
-        f"Global rule in {global_rules_path}: {'installed' if global_rule_installed(global_rules_path) else 'not installed'}"
+        f"  Project rule in {paths.devin_project_agents}: {mark(devin_local.agents_installed(paths.devin_project_agents))}"
+    )
+    print(
+        f"  Global rule in {paths.devin_global_agents}: {mark(devin_local.agents_installed(paths.devin_global_agents))}"
     )
 
 
 def cmd_uninstall(args: argparse.Namespace) -> None:
-    for path in _mcp_paths(args):
+    paths = _paths(args)
+    print("Cascade:")
+    for path in paths.mcp:
         result = remove_from_mcp(path)
         if result.action == "manual":
-            print(f"  {path} isn't plain JSON — remove the `hindsight` server entry yourself.")
+            print(f"  {path} isn't plain JSON — remove the `hindsight` entry yourself.")
         elif result.action == "removed":
             print(f"  Removed the hindsight MCP server from {path}")
         else:
             print(f"  No hindsight MCP server found in {path}")
-    rules_path = _rules_path(args)
-    clear_rule(rules_path)
-    print(f"  Removed the project memory rule at {rules_path}")
-    global_rules_path = _global_rules_path(args)
-    clear_global_rule(global_rules_path)
-    print(f"  Removed the global memory rule block in {global_rules_path}")
+    clear_rule(paths.rules)
+    print(f"  Removed the project rule at {paths.rules}")
+    clear_global_rule(paths.global_rules)
+    print(f"  Removed the global rule block in {paths.global_rules}")
+
+    print("Devin Local:")
+    dc = devin_local.remove_from_config(paths.devin_config)
+    if dc.action == "manual":
+        print(f"  {paths.devin_config} isn't plain JSON — remove the `hindsight` entry yourself.")
+    elif dc.action == "removed":
+        print(f"  Removed the hindsight MCP server + allow-rule from {paths.devin_config}")
+    else:
+        print(f"  No hindsight MCP server found in {paths.devin_config}")
+    devin_local.clear_agents(paths.devin_project_agents)
+    print(f"  Removed the project rule block in {paths.devin_project_agents}")
+    devin_local.clear_agents(paths.devin_global_agents)
+    print(f"  Removed the global rule block in {paths.devin_global_agents}")
 
 
 def _add_overrides(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--mcp-path", default=None, help="mcp_config.json path (default: both ~/.codeium locations)")
-    parser.add_argument("--rules-path", default=None, help="project rule file (default: ./.devin/rules/hindsight.md)")
+    parser.add_argument("--mcp-path", default=None, help="Cascade mcp_config.json (default: both ~/.codeium locations)")
+    parser.add_argument(
+        "--rules-path", default=None, help="Cascade project rule (default: ./.devin/rules/hindsight.md)"
+    )
     parser.add_argument("--global-rules-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--devin-config-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--devin-global-agents-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--project-agents-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--user-config-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--project-dir", default=None, help=argparse.SUPPRESS)
 
@@ -221,7 +312,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--version", action="version", version=f"hindsight-devin-desktop {__version__}")
     sub = parser.add_subparsers(dest="command")
 
-    init_p = sub.add_parser("init", help="Configure Devin Desktop's MCP server + memory rules")
+    init_p = sub.add_parser("init", help="Configure both Devin Desktop agents' MCP server + memory rules")
     init_p.add_argument("--api-url", default=None, help="Hindsight API URL (default: cloud)")
     init_p.add_argument("--api-token", default=None, help="Hindsight API token (for Cloud)")
     init_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
@@ -230,13 +321,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     _add_overrides(init_p)
     init_p.set_defaults(func=cmd_init)
 
-    status_p = sub.add_parser("status", help="Show resolved banks + whether the server/rules are configured")
+    status_p = sub.add_parser("status", help="Show resolved banks + whether both agents are configured")
     status_p.add_argument("--global-bank", default=None, help="Cross-project bank (default: devin-desktop)")
     status_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
     _add_overrides(status_p)
     status_p.set_defaults(func=cmd_status)
 
-    uninst_p = sub.add_parser("uninstall", help="Remove the MCP server + memory rules")
+    uninst_p = sub.add_parser("uninstall", help="Remove the MCP server + memory rules from both agents")
     _add_overrides(uninst_p)
     uninst_p.set_defaults(func=cmd_uninstall)
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -90,13 +90,28 @@ def build_install(
     recall_hook: bool = True,
     retain_hook: bool = True,
     cascade_banner: bool = True,
+    local_only: bool = False,
 ) -> InstallOutcome:
-    """Wire both agents (the testable core)."""
+    """Wire both agents (the testable core).
+
+    ``local_only`` = no shared global bank: everything (project facts + the
+    user's preferences) goes to the single project bank; the global rule files
+    are removed rather than written.
+    """
+    # ``rule_global`` is None in local-only, so the rules route everything to the
+    # project bank. The MCP server keeps the global bank as its X-Bank-Id prefix
+    # (the hooks derive the project bank from it).
+    rule_global = None if local_only else resolved.global_bank
+
     # Cascade
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     mcp = [apply_to_mcp(path, server) for path in paths.mcp]
-    write_rule(paths.rules, resolved.project_bank, resolved.global_bank)
-    global_rule = write_global_rule(paths.global_rules, resolved.global_bank)
+    write_rule(paths.rules, resolved.project_bank, rule_global)
+    if local_only:
+        clear_global_rule(paths.global_rules)
+        global_rule = GlobalRuleResult("removed", paths.global_rules)
+    else:
+        global_rule = write_global_rule(paths.global_rules, resolved.global_bank)
     banner = (
         cascade_hooks.apply_banner(paths.cascade_hooks)
         if cascade_banner
@@ -106,12 +121,14 @@ def build_install(
     # Devin Local
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     devin_config = devin_local.apply_to_config(
-        paths.devin_config, dl_server, recall_hook=recall_hook, retain_hook=retain_hook
+        paths.devin_config, dl_server, recall_hook=recall_hook, retain_hook=retain_hook, local_only=local_only
     )
-    dl_global = devin_local.write_global_agents(paths.devin_global_agents, resolved.global_bank)
-    dl_project = devin_local.write_project_agents(
-        paths.devin_project_agents, resolved.project_bank, resolved.global_bank
-    )
+    if local_only:
+        devin_local.clear_agents(paths.devin_global_agents)
+        dl_global = "removed"
+    else:
+        dl_global = devin_local.write_global_agents(paths.devin_global_agents, resolved.global_bank)
+    dl_project = devin_local.write_project_agents(paths.devin_project_agents, resolved.project_bank, rule_global)
 
     return InstallOutcome(
         mcp=mcp,
@@ -197,17 +214,23 @@ def _scaffold_user_config(resolved: Resolved, path: Path) -> None:
 _VERB = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in", "removed": "Removed"}
 
 
-def _print_only(resolved: Resolved, server: dict, dl_server: dict, recall_hook: bool, retain_hook: bool) -> None:
+def _print_only(
+    resolved: Resolved, server: dict, dl_server: dict, recall_hook: bool, retain_hook: bool, local_only: bool
+) -> None:
+    rule_global = None if local_only else resolved.global_bank
     print("# Cascade agent\nAdd this to ~/.codeium/windsurf/mcp_config.json:\n")
     print(render_snippet(server))
     print(f"\nSave this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
-    print(render_rule(resolved.project_bank, resolved.global_bank))
-    print("Add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
-    print(render_block(resolved.global_bank))
+    print(render_rule(resolved.project_bank, rule_global))
+    if not local_only:
+        print("Add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
+        print(render_block(resolved.global_bank))
     print("\n# Devin Local agent\nMerge this into ~/.config/devin/config.json:\n")
-    print(devin_local.render_snippet(dl_server, recall_hook=recall_hook, retain_hook=retain_hook))
-    print("\nAdd this to AGENTS.md (repo root) and ~/.config/devin/AGENTS.md:\n")
-    print(render_rule_text(resolved.project_bank, resolved.global_bank))
+    print(
+        devin_local.render_snippet(dl_server, recall_hook=recall_hook, retain_hook=retain_hook, local_only=local_only)
+    )
+    print("\nAdd this to AGENTS.md (repo root)" + ("" if local_only else " and ~/.config/devin/AGENTS.md") + ":\n")
+    print(render_rule_text(resolved.project_bank, rule_global))
 
 
 def cmd_init(args: argparse.Namespace) -> None:
@@ -216,19 +239,31 @@ def cmd_init(args: argparse.Namespace) -> None:
     hooks_on = not getattr(args, "no_hooks", False)
     recall_hook = hooks_on
     retain_hook = hooks_on and not getattr(args, "no_retain_hook", False)
+    local_only = getattr(args, "no_global_bank", False)
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
 
     if args.print_only:
-        _print_only(resolved, server, dl_server, recall_hook, retain_hook)
+        _print_only(resolved, server, dl_server, recall_hook, retain_hook, local_only)
         return
 
     print("Setting up Hindsight for Devin Desktop ...")
-    print(f"  Global bank:  {resolved.global_bank}   (shared across all your projects)")
-    print(f"  Project bank: {resolved.project_bank}")
+    if local_only:
+        print("  Mode: local-only (no shared bank — this project's memory stays in its own bank)")
+        print(f"  Project bank: {resolved.project_bank}")
+    else:
+        print(f"  Global bank:  {resolved.global_bank}   (shared across all your projects)")
+        print(f"  Project bank: {resolved.project_bank}")
     print(f"      from {resolved.project_source}")
     _scaffold_user_config(resolved, _user_config_path(args))
-    outcome = build_install(resolved, paths, recall_hook=recall_hook, retain_hook=retain_hook, cascade_banner=hooks_on)
+    outcome = build_install(
+        resolved,
+        paths,
+        recall_hook=recall_hook,
+        retain_hook=retain_hook,
+        cascade_banner=hooks_on,
+        local_only=local_only,
+    )
 
     print("\n  Cascade agent:")
     for result in outcome.mcp:
@@ -365,6 +400,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     init_p.add_argument("--no-hooks", action="store_true", help="Skip both Devin Local hooks (recall + retain-nudge)")
     init_p.add_argument(
         "--no-retain-hook", action="store_true", help="Skip the Stop retain-nudge hook (keep auto-recall)"
+    )
+    init_p.add_argument(
+        "--no-global-bank",
+        action="store_true",
+        help="Local-only: keep all memory in this project's bank (no shared cross-project preferences)",
     )
     _add_overrides(init_p)
     init_p.set_defaults(func=cmd_init)

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-from . import __version__, devin_local
+from . import __version__, cascade_hooks, devin_local
 from .config import USER_CONFIG_FILE, load_config
 from .global_rules import (
     GlobalRuleResult,
@@ -65,6 +65,7 @@ class Paths:
     mcp: List[Path]  # Cascade mcp_config.json (both documented locations)
     rules: Path  # Cascade per-project rule (.devin/rules/hindsight.md)
     global_rules: Path  # Cascade global rule (global_rules.md)
+    cascade_hooks: Path  # Cascade hooks.json (visibility banner)
     devin_config: Path  # Devin Local config.json (MCP + permissions)
     devin_global_agents: Path  # Devin Local global AGENTS.md
     devin_project_agents: Path  # Devin Local per-project AGENTS.md (repo root)
@@ -75,6 +76,7 @@ class InstallOutcome:
     mcp: List[McpResult]
     rules_path: Path
     global_rule: GlobalRuleResult
+    cascade_banner: cascade_hooks.BannerResult
     devin_config: devin_local.ConfigResult
     devin_global_action: str
     devin_global_path: Path
@@ -82,17 +84,30 @@ class InstallOutcome:
     devin_project_path: Path
 
 
-def build_install(resolved: Resolved, paths: Paths, with_hook: bool = True) -> InstallOutcome:
+def build_install(
+    resolved: Resolved,
+    paths: Paths,
+    recall_hook: bool = True,
+    retain_hook: bool = True,
+    cascade_banner: bool = True,
+) -> InstallOutcome:
     """Wire both agents (the testable core)."""
     # Cascade
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     mcp = [apply_to_mcp(path, server) for path in paths.mcp]
     write_rule(paths.rules, resolved.project_bank, resolved.global_bank)
     global_rule = write_global_rule(paths.global_rules, resolved.global_bank)
+    banner = (
+        cascade_hooks.apply_banner(paths.cascade_hooks)
+        if cascade_banner
+        else cascade_hooks.remove_banner(paths.cascade_hooks)
+    )
 
     # Devin Local
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
-    devin_config = devin_local.apply_to_config(paths.devin_config, dl_server, with_hook=with_hook)
+    devin_config = devin_local.apply_to_config(
+        paths.devin_config, dl_server, recall_hook=recall_hook, retain_hook=retain_hook
+    )
     dl_global = devin_local.write_global_agents(paths.devin_global_agents, resolved.global_bank)
     dl_project = devin_local.write_project_agents(
         paths.devin_project_agents, resolved.project_bank, resolved.global_bank
@@ -102,6 +117,7 @@ def build_install(resolved: Resolved, paths: Paths, with_hook: bool = True) -> I
         mcp=mcp,
         rules_path=paths.rules,
         global_rule=global_rule,
+        cascade_banner=banner,
         devin_config=devin_config,
         devin_global_action=dl_global,
         devin_global_path=paths.devin_global_agents,
@@ -120,6 +136,9 @@ def _paths(args: argparse.Namespace) -> Paths:
         mcp=mcp,
         rules=Path(args.rules_path) if args.rules_path else default_rules_path(),
         global_rules=Path(args.global_rules_path) if args.global_rules_path else default_global_rules_path(),
+        cascade_hooks=(
+            Path(args.cascade_hooks_path) if args.cascade_hooks_path else cascade_hooks.default_hooks_path()
+        ),
         devin_config=Path(args.devin_config_path) if args.devin_config_path else devin_local.default_config_path(),
         devin_global_agents=(
             Path(args.devin_global_agents_path)
@@ -178,7 +197,7 @@ def _scaffold_user_config(resolved: Resolved, path: Path) -> None:
 _VERB = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in", "removed": "Removed"}
 
 
-def _print_only(resolved: Resolved, server: dict, dl_server: dict, with_hook: bool) -> None:
+def _print_only(resolved: Resolved, server: dict, dl_server: dict, recall_hook: bool, retain_hook: bool) -> None:
     print("# Cascade agent\nAdd this to ~/.codeium/windsurf/mcp_config.json:\n")
     print(render_snippet(server))
     print(f"\nSave this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
@@ -186,7 +205,7 @@ def _print_only(resolved: Resolved, server: dict, dl_server: dict, with_hook: bo
     print("Add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
     print(render_block(resolved.global_bank))
     print("\n# Devin Local agent\nMerge this into ~/.config/devin/config.json:\n")
-    print(devin_local.render_snippet(dl_server, with_hook=with_hook))
+    print(devin_local.render_snippet(dl_server, recall_hook=recall_hook, retain_hook=retain_hook))
     print("\nAdd this to AGENTS.md (repo root) and ~/.config/devin/AGENTS.md:\n")
     print(render_rule_text(resolved.project_bank, resolved.global_bank))
 
@@ -194,12 +213,14 @@ def _print_only(resolved: Resolved, server: dict, dl_server: dict, with_hook: bo
 def cmd_init(args: argparse.Namespace) -> None:
     resolved = _resolve(args)
     paths = _paths(args)
-    with_hook = not getattr(args, "no_hooks", False)
+    hooks_on = not getattr(args, "no_hooks", False)
+    recall_hook = hooks_on
+    retain_hook = hooks_on and not getattr(args, "no_retain_hook", False)
     server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
     dl_server = devin_local.build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
 
     if args.print_only:
-        _print_only(resolved, server, dl_server, with_hook)
+        _print_only(resolved, server, dl_server, recall_hook, retain_hook)
         return
 
     print("Setting up Hindsight for Devin Desktop ...")
@@ -207,7 +228,7 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"  Project bank: {resolved.project_bank}")
     print(f"      from {resolved.project_source}")
     _scaffold_user_config(resolved, _user_config_path(args))
-    outcome = build_install(resolved, paths, with_hook=with_hook)
+    outcome = build_install(resolved, paths, recall_hook=recall_hook, retain_hook=retain_hook, cascade_banner=hooks_on)
 
     print("\n  Cascade agent:")
     for result in outcome.mcp:
@@ -221,20 +242,28 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"    {g.action.capitalize()} global rule in {g.path}")
     if g.over_cap:
         print(f"    warning: {g.path} is now {g.over_cap} chars (Cascade's cap is 6000); trim it.")
+    b = outcome.cascade_banner
+    if b.action in ("created", "merged"):
+        print(f"    Added a visibility banner hook in {b.path} (shows '🧠 Hindsight: <tool> used')")
+    elif b.action == "manual":
+        print(f"    {b.path} isn't plain JSON — add the post_mcp_tool_use banner hook yourself.")
 
     print("\n  Devin Local agent:")
     dc = outcome.devin_config
     if dc.action == "manual":
         print(f"    {dc.path} isn't plain JSON — merge this yourself:\n")
-        print(devin_local.render_snippet(dl_server))
+        print(devin_local.render_snippet(dl_server, recall_hook=recall_hook, retain_hook=retain_hook))
     else:
         print(f"    {_VERB[dc.action]} {dc.path} (hindsight MCP + auto-approve)")
     print(
         f"    {outcome.devin_project_action.capitalize()} project rule in {outcome.devin_project_path}  (commit this)"
     )
     print(f"    {outcome.devin_global_action.capitalize()} global rule in {outcome.devin_global_path}")
-    if with_hook and dc.action != "manual":
-        print("    Added a SessionStart auto-recall hook (memory is injected even if the model forgets to recall)")
+    if dc.action != "manual":
+        if recall_hook:
+            print("    Added a SessionStart auto-recall hook (memory injected even if the model forgets to recall)")
+        if retain_hook:
+            print("    Added a Stop retain-nudge hook (prompts a retain pass before the session ends)")
 
     print("\nActivate the server in whichever agent you use (config isn't hot-reloaded):")
     print("  - Cascade:     open the MCP panel and press Refresh.")
@@ -257,6 +286,7 @@ def cmd_status(args: argparse.Namespace) -> None:
         print(f"  MCP server in {path}: {mark(server_installed(path))}")
     print(f"  Project rule in {paths.rules}: {mark(rule_installed(paths.rules))}")
     print(f"  Global rule in {paths.global_rules}: {mark(global_rule_installed(paths.global_rules))}")
+    print(f"  Visibility banner in {paths.cascade_hooks}: {mark(cascade_hooks.is_installed(paths.cascade_hooks))}")
     print("Devin Local:")
     print(f"  MCP server in {paths.devin_config}: {mark(devin_local.is_installed(paths.devin_config))}")
     print(
@@ -265,7 +295,12 @@ def cmd_status(args: argparse.Namespace) -> None:
     print(
         f"  Global rule in {paths.devin_global_agents}: {mark(devin_local.agents_installed(paths.devin_global_agents))}"
     )
-    print(f"  Auto-recall hook in {paths.devin_config}: {mark(devin_local.hook_installed(paths.devin_config))}")
+    print(
+        f"  Auto-recall hook in {paths.devin_config}: {mark(devin_local.hook_installed(paths.devin_config, 'recall'))}"
+    )
+    print(
+        f"  Retain-nudge hook in {paths.devin_config}: {mark(devin_local.hook_installed(paths.devin_config, 'retain-nudge'))}"
+    )
 
 
 def cmd_uninstall(args: argparse.Namespace) -> None:
@@ -283,6 +318,8 @@ def cmd_uninstall(args: argparse.Namespace) -> None:
     print(f"  Removed the project rule at {paths.rules}")
     clear_global_rule(paths.global_rules)
     print(f"  Removed the global rule block in {paths.global_rules}")
+    cascade_hooks.remove_banner(paths.cascade_hooks)
+    print(f"  Removed the visibility banner hook from {paths.cascade_hooks}")
 
     print("Devin Local:")
     dc = devin_local.remove_from_config(paths.devin_config)
@@ -304,6 +341,7 @@ def _add_overrides(parser: argparse.ArgumentParser) -> None:
         "--rules-path", default=None, help="Cascade project rule (default: ./.devin/rules/hindsight.md)"
     )
     parser.add_argument("--global-rules-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--cascade-hooks-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--devin-config-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--devin-global-agents-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--project-agents-path", default=None, help=argparse.SUPPRESS)
@@ -324,7 +362,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     init_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
     init_p.add_argument("--global-bank", default=None, help="Cross-project bank (default: devin-desktop)")
     init_p.add_argument("--print-only", action="store_true", help="Print the config to add manually; write nothing")
-    init_p.add_argument("--no-hooks", action="store_true", help="Skip the Devin Local SessionStart auto-recall hook")
+    init_p.add_argument("--no-hooks", action="store_true", help="Skip both Devin Local hooks (recall + retain-nudge)")
+    init_p.add_argument(
+        "--no-retain-hook", action="store_true", help="Skip the Stop retain-nudge hook (keep auto-recall)"
+    )
     _add_overrides(init_p)
     init_p.set_defaults(func=cmd_init)
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -233,9 +233,11 @@ def cmd_init(args: argparse.Namespace) -> None:
     )
     print(f"    {outcome.devin_global_action.capitalize()} global rule in {outcome.devin_global_path}")
 
-    print("\nNow open Devin Desktop and press Refresh in the MCP panel (or restart) —")
-    print("editing config does not hot-reload. Memory then loads for whichever agent")
-    print("you use (Cascade or Devin Local) and is used automatically.")
+    print("\nActivate the server in whichever agent you use (config isn't hot-reloaded):")
+    print("  - Cascade:     open the MCP panel and press Refresh.")
+    print("  - Devin Local: open the Devin MCP Marketplace, find `hindsight` under")
+    print("                 Installed, and click Connect.")
+    print("Memory then loads and is used automatically.")
 
 
 def cmd_status(args: argparse.Namespace) -> None:

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/cli.py
@@ -1,9 +1,15 @@
 """CLI for the Hindsight Devin Desktop integration.
 
-``hindsight-devin-desktop init`` wires the Hindsight MCP server into Devin
-Desktop's ``~/.codeium/windsurf/mcp_config.json`` and writes an always-on
-recall/retain rule into ``.devin/rules/hindsight.md``. Devin then exposes
-``recall``/``retain``/``reflect`` and (via the rule) uses them automatically.
+``hindsight-devin-desktop init`` wires the Hindsight MCP server (multi-bank mode)
+into Devin Desktop's global ``mcp_config.json`` and writes always-on memory rules:
+
+* a per-project ``.devin/rules/hindsight.md`` (committed) naming this repo's
+  project bank plus the user's global bank, and
+* a managed block in ``~/.codeium/windsurf/memories/global_rules.md`` naming the
+  global bank so it's active in every workspace.
+
+The project bank is derived from the repo's git remote so each project keeps its
+own isolated memory while the global bank carries cross-project preferences.
 """
 
 from __future__ import annotations
@@ -13,126 +19,199 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from . import __version__
-from .config import USER_CONFIG_FILE, DevinDesktopConfig, load_config
+from .config import USER_CONFIG_FILE, load_config
+from .global_rules import (
+    GlobalRuleResult,
+    clear_global_rule,
+    default_global_rules_path,
+    render_block,
+    write_global_rule,
+)
+from .global_rules import is_installed as global_rule_installed
 from .mcp_config import (
     McpResult,
     apply_to_mcp,
     build_http_server,
-    default_mcp_path,
+    default_mcp_paths,
     remove_from_mcp,
     render_snippet,
 )
 from .mcp_config import is_installed as server_installed
-from .rules import RULE_TEXT, clear_rule, default_rules_path, write_rule
+from .project import project_bank_id
+from .rules import clear_rule, default_rules_path, render_rule, write_rule
 from .rules import is_installed as rule_installed
 
 
 @dataclass
+class Resolved:
+    """Fully resolved connection + bank settings for a run."""
+
+    api_url: str
+    api_token: Optional[str]
+    global_bank: str
+    project_bank: str
+    project_source: str
+
+
+@dataclass
 class InstallOutcome:
-    mcp: McpResult
+    mcp: List[McpResult]
     rules_path: Path
+    global_rule: GlobalRuleResult
 
 
-def build_install(config: DevinDesktopConfig, mcp_path: Path, rules_path: Path) -> InstallOutcome:
-    """Apply the MCP server entry and the recall/retain rule (the testable core)."""
-    server = build_http_server(config.hindsight_api_url, config.hindsight_api_token, config.bank_id)
-    mcp = apply_to_mcp(mcp_path, server)
-    write_rule(rules_path)
-    return InstallOutcome(mcp=mcp, rules_path=rules_path)
-
-
-def _resolve_config(args: argparse.Namespace) -> DevinDesktopConfig:
-    cfg = load_config(config_file=_user_config_path(args))
-    if args.api_url:
-        cfg.hindsight_api_url = args.api_url
-    if args.api_token:
-        cfg.hindsight_api_token = args.api_token
-    if args.bank_id:
-        cfg.bank_id = args.bank_id
-    return cfg
+def build_install(
+    resolved: Resolved, mcp_paths: List[Path], rules_path: Path, global_rules_path: Path
+) -> InstallOutcome:
+    """Apply the MCP server entry (to each path) and both rule files (testable core)."""
+    server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
+    mcp = [apply_to_mcp(path, server) for path in mcp_paths]
+    write_rule(rules_path, resolved.project_bank, resolved.global_bank)
+    global_rule = write_global_rule(global_rules_path, resolved.global_bank)
+    return InstallOutcome(mcp=mcp, rules_path=rules_path, global_rule=global_rule)
 
 
 def _user_config_path(args: argparse.Namespace) -> Path:
     return Path(args.user_config_path) if args.user_config_path else USER_CONFIG_FILE
 
 
-def _mcp_path(args: argparse.Namespace) -> Path:
-    return Path(args.mcp_path) if args.mcp_path else default_mcp_path()
+def _mcp_paths(args: argparse.Namespace) -> List[Path]:
+    return [Path(args.mcp_path)] if args.mcp_path else default_mcp_paths()
 
 
 def _rules_path(args: argparse.Namespace) -> Path:
     return Path(args.rules_path) if args.rules_path else default_rules_path()
 
 
-def _scaffold_user_config(cfg: DevinDesktopConfig, path: Path) -> None:
+def _global_rules_path(args: argparse.Namespace) -> Path:
+    return Path(args.global_rules_path) if args.global_rules_path else default_global_rules_path()
+
+
+def _resolve(args: argparse.Namespace) -> Resolved:
+    """Config from file/env, CLI overrides, then derive the project bank."""
+    cfg = load_config(config_file=_user_config_path(args))
+    if getattr(args, "api_url", None):
+        cfg.hindsight_api_url = args.api_url
+    if getattr(args, "api_token", None):
+        cfg.hindsight_api_token = args.api_token
+    if getattr(args, "global_bank", None):
+        cfg.global_bank = args.global_bank
+    if getattr(args, "bank_id", None):
+        cfg.project_bank = args.bank_id
+
+    if cfg.project_bank:
+        project_bank, source = cfg.project_bank, "explicit (--bank-id / env)"
+    else:
+        project_dir = Path(args.project_dir) if getattr(args, "project_dir", None) else Path.cwd()
+        derived, source = project_bank_id(cfg.global_bank, project_dir)
+        if derived is None:
+            project_bank = cfg.global_bank
+            source = f"{source} — falling back to the global bank; pass --bank-id to set one"
+        else:
+            project_bank = derived
+
+    return Resolved(
+        api_url=cfg.hindsight_api_url,
+        api_token=cfg.hindsight_api_token,
+        global_bank=cfg.global_bank,
+        project_bank=project_bank,
+        project_source=source,
+    )
+
+
+def _scaffold_user_config(resolved: Resolved, path: Path) -> None:
+    """Persist connection + global bank (NOT the per-repo project bank)."""
     if path.is_file():
         return
-    data = {"hindsightApiUrl": cfg.hindsight_api_url, "bankId": cfg.bank_id}
-    if cfg.hindsight_api_token:
-        data["hindsightApiToken"] = cfg.hindsight_api_token
+    data = {"hindsightApiUrl": resolved.api_url, "globalBank": resolved.global_bank}
+    if resolved.api_token:
+        data["hindsightApiToken"] = resolved.api_token
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def cmd_init(args: argparse.Namespace) -> None:
-    cfg = _resolve_config(args)
-    mcp_path = _mcp_path(args)
+    resolved = _resolve(args)
+    mcp_paths = _mcp_paths(args)
     rules_path = _rules_path(args)
-    server = build_http_server(cfg.hindsight_api_url, cfg.hindsight_api_token, cfg.bank_id)
+    global_rules_path = _global_rules_path(args)
+    server = build_http_server(resolved.api_url, resolved.api_token, resolved.global_bank)
 
     if args.print_only:
-        print("Add this to your ~/.codeium/windsurf/mcp_config.json:\n")
+        print("Add this to your Devin Desktop mcp_config.json:\n")
         print(render_snippet(server))
-        print("\nAnd save this rule as .devin/rules/hindsight.md:\n")
-        print(RULE_TEXT)
+        print(f"\nAnd save this rule as .devin/rules/hindsight.md (project bank: {resolved.project_bank}):\n")
+        print(render_rule(resolved.project_bank, resolved.global_bank))
+        print("And add this block to ~/.codeium/windsurf/memories/global_rules.md:\n")
+        print(render_block(resolved.global_bank))
         return
 
     print("Setting up Hindsight for Devin Desktop ...")
-    _scaffold_user_config(cfg, _user_config_path(args))
-    outcome = build_install(cfg, mcp_path, rules_path)
+    print(f"  Global bank:  {resolved.global_bank}   (shared across all your projects)")
+    print(f"  Project bank: {resolved.project_bank}")
+    print(f"      from {resolved.project_source}")
+    _scaffold_user_config(resolved, _user_config_path(args))
+    outcome = build_install(resolved, mcp_paths, rules_path, global_rules_path)
 
-    if outcome.mcp.action == "manual":
-        print(f"  Your {outcome.mcp.path} isn't plain JSON, so I won't rewrite it.")
-        print("  Add this `mcpServers` entry yourself:\n")
-        print(render_snippet(server))
-    else:
-        verb = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in"}[outcome.mcp.action]
-        print(f"  {verb} {outcome.mcp.path} (MCP server: hindsight -> bank '{cfg.bank_id}')")
-    print(f"  Wrote always-on recall/retain rule to {outcome.rules_path}")
-    print("\nDone. Reload Devin Desktop (or refresh MCP servers) and the")
-    print("hindsight MCP tools (recall/retain/reflect) are available + used automatically.")
+    for result in outcome.mcp:
+        if result.action == "manual":
+            print(f"  Your {result.path} isn't plain JSON, so I won't rewrite it.")
+            print("  Add this `mcpServers` entry yourself:\n")
+            print(render_snippet(server))
+        else:
+            verb = {"created": "Created", "merged": "Updated", "unchanged": "Already configured in"}[result.action]
+            print(f"  {verb} {result.path} (hindsight MCP, multi-bank)")
+    print(f"  Wrote project memory rule to {outcome.rules_path}  (commit this)")
+    g = outcome.global_rule
+    print(f"  {g.action.capitalize()} global memory rule in {g.path}")
+    if g.over_cap:
+        print(f"  warning: {g.path} is now {g.over_cap} chars (Devin's cap is 6000); trim it so nothing is dropped.")
+
+    print("\nNow open Devin Desktop and press Refresh in the MCP panel (or restart) —")
+    print("editing mcp_config.json does not hot-reload. The hindsight tools")
+    print("(recall/retain/reflect) then load and are used automatically.")
 
 
 def cmd_status(args: argparse.Namespace) -> None:
-    mcp_path = _mcp_path(args)
+    resolved = _resolve(args)
+    print(f"Global bank:  {resolved.global_bank}")
+    print(f"Project bank: {resolved.project_bank}  ({resolved.project_source})")
+    for path in _mcp_paths(args):
+        print(f"MCP server in {path}: {'installed' if server_installed(path) else 'not installed'}")
     rules_path = _rules_path(args)
-    print(f"MCP server in {mcp_path}: {'installed' if server_installed(mcp_path) else 'not installed'}")
-    print(f"Recall/retain rule in {rules_path}: {'installed' if rule_installed(rules_path) else 'not installed'}")
+    print(f"Project rule in {rules_path}: {'installed' if rule_installed(rules_path) else 'not installed'}")
+    global_rules_path = _global_rules_path(args)
+    print(
+        f"Global rule in {global_rules_path}: {'installed' if global_rule_installed(global_rules_path) else 'not installed'}"
+    )
 
 
 def cmd_uninstall(args: argparse.Namespace) -> None:
-    mcp_path = _mcp_path(args)
+    for path in _mcp_paths(args):
+        result = remove_from_mcp(path)
+        if result.action == "manual":
+            print(f"  {path} isn't plain JSON — remove the `hindsight` server entry yourself.")
+        elif result.action == "removed":
+            print(f"  Removed the hindsight MCP server from {path}")
+        else:
+            print(f"  No hindsight MCP server found in {path}")
     rules_path = _rules_path(args)
-    result = remove_from_mcp(mcp_path)
-    if result.action == "manual":
-        print(f"  {mcp_path} isn't plain JSON — remove the `hindsight` server entry yourself.")
-    elif result.action == "removed":
-        print(f"  Removed the hindsight MCP server from {mcp_path}")
-    else:
-        print(f"  No hindsight MCP server found in {mcp_path}")
     clear_rule(rules_path)
-    print(f"  Removed the recall/retain rule at {rules_path}")
+    print(f"  Removed the project memory rule at {rules_path}")
+    global_rules_path = _global_rules_path(args)
+    clear_global_rule(global_rules_path)
+    print(f"  Removed the global memory rule block in {global_rules_path}")
 
 
 def _add_overrides(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--mcp-path", default=None, help="mcp_config.json path (default: ~/.codeium/windsurf/mcp_config.json)"
-    )
-    parser.add_argument("--rules-path", default=None, help="rule file path (default: ./.devin/rules/hindsight.md)")
+    parser.add_argument("--mcp-path", default=None, help="mcp_config.json path (default: both ~/.codeium locations)")
+    parser.add_argument("--rules-path", default=None, help="project rule file (default: ./.devin/rules/hindsight.md)")
+    parser.add_argument("--global-rules-path", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--user-config-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--project-dir", default=None, help=argparse.SUPPRESS)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -142,19 +221,22 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--version", action="version", version=f"hindsight-devin-desktop {__version__}")
     sub = parser.add_subparsers(dest="command")
 
-    init_p = sub.add_parser("init", help="Configure Devin Desktop's MCP server + recall/retain rule")
+    init_p = sub.add_parser("init", help="Configure Devin Desktop's MCP server + memory rules")
     init_p.add_argument("--api-url", default=None, help="Hindsight API URL (default: cloud)")
     init_p.add_argument("--api-token", default=None, help="Hindsight API token (for Cloud)")
-    init_p.add_argument("--bank-id", default=None, help="Memory bank for the MCP server (default: devin-desktop)")
+    init_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
+    init_p.add_argument("--global-bank", default=None, help="Cross-project bank (default: devin-desktop)")
     init_p.add_argument("--print-only", action="store_true", help="Print the config to add manually; write nothing")
     _add_overrides(init_p)
     init_p.set_defaults(func=cmd_init)
 
-    status_p = sub.add_parser("status", help="Show whether the MCP server + rule are configured")
+    status_p = sub.add_parser("status", help="Show resolved banks + whether the server/rules are configured")
+    status_p.add_argument("--global-bank", default=None, help="Cross-project bank (default: devin-desktop)")
+    status_p.add_argument("--bank-id", default=None, help="Override the per-project bank (default: derived from git)")
     _add_overrides(status_p)
     status_p.set_defaults(func=cmd_status)
 
-    uninst_p = sub.add_parser("uninstall", help="Remove the MCP server + rule")
+    uninst_p = sub.add_parser("uninstall", help="Remove the MCP server + memory rules")
     _add_overrides(uninst_p)
     uninst_p.set_defaults(func=cmd_uninstall)
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/config.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/config.py
@@ -5,11 +5,17 @@ Devin Desktop is the editor formerly known as Windsurf (Codeium).
 Settings layer (later wins): built-in defaults -> ``~/.hindsight/devin-desktop.json``
 -> environment variables. Resolved into a typed :class:`DevinDesktopConfig`.
 
-The integration is configuration-only: it wires the Hindsight MCP server into
-Devin Desktop's ``~/.codeium/windsurf/mcp_config.json`` and writes an always-on
-recall/retain rule into ``.devin/rules/hindsight.md`` (which Devin applies to
-every request in the workspace). Memory operations run through the MCP server at
-runtime.
+Memory is split into two banks (see :mod:`hindsight_devin_desktop.cli`):
+
+* a **global bank** (default ``devin-desktop``) for the user's cross-project
+  memory — preferences, coding style, identity — shared across every project;
+* a **project bank**, derived per-repository at ``init`` time (see
+  :mod:`hindsight_devin_desktop.project`) so each project keeps its own isolated
+  architecture/decisions/conventions.
+
+Only the global bank lives in this user-level config file. The project bank is
+per-repository, so it is derived fresh in each repo and baked into that repo's
+committed rule file — never persisted globally here.
 """
 
 from __future__ import annotations
@@ -21,7 +27,9 @@ from pathlib import Path
 from typing import Optional
 
 DEFAULT_HINDSIGHT_API_URL = "https://api.hindsight.vectorize.io"
-DEFAULT_BANK_ID = "devin-desktop"
+# The user's cross-project memory bank. Also the historical single-bank default,
+# so an existing setup keeps working — it simply becomes the global bank.
+DEFAULT_GLOBAL_BANK = "devin-desktop"
 
 USER_CONFIG_FILE = Path.home() / ".hindsight" / "devin-desktop.json"
 
@@ -32,21 +40,28 @@ class DevinDesktopConfig:
 
     hindsight_api_url: str = DEFAULT_HINDSIGHT_API_URL
     hindsight_api_token: Optional[str] = None
-    # The memory bank the MCP server is scoped to (the last path segment of the
-    # MCP endpoint URL).
-    bank_id: str = DEFAULT_BANK_ID
+    # Cross-project bank (user preferences / coding style / identity).
+    global_bank: str = DEFAULT_GLOBAL_BANK
+    # Explicit project-bank override. When ``None`` the CLI derives it per-repo
+    # from git; this is never read from / written to the global config file.
+    project_bank: Optional[str] = None
 
 
+# user-config-file key -> attribute. Legacy ``bankId`` maps onto the global bank
+# so a pre-0.2 setup (single bank) keeps that bank as its global one.
 _FILE_KEYS = {
     "hindsightApiUrl": "hindsight_api_url",
     "hindsightApiToken": "hindsight_api_token",
-    "bankId": "bank_id",
+    "globalBank": "global_bank",
+    "bankId": "global_bank",
 }
 
 _ENV_KEYS = {
     "HINDSIGHT_API_URL": "hindsight_api_url",
     "HINDSIGHT_API_TOKEN": "hindsight_api_token",
-    "HINDSIGHT_DEVIN_DESKTOP_BANK_ID": "bank_id",
+    "HINDSIGHT_DEVIN_DESKTOP_GLOBAL_BANK": "global_bank",
+    # Per-run project-bank override (not persisted).
+    "HINDSIGHT_DEVIN_DESKTOP_BANK_ID": "project_bank",
 }
 
 
@@ -61,9 +76,10 @@ def load_config(config_file: Optional[Path] = None, env: Optional[dict] = None) 
             data = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             data = {}
+        # ``globalBank`` wins over the legacy ``bankId`` alias when both are set.
         for key, attr in _FILE_KEYS.items():
             value = data.get(key)
-            if value:
+            if value and not (key == "bankId" and data.get("globalBank")):
                 setattr(cfg, attr, str(value))
 
     for key, attr in _ENV_KEYS.items():
@@ -73,7 +89,7 @@ def load_config(config_file: Optional[Path] = None, env: Optional[dict] = None) 
 
     if not cfg.hindsight_api_url:
         cfg.hindsight_api_url = DEFAULT_HINDSIGHT_API_URL
-    if not cfg.bank_id:
-        cfg.bank_id = DEFAULT_BANK_ID
+    if not cfg.global_bank:
+        cfg.global_bank = DEFAULT_GLOBAL_BANK
 
     return cfg

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
@@ -90,14 +90,16 @@ def build_http_server(api_url: str, api_token: Optional[str], default_bank: Opti
     return server
 
 
-def render_snippet(server: dict[str, Any], recall_hook: bool = True, retain_hook: bool = True) -> str:
+def render_snippet(
+    server: dict[str, Any], recall_hook: bool = True, retain_hook: bool = True, local_only: bool = False
+) -> str:
     """Render the config snippet a user can paste into ``config.json``."""
     snippet: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}, "permissions": {"allow": [ALLOW_PATTERN]}}
     hooks: dict[str, Any] = {}
     if recall_hook:
-        hooks[RECALL_EVENT] = [_our_group("recall")]
+        hooks[RECALL_EVENT] = [_our_group("recall", local_only)]
     if retain_hook:
-        hooks[RETAIN_EVENT] = [_our_group("retain-nudge")]
+        hooks[RETAIN_EVENT] = [_our_group("retain-nudge", local_only)]
     if hooks:
         snippet["hooks"] = hooks
     return json.dumps(snippet, indent=2)
@@ -160,17 +162,21 @@ def _remove_allow(data: dict[str, Any]) -> None:
         data.pop("permissions", None)
 
 
-def hook_command(subcommand: str) -> str:
+def hook_command(subcommand: str, local_only: bool = False) -> str:
     """Shell command Devin runs for one of our hooks (abs-python + ``-m``).
 
     Uses ``sys.executable`` so it works regardless of Devin's PATH; the module is
-    resolvable because that interpreter has the package installed.
+    resolvable because that interpreter has the package installed. ``local_only``
+    appends ``--local-only`` for the bank-routing hooks (recall/retain-nudge).
     """
-    return f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} {subcommand}"
+    cmd = f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} {subcommand}"
+    if local_only and subcommand in ("recall", "retain-nudge"):
+        cmd += " --local-only"
+    return cmd
 
 
-def _our_group(subcommand: str) -> dict[str, Any]:
-    return {"hooks": [{"type": "command", "command": hook_command(subcommand), "timeout": 15}]}
+def _our_group(subcommand: str, local_only: bool = False) -> dict[str, Any]:
+    return {"hooks": [{"type": "command", "command": hook_command(subcommand, local_only), "timeout": 15}]}
 
 
 def _is_ours_for(group: Any, subcommand: str) -> bool:
@@ -186,7 +192,23 @@ def _hook_present(data: dict[str, Any], subcommand: str) -> bool:
     return isinstance(events, list) and any(_is_ours_for(g, subcommand) for g in events)
 
 
-def _ensure_hook(data: dict[str, Any], subcommand: str) -> None:
+def _hook_matches(data: dict[str, Any], subcommand: str, want: bool, local_only: bool) -> bool:
+    """Whether our hook's presence AND exact command match the desired state."""
+    present = _hook_present(data, subcommand)
+    if present != want:
+        return False
+    if not present:
+        return True
+    desired = hook_command(subcommand, local_only)
+    groups = data.get("hooks", {}).get(HOOK_EVENTS[subcommand], [])
+    return any(
+        _is_ours_for(g, subcommand) and any(h.get("command") == desired for h in g.get("hooks", []))
+        for g in groups
+        if isinstance(g, dict)
+    )
+
+
+def _ensure_hook(data: dict[str, Any], subcommand: str, local_only: bool = False) -> None:
     event = HOOK_EVENTS[subcommand]
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
@@ -195,7 +217,7 @@ def _ensure_hook(data: dict[str, Any], subcommand: str) -> None:
     if not isinstance(groups, list):
         groups = []
     groups = [g for g in groups if not _is_ours_for(g, subcommand)]  # replace ours, keep others
-    groups.append(_our_group(subcommand))
+    groups.append(_our_group(subcommand, local_only))
     hooks[event] = groups
     data["hooks"] = hooks
 
@@ -216,25 +238,36 @@ def _remove_hook(data: dict[str, Any], subcommand: str) -> None:
         data.pop("hooks", None)
 
 
-def _apply_hooks(data: dict[str, Any], recall_hook: bool, retain_hook: bool) -> None:
-    (_ensure_hook if recall_hook else _remove_hook)(data, "recall")
-    (_ensure_hook if retain_hook else _remove_hook)(data, "retain-nudge")
+def _apply_hooks(data: dict[str, Any], recall_hook: bool, retain_hook: bool, local_only: bool) -> None:
+    if recall_hook:
+        _ensure_hook(data, "recall", local_only)
+    else:
+        _remove_hook(data, "recall")
+    if retain_hook:
+        _ensure_hook(data, "retain-nudge", local_only)
+    else:
+        _remove_hook(data, "retain-nudge")
 
 
 def apply_to_config(
-    path: Path, server: dict[str, Any], recall_hook: bool = True, retain_hook: bool = True
+    path: Path,
+    server: dict[str, Any],
+    recall_hook: bool = True,
+    retain_hook: bool = True,
+    local_only: bool = False,
 ) -> ConfigResult:
     """Add/update ``mcpServers.hindsight`` + allow-rule (+ hooks) in ``config.json``.
 
     Preserves all other keys (e.g. ``version``). Adds ``permissions.allow`` for
     ``mcp__hindsight__*`` so tools don't prompt, a ``SessionStart`` auto-recall
     hook (``recall_hook``), and a ``Stop`` retain-nudge hook (``retain_hook``).
+    ``local_only`` routes the hooks to the single project bank.
     """
     if not path.is_file():
         path.parent.mkdir(parents=True, exist_ok=True)
         data: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}}
         _ensure_allow(data)
-        _apply_hooks(data, recall_hook, retain_hook)
+        _apply_hooks(data, recall_hook, retain_hook, local_only)
         path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
         return ConfigResult("created", path)
 
@@ -245,13 +278,15 @@ def apply_to_config(
     servers = data.get("mcpServers")
     if not isinstance(servers, dict):
         servers = {}
-    hooks_ok = _hook_present(data, "recall") == recall_hook and _hook_present(data, "retain-nudge") == retain_hook
+    hooks_ok = _hook_matches(data, "recall", recall_hook, local_only) and _hook_matches(
+        data, "retain-nudge", retain_hook, local_only
+    )
     if servers.get(SERVER_NAME) == server and _allow_present(data) and hooks_ok:
         return ConfigResult("unchanged", path)
     servers[SERVER_NAME] = server
     data["mcpServers"] = servers
     _ensure_allow(data)
-    _apply_hooks(data, recall_hook, retain_hook)
+    _apply_hooks(data, recall_hook, retain_hook, local_only)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return ConfigResult("merged", path)
 
@@ -305,8 +340,8 @@ def write_global_agents(path: Path, global_bank: str) -> str:
     return action
 
 
-def write_project_agents(path: Path, project_bank: str, global_bank: str) -> str:
-    """Write/replace our block in the repo-root ``AGENTS.md``; returns the action."""
+def write_project_agents(path: Path, project_bank: str, global_bank: Optional[str]) -> str:
+    """Write/replace our block in the repo-root ``AGENTS.md`` (``global_bank=None`` = local-only)."""
     action, _ = managed_block.upsert(path, render_rule_text(project_bank, global_bank))
     return action
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
@@ -38,9 +38,14 @@ from .rules import global_rule_body, render_rule_text
 SERVER_NAME = "hindsight"
 # Devin Local permission pattern that auto-approves Hindsight's MCP tools.
 ALLOW_PATTERN = "mcp__hindsight__*"
-# Deterministic auto-recall: a SessionStart hook injects memory into context.
-HOOK_EVENT = "SessionStart"
 HOOK_MODULE = "hindsight_devin_desktop.hook"
+# Our two hooks: SessionStart auto-recall, and a Stop retain-nudge.
+RECALL_EVENT = "SessionStart"
+RETAIN_EVENT = "Stop"
+# subcommand -> Devin hook event it registers under.
+HOOK_EVENTS = {"recall": RECALL_EVENT, "retain-nudge": RETAIN_EVENT}
+# Back-compat alias.
+HOOK_EVENT = RECALL_EVENT
 
 
 def _devin_config_dir() -> Path:
@@ -85,11 +90,16 @@ def build_http_server(api_url: str, api_token: Optional[str], default_bank: Opti
     return server
 
 
-def render_snippet(server: dict[str, Any], with_hook: bool = True) -> str:
+def render_snippet(server: dict[str, Any], recall_hook: bool = True, retain_hook: bool = True) -> str:
     """Render the config snippet a user can paste into ``config.json``."""
     snippet: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}, "permissions": {"allow": [ALLOW_PATTERN]}}
-    if with_hook:
-        snippet["hooks"] = {HOOK_EVENT: [_our_hook_group()]}
+    hooks: dict[str, Any] = {}
+    if recall_hook:
+        hooks[RECALL_EVENT] = [_our_group("recall")]
+    if retain_hook:
+        hooks[RETAIN_EVENT] = [_our_group("retain-nudge")]
+    if hooks:
+        snippet["hooks"] = hooks
     return json.dumps(snippet, indent=2)
 
 
@@ -150,72 +160,81 @@ def _remove_allow(data: dict[str, Any]) -> None:
         data.pop("permissions", None)
 
 
-def hook_command() -> str:
-    """Shell command Devin runs for the auto-recall hook (abs-python + ``-m``).
+def hook_command(subcommand: str) -> str:
+    """Shell command Devin runs for one of our hooks (abs-python + ``-m``).
 
     Uses ``sys.executable`` so it works regardless of Devin's PATH; the module is
     resolvable because that interpreter has the package installed.
     """
-    return f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} recall"
+    return f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} {subcommand}"
 
 
-def _our_hook_group() -> dict[str, Any]:
-    return {"hooks": [{"type": "command", "command": hook_command(), "timeout": 15}]}
+def _our_group(subcommand: str) -> dict[str, Any]:
+    return {"hooks": [{"type": "command", "command": hook_command(subcommand), "timeout": 15}]}
 
 
-def _is_our_hook_group(group: Any) -> bool:
+def _is_ours_for(group: Any, subcommand: str) -> bool:
     if not isinstance(group, dict):
         return False
-    return any(isinstance(h, dict) and HOOK_MODULE in h.get("command", "") for h in group.get("hooks", []))
+    needle = f"{HOOK_MODULE} {subcommand}"
+    return any(isinstance(h, dict) and needle in h.get("command", "") for h in group.get("hooks", []))
 
 
-def _hook_present(data: dict[str, Any]) -> bool:
+def _hook_present(data: dict[str, Any], subcommand: str) -> bool:
     hooks = data.get("hooks")
-    events = hooks.get(HOOK_EVENT) if isinstance(hooks, dict) else None
-    return isinstance(events, list) and any(_is_our_hook_group(g) for g in events)
+    events = hooks.get(HOOK_EVENTS[subcommand]) if isinstance(hooks, dict) else None
+    return isinstance(events, list) and any(_is_ours_for(g, subcommand) for g in events)
 
 
-def _ensure_hook(data: dict[str, Any]) -> None:
+def _ensure_hook(data: dict[str, Any], subcommand: str) -> None:
+    event = HOOK_EVENTS[subcommand]
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
         hooks = {}
-    events = hooks.get(HOOK_EVENT)
-    if not isinstance(events, list):
-        events = []
-    events = [g for g in events if not _is_our_hook_group(g)]  # replace ours, keep others
-    events.append(_our_hook_group())
-    hooks[HOOK_EVENT] = events
+    groups = hooks.get(event)
+    if not isinstance(groups, list):
+        groups = []
+    groups = [g for g in groups if not _is_ours_for(g, subcommand)]  # replace ours, keep others
+    groups.append(_our_group(subcommand))
+    hooks[event] = groups
     data["hooks"] = hooks
 
 
-def _remove_hook(data: dict[str, Any]) -> None:
+def _remove_hook(data: dict[str, Any], subcommand: str) -> None:
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
         return
-    events = hooks.get(HOOK_EVENT)
-    if isinstance(events, list):
-        events = [g for g in events if not _is_our_hook_group(g)]
-        if events:
-            hooks[HOOK_EVENT] = events
+    event = HOOK_EVENTS[subcommand]
+    groups = hooks.get(event)
+    if isinstance(groups, list):
+        groups = [g for g in groups if not _is_ours_for(g, subcommand)]
+        if groups:
+            hooks[event] = groups
         else:
-            hooks.pop(HOOK_EVENT, None)
+            hooks.pop(event, None)
     if not hooks:
         data.pop("hooks", None)
 
 
-def apply_to_config(path: Path, server: dict[str, Any], with_hook: bool = True) -> ConfigResult:
-    """Add/update ``mcpServers.hindsight`` + allow-rule (+ auto-recall hook) in ``config.json``.
+def _apply_hooks(data: dict[str, Any], recall_hook: bool, retain_hook: bool) -> None:
+    (_ensure_hook if recall_hook else _remove_hook)(data, "recall")
+    (_ensure_hook if retain_hook else _remove_hook)(data, "retain-nudge")
+
+
+def apply_to_config(
+    path: Path, server: dict[str, Any], recall_hook: bool = True, retain_hook: bool = True
+) -> ConfigResult:
+    """Add/update ``mcpServers.hindsight`` + allow-rule (+ hooks) in ``config.json``.
 
     Preserves all other keys (e.g. ``version``). Adds ``permissions.allow`` for
-    ``mcp__hindsight__*`` so tools don't prompt, and (when ``with_hook``) a
-    ``SessionStart`` hook for deterministic auto-recall.
+    ``mcp__hindsight__*`` so tools don't prompt, a ``SessionStart`` auto-recall
+    hook (``recall_hook``), and a ``Stop`` retain-nudge hook (``retain_hook``).
     """
     if not path.is_file():
         path.parent.mkdir(parents=True, exist_ok=True)
         data: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}}
         _ensure_allow(data)
-        if with_hook:
-            _ensure_hook(data)
+        _apply_hooks(data, recall_hook, retain_hook)
         path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
         return ConfigResult("created", path)
 
@@ -226,29 +245,27 @@ def apply_to_config(path: Path, server: dict[str, Any], with_hook: bool = True) 
     servers = data.get("mcpServers")
     if not isinstance(servers, dict):
         servers = {}
-    hook_ok = _hook_present(data) if with_hook else not _hook_present(data)
-    if servers.get(SERVER_NAME) == server and _allow_present(data) and hook_ok:
+    hooks_ok = _hook_present(data, "recall") == recall_hook and _hook_present(data, "retain-nudge") == retain_hook
+    if servers.get(SERVER_NAME) == server and _allow_present(data) and hooks_ok:
         return ConfigResult("unchanged", path)
     servers[SERVER_NAME] = server
     data["mcpServers"] = servers
     _ensure_allow(data)
-    if with_hook:
-        _ensure_hook(data)
-    else:
-        _remove_hook(data)
+    _apply_hooks(data, recall_hook, retain_hook)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return ConfigResult("merged", path)
 
 
 def remove_from_config(path: Path) -> ConfigResult:
-    """Remove ``mcpServers.hindsight`` + our allow-rule + our hook from ``config.json``."""
+    """Remove ``mcpServers.hindsight`` + our allow-rule + our hooks from ``config.json``."""
     data = _load_strict(path)
     if data is None:
         return ConfigResult("manual" if path.is_file() else "unchanged", path)
 
     servers = data.get("mcpServers")
     present = isinstance(servers, dict) and SERVER_NAME in servers
-    if not present and not _allow_present(data) and not _hook_present(data):
+    any_hook = _hook_present(data, "recall") or _hook_present(data, "retain-nudge")
+    if not present and not _allow_present(data) and not any_hook:
         return ConfigResult("unchanged", path)
 
     if present:
@@ -258,7 +275,8 @@ def remove_from_config(path: Path) -> ConfigResult:
         else:
             data.pop("mcpServers", None)
     _remove_allow(data)
-    _remove_hook(data)
+    _remove_hook(data, "recall")
+    _remove_hook(data, "retain-nudge")
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return ConfigResult("removed", path)
 
@@ -272,10 +290,10 @@ def is_installed(path: Path) -> bool:
     return isinstance(servers, dict) and SERVER_NAME in servers
 
 
-def hook_installed(path: Path) -> bool:
-    """Whether our SessionStart auto-recall hook is present in ``config.json``."""
+def hook_installed(path: Path, subcommand: str = "recall") -> bool:
+    """Whether our hook for ``subcommand`` is present in ``config.json``."""
     data = _load_strict(path)
-    return bool(data) and _hook_present(data)
+    return bool(data) and _hook_present(data, subcommand)
 
 
 # ── AGENTS.md always-on instructions (global + per-project) ─────────────────

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
@@ -24,6 +24,9 @@ For Devin Local:
 from __future__ import annotations
 
 import json
+import os
+import shlex
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -35,16 +38,28 @@ from .rules import global_rule_body, render_rule_text
 SERVER_NAME = "hindsight"
 # Devin Local permission pattern that auto-approves Hindsight's MCP tools.
 ALLOW_PATTERN = "mcp__hindsight__*"
+# Deterministic auto-recall: a SessionStart hook injects memory into context.
+HOOK_EVENT = "SessionStart"
+HOOK_MODULE = "hindsight_devin_desktop.hook"
+
+
+def _devin_config_dir() -> Path:
+    """Devin Local's config directory (``~/.config/devin``; ``%APPDATA%\\devin`` on Windows)."""
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        return base / "devin"
+    return Path.home() / ".config" / "devin"
 
 
 def default_config_path() -> Path:
-    """Devin Local's user config (``~/.config/devin/config.json``)."""
-    return Path.home() / ".config" / "devin" / "config.json"
+    """Devin Local's user config (``config.json`` under the config dir)."""
+    return _devin_config_dir() / "config.json"
 
 
 def default_global_agents_path() -> Path:
-    """Devin Local's global always-on instructions (``~/.config/devin/AGENTS.md``)."""
-    return Path.home() / ".config" / "devin" / "AGENTS.md"
+    """Devin Local's global always-on instructions (``AGENTS.md`` under the config dir)."""
+    return _devin_config_dir() / "AGENTS.md"
 
 
 def default_project_agents_path() -> Path:
@@ -70,12 +85,12 @@ def build_http_server(api_url: str, api_token: Optional[str], default_bank: Opti
     return server
 
 
-def render_snippet(server: dict[str, Any]) -> str:
+def render_snippet(server: dict[str, Any], with_hook: bool = True) -> str:
     """Render the config snippet a user can paste into ``config.json``."""
-    return json.dumps(
-        {"mcpServers": {SERVER_NAME: server}, "permissions": {"allow": [ALLOW_PATTERN]}},
-        indent=2,
-    )
+    snippet: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}, "permissions": {"allow": [ALLOW_PATTERN]}}
+    if with_hook:
+        snippet["hooks"] = {HOOK_EVENT: [_our_hook_group()]}
+    return json.dumps(snippet, indent=2)
 
 
 @dataclass
@@ -135,16 +150,72 @@ def _remove_allow(data: dict[str, Any]) -> None:
         data.pop("permissions", None)
 
 
-def apply_to_config(path: Path, server: dict[str, Any]) -> ConfigResult:
-    """Add/update ``mcpServers.hindsight`` + the allow-rule in ``config.json``.
+def hook_command() -> str:
+    """Shell command Devin runs for the auto-recall hook (abs-python + ``-m``).
+
+    Uses ``sys.executable`` so it works regardless of Devin's PATH; the module is
+    resolvable because that interpreter has the package installed.
+    """
+    return f"{shlex.quote(sys.executable)} -m {HOOK_MODULE} recall"
+
+
+def _our_hook_group() -> dict[str, Any]:
+    return {"hooks": [{"type": "command", "command": hook_command(), "timeout": 15}]}
+
+
+def _is_our_hook_group(group: Any) -> bool:
+    if not isinstance(group, dict):
+        return False
+    return any(isinstance(h, dict) and HOOK_MODULE in h.get("command", "") for h in group.get("hooks", []))
+
+
+def _hook_present(data: dict[str, Any]) -> bool:
+    hooks = data.get("hooks")
+    events = hooks.get(HOOK_EVENT) if isinstance(hooks, dict) else None
+    return isinstance(events, list) and any(_is_our_hook_group(g) for g in events)
+
+
+def _ensure_hook(data: dict[str, Any]) -> None:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = {}
+    events = hooks.get(HOOK_EVENT)
+    if not isinstance(events, list):
+        events = []
+    events = [g for g in events if not _is_our_hook_group(g)]  # replace ours, keep others
+    events.append(_our_hook_group())
+    hooks[HOOK_EVENT] = events
+    data["hooks"] = hooks
+
+
+def _remove_hook(data: dict[str, Any]) -> None:
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+    events = hooks.get(HOOK_EVENT)
+    if isinstance(events, list):
+        events = [g for g in events if not _is_our_hook_group(g)]
+        if events:
+            hooks[HOOK_EVENT] = events
+        else:
+            hooks.pop(HOOK_EVENT, None)
+    if not hooks:
+        data.pop("hooks", None)
+
+
+def apply_to_config(path: Path, server: dict[str, Any], with_hook: bool = True) -> ConfigResult:
+    """Add/update ``mcpServers.hindsight`` + allow-rule (+ auto-recall hook) in ``config.json``.
 
     Preserves all other keys (e.g. ``version``). Adds ``permissions.allow`` for
-    ``mcp__hindsight__*`` so the tools don't prompt on every call.
+    ``mcp__hindsight__*`` so tools don't prompt, and (when ``with_hook``) a
+    ``SessionStart`` hook for deterministic auto-recall.
     """
     if not path.is_file():
         path.parent.mkdir(parents=True, exist_ok=True)
         data: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}}
         _ensure_allow(data)
+        if with_hook:
+            _ensure_hook(data)
         path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
         return ConfigResult("created", path)
 
@@ -155,24 +226,29 @@ def apply_to_config(path: Path, server: dict[str, Any]) -> ConfigResult:
     servers = data.get("mcpServers")
     if not isinstance(servers, dict):
         servers = {}
-    if servers.get(SERVER_NAME) == server and _allow_present(data):
+    hook_ok = _hook_present(data) if with_hook else not _hook_present(data)
+    if servers.get(SERVER_NAME) == server and _allow_present(data) and hook_ok:
         return ConfigResult("unchanged", path)
     servers[SERVER_NAME] = server
     data["mcpServers"] = servers
     _ensure_allow(data)
+    if with_hook:
+        _ensure_hook(data)
+    else:
+        _remove_hook(data)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return ConfigResult("merged", path)
 
 
 def remove_from_config(path: Path) -> ConfigResult:
-    """Remove ``mcpServers.hindsight`` + our allow-rule from ``config.json``."""
+    """Remove ``mcpServers.hindsight`` + our allow-rule + our hook from ``config.json``."""
     data = _load_strict(path)
     if data is None:
         return ConfigResult("manual" if path.is_file() else "unchanged", path)
 
     servers = data.get("mcpServers")
     present = isinstance(servers, dict) and SERVER_NAME in servers
-    if not present and not _allow_present(data):
+    if not present and not _allow_present(data) and not _hook_present(data):
         return ConfigResult("unchanged", path)
 
     if present:
@@ -182,6 +258,7 @@ def remove_from_config(path: Path) -> ConfigResult:
         else:
             data.pop("mcpServers", None)
     _remove_allow(data)
+    _remove_hook(data)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return ConfigResult("removed", path)
 
@@ -193,6 +270,12 @@ def is_installed(path: Path) -> bool:
         return False
     servers = data.get("mcpServers")
     return isinstance(servers, dict) and SERVER_NAME in servers
+
+
+def hook_installed(path: Path) -> bool:
+    """Whether our SessionStart auto-recall hook is present in ``config.json``."""
+    data = _load_strict(path)
+    return bool(data) and _hook_present(data)
 
 
 # ── AGENTS.md always-on instructions (global + per-project) ─────────────────

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/devin_local.py
@@ -1,0 +1,220 @@
+"""Wire Hindsight into the **Devin Local** agent (distinct from Cascade).
+
+Devin Desktop runs two agents with *separate* configuration:
+
+* **Cascade** (legacy) — MCP in ``~/.codeium/windsurf/mcp_config.json`` (field
+  ``serverUrl``), rules in ``.devin/rules/`` + ``…/memories/global_rules.md``
+  (see :mod:`hindsight_devin_desktop.mcp_config` / ``rules`` / ``global_rules``).
+* **Devin Local** (the successor agent, shared with the Devin CLI) — this module.
+
+For Devin Local:
+
+* MCP servers live in ``~/.config/devin/config.json`` under ``mcpServers``, but
+  the remote-server schema differs from Cascade: ``url`` + ``transport: "http"``
+  + ``headers`` (not ``serverUrl``). We preserve any other keys (e.g. ``version``).
+* Devin Local **prompts before every MCP tool call** by default, so we pre-seed a
+  ``permissions.allow`` entry (``mcp__hindsight__*``) so recall/retain run
+  automatically.
+* Always-on instructions use **``AGENTS.md``** files (plain Markdown, no
+  frontmatter) — Devin Local does *not* read Cascade's ``.devin/rules/``. Global:
+  ``~/.config/devin/AGENTS.md``; per-project: the repo-root ``AGENTS.md``. We
+  manage only a fenced block in each (see :mod:`managed_block`).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from . import managed_block
+from .mcp_config import mcp_endpoint_url
+from .rules import global_rule_body, render_rule_text
+
+SERVER_NAME = "hindsight"
+# Devin Local permission pattern that auto-approves Hindsight's MCP tools.
+ALLOW_PATTERN = "mcp__hindsight__*"
+
+
+def default_config_path() -> Path:
+    """Devin Local's user config (``~/.config/devin/config.json``)."""
+    return Path.home() / ".config" / "devin" / "config.json"
+
+
+def default_global_agents_path() -> Path:
+    """Devin Local's global always-on instructions (``~/.config/devin/AGENTS.md``)."""
+    return Path.home() / ".config" / "devin" / "AGENTS.md"
+
+
+def default_project_agents_path() -> Path:
+    """The repo-root ``AGENTS.md`` (per-project always-on instructions)."""
+    return Path.cwd() / "AGENTS.md"
+
+
+def build_http_server(api_url: str, api_token: Optional[str], default_bank: Optional[str]) -> dict[str, Any]:
+    """Build the Devin Local ``mcpServers.hindsight`` entry.
+
+    Multi-bank Streamable-HTTP endpoint via ``url`` + ``transport: "http"``, with
+    a Bearer auth header when a token is set and an ``X-Bank-Id`` header naming
+    ``default_bank`` as the fallback bank for calls that omit ``bank_id``.
+    """
+    server: dict[str, Any] = {"url": mcp_endpoint_url(api_url), "transport": "http"}
+    headers: dict[str, str] = {}
+    if api_token:
+        headers["Authorization"] = f"Bearer {api_token}"
+    if default_bank:
+        headers["X-Bank-Id"] = default_bank
+    if headers:
+        server["headers"] = headers
+    return server
+
+
+def render_snippet(server: dict[str, Any]) -> str:
+    """Render the config snippet a user can paste into ``config.json``."""
+    return json.dumps(
+        {"mcpServers": {SERVER_NAME: server}, "permissions": {"allow": [ALLOW_PATTERN]}},
+        indent=2,
+    )
+
+
+@dataclass
+class ConfigResult:
+    """Outcome of editing ``config.json``.
+
+    ``action`` is ``created``/``merged``/``unchanged``/``removed``/``manual``
+    (file isn't strict JSON — ``snippet`` holds what to paste).
+    """
+
+    action: str
+    path: Path
+    snippet: Optional[str] = None
+
+
+def _load_strict(path: Path) -> Optional[dict[str, Any]]:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _allow_present(data: dict[str, Any]) -> bool:
+    perms = data.get("permissions")
+    allow = perms.get("allow") if isinstance(perms, dict) else None
+    return isinstance(allow, list) and ALLOW_PATTERN in allow
+
+
+def _ensure_allow(data: dict[str, Any]) -> None:
+    perms = data.get("permissions")
+    if not isinstance(perms, dict):
+        perms = {}
+    allow = perms.get("allow")
+    if not isinstance(allow, list):
+        allow = []
+    if ALLOW_PATTERN not in allow:
+        allow.append(ALLOW_PATTERN)
+    perms["allow"] = allow
+    data["permissions"] = perms
+
+
+def _remove_allow(data: dict[str, Any]) -> None:
+    perms = data.get("permissions")
+    if not isinstance(perms, dict):
+        return
+    allow = perms.get("allow")
+    if isinstance(allow, list) and ALLOW_PATTERN in allow:
+        allow = [p for p in allow if p != ALLOW_PATTERN]
+        if allow:
+            perms["allow"] = allow
+        else:
+            perms.pop("allow", None)
+    if not perms:
+        data.pop("permissions", None)
+
+
+def apply_to_config(path: Path, server: dict[str, Any]) -> ConfigResult:
+    """Add/update ``mcpServers.hindsight`` + the allow-rule in ``config.json``.
+
+    Preserves all other keys (e.g. ``version``). Adds ``permissions.allow`` for
+    ``mcp__hindsight__*`` so the tools don't prompt on every call.
+    """
+    if not path.is_file():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data: dict[str, Any] = {"mcpServers": {SERVER_NAME: server}}
+        _ensure_allow(data)
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return ConfigResult("created", path)
+
+    data = _load_strict(path)
+    if data is None:
+        return ConfigResult("manual", path, snippet=render_snippet(server))
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+    if servers.get(SERVER_NAME) == server and _allow_present(data):
+        return ConfigResult("unchanged", path)
+    servers[SERVER_NAME] = server
+    data["mcpServers"] = servers
+    _ensure_allow(data)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return ConfigResult("merged", path)
+
+
+def remove_from_config(path: Path) -> ConfigResult:
+    """Remove ``mcpServers.hindsight`` + our allow-rule from ``config.json``."""
+    data = _load_strict(path)
+    if data is None:
+        return ConfigResult("manual" if path.is_file() else "unchanged", path)
+
+    servers = data.get("mcpServers")
+    present = isinstance(servers, dict) and SERVER_NAME in servers
+    if not present and not _allow_present(data):
+        return ConfigResult("unchanged", path)
+
+    if present:
+        del servers[SERVER_NAME]
+        if servers:
+            data["mcpServers"] = servers
+        else:
+            data.pop("mcpServers", None)
+    _remove_allow(data)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return ConfigResult("removed", path)
+
+
+def is_installed(path: Path) -> bool:
+    """Whether our server is present in Devin Local's ``config.json``."""
+    data = _load_strict(path)
+    if data is None:
+        return False
+    servers = data.get("mcpServers")
+    return isinstance(servers, dict) and SERVER_NAME in servers
+
+
+# ── AGENTS.md always-on instructions (global + per-project) ─────────────────
+
+
+def write_global_agents(path: Path, global_bank: str) -> str:
+    """Write/replace our block in the global ``AGENTS.md``; returns the action."""
+    action, _ = managed_block.upsert(path, global_rule_body(global_bank))
+    return action
+
+
+def write_project_agents(path: Path, project_bank: str, global_bank: str) -> str:
+    """Write/replace our block in the repo-root ``AGENTS.md``; returns the action."""
+    action, _ = managed_block.upsert(path, render_rule_text(project_bank, global_bank))
+    return action
+
+
+def clear_agents(path: Path) -> None:
+    """Remove our managed block from an ``AGENTS.md`` (delete file if empty)."""
+    managed_block.clear(path)
+
+
+def agents_installed(path: Path) -> bool:
+    """Whether our managed block is present in an ``AGENTS.md``."""
+    return managed_block.has(path)

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/global_rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/global_rules.py
@@ -1,0 +1,118 @@
+"""Write Hindsight's global-memory rule into Devin's ``global_rules.md``.
+
+Devin Desktop applies a single ``~/.codeium/windsurf/memories/global_rules.md``
+across **every** workspace, always on (cap: 6,000 characters). We add a small
+managed block there naming the user's cross-project (global) bank, so their
+preferences/coding-style memory is active even in repos that never ran ``init``.
+
+Unlike the per-project rule file (which we own entirely), this file is shared
+with the user's own global rules — so we only manage a fenced
+``<!-- HINDSIGHT:BEGIN -->`` … ``<!-- HINDSIGHT:END -->`` block and never touch
+the rest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+BEGIN_MARKER = "<!-- HINDSIGHT:BEGIN -->"
+END_MARKER = "<!-- HINDSIGHT:END -->"
+
+# Devin's documented cap for global_rules.md.
+GLOBAL_RULES_CAP = 6000
+
+
+def default_global_rules_path() -> Path:
+    """Devin's global rules file (``~/.codeium/windsurf/memories/global_rules.md``)."""
+    return Path.home() / ".codeium" / "windsurf" / "memories" / "global_rules.md"
+
+
+def render_block(global_bank: str) -> str:
+    """The fenced managed block naming the user's global memory bank."""
+    body = (
+        "You have persistent cross-project long-term memory in the Hindsight MCP "
+        f'server\'s `{global_bank}` bank (bank_id: "{global_bank}"). At the start '
+        "of a task, `recall` from it for the user's preferences and coding style; "
+        "`retain` durable user-level facts (preferences, style, identity) to it. "
+        "A specific project may define its own additional project bank in that "
+        "project's rules. Briefly mention when you use memory."
+    )
+    return f"{BEGIN_MARKER}\n{body}\n{END_MARKER}"
+
+
+def _strip_block(text: str) -> str:
+    """Remove an existing HINDSIGHT block (and its surrounding blank lines)."""
+    start = text.find(BEGIN_MARKER)
+    if start == -1:
+        return text
+    end = text.find(END_MARKER, start)
+    if end == -1:
+        return text[:start].rstrip() + "\n"
+    end += len(END_MARKER)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+    if before and after:
+        return f"{before}\n\n{after}"
+    return (before or after).rstrip() + ("\n" if (before or after) else "")
+
+
+@dataclass
+class GlobalRuleResult:
+    """Outcome of editing ``global_rules.md``.
+
+    ``action`` is ``created``/``updated``/``unchanged``. ``over_cap`` is the new
+    total length when it exceeds :data:`GLOBAL_RULES_CAP` (Devin truncates past
+    it), else ``None``.
+    """
+
+    action: str
+    path: Path
+    over_cap: Optional[int] = None
+
+
+def write_global_rule(path: Path, global_bank: str) -> GlobalRuleResult:
+    """Write/replace our managed block at the top of ``global_rules.md``.
+
+    Preserves any user-authored content below our block. Reports ``over_cap`` if
+    the resulting file exceeds Devin's 6,000-char limit (we still write — the
+    user chooses what to trim — but we warn).
+    """
+    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+    had_block = BEGIN_MARKER in existing
+    base = _strip_block(existing).rstrip()
+    block = render_block(global_bank)
+    new_text = f"{block}\n\n{base}\n" if base else f"{block}\n"
+
+    if had_block and existing == new_text:
+        action = "unchanged"
+    elif path.is_file():
+        action = "updated"
+    else:
+        action = "created"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_text, encoding="utf-8")
+    over = len(new_text) if len(new_text) > GLOBAL_RULES_CAP else None
+    return GlobalRuleResult(action, path, over_cap=over)
+
+
+def clear_global_rule(path: Path) -> Path:
+    """Remove our managed block; delete the file if nothing else remains."""
+    if not path.is_file():
+        return path
+    existing = path.read_text(encoding="utf-8")
+    if BEGIN_MARKER not in existing:
+        return path
+    stripped = _strip_block(existing).strip()
+    if stripped:
+        path.write_text(stripped + "\n", encoding="utf-8")
+    else:
+        path.unlink()
+    return path
+
+
+def is_installed(path: Path) -> bool:
+    """Whether our managed block is present in ``global_rules.md``."""
+    return path.is_file() and BEGIN_MARKER in path.read_text(encoding="utf-8")

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/global_rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/global_rules.py
@@ -1,14 +1,13 @@
-"""Write Hindsight's global-memory rule into Devin's ``global_rules.md``.
+"""Write Hindsight's global-memory rule into Cascade's ``global_rules.md``.
 
-Devin Desktop applies a single ``~/.codeium/windsurf/memories/global_rules.md``
-across **every** workspace, always on (cap: 6,000 characters). We add a small
-managed block there naming the user's cross-project (global) bank, so their
+Cascade applies a single ``~/.codeium/windsurf/memories/global_rules.md`` across
+**every** workspace, always on (cap: 6,000 characters). We add a small managed
+block there naming the user's cross-project (global) bank, so their
 preferences/coding-style memory is active even in repos that never ran ``init``.
 
-Unlike the per-project rule file (which we own entirely), this file is shared
-with the user's own global rules — so we only manage a fenced
-``<!-- HINDSIGHT:BEGIN -->`` … ``<!-- HINDSIGHT:END -->`` block and never touch
-the rest.
+This is Cascade-specific; the equivalent for the Devin Local agent is an
+``AGENTS.md`` file (see :mod:`hindsight_devin_desktop.devin_local`). The block
+mechanics are shared via :mod:`hindsight_devin_desktop.managed_block`.
 """
 
 from __future__ import annotations
@@ -17,45 +16,34 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-BEGIN_MARKER = "<!-- HINDSIGHT:BEGIN -->"
-END_MARKER = "<!-- HINDSIGHT:END -->"
+from . import managed_block
+from .managed_block import BEGIN_MARKER, END_MARKER  # re-exported for callers/tests
+from .rules import global_rule_body
 
 # Devin's documented cap for global_rules.md.
 GLOBAL_RULES_CAP = 6000
 
+__all__ = [
+    "BEGIN_MARKER",
+    "END_MARKER",
+    "GLOBAL_RULES_CAP",
+    "GlobalRuleResult",
+    "clear_global_rule",
+    "default_global_rules_path",
+    "is_installed",
+    "render_block",
+    "write_global_rule",
+]
+
 
 def default_global_rules_path() -> Path:
-    """Devin's global rules file (``~/.codeium/windsurf/memories/global_rules.md``)."""
+    """Cascade's global rules file (``~/.codeium/windsurf/memories/global_rules.md``)."""
     return Path.home() / ".codeium" / "windsurf" / "memories" / "global_rules.md"
 
 
 def render_block(global_bank: str) -> str:
     """The fenced managed block naming the user's global memory bank."""
-    body = (
-        "You have persistent cross-project long-term memory in the Hindsight MCP "
-        f'server\'s `{global_bank}` bank (bank_id: "{global_bank}"). At the start '
-        "of a task, `recall` from it for the user's preferences and coding style; "
-        "`retain` durable user-level facts (preferences, style, identity) to it. "
-        "A specific project may define its own additional project bank in that "
-        "project's rules. Briefly mention when you use memory."
-    )
-    return f"{BEGIN_MARKER}\n{body}\n{END_MARKER}"
-
-
-def _strip_block(text: str) -> str:
-    """Remove an existing HINDSIGHT block (and its surrounding blank lines)."""
-    start = text.find(BEGIN_MARKER)
-    if start == -1:
-        return text
-    end = text.find(END_MARKER, start)
-    if end == -1:
-        return text[:start].rstrip() + "\n"
-    end += len(END_MARKER)
-    before = text[:start].rstrip()
-    after = text[end:].lstrip()
-    if before and after:
-        return f"{before}\n\n{after}"
-    return (before or after).rstrip() + ("\n" if (before or after) else "")
+    return managed_block.render_block(global_rule_body(global_bank))
 
 
 @dataclass
@@ -79,40 +67,16 @@ def write_global_rule(path: Path, global_bank: str) -> GlobalRuleResult:
     the resulting file exceeds Devin's 6,000-char limit (we still write — the
     user chooses what to trim — but we warn).
     """
-    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-    had_block = BEGIN_MARKER in existing
-    base = _strip_block(existing).rstrip()
-    block = render_block(global_bank)
-    new_text = f"{block}\n\n{base}\n" if base else f"{block}\n"
-
-    if had_block and existing == new_text:
-        action = "unchanged"
-    elif path.is_file():
-        action = "updated"
-    else:
-        action = "created"
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(new_text, encoding="utf-8")
-    over = len(new_text) if len(new_text) > GLOBAL_RULES_CAP else None
-    return GlobalRuleResult(action, path, over_cap=over)
+    action, size = managed_block.upsert(path, global_rule_body(global_bank))
+    return GlobalRuleResult(action, path, over_cap=size if size > GLOBAL_RULES_CAP else None)
 
 
 def clear_global_rule(path: Path) -> Path:
     """Remove our managed block; delete the file if nothing else remains."""
-    if not path.is_file():
-        return path
-    existing = path.read_text(encoding="utf-8")
-    if BEGIN_MARKER not in existing:
-        return path
-    stripped = _strip_block(existing).strip()
-    if stripped:
-        path.write_text(stripped + "\n", encoding="utf-8")
-    else:
-        path.unlink()
+    managed_block.clear(path)
     return path
 
 
 def is_installed(path: Path) -> bool:
     """Whether our managed block is present in ``global_rules.md``."""
-    return path.is_file() and BEGIN_MARKER in path.read_text(encoding="utf-8")
+    return managed_block.has(path)

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -1,0 +1,170 @@
+"""Devin Local ``SessionStart`` hook — deterministic auto-recall.
+
+Devin runs this at the start of every session. It reads the connection details
+from Devin Local's ``config.json`` (the same ``mcpServers.hindsight`` entry
+``init`` wrote), derives the project bank from ``DEVIN_PROJECT_DIR``, recalls a
+baseline of project + user memory from Hindsight, and prints it as
+``additionalContext`` — which Devin injects into the agent's context **before the
+model acts**. So memory is loaded whether or not the model remembers to call
+``recall``.
+
+Contract (Devin CLI hooks): event JSON arrives on stdin; we return
+``{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}``
+on stdout. The hook must never break a session, so *any* error → exit 0 with no
+output. Config-only and dependency-free (stdlib ``urllib`` for the MCP call).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from . import devin_local
+from .project import project_bank_id
+
+# Broad session-start prime; per-turn relevance still comes from the model's own
+# recall calls guided by the rule.
+RECALL_QUERY = "Key architecture, decisions, conventions, and the user's preferences and coding style for this work."
+MAX_TOKENS = 1024
+
+
+def _extract_connection(config_data: dict) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return ``(url, token, global_bank)`` from a Devin config's hindsight entry."""
+    server = (config_data.get("mcpServers") or {}).get(devin_local.SERVER_NAME) or {}
+    url = server.get("url")
+    headers = server.get("headers") or {}
+    auth = headers.get("Authorization") or ""
+    token = auth[len("Bearer ") :].strip() if auth.startswith("Bearer ") else None
+    return url, token, headers.get("X-Bank-Id")
+
+
+def _mcp(url: str, token: Optional[str], payload: dict, session: Optional[str]) -> Tuple[Optional[str], Optional[dict]]:
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json, text/event-stream")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if session:
+        req.add_header("Mcp-Session-Id", session)
+    with urllib.request.urlopen(req, timeout=8) as r:
+        body = r.read().decode().strip()
+        ctype = r.headers.get("Content-Type") or ""
+        data = None
+        if body:
+            if "text/event-stream" in ctype:
+                data = json.loads("".join(ln[5:].strip() for ln in body.splitlines() if ln.startswith("data:")))
+            else:
+                data = json.loads(body)
+        return r.headers.get("Mcp-Session-Id"), data
+
+
+def _recall(url: str, token: Optional[str], bank: str) -> List[str]:
+    """Recall from one bank via MCP; return memory texts (best-effort, may be empty)."""
+    sid, _ = _mcp(
+        url,
+        token,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "hook", "version": "0"},
+            },
+        },
+        None,
+    )
+    try:
+        _mcp(url, token, {"jsonrpc": "2.0", "method": "notifications/initialized"}, sid)
+    except Exception:
+        pass
+    _, res = _mcp(
+        url,
+        token,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "recall",
+                "arguments": {"query": RECALL_QUERY, "bank_id": bank, "max_tokens": MAX_TOKENS},
+            },
+        },
+        sid,
+    )
+    if not res or "result" not in res:
+        return []
+    text = "\n".join(c.get("text", "") for c in res["result"].get("content", []))
+    try:
+        results = json.loads(text).get("results", [])
+        return [m.get("text", "") for m in results if m.get("text")]
+    except (json.JSONDecodeError, AttributeError):
+        return []
+
+
+def _format_context(project_bank: str, project_mems: List[str], global_bank: str, global_mems: List[str]) -> str:
+    parts = ["Relevant long-term memory (Hindsight) — use what applies, ignore the rest:"]
+    if project_mems:
+        parts.append(f"\nThis project ({project_bank}):")
+        parts += [f"- {m}" for m in project_mems]
+    if global_mems:
+        parts.append(f"\nAbout the user ({global_bank}):")
+        parts += [f"- {m}" for m in global_mems]
+    return "\n".join(parts)
+
+
+def _emit(additional_context: str) -> None:
+    sys.stdout.write(
+        json.dumps(
+            {"hookSpecificOutput": {"hookEventName": devin_local.HOOK_EVENT, "additionalContext": additional_context}}
+        )
+    )
+
+
+def cmd_recall() -> int:
+    config = devin_local.default_config_path()
+    if not config.is_file():
+        return 0
+    try:
+        data = json.loads(config.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return 0
+    url, token, global_bank = _extract_connection(data)
+    if not url or not global_bank:
+        return 0
+
+    project_dir = Path(os.environ.get("DEVIN_PROJECT_DIR") or ".")
+    project_bank, _ = project_bank_id(global_bank, project_dir)
+
+    global_mems = _recall(url, token, global_bank)
+    project_mems = _recall(url, token, project_bank) if project_bank and project_bank != global_bank else []
+    if not project_mems and not global_mems:
+        return 0
+    _emit(_format_context(project_bank or global_bank, project_mems, global_bank, global_mems))
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # Consume Devin's event JSON on stdin (we don't need it for SessionStart recall).
+    try:
+        if not sys.stdin.isatty():
+            sys.stdin.read()
+    except Exception:
+        pass
+    if argv and argv[0] == "recall":
+        try:
+            return cmd_recall()
+        except Exception:
+            # Never break a session — swallow everything.
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -177,14 +177,16 @@ def _emit_context(additional_context: str) -> None:
     )
 
 
-def cmd_recall() -> int:
+def cmd_recall(local_only: bool = False) -> int:
     url, token, global_bank, project_bank = _resolve()
     if not url or not global_bank:
         _log("recall", "skip-not-configured")
         return 0  # not configured for Devin Local — nothing to report
     try:
-        global_mems = _recall(url, token, global_bank)
-        project_mems = _recall(url, token, project_bank) if project_bank and project_bank != global_bank else []
+        project_mems = _recall(url, token, project_bank) if project_bank else []
+        # Local-only: everything lives in the project bank, so don't recall the shared bank.
+        share = not local_only and project_bank != global_bank
+        global_mems = _recall(url, token, global_bank) if share else []
     except Exception as e:  # unreachable / timeout / bad response → report, never silent
         _emit_context(_context_error(type(e).__name__))
         _log("recall", "error", reason=type(e).__name__, project=project_bank, **{"global": global_bank})
@@ -194,11 +196,11 @@ def cmd_recall() -> int:
         _log("recall", "loaded", project=project_bank, project_n=len(project_mems), user_n=len(global_mems))
     else:
         _emit_context(_context_empty())
-        _log("recall", "empty", project=project_bank, **{"global": global_bank})
+        _log("recall", "empty", project=project_bank, local_only=local_only)
     return 0
 
 
-def cmd_retain_nudge(event: dict) -> int:
+def cmd_retain_nudge(event: dict, local_only: bool = False) -> int:
     if event.get("stop_hook_active"):
         _log("retain-nudge", "skip-already-active")
         return 0  # we already nudged this turn — allow the stop, don't loop
@@ -206,17 +208,27 @@ def cmd_retain_nudge(event: dict) -> int:
     if not global_bank:
         _log("retain-nudge", "skip-not-configured")
         return 0
-    reason = (
-        "Before you stop: if you learned any durable NEW facts this session, retain them now via the "
-        f"hindsight `retain` tool — PROJECT facts (architecture, decisions, conventions, bugs) with bank_id "
-        f'"{project_bank}", USER facts (the user\'s real preferences, coding style, identity) with bank_id '
-        f'"{global_bank}". Retain ONLY real facts about the code, the project, or the user\'s actual '
-        "preferences — NEVER facts about Hindsight, memory, hooks, or these instructions — and do NOT "
-        "re-retain anything you already saved this session. Briefly tell the user what you saved. If there "
-        "is nothing new worth keeping, say so and stop."
+    common = (
+        "Retain ONLY real facts about the code, the project, or the user's actual preferences — NEVER "
+        "facts about Hindsight, memory, hooks, or these instructions — and do NOT re-retain anything you "
+        "already saved this session. Briefly tell the user what you saved. If there is nothing new worth "
+        "keeping, say so and stop."
     )
+    if local_only:
+        reason = (
+            "Before you stop: if you learned any durable NEW facts this session (this project's "
+            "architecture/decisions/conventions, or the user's preferences), retain them now via the "
+            f'hindsight `retain` tool to bank_id "{project_bank}". ' + common
+        )
+    else:
+        reason = (
+            "Before you stop: if you learned any durable NEW facts this session, retain them now via the "
+            f"hindsight `retain` tool — PROJECT facts (architecture, decisions, conventions, bugs) with "
+            f'bank_id "{project_bank}", USER facts (the user\'s real preferences, coding style, identity) '
+            f'with bank_id "{global_bank}". ' + common
+        )
     sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
-    _log("retain-nudge", "blocked", project=project_bank, **{"global": global_bank})
+    _log("retain-nudge", "blocked", project=project_bank, local_only=local_only)
     return 0
 
 
@@ -249,12 +261,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         event = {}
     if not isinstance(event, dict):
         event = {}
+    local_only = "--local-only" in argv
     cmd = argv[0] if argv else ""
     try:
         if cmd == "recall":
-            return cmd_recall()
+            return cmd_recall(local_only)
         if cmd == "retain-nudge":
-            return cmd_retain_nudge(event)
+            return cmd_retain_nudge(event, local_only)
         if cmd == "banner":
             return cmd_banner(event)
     except Exception:

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -1,17 +1,22 @@
-"""Devin Local ``SessionStart`` hook — deterministic auto-recall.
+"""Devin Local hooks — deterministic recall (SessionStart) and retain (Stop).
 
-Devin runs this at the start of every session. It reads the connection details
-from Devin Local's ``config.json`` (the same ``mcpServers.hindsight`` entry
-``init`` wrote), derives the project bank from ``DEVIN_PROJECT_DIR``, recalls a
-baseline of project + user memory from Hindsight, and prints it as
-``additionalContext`` — which Devin injects into the agent's context **before the
-model acts**. So memory is loaded whether or not the model remembers to call
-``recall``.
+Two subcommands, both driven by Devin's hook system:
 
-Contract (Devin CLI hooks): event JSON arrives on stdin; we return
-``{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}``
-on stdout. The hook must never break a session, so *any* error → exit 0 with no
-output. Config-only and dependency-free (stdlib ``urllib`` for the MCP call).
+* ``recall`` (``SessionStart``): reads the connection from Devin Local's
+  ``config.json``, derives the project bank from ``DEVIN_PROJECT_DIR``, recalls a
+  baseline of project + user memory, and prints it as ``additionalContext`` —
+  which Devin injects into the agent's context before the model acts. It
+  **always reports status** (loaded / empty / unavailable) so memory use is never
+  silent, and never exits non-zero (never breaks a session).
+
+* ``retain-nudge`` (``Stop``): before the agent stops, returns
+  ``{"decision":"block","reason":...}`` to force one retain pass — the model
+  decides *what* is durable and calls the ``retain`` tool. Loop-guarded via
+  ``stop_hook_active``. This makes retain deterministically *triggered* (Devin's
+  hooks can't hand a transcript to a script, so the model must author the
+  content).
+
+Config-only and dependency-free (stdlib ``urllib`` for the MCP recall).
 """
 
 from __future__ import annotations
@@ -26,8 +31,6 @@ from typing import List, Optional, Tuple
 from . import devin_local
 from .project import project_bank_id
 
-# Broad session-start prime; per-turn relevance still comes from the model's own
-# recall calls guided by the rule.
 RECALL_QUERY = "Key architecture, decisions, conventions, and the user's preferences and coding style for this work."
 MAX_TOKENS = 1024
 
@@ -40,6 +43,22 @@ def _extract_connection(config_data: dict) -> Tuple[Optional[str], Optional[str]
     auth = headers.get("Authorization") or ""
     token = auth[len("Bearer ") :].strip() if auth.startswith("Bearer ") else None
     return url, token, headers.get("X-Bank-Id")
+
+
+def _resolve() -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Read config + env → ``(url, token, global_bank, project_bank)`` (any may be None)."""
+    config = devin_local.default_config_path()
+    if not config.is_file():
+        return None, None, None, None
+    try:
+        data = json.loads(config.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None, None, None, None
+    url, token, global_bank = _extract_connection(data)
+    if not global_bank:
+        return url, token, None, None
+    project_bank, _ = project_bank_id(global_bank, Path(os.environ.get("DEVIN_PROJECT_DIR") or "."))
+    return url, token, global_bank, project_bank
 
 
 def _mcp(url: str, token: Optional[str], payload: dict, session: Optional[str]) -> Tuple[Optional[str], Optional[dict]]:
@@ -63,7 +82,7 @@ def _mcp(url: str, token: Optional[str], payload: dict, session: Optional[str]) 
 
 
 def _recall(url: str, token: Optional[str], bank: str) -> List[str]:
-    """Recall from one bank via MCP; return memory texts (best-effort, may be empty)."""
+    """Recall from one bank via MCP; return memory texts. Raises on transport error."""
     sid, _ = _mcp(
         url,
         token,
@@ -107,62 +126,111 @@ def _recall(url: str, token: Optional[str], bank: str) -> List[str]:
         return []
 
 
-def _format_context(project_bank: str, project_mems: List[str], global_bank: str, global_mems: List[str]) -> str:
-    parts = ["Relevant long-term memory (Hindsight) — use what applies, ignore the rest:"]
+def _context_loaded(project_bank: str, project_mems: List[str], global_bank: str, global_mems: List[str]) -> str:
+    n, m = len(project_mems), len(global_mems)
+    parts = [
+        f"🧠 Hindsight memory loaded ({n} project, {m} user). "
+        "Briefly tell the user you recalled from Hindsight, then use what's relevant:"
+    ]
     if project_mems:
         parts.append(f"\nThis project ({project_bank}):")
-        parts += [f"- {m}" for m in project_mems]
+        parts += [f"- {x}" for x in project_mems]
     if global_mems:
         parts.append(f"\nAbout the user ({global_bank}):")
-        parts += [f"- {m}" for m in global_mems]
+        parts += [f"- {x}" for x in global_mems]
     return "\n".join(parts)
 
 
-def _emit(additional_context: str) -> None:
+def _context_empty() -> str:
+    return "🧠 Hindsight: no stored memory for this project or user yet. Tell the user memory is empty so far."
+
+
+def _context_error(reason: str) -> str:
+    return f"⚠️ Hindsight: could not load memory this session ({reason}). Tell the user memory is unavailable right now."
+
+
+def _emit_context(additional_context: str) -> None:
     sys.stdout.write(
         json.dumps(
-            {"hookSpecificOutput": {"hookEventName": devin_local.HOOK_EVENT, "additionalContext": additional_context}}
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": devin_local.RECALL_EVENT,
+                    "additionalContext": additional_context,
+                }
+            }
         )
     )
 
 
 def cmd_recall() -> int:
-    config = devin_local.default_config_path()
-    if not config.is_file():
-        return 0
-    try:
-        data = json.loads(config.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return 0
-    url, token, global_bank = _extract_connection(data)
+    url, token, global_bank, project_bank = _resolve()
     if not url or not global_bank:
+        return 0  # not configured for Devin Local — nothing to report
+    try:
+        global_mems = _recall(url, token, global_bank)
+        project_mems = _recall(url, token, project_bank) if project_bank and project_bank != global_bank else []
+    except Exception as e:  # unreachable / timeout / bad response → report, never silent
+        _emit_context(_context_error(type(e).__name__))
         return 0
+    if project_mems or global_mems:
+        _emit_context(_context_loaded(project_bank or global_bank, project_mems, global_bank, global_mems))
+    else:
+        _emit_context(_context_empty())
+    return 0
 
-    project_dir = Path(os.environ.get("DEVIN_PROJECT_DIR") or ".")
-    project_bank, _ = project_bank_id(global_bank, project_dir)
 
-    global_mems = _recall(url, token, global_bank)
-    project_mems = _recall(url, token, project_bank) if project_bank and project_bank != global_bank else []
-    if not project_mems and not global_mems:
+def cmd_retain_nudge(event: dict) -> int:
+    if event.get("stop_hook_active"):
+        return 0  # we already nudged this turn — allow the stop, don't loop
+    _, _, global_bank, project_bank = _resolve()
+    if not global_bank:
         return 0
-    _emit(_format_context(project_bank or global_bank, project_mems, global_bank, global_mems))
+    reason = (
+        "Before you stop: if you learned anything durable this session, retain it now via the hindsight "
+        f'`retain` tool — PROJECT facts (architecture, decisions, conventions) with bank_id "{project_bank}", '
+        f'USER facts (preferences, style, identity) with bank_id "{global_bank}". Briefly tell the user what '
+        "you saved. If nothing is worth remembering, just say so and stop."
+    )
+    sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+def cmd_banner(event: dict) -> int:
+    """Cascade ``post_mcp_tool_use`` banner: print a visible line for hindsight tools.
+
+    Cascade has no per-hook matcher, so this fires for every MCP tool; we filter
+    to the hindsight server in-script and stay silent otherwise.
+    """
+    info = event.get("tool_info") or {}
+    if info.get("mcp_server_name") == devin_local.SERVER_NAME:
+        tool = info.get("mcp_tool_name") or "memory"
+        sys.stdout.write(f"🧠 Hindsight: {tool} used")
     return 0
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    # Consume Devin's event JSON on stdin (we don't need it for SessionStart recall).
+    event: dict = {}
     try:
         if not sys.stdin.isatty():
-            sys.stdin.read()
+            raw = sys.stdin.read()
+            if raw.strip():
+                event = json.loads(raw)
     except Exception:
-        pass
-    if argv and argv[0] == "recall":
-        try:
+        event = {}
+    if not isinstance(event, dict):
+        event = {}
+    cmd = argv[0] if argv else ""
+    try:
+        if cmd == "recall":
             return cmd_recall()
-        except Exception:
-            # Never break a session — swallow everything.
-            return 0
+        if cmd == "retain-nudge":
+            return cmd_retain_nudge(event)
+        if cmd == "banner":
+            return cmd_banner(event)
+    except Exception:
+        # Last resort only — never break a session.
+        return 0
     return 0
 
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -34,17 +34,26 @@ from .project import project_bank_id
 
 RECALL_QUERY = "Key architecture, decisions, conventions, and the user's preferences and coding style for this work."
 MAX_TOKENS = 1024
-# Proof-of-life log: every hook invocation appends one line, so you can confirm
-# the hooks actually fire (Devin Local hooks are otherwise silent).
-LOG_PATH = Path.home() / ".hindsight" / "devin-hook.log"
+
+
+def _log_path() -> Optional[Path]:
+    """Where the proof-of-life log goes; ``HINDSIGHT_HOOK_LOG=off`` disables it."""
+    override = os.environ.get("HINDSIGHT_HOOK_LOG")
+    if override == "off":
+        return None
+    return Path(override) if override else Path.home() / ".hindsight" / "devin-hook.log"
 
 
 def _log(cmd: str, outcome: str, **fields: object) -> None:
+    """Append one proof-of-life line per hook run (Devin Local hooks are silent)."""
     try:
+        path = _log_path()
+        if path is None:
+            return
         stamp = time.strftime("%Y-%m-%dT%H:%M:%S")
         extra = " ".join(f"{k}={v}" for k, v in fields.items())
-        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with LOG_PATH.open("a", encoding="utf-8") as f:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
             f.write(f"{stamp} {cmd} {outcome} {extra}\n")
     except Exception:
         pass

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -153,8 +153,10 @@ def _recall(url: str, token: Optional[str], bank: str) -> List[str]:
 def _context_loaded(project_bank: str, project_mems: List[str], global_bank: str, global_mems: List[str]) -> str:
     n, m = len(project_mems), len(global_mems)
     parts = [
-        f"🧠 Hindsight memory loaded ({n} project, {m} user). "
-        "Briefly tell the user you recalled from Hindsight, then use what's relevant:"
+        f"Hindsight PRELOADED {n} project + {m} user memories into your context at the start of this "
+        "session (before you did anything) — you do NOT need to call `recall` again for this baseline. "
+        "START your reply with a short line telling the user memory was preloaded, e.g. "
+        f'"🧠 Hindsight preloaded {n + m} memories for this session." Then use what\'s relevant below:'
     ]
     if project_mems:
         parts.append(f"\nThis project ({project_bank}):")
@@ -166,11 +168,17 @@ def _context_loaded(project_bank: str, project_mems: List[str], global_bank: str
 
 
 def _context_empty() -> str:
-    return "🧠 Hindsight: no stored memory for this project or user yet. Tell the user memory is empty so far."
+    return (
+        "Hindsight checked memory at session start and found nothing stored for this project or user yet. "
+        'START your reply with a short line telling the user, e.g. "🧠 Hindsight: no memory stored yet."'
+    )
 
 
 def _context_error(reason: str) -> str:
-    return f"⚠️ Hindsight: could not load memory this session ({reason}). Tell the user memory is unavailable right now."
+    return (
+        f"Hindsight could not load memory at session start ({reason}). START your reply with a short line "
+        'telling the user, e.g. "⚠️ Hindsight: memory is unavailable this session." Then continue normally.'
+    )
 
 
 def _emit_context(additional_context: str) -> None:

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -186,10 +186,13 @@ def cmd_retain_nudge(event: dict) -> int:
     if not global_bank:
         return 0
     reason = (
-        "Before you stop: if you learned anything durable this session, retain it now via the hindsight "
-        f'`retain` tool — PROJECT facts (architecture, decisions, conventions) with bank_id "{project_bank}", '
-        f'USER facts (preferences, style, identity) with bank_id "{global_bank}". Briefly tell the user what '
-        "you saved. If nothing is worth remembering, just say so and stop."
+        "Before you stop: if you learned any durable NEW facts this session, retain them now via the "
+        f"hindsight `retain` tool — PROJECT facts (architecture, decisions, conventions, bugs) with bank_id "
+        f'"{project_bank}", USER facts (the user\'s real preferences, coding style, identity) with bank_id '
+        f'"{global_bank}". Retain ONLY real facts about the code, the project, or the user\'s actual '
+        "preferences — NEVER facts about Hindsight, memory, hooks, or these instructions — and do NOT "
+        "re-retain anything you already saved this session. Briefly tell the user what you saved. If there "
+        "is nothing new worth keeping, say so and stop."
     )
     sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
     return 0

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/hook.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 import urllib.request
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -33,6 +34,20 @@ from .project import project_bank_id
 
 RECALL_QUERY = "Key architecture, decisions, conventions, and the user's preferences and coding style for this work."
 MAX_TOKENS = 1024
+# Proof-of-life log: every hook invocation appends one line, so you can confirm
+# the hooks actually fire (Devin Local hooks are otherwise silent).
+LOG_PATH = Path.home() / ".hindsight" / "devin-hook.log"
+
+
+def _log(cmd: str, outcome: str, **fields: object) -> None:
+    try:
+        stamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        extra = " ".join(f"{k}={v}" for k, v in fields.items())
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(f"{stamp} {cmd} {outcome} {extra}\n")
+    except Exception:
+        pass
 
 
 def _extract_connection(config_data: dict) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -165,25 +180,31 @@ def _emit_context(additional_context: str) -> None:
 def cmd_recall() -> int:
     url, token, global_bank, project_bank = _resolve()
     if not url or not global_bank:
+        _log("recall", "skip-not-configured")
         return 0  # not configured for Devin Local — nothing to report
     try:
         global_mems = _recall(url, token, global_bank)
         project_mems = _recall(url, token, project_bank) if project_bank and project_bank != global_bank else []
     except Exception as e:  # unreachable / timeout / bad response → report, never silent
         _emit_context(_context_error(type(e).__name__))
+        _log("recall", "error", reason=type(e).__name__, project=project_bank, **{"global": global_bank})
         return 0
     if project_mems or global_mems:
         _emit_context(_context_loaded(project_bank or global_bank, project_mems, global_bank, global_mems))
+        _log("recall", "loaded", project=project_bank, project_n=len(project_mems), user_n=len(global_mems))
     else:
         _emit_context(_context_empty())
+        _log("recall", "empty", project=project_bank, **{"global": global_bank})
     return 0
 
 
 def cmd_retain_nudge(event: dict) -> int:
     if event.get("stop_hook_active"):
+        _log("retain-nudge", "skip-already-active")
         return 0  # we already nudged this turn — allow the stop, don't loop
     _, _, global_bank, project_bank = _resolve()
     if not global_bank:
+        _log("retain-nudge", "skip-not-configured")
         return 0
     reason = (
         "Before you stop: if you learned any durable NEW facts this session, retain them now via the "
@@ -195,6 +216,7 @@ def cmd_retain_nudge(event: dict) -> int:
         "is nothing new worth keeping, say so and stop."
     )
     sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
+    _log("retain-nudge", "blocked", project=project_bank, **{"global": global_bank})
     return 0
 
 
@@ -205,9 +227,13 @@ def cmd_banner(event: dict) -> int:
     to the hindsight server in-script and stay silent otherwise.
     """
     info = event.get("tool_info") or {}
-    if info.get("mcp_server_name") == devin_local.SERVER_NAME:
+    server = info.get("mcp_server_name")
+    if server == devin_local.SERVER_NAME:
         tool = info.get("mcp_tool_name") or "memory"
         sys.stdout.write(f"🧠 Hindsight: {tool} used")
+        _log("banner", "shown", tool=tool)
+    else:
+        _log("banner", "skip-other-server", server=server)
     return 0
 
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/managed_block.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/managed_block.py
@@ -1,0 +1,80 @@
+"""A fenced, sentinel-marked block we own inside a file we share with the user.
+
+Several targets are Markdown files the user may also author (Cascade's
+``global_rules.md``, Devin Local's ``AGENTS.md``). We only manage a fenced
+``<!-- HINDSIGHT:BEGIN -->`` … ``<!-- HINDSIGHT:END -->`` block at the top and
+never touch the rest, so update/removal is idempotent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+BEGIN_MARKER = "<!-- HINDSIGHT:BEGIN -->"
+END_MARKER = "<!-- HINDSIGHT:END -->"
+
+
+def render_block(body: str) -> str:
+    """Wrap ``body`` in our fenced markers (no trailing newline)."""
+    return f"{BEGIN_MARKER}\n{body.strip()}\n{END_MARKER}"
+
+
+def strip_block(text: str) -> str:
+    """Remove an existing HINDSIGHT block (and its surrounding blank lines)."""
+    start = text.find(BEGIN_MARKER)
+    if start == -1:
+        return text
+    end = text.find(END_MARKER, start)
+    if end == -1:
+        return text[:start].rstrip() + "\n"
+    end += len(END_MARKER)
+    before = text[:start].rstrip()
+    after = text[end:].lstrip()
+    if before and after:
+        return f"{before}\n\n{after}"
+    return (before or after).rstrip() + ("\n" if (before or after) else "")
+
+
+def upsert(path: Path, body: str) -> Tuple[str, int]:
+    """Write/replace our managed block at the top of ``path``.
+
+    Preserves any user content below it. Returns ``(action, size)`` where
+    ``action`` is ``created``/``updated``/``unchanged`` and ``size`` is the new
+    file length (for callers that enforce a cap).
+    """
+    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+    had_block = BEGIN_MARKER in existing
+    base = strip_block(existing).rstrip()
+    block = render_block(body)
+    new_text = f"{block}\n\n{base}\n" if base else f"{block}\n"
+
+    if had_block and existing == new_text:
+        action = "unchanged"
+    elif path.is_file():
+        action = "updated"
+    else:
+        action = "created"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_text, encoding="utf-8")
+    return action, len(new_text)
+
+
+def clear(path: Path) -> None:
+    """Remove our managed block; delete the file if nothing else remains."""
+    if not path.is_file():
+        return
+    existing = path.read_text(encoding="utf-8")
+    if BEGIN_MARKER not in existing:
+        return
+    stripped = strip_block(existing).strip()
+    if stripped:
+        path.write_text(stripped + "\n", encoding="utf-8")
+    else:
+        path.unlink()
+
+
+def has(path: Path) -> bool:
+    """Whether our managed block is present in ``path``."""
+    return path.is_file() and BEGIN_MARKER in path.read_text(encoding="utf-8")

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/mcp_config.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/mcp_config.py
@@ -1,24 +1,34 @@
-"""Wire Hindsight into Devin Desktop's MCP config (``~/.codeium/windsurf/mcp_config.json``).
+"""Wire Hindsight into Devin Desktop's MCP config (``~/.codeium/.../mcp_config.json``).
 
-Devin Desktop (formerly Windsurf) reads MCP servers from
-``~/.codeium/windsurf/mcp_config.json`` under the ``mcpServers`` key — the path
-still carries the legacy ``windsurf`` segment, which is the app's on-disk data
-directory and is unchanged by the rebrand. For a remote server it uses a
-``serverUrl`` field (plus optional ``headers``), so the Hindsight MCP endpoint
-connects with no bridge::
+Devin Desktop (formerly Windsurf) reads MCP servers from a global
+``mcp_config.json`` under the ``mcpServers`` key. The on-disk location still
+carries the legacy ``.codeium`` root (unchanged by the rebrand), but Devin's own
+docs disagree on the segment after it — the Cascade page says
+``~/.codeium/windsurf/mcp_config.json`` while the FAQ/plugins pages say
+``~/.codeium/mcp_config.json``. To be safe we write **both** (see
+:func:`default_mcp_paths`).
+
+We register Hindsight in **multi-bank mode** — a single remote ``serverUrl``
+ending in ``/mcp/`` (no bank pinned in the path). In this mode every tool takes
+an optional ``bank_id``, so one connection can address the user's global bank
+*and* the per-project bank; the always-on rule tells the model which to use. An
+``X-Bank-Id`` header names the global bank as the default when the model omits
+``bank_id``::
 
     {
       "mcpServers": {
         "hindsight": {
-          "serverUrl": "https://api.hindsight.vectorize.io/mcp/<bank>/",
-          "headers": { "Authorization": "Bearer hsk_..." }
+          "serverUrl": "https://api.hindsight.vectorize.io/mcp/",
+          "headers": {
+            "Authorization": "Bearer hsk_...",
+            "X-Bank-Id": "devin-desktop"
+          }
         }
       }
     }
 
-Devin Desktop has no project-local MCP file — ``mcp_config.json`` is a single
-global file. We only edit it in place when it parses as strict JSON; otherwise
-we return the exact snippet to paste, never risking the user's file.
+We only edit a file in place when it parses as strict JSON; otherwise we return
+the exact snippet to paste, never risking the user's file.
 """
 
 from __future__ import annotations
@@ -26,31 +36,46 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 SERVER_NAME = "hindsight"
 
 
-def default_mcp_path() -> Path:
-    """The global Devin Desktop MCP config (``~/.codeium/windsurf/mcp_config.json``)."""
-    return Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+def default_mcp_paths() -> List[Path]:
+    """Both documented Devin Desktop MCP config locations (write to each).
 
-
-def mcp_endpoint_url(api_url: str, bank_id: str) -> str:
-    """The Hindsight MCP endpoint for a bank (bank is the last path segment)."""
-    return f"{api_url.rstrip('/')}/mcp/{bank_id}/"
-
-
-def build_http_server(api_url: str, api_token: Optional[str], bank_id: str) -> dict[str, Any]:
-    """Build the ``mcpServers.hindsight`` entry for ``mcp_config.json``.
-
-    A remote MCP server pointing at the Hindsight endpoint via ``serverUrl``,
-    with a Bearer auth header when a token is set (omitted for an open
-    self-hosted server).
+    Devin's docs conflict on the path, so covering both guarantees the installed
+    build reads our entry regardless of which location it honors.
     """
-    server: dict[str, Any] = {"serverUrl": mcp_endpoint_url(api_url, bank_id)}
+    codeium = Path.home() / ".codeium"
+    return [codeium / "windsurf" / "mcp_config.json", codeium / "mcp_config.json"]
+
+
+def default_mcp_path() -> Path:
+    """The primary Devin Desktop MCP config (``~/.codeium/windsurf/mcp_config.json``)."""
+    return default_mcp_paths()[0]
+
+
+def mcp_endpoint_url(api_url: str) -> str:
+    """The Hindsight multi-bank MCP endpoint (no bank pinned in the path)."""
+    return f"{api_url.rstrip('/')}/mcp/"
+
+
+def build_http_server(api_url: str, api_token: Optional[str], default_bank: Optional[str]) -> dict[str, Any]:
+    """Build the multi-bank ``mcpServers.hindsight`` entry for ``mcp_config.json``.
+
+    A remote MCP server at the ``/mcp/`` endpoint, with a Bearer auth header when
+    a token is set and an ``X-Bank-Id`` header naming ``default_bank`` as the
+    fallback bank for any call that omits ``bank_id``.
+    """
+    server: dict[str, Any] = {"serverUrl": mcp_endpoint_url(api_url)}
+    headers: dict[str, str] = {}
     if api_token:
-        server["headers"] = {"Authorization": f"Bearer {api_token}"}
+        headers["Authorization"] = f"Bearer {api_token}"
+    if default_bank:
+        headers["X-Bank-Id"] = default_bank
+    if headers:
+        server["headers"] = headers
     return server
 
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/project.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/project.py
@@ -1,0 +1,94 @@
+"""Derive a stable per-project bank id for the current repository.
+
+Devin Desktop's MCP config is a single global file — it can't carry a different
+bank per workspace, and it passes no reliable project identifier to the MCP
+server. So the project bank must be derived **client-side at ``init`` time**
+(inside the repo, where git context exists) and baked into that repo's committed
+``.devin/rules/hindsight.md``.
+
+Derivation prefers the **git remote** (stable across machines, clones, and
+checkout paths, and identical for teammates → shared project memory), then the
+git repo folder, then the current folder. The result is ``<global>-<slug>`` so
+project banks are grouped under the global bank and never collide with it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def _slugify(text: str) -> str:
+    """Lowercase, collapse non-alphanumerics to single dashes, trim dashes."""
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+
+
+def _run_git(args: list[str], cwd: Path) -> Optional[str]:
+    """Run ``git <args>`` in ``cwd``; return trimmed stdout or ``None``."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def slug_from_remote(url: str) -> Optional[str]:
+    """Slug from a git remote URL's ``owner/repo`` (host and ``.git`` dropped).
+
+    Handles ``git@host:owner/repo.git``, ``https://host/owner/repo.git``, and
+    ``ssh://git@host/owner/repo``. Dropping the host keeps the slug identical for
+    teammates who clone the same repo over different protocols.
+    """
+    url = url.strip()
+    if url.endswith(".git"):
+        url = url[:-4]
+    scp = re.match(r"^[^/@]+@[^:/]+:(.+)$", url)  # scp-like: git@host:owner/repo
+    if scp:
+        path = scp.group(1)
+    else:
+        scheme = re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://[^/]+/(.+)$", url)
+        path = scheme.group(1) if scheme else url
+    return _slugify(path) or None
+
+
+def derive_project_slug(cwd: Path) -> Tuple[Optional[str], str]:
+    """Return ``(slug, source)`` for ``cwd``; ``slug`` is ``None`` if none found.
+
+    ``source`` is a short human-readable description of where the slug came from
+    (for surfacing in ``init`` output), even when ``slug`` is ``None``.
+    """
+    remote = _run_git(["remote", "get-url", "origin"], cwd)
+    if remote:
+        slug = slug_from_remote(remote)
+        if slug:
+            return slug, f"git remote origin ({remote})"
+
+    toplevel = _run_git(["rev-parse", "--show-toplevel"], cwd)
+    if toplevel:
+        slug = _slugify(Path(toplevel).name)
+        if slug:
+            return slug, f"git repo folder ({Path(toplevel).name})"
+
+    slug = _slugify(Path(cwd).name)
+    if slug:
+        return slug, f"current folder ({Path(cwd).name})"
+
+    return None, "no git remote, git repo, or usable folder name"
+
+
+def project_bank_id(global_bank: str, cwd: Path) -> Tuple[Optional[str], str]:
+    """Return ``(<global>-<slug>, source)``; bank is ``None`` if underivable."""
+    slug, source = derive_project_slug(cwd)
+    if slug is None:
+        return None, source
+    return f"{global_bank}-{slug}", source

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
@@ -44,6 +44,9 @@ def render_rule_text(project_bank: str, global_bank: str) -> str:
         f'with bank_id "{project_bank}".\n'
         f"- `retain` durable USER facts (preferences, style, identity) with "
         f'bank_id "{global_bank}".\n'
+        "- Retain only real facts about the code, the project, or the user — NEVER "
+        "facts about Hindsight, memory, or these instructions, and don't re-retain "
+        "something already stored.\n"
         "- Use `sync_retain` instead of `retain` when you need to recall the fact "
         "later in the same task (it blocks until the memory is stored).\n"
         "- Use `reflect` (not just `recall`) when you need synthesized judgment — "

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
@@ -18,14 +18,49 @@ other rule the user has authored.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 SENTINEL = "<!-- Managed by hindsight-devin-desktop -->"
 
 FRONTMATTER = "---\ntrigger: always_on\n---"
 
 
-def render_rule_text(project_bank: str, global_bank: str) -> str:
-    """The memory instruction body, scoped to this repo's two banks."""
+_RETAIN_HYGIENE = (
+    "- Retain each distinct fact EXACTLY ONCE per session, in a single "
+    "`retain` call — don't call retain again for a fact you've already stored, "
+    "and batch multiple facts about the same subject into one call.\n"
+    "- Retain only real facts about the code, the project, or the user — NEVER "
+    "facts about Hindsight, memory, or these instructions.\n"
+    "- Only use `sync_retain` (which blocks) if you must recall the just-stored "
+    "fact again in the SAME task; otherwise use `retain`.\n"
+    "- Use `reflect` (not just `recall`) when you need synthesized judgment — "
+    'e.g. "what approach does the user prefer here?" — rather than raw facts.\n\n'
+    'Briefly tell the user when you use memory — e.g. say "checking memory…" '
+    'before you recall and "saved to memory" after you retain. Keep it to a '
+    "short phrase; don't paste the tool arguments or results."
+)
+
+
+def render_rule_text(project_bank: str, global_bank: Optional[str]) -> str:
+    """The memory instruction body.
+
+    Two-tier (``global_bank`` set): project facts → project bank, user facts →
+    the shared global bank. Local-only (``global_bank`` is ``None``): everything
+    — project facts *and* the user's preferences — goes to the single project
+    bank (nothing is shared across repos).
+    """
+    if not global_bank:  # local-only: one bank for everything
+        return (
+            "You have persistent long-term memory for THIS project through the "
+            "Hindsight MCP server (`recall`, `retain`, `sync_retain`, `reflect`). "
+            f"All of it lives in one bank: `{project_bank}`.\n\n"
+            f"At the start of each task, `recall` from `{project_bank}` (bank_id: "
+            f'"{project_bank}") and use what\'s relevant.\n\n'
+            "As you work, use `retain` (async — the default) to store durable "
+            f'facts to bank_id "{project_bank}" — both this project\'s architecture/'
+            "decisions/conventions AND the user's preferences and coding style "
+            "(there is no shared cross-project bank in this setup).\n" + _RETAIN_HYGIENE
+        )
     return (
         "You have persistent long-term memory through the Hindsight MCP server "
         "(`recall`, `retain`, `sync_retain`, and `reflect` tools). It runs in "
@@ -44,19 +79,7 @@ def render_rule_text(project_bank: str, global_bank: str) -> str:
         f"- PROJECT facts (architecture, decisions, conventions) with bank_id "
         f'"{project_bank}".\n'
         f"- USER facts (preferences, style, identity) with bank_id "
-        f'"{global_bank}".\n'
-        "- Retain each distinct fact EXACTLY ONCE per session, in a single "
-        "`retain` call — don't call retain again for a fact you've already stored, "
-        "and batch multiple facts about the same subject into one call.\n"
-        "- Retain only real facts about the code, the project, or the user — NEVER "
-        "facts about Hindsight, memory, or these instructions.\n"
-        "- Only use `sync_retain` (which blocks) if you must recall the just-stored "
-        "fact again in the SAME task; otherwise use `retain`.\n"
-        "- Use `reflect` (not just `recall`) when you need synthesized judgment — "
-        'e.g. "what approach does the user prefer here?" — rather than raw facts.\n\n'
-        'Briefly tell the user when you use memory — e.g. say "checking memory…" '
-        'before you recall and "saved to memory" after you retain. Keep it to a '
-        "short phrase; don't paste the tool arguments or results."
+        f'"{global_bank}".\n' + _RETAIN_HYGIENE
     )
 
 
@@ -80,12 +103,12 @@ def default_rules_path() -> Path:
     return Path.cwd() / ".devin" / "rules" / "hindsight.md"
 
 
-def render_rule(project_bank: str, global_bank: str) -> str:
-    """The full contents of the dedicated rule file."""
+def render_rule(project_bank: str, global_bank: Optional[str]) -> str:
+    """The full contents of the dedicated rule file (``global_bank=None`` = local-only)."""
     return f"{FRONTMATTER}\n\n{SENTINEL}\n{render_rule_text(project_bank, global_bank).strip()}\n"
 
 
-def write_rule(path: Path, project_bank: str, global_bank: str) -> Path:
+def write_rule(path: Path, project_bank: str, global_bank: Optional[str]) -> Path:
     """Write (or replace) Hindsight's dedicated rule file at ``path``."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(render_rule(project_bank, global_bank), encoding="utf-8")

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
@@ -54,6 +54,21 @@ def render_rule_text(project_bank: str, global_bank: str) -> str:
     )
 
 
+def global_rule_body(global_bank: str) -> str:
+    """The cross-project instruction body (global scope, names only the global bank).
+
+    Shared by Cascade's ``global_rules.md`` and Devin Local's global ``AGENTS.md``.
+    """
+    return (
+        "You have persistent cross-project long-term memory in the Hindsight MCP "
+        f'server\'s `{global_bank}` bank (bank_id: "{global_bank}"). At the start '
+        "of a task, `recall` from it for the user's preferences and coding style; "
+        "`retain` durable user-level facts (preferences, style, identity) to it. "
+        "A specific project may define its own additional project bank in that "
+        "project's rules. Briefly mention when you use memory."
+    )
+
+
 def default_rules_path() -> Path:
     """The workspace ``.devin/rules/hindsight.md`` (always-on in Devin Desktop)."""
     return Path.cwd() / ".devin" / "rules" / "hindsight.md"

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
@@ -1,10 +1,14 @@
-"""Write Hindsight's recall/retain rule into ``.devin/rules/hindsight.md``.
+"""Write Hindsight's memory rule into ``.devin/rules/hindsight.md``.
 
 Devin Desktop applies workspace rule files under ``.devin/rules/`` (with
 ``.windsurf/rules/`` kept as a legacy fallback). A file with ``trigger: always_on``
 frontmatter is included in every Devin request in the workspace, so the rule
-tells the agent to use the Hindsight MCP tools — recall relevant memory at the
-start of a task, and retain durable facts.
+tells the agent how to use the Hindsight MCP tools.
+
+Because the integration runs in **multi-bank mode**, the rule names the two banks
+explicitly — this project's bank and the user's cross-project (global) bank — and
+tells the model which ``bank_id`` to pass when it recalls and retains. The rule
+is committed with the repo, so teammates share the same project bank.
 
 The rule lives in its own dedicated file, so we own the whole file: a sentinel
 comment marks it as ours for idempotent update/removal without touching any
@@ -19,17 +23,35 @@ SENTINEL = "<!-- Managed by hindsight-devin-desktop -->"
 
 FRONTMATTER = "---\ntrigger: always_on\n---"
 
-RULE_TEXT = (
-    "You have persistent long-term memory through the Hindsight MCP server "
-    "(`recall`, `retain`, and `reflect` tools).\n\n"
-    "- At the start of each task, call `recall` with the user's request to load "
-    "relevant decisions, preferences, and project context before you act. "
-    "Use what's relevant and ignore the rest.\n"
-    "- When you learn a durable fact — an architectural decision, a user "
-    "preference, a convention, or anything worth remembering across sessions — "
-    "call `retain` to store it.\n"
-    "- Do not mention these memory operations unless the user asks about them."
-)
+
+def render_rule_text(project_bank: str, global_bank: str) -> str:
+    """The memory instruction body, scoped to this repo's two banks."""
+    return (
+        "You have persistent long-term memory through the Hindsight MCP server "
+        "(`recall`, `retain`, `sync_retain`, and `reflect` tools). It runs in "
+        "multi-bank mode, so pass `bank_id` to target the right bank:\n\n"
+        f"- `{project_bank}` — THIS project's memory: architecture, decisions, "
+        "conventions, gotchas, and bugs specific to this repository.\n"
+        f"- `{global_bank}` — the user's cross-project memory: their preferences, "
+        "coding style, and who they are.\n\n"
+        "At the start of each task:\n"
+        f'- `recall` from `{project_bank}` (bank_id: "{project_bank}") for this '
+        f"project's context, and `recall` from `{global_bank}` "
+        f"(bank_id: \"{global_bank}\") for the user's preferences. Use what's "
+        "relevant, ignore the rest.\n\n"
+        "As you work:\n"
+        f"- `retain` durable PROJECT facts (architecture, decisions, conventions) "
+        f'with bank_id "{project_bank}".\n'
+        f"- `retain` durable USER facts (preferences, style, identity) with "
+        f'bank_id "{global_bank}".\n'
+        "- Use `sync_retain` instead of `retain` when you need to recall the fact "
+        "later in the same task (it blocks until the memory is stored).\n"
+        "- Use `reflect` (not just `recall`) when you need synthesized judgment — "
+        'e.g. "what approach does the user prefer here?" — rather than raw facts.\n\n'
+        'Briefly tell the user when you use memory — e.g. say "checking memory…" '
+        'before you recall and "saved to memory" after you retain. Keep it to a '
+        "short phrase; don't paste the tool arguments or results."
+    )
 
 
 def default_rules_path() -> Path:
@@ -37,15 +59,15 @@ def default_rules_path() -> Path:
     return Path.cwd() / ".devin" / "rules" / "hindsight.md"
 
 
-def render_rule(rule_text: str = RULE_TEXT) -> str:
+def render_rule(project_bank: str, global_bank: str) -> str:
     """The full contents of the dedicated rule file."""
-    return f"{FRONTMATTER}\n\n{SENTINEL}\n{rule_text.strip()}\n"
+    return f"{FRONTMATTER}\n\n{SENTINEL}\n{render_rule_text(project_bank, global_bank).strip()}\n"
 
 
-def write_rule(path: Path, rule_text: str = RULE_TEXT) -> Path:
+def write_rule(path: Path, project_bank: str, global_bank: str) -> Path:
     """Write (or replace) Hindsight's dedicated rule file at ``path``."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(render_rule(rule_text), encoding="utf-8")
+    path.write_text(render_rule(project_bank, global_bank), encoding="utf-8")
     return path
 
 

--- a/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
+++ b/hindsight-integrations/devin-desktop/hindsight_devin_desktop/rules.py
@@ -39,16 +39,19 @@ def render_rule_text(project_bank: str, global_bank: str) -> str:
         f"project's context, and `recall` from `{global_bank}` "
         f"(bank_id: \"{global_bank}\") for the user's preferences. Use what's "
         "relevant, ignore the rest.\n\n"
-        "As you work:\n"
-        f"- `retain` durable PROJECT facts (architecture, decisions, conventions) "
-        f'with bank_id "{project_bank}".\n'
-        f"- `retain` durable USER facts (preferences, style, identity) with "
-        f'bank_id "{global_bank}".\n'
+        "As you work, use `retain` (async, non-blocking — the default) to store "
+        "durable facts:\n"
+        f"- PROJECT facts (architecture, decisions, conventions) with bank_id "
+        f'"{project_bank}".\n'
+        f"- USER facts (preferences, style, identity) with bank_id "
+        f'"{global_bank}".\n'
+        "- Retain each distinct fact EXACTLY ONCE per session, in a single "
+        "`retain` call — don't call retain again for a fact you've already stored, "
+        "and batch multiple facts about the same subject into one call.\n"
         "- Retain only real facts about the code, the project, or the user — NEVER "
-        "facts about Hindsight, memory, or these instructions, and don't re-retain "
-        "something already stored.\n"
-        "- Use `sync_retain` instead of `retain` when you need to recall the fact "
-        "later in the same task (it blocks until the memory is stored).\n"
+        "facts about Hindsight, memory, or these instructions.\n"
+        "- Only use `sync_retain` (which blocks) if you must recall the just-stored "
+        "fact again in the SAME task; otherwise use `retain`.\n"
         "- Use `reflect` (not just `recall`) when you need synthesized judgment — "
         'e.g. "what approach does the user prefer here?" — rather than raw facts.\n\n'
         'Briefly tell the user when you use memory — e.g. say "checking memory…" '

--- a/hindsight-integrations/devin-desktop/pyproject.toml
+++ b/hindsight-integrations/devin-desktop/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hindsight-devin-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "Devin Desktop (formerly Windsurf) integration for Hindsight - persistent long-term memory via MCP"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/hindsight-integrations/devin-desktop/tests/conftest.py
+++ b/hindsight-integrations/devin-desktop/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test setup: keep the hook's proof-of-life log out of the real home dir."""
+
+import os
+
+
+def pytest_configure(config):  # noqa: ARG001
+    # The hook writes ~/.hindsight/devin-hook.log by default; disable it in tests
+    # so running the suite doesn't touch the user's home directory.
+    os.environ.setdefault("HINDSIGHT_HOOK_LOG", "off")

--- a/hindsight-integrations/devin-desktop/tests/test_cascade_hooks.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cascade_hooks.py
@@ -1,0 +1,70 @@
+"""Tests for the Cascade visibility banner hook (hooks.json)."""
+
+import json
+
+from hindsight_devin_desktop.cascade_hooks import (
+    EVENT,
+    apply_banner,
+    banner_command,
+    default_hooks_path,
+    is_installed,
+    remove_banner,
+)
+
+
+def test_default_path():
+    p = default_hooks_path()
+    assert p.name == "hooks.json"
+    assert p.parent.name == "windsurf"
+    assert p.parent.parent.name == ".codeium"
+
+
+def test_banner_command_targets_module():
+    assert "hindsight_devin_desktop.hook banner" in banner_command()
+
+
+def test_creates_with_show_output(tmp_path):
+    p = tmp_path / "hooks.json"
+    result = apply_banner(p)
+    assert result.action == "created"
+    entry = json.loads(p.read_text())["hooks"][EVENT][0]
+    assert entry["show_output"] is True
+    assert "hindsight_devin_desktop.hook banner" in entry["command"]
+    assert "command" in entry and "powershell" in entry  # cross-platform
+    assert is_installed(p)
+
+
+def test_idempotent(tmp_path):
+    p = tmp_path / "hooks.json"
+    apply_banner(p)
+    assert apply_banner(p).action == "unchanged"
+    assert len(json.loads(p.read_text())["hooks"][EVENT]) == 1
+
+
+def test_preserves_user_hooks(tmp_path):
+    p = tmp_path / "hooks.json"
+    p.write_text(json.dumps({"hooks": {EVENT: [{"command": "echo hi", "show_output": True}], "pre_write_code": []}}))
+    apply_banner(p)
+    data = json.loads(p.read_text())
+    cmds = [e["command"] for e in data["hooks"][EVENT]]
+    assert "echo hi" in cmds  # user's kept
+    assert any("hindsight_devin_desktop.hook banner" in c for c in cmds)  # ours added
+    assert "pre_write_code" in data["hooks"]  # untouched
+
+
+def test_non_json_returns_manual(tmp_path):
+    p = tmp_path / "hooks.json"
+    p.write_text("{ not json")
+    assert apply_banner(p).action == "manual"
+    assert p.read_text() == "{ not json"  # untouched
+
+
+def test_remove_keeps_user_hooks(tmp_path):
+    p = tmp_path / "hooks.json"
+    p.write_text(json.dumps({"hooks": {EVENT: [{"command": "echo hi"}]}}))
+    apply_banner(p)
+    remove_banner(p)
+    cmds = [e["command"] for e in json.loads(p.read_text())["hooks"][EVENT]]
+    assert "echo hi" in cmds
+    assert not any("hindsight_devin_desktop.hook banner" in c for c in cmds)
+    assert not is_installed(p)

--- a/hindsight-integrations/devin-desktop/tests/test_cli.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cli.py
@@ -110,9 +110,11 @@ class TestMain:
         assert "devin-desktop-acme-web" in (tmp_path / "rules" / "hindsight.md").read_text()
         assert "devin-desktop-acme-web" in (tmp_path / "AGENTS.md").read_text()
 
-    def test_init_prints_refresh_reminder(self, tmp_path, capsys):
+    def test_init_prints_activation_steps(self, tmp_path, capsys):
         main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *self._common(tmp_path)])
-        assert "refresh" in capsys.readouterr().out.lower()
+        out = capsys.readouterr().out.lower()
+        assert "refresh" in out  # Cascade activation
+        assert "connect" in out  # Devin Local activation
 
     def test_print_only_writes_nothing(self, tmp_path, capsys):
         rc = main(

--- a/hindsight-integrations/devin-desktop/tests/test_cli.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cli.py
@@ -132,5 +132,21 @@ class TestMain:
         out = capsys.readouterr().out
         assert "mcpServers" in out and "Devin Local" in out
 
+    def test_local_only_mode(self, tmp_path):
+        common = self._common(tmp_path)
+        assert (
+            main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", "--no-global-bank", *common]) == 0
+        )
+        # No shared global rule files
+        assert not global_rule_installed(tmp_path / "global_rules.md")
+        assert not devin_local.agents_installed(tmp_path / "devin" / "AGENTS.md")
+        # Project rule is single-bank (mentions the project bank, no separate global)
+        txt = (tmp_path / "AGENTS.md").read_text()
+        assert "proj" in txt and "one bank" in txt.lower()
+        # Devin Local hooks carry --local-only
+        cfg = json.loads((tmp_path / "devin" / "config.json").read_text())
+        cmd = cfg["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        assert "--local-only" in cmd
+
     def test_no_command_returns_1(self):
         assert main([]) == 1

--- a/hindsight-integrations/devin-desktop/tests/test_cli.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cli.py
@@ -1,27 +1,40 @@
 """Tests for the CLI (init/status/uninstall)."""
 
 import json
+import subprocess
 
-from hindsight_devin_desktop.cli import build_install, main
-from hindsight_devin_desktop.config import DevinDesktopConfig
+from hindsight_devin_desktop.cli import Resolved, build_install, main
+from hindsight_devin_desktop.global_rules import is_installed as global_rule_installed
 from hindsight_devin_desktop.mcp_config import SERVER_NAME
 from hindsight_devin_desktop.mcp_config import is_installed as server_installed
 from hindsight_devin_desktop.rules import is_installed as rule_installed
 
 
 class TestBuildInstall:
-    def test_writes_mcp_and_rule(self, tmp_path):
-        mcp = tmp_path / "mcp_config.json"
+    def test_writes_mcp_rule_and_global_rule(self, tmp_path):
+        mcp_a = tmp_path / "a" / "mcp_config.json"
+        mcp_b = tmp_path / "b" / "mcp_config.json"
         rules = tmp_path / "rules" / "hindsight.md"
-        cfg = DevinDesktopConfig(
-            hindsight_api_url="https://api.hindsight.vectorize.io", hindsight_api_token="k", bank_id="proj"
+        global_rules = tmp_path / "memories" / "global_rules.md"
+        resolved = Resolved(
+            api_url="https://api.hindsight.vectorize.io",
+            api_token="k",
+            global_bank="devin-desktop",
+            project_bank="devin-desktop-acme-web",
+            project_source="test",
         )
-        outcome = build_install(cfg, mcp, rules)
-        assert outcome.mcp.action == "created"
-        server = json.loads(mcp.read_text())["mcpServers"][SERVER_NAME]
-        assert server["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/proj/"
-        assert server["headers"]["Authorization"] == "Bearer k"
-        assert rule_installed(rules)
+        outcome = build_install(resolved, [mcp_a, mcp_b], rules, global_rules)
+
+        assert [r.action for r in outcome.mcp] == ["created", "created"]
+        for mcp in (mcp_a, mcp_b):
+            server = json.loads(mcp.read_text())["mcpServers"][SERVER_NAME]
+            # Multi-bank endpoint + global bank as the default header.
+            assert server["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/"
+            assert server["headers"]["Authorization"] == "Bearer k"
+            assert server["headers"]["X-Bank-Id"] == "devin-desktop"
+        rule_text = rules.read_text()
+        assert "devin-desktop-acme-web" in rule_text and "devin-desktop" in rule_text
+        assert global_rule_installed(global_rules)
 
 
 class TestMain:
@@ -31,40 +44,70 @@ class TestMain:
             str(tmp_path / "mcp_config.json"),
             "--rules-path",
             str(tmp_path / "rules" / "hindsight.md"),
+            "--global-rules-path",
+            str(tmp_path / "global_rules.md"),
             "--user-config-path",
             str(tmp_path / "user.json"),
         ]
 
     def test_init_status_uninstall(self, tmp_path, capsys):
         common = self._common(tmp_path)
-        assert main(["init", "--api-url", "http://localhost:8888", "--bank-id", "b", *common]) == 0
+        rc = main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *common])
+        assert rc == 0
         assert server_installed(tmp_path / "mcp_config.json")
         assert rule_installed(tmp_path / "rules" / "hindsight.md")
+        assert global_rule_installed(tmp_path / "global_rules.md")
+
         main(["status", *common])
-        assert "installed" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "installed" in out and "proj" in out
+
         main(["uninstall", *common])
         assert not server_installed(tmp_path / "mcp_config.json")
         assert not (tmp_path / "rules" / "hindsight.md").exists()
+        assert not global_rule_installed(tmp_path / "global_rules.md")
+
+    def test_init_derives_project_bank_from_git(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "remote", "add", "origin", "git@github.com:acme/web.git"], cwd=repo, check=True)
+        rc = main(
+            [
+                "init",
+                "--api-url",
+                "http://localhost:8888",
+                "--project-dir",
+                str(repo),
+                *self._common(tmp_path),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "devin-desktop-acme-web" in out
+        assert "devin-desktop-acme-web" in (tmp_path / "rules" / "hindsight.md").read_text()
+
+    def test_init_prints_refresh_reminder(self, tmp_path, capsys):
+        main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *self._common(tmp_path)])
+        out = capsys.readouterr().out.lower()
+        assert "refresh" in out
 
     def test_print_only_writes_nothing(self, tmp_path, capsys):
         mcp = tmp_path / "mcp_config.json"
-        rules = tmp_path / "rules" / "hindsight.md"
         rc = main(
             [
                 "init",
                 "--print-only",
                 "--api-url",
                 "http://localhost:8888",
-                "--mcp-path",
-                str(mcp),
-                "--rules-path",
-                str(rules),
-                "--user-config-path",
-                str(tmp_path / "user.json"),
+                "--bank-id",
+                "proj",
+                *self._common(tmp_path),
             ]
         )
         assert rc == 0
-        assert not mcp.exists() and not rules.exists()
+        assert not mcp.exists()
+        assert not (tmp_path / "rules" / "hindsight.md").exists()
         assert "mcpServers" in capsys.readouterr().out
 
     def test_no_command_returns_1(self):

--- a/hindsight-integrations/devin-desktop/tests/test_cli.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cli.py
@@ -16,6 +16,7 @@ def _paths(tmp_path):
         mcp=[tmp_path / "a" / "mcp_config.json", tmp_path / "b" / "mcp_config.json"],
         rules=tmp_path / "rules" / "hindsight.md",
         global_rules=tmp_path / "memories" / "global_rules.md",
+        cascade_hooks=tmp_path / "windsurf" / "hooks.json",
         devin_config=tmp_path / "devin" / "config.json",
         devin_global_agents=tmp_path / "devin" / "AGENTS.md",
         devin_project_agents=tmp_path / "proj" / "AGENTS.md",
@@ -40,9 +41,11 @@ class TestBuildInstall:
             server = json.loads(mcp.read_text())["mcpServers"][SERVER_NAME]
             assert server["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/"
             assert server["headers"]["X-Bank-Id"] == "devin-desktop"
-        # Cascade rules
+        # Cascade rules + visibility banner
         assert "devin-desktop-acme-web" in paths.rules.read_text()
         assert global_rule_installed(paths.global_rules)
+        assert outcome.cascade_banner.action == "created"
+        assert "post_mcp_tool_use" in json.loads(paths.cascade_hooks.read_text())["hooks"]
 
         # Devin Local MCP (url + transport) + auto-approve permission
         assert outcome.devin_config.action == "created"
@@ -67,6 +70,8 @@ class TestMain:
             str(tmp_path / "rules" / "hindsight.md"),
             "--global-rules-path",
             str(tmp_path / "global_rules.md"),
+            "--cascade-hooks-path",
+            str(tmp_path / "hooks.json"),
             "--devin-config-path",
             str(tmp_path / "devin" / "config.json"),
             "--devin-global-agents-path",

--- a/hindsight-integrations/devin-desktop/tests/test_cli.py
+++ b/hindsight-integrations/devin-desktop/tests/test_cli.py
@@ -1,21 +1,30 @@
-"""Tests for the CLI (init/status/uninstall)."""
+"""Tests for the CLI (init/status/uninstall) — covers both agents."""
 
 import json
 import subprocess
 
-from hindsight_devin_desktop.cli import Resolved, build_install, main
+from hindsight_devin_desktop import devin_local
+from hindsight_devin_desktop.cli import Paths, Resolved, build_install, main
 from hindsight_devin_desktop.global_rules import is_installed as global_rule_installed
 from hindsight_devin_desktop.mcp_config import SERVER_NAME
 from hindsight_devin_desktop.mcp_config import is_installed as server_installed
 from hindsight_devin_desktop.rules import is_installed as rule_installed
 
 
+def _paths(tmp_path):
+    return Paths(
+        mcp=[tmp_path / "a" / "mcp_config.json", tmp_path / "b" / "mcp_config.json"],
+        rules=tmp_path / "rules" / "hindsight.md",
+        global_rules=tmp_path / "memories" / "global_rules.md",
+        devin_config=tmp_path / "devin" / "config.json",
+        devin_global_agents=tmp_path / "devin" / "AGENTS.md",
+        devin_project_agents=tmp_path / "proj" / "AGENTS.md",
+    )
+
+
 class TestBuildInstall:
-    def test_writes_mcp_rule_and_global_rule(self, tmp_path):
-        mcp_a = tmp_path / "a" / "mcp_config.json"
-        mcp_b = tmp_path / "b" / "mcp_config.json"
-        rules = tmp_path / "rules" / "hindsight.md"
-        global_rules = tmp_path / "memories" / "global_rules.md"
+    def test_wires_both_agents(self, tmp_path):
+        paths = _paths(tmp_path)
         resolved = Resolved(
             api_url="https://api.hindsight.vectorize.io",
             api_token="k",
@@ -23,18 +32,30 @@ class TestBuildInstall:
             project_bank="devin-desktop-acme-web",
             project_source="test",
         )
-        outcome = build_install(resolved, [mcp_a, mcp_b], rules, global_rules)
+        outcome = build_install(resolved, paths)
 
+        # Cascade MCP (serverUrl) in both locations
         assert [r.action for r in outcome.mcp] == ["created", "created"]
-        for mcp in (mcp_a, mcp_b):
+        for mcp in paths.mcp:
             server = json.loads(mcp.read_text())["mcpServers"][SERVER_NAME]
-            # Multi-bank endpoint + global bank as the default header.
             assert server["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/"
-            assert server["headers"]["Authorization"] == "Bearer k"
             assert server["headers"]["X-Bank-Id"] == "devin-desktop"
-        rule_text = rules.read_text()
-        assert "devin-desktop-acme-web" in rule_text and "devin-desktop" in rule_text
-        assert global_rule_installed(global_rules)
+        # Cascade rules
+        assert "devin-desktop-acme-web" in paths.rules.read_text()
+        assert global_rule_installed(paths.global_rules)
+
+        # Devin Local MCP (url + transport) + auto-approve permission
+        assert outcome.devin_config.action == "created"
+        dl = json.loads(paths.devin_config.read_text())
+        dserver = dl["mcpServers"][SERVER_NAME]
+        assert dserver["url"] == "https://api.hindsight.vectorize.io/mcp/"
+        assert dserver["transport"] == "http"
+        assert dserver["headers"]["Authorization"] == "Bearer k"
+        assert dserver["headers"]["X-Bank-Id"] == "devin-desktop"
+        assert dl["permissions"]["allow"] == ["mcp__hindsight__*"]
+        # Devin Local AGENTS.md (project names both banks; global names the global bank)
+        assert "devin-desktop-acme-web" in paths.devin_project_agents.read_text()
+        assert devin_local.agents_installed(paths.devin_global_agents)
 
 
 class TestMain:
@@ -46,69 +67,63 @@ class TestMain:
             str(tmp_path / "rules" / "hindsight.md"),
             "--global-rules-path",
             str(tmp_path / "global_rules.md"),
+            "--devin-config-path",
+            str(tmp_path / "devin" / "config.json"),
+            "--devin-global-agents-path",
+            str(tmp_path / "devin" / "AGENTS.md"),
+            "--project-agents-path",
+            str(tmp_path / "AGENTS.md"),
             "--user-config-path",
             str(tmp_path / "user.json"),
         ]
 
     def test_init_status_uninstall(self, tmp_path, capsys):
         common = self._common(tmp_path)
-        rc = main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *common])
-        assert rc == 0
-        assert server_installed(tmp_path / "mcp_config.json")
+        assert main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *common]) == 0
+        # both agents configured
+        assert server_installed(tmp_path / "mcp_config.json")  # Cascade
         assert rule_installed(tmp_path / "rules" / "hindsight.md")
         assert global_rule_installed(tmp_path / "global_rules.md")
+        assert devin_local.is_installed(tmp_path / "devin" / "config.json")  # Devin Local
+        assert devin_local.agents_installed(tmp_path / "AGENTS.md")
+        assert devin_local.agents_installed(tmp_path / "devin" / "AGENTS.md")
 
         main(["status", *common])
         out = capsys.readouterr().out
-        assert "installed" in out and "proj" in out
+        assert "Cascade" in out and "Devin Local" in out and "proj" in out
 
         main(["uninstall", *common])
         assert not server_installed(tmp_path / "mcp_config.json")
-        assert not (tmp_path / "rules" / "hindsight.md").exists()
-        assert not global_rule_installed(tmp_path / "global_rules.md")
+        assert not devin_local.is_installed(tmp_path / "devin" / "config.json")
+        assert not devin_local.agents_installed(tmp_path / "AGENTS.md")
 
     def test_init_derives_project_bank_from_git(self, tmp_path, capsys):
         repo = tmp_path / "repo"
         repo.mkdir()
         subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
         subprocess.run(["git", "remote", "add", "origin", "git@github.com:acme/web.git"], cwd=repo, check=True)
-        rc = main(
-            [
-                "init",
-                "--api-url",
-                "http://localhost:8888",
-                "--project-dir",
-                str(repo),
-                *self._common(tmp_path),
-            ]
-        )
+        rc = main(["init", "--api-url", "http://localhost:8888", "--project-dir", str(repo), *self._common(tmp_path)])
         assert rc == 0
         out = capsys.readouterr().out
         assert "devin-desktop-acme-web" in out
+        # both agents' project rules carry the derived bank
         assert "devin-desktop-acme-web" in (tmp_path / "rules" / "hindsight.md").read_text()
+        assert "devin-desktop-acme-web" in (tmp_path / "AGENTS.md").read_text()
 
     def test_init_prints_refresh_reminder(self, tmp_path, capsys):
         main(["init", "--api-url", "http://localhost:8888", "--bank-id", "proj", *self._common(tmp_path)])
-        out = capsys.readouterr().out.lower()
-        assert "refresh" in out
+        assert "refresh" in capsys.readouterr().out.lower()
 
     def test_print_only_writes_nothing(self, tmp_path, capsys):
-        mcp = tmp_path / "mcp_config.json"
         rc = main(
-            [
-                "init",
-                "--print-only",
-                "--api-url",
-                "http://localhost:8888",
-                "--bank-id",
-                "proj",
-                *self._common(tmp_path),
-            ]
+            ["init", "--print-only", "--api-url", "http://localhost:8888", "--bank-id", "proj", *self._common(tmp_path)]
         )
         assert rc == 0
-        assert not mcp.exists()
-        assert not (tmp_path / "rules" / "hindsight.md").exists()
-        assert "mcpServers" in capsys.readouterr().out
+        assert not (tmp_path / "mcp_config.json").exists()
+        assert not (tmp_path / "devin" / "config.json").exists()
+        assert not (tmp_path / "AGENTS.md").exists()
+        out = capsys.readouterr().out
+        assert "mcpServers" in out and "Devin Local" in out
 
     def test_no_command_returns_1(self):
         assert main([]) == 1

--- a/hindsight-integrations/devin-desktop/tests/test_config.py
+++ b/hindsight-integrations/devin-desktop/tests/test_config.py
@@ -2,33 +2,56 @@
 
 import json
 
-from hindsight_devin_desktop.config import DEFAULT_BANK_ID, DEFAULT_HINDSIGHT_API_URL, load_config
+from hindsight_devin_desktop.config import DEFAULT_GLOBAL_BANK, DEFAULT_HINDSIGHT_API_URL, load_config
 
 
 def test_defaults(tmp_path):
     cfg = load_config(config_file=tmp_path / "missing.json", env={})
     assert cfg.hindsight_api_url == DEFAULT_HINDSIGHT_API_URL
     assert cfg.hindsight_api_token is None
-    assert cfg.bank_id == DEFAULT_BANK_ID
+    assert cfg.global_bank == DEFAULT_GLOBAL_BANK
+    assert cfg.project_bank is None  # derived per-repo, not from config
 
 
 def test_file_values(tmp_path):
     p = tmp_path / "devin-desktop.json"
-    p.write_text(json.dumps({"hindsightApiToken": "t", "bankId": "proj"}))
+    p.write_text(json.dumps({"hindsightApiToken": "t", "globalBank": "me"}))
     cfg = load_config(config_file=p, env={})
     assert cfg.hindsight_api_token == "t"
-    assert cfg.bank_id == "proj"
+    assert cfg.global_bank == "me"
+
+
+def test_legacy_bank_id_maps_to_global_bank(tmp_path):
+    # Pre-0.2 configs stored the single bank under ``bankId``.
+    p = tmp_path / "devin-desktop.json"
+    p.write_text(json.dumps({"bankId": "legacy"}))
+    cfg = load_config(config_file=p, env={})
+    assert cfg.global_bank == "legacy"
+
+
+def test_global_bank_wins_over_legacy_alias(tmp_path):
+    p = tmp_path / "devin-desktop.json"
+    p.write_text(json.dumps({"bankId": "legacy", "globalBank": "current"}))
+    assert load_config(config_file=p, env={}).global_bank == "current"
 
 
 def test_env_overrides_file(tmp_path):
     p = tmp_path / "devin-desktop.json"
-    p.write_text(json.dumps({"bankId": "from-file"}))
-    cfg = load_config(config_file=p, env={"HINDSIGHT_DEVIN_DESKTOP_BANK_ID": "from-env", "HINDSIGHT_API_TOKEN": "k"})
-    assert cfg.bank_id == "from-env"
+    p.write_text(json.dumps({"globalBank": "from-file"}))
+    cfg = load_config(
+        config_file=p,
+        env={"HINDSIGHT_DEVIN_DESKTOP_GLOBAL_BANK": "from-env", "HINDSIGHT_API_TOKEN": "k"},
+    )
+    assert cfg.global_bank == "from-env"
     assert cfg.hindsight_api_token == "k"
+
+
+def test_env_sets_project_bank_override(tmp_path):
+    cfg = load_config(config_file=tmp_path / "missing.json", env={"HINDSIGHT_DEVIN_DESKTOP_BANK_ID": "proj"})
+    assert cfg.project_bank == "proj"
 
 
 def test_malformed_file_falls_back(tmp_path):
     p = tmp_path / "devin-desktop.json"
     p.write_text("{ broken")
-    assert load_config(config_file=p, env={}).bank_id == DEFAULT_BANK_ID
+    assert load_config(config_file=p, env={}).global_bank == DEFAULT_GLOBAL_BANK

--- a/hindsight-integrations/devin-desktop/tests/test_devin_local.py
+++ b/hindsight-integrations/devin-desktop/tests/test_devin_local.py
@@ -2,8 +2,10 @@
 
 import json
 
+import hindsight_devin_desktop.devin_local as dl
 from hindsight_devin_desktop.devin_local import (
     ALLOW_PATTERN,
+    HOOK_EVENT,
     SERVER_NAME,
     agents_installed,
     apply_to_config,
@@ -12,6 +14,7 @@ from hindsight_devin_desktop.devin_local import (
     default_config_path,
     default_global_agents_path,
     default_project_agents_path,
+    hook_installed,
     is_installed,
     remove_from_config,
     write_global_agents,
@@ -122,3 +125,60 @@ class TestAgentsMd:
         write_global_agents(p, "devin-desktop")
         clear_agents(p)
         assert not agents_installed(p)
+
+
+class TestAutoRecallHook:
+    def test_apply_adds_hook_by_default(self, tmp_path):
+        p = tmp_path / "config.json"
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
+        data = json.loads(p.read_text())
+        assert HOOK_EVENT in data["hooks"]
+        cmd = data["hooks"][HOOK_EVENT][0]["hooks"][0]["command"]
+        assert "hindsight_devin_desktop.hook" in cmd and "recall" in cmd
+        assert hook_installed(p)
+
+    def test_with_hook_false_omits_hook(self, tmp_path):
+        p = tmp_path / "config.json"
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"), with_hook=False)
+        assert "hooks" not in json.loads(p.read_text())
+        assert not hook_installed(p)
+
+    def test_preserves_other_hooks(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"hooks": {HOOK_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
+        groups = json.loads(p.read_text())["hooks"][HOOK_EVENT]
+        cmds = [h["command"] for g in groups for h in g["hooks"]]
+        assert "echo hi" in cmds  # user's hook kept
+        assert any("hindsight_devin_desktop.hook" in c for c in cmds)  # ours added
+
+    def test_unchanged_includes_hook_state(self, tmp_path):
+        p = tmp_path / "config.json"
+        s = build_http_server("http://localhost:8888", "k", "b")
+        apply_to_config(p, s)
+        assert apply_to_config(p, s).action == "unchanged"
+
+    def test_remove_strips_hook_keeps_other(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"hooks": {HOOK_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
+        remove_from_config(p)
+        data = json.loads(p.read_text())
+        cmds = [h["command"] for g in data.get("hooks", {}).get(HOOK_EVENT, []) for h in g["hooks"]]
+        assert "echo hi" in cmds  # user's hook survives
+        assert not any("hindsight_devin_desktop.hook" in c for c in cmds)  # ours gone
+
+
+class TestWindowsPaths:
+    def test_windows_uses_appdata(self, monkeypatch):
+        monkeypatch.setattr(dl.sys, "platform", "win32")
+        monkeypatch.setenv("APPDATA", r"C:\Users\dev\AppData\Roaming")
+        # Path uses forward slashes internally on posix test hosts; check the segments.
+        cfg = dl.default_config_path()
+        assert cfg.name == "config.json"
+        assert "devin" in cfg.parts
+        assert any("Roaming" in part for part in cfg.parts)
+
+    def test_posix_uses_config_dir(self, monkeypatch):
+        monkeypatch.setattr(dl.sys, "platform", "darwin")
+        assert str(default_config_path()).endswith("/.config/devin/config.json")

--- a/hindsight-integrations/devin-desktop/tests/test_devin_local.py
+++ b/hindsight-integrations/devin-desktop/tests/test_devin_local.py
@@ -5,7 +5,8 @@ import json
 import hindsight_devin_desktop.devin_local as dl
 from hindsight_devin_desktop.devin_local import (
     ALLOW_PATTERN,
-    HOOK_EVENT,
+    RECALL_EVENT,
+    RETAIN_EVENT,
     SERVER_NAME,
     agents_installed,
     apply_to_config,
@@ -127,28 +128,36 @@ class TestAgentsMd:
         assert not agents_installed(p)
 
 
-class TestAutoRecallHook:
-    def test_apply_adds_hook_by_default(self, tmp_path):
+class TestHooks:
+    def _cmds(self, data, event):
+        return [h["command"] for g in data.get("hooks", {}).get(event, []) for h in g["hooks"]]
+
+    def test_both_hooks_by_default(self, tmp_path):
         p = tmp_path / "config.json"
         apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
         data = json.loads(p.read_text())
-        assert HOOK_EVENT in data["hooks"]
-        cmd = data["hooks"][HOOK_EVENT][0]["hooks"][0]["command"]
-        assert "hindsight_devin_desktop.hook" in cmd and "recall" in cmd
-        assert hook_installed(p)
+        assert any("hook recall" in c for c in self._cmds(data, RECALL_EVENT))
+        assert any("hook retain-nudge" in c for c in self._cmds(data, RETAIN_EVENT))
+        assert hook_installed(p, "recall") and hook_installed(p, "retain-nudge")
 
-    def test_with_hook_false_omits_hook(self, tmp_path):
+    def test_no_hooks(self, tmp_path):
         p = tmp_path / "config.json"
-        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"), with_hook=False)
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"), recall_hook=False, retain_hook=False)
         assert "hooks" not in json.loads(p.read_text())
-        assert not hook_installed(p)
+        assert not hook_installed(p, "recall") and not hook_installed(p, "retain-nudge")
+
+    def test_recall_only(self, tmp_path):
+        p = tmp_path / "config.json"
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"), retain_hook=False)
+        assert hook_installed(p, "recall")
+        assert not hook_installed(p, "retain-nudge")
+        assert RETAIN_EVENT not in json.loads(p.read_text()).get("hooks", {})
 
     def test_preserves_other_hooks(self, tmp_path):
         p = tmp_path / "config.json"
-        p.write_text(json.dumps({"hooks": {HOOK_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
+        p.write_text(json.dumps({"hooks": {RECALL_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
         apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
-        groups = json.loads(p.read_text())["hooks"][HOOK_EVENT]
-        cmds = [h["command"] for g in groups for h in g["hooks"]]
+        cmds = self._cmds(json.loads(p.read_text()), RECALL_EVENT)
         assert "echo hi" in cmds  # user's hook kept
         assert any("hindsight_devin_desktop.hook" in c for c in cmds)  # ours added
 
@@ -158,15 +167,15 @@ class TestAutoRecallHook:
         apply_to_config(p, s)
         assert apply_to_config(p, s).action == "unchanged"
 
-    def test_remove_strips_hook_keeps_other(self, tmp_path):
+    def test_remove_strips_hooks_keeps_other(self, tmp_path):
         p = tmp_path / "config.json"
-        p.write_text(json.dumps({"hooks": {HOOK_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
+        p.write_text(json.dumps({"hooks": {RECALL_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))
         apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
         remove_from_config(p)
         data = json.loads(p.read_text())
-        cmds = [h["command"] for g in data.get("hooks", {}).get(HOOK_EVENT, []) for h in g["hooks"]]
-        assert "echo hi" in cmds  # user's hook survives
-        assert not any("hindsight_devin_desktop.hook" in c for c in cmds)  # ours gone
+        assert "echo hi" in self._cmds(data, RECALL_EVENT)  # user's hook survives
+        assert not any("hindsight_devin_desktop.hook" in c for c in self._cmds(data, RECALL_EVENT))
+        assert RETAIN_EVENT not in data.get("hooks", {})  # ours gone
 
 
 class TestWindowsPaths:

--- a/hindsight-integrations/devin-desktop/tests/test_devin_local.py
+++ b/hindsight-integrations/devin-desktop/tests/test_devin_local.py
@@ -1,0 +1,124 @@
+"""Tests for the Devin Local agent wiring (config.json + AGENTS.md)."""
+
+import json
+
+from hindsight_devin_desktop.devin_local import (
+    ALLOW_PATTERN,
+    SERVER_NAME,
+    agents_installed,
+    apply_to_config,
+    build_http_server,
+    clear_agents,
+    default_config_path,
+    default_global_agents_path,
+    default_project_agents_path,
+    is_installed,
+    remove_from_config,
+    write_global_agents,
+    write_project_agents,
+)
+
+
+class TestBuildServer:
+    def test_uses_url_transport_and_headers(self):
+        s = build_http_server("https://api.hindsight.vectorize.io", "hsk_x", "devin-desktop")
+        assert s["url"] == "https://api.hindsight.vectorize.io/mcp/"
+        assert s["transport"] == "http"
+        assert s["headers"]["Authorization"] == "Bearer hsk_x"
+        assert s["headers"]["X-Bank-Id"] == "devin-desktop"
+        assert "serverUrl" not in s  # that's Cascade's field
+
+    def test_open_server_omits_auth_keeps_bank(self):
+        s = build_http_server("http://localhost:8888", None, "devin-desktop")
+        assert s["url"] == "http://localhost:8888/mcp/"
+        assert s["headers"] == {"X-Bank-Id": "devin-desktop"}
+
+
+class TestDefaultPaths:
+    def test_paths(self):
+        assert str(default_config_path()).endswith("/.config/devin/config.json")
+        assert str(default_global_agents_path()).endswith("/.config/devin/AGENTS.md")
+        assert default_project_agents_path().name == "AGENTS.md"
+
+
+class TestApplyConfig:
+    def test_creates_with_server_and_allow(self, tmp_path):
+        p = tmp_path / "config.json"
+        s = build_http_server("http://localhost:8888", "k", "b")
+        result = apply_to_config(p, s)
+        assert result.action == "created"
+        data = json.loads(p.read_text())
+        assert data["mcpServers"][SERVER_NAME] == s
+        assert ALLOW_PATTERN in data["permissions"]["allow"]
+
+    def test_preserves_existing_keys(self, tmp_path):
+        p = tmp_path / "config.json"
+        # e.g. a real Devin Local config that already has a version + a user allow rule
+        p.write_text(json.dumps({"version": 1, "permissions": {"allow": ["mcp__other__*"]}}))
+        s = build_http_server("http://localhost:8888", "k", "b")
+        result = apply_to_config(p, s)
+        assert result.action == "merged"
+        data = json.loads(p.read_text())
+        assert data["version"] == 1  # preserved
+        assert "mcp__other__*" in data["permissions"]["allow"]  # user's rule kept
+        assert ALLOW_PATTERN in data["permissions"]["allow"]  # ours added
+
+    def test_unchanged_when_identical(self, tmp_path):
+        p = tmp_path / "config.json"
+        s = build_http_server("http://localhost:8888", "k", "b")
+        apply_to_config(p, s)
+        assert apply_to_config(p, s).action == "unchanged"
+
+    def test_non_json_returns_manual(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text("{ not json")
+        s = build_http_server("http://localhost:8888", "k", "b")
+        result = apply_to_config(p, s)
+        assert result.action == "manual"
+        assert result.snippet and SERVER_NAME in result.snippet
+        assert p.read_text() == "{ not json"  # untouched
+
+    def test_is_installed(self, tmp_path):
+        p = tmp_path / "config.json"
+        assert is_installed(p) is False
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
+        assert is_installed(p) is True
+
+
+class TestRemoveConfig:
+    def test_removes_server_and_allow_keeps_rest(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"version": 1, "permissions": {"allow": ["mcp__other__*"]}}))
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"))
+        result = remove_from_config(p)
+        assert result.action == "removed"
+        data = json.loads(p.read_text())
+        assert "mcpServers" not in data
+        assert data["version"] == 1  # preserved
+        assert data["permissions"]["allow"] == ["mcp__other__*"]  # only ours removed
+
+    def test_unchanged_when_absent(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"version": 1}))
+        assert remove_from_config(p).action == "unchanged"
+
+
+class TestAgentsMd:
+    def test_project_names_both_banks(self, tmp_path):
+        p = tmp_path / "AGENTS.md"
+        write_project_agents(p, "devin-desktop-acme-web", "devin-desktop")
+        text = p.read_text()
+        assert "devin-desktop-acme-web" in text and "devin-desktop" in text
+        assert agents_installed(p)
+
+    def test_global_names_global_bank(self, tmp_path):
+        p = tmp_path / "AGENTS.md"
+        write_global_agents(p, "devin-desktop")
+        assert "devin-desktop" in p.read_text()
+        assert agents_installed(p)
+
+    def test_clear(self, tmp_path):
+        p = tmp_path / "AGENTS.md"
+        write_global_agents(p, "devin-desktop")
+        clear_agents(p)
+        assert not agents_installed(p)

--- a/hindsight-integrations/devin-desktop/tests/test_devin_local.py
+++ b/hindsight-integrations/devin-desktop/tests/test_devin_local.py
@@ -167,6 +167,22 @@ class TestHooks:
         apply_to_config(p, s)
         assert apply_to_config(p, s).action == "unchanged"
 
+    def test_local_only_appends_flag(self, tmp_path):
+        p = tmp_path / "config.json"
+        apply_to_config(p, build_http_server("http://localhost:8888", "k", "b"), local_only=True)
+        data = json.loads(p.read_text())
+        assert all("--local-only" in c for c in self._cmds(data, RECALL_EVENT))
+        assert all("--local-only" in c for c in self._cmds(data, RETAIN_EVENT))
+
+    def test_switching_mode_updates_command(self, tmp_path):
+        p = tmp_path / "config.json"
+        s = build_http_server("http://localhost:8888", "k", "b")
+        apply_to_config(p, s)  # two-tier (no flag)
+        assert "--local-only" not in self._cmds(json.loads(p.read_text()), RECALL_EVENT)[0]
+        result = apply_to_config(p, s, local_only=True)  # switch to local-only
+        assert result.action == "merged"  # command changed → not "unchanged"
+        assert "--local-only" in self._cmds(json.loads(p.read_text()), RECALL_EVENT)[0]
+
     def test_remove_strips_hooks_keeps_other(self, tmp_path):
         p = tmp_path / "config.json"
         p.write_text(json.dumps({"hooks": {RECALL_EVENT: [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}))

--- a/hindsight-integrations/devin-desktop/tests/test_e2e.py
+++ b/hindsight-integrations/devin-desktop/tests/test_e2e.py
@@ -40,7 +40,8 @@ def _rpc(url, payload, session=None):
 
 
 def test_mcp_endpoint_lists_memory_tools():
-    url = mcp_endpoint_url(HINDSIGHT_API_URL, "devin-desktop-e2e")
+    # Multi-bank endpoint (no bank pinned in the path).
+    url = mcp_endpoint_url(HINDSIGHT_API_URL)
     init = {
         "jsonrpc": "2.0",
         "id": 1,

--- a/hindsight-integrations/devin-desktop/tests/test_global_rules.py
+++ b/hindsight-integrations/devin-desktop/tests/test_global_rules.py
@@ -1,0 +1,79 @@
+"""Tests for the global_rules.md managed-block writer."""
+
+from hindsight_devin_desktop.global_rules import (
+    BEGIN_MARKER,
+    END_MARKER,
+    clear_global_rule,
+    default_global_rules_path,
+    is_installed,
+    write_global_rule,
+)
+
+GLOBAL = "devin-desktop"
+
+
+def test_default_path():
+    p = default_global_rules_path()
+    assert p.name == "global_rules.md"
+    assert p.parent.name == "memories"
+    assert p.parent.parent.name == "windsurf"
+
+
+def test_creates_with_managed_block(tmp_path):
+    path = tmp_path / "global_rules.md"
+    result = write_global_rule(path, GLOBAL)
+    assert result.action == "created"
+    text = path.read_text()
+    assert BEGIN_MARKER in text and END_MARKER in text
+    assert GLOBAL in text
+    assert is_installed(path)
+
+
+def test_preserves_user_content(tmp_path):
+    path = tmp_path / "global_rules.md"
+    path.write_text("# My global rules\n\nAlways use tabs.\n")
+    write_global_rule(path, GLOBAL)
+    text = path.read_text()
+    assert text.startswith(BEGIN_MARKER)  # our block leads
+    assert "My global rules" in text and "Always use tabs." in text
+
+
+def test_idempotent_single_block(tmp_path):
+    path = tmp_path / "global_rules.md"
+    path.write_text("# Mine\n")
+    write_global_rule(path, GLOBAL)
+    write_global_rule(path, GLOBAL)
+    text = path.read_text()
+    assert text.count(BEGIN_MARKER) == 1
+    assert "# Mine" in text
+
+
+def test_second_write_is_unchanged(tmp_path):
+    path = tmp_path / "global_rules.md"
+    write_global_rule(path, GLOBAL)
+    assert write_global_rule(path, GLOBAL).action == "unchanged"
+
+
+def test_over_cap_reported(tmp_path):
+    path = tmp_path / "global_rules.md"
+    path.write_text("x" * 6000)
+    result = write_global_rule(path, GLOBAL)
+    assert result.over_cap is not None and result.over_cap > 6000
+
+
+def test_clear_removes_block_keeps_user_content(tmp_path):
+    path = tmp_path / "global_rules.md"
+    path.write_text("# Mine\n\nkeep me\n")
+    write_global_rule(path, GLOBAL)
+    clear_global_rule(path)
+    text = path.read_text()
+    assert BEGIN_MARKER not in text
+    assert "keep me" in text
+    assert not is_installed(path)
+
+
+def test_clear_deletes_file_if_only_our_block(tmp_path):
+    path = tmp_path / "global_rules.md"
+    write_global_rule(path, GLOBAL)
+    clear_global_rule(path)
+    assert not path.exists()

--- a/hindsight-integrations/devin-desktop/tests/test_hook.py
+++ b/hindsight-integrations/devin-desktop/tests/test_hook.py
@@ -104,6 +104,26 @@ def test_cmd_recall_error_reports_status(tmp_path, monkeypatch, capsys):
     assert "unavailable" in ctx.lower()
 
 
+def test_recall_local_only_skips_global(tmp_path, monkeypatch):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+    banks = []
+    monkeypatch.setattr(hook, "_recall", lambda url, token, bank: banks.append(bank) or [])
+    hook.cmd_recall(local_only=True)
+    # only the derived project bank is recalled, not the shared "devin-desktop" bank
+    assert "devin-desktop" not in banks
+    assert any(b.startswith("devin-desktop-") for b in banks)
+
+
+def test_retain_nudge_local_only_one_bank(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+    hook.cmd_retain_nudge({"stop_hook_active": False}, local_only=True)
+    reason = json.loads(capsys.readouterr().out)["reason"]
+    assert "USER facts" not in reason  # not the two-tier routing phrasing
+    assert "retain" in reason.lower()
+
+
 def test_retain_nudge_blocks_once(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
     monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))

--- a/hindsight-integrations/devin-desktop/tests/test_hook.py
+++ b/hindsight-integrations/devin-desktop/tests/test_hook.py
@@ -52,8 +52,9 @@ def test_context_loaded_both_sections():
     out = hook._context_loaded("proj-bank", ["uses Postgres 16"], "global-bank", ["prefers tabs"])
     assert "proj-bank" in out and "uses Postgres 16" in out
     assert "global-bank" in out and "prefers tabs" in out
-    assert out.startswith("🧠 Hindsight memory loaded")
-    assert "tell the user" in out.lower()  # instructs the model to surface it
+    assert "PRELOADED" in out  # names the session-start preload
+    assert "telling the user" in out.lower()  # instructs the model to surface it
+    assert "preloaded 2 memories" in out.lower()  # 1 project + 1 user
 
 
 def test_context_loaded_project_only():
@@ -87,7 +88,7 @@ def test_cmd_recall_empty_reports_status(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(hook, "_recall", lambda url, token, bank: [])
     assert hook.cmd_recall() == 0
     ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
-    assert "empty" in ctx.lower()
+    assert "nothing stored" in ctx.lower() and "session start" in ctx.lower()
 
 
 def test_cmd_recall_error_reports_status(tmp_path, monkeypatch, capsys):

--- a/hindsight-integrations/devin-desktop/tests/test_hook.py
+++ b/hindsight-integrations/devin-desktop/tests/test_hook.py
@@ -1,0 +1,99 @@
+"""Tests for the Devin Local SessionStart auto-recall hook."""
+
+import json
+
+from hindsight_devin_desktop import devin_local, hook
+
+
+def _config(tmp_path, token="hsk_x", bank="devin-desktop"):
+    p = tmp_path / "config.json"
+    p.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "hindsight": {
+                        "url": "http://localhost:8888/mcp/",
+                        "transport": "http",
+                        "headers": {"Authorization": f"Bearer {token}", "X-Bank-Id": bank},
+                    }
+                }
+            }
+        )
+    )
+    return p
+
+
+def test_extract_connection():
+    data = json.loads(_config_text())
+    url, token, bank = hook._extract_connection(data)
+    assert url == "http://localhost:8888/mcp/"
+    assert token == "hsk_x"
+    assert bank == "devin-desktop"
+
+
+def _config_text():
+    return json.dumps(
+        {
+            "mcpServers": {
+                "hindsight": {
+                    "url": "http://localhost:8888/mcp/",
+                    "headers": {"Authorization": "Bearer hsk_x", "X-Bank-Id": "devin-desktop"},
+                }
+            }
+        }
+    )
+
+
+def test_extract_connection_missing():
+    assert hook._extract_connection({}) == (None, None, None)
+
+
+def test_format_context_both_sections():
+    out = hook._format_context("proj-bank", ["uses Postgres 16"], "global-bank", ["prefers tabs"])
+    assert "proj-bank" in out and "uses Postgres 16" in out
+    assert "global-bank" in out and "prefers tabs" in out
+    assert out.startswith("Relevant long-term memory")
+
+
+def test_format_context_project_only():
+    out = hook._format_context("proj-bank", ["uses Postgres 16"], "global-bank", [])
+    assert "uses Postgres 16" in out
+    assert "About the user" not in out
+
+
+def test_cmd_recall_no_config_emits_nothing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: tmp_path / "missing.json")
+    assert hook.cmd_recall() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cmd_recall_emits_additional_context(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+    # Avoid any network: fake recall returns bank-specific memories.
+    monkeypatch.setattr(hook, "_recall", lambda url, token, bank: ["mem in " + bank])
+    assert hook.cmd_recall() == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "mem in devin-desktop" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_cmd_recall_empty_emits_nothing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(hook, "_recall", lambda url, token, bank: [])
+    assert hook.cmd_recall() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_recall_never_raises(tmp_path, monkeypatch):
+    # Even if recall blows up, the hook must exit 0 (never break a session).
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+
+    def boom(*a, **k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(hook, "_recall", boom)
+    assert hook.main(["recall"]) == 0

--- a/hindsight-integrations/devin-desktop/tests/test_hook.py
+++ b/hindsight-integrations/devin-desktop/tests/test_hook.py
@@ -48,15 +48,16 @@ def test_extract_connection_missing():
     assert hook._extract_connection({}) == (None, None, None)
 
 
-def test_format_context_both_sections():
-    out = hook._format_context("proj-bank", ["uses Postgres 16"], "global-bank", ["prefers tabs"])
+def test_context_loaded_both_sections():
+    out = hook._context_loaded("proj-bank", ["uses Postgres 16"], "global-bank", ["prefers tabs"])
     assert "proj-bank" in out and "uses Postgres 16" in out
     assert "global-bank" in out and "prefers tabs" in out
-    assert out.startswith("Relevant long-term memory")
+    assert out.startswith("🧠 Hindsight memory loaded")
+    assert "tell the user" in out.lower()  # instructs the model to surface it
 
 
-def test_format_context_project_only():
-    out = hook._format_context("proj-bank", ["uses Postgres 16"], "global-bank", [])
+def test_context_loaded_project_only():
+    out = hook._context_loaded("proj-bank", ["uses Postgres 16"], "global-bank", [])
     assert "uses Postgres 16" in out
     assert "About the user" not in out
 
@@ -79,11 +80,55 @@ def test_cmd_recall_emits_additional_context(tmp_path, monkeypatch, capsys):
     assert "mem in devin-desktop" in payload["hookSpecificOutput"]["additionalContext"]
 
 
-def test_cmd_recall_empty_emits_nothing(tmp_path, monkeypatch, capsys):
+def test_cmd_recall_empty_reports_status(tmp_path, monkeypatch, capsys):
+    # No silent failures: an empty bank still reports "empty", not nothing.
     monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
     monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
     monkeypatch.setattr(hook, "_recall", lambda url, token, bank: [])
     assert hook.cmd_recall() == 0
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "empty" in ctx.lower()
+
+
+def test_cmd_recall_error_reports_status(tmp_path, monkeypatch, capsys):
+    # No silent failures: a recall exception surfaces a warning, still exits 0.
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+
+    def boom(url, token, bank):
+        raise ConnectionError("down")
+
+    monkeypatch.setattr(hook, "_recall", boom)
+    assert hook.cmd_recall() == 0
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "unavailable" in ctx.lower()
+
+
+def test_retain_nudge_blocks_once(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    monkeypatch.setenv("DEVIN_PROJECT_DIR", str(tmp_path))
+    # First stop: block with a retain instruction.
+    assert hook.cmd_retain_nudge({"stop_hook_active": False}) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decision"] == "block"
+    assert "retain" in payload["reason"].lower()
+
+
+def test_retain_nudge_no_loop_when_active(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(devin_local, "default_config_path", lambda: _config(tmp_path))
+    # Already nudged this turn -> allow stop, emit nothing (no loop).
+    assert hook.cmd_retain_nudge({"stop_hook_active": True}) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_banner_prints_for_hindsight_tool(capsys):
+    hook.cmd_banner({"tool_info": {"mcp_server_name": "hindsight", "mcp_tool_name": "recall"}})
+    out = capsys.readouterr().out
+    assert "Hindsight" in out and "recall" in out
+
+
+def test_banner_silent_for_other_server(capsys):
+    hook.cmd_banner({"tool_info": {"mcp_server_name": "github", "mcp_tool_name": "list_commits"}})
     assert capsys.readouterr().out == ""
 
 

--- a/hindsight-integrations/devin-desktop/tests/test_managed_block.py
+++ b/hindsight-integrations/devin-desktop/tests/test_managed_block.py
@@ -1,0 +1,57 @@
+"""Tests for the shared managed-block writer."""
+
+from hindsight_devin_desktop.managed_block import BEGIN_MARKER, END_MARKER, clear, has, upsert
+
+
+def test_creates_with_block(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    action, size = upsert(p, "hello body")
+    assert action == "created"
+    text = p.read_text()
+    assert BEGIN_MARKER in text and END_MARKER in text and "hello body" in text
+    assert size == len(text)
+    assert has(p)
+
+
+def test_preserves_user_content_on_top(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# My rules\n\nBe terse.\n")
+    upsert(p, "hindsight body")
+    text = p.read_text()
+    assert text.startswith(BEGIN_MARKER)
+    assert "# My rules" in text and "Be terse." in text
+
+
+def test_idempotent(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Mine\n")
+    upsert(p, "body")
+    action, _ = upsert(p, "body")
+    assert action == "unchanged"
+    assert p.read_text().count(BEGIN_MARKER) == 1
+    assert "# Mine" in p.read_text()
+
+
+def test_update_changes_body(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    upsert(p, "old")
+    action, _ = upsert(p, "new body")
+    assert action == "updated"
+    assert "new body" in p.read_text() and "old" not in p.read_text()
+
+
+def test_clear_keeps_user_content(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Mine\n\nkeep\n")
+    upsert(p, "body")
+    clear(p)
+    assert BEGIN_MARKER not in p.read_text()
+    assert "keep" in p.read_text()
+    assert not has(p)
+
+
+def test_clear_deletes_file_if_only_block(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    upsert(p, "body")
+    clear(p)
+    assert not p.exists()

--- a/hindsight-integrations/devin-desktop/tests/test_mcp_config.py
+++ b/hindsight-integrations/devin-desktop/tests/test_mcp_config.py
@@ -6,6 +6,7 @@ from hindsight_devin_desktop.mcp_config import (
     SERVER_NAME,
     apply_to_mcp,
     build_http_server,
+    default_mcp_paths,
     is_installed,
     mcp_endpoint_url,
     remove_from_mcp,
@@ -14,22 +15,35 @@ from hindsight_devin_desktop.mcp_config import (
 
 
 class TestBuildServer:
-    def test_endpoint_url_embeds_bank(self):
-        assert mcp_endpoint_url("https://api.hindsight.vectorize.io", "proj") == (
-            "https://api.hindsight.vectorize.io/mcp/proj/"
-        )
-        assert mcp_endpoint_url("http://localhost:8888/", "b") == "http://localhost:8888/mcp/b/"
+    def test_endpoint_url_is_multibank(self):
+        # Multi-bank mode: the endpoint ends at /mcp/ with no bank pinned.
+        assert mcp_endpoint_url("https://api.hindsight.vectorize.io") == "https://api.hindsight.vectorize.io/mcp/"
+        assert mcp_endpoint_url("http://localhost:8888/") == "http://localhost:8888/mcp/"
 
-    def test_cloud_server_uses_serverurl_with_auth_header(self):
-        s = build_http_server("https://api.hindsight.vectorize.io", "hsk_abc", "proj")
-        assert s["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/proj/"
-        assert s["headers"] == {"Authorization": "Bearer hsk_abc"}
+    def test_cloud_server_uses_serverurl_with_auth_and_default_bank(self):
+        s = build_http_server("https://api.hindsight.vectorize.io", "hsk_abc", "devin-desktop")
+        assert s["serverUrl"] == "https://api.hindsight.vectorize.io/mcp/"
+        assert s["headers"]["Authorization"] == "Bearer hsk_abc"
+        assert s["headers"]["X-Bank-Id"] == "devin-desktop"  # fallback bank
         assert "type" not in s and "url" not in s
 
-    def test_open_server_omits_headers(self):
-        s = build_http_server("http://localhost:8888", None, "proj")
-        assert s == {"serverUrl": "http://localhost:8888/mcp/proj/"}
-        assert "headers" not in s
+    def test_open_server_omits_auth_but_keeps_default_bank(self):
+        s = build_http_server("http://localhost:8888", None, "devin-desktop")
+        assert s["serverUrl"] == "http://localhost:8888/mcp/"
+        assert s["headers"] == {"X-Bank-Id": "devin-desktop"}
+
+    def test_no_token_no_bank_omits_headers(self):
+        s = build_http_server("http://localhost:8888", None, None)
+        assert s == {"serverUrl": "http://localhost:8888/mcp/"}
+
+    def test_default_paths_cover_both_documented_locations(self):
+        paths = default_mcp_paths()
+        assert len(paths) == 2
+        rendered = {str(p) for p in paths}
+        # Both documented locations under ~/.codeium (Devin's docs conflict).
+        assert any(p.endswith("/.codeium/windsurf/mcp_config.json") for p in rendered)
+        assert any(p.endswith("/.codeium/mcp_config.json") for p in rendered)
+        assert all(p.name == "mcp_config.json" for p in paths)
 
 
 class TestApply:

--- a/hindsight-integrations/devin-desktop/tests/test_project.py
+++ b/hindsight-integrations/devin-desktop/tests/test_project.py
@@ -1,0 +1,60 @@
+"""Tests for per-project bank derivation."""
+
+import subprocess
+
+import pytest
+
+from hindsight_devin_desktop.project import derive_project_slug, project_bank_id, slug_from_remote
+
+
+class TestSlugFromRemote:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("git@github.com:acme/web.git", "acme-web"),
+            ("https://github.com/acme/web.git", "acme-web"),
+            ("https://github.com/acme/web", "acme-web"),
+            ("ssh://git@github.com/acme/web.git", "acme-web"),
+            ("git@gitlab.com:group/sub/proj.git", "group-sub-proj"),
+            ("https://user:token@github.com/Acme/My_Repo.git", "acme-my-repo"),
+        ],
+    )
+    def test_owner_repo_slug(self, url, expected):
+        assert slug_from_remote(url) == expected
+
+    def test_same_slug_across_protocols(self):
+        # Teammates cloning over different protocols get the same project bank.
+        assert slug_from_remote("git@github.com:acme/web.git") == slug_from_remote("https://github.com/acme/web.git")
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+class TestDerive:
+    def test_prefers_git_remote(self, tmp_path):
+        _git(["init", "-q"], tmp_path)
+        _git(["remote", "add", "origin", "git@github.com:acme/web.git"], tmp_path)
+        slug, source = derive_project_slug(tmp_path)
+        assert slug == "acme-web"
+        assert "remote" in source
+
+    def test_falls_back_to_repo_folder(self, tmp_path):
+        repo = tmp_path / "MyCoolRepo"
+        repo.mkdir()
+        _git(["init", "-q"], repo)  # no remote
+        slug, source = derive_project_slug(repo)
+        assert slug == "mycoolrepo"
+        assert "folder" in source
+
+    def test_falls_back_to_folder_without_git(self, tmp_path):
+        plain = tmp_path / "Plain Dir"
+        plain.mkdir()
+        slug, source = derive_project_slug(plain)
+        assert slug == "plain-dir"
+
+    def test_project_bank_id_prefixes_global(self, tmp_path):
+        _git(["init", "-q"], tmp_path)
+        _git(["remote", "add", "origin", "git@github.com:acme/web.git"], tmp_path)
+        bank, _ = project_bank_id("devin-desktop", tmp_path)
+        assert bank == "devin-desktop-acme-web"

--- a/hindsight-integrations/devin-desktop/tests/test_rules.py
+++ b/hindsight-integrations/devin-desktop/tests/test_rules.py
@@ -52,6 +52,14 @@ def test_rule_mentions_new_tools():
         assert tool in text
 
 
+def test_local_only_single_bank():
+    # global_bank=None => everything goes to the one project bank, no shared bank.
+    text = render_rule_text(PROJECT, None)
+    assert PROJECT in text
+    assert GLOBAL not in text.replace(PROJECT, "")  # no separate global bank named
+    assert "one bank" in text.lower() and "no shared cross-project" in text.lower()
+
+
 def test_always_on_frontmatter(tmp_path):
     path = tmp_path / "hindsight.md"
     write_rule(path, PROJECT, GLOBAL)

--- a/hindsight-integrations/devin-desktop/tests/test_rules.py
+++ b/hindsight-integrations/devin-desktop/tests/test_rules.py
@@ -1,14 +1,17 @@
 """Tests for the .devin/rules/hindsight.md rule writer."""
 
 from hindsight_devin_desktop.rules import (
-    RULE_TEXT,
     SENTINEL,
     clear_rule,
     default_rules_path,
     is_installed,
     render_rule,
+    render_rule_text,
     write_rule,
 )
+
+PROJECT = "devin-desktop-acme-web"
+GLOBAL = "devin-desktop"
 
 
 def test_default_path_is_devin_rules():
@@ -20,33 +23,55 @@ def test_default_path_is_devin_rules():
 
 def test_write_creates_dedicated_file(tmp_path):
     path = tmp_path / "hindsight.md"
-    write_rule(path)
+    write_rule(path, PROJECT, GLOBAL)
     text = path.read_text()
     assert SENTINEL in text and "recall" in text and "retain" in text
     assert is_installed(path)
 
 
+def test_rule_names_both_banks(tmp_path):
+    path = tmp_path / "hindsight.md"
+    write_rule(path, PROJECT, GLOBAL)
+    text = path.read_text()
+    assert PROJECT in text and GLOBAL in text
+    # explicit bank_id routing guidance
+    assert f'bank_id: "{PROJECT}"' in text or f'bank_id "{PROJECT}"' in text
+
+
+def test_rule_reverses_dont_mention_to_mention(tmp_path):
+    path = tmp_path / "hindsight.md"
+    write_rule(path, PROJECT, GLOBAL)
+    text = path.read_text().lower()
+    assert "do not mention" not in text
+    assert "tell the user when you use memory" in text
+
+
+def test_rule_mentions_new_tools():
+    text = render_rule_text(PROJECT, GLOBAL)
+    for tool in ("recall", "retain", "sync_retain", "reflect"):
+        assert tool in text
+
+
 def test_always_on_frontmatter(tmp_path):
     path = tmp_path / "hindsight.md"
-    write_rule(path)
+    write_rule(path, PROJECT, GLOBAL)
     text = path.read_text()
-    # Frontmatter must lead the file and declare always-on activation.
     assert text.startswith("---\n")
     assert "trigger: always_on" in text.split("---", 2)[1]
 
 
 def test_write_is_idempotent(tmp_path):
     path = tmp_path / "hindsight.md"
-    write_rule(path)
+    write_rule(path, PROJECT, GLOBAL)
     first = path.read_text()
-    write_rule(path)
+    write_rule(path, PROJECT, GLOBAL)
     assert path.read_text() == first
     assert path.read_text().count(SENTINEL) == 1
 
 
 def test_clear_deletes_our_file(tmp_path):
     path = tmp_path / "hindsight.md"
-    write_rule(path)
+    write_rule(path, PROJECT, GLOBAL)
     clear_rule(path)
     assert not path.exists()
 
@@ -58,7 +83,8 @@ def test_clear_leaves_foreign_file(tmp_path):
     assert path.exists()  # no sentinel -> not ours -> untouched
 
 
-def test_render_rule_mentions_all_tools():
-    rendered = render_rule()
-    for tool in ("recall", "retain", "reflect"):
-        assert tool in RULE_TEXT and tool in rendered
+def test_render_rule_wraps_body_in_frontmatter():
+    rendered = render_rule(PROJECT, GLOBAL)
+    assert rendered.startswith("---\n")
+    assert SENTINEL in rendered
+    assert PROJECT in rendered

--- a/hindsight-integrations/devin-desktop/uv.lock
+++ b/hindsight-integrations/devin-desktop/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-devin-desktop"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Why

The Devin Desktop integration hardcoded a **single shared bank** (`devin-desktop`), so every project the user worked on wrote into one memory pool — architecture/decisions from repo A bled into repo B's reasoning (banks isolate the *synthesized* layer too: observations + mental models are computed per-bank). This reworks it into proper **per-project isolation + a shared cross-project bank**, and makes Hindsight usage **visible in chat** (no sound — an explicit product decision).

Follow-up to the just-published **0.1.0**; this is **0.2.0**.

## What changed

**Two-tier bank scoping (multi-bank mode)**
- Connect to the multi-bank `/mcp/` endpoint (was `/mcp/<bank>/`); the model routes `bank_id` per call, guided by the committed rule.
- **Global bank** `devin-desktop` (user prefs/style) — named in `~/.codeium/windsurf/memories/global_rules.md`.
- **Project bank** `devin-desktop-<slug>` — `<slug>` derived from the repo's **git remote** (stable across machines and identical for teammates) — named in the committed `.devin/rules/hindsight.md`.
- `X-Bank-Id: <global>` header as the fallback bank when a call omits `bank_id`.

**Visible memory use (no sound)**
- The always-on rule now tells the agent to briefly acknowledge memory use in chat (reverses the prior "do not mention" line) and to use `reflect` / `sync_retain`.

**Audit fixes (from a docs review of current Devin Desktop)**
- Write **both** documented MCP config locations (`~/.codeium/windsurf/mcp_config.json` and `~/.codeium/mcp_config.json`) — Devin's own docs disagree on the path.
- Explicit **"press Refresh in the MCP panel"** step (config doesn't hot-reload).

**New modules:** `project.py` (git-derivation), `global_rules.py` (managed block in `global_rules.md`).
**Backward-compatible:** legacy `bankId` in `~/.hindsight/devin-desktop.json` maps to the global bank.

## Verification

- **55 unit tests** pass; `ruff check` + `ruff format` clean.
- **Real CLI `init`** in a git repo → all three files generate correctly, project bank derived from the git remote.
- **Live-Cloud round-trip** (`sync_retain` → `recall` across two banks): each bank returns only its own fact — **zero cross-bank leak** — confirming multi-bank routing + isolation + read-after-write on production. (Multi-bank mode + `X-Bank-Id` also verified live on Hindsight Cloud.)

## Reliability note

Routing depends on the model passing the correct `bank_id` per the always-on rule — inherent to Devin's global-only MCP config (no per-workspace MCP file). The `X-Bank-Id` header defaults omitted calls to the global bank as a safety net; the committed rule (which names the exact banks) is the primary lever.

## Deferred (separate follow-up)

Auto-bootstrapping an auto-refreshing mental model per bank ("Project architecture" / "User style").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
