### PR TITLE
fix(control-plane): show bank name (fallback bank_id) in bank selector

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -505,7 +505,11 @@ function BankSelectorInner() {
               aria-expanded={open}
               className="w-[250px] justify-between font-bold border-2 border-primary hover:bg-accent"
             >
-              <span className="truncate">{currentBank || tNavBank("select")}</span>
+              <span className="truncate">
+                {bankInfos.find((b) => b.bank_id === currentBank)?.name ||
+                  currentBank ||
+                  tNavBank("select")}
+              </span>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
@@ -555,8 +559,11 @@ function BankSelectorInner() {
                               isSelected ? "opacity-100" : "opacity-0"
                             )}
                           />
-                          <span className="truncate flex-1 font-medium" title={bank.bank_id}>
-                            {bank.bank_id}
+                          <span
+                            className="truncate flex-1 font-medium"
+                            title={bank.name || bank.bank_id}
+                          >
+                            {bank.name || bank.bank_id}
                           </span>
                           <button
                             type="button"


### PR DESCRIPTION
## Summary

Fixes #2686.

The bank selector rendered `bank_id` for both the dropdown items and the selected-bank trigger, ignoring the bank's friendly `name` — even though it's already on `BankInfo` (`bank-context.tsx`) and returned by the dataplane. Admins who rename a bank via `PATCH /v1/default/banks/{bank_id}` (or multi-tenant setups with ugly `bank_id`s like `tenant_abc123`) only ever saw the immutable id.

## Change (`bank-selector.tsx`)

- **Dropdown items** (the reporter's target): render `bank.name || bank.bank_id` (label + `title`).
- **Trigger** (the selected bank): look up the current bank's name in `bankInfos`, falling back to `currentBank` then the "select" placeholder — so there's **no regression** before the bank list loads or when a bank has no name.

`bank_id` is deliberately preserved everywhere it's an **identifier**: the `CommandItem` `key`/`value`, selection/navigation, and the copy-to-clipboard action (operators paste the id into API/config).

## Notes

- No test: the control-plane vitest env is `environment: "node"` (no jsdom for component-render tests), and this is a pure display fallback with no extractable logic.
- `tsc --noEmit` and `eslint` clean on the changed file (the 2 unused-var warnings on `BankInfo`/`banks` are pre-existing on `main`, unrelated to this change).