### PR TITLE
docs: fix conversation-scoped bank claim in Omnigent post

### DIFF
--- a/hindsight-docs/blog/2026-07-14-omnigent-persistent-memory.md
+++ b/hindsight-docs/blog/2026-07-14-omnigent-persistent-memory.md
@@ -98,7 +98,7 @@ Memory is isolated per bank. Omnigent resolves which bank to use in this order:
 
 1. The explicit `bank_id` in your YAML config (most predictable, recommended for production).
 2. The agent's `agent_id`: one bank per agent, shared across all conversations that agent has.
-3. The `conversation_id`: one bank per conversation, wiped when the conversation ends.
+3. The `conversation_id`: one bank per conversation. A new conversation resolves to a new bank, so memory does not carry across conversations (the earlier bank still exists, it is just no longer referenced).
 
 If you run multiple agents in Omnigent and want them to share a memory (a shared project bank, for example), point them all at the same `bank_id`.
 


### PR DESCRIPTION
The Omnigent post's bank-scoping section says a conversation-scoped bank is *wiped when the conversation ends*. That is inaccurate.

Verified against the source: banks are lazily created and never auto-deleted on conversation end. What actually happens is that a **new conversation resolves to a new bank** (`bank_id` → `agent_id` → `conversation_id`), so memory does not *carry across* conversations. The earlier conversation's bank still exists in storage; it is simply no longer referenced.

**Before**
> The `conversation_id`: one bank per conversation, wiped when the conversation ends.

**After**
> The `conversation_id`: one bank per conversation. A new conversation resolves to a new bank, so memory does not carry across conversations (the earlier bank still exists, it is just no longer referenced).

One-line copy fix, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)