### PR TITLE
Show bank names in control-plane selector

### DIFF
--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -60,6 +60,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { BankInfo } from "@/lib/bank-context";
+import { bankDisplayLabel } from "@/lib/bank-label";
 
 function formatCompact(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
@@ -527,6 +528,7 @@ function BankSelectorInner() {
                   {sortedBanks.map((bank) => {
                     const barPct = (bank.fact_count / maxFactCount) * 100;
                     const isSelected = currentBank === bank.bank_id;
+                    const displayLabel = bankDisplayLabel(bank);
                     return (
                       <CommandItem
                         key={bank.bank_id}
@@ -556,7 +558,7 @@ function BankSelectorInner() {
                             )}
                           />
                           <span className="truncate flex-1 font-medium" title={bank.bank_id}>
-                            {bank.bank_id}
+                            {displayLabel}
                           </span>
                           <button
                             type="button"

--- a/hindsight-control-plane/src/lib/bank-label.ts
+++ b/hindsight-control-plane/src/lib/bank-label.ts
@@ -1,0 +1,6 @@
+import type { BankInfo } from "@/lib/bank-context";
+
+export function bankDisplayLabel(bank: Pick<BankInfo, "bank_id" | "name">): string {
+  const name = bank.name?.trim();
+  return name || bank.bank_id;
+}

--- a/hindsight-control-plane/tests/lib/bank-label.test.ts
+++ b/hindsight-control-plane/tests/lib/bank-label.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { bankDisplayLabel } from "@/lib/bank-label";
+
+describe("bankDisplayLabel", () => {
+  it("uses the bank name when present", () => {
+    expect(bankDisplayLabel({ bank_id: "project-9d6f1542fbee", name: "Tarn (project)" })).toBe(
+      "Tarn (project)"
+    );
+  });
+
+  it("falls back to bank_id when the bank has no display name", () => {
+    expect(bankDisplayLabel({ bank_id: "default", name: null })).toBe("default");
+  });
+
+  it("falls back to bank_id when the display name is blank", () => {
+    expect(bankDisplayLabel({ bank_id: "project-9d6f1542fbee", name: "  " })).toBe(
+      "project-9d6f1542fbee"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- render a bank's display name in the control-plane selector when one is present
- keep the canonical `bank_id` as the hover title and copy value
- add focused coverage for name, null-name, and blank-name fallback behavior

Closes #2714

## Tests
- `npm run test -- tests/lib/bank-label.test.ts`
- `npm run test`
- `npm run build`