### PR TITLE
fix: preserve existing memory_units when update_mode=append

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1197,6 +1197,15 @@ async def _streaming_retain_batch(
                         f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
                         f"will skip matching and preserve existing data"
                     )
+            # When update_mode="append" and the document already exists, use
+            # upsert_document_metadata (same path as recovery) so that old
+            # chunks and their memory_units are preserved instead of being
+            # cascade-deleted by handle_document_tracking.
+            if doc_row and update_mode == "append":
+                is_recovery = True
+                log_buffer.append(
+                    "[streaming] APPEND: document exists — preserving existing chunks and memory_units"
+                )
     except Exception:
         pass  # If we can't load, just process all chunks
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1203,9 +1203,7 @@ async def _streaming_retain_batch(
             # cascade-deleted by handle_document_tracking.
             if doc_row and update_mode == "append":
                 is_recovery = True
-                log_buffer.append(
-                    "[streaming] APPEND: document exists — preserving existing chunks and memory_units"
-                )
+                log_buffer.append("[streaming] APPEND: document exists — preserving existing chunks and memory_units")
     except Exception:
         pass  # If we can't load, just process all chunks
 


### PR DESCRIPTION
## Summary

When `update_mode="append"` is used with a stable `document_id`, the server-side implementation performs a full replace on every retain, silently deleting all existing memory_units for that document. This breaks the documented behavior and causes silent memory loss for integrations that use session-scoped document IDs (OpenClaw, Hermes, etc.).

## Root Cause

In the retain orchestrator, `is_recovery` is only set to True when `content_hash` matches. With `update_mode="append"`, the content is always (old+new), so the hash never matches and `handle_document_tracking` (cascade-delete old chunks + memory_units) is called instead of `upsert_document_metadata` (preserve existing + add new).

## Fix

When `update_mode="append"` and the document already exists, set `is_recovery = True` so `upsert_document_metadata` is used, preserving old chunks whose content_hash hasn't changed and their memory_units.

**9 lines added**, zero existing behavior changed for non-append paths.

## Impact

- Old chunks and memory_units are preserved on re-retain with append mode
- Document text still accumulates correctly
- Only new chunks go through fact extraction
- Orphan entity accumulation is prevented

Closes #2664