### PR TITLE
feat(paperclip): per-agent enable/disable for pilot rollouts

### DIFF
--- a/hindsight-integrations/paperclip/README.md
+++ b/hindsight-integrations/paperclip/README.md
@@ -41,6 +41,7 @@ hindsight-api
 | `bankGranularity`    | `["company", "agent"]`               | Memory isolation when `dynamicBankId` is `true`: per company+agent, per company, or per agent. Add `"user"` for per-user memory isolation (useful for GDPR compliance) |
 | `recallBudget`       | `mid`                                | `low` = fastest, `mid` = balanced, `high` = most thorough                                                                                                              |
 | `autoRetain`         | `true`                               | Automatically retain run output after every run                                                                                                                        |
+| `enabledAgentIds`    | —                                    | Restrict recall/retain to these agent IDs only. Leave empty to enable for all agents (default)                                                                         |
 
 ## Bank ID Format
 

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -74,6 +74,13 @@ const manifest: PaperclipPluginManifestV1 = {
         description: "Automatically retain agent run output to Hindsight when a run completes.",
         default: true,
       },
+      enabledAgentIds: {
+        type: "array",
+        title: "Enabled Agent IDs",
+        description:
+          "Restrict Hindsight recall/retain to these agent IDs only. Leave empty to enable for all agents (default).",
+        items: { type: "string" },
+      },
     },
   },
   tools: [

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -30,6 +30,7 @@ interface PluginConfig {
   bankGranularity?: Array<"company" | "agent" | "user">;
   recallBudget?: "low" | "mid" | "high";
   autoRetain?: boolean;
+  enabledAgentIds?: string[];
 }
 
 interface RunStartedPayload {
@@ -65,6 +66,12 @@ async function resolveApiKey(
   return resolved ?? undefined;
 }
 
+function isAgentEnabled(config: PluginConfig, agentId: string | undefined | null): boolean {
+  const allowlist = config.enabledAgentIds;
+  if (!allowlist || allowlist.length === 0) return true;
+  return !!agentId && allowlist.includes(agentId);
+}
+
 const plugin = definePlugin({
   async setup(ctx) {
     ctx.logger.info("Hindsight memory plugin starting");
@@ -81,6 +88,7 @@ const plugin = definePlugin({
       const config = await getConfig(ctx);
       const { agentId, runId, issueId } = payload;
       const companyId = event.companyId;
+      if (!isAgentEnabled(config, agentId)) return;
       if (!issueId || !companyId) return;
 
       let issue;
@@ -203,6 +211,14 @@ const plugin = definePlugin({
         return;
       }
 
+      if (!isAgentEnabled(config, bankAgentId)) {
+        ctx.logger.debug("Skipping retain — agent not in enabled list", {
+          commentId,
+          agentId: bankAgentId,
+        });
+        return;
+      }
+
       try {
         const apiKey = await resolveApiKey(ctx, config);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
@@ -233,6 +249,8 @@ const plugin = definePlugin({
     // ---------------------------------------------------------------------------
     ctx.events.on("agent.run.finished", async (event) => {
       const payload = event.payload as RunFinishedPayload;
+      const config = await getConfig(ctx);
+      if (!isAgentEnabled(config, payload?.agentId)) return;
       ctx.logger.debug(
         "agent.run.finished received (no-op; retention handled by issue.comment.created)",
         { runId: payload?.runId }

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -587,3 +587,161 @@ describe("onValidateConfig", () => {
     vi.unstubAllGlobals();
   });
 });
+
+// ---------------------------------------------------------------------------
+// enabledAgentIds gate
+// ---------------------------------------------------------------------------
+
+describe("enabledAgentIds", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = mockFetch([
+      { url: /memories\/recall/, body: { results: [] } },
+      { url: /memories$/, body: { success: true } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("skips recall when agent is not in enabledAgentIds allowlist", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: ["ag-1"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Test" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-2", runId: "run-enabled-1", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("performs recall when agent is in enabledAgentIds allowlist", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: ["ag-1"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Test" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-enabled-2", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(fetchMock).toHaveBeenCalled();
+    const recallCall = fetchMock.mock.calls.find((c: unknown[]) =>
+      String(c[0]).includes("/memories/recall")
+    );
+    expect(recallCall).toBeDefined();
+  });
+
+  it("treats empty enabledAgentIds array as all agents allowed", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: [],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Test" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-any", runId: "run-enabled-3", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("treats unset enabledAgentIds as all agents allowed (unchanged behavior)", async () => {
+    const harness = buildHarness(DEFAULT_CONFIG);
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Test" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-any", runId: "run-enabled-4", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("skips retain when agent is not in enabledAgentIds allowlist", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: ["ag-1"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Test",
+      assigneeAgentId: "ag-2",
+    });
+
+    const comment = await harness.ctx.issues.createComment(issue.id, "comment body", "co-1", {
+      authorAgentId: "ag-2",
+    });
+    await harness.emit(
+      "issue.comment.created",
+      { agentId: "ag-2", commentId: comment.id },
+      { companyId: "co-1", entityId: issue.id }
+    );
+
+    const retainCalls = fetchMock.mock.calls.filter(([url]: [string]) => /memories$/.test(url));
+    expect(retainCalls.length).toBe(0);
+  });
+
+  it("performs retain when agent is in enabledAgentIds allowlist", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: ["ag-1"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Test" });
+
+    const comment = await harness.ctx.issues.createComment(issue.id, "comment body", "co-1", {
+      authorAgentId: "ag-1",
+    });
+    await harness.emit(
+      "issue.comment.created",
+      { agentId: "ag-1", commentId: comment.id },
+      { companyId: "co-1", entityId: issue.id }
+    );
+
+    const retainCalls = fetchMock.mock.calls.filter(([url]: [string]) => /memories$/.test(url));
+    expect(retainCalls.length).toBeGreaterThan(0);
+  });
+
+  it("skips retain for issue assignee when assignee not in enabledAgentIds allowlist", async () => {
+    const harness = buildHarness({
+      ...DEFAULT_CONFIG,
+      enabledAgentIds: ["ag-1"],
+    });
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, {
+      companyId: "co-1",
+      title: "Test",
+      assigneeAgentId: "ag-2",
+    });
+
+    const comment = await harness.ctx.issues.createComment(issue.id, "user comment", "co-1");
+    await harness.emit(
+      "issue.comment.created",
+      { commentId: comment.id },
+      { companyId: "co-1", entityId: issue.id }
+    );
+
+    const retainCalls = fetchMock.mock.calls.filter(([url]: [string]) => /memories$/.test(url));
+    expect(retainCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
*Here's my attempt at adding this functionality; first PR to the repo, my apologies if I missed something. I am working on testing this locally myself, but I'm curious to see what tests/validations exist in the PR pipeline, ~~so I'm submitting this as a draft for now~~.*

Add optional `enabledAgentIds` config field to restrict Hindsight recall/retain to a subset of agents.

Behavior:
- When set, only listed agent IDs trigger memory operations
- Unset or empty array (`[]`) = unchanged behavior (all agents)
  - Enables pilot rollouts on high-signal agents before fleet-wide enable, reducing LLM cost/latency risk.
- Add `enabledAgentIds: string[]` to `instanceConfigSchema` (`manifest.ts`)
- Add `isAgentEnabled()` gate function to `worker.ts`
- Gate `agent.run.started` recall, `agent.run.finished`, and `issue.comment.created` retain handlers (the actual LLM-cost operations)
- Add 6 test cases covering `allowlist` pass/fail, empty array, and unset behavior
- Update `README.md` config table

Resolves #1116 