### PR TITLE
Make entities required with an empty-list default so literal models stop dropping them

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -180,7 +180,7 @@ class ExtractedFact(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     what: str = Field(description="Core fact - concise but complete (1-2 sentences)")
@@ -195,7 +195,7 @@ class ExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts, including user preferences, rules, corrections, and constraints even when stated during a conversation. 'assistant' = actions, experiences, or observations the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[Entity] = Field(default_factory=list, description="People, places, concepts")
     causal_relations: list[FactCausalRelation] | None = Field(
         default=None, description="Links to previous facts (target_index < this fact's index)"
     )
@@ -286,7 +286,7 @@ class ExtractedFactVerbose(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     what: str = Field(
@@ -348,8 +348,8 @@ class ExtractedFactVerbose(BaseModel):
         description="'world' = objective/external facts about the user, other people, events, general knowledge, preferences, rules, corrections, or constraints. 'assistant' = actions, experiences, or observations the assistant/agent actually performed (e.g., 'I changed X', 'I discovered Y')."
     )
 
-    entities: list[Entity] | None = Field(
-        default=None,
+    entities: list[Entity] = Field(
+        default_factory=list,
         description="Named entities, objects, AND abstract concepts from the fact. Include: people names, organizations, places, significant objects (e.g., 'coffee maker', 'car'), AND abstract concepts/themes (e.g., 'friendship', 'career growth', 'loss', 'celebration'). Extract anything that could help link related facts together.",
     )
 
@@ -378,7 +378,7 @@ class ExtractedFactNoCausal(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type"]},
+        json_schema_extra={"required": ["what", "when", "where", "who", "why", "fact_type", "entities"]},
     )
 
     # Same fields as ExtractedFact but without causal_relations
@@ -397,8 +397,8 @@ class ExtractedFactNoCausal(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = about the user/others, including user preferences, rules, corrections, and constraints. 'assistant' = actions or experiences the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(
-        default=None,
+    entities: list[Entity] = Field(
+        default_factory=list,
         description="Named entities, objects, and concepts from the fact.",
     )
 
@@ -426,7 +426,7 @@ class VerbatimExtractedFact(BaseModel):
 
     model_config = ConfigDict(
         json_schema_mode="validation",
-        json_schema_extra={"required": ["when", "where", "who", "fact_type"]},
+        json_schema_extra={"required": ["when", "where", "who", "fact_type", "entities"]},
     )
 
     when: str = Field(description="When it happened. 'N/A' if unknown.")
@@ -439,7 +439,7 @@ class VerbatimExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts. 'assistant' = first-person actions, experiences, or observations by the speaker."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[Entity] = Field(default_factory=list, description="People, places, concepts")
 
     @field_validator("entities", mode="before")
     @classmethod
@@ -731,7 +731,8 @@ ENTITIES
 ══════════════════════════════════════════════════════════════════════════
 
 Include: people names, organizations, places, key objects, abstract concepts (career, friendship, etc.)
-Always include "user" when fact is about the user.{examples}"""
+Always include "user" when fact is about the user.
+FORMAT: "entities" must be an array of objects, each an object with a "text" field — never bare strings like ["Emily"].{examples}"""
 
 # Concise mode guidelines
 _CONCISE_GUIDELINES = """══════════════════════════════════════════════════════════════════════════
@@ -767,15 +768,15 @@ Example 1 - Selective extraction (Event Date: June 10, 2024):
 Input: "Hey! How's it going? Good morning! So I'm planning my wedding - want a small outdoor ceremony. Just got back from Emily's wedding, she married Sarah at a rooftop garden. It was nice weather. I grabbed a coffee on the way."
 
 Output: ONLY 2 facts (skip greetings, weather, coffee):
-1. what="User planning wedding, wants small outdoor ceremony", who="user", why="N/A", entities=["user", "wedding"]
-2. what="Emily married Sarah at rooftop garden", who="Emily (user's friend), Sarah", occurred_start="2024-06-09", entities=["Emily", "Sarah", "wedding"]
+1. what="User planning wedding, wants small outdoor ceremony", who="user", why="N/A", entities=[{{"text": "user"}}, {{"text": "wedding"}}]
+2. what="Emily married Sarah at rooftop garden", who="Emily (user's friend), Sarah", occurred_start="2024-06-09", entities=[{{"text": "Emily"}}, {{"text": "Sarah"}}, {{"text": "wedding"}}]
 
 Example 2 - Professional context:
 Input: "Alice has 5 years of Kubernetes experience and holds CKA certification. She's been leading the infrastructure team since March. By the way, she prefers dark roast coffee."
 
 Output: ONLY 2 facts (skip coffee preference - too trivial):
-1. what="Alice has 5 years Kubernetes experience, CKA certified", who="Alice", entities=["Alice", "Kubernetes", "CKA"]
-2. what="Alice leads infrastructure team since March", who="Alice", entities=["Alice", "infrastructure"]
+1. what="Alice has 5 years Kubernetes experience, CKA certified", who="Alice", entities=[{{"text": "Alice"}}, {{"text": "Kubernetes"}}, {{"text": "CKA"}}]
+2. what="Alice leads infrastructure team since March", who="Alice", entities=[{{"text": "Alice"}}, {{"text": "infrastructure"}}]
 
 ══════════════════════════════════════════════════════════════════════════
 QUALITY OVER QUANTITY
@@ -845,6 +846,8 @@ For EACH fact, CAPTURE ALL DETAILS - NEVER SUMMARIZE OR OMIT:
    - For assistant facts: MUST include what the user asked/requested that triggered this!
 
 Plus: fact_type, fact_kind, entities, occurred_start/end (for structured dates), where (structured location)
+
+ENTITIES FORMAT: "entities" must be an array of objects, each an object with a "text" field — never bare strings like ["Emily"].
 
 VERBOSITY REQUIREMENT: Include EVERY detail mentioned. More detail is ALWAYS better than less.
 

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -1,0 +1,103 @@
+"""Regression tests for issue #2749: auto-extracted entities were silently dropped.
+
+The four extraction models declared ``entities`` as an optional field that was
+absent from the schema's ``required`` array. Under a strict JSON schema, a
+literal model resolves the conflict (optional-typed-as-objects, while the
+few-shot examples showed strings) by omitting the field entirely — 0 entities,
+no error, biting precisely the most schema-conformant models.
+
+The fix makes ``entities`` required with an empty-list default and teaches the
+prompts the object form. These tests assert the schema shape (the regression
+that would have caught the bug in CI) and the prompt instruction, without
+needing an LLM.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api.engine.retain.fact_extraction import (
+    ExtractedFact,
+    ExtractedFactNoCausal,
+    ExtractedFactVerbose,
+    VerbatimExtractedFact,
+    _build_extraction_prompt_and_schema,
+)
+
+ALL_EXTRACTION_MODELS = [
+    ExtractedFact,
+    ExtractedFactVerbose,
+    ExtractedFactNoCausal,
+    VerbatimExtractedFact,
+]
+
+
+def _entity_def(schema: dict) -> dict:
+    """Resolve the entities-item $ref to its object definition."""
+    entities = schema["properties"]["entities"]
+    assert entities["type"] == "array", "entities must be an array"
+    ref = entities["items"]["$ref"].split("/")[-1]
+    return schema["$defs"][ref]
+
+
+@pytest.mark.parametrize("model", ALL_EXTRACTION_MODELS)
+def test_entities_is_required_array_of_objects(model):
+    """Each extraction model must list entities as required, typed as an array
+    of objects with a ``text`` field — never bare strings. This is the schema
+    regression behind #2749: an optional field is silently omitted by literal
+    models, so all entities are dropped."""
+    schema = model.model_json_schema()
+
+    assert "entities" in schema["required"], (
+        f"{model.__name__}: 'entities' must be in the schema's required array"
+    )
+
+    entity_def = _entity_def(schema)
+    assert entity_def.get("type") == "object"
+    assert "text" in entity_def.get("properties", {}), (
+        f"{model.__name__}: entities items must be objects with a 'text' field"
+    )
+
+
+@pytest.mark.parametrize("model", ALL_EXTRACTION_MODELS)
+def test_entities_defaults_to_empty_list_when_omitted(model):
+    """Making entities required-in-schema must not break lenient parsing: a
+    response that omits entities must still parse, defaulting to an empty list
+    (not None)."""
+    fields = {"when": "N/A", "where": "N/A", "who": "N/A", "fact_type": "world"}
+    if model is not VerbatimExtractedFact:
+        fields.update({"what": "something happened", "why": "N/A"})
+
+    instance = model(**fields)
+
+    assert instance.entities == []
+
+
+def _config(mode: str) -> MagicMock:
+    config = MagicMock()
+    config.entity_labels = None
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = mode
+    config.retain_extract_causal_links = False
+    config.retain_mission = None
+    config.retain_custom_instructions = None
+    config.llm_output_language = None
+    return config
+
+
+@pytest.mark.parametrize("mode", ["concise", "verbose", "verbatim", "custom"])
+def test_prompt_teaches_entities_object_form(mode):
+    """Every extraction prompt must instruct that entities are an array of
+    objects, so non-strict / no-schema paths stop emitting bare strings."""
+    prompt, _ = _build_extraction_prompt_and_schema(_config(mode))
+
+    assert "array of objects" in prompt
+    assert 'entities=["' not in prompt, "prompt must not show bare-string entity examples"
+
+
+def test_concise_examples_use_object_form():
+    """The concise few-shot examples must demonstrate the object form."""
+    prompt, _ = _build_extraction_prompt_and_schema(_config("concise"))
+
+    assert '{"text": "user"}' in prompt
+    assert '{"text": "Alice"}' in prompt


### PR DESCRIPTION
Fixes #2749.

## Problem

The four extraction models (`ExtractedFact`, `ExtractedFactVerbose`, `ExtractedFactNoCausal`, `VerbatimExtractedFact`) declared `entities` as an optional field that was **absent from `json_schema_extra["required"]`**. Under a strict JSON schema a literal model resolves the conflict — the field is optional and typed as objects, while the few-shot examples taught bare strings — by **omitting it entirely**: zero entities, no error. It bites precisely the most schema-conformant models and reproduces with strict-schema both on and off.

The retain parser is lenient (it coerces string entities into `Entity(text=...)`), so the string-array shape itself survives — the load-bearing defect is the omitted optional field, not the string shape.

## Fix

- **`entities: list[Entity] = Field(default_factory=list, ...)`** on all four models, and `"entities"` added to each model's `required` array. An empty list stays valid, so lenient parsing never hard-fails, but the field is no longer silently omitted by literal models.
- **Prompts teach the object form.** The concise few-shot examples now use `[{"text": ...}]` objects, and an explicit *"array of objects with a `text` field, never bare strings"* instruction is added to the concise/verbatim (base) prompt and the verbose prompt — so non-strict / no-schema paths stop emitting the ambiguous shape.

## Tests

`test_fact_extraction_entities_schema.py` — deterministic, no LLM:

- each of the four models' generated JSON schema lists `entities` as **required**, typed as an **array of objects with a `text` field** (the CI regression that would have caught this);
- omitting `entities` still parses, defaulting to `[]` (lenient path intact);
- every extraction prompt (concise / verbose / verbatim / custom) teaches the object form and shows no bare-string entity examples.

Verified locally: the schema/prompt suite is green, all prompt modes assemble, and the existing `test_fact_extraction_fact_type_prompt.py` still passes. Note the base prompt is `.format()`-ed twice (module assembly, then per-request), so the object examples in the few-shot are escaped accordingly and the standalone format instruction is brace-free.
