### PR TITLE
fix(api): report effective MarkItDown image OCR capability

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2819,6 +2819,7 @@ class FeaturesInfo(BaseModel):
     bank_config_api: bool = Field(description="Whether per-bank configuration API is enabled")
     bank_llm_health: bool = Field(description="Whether the per-bank LLM connectivity probe is enabled")
     file_upload_api: bool = Field(description="Whether file upload/conversion API is enabled")
+    markitdown_image_ocr: bool = Field(description="Whether MarkItDown image OCR is enabled and available")
     document_export_api: bool = Field(description="Whether the document export endpoint is enabled")
     document_import_api: bool = Field(description="Whether the document import endpoint is enabled")
     audit_log: bool = Field(description="Whether audit logging is enabled")
@@ -3500,6 +3501,17 @@ def _register_routes(app: FastAPI):
         from hindsight_api.config import _get_raw_config
 
         config = _get_raw_config()
+        registered_parsers = app.state.memory._parser_registry.list_parsers()
+        allowed_parsers = config.file_parser_allowlist
+        # The OCR config flag alone is insufficient: the upload endpoint may be
+        # disabled, dependencies may prevent parser registration, or the parser
+        # allowlist may make MarkItDown unavailable to callers.
+        markitdown_image_ocr = (
+            config.enable_file_upload_api
+            and config.file_parser_markitdown_ocr_enabled
+            and "markitdown" in registered_parsers
+            and (allowed_parsers is None or "markitdown" in allowed_parsers)
+        )
         return VersionResponse(
             api_version=__version__,
             features=FeaturesInfo(
@@ -3509,6 +3521,7 @@ def _register_routes(app: FastAPI):
                 bank_config_api=config.enable_bank_config_api,
                 bank_llm_health=config.enable_bank_llm_health,
                 file_upload_api=config.enable_file_upload_api,
+                markitdown_image_ocr=markitdown_image_ocr,
                 document_export_api=config.enable_document_export_api,
                 document_import_api=config.enable_document_import_api,
                 audit_log=config.audit_log_enabled,

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -11,6 +11,7 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
+from hindsight_api.engine.memory_engine import MemoryEngine
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -1108,13 +1109,51 @@ async def test_version_endpoint_returns_correct_version(api_client):
     assert "observations" in features
     assert "mcp" in features
     assert "worker" in features
+    assert "markitdown_image_ocr" in features
     assert isinstance(features["observations"], bool)
     assert isinstance(features["mcp"], bool)
     assert isinstance(features["worker"], bool)
+    assert isinstance(features["markitdown_image_ocr"], bool)
     assert isinstance(features["audit_log"], bool)
     assert isinstance(features["llm_trace"], bool)
 
     print(f"Version endpoint returned: api_version={result['api_version']}, features={features}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("file_upload_enabled", "ocr_enabled", "registered_parsers", "parser_allowlist", "expected"),
+    [
+        (True, True, ["markitdown"], None, True),
+        (False, True, ["markitdown"], None, False),
+        (True, True, ["markitdown"], [], False),
+        (True, True, [], None, False),
+        (True, False, ["markitdown"], None, False),
+    ],
+)
+async def test_version_endpoint_reports_effective_markitdown_image_ocr(
+    api_client: httpx.AsyncClient,
+    memory: MemoryEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    file_upload_enabled: bool,
+    ocr_enabled: bool,
+    registered_parsers: list[str],
+    parser_allowlist: list[str] | None,
+    expected: bool,
+) -> None:
+    """OCR is advertised only when both its config and runtime parser are available."""
+    from hindsight_api.config import _get_raw_config
+
+    config = _get_raw_config()
+    monkeypatch.setattr(config, "enable_file_upload_api", file_upload_enabled)
+    monkeypatch.setattr(config, "file_parser_markitdown_ocr_enabled", ocr_enabled)
+    monkeypatch.setattr(config, "file_parser_allowlist", parser_allowlist)
+    monkeypatch.setattr(memory._parser_registry, "list_parsers", lambda: registered_parsers)
+
+    response = await api_client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["markitdown_image_ocr"] is expected
 
 
 @pytest.mark.asyncio

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -5824,6 +5824,10 @@ components:
           description: Whether file upload/conversion API is enabled
           title: File Upload Api
           type: boolean
+        markitdown_image_ocr:
+          description: Whether MarkItDown image OCR is enabled and available
+          title: Markitdown Image Ocr
+          type: boolean
         document_export_api:
           description: Whether the document export endpoint is enabled
           title: Document Export Api
@@ -5853,6 +5857,7 @@ components:
       - document_import_api
       - file_upload_api
       - llm_trace
+      - markitdown_image_ocr
       - mcp
       - observations
       - store_document_text

--- a/hindsight-clients/go/model_features_info.go
+++ b/hindsight-clients/go/model_features_info.go
@@ -33,6 +33,8 @@ type FeaturesInfo struct {
 	BankLlmHealth bool `json:"bank_llm_health"`
 	// Whether file upload/conversion API is enabled
 	FileUploadApi bool `json:"file_upload_api"`
+	// Whether MarkItDown image OCR is enabled and available
+	MarkitdownImageOcr bool `json:"markitdown_image_ocr"`
 	// Whether the document export endpoint is enabled
 	DocumentExportApi bool `json:"document_export_api"`
 	// Whether the document import endpoint is enabled
@@ -51,7 +53,7 @@ type _FeaturesInfo FeaturesInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, bankLlmHealth bool, fileUploadApi bool, documentExportApi bool, documentImportApi bool, auditLog bool, llmTrace bool, storeDocumentText bool) *FeaturesInfo {
+func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi bool, bankLlmHealth bool, fileUploadApi bool, markitdownImageOcr bool, documentExportApi bool, documentImportApi bool, auditLog bool, llmTrace bool, storeDocumentText bool) *FeaturesInfo {
 	this := FeaturesInfo{}
 	this.Observations = observations
 	this.Mcp = mcp
@@ -59,6 +61,7 @@ func NewFeaturesInfo(observations bool, mcp bool, worker bool, bankConfigApi boo
 	this.BankConfigApi = bankConfigApi
 	this.BankLlmHealth = bankLlmHealth
 	this.FileUploadApi = fileUploadApi
+	this.MarkitdownImageOcr = markitdownImageOcr
 	this.DocumentExportApi = documentExportApi
 	this.DocumentImportApi = documentImportApi
 	this.AuditLog = auditLog
@@ -219,6 +222,30 @@ func (o *FeaturesInfo) SetFileUploadApi(v bool) {
 	o.FileUploadApi = v
 }
 
+// GetMarkitdownImageOcr returns the MarkitdownImageOcr field value
+func (o *FeaturesInfo) GetMarkitdownImageOcr() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.MarkitdownImageOcr
+}
+
+// GetMarkitdownImageOcrOk returns a tuple with the MarkitdownImageOcr field value
+// and a boolean to check if the value has been set.
+func (o *FeaturesInfo) GetMarkitdownImageOcrOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.MarkitdownImageOcr, true
+}
+
+// SetMarkitdownImageOcr sets field value
+func (o *FeaturesInfo) SetMarkitdownImageOcr(v bool) {
+	o.MarkitdownImageOcr = v
+}
+
 // GetDocumentExportApi returns the DocumentExportApi field value
 func (o *FeaturesInfo) GetDocumentExportApi() bool {
 	if o == nil {
@@ -355,6 +382,7 @@ func (o FeaturesInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["bank_config_api"] = o.BankConfigApi
 	toSerialize["bank_llm_health"] = o.BankLlmHealth
 	toSerialize["file_upload_api"] = o.FileUploadApi
+	toSerialize["markitdown_image_ocr"] = o.MarkitdownImageOcr
 	toSerialize["document_export_api"] = o.DocumentExportApi
 	toSerialize["document_import_api"] = o.DocumentImportApi
 	toSerialize["audit_log"] = o.AuditLog
@@ -374,6 +402,7 @@ func (o *FeaturesInfo) UnmarshalJSON(data []byte) (err error) {
 		"bank_config_api",
 		"bank_llm_health",
 		"file_upload_api",
+		"markitdown_image_ocr",
 		"document_export_api",
 		"document_import_api",
 		"audit_log",

--- a/hindsight-clients/python/hindsight_client_api/models/features_info.py
+++ b/hindsight-clients/python/hindsight_client_api/models/features_info.py
@@ -32,12 +32,13 @@ class FeaturesInfo(BaseModel):
     bank_config_api: StrictBool = Field(description="Whether per-bank configuration API is enabled")
     bank_llm_health: StrictBool = Field(description="Whether the per-bank LLM connectivity probe is enabled")
     file_upload_api: StrictBool = Field(description="Whether file upload/conversion API is enabled")
+    markitdown_image_ocr: StrictBool = Field(description="Whether MarkItDown image OCR is enabled and available")
     document_export_api: StrictBool = Field(description="Whether the document export endpoint is enabled")
     document_import_api: StrictBool = Field(description="Whether the document import endpoint is enabled")
     audit_log: StrictBool = Field(description="Whether audit logging is enabled")
     llm_trace: StrictBool = Field(description="Whether per-bank LLM request tracing is enabled")
     store_document_text: StrictBool = Field(description="Whether raw source text is persisted. When false, document/chunk source text is not stored.")
-    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "bank_llm_health", "file_upload_api", "document_export_api", "document_import_api", "audit_log", "llm_trace", "store_document_text"]
+    __properties: ClassVar[List[str]] = ["observations", "mcp", "worker", "bank_config_api", "bank_llm_health", "file_upload_api", "markitdown_image_ocr", "document_export_api", "document_import_api", "audit_log", "llm_trace", "store_document_text"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +97,7 @@ class FeaturesInfo(BaseModel):
             "bank_config_api": obj.get("bank_config_api"),
             "bank_llm_health": obj.get("bank_llm_health"),
             "file_upload_api": obj.get("file_upload_api"),
+            "markitdown_image_ocr": obj.get("markitdown_image_ocr"),
             "document_export_api": obj.get("document_export_api"),
             "document_import_api": obj.get("document_import_api"),
             "audit_log": obj.get("audit_log"),

--- a/hindsight-clients/python/tests/test_version.py
+++ b/hindsight-clients/python/tests/test_version.py
@@ -24,6 +24,7 @@ def _version_response() -> VersionResponse:
         bank_config_api=True,
         bank_llm_health=True,
         file_upload_api=True,
+        markitdown_image_ocr=True,
         document_export_api=True,
         document_import_api=True,
         audit_log=True,
@@ -42,6 +43,7 @@ async def test_aget_version_delegates_to_monitoring_api():
 
     assert version.api_version == "0.8.2"
     assert version.features.observations is True
+    assert version.features.markitdown_image_ocr is True
     client._monitoring_api.get_version.assert_awaited_once()
 
 

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -1847,6 +1847,12 @@ export type FeaturesInfo = {
    */
   file_upload_api: boolean;
   /**
+   * Markitdown Image Ocr
+   *
+   * Whether MarkItDown image OCR is enabled and available
+   */
+  markitdown_image_ocr: boolean;
+  /**
    * Document Export Api
    *
    * Whether the document export endpoint is enabled

--- a/hindsight-clients/typescript/tests/version.test.ts
+++ b/hindsight-clients/typescript/tests/version.test.ts
@@ -22,6 +22,7 @@ describe("getVersion", () => {
           custom_llm_provider: true,
           bank_llm_health: true,
           file_conversion: true,
+          markitdown_image_ocr: true,
         },
       },
     } as any);
@@ -36,6 +37,7 @@ describe("getVersion", () => {
 
     expect(version.api_version).toBe("0.8.2");
     expect(version.features.observations).toBe(true);
+    expect(version.features.markitdown_image_ocr).toBe(true);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0][0]).toHaveProperty("client");
   });

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1423,6 +1423,7 @@ export class ControlPlaneClient {
         worker: boolean;
         bank_config_api: boolean;
         file_upload_api: boolean;
+        markitdown_image_ocr: boolean;
         document_export_api: boolean;
         document_import_api: boolean;
         audit_log: boolean;

--- a/hindsight-control-plane/src/lib/features-context.tsx
+++ b/hindsight-control-plane/src/lib/features-context.tsx
@@ -10,6 +10,7 @@ interface Features {
   bank_config_api: boolean;
   bank_llm_health: boolean;
   access_key_auth: boolean;
+  markitdown_image_ocr: boolean;
   document_export_api: boolean;
   document_import_api: boolean;
   audit_log: boolean;
@@ -30,6 +31,7 @@ const defaultFeatures: Features = {
   bank_config_api: false,
   bank_llm_health: false,
   access_key_auth: false,
+  markitdown_image_ocr: false,
   document_export_api: false,
   document_import_api: false,
   audit_log: false,

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -8861,6 +8861,11 @@
             "title": "File Upload Api",
             "description": "Whether file upload/conversion API is enabled"
           },
+          "markitdown_image_ocr": {
+            "type": "boolean",
+            "title": "Markitdown Image Ocr",
+            "description": "Whether MarkItDown image OCR is enabled and available"
+          },
           "document_export_api": {
             "type": "boolean",
             "title": "Document Export Api",
@@ -8895,6 +8900,7 @@
           "bank_config_api",
           "bank_llm_health",
           "file_upload_api",
+          "markitdown_image_ocr",
           "document_export_api",
           "document_import_api",
           "audit_log",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -8861,6 +8861,11 @@
             "title": "File Upload Api",
             "description": "Whether file upload/conversion API is enabled"
           },
+          "markitdown_image_ocr": {
+            "type": "boolean",
+            "title": "Markitdown Image Ocr",
+            "description": "Whether MarkItDown image OCR is enabled and available"
+          },
           "document_export_api": {
             "type": "boolean",
             "title": "Document Export Api",
@@ -8895,6 +8900,7 @@
           "bank_config_api",
           "bank_llm_health",
           "file_upload_api",
+          "markitdown_image_ocr",
           "document_export_api",
           "document_import_api",
           "audit_log",


### PR DESCRIPTION
## Summary

- Expose `features.markitdown_image_ocr` from `GET /version` so clients can distinguish general file upload support from usable MarkItDown image OCR.
- Report the capability only when file uploads and OCR are enabled, MarkItDown registered successfully, and the parser allowlist permits it.
- Regenerate the OpenAPI specification and Python, TypeScript, and Go client models, and update control-plane feature types.

## Why

The optional MarkItDown OCR integration was controlled by dedicated server configuration, but `/version` only exposed `file_upload_api`. Clients could determine that the upload endpoint existed but could not determine whether image OCR was actually available. The missing capability flag made integrations rely on trial requests and conversion failures.

## Impact

Clients can now check `version.features.markitdown_image_ocr` before offering or invoking MarkItDown image OCR. Existing deployments keep the default value `false` unless the complete runtime capability is available.

## Validation

- API integration tests cover enabled, upload-disabled, allowlist-excluded, parser-unavailable, and OCR-disabled states.
- Python SDK version tests pass.
- TypeScript SDK version tests pass.
- Rust and Go clients build successfully during client generation.
- OpenAPI generation, documentation build, and repository lint pass.