### PR TITLE
fix(embed): defer provider credential validation

### DIFF
--- a/hindsight-embed/README.md
+++ b/hindsight-embed/README.md
@@ -150,7 +150,7 @@ Run `hindsight-embed configure` for a guided setup that saves to `~/.hindsight/e
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_EMBED_PROFILE` | Profile name to use (overrides active profile) | None (uses default profile) |
-| `HINDSIGHT_API_LLM_API_KEY` | LLM API key (or use `OPENAI_API_KEY`) | Required |
+| `HINDSIGHT_API_LLM_API_KEY` | LLM API key (or use `OPENAI_API_KEY`); required only when the selected provider uses an API key | Provider-dependent |
 | `HINDSIGHT_API_LLM_PROVIDER` | LLM provider (`openai`, `groq`, `google`, `ollama`) | `openai` |
 | `HINDSIGHT_API_LLM_MODEL` | LLM model | `gpt-4o-mini` |
 | `HINDSIGHT_EMBED_API_URL` | Use external API server instead of starting local daemon | None (starts local daemon) |

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -11,7 +11,7 @@ Usage:
     hindsight-embed daemon status          # Check daemon status
 
 Environment variables:
-    HINDSIGHT_API_LLM_API_KEY: Required. API key for LLM provider.
+    HINDSIGHT_API_LLM_API_KEY: Required when the selected LLM provider uses an API key.
     HINDSIGHT_API_LLM_PROVIDER: Optional. LLM provider (default: "openai").
     HINDSIGHT_API_LLM_MODEL: Optional. LLM model (default: provider-specific, resolved by hindsight-api).
     HINDSIGHT_EMBED_API_URL: Optional. Use external API server instead of starting local daemon.
@@ -1606,14 +1606,6 @@ def main():
 
         # Forward all other commands to hindsight-cli
         config = get_config()
-
-        # Check for LLM API key (not required for vertexai which uses GCP credentials)
-        llm_provider = config.get("llm_provider", "openai")
-        providers_without_api_key = ("ollama", "vertexai", "llamacpp")
-        if not config["llm_api_key"] and llm_provider not in providers_without_api_key:
-            print("Error: LLM API key is required.", file=sys.stderr)
-            print("Run 'hindsight-embed configure' to set up.", file=sys.stderr)
-            sys.exit(1)
 
         from . import daemon_client
 

--- a/hindsight-embed/tests/test_cli_forwarding.py
+++ b/hindsight-embed/tests/test_cli_forwarding.py
@@ -1,0 +1,26 @@
+"""Tests for forwarding commands from hindsight-embed to hindsight-cli."""
+
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+
+def test_no_key_provider_is_forwarded_to_daemon(tmp_path, monkeypatch):
+    """Provider implementations, not the wrapper CLI, own credential validation."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    from hindsight_embed import cli, daemon_client
+
+    config = {"llm_provider": "mock", "llm_api_key": None}
+    run_cli = Mock(return_value=0)
+    monkeypatch.setattr(sys, "argv", ["hindsight-embed", "bank", "list"])
+    monkeypatch.setattr(cli, "get_config", lambda: config)
+    monkeypatch.setattr(daemon_client, "run_cli", run_cli)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 0
+    run_cli.assert_called_once_with(["bank", "list"], config, None)


### PR DESCRIPTION
## Summary

- remove the embed wrapper CLI credential allowlist and defer validation to the selected provider
- add regression coverage proving a no-key provider configuration is forwarded to the daemon
- clarify that the LLM API key requirement depends on the selected provider

Closes #2732

## Testing

- `UV_CACHE_DIR=/tmp/hindsight-uv-cache ./scripts/hooks/lint.sh`
- `UV_CACHE_DIR=/tmp/hindsight-uv-cache uv run ruff format --check hindsight_embed tests/test_cli_forwarding.py`
- `UV_CACHE_DIR=/tmp/hindsight-uv-cache uv run ruff check hindsight_embed tests/test_cli_forwarding.py`
- `UV_CACHE_DIR=/tmp/hindsight-uv-cache uv run ty check hindsight_embed`
- `UV_CACHE_DIR=/tmp/hindsight-uv-cache uv run pytest -p no:rerunfailures tests/ -q` (147 passed)