### PR TITLE
fix(reflect): emit canonical tool result messages

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -578,12 +578,17 @@ class GeminiLLM(LLMInterface):
         # Convert messages
         system_instruction = None
         gemini_contents = []
+        pending_tool_names_by_call_id: dict[str, str] = {}
         msg_list = list(messages)
         i = 0
         while i < len(msg_list):
             msg = msg_list[i]
             role = msg.get("role", "user")
             content = msg.get("content", "")
+
+            if role != "tool" and pending_tool_names_by_call_id:
+                missing_ids = ", ".join(sorted(pending_tool_names_by_call_id))
+                raise ValueError(f"Gemini assistant tool calls require results before the next message: {missing_ids}")
 
             if role == "system":
                 # Always capture system_instruction. _build_tools_config omits it
@@ -600,15 +605,22 @@ class GeminiLLM(LLMInterface):
                 while i < len(msg_list) and msg_list[i].get("role") == "tool":
                     tool_msg = msg_list[i]
                     tool_content = tool_msg.get("content", "")
+                    tool_call_id = tool_msg["tool_call_id"]
+                    tool_name = pending_tool_names_by_call_id.pop(tool_call_id, None)
+                    if tool_name is None:
+                        raise ValueError(f"Gemini tool result references unknown tool_call_id {tool_call_id!r}")
                     parts.append(
                         genai_types.Part(
                             function_response=genai_types.FunctionResponse(
-                                name=tool_msg.get("name", ""),
+                                name=tool_name,
                                 response={"result": tool_content},
                             )
                         )
                     )
                     i += 1
+                if pending_tool_names_by_call_id:
+                    missing_ids = ", ".join(sorted(pending_tool_names_by_call_id))
+                    raise ValueError(f"Gemini assistant tool calls are missing results: {missing_ids}")
                 gemini_contents.append(genai_types.Content(role="user", parts=parts))
             elif role == "assistant":
                 tool_calls_in_msg = msg.get("tool_calls", [])
@@ -619,8 +631,14 @@ class GeminiLLM(LLMInterface):
                     if content:
                         parts.append(genai_types.Part(text=content))
                     for tc in tool_calls_in_msg:
-                        fn = tc.get("function", {})
-                        fn_name = fn.get("name", "")
+                        tool_call_id = tc["id"]
+                        fn = tc["function"]
+                        fn_name = fn["name"]
+                        if tool_call_id in pending_tool_names_by_call_id:
+                            raise ValueError(
+                                f"Gemini assistant tool call id {tool_call_id!r} must be unique within its turn"
+                            )
+                        pending_tool_names_by_call_id[tool_call_id] = fn_name
                         fn_args_str = fn.get("arguments", "{}")
                         fn_args = parse_llm_json(fn_args_str)
                         thought_signature = tc.get("thought_signature")
@@ -636,6 +654,10 @@ class GeminiLLM(LLMInterface):
             else:
                 gemini_contents.append(genai_types.Content(role="user", parts=[genai_types.Part(text=content)]))
                 i += 1
+
+        if pending_tool_names_by_call_id:
+            missing_ids = ", ".join(sorted(pending_tool_names_by_call_id))
+            raise ValueError(f"Gemini assistant tool calls are missing results: {missing_ids}")
 
         # Apply safety settings: context var (per-request bank override) takes precedence over instance default
         effective_safety_settings = _safety_settings_ctx.get()

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -1001,7 +1001,6 @@ async def run_reflect_agent(
                     {
                         "role": "tool",
                         "tool_call_id": done_call.id,
-                        "name": done_call.name,  # Required by Gemini
                         "content": json.dumps(
                             {
                                 "error": "You must search for information first. Use search_mental_models(), search_observations(), or recall() before providing your final answer."
@@ -1066,7 +1065,6 @@ async def run_reflect_agent(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
-                        "name": tc.name,
                         "content": json.dumps(
                             {
                                 "error": f"Tool '{_normalize_tool_name(tc.name)}' is not available. Use only the tools provided to you."
@@ -1160,7 +1158,6 @@ async def run_reflect_agent(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
-                        "name": tc.name,  # Required by Gemini
                         "content": json.dumps(output, default=str, ensure_ascii=False),
                     }
                 )

--- a/hindsight-api-slim/tests/test_gemini_safety_settings.py
+++ b/hindsight-api-slim/tests/test_gemini_safety_settings.py
@@ -204,7 +204,31 @@ async def test_call_with_tools_applies_safety_settings():
     ]
 
     await provider.call_with_tools(
-        messages=[{"role": "user", "content": "hi"}],
+        messages=[
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_test_tool",
+                        "type": "function",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_test_tool", "content": '{"ok": true}'},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_test_tool",
+                        "type": "function",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_test_tool", "content": '{"ok": true}'},
+        ],
         tools=tools,
         scope="test",
     )
@@ -218,6 +242,8 @@ async def test_call_with_tools_applies_safety_settings():
         s.category.value if hasattr(s.category, "value") else str(s.category) for s in config_arg.safety_settings
     ]
     assert "HARM_CATEGORY_HARASSMENT" in categories
+    contents = call_args.kwargs["contents"]
+    assert contents[-1].parts[0].function_response.name == "test_tool"
 
 
 # ─── with_config() override ───────────────────────────────────────────────────

--- a/hindsight-api-slim/tests/test_gemini_safety_settings.py
+++ b/hindsight-api-slim/tests/test_gemini_safety_settings.py
@@ -245,6 +245,25 @@ async def test_call_with_tools_applies_safety_settings():
     contents = call_args.kwargs["contents"]
     assert contents[-1].parts[0].function_response.name == "test_tool"
 
+    with pytest.raises(ValueError, match="missing results: call_test_tool"):
+        await provider.call_with_tools(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_test_tool",
+                            "type": "function",
+                            "function": {"name": "test_tool", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ],
+            tools=tools,
+            scope="test",
+        )
+
 
 # ─── with_config() override ───────────────────────────────────────────────────
 

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -394,6 +394,10 @@ class TestReflectAgentMocked:
         first_choice = mock_llm.call_with_tools.await_args_list[0].kwargs["tool_choice"]
         assert first_choice == {"type": "function", "function": {"name": "search_mental_models"}}
         assert mock_llm.call_with_tools.await_args_list[1].kwargs["tool_choice"] == "auto"
+        tool_result = mock_llm.call_with_tools.await_args_list[1].kwargs["messages"][-1]
+        assert tool_result["role"] == "tool"
+        assert tool_result["tool_call_id"] == "1"
+        assert "name" not in tool_result
 
     @pytest.mark.asyncio
     async def test_short_circuited_agent_may_still_retrieve_under_auto(self, mock_llm, mock_functions):
@@ -901,7 +905,6 @@ class TestContextOverflowHelpers:
             {
                 "role": "tool",
                 "tool_call_id": "x",
-                "name": "recall",
                 "content": '{"memories": ['
                 + ", ".join(
                     [


### PR DESCRIPTION
## Summary
- remove the non-standard `name` field from Reflect role=`tool` messages
- preserve the canonical OpenAI tool-result shape at the shared Reflect producer boundary
- derive Gemini `FunctionResponse.name` from the immediately preceding assistant tool calls by `tool_call_id`
- reject unknown, duplicate-within-turn, and missing tool results while allowing providers that reuse call IDs across turns

## Root cause
Reflect currently adds `name` to tool-result messages for Gemini. Strict OpenAI-compatible gateways reject that extra field because tool-result messages permit `content` and `tool_call_id`; provider-specific requirements should be handled in the provider adapter instead of changing the canonical message shape.

## Verification
- targeted Ruff on all touched files
- `pytest -q tests/test_reflect_agent.py tests/test_gemini_safety_settings.py -k 'not RealLLM and not ContextOverflowIntegration'` (`69 passed`)
- repository pre-commit hooks and lint passed
- `git diff --check`

No second Reflect path or compatibility fallback is introduced.
