### PR TITLE
fix(retain): reassert resolved entities before linking units

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -173,6 +173,22 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        """Protect resolved parents and reinsert any that disappeared before linking.
+
+        Existing rows are locked in deterministic ID order; missing rows are
+        inserted idempotently in the same transaction as unit_entities.
+        """
+        ...
+
+    @abstractmethod
     async def bulk_insert_unit_entities(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -216,7 +216,7 @@ class OracleOps(DataAccessOps):
         for orig_name in missing_names:
             row = await conn.fetchrow(
                 f"""
-                SELECT id, LOWER(canonical_name) AS name_lower
+                SELECT id, canonical_name, LOWER(canonical_name) AS name_lower, $2 AS input_name
                 FROM {table}
                 WHERE bank_id = $1 AND LOWER(canonical_name) = LOWER($2)
                 """,
@@ -224,9 +224,32 @@ class OracleOps(DataAccessOps):
                 orig_name,
             )
             if row:
-                # Wrap in a dict-like to include input_name for downstream compat
                 results.append(row)
         return results
+
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        # Oracle has no FOR KEY SHARE. Lock existing parents in the same stable
+        # order; IDs already pruned are absent here and recreated below.
+        for entity_id in entity_ids:
+            await conn.fetchrow(
+                f"SELECT id FROM {table} WHERE id = $1 FOR UPDATE",
+                entity_id,
+            )
+        await conn.executemany(
+            f"""
+            INSERT INTO {table} (id, bank_id, canonical_name)
+            VALUES ($1, $2, $3)
+            ON CONFLICT DO NOTHING
+            """,
+            [(entity_id, bank_id, canonical_name) for entity_id, canonical_name in zip(entity_ids, canonical_names)],
+        )
 
     async def bulk_insert_unit_entities(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -275,7 +275,7 @@ class PostgreSQLOps(DataAccessOps):
     ) -> list[ResultRow]:
         return await conn.fetch(
             f"""
-            SELECT e.id, LOWER(e.canonical_name) AS name_lower, inputs.input_name
+            SELECT e.id, e.canonical_name, LOWER(e.canonical_name) AS name_lower, inputs.input_name
             FROM {table} e
             JOIN (
                 SELECT LOWER(n) AS input_name_lower, n AS input_name
@@ -285,6 +285,39 @@ class PostgreSQLOps(DataAccessOps):
             """,
             bank_id,
             missing_names,
+        )
+
+    async def bulk_reassert_entities(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+        entity_ids: list[str],
+        canonical_names: list[str],
+    ) -> None:
+        # ON CONFLICT DO NOTHING does not lock an existing row. Lock first so
+        # orphan pruning cannot delete a parent between this method and the FK
+        # insert; IDs absent at this snapshot are recreated below.
+        await conn.fetch(
+            f"""
+            SELECT id
+            FROM {table}
+            WHERE id = ANY($1::uuid[])
+            ORDER BY id
+            FOR KEY SHARE
+            """,
+            entity_ids,
+        )
+        await conn.execute(
+            f"""
+            INSERT INTO {table} (id, bank_id, canonical_name)
+            SELECT entity_id, $1, canonical_name
+            FROM unnest($2::uuid[], $3::text[]) AS t(entity_id, canonical_name)
+            ON CONFLICT DO NOTHING
+            """,
+            bank_id,
+            entity_ids,
+            canonical_names,
         )
 
     async def bulk_insert_unit_entities(

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from .db_utils import acquire_with_retry
 from .memory_engine import fq_table
@@ -25,6 +25,7 @@ from .retain.entity_labels import (
 from .retain.entity_labels import (
     parse_entity_labels as _parse_entity_labels,
 )
+from .retain.types import ResolvedEntity
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +231,7 @@ class EntityResolver:
         unit_event_date,
         conn=None,
         entity_labels: list | None = None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Resolve multiple entities in batch (MUCH faster than sequential).
 
@@ -245,7 +246,7 @@ class EntityResolver:
             conn: Optional connection to use (if None, acquires from pool)
 
         Returns:
-            List of entity IDs in same order as input
+            Resolved entity IDs and canonical names in the same order as input
         """
         if not entities_data:
             return []
@@ -271,7 +272,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         if self.entity_lookup == "trigram":
             # Route to backend-specific fuzzy strategy.
             # Non-PG backends (Oracle) use UTL_MATCH instead of pg_trgm.
@@ -311,7 +312,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """Original strategy: load all bank entities then match in Python."""
         # Query ALL candidates for this bank
         all_entities = await conn.fetch(
@@ -395,7 +396,7 @@ class EntityResolver:
         unit_event_date,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Trigram strategy: fetch only similar candidates per entity name using pg_trgm.
 
@@ -499,7 +500,7 @@ class EntityResolver:
         unit_event_date: datetime | None,
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """
         Oracle strategy: fetch similar candidates using UTL_MATCH.JARO_WINKLER_SIMILARITY.
 
@@ -607,11 +608,11 @@ class EntityResolver:
         cooccurrence_map: dict[str, set[str]],
         taxonomy_lookup: set[str] | None = None,
         labels_cfg=None,
-    ) -> list[str]:
+    ) -> list[ResolvedEntity]:
         """Shared scoring + upsert logic used by both lookup strategies."""
 
         # Resolve each entity using pre-fetched candidates
-        entity_ids = [None] * len(entities_data)
+        resolved_entities: list[ResolvedEntity | None] = [None] * len(entities_data)
         entities_to_update: list[_EntityStat] = []
         entities_to_create: list[_EntityToCreate] = []
 
@@ -638,21 +639,23 @@ class EntityResolver:
 
             if is_label:
                 # Exact case-insensitive match only for label entities
-                exact_match = None
+                exact_match: ResolvedEntity | None = None
                 entity_text_lower = entity_text.lower()
                 for candidate_id, canonical_name, metadata, last_seen, mention_count in candidates:
                     if canonical_name.lower() == entity_text_lower:
-                        exact_match = candidate_id
+                        exact_match = ResolvedEntity(entity_id=candidate_id, canonical_name=canonical_name)
                         break
                 if exact_match:
-                    entity_ids[idx] = exact_match
-                    entities_to_update.append(_EntityStat(entity_id=exact_match, event_date=entity_event_date))
+                    resolved_entities[idx] = exact_match
+                    entities_to_update.append(
+                        _EntityStat(entity_id=str(exact_match.entity_id), event_date=entity_event_date)
+                    )
                 else:
                     entities_to_create.append(_EntityToCreate(idx=idx, name=entity_text, event_date=entity_event_date))
                 continue
 
             # Score candidates
-            best_candidate = None
+            best_candidate: ResolvedEntity | None = None
             best_score = 0.0
 
             nearby_entity_set = {e["text"].lower() for e in nearby_entities if e["text"] != entity_text}
@@ -685,14 +688,16 @@ class EntityResolver:
 
                 if score > best_score:
                     best_score = score
-                    best_candidate = candidate_id
+                    best_candidate = ResolvedEntity(entity_id=candidate_id, canonical_name=canonical_name)
 
             # Apply unified threshold
             threshold = 0.6
 
             if best_score > threshold:
-                entity_ids[idx] = best_candidate
-                entities_to_update.append(_EntityStat(entity_id=best_candidate, event_date=entity_event_date))
+                resolved_entities[idx] = best_candidate
+                entities_to_update.append(
+                    _EntityStat(entity_id=str(best_candidate.entity_id), event_date=entity_event_date)
+                )
             else:
                 entities_to_create.append(
                     _EntityToCreate(idx=idx, name=entity_data["text"], event_date=entity_event_date)
@@ -738,6 +743,9 @@ class EntityResolver:
                 entity_names,
                 entity_dates,
             )
+            canonical_by_name = {
+                name_lower: group.name for name_lower, group in sorted_groups if name_lower in id_by_name
+            }
 
             # Fallback SELECT for names that conflicted (another worker won the race).
             #
@@ -759,11 +767,14 @@ class EntityResolver:
                 )
                 for row in existing_rows:
                     id_by_name[row["name_lower"]] = row["id"]
+                    canonical_by_name[row["name_lower"]] = row["canonical_name"]
                     # Also index by Python's lower() of the original input name so the
                     # assignment loop (which uses Python-lowercased keys) finds it even
                     # when Python and the database produce different lowercase strings.
                     if "input_name" in row:
-                        id_by_name[row["input_name"].lower()] = row["id"]
+                        input_name_lower = row["input_name"].lower()
+                        id_by_name[input_name_lower] = row["id"]
+                        canonical_by_name[input_name_lower] = row["canonical_name"]
 
             # Assign entity IDs back and queue one stat per original mention so that
             # flush_pending_stats() increments mention_count by the true mention count,
@@ -772,15 +783,48 @@ class EntityResolver:
                 entity_id = id_by_name.get(name_lower)
                 if entity_id:
                     for original_idx in g.indices:
-                        entity_ids[original_idx] = entity_id
-                        pending.append(_EntityStat(entity_id=entity_id, event_date=g.event_date))
+                        resolved_entities[original_idx] = ResolvedEntity(
+                            entity_id=entity_id,
+                            canonical_name=canonical_by_name.get(name_lower, g.name),
+                        )
+                        pending.append(_EntityStat(entity_id=str(entity_id), event_date=g.event_date))
 
         # Accumulate into the resolver's pending list; the orchestrator flushes
         # these with await entity_resolver.flush_pending_stats() after the txn.
         key = self._task_key()
         self._pending_stats.setdefault(key, []).extend(pending)
 
-        return entity_ids
+        return cast(list[ResolvedEntity], resolved_entities)
+
+    async def reassert_entities_batch(
+        self,
+        bank_id: str,
+        resolved_entities: list[ResolvedEntity],
+        conn,
+    ) -> None:
+        """Restore resolved parents that graph maintenance pruned between phases."""
+        seen_ids: set[str] = set()
+        unique_entities: list[ResolvedEntity] = []
+        for entity in sorted(resolved_entities, key=lambda item: str(item.entity_id)):
+            entity_id = str(entity.entity_id)
+            if entity_id in seen_ids:
+                continue
+            seen_ids.add(entity_id)
+            unique_entities.append(entity)
+
+        if not unique_entities:
+            return
+
+        # Phase 1 and Phase 2 use different transactions. Reasserting on the
+        # Phase-2 connection immediately before child links closes the window
+        # where orphan pruning can remove an already-resolved parent (#2662).
+        await self._ops.bulk_reassert_entities(
+            conn,
+            fq_table("entities"),
+            bank_id,
+            [str(entity.entity_id) for entity in unique_entities],
+            [entity.canonical_name for entity in unique_entities],
+        )
 
     async def link_units_to_entities_batch(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6613,7 +6613,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # the graph-maintenance run this edit submits.
                     if new_entities is not None:
                         entity_date = new_occ_start or live["mentioned_at"]
-                        _resolved_ids, _e2u, unit_to_entity_ids = await resolve_entities_only(
+                        entity_resolution = await resolve_entities_only(
                             self.entity_resolver,
                             conn,
                             bank_id,
@@ -6625,7 +6625,7 @@ class MemoryEngine(MemoryEngineInterface):
                             entity_labels=entity_labels,
                         )
                         await conn.execute(f"DELETE FROM {ue} WHERE unit_id = $1", str(memory_uuid))
-                        resolved_for_unit = unit_to_entity_ids.get(str(memory_uuid), [])
+                        resolved_for_unit = entity_resolution.unit_to_entity_ids.get(str(memory_uuid), [])
                         if resolved_for_unit:
                             await self.entity_resolver.link_units_to_entities_batch(
                                 [(str(memory_uuid), eid, entity_date) for eid in resolved_for_unit],

--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_processing.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_processing.py
@@ -7,7 +7,7 @@ Handles entity extraction and resolution for stored facts.
 import logging
 
 from . import link_utils
-from .types import ProcessedFact
+from .types import EntityResolutionResult, ProcessedFact
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ async def resolve_entities(
     log_buffer: list[str] = None,
     user_entities_per_content: dict[int, list[dict]] = None,
     entity_labels: list | None = None,
-) -> tuple[list[str], list[tuple], dict[str, list[str]]]:
+) -> EntityResolutionResult:
     """
     Phase 1: Resolve entity names to canonical IDs (read-heavy).
 
@@ -76,10 +76,10 @@ async def resolve_entities(
         entity_labels: Optional entity label taxonomy
 
     Returns:
-        Tuple of (resolved_entity_ids, entity_to_unit, unit_to_entity_ids).
+        Typed identities and unit mappings from Phase 1.
     """
     if not unit_ids or not facts:
-        return [], [], {}
+        return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
 
     if len(unit_ids) != len(facts):
         raise ValueError(f"Mismatch between unit_ids ({len(unit_ids)}) and facts ({len(facts)})")

--- a/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/link_utils.py
@@ -10,7 +10,7 @@ from ..._vector_index import ann_search_tuning_settings, configured_vector_exten
 from ..db.base import DatabaseConnection
 from ..db.ops import DataAccessOps
 from ..memory_engine import fq_table
-from .types import CausalRelation
+from .types import CausalRelation, EntityResolutionResult
 
 logger = logging.getLogger(__name__)
 
@@ -305,7 +305,7 @@ async def resolve_entities_only(
     llm_entities: list[list[dict]],
     log_buffer: list[str] = None,
     entity_labels: list | None = None,
-) -> tuple[list[str], list[tuple], dict[str, list[str]]]:
+) -> EntityResolutionResult:
     """
     Phase 1 of entity processing: resolve entity names to canonical IDs.
 
@@ -326,10 +326,7 @@ async def resolve_entities_only(
         entity_labels: Optional entity label taxonomy
 
     Returns:
-        Tuple of (resolved_entity_ids, entity_to_unit, unit_to_entity_ids) where:
-        - resolved_entity_ids: list of entity IDs in same order as flattened entities
-        - entity_to_unit: maps flat index to (unit_id, local_index, fact_date)
-        - unit_to_entity_ids: maps unit_id to list of resolved entity IDs
+        Typed resolution result with identities and unit mappings.
     """
     all_entities_flat, _all_entities, entity_to_unit = _prepare_entities_for_resolution(
         unit_ids, sentences, fact_dates, llm_entities, log_buffer
@@ -337,10 +334,10 @@ async def resolve_entities_only(
 
     if not all_entities_flat:
         _log(log_buffer, "  [6.2] Entity resolution (batched): 0 entities", level="debug")
-        return [], [], {}
+        return EntityResolutionResult(resolved_entities=[], entity_to_unit=[], unit_to_entity_ids={})
 
     step_start = time.time()
-    resolved_entity_ids = await entity_resolver.resolve_entities_batch(
+    resolved_entities = await entity_resolver.resolve_entities_batch(
         bank_id=bank_id,
         entities_data=all_entities_flat,
         context=context,
@@ -359,7 +356,7 @@ async def resolve_entities_only(
     for idx, (unit_id, _local_idx, _fact_date) in enumerate(entity_to_unit):
         if unit_id not in unit_to_entity_ids:
             unit_to_entity_ids[unit_id] = []
-        unit_to_entity_ids[unit_id].append(resolved_entity_ids[idx])
+        unit_to_entity_ids[unit_id].append(str(resolved_entities[idx].entity_id))
 
     _log(
         log_buffer,
@@ -367,7 +364,11 @@ async def resolve_entities_only(
         level="debug",
     )
 
-    return resolved_entity_ids, entity_to_unit, unit_to_entity_ids
+    return EntityResolutionResult(
+        resolved_entities=resolved_entities,
+        entity_to_unit=entity_to_unit,
+        unit_to_entity_ids=unit_to_entity_ids,
+    )
 
 
 async def create_temporal_links_batch_per_fact(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -247,9 +247,9 @@ from . import (
 )
 from .types import (
     ChunkMetadata,
-    EntityResolutionResult,
     Phase1Result,
     ProcessedFact,
+    ResolvedEntity,
     RetainContent,
     RetainContentDict,
 )
@@ -344,7 +344,7 @@ async def _pre_resolve_phase1(
     embeddings = [fact.embedding for fact in processed_facts]
 
     async with acquire_with_retry(pool) as resolve_conn:
-        resolved_entity_ids, entity_to_unit, unit_to_entity_ids = await entity_processing.resolve_entities(
+        entity_resolution = await entity_processing.resolve_entities(
             entity_resolver,
             resolve_conn,
             bank_id,
@@ -366,11 +366,7 @@ async def _pre_resolve_phase1(
             )
 
     return Phase1Result(
-        entities=EntityResolutionResult(
-            resolved_entity_ids=resolved_entity_ids,
-            entity_to_unit=entity_to_unit,
-            unit_to_entity_ids=unit_to_entity_ids,
-        ),
+        entities=entity_resolution,
         semantic_ann_links=semantic_ann_links,
     )
 
@@ -421,7 +417,7 @@ async def _insert_facts_and_links(
     processed_facts: list[ProcessedFact],
     config,
     log_buffer: list[str],
-    resolved_entity_ids: list[str],
+    resolved_entities: list[ResolvedEntity],
     entity_to_unit: list[tuple],
     unit_to_entity_ids: dict[str, list[str]],
     semantic_ann_links: list[tuple],
@@ -448,6 +444,7 @@ async def _insert_facts_and_links(
         # Entity resolution was done in Phase 1 (separate connection).
         # Remap placeholder IDs to actual unit IDs.
         step_start = time.time()
+        resolved_entity_ids = [str(entity.entity_id) for entity in resolved_entities]
         remapped_entity_to_unit, _remapped_unit_to_entity_ids, remapped_semantic = _remap_phase1_results(
             resolved_entity_ids, entity_to_unit, unit_to_entity_ids, semantic_ann_links or [], unit_ids
         )
@@ -460,6 +457,7 @@ async def _insert_facts_and_links(
             (unit_id, resolved_entity_ids[idx], fact_date)
             for idx, (unit_id, _local_idx, fact_date) in enumerate(remapped_entity_to_unit)
         ]
+        await entity_resolver.reassert_entities_batch(bank_id, resolved_entities, conn=conn)
         await entity_resolver.link_units_to_entities_batch(unit_entity_pairs, conn=conn)
         log_buffer.append(f"  Insert unit_entities: {len(unit_entity_pairs)} pairs in {time.time() - step_start:.3f}s")
 
@@ -1602,7 +1600,7 @@ async def _streaming_retain_batch(
                         batch_processed,
                         config,
                         log_buffer,
-                        resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                        resolved_entities=phase1.entities.resolved_entities,
                         entity_to_unit=phase1.entities.entity_to_unit,
                         unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                         semantic_ann_links=[],
@@ -2198,7 +2196,7 @@ async def _try_delta_retain(
                     processed_facts,
                     config,
                     log_buffer,
-                    resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                    resolved_entities=phase1.entities.resolved_entities,
                     entity_to_unit=phase1.entities.entity_to_unit,
                     unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                     semantic_ann_links=phase1.semantic_ann_links,

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -229,6 +229,14 @@ class ProcessedFact:
 
 
 @dataclass
+class ResolvedEntity:
+    """Entity identity carried from resolution into the write transaction."""
+
+    entity_id: str | UUID
+    canonical_name: str
+
+
+@dataclass
 class EntityResolutionResult:
     """
     Result of Phase 1 entity resolution.
@@ -237,9 +245,14 @@ class EntityResolutionResult:
     placeholder unit IDs to real IDs after fact insertion in Phase 2.
     """
 
-    resolved_entity_ids: list[str]
+    resolved_entities: list[ResolvedEntity]
     entity_to_unit: list[tuple]
     unit_to_entity_ids: dict[str, list[str]]
+
+    @property
+    def resolved_entity_ids(self) -> list[str]:
+        """Return IDs in the flattened entity order used by link creation."""
+        return [str(entity.entity_id) for entity in self.resolved_entities]
 
 
 @dataclass

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -538,7 +538,7 @@ async def _import_one_document(
                 processed_facts,
                 config,
                 log_buffer,
-                resolved_entity_ids=phase1.entities.resolved_entity_ids,
+                resolved_entities=phase1.entities.resolved_entities,
                 entity_to_unit=phase1.entities.entity_to_unit,
                 unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
                 semantic_ann_links=phase1.semantic_ann_links,

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -9,7 +9,6 @@ and verify label entities are extracted and stored correctly.
 """
 
 import uuid
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -2194,7 +2193,7 @@ async def test_entity_resolution_does_not_merge_distinct_label_values(memory, re
         ]
 
         async with memory._pool.acquire() as conn:
-            resolved_entity_ids, entity_to_unit, unit_to_entity_ids = await resolve_entities(
+            resolution = await resolve_entities(
                 entity_resolver=memory.entity_resolver,
                 conn=conn,
                 bank_id=bank_id,
@@ -2202,6 +2201,7 @@ async def test_entity_resolution_does_not_merge_distinct_label_values(memory, re
                 facts=facts,
                 entity_labels=entity_labels,
             )
+        resolved_entity_ids = resolution.resolved_entity_ids
 
         # We should get 2 DISTINCT entity IDs, not the same ID twice
         assert len(resolved_entity_ids) == 2, f"Expected 2 resolved entity IDs, got {len(resolved_entity_ids)}"

--- a/hindsight-api-slim/tests/test_entity_resolver.py
+++ b/hindsight-api-slim/tests/test_entity_resolver.py
@@ -5,13 +5,14 @@ Tests for EntityResolver edge cases.
 import json
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from hindsight_api.engine.db import create_database_backend
 from hindsight_api.engine.db.result import DictResultRow as ResultRow
 from hindsight_api.engine.entity_resolver import EntityResolver
+from hindsight_api.engine.retain.types import ResolvedEntity
 from hindsight_api.pg0 import resolve_database_url
 
 # ---------------------------------------------------------------------------
@@ -85,7 +86,7 @@ async def test_resolve_entities_batch_handles_unicode_lower_conflicts(pg0_db_url
                 event_date,
             )
 
-            resolved_ids = await resolver.resolve_entities_batch(
+            resolved_entities = await resolver.resolve_entities_batch(
                 bank_id=bank_id,
                 entities_data=[
                     {
@@ -109,7 +110,7 @@ async def test_resolve_entities_batch_handles_unicode_lower_conflicts(pg0_db_url
                 bank_id,
             )
 
-        assert resolved_ids == [existing_entity_id]
+        assert resolved_entities == [ResolvedEntity(entity_id=existing_entity_id, canonical_name="İstanbul")]
         assert len(entity_rows) == 1
         assert entity_rows[0]["id"] == existing_entity_id
         assert entity_rows[0]["canonical_name"] == "İstanbul"

--- a/hindsight-api-slim/tests/test_retain_entity_prune_race.py
+++ b/hindsight-api-slim/tests/test_retain_entity_prune_race.py
@@ -1,0 +1,217 @@
+"""Regression coverage for the retain Phase-1 / orphan-prune race (#2662)."""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from hindsight_api.engine.db import create_database_backend
+from hindsight_api.engine.db.ops_oracle import OracleOps
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+from hindsight_api.engine.db.postgresql import PostgresConnection
+from hindsight_api.engine.entity_resolver import EntityResolver
+from hindsight_api.engine.memory_engine import fq_table
+from hindsight_api.engine.retain.orchestrator import (
+    _insert_facts_and_links,
+    _pre_resolve_phase1,
+)
+from hindsight_api.engine.retain.types import EntityRef, ProcessedFact, ResolvedEntity, RetainContent
+from hindsight_api.pg0 import resolve_database_url
+
+
+@pytest.mark.asyncio
+async def test_oracle_reassert_locks_entities_in_stable_order_before_insert():
+    """The Oracle adapter must acquire parent locks before its idempotent insert."""
+    ops = OracleOps()
+    resolver = EntityResolver(pool=SimpleNamespace(ops=ops))
+    conn = AsyncMock()
+    resolved_entities = [
+        ResolvedEntity(entity_id="00000000-0000-0000-0000-000000000002", canonical_name="Bob"),
+        ResolvedEntity(entity_id="00000000-0000-0000-0000-000000000001", canonical_name="Alice"),
+    ]
+
+    await resolver.reassert_entities_batch("bank-1", resolved_entities, conn)
+
+    lock_ids = [awaited.args[1] for awaited in conn.fetchrow.await_args_list]
+    assert lock_ids == sorted(lock_ids)
+    assert all("FOR UPDATE" in awaited.args[0] for awaited in conn.fetchrow.await_args_list)
+    insert_sql, rows = conn.executemany.await_args.args
+    assert "ON CONFLICT DO NOTHING" in insert_sql
+    assert rows == [
+        ("00000000-0000-0000-0000-000000000001", "bank-1", "Alice"),
+        ("00000000-0000-0000-0000-000000000002", "bank-1", "Bob"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reassert_locks_existing_parent_until_child_insert(pg0_db_url):
+    """Pruning must block when the parent still exists at reassert time."""
+    bank_id = f"test-reassert-lock-{uuid.uuid4().hex[:8]}"
+    setup = await asyncpg.connect(pg0_db_url)
+    phase2_conn = await asyncpg.connect(pg0_db_url)
+    prune_conn = await asyncpg.connect(pg0_db_url)
+    ops = PostgreSQLOps()
+
+    try:
+        entity_id = await setup.fetchval(
+            "INSERT INTO entities (bank_id, canonical_name) VALUES ($1, 'Alice Smith') RETURNING id",
+            bank_id,
+        )
+
+        phase2_tx = phase2_conn.transaction()
+        await phase2_tx.start()
+        unit_id = await phase2_conn.fetchval(
+            """
+            INSERT INTO memory_units (bank_id, text, event_date, fact_type)
+            VALUES ($1, 'Alice Smith joined the project.', now(), 'world')
+            RETURNING id
+            """,
+            bank_id,
+        )
+        wrapped_phase2 = PostgresConnection(phase2_conn)
+        await ops.bulk_reassert_entities(
+            wrapped_phase2,
+            "entities",
+            bank_id,
+            [str(entity_id)],
+            ["Alice Smith"],
+        )
+
+        await prune_conn.execute("SET statement_timeout = '500ms'")
+        with pytest.raises(asyncpg.QueryCanceledError):
+            await prune_conn.execute("DELETE FROM entities WHERE id = $1", entity_id)
+
+        await ops.bulk_insert_unit_entities(
+            wrapped_phase2,
+            "unit_entities",
+            [str(unit_id)],
+            [str(entity_id)],
+        )
+        await phase2_tx.commit()
+
+        assert (
+            await setup.fetchval(
+                "SELECT count(*) FROM unit_entities WHERE unit_id = $1 AND entity_id = $2",
+                unit_id,
+                entity_id,
+            )
+            == 1
+        )
+    finally:
+        await setup.execute("DELETE FROM memory_units WHERE bank_id = $1", bank_id)
+        await setup.execute("DELETE FROM entities WHERE bank_id = $1", bank_id)
+        await setup.close()
+        await phase2_conn.close()
+        await prune_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_phase2_reasserts_entity_pruned_after_resolution(pg0_db_url):
+    """A prune between retain phases must not turn the child insert into data loss."""
+    resolved_url = await resolve_database_url(pg0_db_url)
+    backend = create_database_backend("postgresql")
+    await backend.initialize(resolved_url, min_size=1, max_size=3, command_timeout=30)
+
+    bank_id = f"test-retain-prune-race-{uuid.uuid4().hex[:8]}"
+    event_date = datetime(2026, 7, 13, 12, tzinfo=UTC)
+    resolver = EntityResolver(pool=backend, entity_lookup="full")
+    config = SimpleNamespace(entity_labels=None)
+    contents = [RetainContent(content="Alice Smit joined the project.")]
+    processed_facts = [
+        ProcessedFact(
+            fact_text="Alice Smit joined the project.",
+            fact_type="world",
+            embedding=[0.0] * 384,
+            occurred_start=event_date,
+            occurred_end=None,
+            mentioned_at=event_date,
+            context="",
+            metadata={},
+            entities=[EntityRef(name="Alice Smit")],
+        )
+    ]
+
+    try:
+        async with backend.acquire() as conn:
+            original_entity_id = await conn.fetchval(
+                f"""
+                INSERT INTO {fq_table("entities")}
+                    (bank_id, canonical_name, first_seen, last_seen, mention_count)
+                VALUES ($1, 'Alice Smith', $2, $2, 1)
+                RETURNING id
+                """,
+                bank_id,
+                event_date,
+            )
+
+        phase1 = await _pre_resolve_phase1(
+            backend,
+            resolver,
+            bank_id,
+            contents,
+            processed_facts,
+            config,
+            [],
+            skip_semantic_ann=True,
+        )
+        assert phase1.entities.resolved_entities[0].entity_id == original_entity_id
+        # The input is a fuzzy alias. Phase 2 must carry the stored canonical
+        # value because it cannot recover that value after the prune.
+        assert phase1.entities.resolved_entities[0].canonical_name == "Alice Smith"
+
+        async with backend.acquire() as prune_conn:
+            async with prune_conn.transaction():
+                pruned = await backend.ops.prune_orphan_entities(
+                    prune_conn,
+                    fq_table("entities"),
+                    fq_table("unit_entities"),
+                    bank_id,
+                )
+        assert pruned == 1
+
+        async with backend.acquire() as phase2_conn:
+            async with phase2_conn.transaction():
+                result = await _insert_facts_and_links(
+                    phase2_conn,
+                    resolver,
+                    bank_id,
+                    contents,
+                    [],
+                    processed_facts,
+                    config,
+                    [],
+                    resolved_entities=phase1.entities.resolved_entities,
+                    entity_to_unit=phase1.entities.entity_to_unit,
+                    unit_to_entity_ids=phase1.entities.unit_to_entity_ids,
+                    semantic_ann_links=[],
+                    skip_semantic_links=True,
+                    ops=backend.ops,
+                )
+
+        assert len(result[0]) == 1
+        async with backend.acquire() as verify_conn:
+            restored = await verify_conn.fetchrow(
+                f"SELECT id, canonical_name FROM {fq_table('entities')} WHERE id = $1",
+                original_entity_id,
+            )
+            linked_entity_id = await verify_conn.fetchval(
+                f"""
+                SELECT ue.entity_id
+                FROM {fq_table("unit_entities")} ue
+                JOIN {fq_table("memory_units")} mu ON mu.id = ue.unit_id
+                WHERE mu.bank_id = $1
+                """,
+                bank_id,
+            )
+
+        assert restored is not None
+        assert restored["canonical_name"] == "Alice Smith"
+        assert linked_entity_id == original_entity_id
+    finally:
+        async with backend.acquire() as conn:
+            await conn.execute(f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1", bank_id)
+            await conn.execute(f"DELETE FROM {fq_table('entities')} WHERE bank_id = $1", bank_id)
+        await backend.shutdown()


### PR DESCRIPTION
## Summary

- carry each resolved entity's ID and stored canonical name across the retain phase boundary
- in the Phase-2 write transaction, lock parents that still exist and idempotently recreate parents pruned after Phase 1
- implement the reassert operation for PostgreSQL and Oracle before inserting `unit_entities`

`ON CONFLICT DO NOTHING` alone does not lock an existing PostgreSQL row, so the PostgreSQL path first takes `FOR KEY SHARE` locks in stable ID order. The Oracle path uses its `FOR UPDATE` equivalent. This keeps orphan pruning from deleting a parent in the small interval before the child FK insert, while still restoring a parent that was already pruned.

## Tests

- added a real PostgreSQL concurrency regression proving prune blocks until the child link is inserted
- added an end-to-end Phase-1 → prune → Phase-2 regression using a fuzzy alias, verifying the original ID and canonical name are restored
- added Oracle adapter coverage for stable lock order and idempotent reinsert data
- 165 related resolver, DB abstraction, retain, curation, and transfer tests pass
- entity-label resolution regression passes
- Ruff and `ty check hindsight_api` pass

Fixes #2662
