### PR TITLE
docs(embed): expose local CPU workarounds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
 # For local provider:
 # HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
+# Force CPU if local embeddings hit MPS/XPC instability on macOS:
+# HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=false
 # For ONNX provider (local CPU embeddings without an Ollama/TEI sidecar):
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=onnx
 # HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID=intfloat/multilingual-e5-small
@@ -188,6 +190,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_PROVIDER=local
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+# Force CPU if the local reranker hits MPS/XPC instability on macOS:
+# HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -147,6 +147,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=local
 # For local provider:
 # HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5
+# Force CPU if local embeddings hit MPS/XPC instability on macOS:
+# HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=false
 # For ONNX provider (local CPU embeddings without an Ollama/TEI sidecar):
 # HINDSIGHT_API_EMBEDDINGS_PROVIDER=onnx
 # HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_ID=intfloat/multilingual-e5-small
@@ -188,6 +190,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_PROVIDER=local
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+# Force CPU if the local reranker hits MPS/XPC instability on macOS:
+# HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
 

--- a/hindsight-embed/tests/test_env_template.py
+++ b/hindsight-embed/tests/test_env_template.py
@@ -57,6 +57,14 @@ def test_documentation_is_preserved():
     assert "Supported providers:" in text
 
 
+def test_template_documents_macos_cpu_workarounds():
+    """Installed profile templates should expose both supported MPS/XPC workarounds."""
+    text = load_template()
+    assert text is not None
+    assert "# HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=false" in text
+    assert "# HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false" in text
+
+
 def test_unknown_keys_are_appended():
     text = render_config({"HINDSIGHT_API_LLM_PROVIDER": "openai", "KEY": "value"})
     assert _active_keys(text)["KEY"] == "value"


### PR DESCRIPTION
## Summary

- document the existing `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` setting in both self-documenting env templates
- document the existing `HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU` setting in both templates
- add regression coverage that keeps the root and bundled templates synchronized and preserves the commented/default-false contract

## Why

These settings are already supported by the embedded runtime and documented in the configuration reference, but they are absent from the env templates users discover during profile setup. Exposing them there makes the existing macOS MPS/XPC workaround discoverable without changing defaults for other platforms.

Both settings remain commented out and default to `false`.

## Verification

- `uv run --project hindsight-embed pytest hindsight-embed/tests/test_env_template.py hindsight-embed/tests/test_profile_manager.py hindsight-embed/tests/test_embed_manager.py hindsight-embed/tests/test_profile_daemon_config.py -q` — 70 passed
- `uv run --project hindsight-embed ruff check hindsight-embed/tests/test_env_template.py`
- `uv run --project hindsight-embed ruff format --check hindsight-embed/tests/test_env_template.py`
- root and bundled env templates are byte-identical
