### PR TITLE
fix(api): decode memory observation scopes

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7681,7 +7681,9 @@ class MemoryEngine(MemoryEngineInterface):
                 "chunk_id": str(row["chunk_id"]) if row["chunk_id"] else None,
                 "tags": row["tags"] if row["tags"] else [],
                 "metadata": conn.parse_json(row["metadata"]) if row["metadata"] is not None else {},
-                "observation_scopes": row["observation_scopes"] if row["observation_scopes"] else None,
+                "observation_scopes": (
+                    conn.parse_json(row["observation_scopes"]) if row["observation_scopes"] is not None else None
+                ),
                 "state": unit_state,
                 "invalidation_reason": row["invalidation_reason"],
                 "invalidated_at": row["invalidated_at"].isoformat() if row["invalidated_at"] else None,

--- a/hindsight-api-slim/tests/test_memory_curation.py
+++ b/hindsight-api-slim/tests/test_memory_curation.py
@@ -165,6 +165,11 @@ class TestInvalidate:
             m2 = await _insert_memory(conn, memory, bank_id, "srv-04 is in the eu-west datacenter.")
             obs_id = await _insert_observation(conn, bank_id, "srv-04 runs PG14 in eu-west.", [m1, m2])
             await _insert_link(conn, bank_id, m1, m2)
+            await conn.execute(
+                "UPDATE memory_units SET observation_scopes = $1::jsonb WHERE id = $2",
+                json.dumps("shared"),
+                m1,
+            )
 
         with (
             patch.object(memory, "submit_async_consolidation", new=AsyncMock()),
@@ -178,6 +183,7 @@ class TestInvalidate:
         assert result["state"] == "invalidated"
         assert result["invalidation_reason"] == "decommissioned"
         assert result["invalidated_at"] is not None
+        assert result["observation_scopes"] == "shared"
 
         async with pool.acquire() as conn:
             assert not await _in_live(conn, m1), "invalidated row must leave memory_units"


### PR DESCRIPTION
## Summary

- deserialize the JSONB `observation_scopes` column before returning memory detail/update responses
- preserve named modes such as `shared` and explicit tag-group arrays as native JSON values
- extend the existing invalidation regression to cover the archived memory response shape

## Why

The PostgreSQL adapter returns JSONB as encoded JSON text. `get_memory_unit()` already deserializes other JSON columns but returned `observation_scopes` directly. A stored `shared` mode was therefore emitted as the JSON string `"\"shared\""` rather than `"shared"`. Strict OpenAPI-compatible clients reject that response after update/invalidation succeeds.

The fix is at the database/API producer boundary and uses the existing backend-aware JSON deserializer, preserving both PostgreSQL and Oracle behavior.

## Validation

- existing PostgreSQL curation/invalidation regression passed with `observation_scopes="shared"`
- Ruff check passed
- Ruff format check passed
