### PR TITLE
fix(retain): enforce entity extraction contract

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -180,7 +180,7 @@ class ExtractedFact(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     what: str = Field(description="Core fact - concise but complete (1-2 sentences)")
@@ -195,7 +195,7 @@ class ExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts, including user preferences, rules, corrections, and constraints even when stated during a conversation. 'assistant' = actions, experiences, or observations the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[Entity] = Field(default_factory=list, description="People, places, concepts")
     causal_relations: list[FactCausalRelation] | None = Field(
         default=None, description="Links to previous facts (target_index < this fact's index)"
     )
@@ -286,7 +286,7 @@ class ExtractedFactVerbose(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     what: str = Field(
@@ -348,8 +348,8 @@ class ExtractedFactVerbose(BaseModel):
         description="'world' = objective/external facts about the user, other people, events, general knowledge, preferences, rules, corrections, or constraints. 'assistant' = actions, experiences, or observations the assistant/agent actually performed (e.g., 'I changed X', 'I discovered Y')."
     )
 
-    entities: list[Entity] | None = Field(
-        default=None,
+    entities: list[Entity] = Field(
+        default_factory=list,
         description="Named entities, objects, AND abstract concepts from the fact. Include: people names, organizations, places, significant objects (e.g., 'coffee maker', 'car'), AND abstract concepts/themes (e.g., 'friendship', 'career growth', 'loss', 'celebration'). Extract anything that could help link related facts together.",
     )
 
@@ -378,7 +378,7 @@ class ExtractedFactNoCausal(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     # Same fields as ExtractedFact but without causal_relations
@@ -397,8 +397,8 @@ class ExtractedFactNoCausal(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = about the user/others, including user preferences, rules, corrections, and constraints. 'assistant' = actions or experiences the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(
-        default=None,
+    entities: list[Entity] = Field(
+        default_factory=list,
         description="Named entities, objects, and concepts from the fact.",
     )
 
@@ -426,7 +426,7 @@ class VerbatimExtractedFact(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["when", "where", "who", "fact_type"]},
+        json_schema_extra={"required": ["when", "where", "who", "fact_type", "entities"]},
     )
 
     when: str = Field(description="When it happened. 'N/A' if unknown.")
@@ -439,7 +439,7 @@ class VerbatimExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts. 'assistant' = first-person actions, experiences, or observations by the speaker."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[Entity] = Field(default_factory=list, description="People, places, concepts")
 
     @field_validator("entities", mode="before")
     @classmethod
@@ -731,6 +731,7 @@ ENTITIES
 ══════════════════════════════════════════════════════════════════════════
 
 Include: people names, organizations, places, key objects, abstract concepts (career, friendship, etc.)
+Always return the "entities" field as an array of objects with a "text" field, never as an array of strings.
 Always include "user" when fact is about the user.{examples}"""
 
 # Concise mode guidelines
@@ -767,15 +768,15 @@ Example 1 - Selective extraction (Event Date: June 10, 2024):
 Input: "Hey! How's it going? Good morning! So I'm planning my wedding - want a small outdoor ceremony. Just got back from Emily's wedding, she married Sarah at a rooftop garden. It was nice weather. I grabbed a coffee on the way."
 
 Output: ONLY 2 facts (skip greetings, weather, coffee):
-1. what="User planning wedding, wants small outdoor ceremony", who="user", why="N/A", entities=["user", "wedding"]
-2. what="Emily married Sarah at rooftop garden", who="Emily (user's friend), Sarah", occurred_start="2024-06-09", entities=["Emily", "Sarah", "wedding"]
+1. what="User planning wedding, wants small outdoor ceremony", who="user", why="N/A", entities=[{{"text": "user"}}, {{"text": "wedding"}}]
+2. what="Emily married Sarah at rooftop garden", who="Emily (user's friend), Sarah", occurred_start="2024-06-09", entities=[{{"text": "Emily"}}, {{"text": "Sarah"}}, {{"text": "wedding"}}]
 
 Example 2 - Professional context:
 Input: "Alice has 5 years of Kubernetes experience and holds CKA certification. She's been leading the infrastructure team since March. By the way, she prefers dark roast coffee."
 
 Output: ONLY 2 facts (skip coffee preference - too trivial):
-1. what="Alice has 5 years Kubernetes experience, CKA certified", who="Alice", entities=["Alice", "Kubernetes", "CKA"]
-2. what="Alice leads infrastructure team since March", who="Alice", entities=["Alice", "infrastructure"]
+1. what="Alice has 5 years Kubernetes experience, CKA certified", who="Alice", entities=[{{"text": "Alice"}}, {{"text": "Kubernetes"}}, {{"text": "CKA"}}]
+2. what="Alice leads infrastructure team since March", who="Alice", entities=[{{"text": "Alice"}}, {{"text": "infrastructure"}}]
 
 ══════════════════════════════════════════════════════════════════════════
 QUALITY OVER QUANTITY
@@ -932,6 +933,7 @@ Extract ALL of the following from the fact:
 - Significant objects mentioned (coffee maker, new car, wedding dress)
 - Abstract concepts/themes (friendship, career growth, loss, celebration)
 
+Always return the "entities" field as an array of objects with a "text" field, never as an array of strings.
 ALWAYS include "user" when fact is about the user.
 Extract anything that could help link related facts together."""
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1156,12 +1156,15 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
             # required array (the base class json_schema_extra overrides required entirely)
             base_extra = base_fact_class.model_config.get("json_schema_extra")
             base_required = cast(dict, base_extra).get("required", []) if isinstance(base_extra, dict) else []
+            # Labels-only mode deliberately suppresses free-form entities, so do not make
+            # that field mandatory in the generated schema even though the base model does.
+            required_fields = [field for field in base_required if free_form_entities or field != "entities"]
             DynamicFact = create_model(
                 "LabelsFact",
                 __base__=base_fact_class,
                 __config__=ConfigDict(
                     json_schema_mode="validation",
-                    json_schema_extra={"required": [*base_required, "labels"]},
+                    json_schema_extra={"required": [*required_fields, "labels"]},
                 ),
                 **dynamic_fields,
             )

--- a/hindsight-api-slim/tests/test_fact_extraction_entity_contract.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entity_contract.py
@@ -1,0 +1,78 @@
+"""Regression coverage for the fact-extraction entity output contract."""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.retain.fact_extraction import (
+    ExtractedFact,
+    ExtractedFactNoCausal,
+    ExtractedFactVerbose,
+    VerbatimExtractedFact,
+    _build_extraction_prompt_and_schema,
+    extract_facts_from_text,
+)
+from tests.llm_judge import assert_meets_criteria
+
+
+def _baseline_config() -> MagicMock:
+    config = MagicMock()
+    config.entity_labels = None
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = False
+    config.retain_mission = None
+    config.retain_custom_instructions = None
+    config.llm_output_language = None
+    return config
+
+
+@pytest.mark.parametrize(
+    "model",
+    [ExtractedFact, ExtractedFactVerbose, ExtractedFactNoCausal, VerbatimExtractedFact],
+)
+def test_entities_are_required_object_arrays_with_empty_default(model):
+    schema = model.model_json_schema()
+
+    assert "entities" in schema["required"]
+    assert schema["properties"]["entities"]["type"] == "array"
+
+    values = {"when": "N/A", "where": "N/A", "who": "N/A", "fact_type": "world"}
+    if model is not VerbatimExtractedFact:
+        values.update({"what": "Alice works at Acme", "why": "N/A"})
+    assert model(**values).entities == []
+
+
+def test_concise_prompt_teaches_object_shaped_entities():
+    prompt, _ = _build_extraction_prompt_and_schema(_baseline_config())
+
+    assert 'entities=[{"text": "Alice"}, {"text": "Kubernetes"}, {"text": "CKA"}]' in prompt
+    assert 'entities=["Alice", "Kubernetes", "CKA"]' not in prompt
+    assert 'array of objects with a "text" field, never as an array of strings' in prompt
+
+
+@pytest.mark.hs_llm_core
+@pytest.mark.asyncio
+async def test_fact_extraction_returns_relevant_entities():
+    facts, _, _ = await extract_facts_from_text(
+        text="Alice leads the Kubernetes platform team at Acme Corporation in Berlin.",
+        event_date=datetime(2026, 7, 16),
+        llm_config=LLMConfig.from_env(),
+        agent_name="assistant",
+        context="employee profile",
+        config=_get_raw_config(),
+    )
+
+    entity_summary = json.dumps([entity.text for fact in facts for entity in (fact.entities or [])], ensure_ascii=False)
+    await assert_meets_criteria(
+        response=entity_summary,
+        criteria=(
+            "The extracted entity list is non-empty and contains the named person Alice plus relevant named entities "
+            "from the source, especially Acme Corporation and Kubernetes or Berlin."
+        ),
+        context="Source: Alice leads the Kubernetes platform team at Acme Corporation in Berlin.",
+    )

--- a/hindsight-api-slim/tests/test_fact_extraction_entity_contract.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entity_contract.py
@@ -55,6 +55,19 @@ def test_concise_prompt_teaches_object_shaped_entities():
     assert 'array of objects with a "text" field, never as an array of strings' in prompt
 
 
+@pytest.mark.parametrize("free_form_entities, entities_required", [(True, True), (False, False)])
+def test_labels_schema_matches_free_form_entity_setting(free_form_entities, entities_required):
+    config = _baseline_config()
+    config.entity_labels = [{"key": "topic", "values": [{"value": "math"}]}]
+    config.entities_allow_free_form = free_form_entities
+
+    _, schema = _build_extraction_prompt_and_schema(config)
+    fact_schema = schema.model_json_schema()["$defs"]["LabelsFact"]
+
+    assert ("entities" in fact_schema["required"]) is entities_required
+    assert "labels" in fact_schema["required"]
+
+
 @pytest.mark.hs_llm_core
 @pytest.mark.asyncio
 async def test_fact_extraction_returns_relevant_entities():


### PR DESCRIPTION
## Summary

- require object-shaped `entities` arrays in every fact-extraction response schema while retaining an empty-list fallback
- update concise examples and shared/verbose instructions to match the `Entity` model contract
- add deterministic schema/prompt regression coverage and a real-LLM entity extraction judge test

Closes #2749

## Testing

- `UV_CACHE_DIR=/tmp/hindsight-uv-cache ./scripts/hooks/lint.sh`
- `uv run pytest tests/test_fact_extraction_entity_contract.py tests/test_fact_extraction_fact_type_prompt.py -m "not hs_llm_core" -q` (7 passed)
- `uv run pytest tests/test_entity_labels.py -m "not hs_llm_core" -k "not entity_resolution_does_not_merge_distinct_label_values" -q` (76 passed)
- real extraction produced `Alice`, `Kubernetes`, `Acme Corporation`, and `Berlin`; the local Gemini judge endpoint timed out, so the committed `hs_llm_core` test is left for the standard quality CI environment