### PR TITLE
Fix day+month+year dates collapsing to the whole month

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
@@ -128,6 +128,11 @@ def _extract_non_chinese_period(query: str, reference_date: datetime) -> DateRan
         "december|diciembre|dicembre|d[ée]cembre|dezember": 12,
     }
     for pattern, month_num in month_patterns.items():
+        # Skip when a day number precedes the month ("13 июля 2026", "13 July 2026"):
+        # that is an exact date, and collapsing it to the whole month loses precision.
+        # dateparser resolves those correctly, so let them fall through to it.
+        if re.search(rf"\b\d{{1,2}}\s+({pattern})\b", query, re.IGNORECASE):
+            continue
         match = re.search(rf"\b({pattern})\s+(\d{{4}})\b", query, re.IGNORECASE)
         if match:
             year = int(match.group(2))

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -825,3 +825,24 @@ def test_query_analyzer_dateparser_crash_returns_no_constraint(query_analyzer, m
         "dateparser failures should be treated as no temporal constraint, not propagated"
     )
     assert any("dateparser" in rec.message for rec in caplog.records), "Should log a warning when dateparser fails"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # A day number before the month means an exact date, not the whole month.
+        # The period table runs before dateparser, so without the day-number guard
+        # this collapsed to a month range. This is language-agnostic — it affects
+        # every language in the period table; the English case is shown here.
+        ("meeting on 13 July 2024", datetime(2024, 7, 13)),
+    ],
+)
+def test_query_analyzer_day_month_year_stays_exact(query_analyzer, query, expected):
+    """An explicit day+month+year must not be widened to the whole month."""
+    reference_date = datetime(2025, 1, 15, 12, 0, 0)
+
+    analysis = query_analyzer.analyze(query, reference_date)
+
+    assert analysis.temporal_constraint is not None
+    assert analysis.temporal_constraint.start_date.date() == expected.date()
+    assert analysis.temporal_constraint.end_date.date() == expected.date()


### PR DESCRIPTION
## Problem

`extract_period()` (the deterministic period table) runs before dateparser and matches `<month> <year>`. When a day number precedes the month, the table still fires and widens the query to the whole month, dropping the day:

```
meeting on 13 July 2024  ->  2024-07-01 .. 2024-07-31   (should be 2024-07-13)
```

This is **language-agnostic** — it affects every language in the period table, and it bites English today.

## Fix

Guard the month-table match with a day-number check: if a day precedes the month, skip the table and let dateparser resolve the exact date (dateparser handles `13 July 2024` correctly).

## Tests

Added `test_query_analyzer_day_month_year_stays_exact` (English case). Verified locally on **both** dateparser versions:

- `1.2.2` — the version pinned in the lock / run by CI
- `1.4.1` — the version actually shipped inside the `ghcr.io/vectorize-io/hindsight:0.8.4` image

Full `test_query_analyzer.py` is green (383 passed) on both.

## Context

Split out of #2767 per @benfrank241's review, so this correctness fix can land independently of the Russian-coverage change. #2767 now stacks on this PR.
