### PR TITLE
feat(reranker): add llamacpp reranker provider for llama.cpp /rerank servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# For llamacpp provider (existing llama-server started with --rerank):
+# HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+# HINDSIGHT_API_RERANKER_LLAMACPP_MODEL=  # optional; only needed in router (multi-model) mode
+# HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY=  # optional; only if llama-server uses --api-key
 
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -398,6 +398,7 @@ ENV_RERANKER_COHERE_TIMEOUT = "HINDSIGHT_API_RERANKER_COHERE_TIMEOUT"
 ENV_RERANKER_OPENROUTER_TIMEOUT = "HINDSIGHT_API_RERANKER_OPENROUTER_TIMEOUT"
 ENV_RERANKER_ZEROENTROPY_TIMEOUT = "HINDSIGHT_API_RERANKER_ZEROENTROPY_TIMEOUT"
 ENV_RERANKER_SILICONFLOW_TIMEOUT = "HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT"
+ENV_RERANKER_LLAMACPP_TIMEOUT = "HINDSIGHT_API_RERANKER_LLAMACPP_TIMEOUT"
 ENV_RERANKER_ALIBABA_TIMEOUT = "HINDSIGHT_API_RERANKER_ALIBABA_TIMEOUT"
 ENV_RERANKER_LITELLM_TIMEOUT = "HINDSIGHT_API_RERANKER_LITELLM_TIMEOUT"
 ENV_RERANKER_LITELLM_SDK_TIMEOUT = "HINDSIGHT_API_RERANKER_LITELLM_SDK_TIMEOUT"
@@ -417,6 +418,12 @@ ENV_RERANKER_ZEROENTROPY_BASE_URL = "HINDSIGHT_API_RERANKER_ZEROENTROPY_BASE_URL
 ENV_RERANKER_SILICONFLOW_API_KEY = "HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY"
 ENV_RERANKER_SILICONFLOW_MODEL = "HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL"
 ENV_RERANKER_SILICONFLOW_BASE_URL = "HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL"
+
+# llama.cpp configuration (reranker only; connects to an existing llama-server
+# started with --rerank, which exposes a Cohere/Jina-compatible /rerank endpoint)
+ENV_RERANKER_LLAMACPP_API_KEY = "HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY"
+ENV_RERANKER_LLAMACPP_MODEL = "HINDSIGHT_API_RERANKER_LLAMACPP_MODEL"
+ENV_RERANKER_LLAMACPP_BASE_URL = "HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL"
 
 # Alibaba Cloud DashScope configuration (reranker only)
 ENV_RERANKER_ALIBABA_API_KEY = "HINDSIGHT_API_RERANKER_ALIBABA_API_KEY"
@@ -786,6 +793,7 @@ DEFAULT_RERANKER_COHERE_TIMEOUT = 60.0
 DEFAULT_RERANKER_OPENROUTER_TIMEOUT = 60.0
 DEFAULT_RERANKER_ZEROENTROPY_TIMEOUT = 60.0
 DEFAULT_RERANKER_SILICONFLOW_TIMEOUT = 60.0
+DEFAULT_RERANKER_LLAMACPP_TIMEOUT = 60.0
 DEFAULT_RERANKER_ALIBABA_TIMEOUT = 60.0
 DEFAULT_RERANKER_LITELLM_TIMEOUT = 60.0
 DEFAULT_RERANKER_LITELLM_SDK_TIMEOUT = 60.0
@@ -891,6 +899,11 @@ DEFAULT_RERANKER_ZEROENTROPY_MODEL = "zerank-2"
 
 DEFAULT_RERANKER_SILICONFLOW_MODEL = "BAAI/bge-reranker-v2-m3"
 DEFAULT_RERANKER_SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
+
+# Empty model is valid for llama.cpp: single-model servers ignore the field;
+# multi-model (router-mode) servers need it set explicitly. No default base URL —
+# there is no canonical address for a self-hosted server.
+DEFAULT_RERANKER_LLAMACPP_MODEL = ""
 
 DEFAULT_RERANKER_ALIBABA_MODEL = "qwen3-rerank"
 
@@ -1775,6 +1788,10 @@ class HindsightConfig:
     reranker_siliconflow_model: str
     reranker_siliconflow_base_url: str
     reranker_siliconflow_timeout: float
+    reranker_llamacpp_api_key: str | None
+    reranker_llamacpp_model: str
+    reranker_llamacpp_base_url: str | None
+    reranker_llamacpp_timeout: float
     reranker_alibaba_api_key: str | None
     reranker_alibaba_model: str
     reranker_alibaba_timeout: float
@@ -2054,6 +2071,7 @@ class HindsightConfig:
         "embeddings_zeroentropy_base_url",
         "reranker_zeroentropy_base_url",
         "reranker_siliconflow_base_url",
+        "reranker_llamacpp_base_url",
         # Service Account Keys
         "llm_vertexai_service_account_key",
         "embeddings_vertexai_service_account_key",
@@ -2061,6 +2079,8 @@ class HindsightConfig:
         # Embeddings API keys
         "embeddings_gemini_api_key",
         "embeddings_zeroentropy_api_key",
+        # Reranker API keys
+        "reranker_llamacpp_api_key",
         # File storage credentials
         "file_storage_s3_access_key_id",
         "file_storage_s3_secret_access_key",
@@ -2734,6 +2754,13 @@ class HindsightConfig:
             ),
             reranker_siliconflow_timeout=float(
                 os.getenv(ENV_RERANKER_SILICONFLOW_TIMEOUT, str(DEFAULT_RERANKER_SILICONFLOW_TIMEOUT))
+            ),
+            # llama.cpp reranker (Cohere/Jina-compatible /rerank endpoint)
+            reranker_llamacpp_api_key=os.getenv(ENV_RERANKER_LLAMACPP_API_KEY),
+            reranker_llamacpp_model=os.getenv(ENV_RERANKER_LLAMACPP_MODEL, DEFAULT_RERANKER_LLAMACPP_MODEL),
+            reranker_llamacpp_base_url=os.getenv(ENV_RERANKER_LLAMACPP_BASE_URL) or None,
+            reranker_llamacpp_timeout=float(
+                os.getenv(ENV_RERANKER_LLAMACPP_TIMEOUT, str(DEFAULT_RERANKER_LLAMACPP_TIMEOUT))
             ),
             # Alibaba Cloud DashScope reranker
             reranker_alibaba_api_key=os.getenv(ENV_RERANKER_ALIBABA_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -27,6 +27,7 @@ from ..config import (
     DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC,
     DEFAULT_RERANKER_LITELLM_MODEL,
     DEFAULT_RERANKER_LITELLM_SDK_MODEL,
+    DEFAULT_RERANKER_LLAMACPP_MODEL,
     DEFAULT_RERANKER_LOCAL_BATCH_SIZE,
     DEFAULT_RERANKER_LOCAL_MODEL,
     DEFAULT_RERANKER_SILICONFLOW_BASE_URL,
@@ -41,6 +42,7 @@ from ..config import (
     ENV_RERANKER_FLASHRANK_CPU_MEM_ARENA,
     ENV_RERANKER_FLASHRANK_MODEL,
     ENV_RERANKER_GOOGLE_PROJECT_ID,
+    ENV_RERANKER_LLAMACPP_BASE_URL,
     ENV_RERANKER_PROVIDER,
     ENV_RERANKER_SILICONFLOW_API_KEY,
     ENV_RERANKER_TEI_URL,
@@ -840,6 +842,56 @@ class SiliconFlowCrossEncoder(CrossEncoderModel):
         logger.info(f"Reranker: initializing SiliconFlow provider at {self.base_url} with model {self.model}")
         await self._client.initialize()
         logger.info("Reranker: SiliconFlow provider initialized")
+
+    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        return await self._client.predict(pairs)
+
+
+class LlamaCppCrossEncoder(CrossEncoderModel):
+    """
+    llama.cpp cross-encoder implementation.
+
+    Connects to an existing llama-server started with --rerank (unlike the
+    `llamacpp` LLM provider, which spawns a managed server process). llama.cpp
+    exposes a Cohere/Jina-compatible rerank endpoint at /rerank, also aliased
+    at /v1/rerank — so both `http://host:8080` and `http://host:8080/v1` work
+    as base_url. Scores are raw logits; downstream, CrossEncoderReranker
+    sigmoid-normalizes scores only when a batch contains values outside [0, 1] —
+    raw provider scores already inside [0, 1] pass through unchanged.
+    """
+
+    RERANK_PATH = "/rerank"
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str = DEFAULT_RERANKER_LLAMACPP_MODEL,
+        api_key: str | None = None,
+        timeout: float = 60.0,
+    ):
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self._client = _CohereCompatibleRerankClient(
+            # llama.cpp only checks the key when started with --api-key; a dummy
+            # value keeps the Bearer header well-formed when no key is configured.
+            api_key=api_key or "no-key",
+            model=model,
+            rerank_url=f"{self.base_url}{self.RERANK_PATH}",
+            timeout=timeout,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "llamacpp"
+
+    async def initialize(self) -> None:
+        if self._client._async_client is not None:
+            return
+        logger.info(
+            f"Reranker: initializing llama.cpp provider at {self.base_url} with model {self.model or '(server default)'}"
+        )
+        await self._client.initialize()
+        logger.info("Reranker: llama.cpp provider initialized")
 
     async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         return await self._client.predict(pairs)
@@ -1725,6 +1777,16 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
             base_url=config.reranker_siliconflow_base_url,
             timeout=config.reranker_siliconflow_timeout,
         )
+    elif provider == "llamacpp":
+        base_url = config.reranker_llamacpp_base_url
+        if not base_url:
+            raise ValueError(f"{ENV_RERANKER_LLAMACPP_BASE_URL} is required when {ENV_RERANKER_PROVIDER} is 'llamacpp'")
+        return LlamaCppCrossEncoder(
+            base_url=base_url,
+            model=config.reranker_llamacpp_model,
+            api_key=config.reranker_llamacpp_api_key,
+            timeout=config.reranker_llamacpp_timeout,
+        )
     elif provider == "google":
         project_id = config.reranker_google_project_id
         if not project_id:
@@ -1753,5 +1815,5 @@ def create_cross_encoder_from_env() -> CrossEncoderModel:
         return JinaMLXCrossEncoder()
     else:
         raise ValueError(
-            f"Unknown reranker provider: {provider}. Supported: 'local', 'tei', 'cohere', 'zeroentropy', 'siliconflow', 'alibaba', 'google', 'flashrank', 'litellm', 'litellm-sdk', 'rrf', 'jina-mlx'"
+            f"Unknown reranker provider: {provider}. Supported: 'local', 'tei', 'cohere', 'openrouter', 'zeroentropy', 'siliconflow', 'llamacpp', 'alibaba', 'google', 'flashrank', 'litellm', 'litellm-sdk', 'rrf', 'jina-mlx'"
         )

--- a/hindsight-api-slim/tests/test_llamacpp_cross_encoder.py
+++ b/hindsight-api-slim/tests/test_llamacpp_cross_encoder.py
@@ -1,0 +1,230 @@
+"""
+Tests for the llamacpp reranker provider (issue #2665).
+
+llama.cpp's llama-server exposes a Cohere/Jina-compatible rerank endpoint
+(aliases /rerank, /reranking, /v1/rerank, /v1/reranking) when started with
+--rerank. These tests cover the factory wiring from env vars and the HTTP
+behavior against a mocked server response.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.cross_encoder import LlamaCppCrossEncoder, create_cross_encoder_from_env
+
+
+class TestLlamaCppCrossEncoder:
+    """Test suite for LlamaCppCrossEncoder against a mocked llama.cpp server."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "relevance_scores",
+        [
+            # already-normalized-looking scores
+            [0.9, 0.7, 0.5],
+            # raw logits as llama.cpp actually returns them (res->score = embd[0]):
+            # negative and >1 values must be passed through untouched
+            [-2.3, 4.1, 0.0],
+        ],
+    )
+    async def test_predict_single_query(self, relevance_scores):
+        """Scores map back to original pair order by results[].index, raw values preserved."""
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080", model="bge-reranker-v2-m3")
+        await encoder.initialize()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"index": i, "relevance_score": s} for i, s in enumerate(relevance_scores)]
+        }
+        mock_response.raise_for_status = MagicMock()
+        encoder._client._async_client.post = AsyncMock(return_value=mock_response)
+
+        pairs = [
+            ("What is a panda?", "The giant panda is a bear species endemic to China."),
+            ("What is a panda?", "It is a bear."),
+            ("What is a panda?", "hi"),
+        ]
+        scores = await encoder.predict(pairs)
+
+        assert scores == relevance_scores
+
+        encoder._client._async_client.post.assert_called_once()
+        call_args = encoder._client._async_client.post.call_args
+        assert call_args[0][0] == "http://localhost:8080/rerank"
+        body = call_args.kwargs["json"]
+        assert body["model"] == "bge-reranker-v2-m3"
+        assert body["query"] == "What is a panda?"
+        assert len(body["documents"]) == 3
+        assert body["top_n"] == 3
+        assert body["return_documents"] is False
+
+    @pytest.mark.asyncio
+    async def test_predict_multiple_queries(self):
+        """Pairs are grouped per unique query: one POST per query, indices remapped."""
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+
+        response_1 = MagicMock()
+        response_1.json.return_value = {
+            "results": [{"index": 0, "relevance_score": 0.9}, {"index": 1, "relevance_score": 0.7}]
+        }
+        response_1.raise_for_status = MagicMock()
+        response_2 = MagicMock()
+        response_2.json.return_value = {"results": [{"index": 0, "relevance_score": 0.8}]}
+        response_2.raise_for_status = MagicMock()
+        encoder._client._async_client.post = AsyncMock(side_effect=[response_1, response_2])
+
+        pairs = [
+            ("What is Python?", "Python is a programming language"),
+            ("What is Python?", "Python is a snake"),
+            ("What is Java?", "Java is a programming language"),
+        ]
+        scores = await encoder.predict(pairs)
+
+        assert scores == [0.9, 0.7, 0.8]
+        assert encoder._client._async_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_predict_remaps_permuted_result_indices(self):
+        """results[].index is authoritative even when the server returns scores out of order."""
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+
+        mock_response = MagicMock()
+        # Server returns documents scored in reverse/permuted order relative to request.
+        mock_response.json.return_value = {
+            "results": [
+                {"index": 2, "relevance_score": 0.1},
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.5},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        encoder._client._async_client.post = AsyncMock(return_value=mock_response)
+
+        pairs = [
+            ("What is a panda?", "The giant panda is a bear species endemic to China."),
+            ("What is a panda?", "It is a bear."),
+            ("What is a panda?", "hi"),
+        ]
+        scores = await encoder.predict(pairs)
+
+        assert scores == [0.9, 0.5, 0.1]
+
+    @pytest.mark.asyncio
+    async def test_predict_empty_pairs(self):
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+        assert await encoder.predict([]) == []
+
+    @pytest.mark.asyncio
+    async def test_predict_not_initialized(self):
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await encoder.predict([("query", "document")])
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self):
+        """HTTP errors from the llama.cpp server surface to the caller."""
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=MagicMock(status_code=503),
+        )
+        encoder._client._async_client.post = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await encoder.predict([("query", "document")])
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_sends_dummy_bearer(self):
+        """Without an API key the Authorization header stays well-formed (Bearer no-key)."""
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+        assert encoder._client._async_client.headers["Authorization"] == "Bearer no-key"
+
+    @pytest.mark.asyncio
+    async def test_initialize_idempotent(self):
+        encoder = LlamaCppCrossEncoder(base_url="http://localhost:8080")
+        await encoder.initialize()
+        client = encoder._client._async_client
+        await encoder.initialize()
+        assert encoder._client._async_client is client
+
+
+class TestFactoryFunction:
+    """Test suite for create_cross_encoder_from_env with provider=llamacpp."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "base_url, expected_rerank_url",
+        [
+            # bare host → /rerank
+            ("http://localhost:8080", "http://localhost:8080/rerank"),
+            # trailing slash is stripped
+            ("http://localhost:8080/", "http://localhost:8080/rerank"),
+            # /v1-suffixed base also works: llama.cpp aliases /v1/rerank to the same handler
+            ("http://reranker.internal:8012/v1", "http://reranker.internal:8012/v1/rerank"),
+        ],
+    )
+    async def test_create_llamacpp_from_env(self, base_url, expected_rerank_url):
+        """Factory builds a llamacpp encoder from env vars; base URL shape is forgiving."""
+        env_vars = {
+            "HINDSIGHT_API_RERANKER_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL": base_url,
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            config = HindsightConfig.from_env()
+
+            with patch("hindsight_api.config.get_config", return_value=config):
+                encoder = create_cross_encoder_from_env()
+
+                assert encoder.provider_name == "llamacpp"
+                assert encoder._client.rerank_url == expected_rerank_url
+                # No API key configured: dummy value keeps the Bearer header well-formed
+                # (llama.cpp ignores it unless started with --api-key).
+                assert encoder._client.api_key == "no-key"
+                # Model defaults to empty: single-model llama.cpp servers ignore it.
+                assert encoder._client.model == ""
+
+    @pytest.mark.asyncio
+    async def test_create_llamacpp_with_model_and_api_key(self):
+        """Optional model and API key env vars reach the HTTP client."""
+        env_vars = {
+            "HINDSIGHT_API_RERANKER_PROVIDER": "llamacpp",
+            "HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL": "http://localhost:8080",
+            "HINDSIGHT_API_RERANKER_LLAMACPP_MODEL": "bge-reranker-v2-m3",
+            "HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY": "secret",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            config = HindsightConfig.from_env()
+
+            with patch("hindsight_api.config.get_config", return_value=config):
+                encoder = create_cross_encoder_from_env()
+
+                assert encoder.provider_name == "llamacpp"
+                assert encoder._client.model == "bge-reranker-v2-m3"
+                assert encoder._client.api_key == "secret"
+
+    @pytest.mark.asyncio
+    async def test_missing_base_url_raises(self):
+        """provider=llamacpp without a base URL fails fast, naming the env var."""
+        env_vars = {"HINDSIGHT_API_RERANKER_PROVIDER": "llamacpp"}
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            os.environ.pop("HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL", None)
+            config = HindsightConfig.from_env()
+
+            with patch("hindsight_api.config.get_config", return_value=config):
+                with pytest.raises(ValueError, match="HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL"):
+                    create_cross_encoder_from_env()

--- a/hindsight-api-slim/tests/test_reranker_timeouts.py
+++ b/hindsight-api-slim/tests/test_reranker_timeouts.py
@@ -79,6 +79,12 @@ def _make_config(**overrides) -> HindsightConfig:
             ("_client", "timeout"),
         ),
         (
+            "llamacpp",
+            {"reranker_llamacpp_base_url": "http://localhost:8080"},
+            "reranker_llamacpp_timeout",
+            ("_client", "timeout"),
+        ),
+        (
             "litellm",
             {"reranker_litellm_api_base": "http://localhost:4000"},
             "reranker_litellm_timeout",
@@ -123,6 +129,7 @@ def test_default_timeouts_preserve_60s_behavior():
     assert config.reranker_zeroentropy_timeout == 60.0
     assert config.reranker_siliconflow_timeout == 60.0
     assert config.reranker_alibaba_timeout == 60.0
+    assert config.reranker_llamacpp_timeout == 60.0
     assert config.reranker_litellm_timeout == 60.0
     assert config.reranker_litellm_sdk_timeout == 60.0
     assert config.reranker_google_timeout == 60.0

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -747,6 +747,13 @@ export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=your-azure-api-key
 export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small
 export HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/deployments/your-deployment
 
+# llama.cpp - self-hosted embeddings via llama.cpp's OpenAI-compatible /v1/embeddings
+# (start llama-server with: llama-server --embedding -m your-embedding-model.gguf)
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=no-key  # llama.cpp ignores it, but the client requires a non-empty value
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=your-embedding-model
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=http://localhost:8080/v1
+
 # TEI - HuggingFace Text Embeddings Inference (recommended for production)
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=tei
 export HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
@@ -839,7 +846,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `llamacpp`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
@@ -876,6 +883,10 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL` | SiliconFlow rerank model (e.g., `BAAI/bge-reranker-v2-m3`) | `BAAI/bge-reranker-v2-m3` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL` | Base URL for the SiliconFlow `/rerank` endpoint | `https://api.siliconflow.cn/v1` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT` | HTTP request timeout for SiliconFlow reranker (seconds). | `60.0` |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL` | Base URL of an existing llama.cpp `llama-server` started with `--rerank` (e.g. `http://localhost:8080`; a `/v1`-suffixed URL also works). Required for the `llamacpp` provider. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_MODEL` | Model name sent in rerank requests. Optional: single-model servers ignore it; set it when llama.cpp runs in router (multi-model) mode. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY` | API key, only needed when `llama-server` runs with `--api-key`. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_TIMEOUT` | HTTP request timeout for the llama.cpp reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_ALIBABA_API_KEY` | Alibaba Cloud DashScope API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_ALIBABA_MODEL` | DashScope rerank model | `qwen3-rerank` |
 | `HINDSIGHT_API_RERANKER_ALIBABA_TIMEOUT` | HTTP request timeout for the Alibaba Cloud DashScope reranker (seconds). | `60.0` |
@@ -942,6 +953,17 @@ export HINDSIGHT_API_RERANKER_PROVIDER=siliconflow
 export HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY=your-api-key
 export HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL=BAAI/bge-reranker-v2-m3
 # export HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1  # default
+
+# llama.cpp - self-hosted reranking against an existing llama-server
+#
+# Start llama.cpp with reranking enabled, e.g.:
+#   llama-server --rerank -m bge-reranker-v2-m3.gguf --port 8080
+# then point Hindsight at it. Note: unlike the `llamacpp` LLM provider (which
+# spawns a managed llama.cpp process), this connects to a server you run yourself.
+export HINDSIGHT_API_RERANKER_PROVIDER=llamacpp
+export HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+# export HINDSIGHT_API_RERANKER_LLAMACPP_MODEL=bge-reranker-v2-m3  # only needed in router (multi-model) mode
+# export HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY=your-key          # only if llama-server uses --api-key
 
 # Alibaba Cloud DashScope - qwen3-rerank via Cohere-compatible /reranks endpoint
 export HINDSIGHT_API_RERANKER_PROVIDER=alibaba

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -515,7 +515,7 @@ Converts text into dense vector representations for semantic similarity search.
 |----------|-------------|----------|
 | `local` | SentenceTransformers (default) | Development, low latency |
 | `onnx` | In-process ONNX Runtime embedder (no Ollama/TEI/API sidecar) | Lightweight local CPU, multilingual |
-| `openai` | OpenAI embeddings API | Production, high quality |
+| `openai` | OpenAI embeddings API — also covers any OpenAI-compatible `/v1/embeddings` server (e.g. a llama.cpp `llama-server --embedding`) via `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Production, high quality; self-hosted llama.cpp |
 | `openai-codex` | OpenAI embeddings via Codex OAuth (ChatGPT Plus/Pro, no API key) | Existing ChatGPT/Codex subscribers |
 | `openrouter` | OpenRouter embeddings (OpenAI-compatible gateway) | Multi-provider setups |
 | `cohere` | Cohere embeddings API | Production, multilingual |
@@ -642,6 +642,7 @@ Reranks initial search results to improve precision.
 | `openrouter` | OpenRouter rerank API (Cohere-compatible gateway) | Multi-provider setups |
 | `zeroentropy` | ZeroEntropy rerank API (zerank-2) | Production, state-of-the-art accuracy |
 | `siliconflow` | SiliconFlow rerank API (Cohere-compatible `/rerank` endpoint) | Users in China or anyone on SiliconFlow's platform |
+| `llamacpp` | Existing llama.cpp `llama-server` with `--rerank` (Cohere-compatible `/rerank` endpoint) | Self-hosted, private, CPU-friendly reranking |
 | `alibaba` | Alibaba Cloud DashScope rerank API (qwen3-rerank) | Users on Alibaba Cloud / DashScope |
 | `google` | Google Discovery Engine ranking API (REST + Google auth) | Production, GCP integration |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
@@ -681,6 +682,25 @@ SiliconFlow hosts a range of open-weight rerankers behind a Cohere-compatible `/
 |-------|----------|
 | `BAAI/bge-reranker-v2-m3` | Multilingual, strong default |
 | `Qwen/Qwen3-Reranker-8B` | Larger, higher accuracy |
+
+### llama.cpp Models
+
+Run any GGUF reranker model on an existing llama.cpp server (this connects to a server
+you run yourself, unlike the `llamacpp` LLM provider which spawns one):
+
+```bash
+llama-server --rerank -m bge-reranker-v2-m3.gguf --port 8080
+```
+
+```bash
+export HINDSIGHT_API_RERANKER_PROVIDER=llamacpp
+export HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+```
+
+| Model | Use Case |
+|-------|----------|
+| `bge-reranker-v2-m3` (GGUF) | Multilingual, strong default |
+| `jina-reranker-v1-tiny-en` (GGUF) | Tiny, fast CPU reranking |
 
 ### Alibaba Cloud Models
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -200,6 +200,10 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# For llamacpp provider (existing llama-server started with --rerank):
+# HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+# HINDSIGHT_API_RERANKER_LLAMACPP_MODEL=  # optional; only needed in router (multi-model) mode
+# HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY=  # optional; only if llama-server uses --api-key
 
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -747,6 +747,13 @@ export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=your-azure-api-key
 export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small
 export HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/deployments/your-deployment
 
+# llama.cpp - self-hosted embeddings via llama.cpp's OpenAI-compatible /v1/embeddings
+# (start llama-server with: llama-server --embedding -m your-embedding-model.gguf)
+export HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=no-key  # llama.cpp ignores it, but the client requires a non-empty value
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=your-embedding-model
+export HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL=http://localhost:8080/v1
+
 # TEI - HuggingFace Text Embeddings Inference (recommended for production)
 export HINDSIGHT_API_EMBEDDINGS_PROVIDER=tei
 export HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080
@@ -839,7 +846,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `llamacpp`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |
@@ -876,6 +883,10 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL` | SiliconFlow rerank model (e.g., `BAAI/bge-reranker-v2-m3`) | `BAAI/bge-reranker-v2-m3` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL` | Base URL for the SiliconFlow `/rerank` endpoint | `https://api.siliconflow.cn/v1` |
 | `HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT` | HTTP request timeout for SiliconFlow reranker (seconds). | `60.0` |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL` | Base URL of an existing llama.cpp `llama-server` started with `--rerank` (e.g. `http://localhost:8080`; a `/v1`-suffixed URL also works). Required for the `llamacpp` provider. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_MODEL` | Model name sent in rerank requests. Optional: single-model servers ignore it; set it when llama.cpp runs in router (multi-model) mode. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY` | API key, only needed when `llama-server` runs with `--api-key`. | - |
+| `HINDSIGHT_API_RERANKER_LLAMACPP_TIMEOUT` | HTTP request timeout for the llama.cpp reranker (seconds). | `60.0` |
 | `HINDSIGHT_API_RERANKER_ALIBABA_API_KEY` | Alibaba Cloud DashScope API key for reranking | - |
 | `HINDSIGHT_API_RERANKER_ALIBABA_MODEL` | DashScope rerank model | `qwen3-rerank` |
 | `HINDSIGHT_API_RERANKER_ALIBABA_TIMEOUT` | HTTP request timeout for the Alibaba Cloud DashScope reranker (seconds). | `60.0` |
@@ -942,6 +953,17 @@ export HINDSIGHT_API_RERANKER_PROVIDER=siliconflow
 export HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY=your-api-key
 export HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL=BAAI/bge-reranker-v2-m3
 # export HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1  # default
+
+# llama.cpp - self-hosted reranking against an existing llama-server
+#
+# Start llama.cpp with reranking enabled, e.g.:
+#   llama-server --rerank -m bge-reranker-v2-m3.gguf --port 8080
+# then point Hindsight at it. Note: unlike the `llamacpp` LLM provider (which
+# spawns a managed llama.cpp process), this connects to a server you run yourself.
+export HINDSIGHT_API_RERANKER_PROVIDER=llamacpp
+export HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+# export HINDSIGHT_API_RERANKER_LLAMACPP_MODEL=bge-reranker-v2-m3  # only needed in router (multi-model) mode
+# export HINDSIGHT_API_RERANKER_LLAMACPP_API_KEY=your-key          # only if llama-server uses --api-key
 
 # Alibaba Cloud DashScope - qwen3-rerank via Cohere-compatible /reranks endpoint
 export HINDSIGHT_API_RERANKER_PROVIDER=alibaba

--- a/skills/hindsight-docs/references/developer/models.md
+++ b/skills/hindsight-docs/references/developer/models.md
@@ -571,7 +571,7 @@ Converts text into dense vector representations for semantic similarity search.
 |----------|-------------|----------|
 | `local` | SentenceTransformers (default) | Development, low latency |
 | `onnx` | In-process ONNX Runtime embedder (no Ollama/TEI/API sidecar) | Lightweight local CPU, multilingual |
-| `openai` | OpenAI embeddings API | Production, high quality |
+| `openai` | OpenAI embeddings API — also covers any OpenAI-compatible `/v1/embeddings` server (e.g. a llama.cpp `llama-server --embedding`) via `HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL` | Production, high quality; self-hosted llama.cpp |
 | `openai-codex` | OpenAI embeddings via Codex OAuth (ChatGPT Plus/Pro, no API key) | Existing ChatGPT/Codex subscribers |
 | `openrouter` | OpenRouter embeddings (OpenAI-compatible gateway) | Multi-provider setups |
 | `cohere` | Cohere embeddings API | Production, multilingual |
@@ -697,6 +697,7 @@ Reranks initial search results to improve precision.
 | `openrouter` | OpenRouter rerank API (Cohere-compatible gateway) | Multi-provider setups |
 | `zeroentropy` | ZeroEntropy rerank API (zerank-2) | Production, state-of-the-art accuracy |
 | `siliconflow` | SiliconFlow rerank API (Cohere-compatible `/rerank` endpoint) | Users in China or anyone on SiliconFlow's platform |
+| `llamacpp` | Existing llama.cpp `llama-server` with `--rerank` (Cohere-compatible `/rerank` endpoint) | Self-hosted, private, CPU-friendly reranking |
 | `alibaba` | Alibaba Cloud DashScope rerank API (qwen3-rerank) | Users on Alibaba Cloud / DashScope |
 | `google` | Google Discovery Engine ranking API (REST + Google auth) | Production, GCP integration |
 | `tei` | HuggingFace Text Embeddings Inference | Production, self-hosted |
@@ -736,6 +737,25 @@ SiliconFlow hosts a range of open-weight rerankers behind a Cohere-compatible `/
 |-------|----------|
 | `BAAI/bge-reranker-v2-m3` | Multilingual, strong default |
 | `Qwen/Qwen3-Reranker-8B` | Larger, higher accuracy |
+
+### llama.cpp Models
+
+Run any GGUF reranker model on an existing llama.cpp server (this connects to a server
+you run yourself, unlike the `llamacpp` LLM provider which spawns one):
+
+```bash
+llama-server --rerank -m bge-reranker-v2-m3.gguf --port 8080
+```
+
+```bash
+export HINDSIGHT_API_RERANKER_PROVIDER=llamacpp
+export HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
+```
+
+| Model | Use Case |
+|-------|----------|
+| `bge-reranker-v2-m3` (GGUF) | Multilingual, strong default |
+| `jina-reranker-v1-tiny-en` (GGUF) | Tiny, fast CPU reranking |
 
 ### Alibaba Cloud Models
 


### PR DESCRIPTION
## Summary

Adds first-class `llamacpp` as a **reranker provider** (`HINDSIGHT_API_RERANKER_PROVIDER=llamacpp`), so a local `llama-server --rerank` instance can be used directly instead of spoofing the `openrouter` provider with a rewritten base URL. Also documents the existing recipe for llama.cpp **embeddings** via `HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai` + base URL — the docs-only scope the maintainer confirmed in the issue thread.

Fixes vectorize-io/hindsight#2665

## Root cause

llama.cpp already speaks the Jina/Cohere-compatible `/rerank` contract that Hindsight's `_CohereCompatibleRerankClient` implements — the only thing missing was a dispatch branch in `create_cross_encoder_from_env()` plus config constants. No wire-format work was needed.

## How it works

```mermaid
flowchart LR
    subgraph env [Config]
        A["HINDSIGHT_API_RERANKER_PROVIDER=llamacpp<br/>HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL<br/>(+ optional MODEL / API_KEY / TIMEOUT)"]
    end
    A --> B["create_cross_encoder_from_env()"]
    B -->|"provider == 'llamacpp'"| C["LlamaCppCrossEncoder"]
    B -->|"missing base URL"| E["ValueError at startup<br/>(same shape as tei)"]
    C --> D["_CohereCompatibleRerankClient<br/>POST {base_url}/v1/rerank"]
    D --> F["llama-server --rerank<br/>(reranker GGUF)"]
    F -->|"results[].index remapped<br/>to input order"| C
```

## Changes

- `LlamaCppCrossEncoder` composing the existing `_CohereCompatibleRerankClient` (`/rerank` contract; permuted `results[].index` remapping covered by a dedicated test)
- Factory branch with required-base-URL `ValueError` (same shape as `tei`)
- Config: `ENV_RERANKER_LLAMACPP_*` constants, dataclass fields, `from_env()`, credential fields (base URL + API key)
- Docs: `configuration.md` + `models.mdx` reranker sections, plus the llama.cpp embeddings recipe (docs-only, per maintainer scoping)
- `.env.example` + bundled `hindsight-embed` template kept in sync (`test_bundled_template_matches_repo_root` guards this)
- Review fixes folded in: the unsupported-provider error message now lists `openrouter` (dispatched but missing from the message); `skills/hindsight-docs` regenerated in-sync with the docs change; score-normalization docstring corrected to match the conditional-sigmoid behavior in `reranking.py`

## How to test

```bash
cd hindsight-api-slim
uv run pytest tests/test_llamacpp_cross_encoder.py tests/test_reranker_timeouts.py -v
uv run ruff check hindsight_api/engine/cross_encoder.py hindsight_api/config.py
uv run ty check hindsight_api/engine/cross_encoder.py

# live (optional): llama-server with a reranker GGUF, then
export HINDSIGHT_API_RERANKER_PROVIDER=llamacpp
export HINDSIGHT_API_RERANKER_LLAMACPP_BASE_URL=http://localhost:8080
```

## Test evidence

Run post-rebase on upstream `main` (`ca87e2989`), squashed branch:

| Check | Result |
|---|---|
| `test_llamacpp_cross_encoder.py` + `test_reranker_timeouts.py` + `test_cohere_cross_encoder.py` | **36 passed** |
| `hindsight-embed/tests/test_env_template.py` (template sync) | **7 passed** |
| `ruff check` / `ruff format --check` on touched files | clean |
| `ty check hindsight_api/engine/cross_encoder.py` | clean |

## Notes for reviewers

- Additive only: no schema, API-surface, or default-behavior changes. This provider **connects to** an existing `llama-server --rerank`; it does not spawn one (unlike the `llamacpp` LLM provider).
- Out of scope (follow-ups welcome): a generic `RERANK_BASE_URL` for arbitrary Jina/Cohere-spec servers (raised by @adoreparler in the issue thread), ollama reranker, per-bank reranker config.
