### PR TITLE
fix(opencode): queue explicit retains asynchronously

### DIFF
--- a/hindsight-docs/docs-integrations/opencode.md
+++ b/hindsight-docs/docs-integrations/opencode.md
@@ -6,7 +6,7 @@ description: "Add long-term memory to OpenCode with Hindsight. Automatically cap
 
 # OpenCode
 
-Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides retain/recall/reflect tools the agent can call directly.
+Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides asynchronous retain, operation status, recall, and reflect tools the agent can call directly.
 
 ## Quick Start
 
@@ -56,11 +56,12 @@ Or configure inline via plugin options in `opencode.json`:
 
 ### Custom Tools
 
-The plugin registers three tools the agent can call explicitly:
+The plugin registers four tools the agent can call explicitly:
 
 | Tool | Description |
 |---|---|
-| `hindsight_retain` | Store information in long-term memory |
+| `hindsight_retain` | Queue information for long-term memory processing |
+| `hindsight_operation_status` | Poll an asynchronous retain operation |
 | `hindsight_recall` | Search long-term memory for relevant information |
 | `hindsight_reflect` | Generate a synthesized answer from long-term memory |
 
@@ -170,6 +171,6 @@ export HINDSIGHT_USER_ID="user123"
 1. **Plugin loads** when OpenCode starts — creates a `HindsightClient`, derives the bank ID, and registers tools + hooks
 2. **Session starts** — `session.created` event triggers, plugin marks session for recall injection
 3. **System transform** — on the first LLM call, recalled memories are injected into the system prompt
-4. **Agent works** — can call `hindsight_recall` and `hindsight_retain` explicitly during the session
+4. **Agent works** — can retain asynchronously, poll operation status, and recall memories explicitly during the session
 5. **Session idles** — `session.idle` event triggers auto-retain of the conversation
 6. **Compaction** — if the context window fills up, memories are preserved through the compaction

--- a/hindsight-integrations/opencode/README.md
+++ b/hindsight-integrations/opencode/README.md
@@ -4,7 +4,7 @@ Hindsight memory plugin for [OpenCode](https://opencode.ai) — give your AI cod
 
 ## Features
 
-- **Custom tools**: `hindsight_retain`, `hindsight_recall`, `hindsight_reflect` — the agent calls these explicitly
+- **Custom tools**: `hindsight_retain`, `hindsight_operation_status`, `hindsight_recall`, `hindsight_reflect` — the agent calls these explicitly
 - **Auto-retain**: Captures conversation on `session.idle` and stores to Hindsight
 - **Memory injection**: Recalls relevant memories when a new session starts
 - **Compaction hook**: Injects memories during context compaction so they survive window trimming
@@ -140,7 +140,11 @@ Settings are loaded in this order (later wins):
 
 ### `hindsight_retain`
 
-Store information in long-term memory. The agent uses this to save important facts, user preferences, project context, and decisions.
+Queue information for long-term memory processing. The tool returns an operation ID immediately instead of waiting for extraction and indexing to finish.
+
+### `hindsight_operation_status`
+
+Poll an asynchronous retain operation by the ID returned from `hindsight_retain`.
 
 ### `hindsight_recall`
 

--- a/hindsight-integrations/opencode/src/e2e.test.ts
+++ b/hindsight-integrations/opencode/src/e2e.test.ts
@@ -68,10 +68,26 @@ describeLive("live: OpenCode plugin against Hindsight", () => {
       { content: "User's favourite programming language is Haskell." } as any,
       {} as any
     );
-    expect(String(retainOut)).toMatch(/stored/i);
+    expect(String(retainOut)).toMatch(/queued/i);
+    const operationId = String(retainOut).match(/Operation ID: ([\w-]+)/)?.[1];
+    expect(operationId).toBeTruthy();
 
-    // Server-side fact extraction is asynchronous; give it time before recall.
-    await new Promise((r) => setTimeout(r, 6000));
+    let status = "pending";
+    for (
+      let attempt = 0;
+      attempt < 50 && !["completed", "failed", "cancelled"].includes(status);
+      attempt++
+    ) {
+      const statusOut = await plugin.tool!.hindsight_operation_status.execute(
+        { operationId } as any,
+        {} as any
+      );
+      status = JSON.parse(String(statusOut)).status;
+      if (status === "pending" || status === "processing") {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    expect(status).toBe("completed");
 
     const recallOut = await plugin.tool!.hindsight_recall.execute(
       { query: "favourite programming language" } as any,

--- a/hindsight-integrations/opencode/src/index.ts
+++ b/hindsight-integrations/opencode/src/index.ts
@@ -2,7 +2,7 @@
  * Hindsight OpenCode Plugin — persistent long-term memory for OpenCode agents.
  *
  * Provides:
- *   - Custom tools: hindsight_retain, hindsight_recall, hindsight_reflect
+ *   - Custom tools: retain, operation status, recall, and reflect
  *   - Auto-retain on session.idle
  *   - Memory injection on session.created via system transform
  *   - Memory preservation during context compaction

--- a/hindsight-integrations/opencode/src/tools.test.ts
+++ b/hindsight-integrations/opencode/src/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { createTools } from "./tools.js";
 import { makeConfig } from "./test-helpers.js";
 
@@ -14,11 +14,16 @@ const mockContext = {
 };
 
 describe("createTools", () => {
-  it("creates all three tools", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates all four tools", () => {
     const client = { retain: vi.fn(), recall: vi.fn(), reflect: vi.fn() } as any;
     const tools = createTools(client, "test-bank", makeConfig());
 
     expect(tools.hindsight_retain).toBeDefined();
+    expect(tools.hindsight_operation_status).toBeDefined();
     expect(tools.hindsight_recall).toBeDefined();
     expect(tools.hindsight_reflect).toBeDefined();
   });
@@ -36,7 +41,7 @@ describe("createTools", () => {
   describe("hindsight_retain", () => {
     it("calls client.retain with correct bank and content", async () => {
       const client = {
-        retain: vi.fn().mockResolvedValue({}),
+        retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
         recall: vi.fn(),
         reflect: vi.fn(),
       } as any;
@@ -51,13 +56,17 @@ describe("createTools", () => {
         context: "opencode",
         tags: undefined,
         metadata: undefined,
+        async: true,
       });
-      expect(result).toBe("Memory stored successfully.");
+      expect(result).toBe(
+        "Memory queued successfully. Operation ID: op-123. " +
+          "Use hindsight_operation_status to poll for completion."
+      );
     });
 
     it("passes optional context", async () => {
       const client = {
-        retain: vi.fn().mockResolvedValue({}),
+        retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
         recall: vi.fn(),
         reflect: vi.fn(),
       } as any;
@@ -72,12 +81,13 @@ describe("createTools", () => {
         context: "from conversation",
         tags: undefined,
         metadata: undefined,
+        async: true,
       });
     });
 
     it("includes tags and metadata from config", async () => {
       const client = {
-        retain: vi.fn().mockResolvedValue({}),
+        retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
         recall: vi.fn(),
         reflect: vi.fn(),
       } as any;
@@ -93,7 +103,96 @@ describe("createTools", () => {
         context: "opencode",
         tags: ["coding"],
         metadata: { source: "opencode" },
+        async: true,
       });
+    });
+
+    it("rejects an async response without an operation ID", async () => {
+      const client = {
+        retain: vi.fn().mockResolvedValue({ async: true }),
+        recall: vi.fn(),
+        reflect: vi.fn(),
+      } as any;
+      const tools = createTools(client, "test-bank", makeConfig());
+
+      await expect(
+        tools.hindsight_retain.execute({ content: "Fact" }, mockContext)
+      ).rejects.toThrow("Async retain did not return an operation ID.");
+    });
+  });
+
+  describe("hindsight_operation_status", () => {
+    it("fetches operation status with authentication", async () => {
+      const operation = {
+        operation_id: "550e8400-e29b-41d4-a716-446655440000",
+        status: "processing",
+        error_message: null,
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(operation),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const client = { retain: vi.fn(), recall: vi.fn(), reflect: vi.fn() } as any;
+      const config = makeConfig({
+        hindsightApiUrl: "https://hindsight.example/",
+        hindsightApiToken: "secret-token",
+      });
+      const tools = createTools(client, "test bank", config);
+
+      const result = await tools.hindsight_operation_status.execute(
+        { operationId: "550e8400-e29b-41d4-a716-446655440000" },
+        mockContext
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://hindsight.example/v1/default/banks/test%20bank/operations/550e8400-e29b-41d4-a716-446655440000",
+        { headers: { Authorization: "Bearer secret-token" } }
+      );
+      expect(JSON.parse(result)).toEqual(operation);
+    });
+
+    it("returns the API not_found status", async () => {
+      const operation = {
+        operation_id: "550e8400-e29b-41d4-a716-446655440000",
+        status: "not_found",
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue(operation),
+        })
+      );
+      const client = { retain: vi.fn(), recall: vi.fn(), reflect: vi.fn() } as any;
+      const tools = createTools(client, "test-bank", makeConfig());
+
+      const result = await tools.hindsight_operation_status.execute(
+        { operationId: operation.operation_id },
+        mockContext
+      );
+
+      expect(JSON.parse(result)).toEqual(operation);
+    });
+
+    it("propagates operation status errors", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: vi.fn().mockResolvedValue("internal error"),
+        })
+      );
+      const client = { retain: vi.fn(), recall: vi.fn(), reflect: vi.fn() } as any;
+      const tools = createTools(client, "test-bank", makeConfig());
+
+      await expect(
+        tools.hindsight_operation_status.execute(
+          { operationId: "550e8400-e29b-41d4-a716-446655440000" },
+          mockContext
+        )
+      ).rejects.toThrow("Operation status failed (500): internal error");
     });
   });
 
@@ -250,7 +349,7 @@ describe("createTools", () => {
   describe("bank mission setup", () => {
     it("calls ensureBankMission before retain when missionsSet provided", async () => {
       const client = {
-        retain: vi.fn().mockResolvedValue({}),
+        retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
         recall: vi.fn(),
         reflect: vi.fn(),
         createBank: vi.fn().mockResolvedValue({}),
@@ -288,7 +387,7 @@ describe("createTools", () => {
 
     it("skips mission setup when missionsSet not provided (backward compat)", async () => {
       const client = {
-        retain: vi.fn().mockResolvedValue({}),
+        retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
         recall: vi.fn(),
         reflect: vi.fn(),
       } as any;
@@ -303,7 +402,7 @@ describe("createTools", () => {
 
   it("always uses constructor bankId", async () => {
     const client = {
-      retain: vi.fn().mockResolvedValue({}),
+      retain: vi.fn().mockResolvedValue({ operation_id: "op-123" }),
       recall: vi.fn().mockResolvedValue({ results: [] }),
       reflect: vi.fn().mockResolvedValue({ text: "ok" }),
     } as any;

--- a/hindsight-integrations/opencode/src/tools.ts
+++ b/hindsight-integrations/opencode/src/tools.ts
@@ -1,8 +1,8 @@
 /**
  * Custom tool definitions for the Hindsight OpenCode plugin.
  *
- * Registers hindsight_retain, hindsight_recall, and hindsight_reflect
- * as tools the agent can call explicitly.
+ * Registers retain, operation status, recall, and reflect tools the agent can
+ * call explicitly.
  */
 
 import { tool } from "@opencode-ai/plugin/tool";
@@ -15,6 +15,7 @@ import { Logger } from "./logger.js";
 
 export interface HindsightTools {
   hindsight_retain: ToolDefinition;
+  hindsight_operation_status: ToolDefinition;
   hindsight_recall: ToolDefinition;
   hindsight_reflect: ToolDefinition;
   // Index signature so the object is assignable to OpenCode's Hooks.tool
@@ -47,12 +48,45 @@ export function createTools(
       if (missionsSet) {
         await ensureBankMission(client, bankId, config, missionsSet, logger);
       }
-      await client.retain(bankId, args.content, {
+      const response = await client.retain(bankId, args.content, {
         context: args.context || config.retainContext,
         tags: config.retainTags.length ? config.retainTags : undefined,
         metadata: Object.keys(config.retainMetadata).length ? config.retainMetadata : undefined,
+        async: true,
       });
-      return "Memory stored successfully.";
+      if (!response.operation_id) {
+        throw new Error("Async retain did not return an operation ID.");
+      }
+      return (
+        `Memory queued successfully. Operation ID: ${response.operation_id}. ` +
+        "Use hindsight_operation_status to poll for completion."
+      );
+    },
+  });
+
+  const hindsight_operation_status = tool({
+    description:
+      "Check the status of an asynchronous Hindsight operation returned by hindsight_retain.",
+    args: {
+      operationId: tool.schema.string().describe("The operation ID returned by hindsight_retain."),
+    },
+    async execute(args) {
+      // The high-level client supports async retain but does not expose operation status.
+      const baseUrl = config.hindsightApiUrl!.replace(/\/$/, "");
+      const response = await fetch(
+        `${baseUrl}/v1/default/banks/${encodeURIComponent(bankId)}/operations/${encodeURIComponent(args.operationId)}`,
+        {
+          headers: config.hindsightApiToken
+            ? { Authorization: `Bearer ${config.hindsightApiToken}` }
+            : undefined,
+        }
+      );
+      if (!response.ok) {
+        const details = await response.text();
+        throw new Error(`Operation status failed (${response.status}): ${details.slice(0, 500)}`);
+      }
+
+      return JSON.stringify(await response.json(), null, 2);
     },
   });
 
@@ -108,5 +142,5 @@ export function createTools(
     },
   });
 
-  return { hindsight_retain, hindsight_recall, hindsight_reflect };
+  return { hindsight_retain, hindsight_operation_status, hindsight_recall, hindsight_reflect };
 }

--- a/skills/hindsight-docs/references/sdks/integrations/opencode.md
+++ b/skills/hindsight-docs/references/sdks/integrations/opencode.md
@@ -1,7 +1,7 @@
 
 # OpenCode
 
-Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides retain/recall/reflect tools the agent can call directly.
+Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides asynchronous retain, operation status, recall, and reflect tools the agent can call directly.
 
 ## Quick Start
 
@@ -51,11 +51,12 @@ Or configure inline via plugin options in `opencode.json`:
 
 ### Custom Tools
 
-The plugin registers three tools the agent can call explicitly:
+The plugin registers four tools the agent can call explicitly:
 
 | Tool | Description |
 |---|---|
-| `hindsight_retain` | Store information in long-term memory |
+| `hindsight_retain` | Queue information for long-term memory processing |
+| `hindsight_operation_status` | Poll an asynchronous retain operation |
 | `hindsight_recall` | Search long-term memory for relevant information |
 | `hindsight_reflect` | Generate a synthesized answer from long-term memory |
 
@@ -165,6 +166,6 @@ export HINDSIGHT_USER_ID="user123"
 1. **Plugin loads** when OpenCode starts — creates a `HindsightClient`, derives the bank ID, and registers tools + hooks
 2. **Session starts** — `session.created` event triggers, plugin marks session for recall injection
 3. **System transform** — on the first LLM call, recalled memories are injected into the system prompt
-4. **Agent works** — can call `hindsight_recall` and `hindsight_retain` explicitly during the session
+4. **Agent works** — can retain asynchronously, poll operation status, and recall memories explicitly during the session
 5. **Session idles** — `session.idle` event triggers auto-retain of the conversation
 6. **Compaction** — if the context window fills up, memories are preserved through the compaction


### PR DESCRIPTION
## Summary
- submit explicit `hindsight_retain` calls with `async: true` and return the operation ID immediately
- add `hindsight_operation_status` so agents can poll pending, processing, completed, failed, cancelled, and not-found operations
- update unit/live integration coverage and synchronize the package, integration, and generated skill documentation

## Motivation
Explicit retains currently wait for fact extraction and indexing to finish. Behind a reverse proxy such as Cloudflare, that can exceed the request timeout and return a 524 even though Hindsight supports asynchronous retain operations already. Auto-retain already uses the asynchronous path; this makes the explicit tool consistent with it.

## Verification
- `npm test` in `hindsight-integrations/opencode`: 121 passed, 3 skipped
- `npm run build` in `hindsight-integrations/opencode`
- `./scripts/hooks/lint.sh`
- generated Hindsight docs skill link validation