### PR TITLE
fix(reflect): keep horizontal rules inside fenced code blocks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -177,20 +177,17 @@ _HEADING_RX = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _BULLET_RX = re.compile(r"^\s*[-*+]\s+(.*)$")
 _ORDERED_RX = re.compile(r"^\s*\d+[.)]\s+(.*)$")
 _FENCE_RX = re.compile(r"^```([A-Za-z0-9_+-]*)\s*$")
-
-
-def _strip_separators(lines: list[str]) -> list[str]:
-    """Drop horizontal-rule lines (`---`, `***`) used as section separators.
-
-    Our renderer never emits these, but LLM output frequently includes them
-    between sections; treating them as blank lines avoids parsing them as
-    paragraphs.
-    """
-    return ["" if re.fullmatch(r"\s*([-*_])\1{2,}\s*", line) else line for line in lines]
+_SEPARATOR_RX = re.compile(r"\s*([-*_])\1{2,}\s*")
 
 
 def _split_blocks(lines: list[str]) -> list[list[str]]:
-    """Group consecutive non-blank lines into block chunks."""
+    """Group consecutive non-blank lines into block chunks.
+
+    Horizontal-rule lines (`---`, `***`) count as blank.  Our renderer never
+    emits these, but LLM output frequently includes them between sections;
+    treating them as blank avoids parsing them as paragraphs.  Inside a fence
+    they are code, not a separator, so they are kept verbatim.
+    """
     chunks: list[list[str]] = []
     current: list[str] = []
     in_fence = False
@@ -202,7 +199,7 @@ def _split_blocks(lines: list[str]) -> list[list[str]]:
         if in_fence:
             current.append(line)
             continue
-        if line.strip() == "":
+        if line.strip() == "" or _SEPARATOR_RX.fullmatch(line):
             if current:
                 chunks.append(current)
                 current = []
@@ -250,8 +247,7 @@ def parse_markdown(markdown: str) -> StructuredDocument:
     so we never silently drop user content.  Section IDs are unique slugs of
     their headings.
     """
-    raw_lines = (markdown or "").splitlines()
-    lines = _strip_separators(raw_lines)
+    lines = (markdown or "").splitlines()
 
     sections: list[Section] = []
     used_ids: set[str] = set()

--- a/hindsight-api-slim/tests/test_structured_doc.py
+++ b/hindsight-api-slim/tests/test_structured_doc.py
@@ -171,6 +171,26 @@ class TestParser:
         # Horizontal rule must NOT become a paragraph.
         assert all(not (isinstance(b, ParagraphBlock) and "---" in b.text) for s in doc.sections for b in s.blocks)
 
+    def test_horizontal_rule_inside_code_fence_is_preserved(self):
+        # `---` is the YAML document separator, so treating it as a section
+        # separator inside a fence merges two documents into one invalid one.
+        markdown = (
+            "## Deploy Manifest\n\n```yaml\napiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret\n```\n"
+        )
+        doc = parse_markdown(markdown)
+        block = doc.sections[0].blocks[0]
+        assert isinstance(block, CodeBlock)
+        assert block.text == "apiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret"
+        assert render_document(doc) == markdown
+
+    def test_rule_spellings_inside_code_fence_are_preserved(self):
+        for rule in ("---", "***", "___", "-----", "  ---"):
+            markdown = f"## Snippet\n\n```text\nbefore\n{rule}\nafter\n```\n"
+            doc = parse_markdown(markdown)
+            block = doc.sections[0].blocks[0]
+            assert isinstance(block, CodeBlock), rule
+            assert block.text == f"before\n{rule}\nafter", rule
+
     def test_ordered_list(self):
         markdown = "## Steps\n\n1. one\n2. two\n3. three\n"
         doc = parse_markdown(markdown)


### PR DESCRIPTION
## Root cause

`parse_markdown()` runs two passes that are each correct on their own, in the wrong order.

- `_strip_separators()` (`structured_doc.py:182`) blanked every line matching `\s*([-*_])\1{2,}\s*` across the whole line list. It is fence-unaware, and its own docstring scopes the intent to rules between sections: "LLM output frequently includes them between sections".
- `_split_blocks()` (`:192`) is the pass that tracks fences, via `_FENCE_RX`.

`parse_markdown()` called `_strip_separators(raw_lines)` at `:254`, before any fence tracking ran, so by the time `_split_blocks()` knew it was inside a fence the rule line was already `""`. Nothing raises and the block still parses as a `CodeBlock`, so the content is lost silently.

## Invariant

A line inside a fenced code block is code: it is content, not markup, and the parser must pass it through unchanged. Only a rule *between* sections is a separator.

`---` is the case that bites, because it is also the YAML document separator: a two-document manifest in a fenced `yaml` block parses back as one invalid document. This is the guarantee the test module says it protects, "Round-trip parse to render is stable for canonical markdown".

## Fix

Fold the rule-skip into `_split_blocks()`, which already carries the `in_fence` state, and drop `_strip_separators()`. That leaves one fence state machine instead of two that can drift apart. Outside a fence a rule still counts as blank, so it still never becomes a paragraph: the existing `test_horizontal_rule_treated_as_blank` (`:167`) is untouched and still passes.

I preferred this to giving `_strip_separators()` its own `_FENCE_RX` toggle, which would have added a second, independently drifting fence tracker.

## How I verified

Clean `ghcr.io/astral-sh/uv:python3.11-bookworm` container, branch off `c27fafb`, `uv sync --group dev`.

- **The new tests fail on main and pass here.** This PR also touches the test file, so I ran the NEW tests against the UNFIXED source rather than a checkout of main (which would run the old tests and pass for the wrong reason): 2 failed, 4 passed, both failures on the assertion. Swapping only that file back: 6 passed.
- `tests/test_structured_doc.py`: 41 passed.
- **Blast radius**, old vs new `parse_markdown` over 26 inputs: byte-identical on all 17 non-fence cases, differing only on the 9 fence cases. The non-fence cases include a rule between sections in all three spellings, a rule with no blank lines around it, `Title` followed by `---`, YAML front matter at position 0, a document that is only a rule, `- - -`, `--`, an indented rule outside a fence, and the empty document. The change moves behavior only where the bug is.
- `ruff check .` passes, `ruff format --check` reports both files already formatted, and `ty check hindsight_api` reports 22 diagnostics on this branch and the same 22 on main.

## What I did not verify

- `tests/test_mental_model_delta.py` needs an embedded Postgres (`pg0`) I did not have, so 9 of its tests error at setup. That is identical on main and on this branch (8 passed, 4 skipped, 9 errors both sides), so I have no evidence either way from that file.
- I have not observed this through a live mental-model delta refresh, and I make no claim about how often real LLM output puts a rule inside a fence. What I measured is the parser behavior above.

## Deliberately out of scope

`_FENCE_RX` only recognizes triple-backtick fences, so `~~~` and four-backtick fences are not treated as fences by this parser at all, and a rule inside one of those is still blanked. That is pre-existing and unchanged here; I left it rather than widen the diff. Happy to follow up if you want it covered.

Fixes #2752

I used an AI coding assistant on this change. The commands and numbers above are executed output, not generated text.
