### PR TITLE
fix(ci): avoid rebuilding docs in verify-generated-files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1224,10 +1224,10 @@ jobs:
 
   build-docs:
     needs: [detect-changes]
-    if: >-
-      (github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.docs == 'true' ||
-      needs.detect-changes.outputs.ci == 'true')
+    # Keep the production docs build as an unconditional PR check. OpenAPI
+    # generation used to build the site again inside verify-generated-files;
+    # running the existing job for every PR preserves that coverage without
+    # serializing two full Docusaurus builds in the generated-files check.
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -4766,7 +4766,8 @@ jobs:
         cd ../hindsight-embed && uv sync --frozen --index-strategy unsafe-best-match
 
     - name: Run generate-openapi
-      run: ./scripts/generate-openapi.sh
+      working-directory: hindsight-dev
+      run: uv run generate-openapi
 
     - name: Run generate-bank-template-schema
       run: ./scripts/generate-bank-template-schema.sh


### PR DESCRIPTION
## Summary

- Run the existing `build-docs` job for every PR so the production documentation build remains an unconditional check.
- Generate OpenAPI directly in `verify-generated-files` instead of calling the wrapper that also rebuilds the Docusaurus site.
- Preserve the existing generated-client, Rust release build, lint, and generated-file diff checks.

## Impact

This removes a duplicate Docusaurus production build from the serialized `verify-generated-files` job while keeping the same documentation build coverage in the existing parallel `build-docs` job. Based on recent CI timings, `verify-generated-files` should drop from about 6:49 to about 3:38, making `build-docs` the longest job at about 4:03.

## Validation

- `./scripts/hooks/lint.sh`
- YAML parse check
- `git diff --check`