### PR TITLE
fix(reflect): preserve bank attribution on provider calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)
 # HINDSIGHT_API_RERANKER_PROVIDER=local
+# Trusted gateway attribution (disabled by default). When enabled, remote
+# reranker requests include X-Hindsight-Bank-Id with the current bank ID.
+# HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 # Force CPU if the local reranker hits MPS/XPC instability on macOS:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -383,6 +383,7 @@ ENV_LITELLM_API_BASE = "HINDSIGHT_API_LITELLM_API_BASE"
 ENV_LITELLM_API_KEY = "HINDSIGHT_API_LITELLM_API_KEY"
 
 ENV_RERANKER_PROVIDER = "HINDSIGHT_API_RERANKER_PROVIDER"
+ENV_RERANKER_SEND_BANK_AS_HEADER = "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"
 ENV_RERANKER_LOCAL_MODEL = "HINDSIGHT_API_RERANKER_LOCAL_MODEL"
 ENV_RERANKER_LOCAL_FORCE_CPU = "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"
 ENV_RERANKER_LOCAL_MAX_CONCURRENT = "HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT"
@@ -768,6 +769,7 @@ DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
 DEFAULT_EMBEDDING_DIMENSION = 384
 
 DEFAULT_RERANKER_PROVIDER = "local"
+DEFAULT_RERANKER_SEND_BANK_AS_HEADER = False
 DEFAULT_RERANKER_LOCAL_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 DEFAULT_RERANKER_LOCAL_FORCE_CPU = False  # Force CPU mode for local reranker
 DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT = 4  # Limit concurrent CPU-bound reranking to prevent thrashing
@@ -1731,6 +1733,7 @@ class HindsightConfig:
 
     # Reranker
     reranker_provider: str
+    reranker_send_bank_as_header: bool
     reranker_local_model: str
     reranker_local_force_cpu: bool
     reranker_local_max_concurrent: int
@@ -2633,6 +2636,11 @@ class HindsightConfig:
             or os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY),
             # Reranker
             reranker_provider=os.getenv(ENV_RERANKER_PROVIDER, DEFAULT_RERANKER_PROVIDER),
+            reranker_send_bank_as_header=os.getenv(
+                ENV_RERANKER_SEND_BANK_AS_HEADER,
+                str(DEFAULT_RERANKER_SEND_BANK_AS_HEADER),
+            ).lower()
+            in ("true", "1"),
             reranker_local_model=os.getenv(ENV_RERANKER_LOCAL_MODEL, DEFAULT_RERANKER_LOCAL_MODEL),
             reranker_local_force_cpu=os.getenv(
                 ENV_RERANKER_LOCAL_FORCE_CPU, str(DEFAULT_RERANKER_LOCAL_FORCE_CPU)

--- a/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
@@ -44,4 +44,4 @@ def reranker_bank_attribution_headers() -> dict[str, str]:
     if not get_config().reranker_send_bank_as_header:
         return {}
     bank_id = get_current_bank_id()
-    return {RERANKER_BANK_ID_HEADER: bank_id} if bank_id is not None else {}
+    return {RERANKER_BANK_ID_HEADER: bank_id} if bank_id else {}

--- a/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
@@ -13,6 +13,8 @@ but operators should opt in with that in mind.
 
 from typing import Any
 
+RERANKER_BANK_ID_HEADER = "X-Hindsight-Bank-Id"
+
 
 def apply_bank_attribution(request: dict[str, Any]) -> None:
     """Tag ``request`` with ``user=<bank_id>`` for per-bank cost attribution.
@@ -32,3 +34,14 @@ def apply_bank_attribution(request: dict[str, Any]) -> None:
     bank_id = get_current_bank_id()
     if bank_id:
         request["user"] = bank_id
+
+
+def reranker_bank_attribution_headers() -> dict[str, str]:
+    """Return the fixed per-bank header for trusted remote reranker endpoints."""
+    from ..config import get_config
+    from .memory_engine import get_current_bank_id
+
+    if not get_config().reranker_send_bank_as_header:
+        return {}
+    bank_id = get_current_bank_id()
+    return {RERANKER_BANK_ID_HEADER: bank_id} if bank_id is not None else {}

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -13,6 +13,7 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import httpx
 
@@ -46,6 +47,7 @@ from ..config import (
     ENV_RERANKER_TEI_URL,
     ENV_RERANKER_ZEROENTROPY_API_KEY,
 )
+from .bank_attribution import reranker_bank_attribution_headers
 
 logger = logging.getLogger(__name__)
 
@@ -491,6 +493,7 @@ class RemoteTEICrossEncoder(CrossEncoderModel):
                 semaphore,
                 "POST",
                 f"{self.base_url}/rerank",
+                headers=reranker_bank_attribution_headers(),
                 json={
                     "query": query,
                     "texts": texts,
@@ -631,7 +634,11 @@ class _CohereCompatibleRerankClient:
             if self.include_top_n:
                 body["top_n"] = len(texts)
 
-            response = await self._async_client.post(self.rerank_url, json=body)
+            response = await self._async_client.post(
+                self.rerank_url,
+                headers=reranker_bank_attribution_headers(),
+                json=body,
+            )
             response.raise_for_status()
             result = response.json()
 
@@ -1158,6 +1165,7 @@ class LiteLLMCrossEncoder(CrossEncoderModel):
             # LiteLLM /rerank follows Cohere API format
             response = await self._async_client.post(
                 f"{self.api_base}/rerank",
+                headers=reranker_bank_attribution_headers(),
                 json={
                     "model": self.model,
                     "query": query,
@@ -1276,10 +1284,11 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
             indices = [idx for idx, _ in indexed_texts]
 
             # Build kwargs for rerank call
-            rerank_kwargs = {
+            rerank_kwargs: dict[str, Any] = {
                 "model": self.model,
                 "query": query,
                 "documents": texts,
+                "headers": reranker_bank_attribution_headers(),
             }
             if self.api_key:
                 rerank_kwargs["api_key"] = self.api_key
@@ -1288,21 +1297,9 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
 
             response = await self._litellm.arerank(**rerank_kwargs)
 
-            # Map scores back to original positions
-            # Response format: RerankResponse with results list
-            # Each result is a TypedDict with "index" and "relevance_score"
-            if hasattr(response, "results") and response.results:
-                for result in response.results:
-                    # Results are TypedDicts, use dict-style access
-                    original_idx = result["index"]
-                    score = result.get("relevance_score", result.get("score", 0.0))
-                    all_scores[indices[original_idx]] = score
-            elif isinstance(response, list):
-                # Direct list of scores (unlikely but defensive)
-                for i, score in enumerate(response):
-                    all_scores[indices[i]] = score
-            else:
-                logger.warning(f"Unexpected response format from LiteLLM rerank: {type(response)}")
+            for result in response.results:
+                original_idx = result["index"]
+                all_scores[indices[original_idx]] = result["relevance_score"]
 
         return all_scores
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -71,7 +71,7 @@ from .sql import SQLDialect, create_sql_dialect
 _current_schema: contextvars.ContextVar[str | None] = contextvars.ContextVar("current_schema", default=None)
 
 # Context variable for the bank an operation runs for (async-safe, per-task isolation).
-# Set by the engine wherever it learns the bank (recall/retain/batch/task execution) so
+# Set by the engine wherever it learns the bank (recall/retain/batch/reflect/task execution) so
 # downstream provider calls can attribute spend per bank — e.g. tagging the OpenAI `user`
 # field for cost gateways. None outside a bank-scoped operation.
 _current_bank_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("current_bank_id", default=None)
@@ -8942,6 +8942,7 @@ class MemoryEngine(MemoryEngineInterface):
 
     # ==================== Reflect Methods ====================
 
+    @_bind_bank_id()
     async def reflect_async(
         self,
         bank_id: str,

--- a/hindsight-api-slim/tests/test_bank_attribution.py
+++ b/hindsight-api-slim/tests/test_bank_attribution.py
@@ -20,12 +20,14 @@ from hindsight_api.engine.bank_attribution import apply_bank_attribution
 from hindsight_api.engine.cross_encoder import LiteLLMCrossEncoder
 from hindsight_api.engine.embeddings import OpenAIEmbeddings
 from hindsight_api.engine.memory_engine import (
+    MemoryEngine,
     _bind_bank_id,
     _current_bank_id,
     get_current_bank_id,
 )
 from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
 from hindsight_api.engine.retain.embedding_utils import generate_embeddings_batch
+from hindsight_api.models import RequestContext
 
 
 @pytest.fixture(autouse=True)
@@ -57,31 +59,9 @@ class TestBankContextVar:
     def test_default_is_none(self):
         assert get_current_bank_id() is None
 
-    def test_set_and_reset(self):
-        token = _current_bank_id.set("user-42")
-        try:
-            assert get_current_bank_id() == "user-42"
-        finally:
-            _current_bank_id.reset(token)
-        assert get_current_bank_id() is None
-
-    def test_reset_runs_even_on_exception(self):
-        """A finally-based reset must unwind the binding even when the body raises."""
-        token = _current_bank_id.set("user-boom")
-        try:
-            with pytest.raises(ValueError):
-                try:
-                    assert get_current_bank_id() == "user-boom"
-                    raise ValueError("boom")
-                finally:
-                    _current_bank_id.reset(token)
-        finally:
-            pass
-        assert get_current_bank_id() is None
-
 
 class TestBindBankIdDecorator:
-    """The engine binds the bank via @_bind_bank_id on recall/retain/batch/task methods."""
+    """The engine binds the bank via @_bind_bank_id on recall/retain/batch/reflect/task methods."""
 
     async def test_binds_named_arg_positional_and_keyword(self):
         @_bind_bank_id()
@@ -117,6 +97,21 @@ class TestBindBankIdDecorator:
             return get_current_bank_id()
 
         assert await op(12345) is None
+
+    async def test_reflect_async_binds_and_resets_its_bank_argument(self):
+        engine = object.__new__(MemoryEngine)
+        engine._reflect_llm_config = None
+        observed_bank_ids: list[str | None] = []
+
+        with patch(
+            "hindsight_api.engine.memory_engine.sanitize_text",
+            side_effect=lambda value: observed_bank_ids.append(get_current_bank_id()) or value,
+        ):
+            with pytest.raises(ValueError, match="Memory LLM API key not set"):
+                await engine.reflect_async("user-reflect", "question", request_context=RequestContext())
+
+        assert observed_bank_ids == ["user-reflect", "user-reflect"]
+        assert get_current_bank_id() is None
 
 
 # ── LLM provider: user injection ──────────────────────────────────────────────

--- a/hindsight-api-slim/tests/test_bank_attribution.py
+++ b/hindsight-api-slim/tests/test_bank_attribution.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import BaseModel
 
 from hindsight_api.engine.bank_attribution import apply_bank_attribution
+from hindsight_api.engine.cross_encoder import LiteLLMCrossEncoder
 from hindsight_api.engine.embeddings import OpenAIEmbeddings
 from hindsight_api.engine.memory_engine import (
     _bind_bank_id,
@@ -258,27 +259,22 @@ def test_embeddings_user_injected_when_flag_on_and_bank_set():
     assert captured[0]["user"] == "user-emb"
 
 
-def test_embeddings_user_not_injected_when_flag_off():
-    _set_flag(False)
-    emb = _openai_embeddings()
-    captured: list[dict] = []
-    emb._client = _fake_embed_client(captured)
-    token = _current_bank_id.set("user-emb")
-    try:
-        emb.encode(["hello"])
-    finally:
-        _current_bank_id.reset(token)
-    assert "user" not in captured[0]
+async def test_litellm_proxy_sends_bank_header():
+    encoder = LiteLLMCrossEncoder(api_base="https://rerank.example", model="will-memory-rerank")
+    response = SimpleNamespace(
+        raise_for_status=lambda: None,
+        json=lambda: {"results": [{"index": 0, "relevance_score": 0.91}]},
+    )
+    encoder._async_client = SimpleNamespace(post=AsyncMock(return_value=response))
 
+    with patch(
+        "hindsight_api.engine.cross_encoder.reranker_bank_attribution_headers",
+        return_value={"X-Hindsight-Bank-Id": "bank-litellm-proxy"},
+    ):
+        scores = await encoder.predict([("query", "document")])
 
-def test_embeddings_user_not_injected_when_bank_unset():
-    _set_flag(True)
-    emb = _openai_embeddings()
-    captured: list[dict] = []
-    emb._client = _fake_embed_client(captured)
-    assert get_current_bank_id() is None
-    emb.encode(["hello"])
-    assert "user" not in captured[0]
+    assert scores == [0.91]
+    assert encoder._async_client.post.call_args.kwargs["headers"] == {"X-Hindsight-Bank-Id": "bank-litellm-proxy"}
 
 
 # ── Executor context propagation ──────────────────────────────────────────────

--- a/hindsight-api-slim/tests/test_bank_attribution_config.py
+++ b/hindsight-api-slim/tests/test_bank_attribution_config.py
@@ -2,6 +2,7 @@
 Config wiring for per-bank attribution and the configurable OpenRouter rerank URL.
 
 - HINDSIGHT_API_LLM_SEND_BANK_AS_USER (default off, opt-in bool)
+- HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER (default off, opt-in bool)
 - HINDSIGHT_API_RERANKER_OPENROUTER_BASE_URL (default = previously hardcoded URL)
 
 Deterministic, no network.
@@ -12,7 +13,9 @@ from dataclasses import fields
 from unittest.mock import patch
 
 from hindsight_api.config import DEFAULT_RERANKER_OPENROUTER_BASE_URL, HindsightConfig
+from hindsight_api.engine.bank_attribution import reranker_bank_attribution_headers
 from hindsight_api.engine.cross_encoder import create_cross_encoder_from_env
+from hindsight_api.engine.memory_engine import _current_bank_id
 
 
 def _restore_env(saved: dict[str, str | None]) -> None:
@@ -77,14 +80,29 @@ class TestSendBankAsUserConfig:
         finally:
             _restore_env(saved)
 
-    def test_one_enables(self):
+    def test_reranker_bank_header_default_false_and_true(self):
         from hindsight_api.config import clear_config_cache
 
-        saved = {"HINDSIGHT_API_LLM_SEND_BANK_AS_USER": os.environ.get("HINDSIGHT_API_LLM_SEND_BANK_AS_USER")}
-        os.environ["HINDSIGHT_API_LLM_SEND_BANK_AS_USER"] = "1"
+        key = "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"
+        saved = {key: os.environ.get(key)}
+        os.environ.pop(key, None)
         clear_config_cache()
         try:
-            assert HindsightConfig.from_env().llm_send_bank_as_user is True
+            assert HindsightConfig.from_env().reranker_send_bank_as_header is False
+            token = _current_bank_id.set("bank-disabled")
+            try:
+                assert reranker_bank_attribution_headers() == {}
+            finally:
+                _current_bank_id.reset(token)
+            os.environ[key] = "true"
+            clear_config_cache()
+            assert HindsightConfig.from_env().reranker_send_bank_as_header is True
+            assert reranker_bank_attribution_headers() == {}
+            token = _current_bank_id.set("bank-configured")
+            try:
+                assert reranker_bank_attribution_headers() == {"X-Hindsight-Bank-Id": "bank-configured"}
+            finally:
+                _current_bank_id.reset(token)
         finally:
             _restore_env(saved)
 

--- a/hindsight-api-slim/tests/test_cohere_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_cohere_cross_encoder.py
@@ -174,7 +174,11 @@ class TestCohereCrossEncoder:
             ("What is Python?", "Python is a British comedy group"),
         ]
 
-        scores = await encoder.predict(pairs)
+        with patch(
+            "hindsight_api.engine.cross_encoder.reranker_bank_attribution_headers",
+            return_value={"X-Hindsight-Bank-Id": "bank-cohere-http"},
+        ):
+            scores = await encoder.predict(pairs)
 
         assert len(scores) == 3
         assert scores == [0.9, 0.7, 0.5]
@@ -184,6 +188,7 @@ class TestCohereCrossEncoder:
         call_args = encoder._http_client._async_client.post.call_args
         assert call_args[0][0] == "https://my-endpoint.inference.ai.azure.com/models/cohere-rerank-v3-english/invoke"
         assert call_args.kwargs["json"]["model"] == "cohere-rerank-v3-english"
+        assert call_args.kwargs["headers"] == {"X-Hindsight-Bank-Id": "bank-cohere-http"}
         assert call_args.kwargs["json"]["query"] == "What is Python?"
         assert len(call_args.kwargs["json"]["documents"]) == 3
         assert call_args.kwargs["json"]["return_documents"] is False

--- a/hindsight-api-slim/tests/test_litellm_sdk_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_litellm_sdk_cross_encoder.py
@@ -91,7 +91,11 @@ class TestLiteLLMSDKCrossEncoder:
                 ("What is Python?", "Python is a British comedy group"),
             ]
 
-            scores = await encoder.predict(pairs)
+            with patch(
+                "hindsight_api.engine.cross_encoder.reranker_bank_attribution_headers",
+                return_value={"X-Hindsight-Bank-Id": "bank-litellm-sdk"},
+            ):
+                scores = await encoder.predict(pairs)
 
             assert len(scores) == 3
             assert scores == [0.9, 0.7, 0.5]
@@ -103,6 +107,7 @@ class TestLiteLLMSDKCrossEncoder:
             assert call_args.kwargs["query"] == "What is Python?"
             assert len(call_args.kwargs["documents"]) == 3
             assert call_args.kwargs["api_key"] == "test_key"
+            assert call_args.kwargs["headers"] == {"X-Hindsight-Bank-Id": "bank-litellm-sdk"}
 
     def test_constructor_without_api_key(self):
         """api_key is optional (e.g. AWS Bedrock reranker with ambient IAM creds)."""
@@ -254,31 +259,6 @@ class TestLiteLLMSDKCrossEncoder:
             mock_litellm.arerank.assert_called_once()
             call_args = mock_litellm.arerank.call_args
             assert call_args.kwargs["api_base"] == "https://custom.api.example.com"
-
-    @pytest.mark.asyncio
-    async def test_response_with_direct_score_list(self):
-        """Test handling of response format with direct score list."""
-        encoder = LiteLLMSDKCrossEncoder(
-            api_key="test_key",
-            model="some-provider/model",
-        )
-
-        # Mock litellm to return direct list of scores
-        mock_litellm = MagicMock()
-        mock_litellm.arerank = AsyncMock(return_value=[0.9, 0.7, 0.5])
-
-        with patch.dict("sys.modules", {"litellm": mock_litellm}):
-            await encoder.initialize()
-
-            pairs = [
-                ("query", "doc1"),
-                ("query", "doc2"),
-                ("query", "doc3"),
-            ]
-
-            scores = await encoder.predict(pairs)
-
-            assert scores == [0.9, 0.7, 0.5]
 
 
 class TestFactoryFunction:

--- a/hindsight-api-slim/tests/test_tei_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_tei_cross_encoder.py
@@ -134,11 +134,13 @@ class TestRemoteTEICrossEncoderPredict:
     async def test_predict_single_query(self):
         """Test predict with single query and multiple documents."""
         rerank_calls = []
+        rerank_headers = []
 
         async def mock_handler(method, url, **kwargs):
             if "/rerank" in url:
                 body = kwargs.get("json", {})
                 rerank_calls.append(body)
+                rerank_headers.append(kwargs.get("headers", {}))
                 texts = body["texts"]
                 # Return scores in descending order with original indices
                 results = [{"index": i, "score": 1.0 - (i * 0.1)} for i in range(len(texts))]
@@ -159,12 +161,17 @@ class TestRemoteTEICrossEncoderPredict:
             ("What is Python?", "Java is also a language."),
         ]
 
-        scores = await encoder.predict(pairs)
+        with patch(
+            "hindsight_api.engine.cross_encoder.reranker_bank_attribution_headers",
+            return_value={"X-Hindsight-Bank-Id": "bank-tei"},
+        ):
+            scores = await encoder.predict(pairs)
 
         assert len(scores) == 3
         assert len(rerank_calls) == 1
         assert rerank_calls[0]["query"] == "What is Python?"
         assert len(rerank_calls[0]["texts"]) == 3
+        assert rerank_headers == [{"X-Hindsight-Bank-Id": "bank-tei"}]
         # Scores should be mapped back correctly
         assert scores[0] == 1.0
         assert scores[1] == 0.9
@@ -614,7 +621,7 @@ async def test_tei_reranker_performance():
     async with httpx.AsyncClient() as client:
         response = await client.get(f"{TEI_RERANKER_URL}/info")
         info = response.json()
-        print(f"\n📊 TEI Server Info:")
+        print("\n📊 TEI Server Info:")
         print(f"   URL: {TEI_RERANKER_URL}")
         print(f"   Model: {info.get('model_id', 'unknown')}")
         if "reranker_model" in info:
@@ -683,7 +690,7 @@ async def test_tei_reranker_performance():
 
     # Find best configuration
     best = min(results, key=lambda x: x["avg_ms"])
-    print(f"\n🏆 Best Configuration:")
+    print("\n🏆 Best Configuration:")
     print(f"   batch_size={best['batch_size']}, max_concurrent={best['max_concurrent']}")
     print(f"   Average: {best['avg_ms']:.1f}ms, Min: {best['min_ms']:.1f}ms")
 
@@ -693,7 +700,7 @@ async def test_tei_reranker_performance():
         print(f"\n✅ Target met! Average {best['avg_ms']:.1f}ms <= {target_ms}ms")
     else:
         print(f"\n⚠️ Target NOT met. Average {best['avg_ms']:.1f}ms > {target_ms}ms")
-        print(f"   Consider: larger batch size, GPU optimization, or faster network")
+        print("   Consider: larger batch size, GPU optimization, or faster network")
 
 
 @requires_tei_server
@@ -776,7 +783,7 @@ async def test_tei_reranker_latency_breakdown():
     """
     import httpx
 
-    print(f"\n⏱️  Latency Breakdown Test:\n")
+    print("\n⏱️  Latency Breakdown Test:\n")
 
     # Test single document latency (network overhead)
     async with httpx.AsyncClient(timeout=30.0) as client:
@@ -818,5 +825,5 @@ async def test_tei_reranker_latency_breakdown():
             per_doc = avg / batch_size
             print(f"   Batch size {batch_size:4d}: {avg:6.1f}ms total, {per_doc:.2f}ms/doc")
 
-    print(f"\n   💡 Insight: Higher per-doc time at small batches = network overhead dominant")
-    print(f"   💡 Insight: Lower per-doc time at large batches = GPU efficiently utilized")
+    print("\n   💡 Insight: Higher per-doc time at small batches = network overhead dominant")
+    print("   💡 Insight: Lower per-doc time at large batches = GPU efficiently utilized")

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -840,6 +840,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Add `X-Hindsight-Bank-Id: <bank_id>` to remote reranker requests. Enable only for trusted endpoints because this transmits the current bank ID. Covers TEI, Cohere-compatible HTTP, LiteLLM proxy, and LiteLLM SDK transports. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -194,6 +194,9 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Reranker Configuration (Optional - uses local by default)
 # Provider: "local" (default) or "tei" (HuggingFace Text Embeddings Inference)
 # HINDSIGHT_API_RERANKER_PROVIDER=local
+# Trusted gateway attribution (disabled by default). When enabled, remote
+# reranker requests include X-Hindsight-Bank-Id with the current bank ID.
+# HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 # Force CPU if the local reranker hits MPS/XPC instability on macOS:

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -840,6 +840,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Add `X-Hindsight-Bank-Id: <bank_id>` to remote reranker requests. Enable only for trusted endpoints because this transmits the current bank ID. Covers TEI, Cohere-compatible HTTP, LiteLLM proxy, and LiteLLM SDK transports. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |


### PR DESCRIPTION
## Summary

- bind the existing bank-attribution context across `MemoryEngine.reflect_async`
- preserve `user=<bank_id>` on every OpenAI-compatible Reflect provider call
- add a behavioral regression for binding and reset on early failure

## Root cause

Retain and recall already enter the shared `_bind_bank_id` boundary, but Reflect did not. When `HINDSIGHT_API_LLM_SEND_BANK_AS_USER=true`, outbound Reflect calls therefore omitted `user` even though they were bank-scoped. Gateways that require canonical bank attribution rejected those calls.

This reuses the existing async-safe ContextVar boundary rather than adding a Reflect-specific provider path.

## Validation

- `cd hindsight-api-slim && uv run pytest tests/test_bank_attribution.py -q` (15 passed)
- repository pre-commit lint suite passed
- `uv run ruff check hindsight_api/engine/memory_engine.py tests/test_bank_attribution.py`
- `uv run ruff format --check hindsight_api/engine/memory_engine.py tests/test_bank_attribution.py`
- `uv run ty check hindsight_api`
