### PR TITLE
fix(gemini): grammar-enforce batch structured output regardless of strict flag

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -1030,7 +1030,7 @@ class GeminiLLM(LLMInterface):
         Mirrors the synchronous ``call`` path: system messages become
         ``systemInstruction``; a ``response_format`` json_schema forces JSON
         output (``responseMimeType``), appends the schema as a textual hint, and
-        grammar-enforces via ``responseJsonSchema`` when ``strict`` is set.
+        grammar-enforces via ``responseJsonSchema`` whenever a schema is present.
         """
         system_texts: list[str] = []
         contents: list[dict[str, Any]] = []
@@ -1059,8 +1059,13 @@ class GeminiLLM(LLMInterface):
                 system_texts.append(
                     "You must respond with valid JSON matching this schema:\n" + json.dumps(schema, ensure_ascii=False)
                 )
-                if json_schema.get("strict"):
-                    generation_config["responseJsonSchema"] = schema
+                # #2699: Gemini always grammar-enforces structured output via its native
+                # response_schema (``strict`` is an OpenAI concept, meaningless here). Set
+                # the native schema whenever one is present so the batch path mirrors the
+                # interactive path; otherwise batch requests at default config
+                # (HINDSIGHT_API_LLM_STRICT_SCHEMA=False) get only a textual hint and
+                # intermittently emit malformed JSON, losing every fact in the chunk.
+                generation_config["responseJsonSchema"] = schema
 
         request: dict[str, Any] = {"contents": contents}
         if system_texts:

--- a/hindsight-api-slim/tests/test_gemini_batch.py
+++ b/hindsight-api-slim/tests/test_gemini_batch.py
@@ -103,18 +103,22 @@ def test_body_translation_maps_roles_and_generation_config():
     assert gc["temperature"] == 0.1
     assert gc["maxOutputTokens"] == 2048
     assert gc["responseMimeType"] == "application/json"
-    # strict=True -> grammar-enforced via responseJsonSchema
+    # grammar-enforced via responseJsonSchema
     assert gc["responseJsonSchema"] == {"type": "object", "properties": {"facts": {"type": "array"}}}
     # schema is also appended as a textual hint (mirrors the sync call path)
     assert "valid JSON matching this schema" in req["systemInstruction"]["parts"][0]["text"]
 
 
-def test_body_translation_omits_response_json_schema_when_not_strict():
+def test_body_translation_grammar_enforces_schema_without_strict():
+    # #2699: Gemini always grammar-enforces via its native response_schema, so the
+    # batch path must set responseJsonSchema even when strict is absent/False
+    # (the interactive path already does). Otherwise batch requests at default
+    # config (HINDSIGHT_API_LLM_STRICT_SCHEMA=False) only get a textual schema hint
+    # and intermittently emit malformed JSON, dropping every fact in the chunk.
     req = GeminiLLM._openai_body_to_gemini_request(_openai_request("c", strict=False)["body"])
     gc = req["generationConfig"]
-    # Non-strict still forces JSON output, but does not grammar-enforce the schema
     assert gc["responseMimeType"] == "application/json"
-    assert "responseJsonSchema" not in gc
+    assert gc["responseJsonSchema"] == {"type": "object", "properties": {"facts": {"type": "array"}}}
 
 
 def test_assistant_role_maps_to_model():


### PR DESCRIPTION
## Problem

With `LLM_PROVIDER=gemini` and `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true`, the Gemini **batch** request builder (`_openai_body_to_gemini_request` in `gemini_llm.py`) only set the native grammar schema (`responseJsonSchema`) when `json_schema.strict` was truthy. But `HINDSIGHT_API_LLM_STRICT_SCHEMA` defaults to `False`.

This created a batch-vs-interactive asymmetry: the **interactive** Gemini path always grammar-enforces structured output via its native `response_schema` regardless of `strict` (as its docstring states). `strict` is an OpenAI concept and is meaningless to Gemini.

As a result, at default config batch requests received only `responseMimeType: application/json` plus a textual schema hint in the system instruction — no native grammar enforcement. Gemini then intermittently emitted malformed JSON, and since a chunk's facts are parsed as a unit, **all facts in the affected chunk were lost**.

## Fix

Set `generationConfig["responseJsonSchema"] = schema` whenever a schema is present, regardless of `strict`, so the batch path mirrors the interactive path. The always-set `responseMimeType` and the textual schema hint are unchanged. A comment references #2699.

## Test

Updated the pure translation unit test in `tests/test_gemini_batch.py` (`test_body_translation_grammar_enforces_schema_without_strict`) to build an OpenAI-style body with `strict=False` and assert the resulting Gemini `generationConfig` contains `responseJsonSchema` equal to the schema. This replaces the prior test that asserted the buggy omit-when-not-strict behavior. No DB/LLM — runs fast.

```
27 passed in 7.26s
```

Fixes #2699