### PR TITLE
perf(postgresql): replace correlated NOT EXISTS with set-based EXCEPT in prune_stale_cooccurrences (#2660)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -389,22 +389,26 @@ class PostgreSQLOps(DataAccessOps):
         entities_table: str,
         bank_id: str,
     ) -> int:
-        # Scope by joining through entities.bank_id (entity_cooccurrences itself
-        # has no bank_id column — entities don't span banks, so scoping via
-        # entity_id_1 is sufficient).
+        # Materialize the stale cooccurrence target set via EXCEPT and delete
+        # set-wise. The correlated NOT EXISTS self-join (original Pass-3) evaluates
+        # per-row and hits a 300s statement_timeout on large graphs (50K+ entities,
+        # 1M+ unit_entities). The set-based EXCEPT form evaluates once and the
+        # DELETE joins against the materialized stale set — same result, ~90x faster.
         result = await conn.execute(
             f"""
             DELETE FROM {ec_table} c
-            USING {entities_table} e
-            WHERE e.id = c.entity_id_1
-              AND e.bank_id = $1
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM {ue_table} u1
-                  JOIN {ue_table} u2 ON u1.unit_id = u2.unit_id
-                  WHERE u1.entity_id = c.entity_id_1
-                    AND u2.entity_id = c.entity_id_2
-              )
+            USING (
+                SELECT c2.entity_id_1, c2.entity_id_2
+                FROM {ec_table} c2
+                JOIN {entities_table} e ON e.id = c2.entity_id_1
+                WHERE e.bank_id = $1
+                EXCEPT
+                SELECT DISTINCT u1.entity_id, u2.entity_id
+                FROM {ue_table} u1
+                JOIN {ue_table} u2 ON u1.unit_id = u2.unit_id
+            ) AS stale
+            WHERE c.entity_id_1 = stale.entity_id_1
+              AND c.entity_id_2 = stale.entity_id_2
             """,
             bank_id,
         )


### PR DESCRIPTION
## Summary

The original Pass-3 `prune_stale_cooccurrences` uses a correlated `NOT EXISTS` self-join on `unit_entities` that evaluates per-row. On large graphs:
- 50K+ entities
- 1M+ `unit_entities` rows
- 660K+ `entity_cooccurrences` rows

This hits a 300s `statement_timeout` with 0 rows pruned because Postgres can't complete the per-row evaluation in time.

## Changes

Replaced the correlated `NOT EXISTS` with a set-based `EXCEPT`:

1. Materialize the stale cooccurrence target set: `cooccurrences EXCEPT valid_witness_pairs`
2. DELETE joining against the materialized stale set

This produces the **identical result set** (verified via bidirectional `EXCEPT` and ordered digest match) while completing in ~3.4s vs >300s for the correlated form — ~**90x faster**.

## Verification

- Same target set: `OLD EXCEPT NEW = 0`, `NEW EXCEPT OLD = 0`
- Ordered digest matches
- Only targets cooccurrences belonging to the bank (via entity → bank_id join)
- Preserves duplicate/cooccurrence semantics

Closes #2660