### PR TITLE
fix(docker): build official images from the committed workspace lock

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -41,28 +41,43 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv
 
-# Copy dependency files and README (required by pyproject.toml)
+# Copy the workspace lock and member metadata before source code so dependency
+# installation stays cacheable while matching the versions tested in CI.
+COPY pyproject.toml uv.lock ./
+COPY hindsight-all/pyproject.toml ./hindsight-all/
+COPY hindsight-api/pyproject.toml ./hindsight-api/
 COPY hindsight-api-slim/pyproject.toml ./api/
 COPY hindsight-api-slim/README.md ./api/
-
-WORKDIR /app/api
+COPY hindsight-all-slim/pyproject.toml ./hindsight-all-slim/
+COPY hindsight-dev/pyproject.toml ./hindsight-dev/
+COPY hindsight-clients/python/pyproject.toml ./hindsight-clients/python/
+COPY hindsight-embed/pyproject.toml ./hindsight-embed/
+RUN ln -s api hindsight-api-slim
 
 # Sync dependencies using appropriate extras based on INCLUDE_LOCAL_MODELS
 # local-ml: torch, sentence-transformers, transformers, einops, flashrank, mlx (optional)
 # embedded-db: pg0-embedded (always included for embedded PostgreSQL support)
 # ONNX Runtime embeddings are intentionally not bundled into the official
 # standalone image; install the local-onnx extra in custom images when needed.
+ENV UV_PROJECT_ENVIRONMENT=/app/api/.venv
 RUN if [ "$INCLUDE_LOCAL_MODELS" = "true" ]; then \
-        uv sync --extra local-ml --extra embedded-db; \
+        uv sync --locked --package hindsight-api-slim --no-install-package hindsight-api-slim --extra local-ml --extra embedded-db; \
     else \
-        uv sync --extra embedded-db; \
+        uv sync --locked --package hindsight-api-slim --no-install-package hindsight-api-slim --extra embedded-db; \
     fi
 
 # Copy source code (alembic migrations are inside hindsight_api/)
+WORKDIR /app/api
 COPY hindsight-api-slim/hindsight_api ./hindsight_api
 
-# Install the local package (uv sync only installed dependencies, not the package itself)
-RUN uv pip install -e .
+# Install the local package from the same validated lock after source is present.
+WORKDIR /app
+RUN if [ "$INCLUDE_LOCAL_MODELS" = "true" ]; then \
+        uv sync --locked --package hindsight-api-slim --extra local-ml --extra embedded-db; \
+    else \
+        uv sync --locked --package hindsight-api-slim --extra embedded-db; \
+    fi \
+    && uv pip check --python /app/api/.venv/bin/python
 
 # =============================================================================
 # Stage: SDK Builder (needed for Control Plane)


### PR DESCRIPTION
## Summary

- install standalone API image dependencies from the repository's committed workspace `uv.lock`
- keep the dependency layer cacheable by excluding only the local API package until its source is copied
- install the local package with the same locked workspace resolution and validate the final virtual environment with `uv pip check`
- preserve both the `local-ml + embedded-db` and `embedded-db`-only image variants

This prevents release images from resolving a newer transitive dependency set than the one exercised by the repository. The drift was visible with `dateparser`: the workspace lock selects 1.2.2 while the previous member-only Docker sync resolved 1.4.1.

## Validation

- built `api-builder` with `INCLUDE_LOCAL_MODELS=false`; `uv pip check` passed for 206 packages and the image reports `hindsight-api-slim==0.8.4`, `dateparser==1.2.2`
- built `api-builder` with `INCLUDE_LOCAL_MODELS=true`; `uv pip check` passed for 220 packages and the image reports `hindsight-api-slim==0.8.4`, `dateparser==1.2.2`, `torch==2.10.0+cpu`
- built the final `api-only` slim image and verified the installed `dateparser` version matches the lock

## Review note

Adversarial review raised a conditional concern about workspace-member dependencies. The live `hindsight-api-slim` metadata has no workspace package sources, and both locked variants were built end-to-end; if that dependency graph changes later, the locked Docker build will fail rather than silently resolve a different environment.
