### PR TITLE
fix(mental-models): align stale checks with refresh tag scope

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11215,17 +11215,16 @@ class MemoryEngine(MemoryEngineInterface):
         """Check whether a mental model is out of date.
 
         A mental model is stale when a memory in its **scope** has been ingested after
-        ``last_refreshed_at``. The scope is defined by the model's ``tags`` +
-        ``trigger.tags_match`` semantics (``any`` / ``all`` / ``any_strict`` /
-        ``all_strict``, matching recall semantics) and its ``trigger.fact_types`` filter
-        when set. Memories still pending consolidation are included because they are
-        already rows in ``memory_units``; no separate ``pending_consolidation`` signal is
-        needed — it would bypass the tag scope and falsely flag unrelated MMs.
+        ``last_refreshed_at``. The scope uses the same resolved flat-tag or compound
+        ``trigger.tag_groups`` filtering as the refresh it gates, plus the
+        ``trigger.fact_types`` filter when set. Memories still pending consolidation are
+        included because they are already rows in ``memory_units``; no separate
+        ``pending_consolidation`` signal is needed — it would bypass the tag scope and
+        falsely flag unrelated MMs.
 
         Untagged mental model defaults to ``tags_match="any"`` so it matches any memory
         ingested in the bank (what a user would expect for a "global" MM).
         """
-        from hindsight_api.engine.search.tags import _parse_tags_match
 
         def _get(key: str) -> Any:
             if isinstance(mm_row, dict):
@@ -11250,22 +11249,28 @@ class MemoryEngine(MemoryEngineInterface):
                 trigger = None
         trigger = trigger or {}
         fact_types: list[str] = list(trigger.get("fact_types") or [])
-        tags_match = trigger.get("tags_match")
-        if not tags_match:
-            tags_match = "any"  # default: untagged MM is "global", tagged MM matches any overlap
+        tag_filtering = _resolve_refresh_tag_filtering(mm_tags, trigger)
 
         params: list[Any] = [bank_id, last_refreshed_at]
         where = ["bank_id = $1", "updated_at > $2"]
 
-        if mm_tags:
-            operator, include_untagged = _parse_tags_match(tags_match)
-            params.append(mm_tags)
-            tag_idx = len(params)
-            if include_untagged:
-                where.append(f"(tags IS NULL OR tags = '{{}}' OR tags {operator} ${tag_idx}::varchar[])")
-            else:
-                where.append(f"(tags IS NOT NULL AND tags != '{{}}' AND tags {operator} ${tag_idx}::varchar[])")
-        # else: untagged MM → no tag constraint, matches any ingested memory in scope
+        tag_clause, tag_params, next_param = build_tags_where_clause(
+            tag_filtering.tags,
+            param_offset=len(params) + 1,
+            match=tag_filtering.tags_match,
+        )
+        if tag_clause:
+            where.append(tag_clause.removeprefix("AND "))
+            params.extend(tag_params)
+
+        group_clause, group_params, _ = build_tag_groups_where_clause(
+            tag_filtering.tag_groups,
+            param_offset=next_param,
+        )
+        if group_clause:
+            where.append(group_clause.removeprefix("AND "))
+            params.extend(group_params)
+        # Untagged MM without tag_groups → no tag constraint, matching any bank memory.
 
         if fact_types:
             params.append(fact_types)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1152,7 +1152,7 @@ class TestMentalModelStaleness:
         assert got["is_stale"] is False
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_tagged_mm_stale_on_overlapping_memory(self, memory: MemoryEngine, request_context):
+    async def test_tagged_mm_defaults_to_all_strict(self, memory: MemoryEngine, request_context):
         bank_id = f"test-mm-stale-overlap-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
         mm = await memory.create_mental_model(
@@ -1160,10 +1160,121 @@ class TestMentalModelStaleness:
             name="MM",
             source_query="q",
             content="c",
-            tags=["user_a"],
+            tags=["user_a", "proj_x"],
             request_context=request_context,
         )
         await self._insert_memory(memory, bank_id, tags=["user_a", "extra"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(memory, bank_id, tags=["user_a", "proj_x"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tags_match_any_keeps_overlap_behavior(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-mm-stale-any-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a", "proj_x"],
+            trigger={"refresh_after_consolidation": False, "tags_match": "any"},
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tag_groups_define_stale_scope(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-mm-stale-groups-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["ignored-flat-tag"],
+            trigger={
+                "refresh_after_consolidation": False,
+                "tag_groups": [{"and": [{"tags": ["user_a"]}, {"tags": ["proj_x"]}]}],
+            },
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(memory, bank_id, tags=["user_a", "proj_x"])
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_flat_tags_and_fact_types_share_stale_scope(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-mm-stale-flat-fact-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            tags=["user_a"],
+            trigger={"refresh_after_consolidation": False, "fact_types": ["world"]},
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=["user_a"], fact_type="experience")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(memory, bank_id, tags=["user_a"], fact_type="world")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is True
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_tag_groups_and_fact_types_share_stale_scope(self, memory: MemoryEngine, request_context):
+        bank_id = f"test-mm-stale-group-fact-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="MM",
+            source_query="q",
+            content="c",
+            trigger={
+                "refresh_after_consolidation": False,
+                "tag_groups": [
+                    {"tags": ["user_a", "team_red"], "match": "all_strict"},
+                    {"or": [{"tags": ["proj_x"]}, {"tags": ["proj_y"]}]},
+                ],
+                "fact_types": ["world"],
+            },
+            request_context=request_context,
+        )
+        await self._insert_memory(memory, bank_id, tags=["user_a", "team_red"], fact_type="world")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(memory, bank_id, tags=["user_a", "proj_x"], fact_type="world")
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(
+            memory,
+            bank_id,
+            tags=["user_a", "team_red", "proj_x"],
+            fact_type="experience",
+        )
+        got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
+        assert got["is_stale"] is False
+
+        await self._insert_memory(
+            memory,
+            bank_id,
+            tags=["user_a", "team_red", "proj_y"],
+            fact_type="world",
+        )
         got = await memory.get_mental_model(bank_id, mm["id"], request_context=request_context)
         assert got["is_stale"] is True
         await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

- make mental-model staleness use the same resolved tag filtering as refresh
- preserve tagged-model `all_strict` defaults and explicit `tags_match` behavior
- support compound `trigger.tag_groups` when deciding whether a scheduled refresh is stale
- keep `fact_types` as an additional scope constraint

## Why

The scheduled-refresh gate and the refresh itself currently resolve tag scope differently. Refresh uses `_resolve_refresh_tag_filtering()`, including `tag_groups` and the tagged-model `all_strict` default, while `compute_mental_model_is_stale()` ignores `tag_groups` and defaults tagged models to `any`.

That can mark a model stale because of an out-of-scope memory, spend an unnecessary refresh LLM call, and then refresh against a different (or empty) corpus. This was surfaced while tracing #2800.

## Testing

- `uv run pytest tests/test_mental_models.py::TestMentalModelStaleness -q -n 0` (12 passed)
- `uv run ruff format hindsight_api/engine/memory_engine.py tests/test_mental_models.py`
- `uv run ruff check hindsight_api/engine/memory_engine.py`

The regression coverage includes default `all_strict`, explicit `any`, compound tag groups, untagged/global behavior, and flat/group tag filters composed with `fact_types`, including multi-group near misses.

Related to #2800.
