### PR TITLE
fix(retain): preserve oversized document deltas

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3456,7 +3456,42 @@ class MemoryEngine(MemoryEngineInterface):
         config = get_config()
         tokens_per_batch = config.retain_batch_tokens
 
-        if total_tokens > tokens_per_batch:
+        full_document_delta = None
+        memory_defense_screened = False
+        if (
+            total_tokens > tokens_per_batch
+            and len(contents) == 1
+            and (document_id or contents[0].get("document_id"))
+            and contents[0].get("update_mode", "replace") == "replace"
+        ):
+            from .retain import orchestrator
+
+            try:
+                # Delta comparison must use the configured logical chunking,
+                # before the OOM guard fragments one document into transport
+                # sub-batches with unrelated boundaries.
+                full_document_delta = await self._retain_batch_async_internal(
+                    bank_id=bank_id,
+                    contents=contents,
+                    request_context=request_context,
+                    document_id=document_id,
+                    is_first_batch=True,
+                    fact_type_override=fact_type_override,
+                    document_tags=document_tags,
+                    operation_id=operation_id,
+                    strategy=strategy,
+                    outbox_callback=outbox_callback,
+                    outbox_callback_factory=outbox_callback_factory,
+                    delta_only=True,
+                )
+            except orchestrator.DeltaRetainUnavailable:
+                # The delta-only attempt already screened this single item. Its
+                # bounded fallback must not emit duplicate defense events.
+                memory_defense_screened = True
+
+        if full_document_delta is not None:
+            result, total_usage, total_processed_content_tokens = full_document_delta
+        elif total_tokens > tokens_per_batch:
             # Split into smaller batches based on token count
             logger.info(
                 f"Large batch detected ({total_tokens:,} tokens from {len(contents)} items). Splitting into sub-batches of ~{tokens_per_batch:,} tokens each..."
@@ -3591,6 +3626,7 @@ class MemoryEngine(MemoryEngineInterface):
                     outbox_callback_factory=outbox_callback_factory if i == len(sub_batches) else None,
                     document_body_override=document_body_overrides[i - 1],
                     chunk_index_offset=sub_offset,
+                    memory_defense_screened=memory_defense_screened,
                 )
 
                 # Advance the document's chunk_index cursor by the number of
@@ -3748,6 +3784,8 @@ class MemoryEngine(MemoryEngineInterface):
         strategy: str | None = None,
         document_body_override: str | None = None,
         chunk_index_offset: int = 0,
+        delta_only: bool = False,
+        memory_defense_screened: bool = False,
     ) -> tuple[list[list[str]], "TokenUsage", int | None]:
         """
         Internal method for batch processing without chunking logic.
@@ -3820,6 +3858,8 @@ class MemoryEngine(MemoryEngineInterface):
                 webhook_manager=self._webhook_manager,
                 memory_defense_extension=self._memory_defense,
                 audit_logger=self._audit_logger,
+                delta_only=delta_only,
+                memory_defense_screened=memory_defense_screened,
             )
             # Map the created facts onto this retain's trace so the trace view can
             # show which memories the ingestion produced. result[0] is the

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -45,6 +45,10 @@ class MemoryDefenseAllBlockedError(Exception):
         super().__init__(f"all {len(violations)} items blocked by Memory Defense policy")
 
 
+class DeltaRetainUnavailable(Exception):
+    """Signal that a delta-only retain must fall back to bounded processing."""
+
+
 def utcnow():
     """Get current UTC time."""
     return datetime.now(UTC)
@@ -578,6 +582,8 @@ async def retain_batch(
     webhook_manager: Any = None,
     memory_defense_extension: "MemoryDefenseExtension | None" = None,
     audit_logger: Any = None,
+    delta_only: bool = False,
+    memory_defense_screened: bool = False,
 ) -> tuple[list[list[str]], TokenUsage, int | None]:
     """
     Process a batch of content through the retain pipeline.
@@ -672,6 +678,8 @@ async def retain_batch(
                     webhook_manager=webhook_manager,
                     memory_defense_extension=memory_defense_extension,
                     audit_logger=audit_logger,
+                    delta_only=delta_only,
+                    memory_defense_screened=memory_defense_screened,
                 )
                 for group_idx, orig_idx in enumerate(original_indices[doc_key]):
                     if group_idx < len(group_ids):
@@ -688,7 +696,7 @@ async def retain_batch(
     _policy = parse_policy(getattr(config, "memory_defense", None))
     _blocked_violations: list[BlockedViolation] = []
 
-    if memory_defense_extension is not None and _policy.enabled:
+    if not memory_defense_screened and memory_defense_extension is not None and _policy.enabled:
         async with acquire_with_retry(pool) as _defense_conn:
             for _idx, _content in enumerate(contents):
                 # Prefer the per-item document_id over the batch-level value so
@@ -922,9 +930,15 @@ async def retain_batch(
             outbox_callback,
             db_semaphore,
             document_body_override=document_body_override,
+            delta_only=delta_only,
         )
         if delta_result is not None:
             return delta_result
+        if delta_only:
+            # The caller will retain the same screened content through bounded
+            # sub-batches; never let a failed full-document delta fall through
+            # to the unbounded streaming setup that oversized inputs avoid.
+            raise DeltaRetainUnavailable
 
     # --- Always use the streaming pipeline (producer-consumer batching) ---
     # Even small documents go through the same path — they just end up as a
@@ -1354,7 +1368,11 @@ async def _streaming_retain_batch(
                 await _process_db_batch(
                     batch,
                     consumer_batch_idx,
-                    is_last=False,
+                    # A document whose chunk count is exactly divisible by the
+                    # batch size leaves no remainder for the queue sentinel.
+                    # Mark the final full batch here so transactional outbox
+                    # work is not silently skipped on that boundary.
+                    is_last=chunks_committed + len(batch) >= total_chunks,
                 )
                 consumer_batch_idx += 1
                 chunks_committed += len(batch)
@@ -1890,6 +1908,7 @@ async def _try_delta_retain(
     db_semaphore: "asyncio.Semaphore | None" = None,
     *,
     document_body_override: str | None = None,
+    delta_only: bool = False,
 ) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
     Attempt delta retain for a document upsert. Returns result tuple if delta
@@ -1990,6 +2009,16 @@ async def _try_delta_retain(
             config=config,
         )
 
+    processed_tokens = _count_delta_content_tokens(delta_contents)
+    chunk_batch_size = getattr(config, "retain_chunk_batch_size", 100)
+    if delta_only and (
+        processed_tokens > config.retain_batch_tokens or (chunk_batch_size and len(delta_contents) > chunk_batch_size)
+    ):
+        # A full-document preflight may compare every logical chunk, but it may
+        # bypass the streaming splitter only when the changed work fits the
+        # same token and chunk-count bounds as a regular retain batch.
+        return None
+
     # Freshness recheck BEFORE the (expensive) LLM extraction.
     #
     # We snapshotted the document hash and chunks outside any lock. A concurrent
@@ -2075,7 +2104,7 @@ async def _try_delta_retain(
     result_unit_ids: list[list[str]] = []
     log_buffer_pre_db = len(log_buffer)
 
-    async def _run_delta_db_work() -> None:
+    async def _run_delta_db_work() -> bool:
         nonlocal result_unit_ids
         del log_buffer[log_buffer_pre_db:]
         for pf in processed_facts:
@@ -2108,8 +2137,7 @@ async def _try_delta_retain(
                         f"since chunks were loaded — aborting delta, falling back to full retain"
                     )
                     logger.info("\n" + "\n".join(log_buffer) + "\n")
-                    # Return None to fall back to streaming (which has full FOR UPDATE protection)
-                    return None
+                    return False
 
                 # Update document metadata (no delete)
                 step_start = time.time()
@@ -2221,17 +2249,20 @@ async def _try_delta_retain(
             log_buffer.append(f"Document: {effective_doc_id}")
             log_buffer.append(f"{'=' * 60}")
             logger.info("\n" + "\n".join(log_buffer) + "\n")
+        return True
 
     if db_semaphore is not None:
         async with db_semaphore:
-            await _run_delta_db_work()
+            delta_committed = await _run_delta_db_work()
     else:
-        await _run_delta_db_work()
-    # Count content + context tokens that actually went through extraction.
-    # ``delta_contents`` holds the per-chunk RetainContent items for the
-    # changed/new chunks (see ``_build_delta_contents``) — i.e. exactly what
-    # the LLM pipeline saw this call. Unchanged chunks contribute zero.
-    processed_tokens = _count_delta_content_tokens(delta_contents)
+        delta_committed = await _run_delta_db_work()
+    if not delta_committed:
+        return None
+    if delta_only:
+        # The preflight represents one submitted document even when its delta
+        # spans multiple logical chunks. Preserve the public one-result-slot
+        # contract while returning every newly inserted unit ID.
+        result_unit_ids = [[unit_id for chunk_result in result_unit_ids for unit_id in chunk_result]]
     return result_unit_ids, usage, processed_tokens
 
 

--- a/hindsight-api-slim/tests/test_large_document_replacement.py
+++ b/hindsight-api-slim/tests/test_large_document_replacement.py
@@ -14,10 +14,14 @@ stored ``original_text`` exactly matches the submitted replacement body.
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
-from hindsight_api.config import clear_config_cache
+from hindsight_api.config import DEFAULT_RETAIN_CHUNK_SIZE, clear_config_cache, get_config
+from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.retain.types import ChunkMetadata, ExtractedFact, RetainContent
+from hindsight_api.engine.token_encoding import count_tokens
 
 
 def _ts() -> float:
@@ -144,3 +148,240 @@ async def test_repeated_large_same_id_replacement_is_idempotent(memory, request_
 
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_oversized_changed_tail_does_not_reextract_unchanged_history(memory, request_context, monkeypatch):
+    """A changed tail above the batch threshold must retain against the full document."""
+    from hindsight_api.engine.retain import fact_extraction, orchestrator
+
+    bank_id = f"test_large_delta_tail_{_ts()}"
+    document_id = "claude-code-transcript-delta-tail"
+    history_markers = {i: f"UNCHANGED_HISTORY_SENTINEL_{i}" for i in (0, 25, 50, 75)}
+    tail = "NEW_TAIL_SENTINEL"
+    history = "\n".join(
+        f"[role: user] turn {i}: {history_markers.get(i, 'historical')} "
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november"
+        for i in range(120)
+    )
+
+    def _set_batch_tokens(value: int) -> None:
+        monkeypatch.setenv("HINDSIGHT_API_RETAIN_BATCH_TOKENS", str(value))
+        clear_config_cache()
+        memory._config_resolver._global_config.retain_batch_tokens = value
+
+    try:
+        _set_batch_tokens(10000)
+        assert count_tokens(history) <= get_config().retain_batch_tokens
+        await memory.retain_async(
+            bank_id=bank_id,
+            content=history,
+            context="session transcript",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        extracted_contents: list[str] = []
+        outbox_calls = 0
+
+        async def _record_outbox(_conn: Any) -> None:
+            nonlocal outbox_calls
+            outbox_calls += 1
+
+        async def _record_extraction(contents: list[RetainContent], *args: Any, **kwargs: Any) -> Any:
+            extracted_contents.extend(item.content for item in contents)
+            facts = [
+                ExtractedFact(
+                    fact_text=f"Synthetic extracted fact {index}",
+                    fact_type="world",
+                    content_index=index,
+                    chunk_index=index,
+                    context=item.context,
+                    tags=item.tags,
+                )
+                for index, item in enumerate(contents)
+            ]
+            chunks = [
+                ChunkMetadata(
+                    chunk_text=item.content,
+                    fact_count=1,
+                    content_index=index,
+                    chunk_index=index,
+                )
+                for index, item in enumerate(contents)
+            ]
+            return facts, chunks, TokenUsage()
+
+        monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _record_extraction)
+        monkeypatch.setattr(
+            memory.embeddings,
+            "encode_documents",
+            lambda texts: [[0.0] * memory.embeddings.dimension for _ in texts],
+        )
+
+        _set_batch_tokens(2000)
+        replacement = f"{history}\n[role: user] turn 120: {tail}"
+        assert count_tokens(replacement) > get_config().retain_batch_tokens
+
+        result = await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": replacement,
+                    "context": "session transcript",
+                    "document_id": document_id,
+                }
+            ],
+            request_context=request_context,
+            outbox_callback=_record_outbox,
+        )
+
+        extracted_text = "\n".join(extracted_contents)
+        assert len(result) == 1, "Delta results must stay aligned with the single submitted document"
+        assert outbox_calls == 1, "successful delta retain must commit the outbox exactly once"
+        assert tail in extracted_text, "the changed tail must be extracted"
+        assert not any(marker in extracted_text for marker in history_markers.values()), (
+            "unchanged historical chunks were sent through extraction again"
+        )
+
+        extracted_contents.clear()
+        appended_turns = "\n".join(
+            f"[role: user] appended turn {i}: MULTI_CHUNK_TAIL_SENTINEL_{i} "
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november"
+            for i in range(30)
+        )
+        multi_chunk_append = f"{replacement}\n{appended_turns}"
+        chunk_size = DEFAULT_RETAIN_CHUNK_SIZE
+        previous_chunks = fact_extraction.chunk_text(replacement, chunk_size)
+        appended_chunks = fact_extraction.chunk_text(multi_chunk_append, chunk_size)
+        changed_indices = [
+            i for i, chunk in enumerate(appended_chunks) if i >= len(previous_chunks) or chunk != previous_chunks[i]
+        ]
+        context_tokens = count_tokens("session transcript")
+        changed_tokens = sum(count_tokens(appended_chunks[i]) + context_tokens for i in changed_indices)
+        assert count_tokens(multi_chunk_append) > get_config().retain_batch_tokens
+        assert len(changed_indices) > 1, "the regression must cross a logical chunk boundary"
+        assert changed_tokens <= get_config().retain_batch_tokens
+
+        original_insert = orchestrator._insert_facts_and_links
+
+        async def _synthetic_insert(*args: Any, outbox_callback: Any = None, **kwargs: Any) -> list[list[str]]:
+            if outbox_callback is not None:
+                await outbox_callback(args[0])
+            return [[f"delta-unit-{index}"] for index in range(len(args[3]))]
+
+        monkeypatch.setattr(orchestrator, "_insert_facts_and_links", _synthetic_insert)
+        outbox_calls = 0
+
+        multi_chunk_result = await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": multi_chunk_append,
+                    "context": "session transcript",
+                    "document_id": document_id,
+                }
+            ],
+            request_context=request_context,
+            outbox_callback=_record_outbox,
+        )
+
+        multi_chunk_extracted = "\n".join(extracted_contents)
+        assert multi_chunk_result == [[f"delta-unit-{i}" for i in range(len(changed_indices))]], (
+            "multi-chunk Delta unit IDs must collapse into the submitted document's result slot"
+        )
+        assert outbox_calls == 1, "multi-chunk delta retain must commit the outbox exactly once"
+        assert len(extracted_contents) > 1, "the test must extract more than one changed logical chunk"
+        assert "MULTI_CHUNK_TAIL_SENTINEL_0" in multi_chunk_extracted
+        assert "MULTI_CHUNK_TAIL_SENTINEL_29" in multi_chunk_extracted
+        assert not any(marker in multi_chunk_extracted for marker in history_markers.values()), (
+            "a bounded multi-chunk append re-extracted unchanged history"
+        )
+
+        monkeypatch.setattr(orchestrator, "_insert_facts_and_links", original_insert)
+        extracted_contents.clear()
+        chunk_limited_turns = "\n".join(
+            f"[role: user] chunk-limited turn {i}: CHUNK_LIMIT_TAIL_SENTINEL_{i} "
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november"
+            for i in range(30)
+        )
+        chunk_limited_append = f"{multi_chunk_append}\n{chunk_limited_turns}"
+        chunk_limited_chunks = fact_extraction.chunk_text(chunk_limited_append, chunk_size)
+        chunk_limited_indices = [
+            i
+            for i, chunk in enumerate(chunk_limited_chunks)
+            if i >= len(appended_chunks) or chunk != appended_chunks[i]
+        ]
+        chunk_limited_tokens = sum(
+            count_tokens(chunk_limited_chunks[i]) + context_tokens for i in chunk_limited_indices
+        )
+        assert len(chunk_limited_indices) > 1
+        assert chunk_limited_tokens <= get_config().retain_batch_tokens
+
+        original_internal = memory._retain_batch_async_internal
+        internal_delta_modes: list[bool] = []
+
+        async def _record_internal_modes(*args: Any, **kwargs: Any) -> Any:
+            internal_delta_modes.append(kwargs.get("delta_only", False))
+            return await original_internal(*args, **kwargs)
+
+        monkeypatch.setattr(memory, "_retain_batch_async_internal", _record_internal_modes)
+        memory._config_resolver._global_config.retain_chunk_batch_size = 1
+        outbox_calls = 0
+        chunk_limited_result = await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": chunk_limited_append,
+                    "context": "session transcript",
+                    "document_id": document_id,
+                }
+            ],
+            request_context=request_context,
+            outbox_callback=_record_outbox,
+        )
+        assert len(chunk_limited_result) == 1
+        assert internal_delta_modes[0] is True and False in internal_delta_modes, (
+            "a changed delta above retain_chunk_batch_size must use bounded fallback"
+        )
+        assert outbox_calls == 1, "chunk-count fallback must commit the outbox exactly once"
+        monkeypatch.setattr(memory, "_retain_batch_async_internal", original_internal)
+        memory._config_resolver._global_config.retain_chunk_batch_size = 100
+
+        multi_chunk_replacement = chunk_limited_append
+        for turn, marker in history_markers.items():
+            multi_chunk_replacement = multi_chunk_replacement.replace(marker, f"CHANGED_HISTORY_{turn}")
+        rewritten_chunks = fact_extraction.chunk_text(multi_chunk_replacement, chunk_size)
+        rewritten_indices = [
+            i
+            for i, chunk in enumerate(rewritten_chunks)
+            if i >= len(chunk_limited_chunks) or chunk != chunk_limited_chunks[i]
+        ]
+        rewritten_tokens = sum(count_tokens(rewritten_chunks[i]) + context_tokens for i in rewritten_indices)
+        assert rewritten_tokens > get_config().retain_batch_tokens, "the rewrite must exercise bounded fallback"
+        internal_delta_modes.clear()
+        monkeypatch.setattr(memory, "_retain_batch_async_internal", _record_internal_modes)
+        outbox_calls = 0
+        fallback_result = await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {
+                    "content": multi_chunk_replacement,
+                    "context": "session transcript",
+                    "document_id": document_id,
+                }
+            ],
+            request_context=request_context,
+            outbox_callback=_record_outbox,
+        )
+        assert len(fallback_result) == 1, "bounded fallback must preserve one result slot per submitted document"
+        assert internal_delta_modes[0] is True and False in internal_delta_modes, (
+            "a changed delta above retain_batch_tokens must use bounded fallback"
+        )
+        assert outbox_calls == 1, "token-count fallback must commit the outbox exactly once"
+        stored = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert stored is not None
+        assert stored["original_text"] == multi_chunk_replacement
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+        clear_config_cache()


### PR DESCRIPTION
> **Transparency note:** This pull request was implemented by an AI coding agent under direct user supervision. The user supplied the production use case, approved the intended behavior, and supervised the investigation, implementation, and verification.

## Summary

Preserve Delta Retain's changed-chunk-only extraction for oversized full-document replacements.

This matters for append-only documents such as chat transcripts: callers can safely keep sending the canonical full transcript with `update_mode=replace`, while unchanged history is excluded from LLM extraction whenever the actual delta fits the configured retain bounds.

## Failure mode

Assume the stored transcript has logical retain chunks:

`A B C D E`

The next scheduled retain submits the canonical replacement document:

`A B C D E + new tail`

When that document exceeded `retain_batch_tokens`, the old flow split it into transport-sized fragments before running Delta Retain. Those transport boundaries do not necessarily align with the logical chunks stored for the document, so unchanged history could no longer be matched reliably. The result was that an incremental update could re-enter LLM extraction as if it were new content, defeating Delta Retain's cost-saving behavior.

## Root cause

`MemoryEngine.retain_batch_async` applied transport/OOM splitting before `orchestrator._try_delta_retain`.

Delta Retain therefore compared partial transport slices instead of comparing the complete canonical replacement document with the previously stored logical document chunks.

## Why this required a deeper fix

The motivating workload is a periodically retained chat transcript. The caller intentionally resubmits the full canonical transcript with `update_mode=replace` so retries are idempotent and the stored document remains correct. Only the newly changed logical chunks should incur extraction cost. Once a transcript crossed the transport batch limit, however, the order of operations silently broke that cost guarantee.

Fixing this safely was more involved than moving Delta Retain ahead of the splitter. That change crosses several retain invariants at once:

- Delta work must remain bounded by both token and chunk-count limits.
- A genuine full rewrite must retain the existing streaming and OOM fallback behavior.
- One submitted document must still produce one public result slot, even when its delta spans several extraction chunks.
- Memory Defense must screen once rather than emit duplicate work or events during fallback.
- A concurrent document update between comparison and commit must not be mistaken for a successful delta retain.
- Transactional outbox completion must still fire exactly once on every successful path, including exact batch-boundary cases.

The implementation therefore required tracing the full retain pipeline, reproducing the oversized replacement behavior with realistic multi-chunk documents, defining bounded eligibility for the pre-split delta path, and adding regression tests around every affected fallback and completion contract. The result preserves the existing resilience mechanisms while restoring Delta Retain's intended LLM-cost behavior for growing documents.

## How this fixes it

For a single oversized `update_mode=replace` item with a `document_id`, the retain path now:

1. Runs Delta Retain against the complete replacement document before transport splitting.
2. Computes the changed/new logical chunks and their required context.
3. Uses the delta path only when both the changed token count fits `retain_batch_tokens` and the changed chunk count fits `retain_chunk_batch_size`.
4. Falls back to the existing bounded streaming/OOM-safe splitter for a genuine large rewrite or oversized delta.

Additional correctness fixes included in the same path:

- Multi-chunk delta unit IDs are flattened into the single public result slot associated with the submitted document.
- Memory Defense screens the replacement once; fallback paths do not duplicate screening or related events.
- A post-extraction document-hash race now propagates to bounded fallback instead of being reported as a successful delta commit.
- A full streaming batch is marked final when the total chunk count is exactly divisible by `retain_chunk_batch_size`, ensuring the transactional outbox callback is not skipped.

## Safety properties

- Unchanged logical chunks do not enter extraction on a bounded delta.
- `processed_content_tokens` reflects changed work rather than the full replacement document.
- The stored document body remains the complete canonical replacement, not only the delta.
- Large rewrites retain the existing bounded streaming and OOM protection.
- `update_mode=append` behavior is unchanged.
- No API, schema, or migration changes are required.

## Verification

Added regression coverage proving that:

- A one-chunk changed tail skips unchanged transcript history.
- A bounded delta spanning multiple logical chunks still skips unchanged history.
- Multi-chunk delta extraction preserves one result slot per submitted document.
- Token-count and chunk-count limits independently force bounded fallback.
- The outbox callback runs exactly once after delta success and after either fallback, including an exact chunk-batch boundary.
- The committed document remains the full replacement.
- Existing oversized Memory Defense redaction, async completion, webhook, and batch chunking behavior remains green.

Validation completed locally:

- 49 targeted tests passed.
- Ruff lint and format checks passed.
- `ty check hindsight_api/` passed.
- Repository lint hook and pre-commit hooks passed.
