### PR TITLE
fix(retain): preserve initial call with zero retry budget

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1362,10 +1362,11 @@ async def _extract_facts_from_chunk(
     llm_max_retries = (
         config.retain_llm_max_retries if config.retain_llm_max_retries is not None else config.llm_max_retries
     )
+    extraction_attempts = max(1, llm_max_retries)
     last_error: Exception | None = None
 
     usage = TokenUsage()  # Track cumulative usage across retries
-    for attempt in range(llm_max_retries):
+    for attempt in range(extraction_attempts):
         try:
             initial_backoff = (
                 config.retain_llm_initial_backoff
@@ -1672,7 +1673,7 @@ async def _extract_facts_from_chunk(
     # If we exhausted all retries, raise the last error or a descriptive fallback
     if last_error is not None:
         raise last_error
-    raise RuntimeError(f"Fact extraction failed after {llm_max_retries} attempts: LLM did not return valid JSON")
+    raise RuntimeError(f"Fact extraction failed after {extraction_attempts} attempts: LLM did not return valid JSON")
 
 
 async def _extract_facts_with_auto_split(

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -264,6 +264,33 @@ async def test_retain_llm_max_retries_overrides_global():
 
 
 @pytest.mark.asyncio
+async def test_zero_retain_retry_budget_still_makes_initial_call():
+    """A zero transport retry budget must not skip fact extraction."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    config = _make_config(llm_max_retries=10, retain_llm_max_retries=0)
+    llm_config = _make_llm_config(mock_response={"facts": [], "entities": []})
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        await _extract_facts_from_chunk(
+            chunk="Bob likes Python.",
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm_config,
+            config=config,
+            agent_name="agent",
+        )
+
+    llm_config.call.assert_awaited_once()
+    assert llm_config.call.await_args.kwargs["max_retries"] == 0
+
+
+@pytest.mark.asyncio
 async def test_none_event_date_with_empty_facts_no_crash():
     """
     When event_date is None and the LLM returns an empty facts list,


### PR DESCRIPTION
## Summary

- make fact extraction perform one initial request when `retain_llm_max_retries=0`
- keep forwarding the configured zero transport retry budget to the provider
- report the actual outer attempt count in the exhausted-attempt fallback

Closes #2731.

## Validation

- `uv run --package hindsight-api-slim pytest hindsight-api-slim/tests/test_fact_extraction_retry.py -q` (13 passed)
- `uv run --package hindsight-api-slim ruff check hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py hindsight-api-slim/tests/test_fact_extraction_retry.py`
- `uv run --package hindsight-api-slim ruff format --check hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py hindsight-api-slim/tests/test_fact_extraction_retry.py`
- `git diff --check`