### PR TITLE
docs(retain): correct entity resolution (no nickname resolution)

### DIFF
--- a/hindsight-docs/docs/developer/retain.md
+++ b/hindsight-docs/docs/developer/retain.md
@@ -89,9 +89,10 @@ Hindsight automatically identifies and tracks **entities** — the people, organ
 
 ### Entity Resolution
 
-The same entity mentioned different ways gets unified:
+The same entity mentioned different ways gets unified through **fuzzy name matching**, reinforced by co-occurrence and temporal proximity:
 - "Alice" + "Alice Chen" + "Alice C." → one person
-- "Bob" + "Robert Chen" → one person (nickname resolution)
+
+Because resolution keys off name similarity, close variants merge automatically. Names that do not resemble each other (a nickname and an unrelated formal name, for example) are not unified on the name alone, though shared co-occurring entities can still link them.
 
 **Why it matters:** You can ask "What do I know about Alice?" and get everything, even if she was mentioned as "Alice Chen" in some conversations.
 


### PR DESCRIPTION
## Summary

The Entity Resolution section of `retain.md` claimed:

> - "Bob" + "Robert Chen" → one person (nickname resolution)

There is **no nickname/alias resolution** in the code. Resolution in `entity_resolver.py` is:
- fuzzy name similarity (`SequenceMatcher`, ~0.5 weight),
- co-occurring-entity overlap (~0.3 weight),
- temporal proximity,

combined against a ~0.6 acceptance threshold. Dissimilar strings like "Bob" and "Robert Chen" score near-zero on name similarity and are **not** unified on the name alone, so the example was misleading.

## Change

- Reframe the section around **fuzzy name matching** (the mechanism that actually merges "Alice" / "Alice Chen" / "Alice C.").
- Remove the "Bob" + "Robert Chen" nickname example.
- Add an honest caveat that dissimilar names are not unified by name alone (though shared co-occurring entities can still link them).

## Verification

Confirmed against `hindsight-api-slim/hindsight_api/engine/retain/entity_resolver.py` (name similarity + co-occurrence + temporal scoring, threshold 0.6; no `nickname`/`alias` logic exists in the resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)