### PR TITLE
fix(control-plane): show bank name in selector, fall back to bank_id

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -556,7 +556,7 @@ function BankSelectorInner() {
                             )}
                           />
                           <span className="truncate flex-1 font-medium" title={bank.bank_id}>
-                            {bank.bank_id}
+                            {bank.name || bank.bank_id}
                           </span>
                           <button
                             type="button"


### PR DESCRIPTION
## What

Render a bank's `name` as the selector label when it's set, falling back to `bank_id`:

```diff
-                          <span className="truncate flex-1 font-medium" title={bank.bank_id}>
-                            {bank.bank_id}
+                          <span className="truncate flex-1 font-medium" title={bank.bank_id}>
+                            {bank.name || bank.bank_id}
                           </span>
```

`title={bank.bank_id}` and the copy button are unchanged, so the canonical identifier stays one hover/click away.

## Why

When banks are keyed on stable, opaque identifiers (immutable, rename-safe ids rather than human-friendly slugs), the selector is hard to read — every bank shows as its raw id (e.g. `project-9d6f1542fbee`). Banks can already carry a human-readable `name` (settable via `PATCH /v1/default/banks/{bank_id}`), and the control plane **already fetches it into client state** — `BankInfo` in `src/lib/bank-context.tsx` declares `name: string | null` and populates it from the API response (`name: bank.name ?? null`). Only the selector's render line hard-codes the id.

## Scope / safety

- One-line render change; no new fetch, no type change, no API change.
- Banks without a `name` are unchanged — they already fall back to the id via `||`.
- Canonical `bank_id` remains visible (tooltip) and copyable (copy button).

## Note on the deprecated `name` field

`hindsight-api` marks `name` deprecated server-side (the `PATCH` handler stores it "for display only, deprecated"; `CreateBankRequest.name` is "display label only, not advertised"). This PR assumes a human-readable label is still worth showing where one exists. If the plan is to fully retire `name`, I'd love to know the supported way to attach a display label to a bank whose `bank_id` must stay opaque — happy to adjust this PR to whatever surface you prefer.

Linked issue: #2714
