### PR TITLE
fix(retain): make lazy bank creation atomic (#2695)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -189,7 +189,8 @@ async def get_or_create_bank_profile(pool, bank_id: str) -> BankProfileResult:
     ``get_or_create_bank_profile_on_conn`` instead.
     """
     async with acquire_with_retry(pool) as conn:
-        return await get_or_create_bank_profile_on_conn(conn, bank_id, ops=pool.ops)
+        async with conn.transaction():
+            return await get_or_create_bank_profile_on_conn(conn, bank_id, ops=pool.ops)
 
 
 async def get_or_create_bank_profile_on_conn(conn, bank_id: str, *, ops) -> BankProfileResult:

--- a/hindsight-api-slim/tests/test_bank_utils.py
+++ b/hindsight-api-slim/tests/test_bank_utils.py
@@ -1,0 +1,76 @@
+from contextlib import asynccontextmanager
+
+import pytest
+
+from hindsight_api.engine.retain import bank_utils
+
+
+class _FailingIndexOps:
+    async def create_bank_vector_indexes(self, *args, **kwargs) -> None:
+        raise RuntimeError("simulated per-bank vector index DDL failure")
+
+
+class _FakeTransaction:
+    def __init__(self, conn: "_FakeConnection") -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> None:
+        self._conn.in_transaction = True
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if exc_type is None:
+            self._conn.committed_bank = self._conn.pending_bank
+        self._conn.pending_bank = None
+        self._conn.in_transaction = False
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.committed_bank: str | None = None
+        self.pending_bank: str | None = None
+        self.in_transaction = False
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction(self)
+
+    async def fetchrow(self, query: str, bank_id: str):
+        visible_bank = self.pending_bank if self.in_transaction else self.committed_bank
+        if visible_bank != bank_id:
+            return None
+        return {
+            "name": bank_id,
+            "disposition": bank_utils.DEFAULT_DISPOSITION,
+            "mission": "",
+        }
+
+    async def fetchval(self, query: str, bank_id: str, *args):
+        if self.in_transaction:
+            self.pending_bank = bank_id
+        else:
+            self.committed_bank = bank_id
+        return bank_id
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConnection) -> None:
+        self.conn = conn
+        self.ops = _FailingIndexOps()
+
+
+@pytest.mark.asyncio
+async def test_lazy_bank_create_rolls_back_on_vector_index_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed per-bank index DDL must not leave an orphaned bank row."""
+    conn = _FakeConnection()
+    pool = _FakePool(conn)
+
+    @asynccontextmanager
+    async def acquire_without_transaction(*args, **kwargs):
+        yield conn
+
+    monkeypatch.setattr(bank_utils, "acquire_with_retry", acquire_without_transaction)
+
+    with pytest.raises(RuntimeError, match="simulated per-bank vector index DDL failure"):
+        await bank_utils.get_or_create_bank_profile(pool, "atomicity-test-bank")
+
+    profile = await bank_utils.get_bank_profile_if_exists(pool, "atomicity-test-bank")
+    assert profile is None, "bank row should roll back when per-bank vector index creation fails"


### PR DESCRIPTION
## Summary

- wrap the dedicated lazy bank-create path in `conn.transaction()`
- make the bank INSERT and per-bank vector index DDL commit or roll back atomically
- add regression coverage that forces vector-index creation to fail and verifies no bank row survives

## Why

The dedicated-connection path in `get_or_create_bank_profile()` acquired an autocommit connection and then called `get_or_create_bank_profile_on_conn()`. A new bank row could therefore commit before `create_bank_vector_indexes()` ran. If that DDL failed, the empty bank remained even though setup did not complete.

This implements the fix described by @benfrank241 in #2695: the existing connection-bound helper stays unchanged, while the wrapper that owns the connection supplies the missing transaction boundary.

## Test plan

- `uv run pytest tests/test_bank_utils.py -v -n 0`
  - verified RED before the production change
  - passes after the transaction wrapper is added
- `uv run pytest tests/test_vector_index.py tests/test_bank_utils.py -v -n 0` — 20 passed
- `uv run ruff check hindsight_api/engine/retain/bank_utils.py tests/test_bank_utils.py`
- `uv run ruff format --check hindsight_api/engine/retain/bank_utils.py tests/test_bank_utils.py`
- `uv run ty check hindsight_api/engine/retain/bank_utils.py`
- `py_compile` for both changed Python files

## Environment note

A broader local selection that includes DB-backed hierarchical-config tests could not start because the optional `pg0-embedded` dependency is not installed in this environment. The focused regression test uses a transaction-aware fake connection so it deterministically exercises the pre-fix autocommit behavior without requiring embedded PostgreSQL.

Fixes #2695
