### PR TITLE
feat(admin): backfill-vector-indexes command to reconcile per-bank vector index coverage (#2645)

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -9,6 +9,7 @@ import io
 import json
 import logging
 import zipfile
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -17,7 +18,12 @@ import asyncpg
 import typer
 
 from ..config import DEFAULT_DATABASE_SCHEMA, HindsightConfig
-from ..engine.memory_engine import _current_schema
+from ..engine.memory_engine import _current_schema, fq_table
+from ..engine.retain.bank_utils import (
+    _BANK_INDEX_FACT_TYPES,
+    _bank_index_name,
+    _vector_index_clause,
+)
 from ..engine.schema import fq_table_explicit as _fq_table
 from ..engine.transfer import export_bank
 from ..extensions import TenantExtension, load_extension
@@ -351,6 +357,220 @@ def run_db_migration(
     )
 
     typer.echo(f"Database migrations completed successfully for {len(schemas)} schema(s)")
+
+
+@dataclass
+class SchemaBackfillResult:
+    """Per-schema outcome of the vector-index backfill scan.
+
+    ``created``/``skipped`` are mutually exclusive per missing index: with
+    ``--dry-run`` a missing index lands in ``skipped``, otherwise a successful
+    CONCURRENTLY build lands in ``created`` and a failed one in ``failed``.
+    """
+
+    schema: str
+    banks_scanned: int = 0
+    already_present: int = 0
+    created: int = 0
+    skipped: int = 0
+    failed: int = 0
+    failed_indexes: list[str] = field(default_factory=list)
+
+
+async def _backfill_schema(
+    conn: asyncpg.Connection,
+    schema: str,
+    index_clause: str,
+    *,
+    dry_run: bool,
+) -> SchemaBackfillResult:
+    """Reconcile per-(bank, fact_type) partial vector indexes for one schema.
+
+    Runs over a raw autocommit connection (``CREATE INDEX CONCURRENTLY`` cannot
+    run inside a transaction block). ``_current_schema`` must already be set to
+    ``schema`` so ``fq_table`` resolves correctly.
+    """
+    result = SchemaBackfillResult(schema=schema)
+
+    banks = await conn.fetch(f"SELECT bank_id, internal_id FROM {fq_table('banks')} ORDER BY bank_id")  # noqa: S608
+    result.banks_scanned = len(banks)
+    if not banks:
+        return result
+
+    mu_table = fq_table("memory_units")
+    for bank in banks:
+        bank_id = bank["bank_id"]
+        internal_id = str(bank["internal_id"])
+        escaped = bank_id.replace("'", "''")
+        for ft in _BANK_INDEX_FACT_TYPES:
+            idx_name = _bank_index_name(ft, internal_id)
+
+            exists = await conn.fetchval(
+                "SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2",
+                schema,
+                idx_name,
+            )
+            if exists:
+                result.already_present += 1
+                continue
+
+            if dry_run:
+                result.skipped += 1
+                typer.echo(f"  [dry-run] would create {schema}.{idx_name} (bank={bank_id}, fact_type={ft})")
+                continue
+
+            try:
+                await conn.execute(
+                    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {idx_name} "
+                    f"ON {mu_table} {index_clause} "
+                    f"WHERE fact_type = '{ft}' AND bank_id = '{escaped}'"
+                )
+                result.created += 1
+                typer.echo(f"  created {schema}.{idx_name} (bank={bank_id}, fact_type={ft})")
+            except Exception as exc:  # noqa: BLE001 — one failed index must not abort the run
+                result.failed += 1
+                result.failed_indexes.append(f"{schema}.{idx_name}")
+                # A failed CONCURRENTLY build leaves an INVALID index behind that
+                # would shadow the good one; drop it so a re-run can retry cleanly.
+                logger.warning(
+                    "Failed to build vector index %s.%s (bank=%s, fact_type=%s): %s — "
+                    "dropping the invalid leftover so a re-run can retry.",
+                    schema,
+                    idx_name,
+                    bank_id,
+                    ft,
+                    exc,
+                )
+                try:
+                    await conn.execute(f"DROP INDEX IF EXISTS {schema}.{idx_name}")
+                except Exception as drop_exc:  # noqa: BLE001
+                    logger.warning(
+                        "Cleanup DROP INDEX for %s.%s also failed: %s (manual cleanup may be needed).",
+                        schema,
+                        idx_name,
+                        drop_exc,
+                    )
+
+    return result
+
+
+async def _run_backfill_vector_indexes(
+    db_url: str,
+    schema: str | None = None,
+    base_schema: str = DEFAULT_DATABASE_SCHEMA,
+    *,
+    dry_run: bool = False,
+) -> list[SchemaBackfillResult]:
+    """Backfill missing per-(bank, fact_type) partial vector indexes.
+
+    Iterates one schema (``--schema``) or the base schema plus all discovered
+    tenant schemas, using a raw autocommit connection per schema so
+    ``CREATE INDEX CONCURRENTLY`` never blocks the live fleet. Returns one
+    result per schema (empty list when the backend does not use per-bank
+    indexes — see the backend guard in the command).
+    """
+    if schema:
+        schemas = [schema]
+    else:
+        tenant_extension = load_extension("TENANT", TenantExtension)
+        schemas = [base_schema or DEFAULT_DATABASE_SCHEMA]
+        if tenant_extension:
+            tenants = await tenant_extension.list_tenants()
+            schemas.extend(tenant.schema for tenant in tenants if tenant.schema)
+        # Preserve order while removing duplicates.
+        schemas = list(dict.fromkeys(schemas))
+
+    index_clause = _vector_index_clause()
+    # Guarded by the command before we get here, but assert defensively so this
+    # helper is never called for a backend that doesn't use per-bank indexes.
+    assert index_clause is not None
+
+    conn = await _admin_connect(db_url)
+    try:
+        results: list[SchemaBackfillResult] = []
+        for target_schema in schemas:
+            _current_schema.set(target_schema)
+            typer.echo(f"Scanning schema '{target_schema}'...")
+            result = await _backfill_schema(conn, target_schema, index_clause, dry_run=dry_run)
+            typer.echo(
+                f"  schema '{target_schema}': {result.banks_scanned} bank(s) scanned, "
+                f"{result.already_present} present, {result.created} created, "
+                f"{result.skipped} to-create (dry-run), {result.failed} failed"
+            )
+            results.append(result)
+        return results
+    finally:
+        await conn.close()
+
+
+@app.command(name="backfill-vector-indexes")
+def backfill_vector_indexes(
+    schema: str | None = typer.Option(
+        None,
+        "--schema",
+        "-s",
+        help="Database schema to backfill. If omitted, backfill the base schema and all discovered tenant schemas.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Report which per-bank vector indexes WOULD be created, without creating any.",
+    ),
+):
+    """Backfill missing per-(bank, fact_type) partial vector indexes on populated banks.
+
+    Per-bank partial vector indexes are normally created when a bank is first
+    created (instant on an empty bank). Banks that arrive populated — via restore,
+    a cross-version upgrade, or a vector-extension switch — never hit that path,
+    so their queries silently fall back to a global index + post-filter (slower,
+    lower recall). This command reconciles the missing indexes, building them with
+    CREATE INDEX CONCURRENTLY so it never blocks the live fleet. Idempotent and
+    safe to re-run.
+    """
+    config = HindsightConfig.from_env()
+
+    if not config.database_url:
+        typer.echo("Error: Database URL not configured.", err=True)
+        typer.echo("Set HINDSIGHT_API_DATABASE_URL environment variable.", err=True)
+        raise typer.Exit(1)
+
+    # Backend guard: backends that use a single global vector index (AlloyDB
+    # ScaNN, Oracle) have no per-bank indexes to backfill.
+    if _vector_index_clause() is None:
+        typer.echo("Configured vector backend does not use per-bank vector indexes — nothing to backfill.")
+        return
+
+    if schema:
+        typer.echo(f"Backfilling per-bank vector indexes for schema: {schema}...")
+    else:
+        typer.echo("Backfilling per-bank vector indexes for base schema and all discovered tenant schemas...")
+    if dry_run:
+        typer.echo("Dry run: no indexes will be created.")
+
+    results = asyncio.run(
+        _run_backfill_vector_indexes(
+            config.database_url,
+            schema=schema,
+            base_schema=config.database_schema,
+            dry_run=dry_run,
+        )
+    )
+
+    total_banks = sum(r.banks_scanned for r in results)
+    total_present = sum(r.already_present for r in results)
+    total_created = sum(r.created for r in results)
+    total_skipped = sum(r.skipped for r in results)
+    total_failed = sum(r.failed for r in results)
+
+    typer.echo(
+        f"Done: {len(results)} schema(s), {total_banks} bank(s) scanned, "
+        f"{total_present} already present, {total_created} created, "
+        f"{total_skipped} to-create (dry-run), {total_failed} failed"
+    )
+    if total_failed:
+        failed_names = [name for r in results for name in r.failed_indexes]
+        typer.echo(f"Failed indexes (dropped, retry with a re-run): {', '.join(failed_names)}", err=True)
+        raise typer.Exit(1)
 
 
 async def _run_export_bank(db_url: str, bank_id: str, output: Path, schema: str, include_history: bool) -> int:

--- a/hindsight-api-slim/tests/test_backfill_vector_indexes.py
+++ b/hindsight-api-slim/tests/test_backfill_vector_indexes.py
@@ -1,0 +1,196 @@
+"""Regression tests for `hindsight-admin backfill-vector-indexes` (issue #2645).
+
+Per-(bank, fact_type) partial vector indexes are only created at fresh-bank
+creation time. Banks that arrive already populated — via restore, a cross-version
+upgrade, or a vector-extension switch — never hit that path, so their queries
+silently fall back to a global index + post-filter (slower, ~30% recall@10 miss).
+
+These tests prove the operator escape hatch:
+
+* the core regression — a populated bank whose per-bank indexes were dropped
+  (simulating restore/upgrade) gets them rebuilt by the backfill;
+* `--dry-run` creates nothing;
+* a re-run is idempotent (no error, no duplicates);
+* a backend that doesn't use per-bank indexes is a no-op.
+
+Everything asserted is deterministic (index presence via pg_indexes) — no LLM is
+needed, so memory_units are inserted directly with the `memory` (MockLLM) fixture.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.admin import cli
+from hindsight_api.admin.cli import _run_backfill_vector_indexes
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.retain.bank_utils import _BANK_INDEX_FACT_TYPES, _bank_index_name
+
+_TEST_SCHEMA = "public"
+
+
+async def _bank_internal_id(conn, bank_id: str) -> str:
+    row = await conn.fetchrow("SELECT internal_id FROM banks WHERE bank_id = $1", bank_id)
+    assert row is not None, f"bank {bank_id} not found"
+    return str(row["internal_id"])
+
+
+async def _index_exists(conn, idx_name: str) -> bool:
+    return bool(
+        await conn.fetchval(
+            "SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2",
+            _TEST_SCHEMA,
+            idx_name,
+        )
+    )
+
+
+async def _expected_index_names(conn, bank_id: str) -> list[str]:
+    internal_id = await _bank_internal_id(conn, bank_id)
+    return [_bank_index_name(ft, internal_id) for ft in _BANK_INDEX_FACT_TYPES]
+
+
+async def _seed_bank(memory: MemoryEngine, request_context: RequestContext) -> str:
+    """Create a bank (auto-creates internal_id + per-bank indexes) and populate it."""
+    bank_id = f"test-backfill-{uuid.uuid4().hex[:8]}"
+    # get_bank_profile lazily creates the bank row, which also creates the
+    # per-bank vector indexes (instant on an empty bank).
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        for ft in _BANK_INDEX_FACT_TYPES:
+            await conn.execute(
+                """
+                INSERT INTO memory_units (id, bank_id, text, fact_type, event_date, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW())
+                """,
+                uuid.uuid4(),
+                bank_id,
+                f"seed {ft} fact",
+                ft,
+            )
+    return bank_id
+
+
+async def _drop_bank_indexes(conn, bank_id: str) -> list[str]:
+    """Drop every per-(bank, fact_type) index to simulate the restore/upgrade gap."""
+    names = await _expected_index_names(conn, bank_id)
+    for name in names:
+        await conn.execute(f"DROP INDEX IF EXISTS {_TEST_SCHEMA}.{name}")
+    return names
+
+
+class TestBackfillVectorIndexes:
+    @pytest.mark.asyncio
+    async def test_backfill_recreates_dropped_indexes(
+        self, memory: MemoryEngine, request_context: RequestContext, pg0_db_url: str
+    ):
+        bank_id = await _seed_bank(memory, request_context)
+        pool = await memory._get_pool()
+
+        try:
+            async with pool.acquire() as conn:
+                names = await _drop_bank_indexes(conn, bank_id)
+                # Simulated uncovered state: none of the per-bank indexes exist.
+                for name in names:
+                    assert not await _index_exists(conn, name), f"{name} should be dropped"
+
+            results = await _run_backfill_vector_indexes(pg0_db_url, schema=_TEST_SCHEMA)
+
+            # One schema scanned; our seeded fact types were all rebuilt.
+            assert len(results) == 1
+            result = results[0]
+            assert result.schema == _TEST_SCHEMA
+            assert result.failed == 0
+            assert result.created >= len(_BANK_INDEX_FACT_TYPES)
+
+            async with pool.acquire() as conn:
+                for name in names:
+                    assert await _index_exists(conn, name), f"{name} should be rebuilt"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_dry_run_creates_nothing(
+        self, memory: MemoryEngine, request_context: RequestContext, pg0_db_url: str
+    ):
+        bank_id = await _seed_bank(memory, request_context)
+        pool = await memory._get_pool()
+
+        try:
+            async with pool.acquire() as conn:
+                names = await _drop_bank_indexes(conn, bank_id)
+
+            results = await _run_backfill_vector_indexes(pg0_db_url, schema=_TEST_SCHEMA, dry_run=True)
+
+            result = results[0]
+            assert result.created == 0
+            assert result.skipped >= len(_BANK_INDEX_FACT_TYPES)
+
+            # Dry run must not have created any index.
+            async with pool.acquire() as conn:
+                for name in names:
+                    assert not await _index_exists(conn, name), f"{name} must NOT exist after dry-run"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_rerun_is_idempotent(self, memory: MemoryEngine, request_context: RequestContext, pg0_db_url: str):
+        bank_id = await _seed_bank(memory, request_context)
+        pool = await memory._get_pool()
+
+        try:
+            async with pool.acquire() as conn:
+                names = await _drop_bank_indexes(conn, bank_id)
+
+            first = (await _run_backfill_vector_indexes(pg0_db_url, schema=_TEST_SCHEMA))[0]
+            assert first.created >= len(_BANK_INDEX_FACT_TYPES)
+
+            # Second run: everything already present, nothing created, no error.
+            second = (await _run_backfill_vector_indexes(pg0_db_url, schema=_TEST_SCHEMA))[0]
+            assert second.created == 0
+            assert second.failed == 0
+            assert second.already_present >= len(_BANK_INDEX_FACT_TYPES)
+
+            async with pool.acquire() as conn:
+                for name in names:
+                    # Exactly one index per name — no duplicates.
+                    count = await conn.fetchval(
+                        "SELECT count(*) FROM pg_indexes WHERE schemaname = $1 AND indexname = $2",
+                        _TEST_SCHEMA,
+                        name,
+                    )
+                    assert count == 1, f"{name} should exist exactly once"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_backend_without_per_bank_indexes_is_noop(
+        self, memory: MemoryEngine, request_context: RequestContext, pg0_db_url: str, monkeypatch
+    ):
+        bank_id = await _seed_bank(memory, request_context)
+        pool = await memory._get_pool()
+
+        try:
+            async with pool.acquire() as conn:
+                names = await _drop_bank_indexes(conn, bank_id)
+
+            # Simulate a backend (AlloyDB ScaNN / Oracle) that uses a single
+            # global vector index — the command must be a no-op.
+            monkeypatch.setattr(cli, "_vector_index_clause", lambda: None)
+
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(cli.app, ["backfill-vector-indexes", "--schema", _TEST_SCHEMA])
+            assert result.exit_code == 0, result.output
+            assert "does not use per-bank vector indexes" in result.output
+
+            # No indexes were created.
+            async with pool.acquire() as conn:
+                for name in names:
+                    assert not await _index_exists(conn, name), f"{name} must NOT exist for no-op backend"
+        finally:
+            await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
Addresses #2645 (part 1 of 2).

## Problem

Per-(bank, fact_type) partial vector indexes are only created at fresh-bank-creation time. Banks that arrive **already populated** — via logical restore, cross-version upgrade, or a vector-extension switch (e.g. ScaNN→pgvector) — never hit that path, so their recall silently falls back to the global HNSW + post-filter. As @iRonin measured on a live 40-bank deployment, that's not just a latency hit: it's **recall@10 of ~0.63–0.72 (only ~6.3–7.5 of 10 in-bank neighbors returned)** — a silent ~30% top-10 miss, i.e. a correctness regression, on any bank in the uncovered state.

## This PR — the operator escape hatch

`hindsight-admin backfill-vector-indexes` reconciles the missing per-bank partial indexes on populated banks — first-classing exactly what @iRonin did by hand (63 indexes across 20 banks).

- **`CREATE INDEX CONCURRENTLY`** — never takes `ACCESS EXCLUSIVE` on the shared `memory_units`, so backfilling one bank can't stall the fleet's retain/recall/consolidation. (It runs on the admin CLI's raw autocommit connection, since `CONCURRENTLY` can't run in a txn.)
- **Idempotent** — `pg_indexes` existence check + `IF NOT EXISTS`; safe to re-run.
- **Invalid-index cleanup** — a failed concurrent build leaves an INVALID index behind; it's dropped with a loud warning so a re-run retries cleanly, and the command exits non-zero listing any failures.
- **`--dry-run`** reports what would be built without touching anything.
- **Multi-tenant** — base schema + all discovered tenant schemas (or `--schema`).
- **Backend guard** — no-op for backends that use a single global index (AlloyDB ScaNN, Oracle).
- Reuses the existing index-name scheme (`_bank_index_name` / `_BANK_INDEX_FACT_TYPES` / `_vector_index_clause`) so backfilled indexes are byte-identical to create-time ones.

## Deliberately scoped — follow-up (part 2)

Per the design locked in #2645, the **ongoing convergence** layer (boot/periodic background reconcile as the primary guarantee, plus a lightweight retain-path `pg_class` existence check as belt-and-suspenders) is a separate PR — it touches the worker/retain hot paths and deserves its own review. This PR is the immediate, self-contained escape hatch that closes the *current* uncovered state and is directly testable.

## Tests

`tests/test_backfill_vector_indexes.py` (4 tests, deterministic, pg0):
- core regression: a populated bank whose per-bank indexes are dropped (simulating restore/upgrade) gets them rebuilt;
- `--dry-run` creates nothing;
- re-run is idempotent (no error, no dupes);
- no-op for a backend without per-bank indexes.

cc @iRonin — this is the command; happy to have you point it at the staging copy of your deployment with your recall@K harness for a before/after once CI is green. The boot-reconcile follow-up will land separately.
