### PR TITLE
Make the Control Plane embeddable in a cross-site iframe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -322,3 +322,31 @@ HINDSIGHT_API_LOG_LEVEL=info
 # When set, visitors see a login page and must enter the key before
 # accessing the dashboard or any /api/* routes (except /api/health).
 # HINDSIGHT_CP_ACCESS_KEY=your-shared-secret-key
+
+# --- Embedding the Control Plane in an iframe ---
+# The three settings below let another app embed the CP. Note the access key is
+# all-or-nothing: an embedded iframe is a full admin console over every bank.
+# The embedding app is therefore responsible for deciding who may load it, and
+# the access key must stay server-side (never shipped to the browser). If you
+# need per-user scoping, put a reverse proxy in front that pins each embed to
+# its own bank(s) and rejects requests referencing any other bank.
+
+# Optional: Origins allowed to embed the Control Plane in an iframe
+# (Content-Security-Policy: frame-ancestors). Space- or comma-separated list.
+# Falls back to 'self' when unset, never '*'. These origins are also the
+# allowlist for cross-site state-changing /api/* requests (the CSRF gate below),
+# so the embedding page's auto-login POST must come from an origin listed here.
+# HINDSIGHT_CP_FRAME_ANCESTORS=https://app.example.com
+
+# Optional: SameSite policy for the CP session cookie. Set to "none" so the
+# cookie survives inside a cross-site iframe (adds Secure + Partitioned/CHIPS;
+# requires HTTPS). Leave unset for local http dev to keep SameSite=Lax.
+# With "none" the browser's implicit CSRF defense is gone, so state-changing
+# /api/* requests are instead gated by an Origin check against same-origin plus
+# the HINDSIGHT_CP_FRAME_ANCESTORS allowlist above.
+# HINDSIGHT_CP_COOKIE_SAMESITE=none
+
+# To auto-login the iframe, the embedding page POSTs the access key to
+# /api/auth/embed-login (form-encoded or JSON, with an optional returnTo); the
+# CP sets the session cookie and 302s the frame to the dashboard. That POST must
+# originate from an allowlisted origin above.

--- a/hindsight-control-plane/src/app/api/auth/embed-login/route.ts
+++ b/hindsight-control-plane/src/app/api/auth/embed-login/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
+
+import {
+  ACCESS_KEY_COOKIE,
+  SESSION_MAX_AGE_SECONDS,
+  createSessionToken,
+  sessionCookieOptions,
+} from "@/lib/auth/session";
+import { sanitizeReturnTo, withBasePath } from "@/lib/base-path";
+
+const DEFAULT_RETURN_TO = "/dashboard";
+
+/**
+ * Cross-site auto-login for an embedding page. A hidden `<form target=iframe>`
+ * POSTs the access key here (form-encoded or JSON); we force-recreate the
+ * session cookie and 302 to the sanitized `returnTo` so the iframe lands
+ * directly on the dashboard. The 302 + Set-Cookie is what makes a single
+ * cross-site POST render the app.
+ *
+ * This endpoint is only reachable from an origin listed in
+ * `HINDSIGHT_CP_FRAME_ANCESTORS` (middleware applies the Origin check to
+ * `/api/auth/*` too), so a hostile page cannot silently swap a visitor's
+ * session. The embedder is responsible for deciding who may load the iframe;
+ * the access key must stay server-side and never reach the browser.
+ */
+export async function POST(request: NextRequest) {
+  const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
+  const contentType = request.headers.get("content-type") ?? "";
+  const isJson = contentType.includes("application/json");
+
+  if (!accessKey) {
+    return isJson
+      ? NextResponse.json(
+          localizeApiErrorPayload(request, {
+            error: "Access key not configured",
+            errorKey: "api.errors.auth.accessKeyNotConfigured",
+          }),
+          { status: 503 }
+        )
+      : htmlError(503, "Access key not configured");
+  }
+
+  let token: string | undefined;
+  let returnTo: string | null | undefined;
+
+  if (isJson) {
+    try {
+      const body = (await request.json()) as { token?: string; returnTo?: string };
+      token = body.token;
+      returnTo = body.returnTo;
+    } catch {
+      return NextResponse.json(
+        localizeApiErrorPayload(request, {
+          error: "Invalid request body",
+          errorKey: "api.errors.auth.invalidRequestBody",
+        }),
+        { status: 400 }
+      );
+    }
+  } else {
+    const form = await request.formData();
+    const rawToken = form.get("token");
+    const rawReturnTo = form.get("returnTo");
+    token = typeof rawToken === "string" ? rawToken : undefined;
+    returnTo = typeof rawReturnTo === "string" ? rawReturnTo : undefined;
+  }
+
+  if (!token || !constantTimeEqual(token, accessKey)) {
+    return isJson
+      ? NextResponse.json(
+          localizeApiErrorPayload(request, {
+            error: "Invalid access key",
+            errorKey: "api.errors.auth.invalidAccessKey",
+          }),
+          { status: 401 }
+        )
+      : htmlError(401, "Invalid access key");
+  }
+
+  // Relative (path-only) Location so the browser resolves it against the public
+  // origin it actually loaded, not the internal upstream host (request.url is
+  // e.g. 0.0.0.0:9999 behind a proxy). sanitizeReturnTo already forbids
+  // off-origin targets, so a relative path can never become an open redirect.
+  const target = withBasePath(sanitizeReturnTo(returnTo, DEFAULT_RETURN_TO));
+  const response = new NextResponse(null, {
+    status: 302,
+    // no-store so the session-bearing 302 is never cached by a shared proxy and
+    // replayed to another viewer.
+    headers: { Location: target, "Cache-Control": "no-store" },
+  });
+
+  response.cookies.set({
+    name: ACCESS_KEY_COOKIE,
+    value: await createSessionToken(accessKey),
+    ...sessionCookieOptions(request),
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  return response;
+}
+
+function htmlError(status: number, message: string): NextResponse {
+  return new NextResponse(`<!doctype html><html><body><p>${message}</p></body></html>`, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   try {
@@ -16,10 +16,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       );
     }
 
-    const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/observations/scopes`,
-      { headers: getDataplaneHeaders() }
-    );
+    const response = await fetch(dataplaneBankUrl(bankId, "/observations/scopes"), {
+      headers: getDataplaneHeaders(),
+    });
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }));

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/chunks/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(
   request: NextRequest,
@@ -25,7 +25,10 @@ export async function GET(
     const offset = searchParams.get("offset") || "0";
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/chunks?limit=${limit}&offset=${offset}`,
+      dataplaneBankUrl(
+        bankId,
+        `/documents/${encodeURIComponent(documentId)}/chunks?limit=${limit}&offset=${offset}`
+      ),
       {
         headers: getDataplaneHeaders(),
       }

--- a/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
+++ b/hindsight-control-plane/src/app/api/documents/[documentId]/reprocess/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function POST(
   request: NextRequest,
@@ -22,7 +22,7 @@ export async function POST(
     }
 
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/documents/${documentId}/reprocess`,
+      dataplaneBankUrl(bankId, `/documents/${encodeURIComponent(documentId)}/reprocess`),
       {
         method: "POST",
         headers: getDataplaneHeaders({ "Content-Type": "application/json" }),

--- a/hindsight-control-plane/src/app/api/graph/route.ts
+++ b/hindsight-control-plane/src/app/api/graph/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
-import { DATAPLANE_URL, getDataplaneHeaders } from "@/lib/hindsight-client";
+import { dataplaneBankUrl, getDataplaneHeaders } from "@/lib/hindsight-client";
 
 export async function GET(request: NextRequest) {
   try {
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
     const chunkId = searchParams.get("chunk_id");
     if (chunkId) params.append("chunk_id", chunkId);
 
-    const response = await fetch(`${DATAPLANE_URL}/v1/default/banks/${bankId}/graph?${params}`, {
+    const response = await fetch(dataplaneBankUrl(bankId, `/graph?${params}`), {
       headers: getDataplaneHeaders(),
     });
 

--- a/hindsight-control-plane/src/lib/auth/request-guard.ts
+++ b/hindsight-control-plane/src/lib/auth/request-guard.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from "next/server";
+
+/** Public host the client actually addressed, honoring a reverse proxy. */
+function requestHost(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-host")?.split(",")[0]?.trim() ||
+    request.headers.get("host")?.trim() ||
+    request.nextUrl.host
+  );
+}
+
+/**
+ * Absolute origins permitted to make cross-site state-changing calls, derived
+ * from `HINDSIGHT_CP_FRAME_ANCESTORS` (the same allowlist that authorizes
+ * framing). `'self'`/`'none'` are CSP keywords, not origins, so they're
+ * dropped; anything that doesn't parse as a URL is ignored.
+ */
+function allowedEmbedOrigins(): string[] {
+  return (process.env.HINDSIGHT_CP_FRAME_ANCESTORS || "")
+    .split(/[\s,]+/)
+    .filter((value) => value && value !== "'self'" && value !== "'none'")
+    .flatMap((value) => {
+      try {
+        return [new URL(value).origin];
+      } catch {
+        return [];
+      }
+    });
+}
+
+/**
+ * CSRF guard for state-changing `/api/*` calls. With `SameSite=None` (needed for
+ * cross-site iframe embedding) the session cookie rides along on cross-site
+ * requests, so `SameSite` no longer blocks CSRF; this restores that defense via
+ * an `Origin` check. A non-GET request is cross-site when its `Origin` is
+ * neither same-origin nor an allowed embed origin. When no `Origin` is present
+ * we fall back to `Sec-Fetch-Site`; when neither header is present (non-browser
+ * API clients) we allow, since a browser CSRF always carries one of them.
+ */
+export function isCrossSiteWrite(request: NextRequest): boolean {
+  const method = request.method.toUpperCase();
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") return false;
+
+  const origin = request.headers.get("origin");
+  if (origin) {
+    let originUrl: URL;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      return true;
+    }
+    if (originUrl.host === requestHost(request)) return false;
+    return !allowedEmbedOrigins().includes(originUrl.origin);
+  }
+
+  const secFetchSite = request.headers.get("sec-fetch-site");
+  if (secFetchSite) {
+    return secFetchSite !== "same-origin" && secFetchSite !== "none";
+  }
+
+  return false;
+}

--- a/hindsight-control-plane/src/lib/auth/session.ts
+++ b/hindsight-control-plane/src/lib/auth/session.ts
@@ -55,11 +55,40 @@ export function isSecureRequest(request: NextRequest): boolean {
   return request.nextUrl.protocol === "https:";
 }
 
-export function sessionCookieOptions(request: NextRequest) {
+/**
+ * Cookie attributes for the session. When `HINDSIGHT_CP_COOKIE_SAMESITE=none`
+ * the cookie is emitted as `SameSite=None; Secure; Partitioned` so it survives
+ * inside a cross-site iframe (CHIPS). Otherwise it stays `SameSite=Lax` with
+ * `Secure` derived from the request protocol, keeping plain-http dev working.
+ *
+ * Note: `SameSite=None` drops the browser's implicit CSRF defense. The Origin
+ * check in `lib/auth/request-guard.ts` (applied in middleware) is what replaces
+ * it, so the two are deliberately shipped together.
+ *
+ * `partitioned` is not yet in the Next.js cookie option types, so the return is
+ * loosely typed to carry it through to `cookies().set(...)`.
+ */
+export function sessionCookieOptions(request: NextRequest): {
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "lax" | "none";
+  path: string;
+  partitioned?: boolean;
+} {
+  if (process.env.HINDSIGHT_CP_COOKIE_SAMESITE === "none") {
+    return {
+      httpOnly: true,
+      secure: true,
+      sameSite: "none",
+      path: "/",
+      partitioned: true,
+    };
+  }
+
   return {
     httpOnly: true,
     secure: isSecureRequest(request),
-    sameSite: "lax" as const,
+    sameSite: "lax",
     path: "/",
   };
 }

--- a/hindsight-control-plane/src/lib/hindsight-client.ts
+++ b/hindsight-control-plane/src/lib/hindsight-client.ts
@@ -26,11 +26,33 @@ export function getDataplaneHeaders(extra?: Record<string, string>): Record<stri
 }
 
 /**
+ * True when a bank id contains a path separator (`/` or `\`) or a `..` path
+ * segment — the shapes that let an id escape its bank path once the URL is
+ * normalized. A bank id is a single path segment, so none of these are ever
+ * legitimate.
+ */
+export function bankIdHasTraversal(bankId: string): boolean {
+  if (bankId.includes("/") || bankId.includes("\\")) return true;
+  // A ".." segment, bounded by start/end or a separator on either side.
+  return /(^|[/\\])\.\.([/\\]|$)/.test(bankId);
+}
+
+/**
  * Build a dataplane URL for a bank-scoped endpoint with the bank id properly encoded.
- * Bank ids may contain `:`, `/`, `%`, etc. (e.g. openclaw `agent::channel::user`),
+ * Bank ids may contain `:`, `%`, etc. (e.g. openclaw `agent::channel::user`),
  * which must be percent-encoded before being interpolated into a URL path.
+ *
+ * Throws on a traversal-shaped id rather than encoding it. Encoding alone makes
+ * the id safe *here*, but a bank id reaching this helper with a `/` or `..` in
+ * it is malformed by definition, and callers that build a URL by hand would
+ * silently resolve it to a different bank once WHATWG URL normalization
+ * collapses the dot segment. Failing loudly keeps that class of bug from being
+ * reintroduced by a route that forgets to use this helper.
  */
 export function dataplaneBankUrl(bankId: string, suffix = ""): string {
+  if (bankIdHasTraversal(bankId)) {
+    throw new Error("Invalid bank_id: path separators and '..' segments are not allowed");
+  }
   return `${DATAPLANE_URL}/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
 }
 

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "Zugriffsschlüssel ist nicht konfiguriert",
         "invalidRequestBody": "Ungültiger Anfrageinhalt",
         "invalidAccessKey": "Ungültiger Zugriffsschlüssel",
-        "unauthorized": "Nicht autorisiert"
+        "unauthorized": "Nicht autorisiert",
+        "forbidden": "Verboten"
       },
       "validation": {
         "bankIdRequired": "bank_id ist erforderlich",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "Access key not configured",
         "invalidRequestBody": "Invalid request body",
         "invalidAccessKey": "Invalid access key",
-        "unauthorized": "Unauthorized"
+        "unauthorized": "Unauthorized",
+        "forbidden": "Forbidden"
       },
       "validation": {
         "bankIdRequired": "bank_id is required",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "La clave de acceso no está configurada",
         "invalidRequestBody": "El cuerpo de la solicitud no es válido",
         "invalidAccessKey": "La clave de acceso no es válida",
-        "unauthorized": "No autorizado"
+        "unauthorized": "No autorizado",
+        "forbidden": "Prohibido"
       },
       "validation": {
         "bankIdRequired": "bank_id es obligatorio",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "La clé d'accès n'est pas configurée",
         "invalidRequestBody": "Corps de requête invalide",
         "invalidAccessKey": "Clé d'accès invalide",
-        "unauthorized": "Non autorisé"
+        "unauthorized": "Non autorisé",
+        "forbidden": "Interdit"
       },
       "validation": {
         "bankIdRequired": "bank_id est obligatoire",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "アクセスキーが設定されていません",
         "invalidRequestBody": "リクエスト本文が無効です",
         "invalidAccessKey": "アクセスキーが無効です",
-        "unauthorized": "認証されていません"
+        "unauthorized": "認証されていません",
+        "forbidden": "アクセスが拒否されました"
       },
       "validation": {
         "bankIdRequired": "bank_id は必須です",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "액세스 키가 구성되지 않았습니다",
         "invalidRequestBody": "요청 본문이 유효하지 않습니다",
         "invalidAccessKey": "액세스 키가 유효하지 않습니다",
-        "unauthorized": "인증되지 않았습니다"
+        "unauthorized": "인증되지 않았습니다",
+        "forbidden": "접근이 거부되었습니다"
       },
       "validation": {
         "bankIdRequired": "bank_id는 필수입니다",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "A chave de acesso não está configurada",
         "invalidRequestBody": "O corpo da solicitação é inválido",
         "invalidAccessKey": "A chave de acesso é inválida",
-        "unauthorized": "Não autorizado"
+        "unauthorized": "Não autorizado",
+        "forbidden": "Proibido"
       },
       "validation": {
         "bankIdRequired": "bank_id é obrigatório",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "尚未設定存取金鑰",
         "invalidRequestBody": "請求內容無效",
         "invalidAccessKey": "存取金鑰無效",
-        "unauthorized": "未獲授權"
+        "unauthorized": "未獲授權",
+        "forbidden": "禁止存取"
       },
       "validation": {
         "bankIdRequired": "必須提供 bank_id",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "未配置访问密钥",
         "invalidRequestBody": "请求体无效",
         "invalidAccessKey": "访问密钥无效",
-        "unauthorized": "未授权"
+        "unauthorized": "未授权",
+        "forbidden": "禁止访问"
       },
       "validation": {
         "bankIdRequired": "bank_id 为必填项",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -1589,7 +1589,8 @@
         "accessKeyNotConfigured": "尚未設定存取金鑰",
         "invalidRequestBody": "請求內容無效",
         "invalidAccessKey": "存取金鑰無效",
-        "unauthorized": "未授權"
+        "unauthorized": "未授權",
+        "forbidden": "禁止存取"
       },
       "validation": {
         "bankIdRequired": "bank_id 為必填欄位",

--- a/hindsight-control-plane/src/middleware.ts
+++ b/hindsight-control-plane/src/middleware.ts
@@ -4,6 +4,7 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 import createIntlMiddleware from "next-intl/middleware";
 
 import { ACCESS_KEY_COOKIE, verifySessionToken } from "@/lib/auth/session";
+import { isCrossSiteWrite } from "@/lib/auth/request-guard";
 import { stripBasePath, withBasePath } from "@/lib/base-path";
 import { routing } from "@/i18n/routing";
 
@@ -22,7 +23,57 @@ const PUBLIC_PATTERNS = [
 
 const intlMiddleware = createIntlMiddleware(routing);
 
-export async function middleware(request: NextRequest) {
+function forbidden(request: NextRequest): NextResponse {
+  return NextResponse.json(
+    localizeApiErrorPayload(request, {
+      error: "Forbidden",
+      errorKey: "api.errors.auth.forbidden",
+    }),
+    { status: 403 }
+  );
+}
+
+/**
+ * Origins allowed to embed the Control Plane, read per-request so the runtime
+ * env controls framing (Next bakes next.config `headers()` at build time, which
+ * would ignore a container-time env). Space- or comma-separated; falls back to
+ * `'self'` when unset, never `*`.
+ */
+function frameAncestorsValue(): string {
+  return (process.env.HINDSIGHT_CP_FRAME_ANCESTORS || "'self'")
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .join(" ");
+}
+
+function withFrameAncestors(response: NextResponse): NextResponse {
+  response.headers.set("Content-Security-Policy", `frame-ancestors ${frameAncestorsValue()};`);
+  return response;
+}
+
+/**
+ * Public origin the client actually loaded, honoring a reverse proxy. Middleware
+ * redirects must be absolute (a relative Location makes Next throw), and
+ * request.url behind a proxy is the internal upstream host (e.g. 0.0.0.0:9999).
+ * Prefer x-forwarded-proto/x-forwarded-host, fall back to host, then nextUrl.
+ */
+function publicRedirect(request: NextRequest, path: string): NextResponse {
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost =
+    request.headers.get("x-forwarded-host")?.split(",")[0]?.trim() ||
+    request.headers.get("host")?.trim();
+
+  const proto = forwardedProto || request.nextUrl.protocol.replace(/:$/, "");
+  const host = forwardedHost || request.nextUrl.host;
+
+  return NextResponse.redirect(new URL(path, `${proto}://${host}`));
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  return withFrameAncestors(await handle(request));
+}
+
+async function handle(request: NextRequest): Promise<NextResponse> {
   const accessKey = process.env.HINDSIGHT_CP_ACCESS_KEY;
   const { pathname } = request.nextUrl;
   const appPathname = stripBasePath(pathname);
@@ -31,6 +82,16 @@ export async function middleware(request: NextRequest) {
   if (appPathname.startsWith("/api/")) {
     if (!accessKey) {
       return NextResponse.next();
+    }
+
+    // CSRF: block cross-site state-changing requests before anything else, so it
+    // also covers the public auth endpoints (`/api/auth/login`,
+    // `/api/auth/embed-login`) — otherwise a `SameSite=None` cookie lets any
+    // origin drive writes or silently swap the session (login-CSRF). Legitimate
+    // in-iframe calls are same-origin to the API; the embedding page's
+    // auto-login POST comes from a configured embed origin. Both are allowed.
+    if (isCrossSiteWrite(request)) {
+      return forbidden(request);
     }
 
     const isPublic = PUBLIC_PATTERNS.some((pattern) => appPathname.startsWith(pattern));
@@ -68,9 +129,8 @@ export async function middleware(request: NextRequest) {
         // Next.js middleware redirects do not automatically inherit next.config basePath.
         // Prefix the target explicitly, but keep returnTo as the app-relative path so
         // client-side router.push() does not double-prefix after login.
-        const loginUrl = new URL(withBasePath("/login"), request.url);
-        loginUrl.searchParams.set("returnTo", appPathname);
-        return NextResponse.redirect(loginUrl);
+        const loginPath = `${withBasePath("/login")}?returnTo=${encodeURIComponent(appPathname)}`;
+        return publicRedirect(request, loginPath);
       }
     }
   }

--- a/hindsight-control-plane/tests/lib/auth/request-guard.test.ts
+++ b/hindsight-control-plane/tests/lib/auth/request-guard.test.ts
@@ -1,0 +1,118 @@
+import type { NextRequest } from "next/server";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isCrossSiteWrite } from "@/lib/auth/request-guard";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+function fakeRequest({
+  method = "GET",
+  headers = {},
+}: {
+  method?: string;
+  headers?: Record<string, string>;
+} = {}): NextRequest {
+  return {
+    method,
+    headers: new Headers(headers),
+    nextUrl: { host: "cp.example.com" },
+  } as unknown as NextRequest;
+}
+
+describe("isCrossSiteWrite", () => {
+  it("never blocks safe methods, whatever the origin", () => {
+    expect(isCrossSiteWrite(fakeRequest({ method: "GET" }))).toBe(false);
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "GET", headers: { origin: "https://evil.com" } }))
+    ).toBe(false);
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "HEAD", headers: { origin: "https://evil.com" } }))
+    ).toBe(false);
+  });
+
+  it("allows a same-origin write", () => {
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({ method: "POST", headers: { origin: "https://cp.example.com" } })
+      )
+    ).toBe(false);
+  });
+
+  it("honors x-forwarded-host for same-origin behind a proxy", () => {
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({
+          method: "POST",
+          headers: {
+            origin: "https://public.example.com",
+            "x-forwarded-host": "public.example.com",
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("blocks a cross-site write from a non-allowlisted origin", () => {
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "POST", headers: { origin: "https://evil.com" } }))
+    ).toBe(true);
+  });
+
+  it("allows a write from a configured embed origin", () => {
+    process.env.HINDSIGHT_CP_FRAME_ANCESTORS = "https://app.example.com";
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({ method: "POST", headers: { origin: "https://app.example.com" } })
+      )
+    ).toBe(false);
+  });
+
+  it("ignores CSP keywords when reading the embed allowlist", () => {
+    process.env.HINDSIGHT_CP_FRAME_ANCESTORS = "'self' https://app.example.com";
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "POST", headers: { origin: "https://evil.com" } }))
+    ).toBe(true);
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({ method: "POST", headers: { origin: "https://app.example.com" } })
+      )
+    ).toBe(false);
+  });
+
+  it("does not treat a scheme/port mismatch as the same origin", () => {
+    process.env.HINDSIGHT_CP_FRAME_ANCESTORS = "https://app.example.com";
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({ method: "POST", headers: { origin: "http://app.example.com" } })
+      )
+    ).toBe(true);
+  });
+
+  it("falls back to Sec-Fetch-Site when Origin is absent", () => {
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "POST", headers: { "sec-fetch-site": "cross-site" } }))
+    ).toBe(true);
+    expect(
+      isCrossSiteWrite(
+        fakeRequest({ method: "POST", headers: { "sec-fetch-site": "same-origin" } })
+      )
+    ).toBe(false);
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "POST", headers: { "sec-fetch-site": "none" } }))
+    ).toBe(false);
+  });
+
+  it("allows non-browser writes that carry neither Origin nor Sec-Fetch-Site", () => {
+    expect(isCrossSiteWrite(fakeRequest({ method: "POST" }))).toBe(false);
+  });
+
+  it("blocks a write with an unparseable Origin", () => {
+    expect(
+      isCrossSiteWrite(fakeRequest({ method: "POST", headers: { origin: "not a url" } }))
+    ).toBe(true);
+  });
+});

--- a/hindsight-control-plane/tests/lib/auth/session.test.ts
+++ b/hindsight-control-plane/tests/lib/auth/session.test.ts
@@ -5,6 +5,7 @@ import {
   SESSION_MAX_AGE_SECONDS,
   createSessionToken,
   isSecureRequest,
+  sessionCookieOptions,
   verifySessionToken,
 } from "@/lib/auth/session";
 
@@ -128,6 +129,41 @@ describe("isSecureRequest", () => {
 
   it("is case-insensitive on the forwarded value", () => {
     expect(isSecureRequest(fakeRequest({ forwardedProto: "HTTPS" }))).toBe(true);
+  });
+});
+
+describe("sessionCookieOptions", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("defaults to SameSite=Lax with Secure derived from the request", () => {
+    delete process.env.HINDSIGHT_CP_COOKIE_SAMESITE;
+    expect(sessionCookieOptions(fakeRequest({ protocol: "http:" }))).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: "lax",
+      path: "/",
+    });
+    expect(sessionCookieOptions(fakeRequest({ forwardedProto: "https" })).secure).toBe(true);
+  });
+
+  it("emits SameSite=None; Secure; Partitioned when opted in, even over plain http", () => {
+    process.env.HINDSIGHT_CP_COOKIE_SAMESITE = "none";
+    expect(sessionCookieOptions(fakeRequest({ protocol: "http:" }))).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: "none",
+      path: "/",
+      partitioned: true,
+    });
+  });
+
+  it("ignores an unrelated value and stays on Lax", () => {
+    process.env.HINDSIGHT_CP_COOKIE_SAMESITE = "strict";
+    expect(sessionCookieOptions(fakeRequest()).sameSite).toBe("lax");
   });
 });
 

--- a/hindsight-control-plane/tests/lib/hindsight-client.test.ts
+++ b/hindsight-control-plane/tests/lib/hindsight-client.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@vectorize-io/hindsight-client", () => ({
+  HindsightClient: class {},
+  HindsightError: class extends Error {},
+  createClient: () => ({}),
+  createConfig: (c: unknown) => c,
+  sdk: {},
+}));
+
+import { bankIdHasTraversal, dataplaneBankUrl } from "@/lib/hindsight-client";
+
+describe("bankIdHasTraversal", () => {
+  it("flags path separators and bounded .. segments", () => {
+    expect(bankIdHasTraversal("a/b")).toBe(true);
+    expect(bankIdHasTraversal("a\\b")).toBe(true);
+    expect(bankIdHasTraversal("..")).toBe(true);
+    expect(bankIdHasTraversal("../x")).toBe(true);
+    expect(bankIdHasTraversal("x/..")).toBe(true);
+    expect(bankIdHasTraversal("u2--x/../victim")).toBe(true);
+  });
+
+  it("does not flag legitimate bank ids", () => {
+    expect(bankIdHasTraversal("u2")).toBe(false);
+    expect(bankIdHasTraversal("u2--notes")).toBe(false);
+    expect(bankIdHasTraversal("agent-1::channel-2::user-3")).toBe(false);
+    expect(bankIdHasTraversal("SX.Products.GovComply.Build")).toBe(false);
+    expect(bankIdHasTraversal("a..b")).toBe(false); // not a bounded ".." segment
+  });
+});
+
+describe("dataplaneBankUrl", () => {
+  it("percent-encodes the bank id into a single path segment", () => {
+    expect(dataplaneBankUrl("my bank")).toContain("/v1/default/banks/my%20bank");
+    expect(dataplaneBankUrl("agent-1::channel-2")).toContain(
+      "/v1/default/banks/agent-1%3A%3Achannel-2"
+    );
+  });
+
+  it("appends the suffix after the encoded id", () => {
+    expect(dataplaneBankUrl("u2", "/graph?limit=5")).toContain(
+      "/v1/default/banks/u2/graph?limit=5"
+    );
+  });
+
+  it("throws on a traversal-shaped bank id instead of building a URL", () => {
+    // Without the guard this would normalize to .../banks/victim/graph.
+    expect(() => dataplaneBankUrl("u2--x/../victim", "/graph")).toThrow(/Invalid bank_id/);
+    expect(() => dataplaneBankUrl("../victim")).toThrow(/Invalid bank_id/);
+    expect(() => dataplaneBankUrl("a\\b")).toThrow(/Invalid bank_id/);
+  });
+
+  it("keeps a normalized URL free of dot segments", () => {
+    const url = dataplaneBankUrl("u2--notes", "/documents/d1/chunks");
+    expect(new URL(url).pathname).toBe("/v1/default/banks/u2--notes/documents/d1/chunks");
+  });
+});


### PR DESCRIPTION
Reworked per review: this is now **embeddability-only**. The prefix-based authz (`tokens.ts`, `bank-guard.ts`, session prefix, middleware prefix checks, `whoami`, bank-selector `isAdmin`) has been dropped — see [the discussion below](https://github.com/vectorize-io/hindsight/pull/2698#issuecomment-5185423891). Went from 37 files / ~1050 added lines to 19 changed + 4 new.

## What this adds

Lets another app embed the Control Plane in an iframe.

- **`HINDSIGHT_CP_FRAME_ANCESTORS`** — applied as a runtime `frame-ancestors` CSP in middleware. It has to be runtime: Next bakes `next.config` `headers()` at build time, so a container-time env would be silently ignored. Falls back to `'self'`, never `*`.
- **`HINDSIGHT_CP_COOKIE_SAMESITE=none`** — emits the session cookie as `SameSite=None; Secure; Partitioned` (CHIPS) so it survives in a cross-site frame. Default stays `SameSite=Lax`, so nothing changes unless you opt in.
- **`/api/auth/embed-login`** — the embedding page POSTs the access key (form-encoded or JSON, optional `returnTo`) and the frame lands on the dashboard in one round trip via `302` + `Set-Cookie`, with `Cache-Control: no-store`.
- **Origin/CSRF gate** — `SameSite=None` drops the browser's implicit CSRF defense, so this replaces it: cross-site state-changing `/api/*` requests are rejected unless the `Origin` is same-origin or in the `frame-ancestors` allowlist. Falls back to `Sec-Fetch-Site`; header-less non-browser clients still work. Deliberately coupled to the cookie change, and applied *before* the public-path bypass so it also covers `login` and `embed-login` (login-CSRF).
- **Proxy redirect fix** — post-login redirects were building `Location` from `request.url`, which behind a reverse proxy is the internal upstream (`0.0.0.0:9999`), sending the frame somewhere dead. Now built from `x-forwarded-proto`/`x-forwarded-host`.

## Also included: bank-id traversal guard

Independent of the authz discussion, and a live bug on `main` today. Four routes hand-build their dataplane URL and interpolate `bank_id` unencoded:

- `api/graph/route.ts`
- `api/documents/[documentId]/chunks/route.ts`
- `api/documents/[documentId]/reprocess/route.ts`
- `api/banks/[bankId]/observations/scopes/route.ts`

A `bank_id` of `x/../y` normalizes to a different bank's path before it ever reaches the dataplane. These now go through `dataplaneBankUrl()`, which additionally **throws** on a path separator or `..` segment rather than encoding it — a bank id is a single path segment, so those shapes are malformed by definition, and failing loudly stops the next hand-built URL from quietly reintroducing it.

## Security model

Worth being explicit, since it drives the division of responsibility: the access key is all-or-nothing, so **an embedded iframe is a full admin console over every bank**. The embedding app decides who may load it, and the key must stay server-side and never reach the browser. For per-user scoping, put a reverse proxy in front that pins each embed to its own bank(s). This is documented in `.env.example`.

## Testing

- `tests/lib/auth/request-guard.test.ts` — Origin/CSRF logic: safe methods, same-origin (incl. `x-forwarded-host`), allowlisted embed origin, scheme/port mismatch, CSP-keyword filtering, `Sec-Fetch-Site` fallback, unparseable origin
- `tests/lib/hindsight-client.test.ts` — traversal rejection + encoding, incl. asserting a normalized URL keeps its intended path
- `tests/lib/auth/session.test.ts` — extended for the `SameSite=None; Secure; Partitioned` opt-in and the `Lax` default

138 tests pass; `i18n:check` clean (added the `forbidden` key across all 10 locales); `next build` + standalone OK.