### PR TITLE
test(openrouter): set cached-token fields in mock to stop intermittent MagicMock crash

### DIFF
--- a/hindsight-api-slim/tests/test_openrouter_null_content.py
+++ b/hindsight-api-slim/tests/test_openrouter_null_content.py
@@ -39,6 +39,10 @@ def _make_chat_response(content: str | None) -> MagicMock:
     - response.model_dump()          (returns dict without 'error' key)
     - choice.message.tool_calls/refusal  (otherwise truthy MagicMock in error msg)
     - usage.completion_tokens_details  (otherwise reasoning-token math crashes, #2378)
+    - usage.cached_tokens / usage.prompt_tokens_details  (otherwise the cached-
+      token extraction reads an auto-MagicMock and metrics' `cached_input_tokens
+      > 0` raises "'>' not supported between MagicMock and int" — only when the
+      metrics path runs, which makes it an intermittent xdist failure)
     """
     choice = MagicMock()
     choice.finish_reason = "stop"
@@ -53,6 +57,10 @@ def _make_chat_response(content: str | None) -> MagicMock:
     response.usage.completion_tokens = 0 if content is None else 5
     response.usage.total_tokens = 10 if content is None else 15
     response.usage.completion_tokens_details = None
+    # Cover both cached-token extraction paths (response_usage.cached_tokens and
+    # usage.prompt_tokens_details.cached_tokens) so neither leaks a MagicMock.
+    response.usage.cached_tokens = 0
+    response.usage.prompt_tokens_details = None
     response.choices = [choice]
     return response
 


### PR DESCRIPTION
`test_null_content_recovers_on_retry` failed intermittently on the `test-api` shard:

```
hindsight_api/metrics.py:591: TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```
(`if cached_input_tokens > 0:`)

`_make_chat_response` set `completion_tokens_details` (added for #2378) but not the **cached-token** fields. So the cached-token extraction — `openai_compatible_llm.py:948` (`response_usage.cached_tokens`) and the `usage.prompt_tokens_details.cached_tokens` path — read an auto-`MagicMock` and passed it to the metrics recorder. It only surfaced when the metrics path actually ran, which depends on telemetry state that leaks across pytest-xdist workers — so it presented as an **intermittent, co-scheduling-dependent** failure (passed on some runs, failed on others with identical code).

**Fix:** set `usage.cached_tokens = 0` and `usage.prompt_tokens_details = None` so both extraction paths yield int `0`.

Verified locally: both tests pass, and both extraction paths return int `0` (no `MagicMock` reaches the `> 0` comparison).

Context: this was the lone remaining red on #2727 after the native-import (#2761) and judge-hardening (#2769) fixes — a pre-existing flake unrelated to that PR's dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)