### PR TITLE
security(pg0): add HINDSIGHT_API_PG0_PASSWORD env var and log warning on default

### DIFF
--- a/hindsight-api-slim/hindsight_api/pg0.py
+++ b/hindsight-api-slim/hindsight_api/pg0.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,8 +11,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_USERNAME = "hindsight"
-DEFAULT_PASSWORD = "hindsight"
+_DEFAULT_PASSWORD = "hindsight"
 DEFAULT_DATABASE = "hindsight"
+
+
+def _resolve_default_password() -> str:
+    """Return the pg0 password, preferring the env var over the hardcoded default.
+
+    When only the hardcoded default is active, a warning is logged because
+    a known password on the embedded database is a security risk — especially
+    in containerised deployments where the pg0 port may be accidentally exposed
+    or mapped to the host.
+
+    Set ``HINDSIGHT_API_PG0_PASSWORD`` to suppress the warning and use a
+    custom password.
+    """
+    env_password = os.getenv("HINDSIGHT_API_PG0_PASSWORD")
+    if env_password:
+        return env_password
+    logger.warning(
+        "pg0 embedded database is using the hardcoded default password. "
+        "Set HINDSIGHT_API_PG0_PASSWORD to a random value for production deployments."
+    )
+    return _DEFAULT_PASSWORD
 
 
 class EmbeddedPostgres:
@@ -21,7 +43,7 @@ class EmbeddedPostgres:
         self,
         port: int | None = None,
         username: str = DEFAULT_USERNAME,
-        password: str = DEFAULT_PASSWORD,
+        password: str | None = None,
         database: str = DEFAULT_DATABASE,
         name: str = "hindsight",
         config: dict[str, str] | None = None,
@@ -29,7 +51,7 @@ class EmbeddedPostgres:
     ):
         self.port = port  # None means pg0 will auto-assign
         self.username = username
-        self.password = password
+        self.password = password if password is not None else _resolve_default_password()
         self.database = database
         self.name = name
         # Extra postgresql.conf settings forwarded to Pg0 (e.g. ``max_connections``).


### PR DESCRIPTION
## Summary

The pg0 embedded PostgreSQL database used hardcoded credentials (`user='hindsight'`, `password='hindsight'`) with no way to override except by passing explicit kwargs to `EmbeddedPostgres()`.

While pg0 only listens on localhost by default, containerized deployments where the pg0 port is accidentally mapped to the host create a risk — an attacker on the same network could connect with known credentials.

## Changes

- Added `HINDSIGHT_API_PG0_PASSWORD` env var to override the default password
- Added `_resolve_default_password()` function that checks the env var first
- `EmbeddedPostgres.__init__()` now uses `None` as default for `password`, resolving via `_resolve_default_password()`
- Log `WARNING` when the hardcoded default is active
- **Backward compatible**: all existing callers continue to work unchanged

## Verification

- Explicit password kwarg still takes precedence (e.g., tests)
- Env var `HINDSIGHT_API_PG0_PASSWORD` overrides the hardcoded default
- Default behavior unchanged (same password, just with a warning log)

Found during cybersecurity audit.