### PR TITLE
fix(embed): green main — use --target sibling binary unconditionally (#2676 vs #1240)

### DIFF
--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -262,7 +262,13 @@ class DaemonEmbedManager(EmbedManager):
         package_root = Path(__file__).parent.parent
         for bin_dir in ("bin", "Scripts"):
             candidate = package_root / bin_dir / binary_name
-            if candidate.exists() and self._can_use_installed_api_binary(env):
+            if candidate.exists():
+                # A hindsight-api binary bundled into a --target layout is a
+                # deliberate slim-bundle install; use it unconditionally. Falling
+                # back to uvx here reintroduces issue #1240 (the Windows embed
+                # smoke test enforces this). The #2676 "missing local ML deps ->
+                # uvx" fallback intentionally applies only to the sysconfig-scripts
+                # path above (standard venv installs), not to a --target bundle.
                 return [str(candidate)]
 
         # Fall back to uvx for the installed version (resolved by the caller).

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -160,14 +160,21 @@ def test_find_api_command_skips_slim_binary_without_local_ml(tmp_path, monkeypat
     installed. In that case, use the uvx full-package fallback instead of
     starting a daemon that immediately fails during local provider init.
     """
-    scripts_dir = tmp_path / "bin"
+    scripts_dir = tmp_path / "venv_bin"
     scripts_dir.mkdir()
     (scripts_dir / "hindsight-api").touch()
 
+    # Realistic venv layout: the module lives under site-packages, so the
+    # __file__-relative --target path (<site-packages>/bin) is distinct from the
+    # sysconfig scripts dir and finds no binary. The slim sibling is only in the
+    # sysconfig scripts dir — exactly where the #2676 uvx fallback applies (a
+    # --target bundle's sibling would instead be used unconditionally, per #1240).
+    module_path = tmp_path / "site-packages" / "hindsight_embed" / "daemon_embed_manager.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text("")
+
     manager = DaemonEmbedManager()
-    monkeypatch.setattr(
-        "hindsight_embed.daemon_embed_manager.__file__", str(tmp_path / "hindsight_embed" / "daemon_embed_manager.py")
-    )
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(module_path))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(scripts_dir))
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
     monkeypatch.setattr("hindsight_embed.daemon_embed_manager.find_spec", lambda name: None)
@@ -224,6 +231,39 @@ def test_find_api_command_target_install_uses_file_relative_fallback(tmp_path, m
     _mock_sentence_transformers_present(monkeypatch)
 
     assert manager._find_api_command("0.0.0") == [str(sibling_bin)]
+
+
+def test_find_api_command_target_install_uses_sibling_even_without_local_ml(tmp_path, monkeypatch):
+    """A --target-bundled sibling binary must be used even when local ML deps
+    are missing.
+
+    Regression for the #2676 vs #1240 conflict: the "missing sentence-transformers
+    -> uvx" fallback (#2676) applies only to the sysconfig-scripts path (standard
+    venv installs). A deliberate --target bundle must still use its sibling binary,
+    because falling back to uvx on --target installs reintroduces #1240 (enforced
+    by the Windows embed smoke test).
+    """
+    venv_scripts = tmp_path / "venv_bin"
+    venv_scripts.mkdir()
+
+    target_dir = tmp_path / "target"
+    pkg_dir = target_dir / "hindsight_embed"
+    pkg_dir.mkdir(parents=True)
+    fake_module = pkg_dir / "daemon_embed_manager.py"
+    fake_module.write_text("")
+    sibling_bin = target_dir / "bin" / "hindsight-api"
+    sibling_bin.parent.mkdir()
+    sibling_bin.touch()
+
+    manager = DaemonEmbedManager()
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.__file__", str(fake_module))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.sysconfig.get_path", lambda key: str(venv_scripts))
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.platform.system", lambda: "Linux")
+    # Default local providers + no sentence_transformers: the sysconfig path would
+    # fall back to uvx, but the --target sibling must still win.
+    monkeypatch.setattr("hindsight_embed.daemon_embed_manager.find_spec", lambda name: None)
+
+    assert manager._find_api_command("1.2.3", env={}) == [str(sibling_bin)]
 
 
 def test_find_api_command_falls_back_to_uvx_when_no_binary(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Greens `main` (`test-embed-windows` is red) by resolving a conflict between two prior fixes.

## Root cause

**#2676** ("Avoid slim embedded daemon startup without local ML deps") added `_can_use_installed_api_binary()`: when default-local embeddings need `sentence_transformers` but it isn't importable, fall back to `uvx hindsight-api@<version>`. But it gated **both** binary-resolution paths in `_find_api_command` — including the `__file__`-relative `--target` path. On a `pip install --target` layout where the sibling `hindsight-api` is bundled but ML deps aren't installed, the daemon now falls back to `uvx`, which **reintroduces #1240** — and the Windows embed smoke test (`test.yml`) asserts exactly this ("Falling back to uvx on --target installs reintroduces issue #1240").

## Fix

Scope the #2676 `uvx` fallback to the **sysconfig-scripts** path only (standard venv installs — the fresh-venv / #2671 case it was written for). A **`--target`-bundled sibling** is a deliberate slim bundle and is now used **unconditionally**, preserving #1240.

- Regression test `test_find_api_command_target_install_uses_sibling_even_without_local_ml` asserts the `--target` sibling is used even when `sentence_transformers` is missing (the exact smoke-test scenario).
- Fixed the `test_find_api_command_skips_slim_binary_without_local_ml` fixture, which conflated the sysconfig scripts dir with the `--target` package-relative dir (it only passed before because both paths were gated identically); it now uses a realistic `site-packages` layout so the sysconfig `uvx` fallback is still exercised.

## Verified

`tests/test_embed_manager.py` — 21 passed (incl. the new regression). Ruff clean on the two changed files (one pre-existing E721 at test line 57 is unrelated and untouched).