### PR TITLE
feat(api): opt-in per-bank attribution for remote reranker requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# Opt-in: send X-Hindsight-Bank-Id on Cohere-compatible remote rerank calls (trusted gateways only)
+# HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
 
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -383,6 +383,7 @@ ENV_LITELLM_API_BASE = "HINDSIGHT_API_LITELLM_API_BASE"
 ENV_LITELLM_API_KEY = "HINDSIGHT_API_LITELLM_API_KEY"
 
 ENV_RERANKER_PROVIDER = "HINDSIGHT_API_RERANKER_PROVIDER"
+ENV_RERANKER_SEND_BANK_AS_HEADER = "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"
 ENV_RERANKER_LOCAL_MODEL = "HINDSIGHT_API_RERANKER_LOCAL_MODEL"
 ENV_RERANKER_LOCAL_FORCE_CPU = "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"
 ENV_RERANKER_LOCAL_MAX_CONCURRENT = "HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT"
@@ -768,6 +769,7 @@ DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
 DEFAULT_EMBEDDING_DIMENSION = 384
 
 DEFAULT_RERANKER_PROVIDER = "local"
+DEFAULT_RERANKER_SEND_BANK_AS_HEADER = False  # Opt-in: tag remote rerank calls with X-Hindsight-Bank-Id
 DEFAULT_RERANKER_LOCAL_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 DEFAULT_RERANKER_LOCAL_FORCE_CPU = False  # Force CPU mode for local reranker
 DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT = 4  # Limit concurrent CPU-bound reranking to prevent thrashing
@@ -1731,6 +1733,13 @@ class HindsightConfig:
 
     # Reranker
     reranker_provider: str
+    # Tags outbound Cohere-compatible remote rerank requests with
+    # `X-Hindsight-Bank-Id: <bank_id>` for per-bank cost attribution. Opt-in;
+    # covers Cohere (base_url path), OpenRouter, ZeroEntropy, SiliconFlow, Alibaba,
+    # and the LiteLLM proxy (not the LiteLLM SDK).
+    # The bank id is transmitted to the configured reranker endpoint — trusted
+    # gateways/proxies only.
+    reranker_send_bank_as_header: bool
     reranker_local_model: str
     reranker_local_force_cpu: bool
     reranker_local_max_concurrent: int
@@ -2633,6 +2642,10 @@ class HindsightConfig:
             or os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY),
             # Reranker
             reranker_provider=os.getenv(ENV_RERANKER_PROVIDER, DEFAULT_RERANKER_PROVIDER),
+            reranker_send_bank_as_header=os.getenv(
+                ENV_RERANKER_SEND_BANK_AS_HEADER, str(DEFAULT_RERANKER_SEND_BANK_AS_HEADER)
+            ).lower()
+            in ("true", "1"),
             reranker_local_model=os.getenv(ENV_RERANKER_LOCAL_MODEL, DEFAULT_RERANKER_LOCAL_MODEL),
             reranker_local_force_cpu=os.getenv(
                 ENV_RERANKER_LOCAL_FORCE_CPU, str(DEFAULT_RERANKER_LOCAL_FORCE_CPU)

--- a/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_attribution.py
@@ -1,17 +1,27 @@
-"""Per-bank provider cost attribution via the OpenAI ``user`` field.
+"""Per-bank provider cost attribution.
 
-Shared by the OpenAI-compatible LLM path and the OpenAI embeddings path so both
-tag outbound requests identically. Opt-in via ``HINDSIGHT_API_LLM_SEND_BANK_AS_USER``;
-downstream cost gateways (OpenRouter usage accounting, LiteLLM, Helicone) key spend
-on the OpenAI ``user`` field.
+Two transport mechanisms, both opt-in:
 
-Note: when enabled, the bank id is transmitted to the upstream provider as the
-end-user identifier. Banks that are themselves end-user identifiers are therefore
-forwarded to the provider — which is exactly what the OpenAI ``user`` field is for,
-but operators should opt in with that in mind.
+1. OpenAI ``user`` field (``HINDSIGHT_API_LLM_SEND_BANK_AS_USER``) — shared by the
+   OpenAI-compatible LLM path and the OpenAI embeddings path. Downstream cost
+   gateways (OpenRouter usage accounting, LiteLLM, Helicone) key spend on the
+   OpenAI ``user`` field.
+2. ``X-Hindsight-Bank-Id`` header (``HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER``)
+   — shared by the Cohere-compatible remote rerank path (Cohere base_url,
+   OpenRouter, ZeroEntropy, SiliconFlow, Alibaba) and the LiteLLM proxy rerank
+   path. The Cohere rerank wire format has no OpenAI ``user`` field, so rerank
+   attribution rides a header instead. Does not apply to local, TEI, native
+   Cohere SDK, LiteLLM SDK, or Google rerankers.
+
+Note: when enabled, the bank id is transmitted to the upstream provider. Banks
+that are themselves end-user identifiers are therefore forwarded to the
+provider — operators should opt in with that in mind, and only against trusted
+gateways/proxies for the header path.
 """
 
 from typing import Any
+
+RERANK_BANK_HEADER = "X-Hindsight-Bank-Id"
 
 
 def apply_bank_attribution(request: dict[str, Any]) -> None:
@@ -32,3 +42,24 @@ def apply_bank_attribution(request: dict[str, Any]) -> None:
     bank_id = get_current_bank_id()
     if bank_id:
         request["user"] = bank_id
+
+
+def bank_attribution_headers() -> dict[str, str]:
+    """Per-bank attribution headers for outbound remote rerank requests.
+
+    Empty dict when the flag is off or no bank is bound — callers splat it
+    unconditionally. The Cohere rerank wire format has no OpenAI ``user`` field,
+    so rerank attribution rides a header instead of the body.
+    """
+    from ..config import get_config  # lazy: same circular-import reason as above
+    from .memory_engine import get_current_bank_id
+
+    if not get_config().reranker_send_bank_as_header:
+        return {}
+    bank_id = get_current_bank_id()
+    # Header values must be ASCII per httpx; bank ids are free-form path params, so
+    # non-ASCII ids are skipped rather than percent-encoded — attribution is
+    # best-effort, and an encoded id wouldn't match billing dashboards anyway.
+    if not bank_id or not bank_id.isascii():
+        return {}
+    return {RERANK_BANK_HEADER: bank_id}

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -46,6 +46,7 @@ from ..config import (
     ENV_RERANKER_TEI_URL,
     ENV_RERANKER_ZEROENTROPY_API_KEY,
 )
+from .bank_attribution import bank_attribution_headers
 
 logger = logging.getLogger(__name__)
 
@@ -612,6 +613,11 @@ class _CohereCompatibleRerankClient:
         if not pairs:
             return []
 
+        # Compute once per predict(); empty when flag off or no bank bound.
+        # Must be per-request (not client default) so a shared client does not
+        # pin bank A's id onto bank B's later call.
+        headers = bank_attribution_headers()
+
         query_groups: dict[str, list[tuple[int, str]]] = {}
         for idx, (query, text) in enumerate(pairs):
             query_groups.setdefault(query, []).append((idx, text))
@@ -631,7 +637,7 @@ class _CohereCompatibleRerankClient:
             if self.include_top_n:
                 body["top_n"] = len(texts)
 
-            response = await self._async_client.post(self.rerank_url, json=body)
+            response = await self._async_client.post(self.rerank_url, json=body, headers=headers)
             response.raise_for_status()
             result = response.json()
 
@@ -1140,6 +1146,11 @@ class LiteLLMCrossEncoder(CrossEncoderModel):
         if not pairs:
             return []
 
+        # Compute once per predict(); empty when flag off or no bank bound.
+        # Must be per-request (not client default) so a shared client does not
+        # pin bank A's id onto bank B's later call.
+        headers = bank_attribution_headers()
+
         # Group pairs by query (LiteLLM rerank expects one query with multiple documents)
         query_groups: dict[str, list[tuple[int, str]]] = {}
         for idx, (query, text) in enumerate(pairs):
@@ -1164,6 +1175,7 @@ class LiteLLMCrossEncoder(CrossEncoderModel):
                     "documents": texts,
                     "top_n": len(texts),  # Return all scores
                 },
+                headers=headers,
             )
             response.raise_for_status()
             result = response.json()

--- a/hindsight-api-slim/tests/test_bank_attribution_config.py
+++ b/hindsight-api-slim/tests/test_bank_attribution_config.py
@@ -2,6 +2,7 @@
 Config wiring for per-bank attribution and the configurable OpenRouter rerank URL.
 
 - HINDSIGHT_API_LLM_SEND_BANK_AS_USER (default off, opt-in bool)
+- HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER (default off, opt-in bool)
 - HINDSIGHT_API_RERANKER_OPENROUTER_BASE_URL (default = previously hardcoded URL)
 
 Deterministic, no network.
@@ -87,6 +88,51 @@ class TestSendBankAsUserConfig:
             assert HindsightConfig.from_env().llm_send_bank_as_user is True
         finally:
             _restore_env(saved)
+
+
+class TestRerankerSendBankAsHeaderConfig:
+    def test_default_is_false(self):
+        from hindsight_api.config import clear_config_cache
+
+        saved = {
+            "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER": os.environ.get("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER")
+        }
+        os.environ.pop("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER", None)
+        clear_config_cache()
+        try:
+            assert HindsightConfig.from_env().reranker_send_bank_as_header is False
+        finally:
+            _restore_env(saved)
+
+    def test_true_enables(self):
+        from hindsight_api.config import clear_config_cache
+
+        saved = {
+            "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER": os.environ.get("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER")
+        }
+        os.environ["HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"] = "true"
+        clear_config_cache()
+        try:
+            assert HindsightConfig.from_env().reranker_send_bank_as_header is True
+        finally:
+            _restore_env(saved)
+
+    def test_one_enables(self):
+        from hindsight_api.config import clear_config_cache
+
+        saved = {
+            "HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER": os.environ.get("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER")
+        }
+        os.environ["HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"] = "1"
+        clear_config_cache()
+        try:
+            assert HindsightConfig.from_env().reranker_send_bank_as_header is True
+        finally:
+            _restore_env(saved)
+
+    def test_flag_is_static_not_configurable(self):
+        assert "reranker_send_bank_as_header" not in HindsightConfig.get_configurable_fields()
+        assert "reranker_send_bank_as_header" in HindsightConfig.get_static_fields()
 
 
 class TestRerankerOpenRouterBaseUrlConfig:

--- a/hindsight-api-slim/tests/test_reranker_bank_attribution.py
+++ b/hindsight-api-slim/tests/test_reranker_bank_attribution.py
@@ -1,0 +1,258 @@
+"""
+Tests for opt-in per-bank attribution on Cohere-compatible remote rerank requests.
+
+Covers the shared `_CohereCompatibleRerankClient` path used by Cohere (base_url),
+OpenRouter, ZeroEntropy, SiliconFlow, and Alibaba, plus the `LiteLLMCrossEncoder`
+proxy path (httpx POST to a LiteLLM proxy /rerank). Opt-in via
+`HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER`; when enabled, outbound rerank posts
+carry `X-Hindsight-Bank-Id: <bank_id>`.
+
+All deterministic — no network, stdlib/pytest/httpx only.
+"""
+
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from hindsight_api.engine.cross_encoder import LiteLLMCrossEncoder, _CohereCompatibleRerankClient
+from hindsight_api.engine.memory_engine import _current_bank_id
+
+
+@pytest.fixture(autouse=True)
+def restore_reranker_send_bank_env():
+    """Save/restore the reranker attribution env var and clear the cached config."""
+    from hindsight_api.config import clear_config_cache
+
+    original = os.environ.get("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER")
+    clear_config_cache()
+    yield
+    if original is None:
+        os.environ.pop("HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER", None)
+    else:
+        os.environ["HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"] = original
+    clear_config_cache()
+
+
+def _set_flag(enabled: bool) -> None:
+    from hindsight_api.config import clear_config_cache
+
+    os.environ["HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER"] = "true" if enabled else "false"
+    clear_config_cache()
+
+
+async def _make_initialized_client(transport: httpx.MockTransport) -> _CohereCompatibleRerankClient:
+    client = _CohereCompatibleRerankClient(
+        api_key="k",
+        model="m",
+        rerank_url="https://gw.example/rerank",
+    )
+    # Capture the real class BEFORE patching: the lambda body resolves
+    # httpx.AsyncClient at CALL time, so referencing it directly would re-enter
+    # the mock and recurse.
+    real_async_client = httpx.AsyncClient
+    # side_effect (NOT return_value) so initialize()'s real headers=
+    # {Authorization, Content-Type} kwarg survives.
+    with patch.object(
+        httpx,
+        "AsyncClient",
+        side_effect=lambda **kw: real_async_client(**kw, transport=transport),
+    ):
+        await client.initialize()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_bank_header_sent_when_enabled():
+    _set_flag(True)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    token = _current_bank_id.set("bank-42")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert captured["headers"]["X-Hindsight-Bank-Id"] == "bank-42"
+
+
+@pytest.mark.asyncio
+async def test_bank_header_absent_when_flag_off():
+    _set_flag(False)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    token = _current_bank_id.set("bank-42")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert "X-Hindsight-Bank-Id" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_bank_header_absent_when_no_bank_bound():
+    _set_flag(True)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    await client.predict([("q", "d")])
+
+    assert "X-Hindsight-Bank-Id" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_auth_and_content_type_headers_survive_when_enabled():
+    _set_flag(True)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    token = _current_bank_id.set("bank-42")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert captured["headers"]["Authorization"] == "Bearer k"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["headers"]["X-Hindsight-Bank-Id"] == "bank-42"
+
+
+@pytest.mark.asyncio
+async def test_header_is_per_request_not_client_default():
+    """Two predict() calls on the same client must each carry their own bank.
+
+    Catches an implementation that pins the bank into client defaults at
+    initialize() time and mis-attributes every later bank.
+    """
+    _set_flag(True)
+    seen: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("X-Hindsight-Bank-Id"))
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    token_a = _current_bank_id.set("bank-a")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token_a)
+
+    token_b = _current_bank_id.set("bank-b")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token_b)
+
+    assert seen == ["bank-a", "bank-b"]
+
+
+@pytest.mark.asyncio
+async def test_bank_header_skipped_for_non_ascii_bank_id():
+    """Non-ASCII bank ids are skipped (httpx header values must be ASCII) — the
+    request still succeeds, just without attribution."""
+    _set_flag(True)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_client(transport)
+
+    token = _current_bank_id.set("bänk-中文")
+    try:
+        scores = await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert scores == [0.9]
+    assert "X-Hindsight-Bank-Id" not in captured["headers"]
+
+
+async def _make_initialized_litellm_client(transport: httpx.MockTransport) -> LiteLLMCrossEncoder:
+    client = LiteLLMCrossEncoder(api_base="https://proxy.example", api_key="k", model="m")
+    # Same capture-before-patch dance as _make_initialized_client above.
+    real_async_client = httpx.AsyncClient
+    with patch.object(
+        httpx,
+        "AsyncClient",
+        side_effect=lambda **kw: real_async_client(**kw, transport=transport),
+    ):
+        await client.initialize()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_litellm_proxy_bank_header_sent_when_enabled():
+    _set_flag(True)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_litellm_client(transport)
+
+    token = _current_bank_id.set("bank-42")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert captured["headers"]["X-Hindsight-Bank-Id"] == "bank-42"
+    # Client-default headers from initialize() must survive the per-request merge.
+    assert captured["headers"]["Authorization"] == "Bearer k"
+
+
+@pytest.mark.asyncio
+async def test_litellm_proxy_bank_header_absent_when_flag_off():
+    _set_flag(False)
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    client = await _make_initialized_litellm_client(transport)
+
+    token = _current_bank_id.set("bank-42")
+    try:
+        await client.predict([("q", "d")])
+    finally:
+        _current_bank_id.reset(token)
+
+    assert "X-Hindsight-Bank-Id" not in captured["headers"]

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -840,6 +840,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Tag outbound Cohere-compatible remote rerank requests with `X-Hindsight-Bank-Id: <bank_id>` so gateways can attribute spend per bank. Transmits the bank id to the configured reranker endpoint — use only with trusted gateways/proxies. Covers Cohere (`base_url` HTTP path), OpenRouter, ZeroEntropy, SiliconFlow, Alibaba, and the LiteLLM proxy. Does not apply to local, TEI, native Cohere SDK, LiteLLM SDK, or Google rerankers. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -200,6 +200,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false
 # For TEI provider:
 # HINDSIGHT_API_RERANKER_TEI_URL=http://localhost:8081
+# Opt-in: send X-Hindsight-Bank-Id on Cohere-compatible remote rerank calls (trusted gateways only)
+# HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
 
 # Observability & Tracing (Optional - disabled by default)
 # Enable OpenTelemetry tracing for LLM calls (GenAI semantic conventions)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -840,6 +840,7 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Tag outbound Cohere-compatible remote rerank requests with `X-Hindsight-Bank-Id: <bank_id>` so gateways can attribute spend per bank. Transmits the bank id to the configured reranker endpoint — use only with trusted gateways/proxies. Covers Cohere (`base_url` HTTP path), OpenRouter, ZeroEntropy, SiliconFlow, Alibaba, and the LiteLLM proxy. Does not apply to local, TEI, native Cohere SDK, LiteLLM SDK, or Google rerankers. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |
 | `HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE` | Allow loading models with custom code (security risk, disabled by default) | `false` |


### PR DESCRIPTION
## Summary

Opt-in per-bank cost attribution for remote rerank requests. When `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=true`, outbound rerank `POST`s carry `X-Hindsight-Bank-Id: <bank_id>`. Default is `false` — a byte-identical no-op.

**Covers:** the Cohere-compatible HTTP client (Cohere via base URL, OpenRouter, ZeroEntropy, SiliconFlow, Alibaba) **and the LiteLLM proxy reranker** (`LiteLLMCrossEncoder`, same per-request pattern).

Fixes vectorize-io/hindsight#2729

## Root cause

`_CohereCompatibleRerankClient.predict` posted with no per-request headers. The process-wide client only carries `Authorization`/`Content-Type` and is **shared across banks**, so a client-default header could pin bank A's id onto bank B's requests. The existing `apply_bank_attribution()` body mutator can't help — the Cohere rerank wire format has no OpenAI-style `user` field.

```mermaid
sequenceDiagram
    participant R as recall / reflect
    participant CV as _current_bank_id (contextvar)
    participant C as shared rerank client<br/>(one per process, all banks)
    participant P as remote provider
    R->>CV: bind bank_id
    R->>C: predict(query, docs)
    C->>C: bank_attribution_headers()<br/>flag on + bank bound → {X-Hindsight-Bank-Id}
    C->>P: POST /rerank (per-request headers,<br/>never client defaults)
    Note over C,P: bank A and bank B requests on the same client<br/>each carry their own id — no bleed
```

## Design notes

- **Per-request headers, not client defaults** — the client is shared across banks; defaults would misattribute. A dedicated two-bank isolation test proves requests interleaved on the same client carry distinct ids.
- Flag is **static** (server-level), not bank-configurable — it's an infrastructure/billing concern.
- Header and flag names match the contract proposed in the issue exactly. The issue's open question about an `X-Bank-Id` spelling for MCP surfaces is left to maintainers — trivial rename if preferred.
- Reranks issued during `reflect` currently run with no bank bound; upstream #2764 fixes that binding orthogonally, and this feature picks it up automatically once merged.
- **Non-ASCII bank ids are skipped** (no header) rather than percent-encoded: httpx requires ASCII header values, and an encoded id wouldn't match billing dashboards. Covered by a dedicated test — a unicode bank id can never 500 a recall.

## How this differs from #2740

Strictly additive and scoped to the issue's stated minimum plus the safe LiteLLM **proxy** path: no existing attribution/LiteLLM tests are deleted, the LiteLLM legacy response fallback is untouched, and the unrelated reflect-binding change stays in #2764. The LiteLLM **SDK** path is deliberately left out: passing `headers=` into `litellm.arerank` unconditionally is unverified against litellm's rerank signature (it may break SDK reranks even with the flag off). Tests here exercise the real env flag + contextvar end-to-end through `httpx.MockTransport` — including absent-by-default, absent-when-no-bank, auth-header survival, and two-bank per-request isolation — rather than patching the header helper.

## Out of scope (follow-ups)

Native Cohere SDK, LiteLLM SDK (pending kwarg verification), Google, TEI (self-hosted; attribution value low), local/FlashRank/JinaMLX/RRF (no remote spend to attribute).

## How to test

```bash
cd hindsight-api-slim
uv run pytest tests/test_reranker_bank_attribution.py tests/test_bank_attribution_config.py -v
uv run pytest tests/test_cohere_cross_encoder.py tests/test_bank_attribution.py \
              tests/test_tei_cross_encoder.py tests/test_reranker_timeouts.py -q
uv run ty check hindsight_api/engine/bank_attribution.py hindsight_api/engine/cross_encoder.py
cd ../hindsight-embed && uv run pytest tests/test_env_template.py -q
```

## Test evidence

Run on the de-stacked, squashed branch (single commit on upstream `main`):

| Check | Result |
|---|---|
| attribution + cohere + tei + timeouts suites (6 files) | **72 passed**, 3 skipped |
| `hindsight-embed/tests/test_env_template.py` | **7 passed** |
| `ruff check` / `ruff format --check` on touched files | clean |
| `ty check` on `bank_attribution.py` + `cross_encoder.py` | clean |
| `generate-docs-skill.sh` idempotency | clean (no drift) |
