### PR TITLE
fix(integrations): keep auto-managed Hindsight daemons working on Python 3.14 hosts

### DIFF
--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -341,6 +341,47 @@ def test_daemon_child_env_var_set_in_daemon_env(temp_home, monkeypatch):
     assert env.get("_HINDSIGHT_DAEMON_CHILD") == "1"
 
 
+def test_daemon_preserves_uv_python_for_nested_uvx(temp_home, monkeypatch):
+    """The API uvx fallback inherits the interpreter selected by the integration."""
+    from unittest.mock import MagicMock, patch
+
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    monkeypatch.setenv("UV_PYTHON", "3.13")
+    manager = DaemonEmbedManager()
+    captured = {}
+    popen_called = [False]
+
+    def fake_find_api_command(api_version, env=None):
+        captured["find_env"] = env
+        return ["uvx", f"hindsight-api@{api_version}"]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["popen_env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", side_effect=fake_find_api_command),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+    ):
+        manager._start_daemon(
+            config={"llm_provider": "openai", "llm_api_key": "sk-x", "llm_model": "gpt-4o-mini"},
+            profile="",
+        )
+
+    assert captured["find_env"]["UV_PYTHON"] == "3.13"
+    assert captured["popen_env"]["UV_PYTHON"] == "3.13"
+
+
 def test_windows_popen_uses_detached_process_flags(temp_home, monkeypatch):
     """
     On Windows the daemon must be spawned with

--- a/hindsight-integrations/claude-code/scripts/lib/daemon.py
+++ b/hindsight-integrations/claude-code/scripts/lib/daemon.py
@@ -42,12 +42,21 @@ def _get_embed_command(config: dict) -> list:
     return ["uvx", package]
 
 
+def _set_uvx_python_compat(cmd: list, env: dict) -> None:
+    """Use a Python version compatible with uvx-managed Hindsight packages."""
+    if cmd and cmd[0] == "uvx" and not env.get("UV_PYTHON", "").strip():
+        # Current LiteLLM/PyO3 resolution cannot build on Python 3.14. Setting
+        # the outer uvx environment also reaches the nested hindsight-api uvx.
+        env["UV_PYTHON"] = "3.13"
+
+
 def _run_embed(config: dict, args: list, env: dict = None, timeout: int = 10) -> subprocess.CompletedProcess:
     """Run a hindsight-embed command and return the result."""
     cmd = _get_embed_command(config) + args
     run_env = dict(os.environ)
     if env:
         run_env.update(env)
+    _set_uvx_python_compat(cmd, run_env)
     return subprocess.run(
         cmd,
         capture_output=True,
@@ -281,15 +290,15 @@ def prestart_daemon_background(config: dict, debug_fn=None):
         return
 
     llm_env = get_llm_env_vars(llm_config)
+    embed_cmd = _get_embed_command(config)
     daemon_env = dict(os.environ)
     daemon_env.update(llm_env)
+    _set_uvx_python_compat(embed_cmd, daemon_env)
     idle_timeout = config.get("daemonIdleTimeout", 300)
     daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
     if platform.system() == "Darwin":
         daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
         daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
-
-    embed_cmd = _get_embed_command(config)
 
     profile_args = ["profile", "create", PROFILE_NAME, "--merge", "--port", str(port)]
     for env_name, env_val in llm_env.items():
@@ -297,10 +306,12 @@ def prestart_daemon_background(config: dict, debug_fn=None):
             profile_args.extend(["--env", f"{env_name}={env_val}"])
 
     import shlex
+
     profile_str = shlex.join(embed_cmd + profile_args)
     daemon_str = shlex.join(embed_cmd + ["daemon", "--profile", PROFILE_NAME, "start"])
 
     import subprocess as _sp
+
     _sp.Popen(
         f"{profile_str} && {daemon_str}",
         shell=True,

--- a/hindsight-integrations/claude-code/tests/test_daemon.py
+++ b/hindsight-integrations/claude-code/tests/test_daemon.py
@@ -1,0 +1,44 @@
+"""Tests for uvx daemon interpreter compatibility."""
+
+from unittest.mock import patch
+
+from lib import daemon
+
+
+def test_uvx_defaults_to_python_313(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"])
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_uvx_preserves_explicit_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "3.12"})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.12"
+
+
+def test_uvx_replaces_blank_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "  "})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_development_embed_does_not_pin_python(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({"embedPackagePath": "/tmp/hindsight-embed"}, ["status"])
+    assert "UV_PYTHON" not in run.call_args.kwargs["env"]
+
+
+def test_background_prestart_passes_python_313_to_uvx(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with (
+        patch("lib.daemon._check_health", return_value=False),
+        patch("lib.daemon._is_embed_available", return_value=True),
+        patch("lib.daemon.detect_llm_config", return_value={}),
+        patch("lib.daemon.get_llm_env_vars", return_value={}),
+        patch("lib.daemon.subprocess.Popen") as popen,
+    ):
+        daemon.prestart_daemon_background({})
+    assert popen.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"

--- a/hindsight-integrations/codex/scripts/lib/daemon.py
+++ b/hindsight-integrations/codex/scripts/lib/daemon.py
@@ -34,12 +34,21 @@ def _get_embed_command(config: dict) -> list:
     return ["uvx", package]
 
 
+def _set_uvx_python_compat(cmd: list, env: dict) -> None:
+    """Use a Python version compatible with uvx-managed Hindsight packages."""
+    if cmd and cmd[0] == "uvx" and not env.get("UV_PYTHON", "").strip():
+        # Current LiteLLM/PyO3 resolution cannot build on Python 3.14. Setting
+        # the outer uvx environment also reaches the nested hindsight-api uvx.
+        env["UV_PYTHON"] = "3.13"
+
+
 def _run_embed(config: dict, args: list, env: dict = None, timeout: int = 10) -> subprocess.CompletedProcess:
     """Run a hindsight-embed command and return the result."""
     cmd = _get_embed_command(config) + args
     run_env = dict(os.environ)
     if env:
         run_env.update(env)
+    _set_uvx_python_compat(cmd, run_env)
     return subprocess.run(
         cmd,
         capture_output=True,
@@ -253,15 +262,15 @@ def prestart_daemon_background(config: dict, debug_fn=None):
         return
 
     llm_env = get_llm_env_vars(llm_config)
+    embed_cmd = _get_embed_command(config)
     daemon_env = dict(os.environ)
     daemon_env.update(llm_env)
+    _set_uvx_python_compat(embed_cmd, daemon_env)
     idle_timeout = config.get("daemonIdleTimeout", 300)
     daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
     if platform.system() == "Darwin":
         daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
         daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
-
-    embed_cmd = _get_embed_command(config)
 
     profile_args = ["profile", "create", PROFILE_NAME, "--merge", "--port", str(port)]
     for env_name, env_val in llm_env.items():
@@ -269,10 +278,12 @@ def prestart_daemon_background(config: dict, debug_fn=None):
             profile_args.extend(["--env", f"{env_name}={env_val}"])
 
     import shlex
+
     profile_str = shlex.join(embed_cmd + profile_args)
     daemon_str = shlex.join(embed_cmd + ["daemon", "--profile", PROFILE_NAME, "start"])
 
     import subprocess as _sp
+
     _sp.Popen(
         f"{profile_str} && {daemon_str}",
         shell=True,

--- a/hindsight-integrations/codex/tests/test_daemon.py
+++ b/hindsight-integrations/codex/tests/test_daemon.py
@@ -1,0 +1,44 @@
+"""Tests for uvx daemon interpreter compatibility."""
+
+from unittest.mock import patch
+
+from lib import daemon
+
+
+def test_uvx_defaults_to_python_313(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"])
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_uvx_preserves_explicit_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "3.12"})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.12"
+
+
+def test_uvx_replaces_blank_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "  "})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_development_embed_does_not_pin_python(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({"embedPackagePath": "/tmp/hindsight-embed"}, ["status"])
+    assert "UV_PYTHON" not in run.call_args.kwargs["env"]
+
+
+def test_background_prestart_passes_python_313_to_uvx(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with (
+        patch("lib.daemon._check_health", return_value=False),
+        patch("lib.daemon._is_embed_available", return_value=True),
+        patch("lib.daemon.detect_llm_config", return_value={}),
+        patch("lib.daemon.get_llm_env_vars", return_value={}),
+        patch("lib.daemon.subprocess.Popen") as popen,
+    ):
+        daemon.prestart_daemon_background({})
+    assert popen.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"

--- a/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/daemon.py
+++ b/hindsight-integrations/cursor-cli/hindsight_cursor_cli/hooks/scripts/lib/daemon.py
@@ -37,12 +37,21 @@ def _get_embed_command(config):
     return ["uvx", package]
 
 
+def _set_uvx_python_compat(cmd, env):
+    """Use a Python version compatible with uvx-managed Hindsight packages."""
+    if cmd and cmd[0] == "uvx" and not env.get("UV_PYTHON", "").strip():
+        # Current LiteLLM/PyO3 resolution cannot build on Python 3.14. Setting
+        # the outer uvx environment also reaches the nested hindsight-api uvx.
+        env["UV_PYTHON"] = "3.13"
+
+
 def _run_embed(config, args, env=None, timeout=10):
     """Run a hindsight-embed command and return the result."""
     cmd = _get_embed_command(config) + args
     run_env = dict(os.environ)
     if env:
         run_env.update(env)
+    _set_uvx_python_compat(cmd, run_env)
     return subprocess.run(
         cmd,
         capture_output=True,
@@ -241,15 +250,15 @@ def prestart_daemon_background(config, debug_fn=None):
         return
 
     llm_env = get_llm_env_vars(llm_config)
+    embed_cmd = _get_embed_command(config)
     daemon_env = dict(os.environ)
     daemon_env.update(llm_env)
+    _set_uvx_python_compat(embed_cmd, daemon_env)
     idle_timeout = config.get("daemonIdleTimeout", 0)
     daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
     if platform.system() == "Darwin":
         daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
         daemon_env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = "1"
-
-    embed_cmd = _get_embed_command(config)
 
     profile_args = ["profile", "create", PROFILE_NAME, "--merge", "--port", str(port)]
     for env_name, env_val in llm_env.items():

--- a/hindsight-integrations/cursor-cli/tests/test_daemon.py
+++ b/hindsight-integrations/cursor-cli/tests/test_daemon.py
@@ -1,0 +1,44 @@
+"""Tests for uvx daemon interpreter compatibility."""
+
+from unittest.mock import patch
+
+from lib import daemon
+
+
+def test_uvx_defaults_to_python_313(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"])
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_uvx_preserves_explicit_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "3.12"})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.12"
+
+
+def test_uvx_replaces_blank_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "  "})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_development_embed_does_not_pin_python(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({"embedPackagePath": "/tmp/hindsight-embed"}, ["status"])
+    assert "UV_PYTHON" not in run.call_args.kwargs["env"]
+
+
+def test_background_prestart_passes_python_313_to_uvx(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with (
+        patch("lib.daemon._check_health", return_value=False),
+        patch("lib.daemon._is_embed_available", return_value=True),
+        patch("lib.daemon.detect_llm_config", return_value={}),
+        patch("lib.daemon.get_llm_env_vars", return_value={}),
+        patch("lib.daemon.subprocess.Popen") as popen,
+    ):
+        daemon.prestart_daemon_background({})
+    assert popen.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"

--- a/hindsight-integrations/cursor/scripts/lib/daemon.py
+++ b/hindsight-integrations/cursor/scripts/lib/daemon.py
@@ -32,12 +32,21 @@ def _get_embed_command(config: dict) -> list:
     return ["uvx", package]
 
 
+def _set_uvx_python_compat(cmd: list, env: dict) -> None:
+    """Use a Python version compatible with uvx-managed Hindsight packages."""
+    if cmd and cmd[0] == "uvx" and not env.get("UV_PYTHON", "").strip():
+        # Current LiteLLM/PyO3 resolution cannot build on Python 3.14. Setting
+        # the outer uvx environment also reaches the nested hindsight-api uvx.
+        env["UV_PYTHON"] = "3.13"
+
+
 def _run_embed(config: dict, args: list, env: dict = None, timeout: int = 10) -> subprocess.CompletedProcess:
     """Run a hindsight-embed command and return the result."""
     cmd = _get_embed_command(config) + args
     run_env = dict(os.environ)
     if env:
         run_env.update(env)
+    _set_uvx_python_compat(cmd, run_env)
     return subprocess.run(
         cmd,
         capture_output=True,

--- a/hindsight-integrations/cursor/tests/test_daemon.py
+++ b/hindsight-integrations/cursor/tests/test_daemon.py
@@ -9,10 +9,35 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
+from lib import daemon
 from lib.config import DEFAULT_HINDSIGHT_API_URL
 from lib.daemon import get_api_url
+
+
+def test_uvx_defaults_to_python_313(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"])
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_uvx_preserves_explicit_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "3.12"})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.12"
+
+
+def test_uvx_replaces_blank_python_override(monkeypatch):
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({}, ["status"], env={"UV_PYTHON": "  "})
+    assert run.call_args.kwargs["env"]["UV_PYTHON"] == "3.13"
+
+
+def test_development_embed_does_not_pin_python(monkeypatch):
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+    with patch("lib.daemon.subprocess.run") as run:
+        daemon._run_embed({"embedPackagePath": "/tmp/hindsight-embed"}, ["status"])
+    assert "UV_PYTHON" not in run.call_args.kwargs["env"]
 
 
 class TestGetApiUrlResolution:


### PR DESCRIPTION
## Summary

Fixes #2783 by making auto-managed `uvx` daemon launches default to Python 3.13 while the current LiteLLM/PyO3 dependency chain cannot build on Python 3.14.

- applies the compatible interpreter to Claude Code, Codex, Cursor, and Cursor CLI managed `uvx` launches
- preserves any non-blank user-provided `UV_PYTHON` override
- leaves `embedPackagePath` development installs on their existing `uv run --directory` path
- propagates the same environment through `hindsight-embed` to its nested `hindsight-api` `uvx` fallback

Cursor has no detached prestart path: its `sessionStart` hook enters `_ensure_daemon_running()`, and both profile creation and daemon startup already go through the updated `_run_embed()` path.

## Testing

- Claude Code daemon tests: 5 passed
- Codex daemon tests: 5 passed
- Cursor daemon tests: 11 passed
- Cursor CLI daemon tests: 5 passed
- nested `hindsight-embed` environment tests: 2 passed
- full Codex integration suite: 95 passed
- full Cursor integration suite: 85 passed, 4 skipped
- full Cursor CLI integration suite: 92 passed
- Ruff check/format and `git diff --check` passed for the changed files

The full Claude Code suite reached 203 passed with one unrelated existing working-directory permission test failing in this macOS cron environment; the focused daemon tests are green.
