### PR TITLE
fix(audit): add missing @audited decorator to api_update_memory

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3749,6 +3749,7 @@ def _register_routes(app: FastAPI):
         operation_id="update_memory",
         tags=["Memory"],
     )
+    @audited("update_memory")
     async def api_update_memory(
         bank_id: str,
         memory_id: str,


### PR DESCRIPTION
## Summary

The `PATCH /v1/default/banks/{bank_id}/memories/{memory_id}` endpoint (curate/invalidate/revert) was the **only data-mutation endpoint without an audit trail**. All other mutation endpoints have `@audited`:

- `delete_memory` → `@audited("delete_memory")`
- `update_document` → `@audited("update_document")`
- `delete_document` → `@audited("delete_document")`
- `create_mental_model` → `@audited("create_mental_model")`
- `update_memory` → ❌ (missing)

## Changes

- Added `@audited("update_memory")` decorator to `api_update_memory`

## Verification

- Decorator is placed after `@app.patch(...)` and before `async def`, matching the pattern of all other audited endpoints
- Memory curation operations are now recorded in the audit log for forensic traceability

Found during cybersecurity audit.