### PR TITLE
fix(mental-models): default refresh tag matching to any

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2010,9 +2010,9 @@ class MentalModelTrigger(BaseModel):
         default=None,
         description=(
             "Override how the model's tags filter memories during refresh. "
-            "If not set, defaults to 'all_strict' when the model has tags (security isolation) "
-            "or 'any' when the model has no tags. "
-            "Set to 'any' to include untagged memories alongside tagged ones during refresh."
+            "If not set, defaults to 'any', matching recall and reflect: memories with any model tag "
+            "and untagged memories are included. Set an explicit strict mode such as 'all_strict' "
+            "when refresh must exclude untagged or partially matching memories."
         ),
     )
     tag_groups: list[TagGroup] | None = Field(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -829,7 +829,7 @@ def _resolve_refresh_tag_filtering(
     Priority:
     - If trigger has tag_groups, use those (overrides flat tags entirely)
     - If trigger has tags_match, use model's tags with that match mode
-    - Otherwise default to all_strict when tags present (security isolation)
+    - Otherwise default to any, matching recall, reflect, and staleness checks
     """
     trigger_tag_groups = trigger_data.get("tag_groups")
     if trigger_tag_groups is not None:
@@ -840,7 +840,7 @@ def _resolve_refresh_tag_filtering(
         return RefreshTagFiltering(tags=None, tags_match="any", tag_groups=parsed)
 
     trigger_tags_match = trigger_data.get("tags_match")
-    tags_match: TagsMatch = trigger_tags_match if trigger_tags_match else ("all_strict" if model_tags else "any")
+    tags_match: TagsMatch = trigger_tags_match if trigger_tags_match else "any"
     return RefreshTagFiltering(tags=model_tags, tags_match=tags_match, tag_groups=None)
 
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -8,7 +8,7 @@ import uuid
 
 import pytest
 
-from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
+from hindsight_api.engine.memory_engine import MemoryEngine, _resolve_refresh_tag_filtering, fq_table
 from hindsight_api.engine.retain import embedding_utils
 from tests.llm_judge import assert_meets_criteria, evaluate
 
@@ -1540,6 +1540,25 @@ class TestMentalModelRefreshTagSecurity:
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
+class TestRefreshTagFiltering:
+    def test_tagged_model_defaults_to_any(self):
+        filtering = _resolve_refresh_tag_filtering(["projects", "mental-model"], {})
+
+        assert filtering.tags == ["projects", "mental-model"]
+        assert filtering.tags_match == "any"
+        assert filtering.tag_groups is None
+
+    def test_explicit_all_strict_is_preserved(self):
+        filtering = _resolve_refresh_tag_filtering(
+            ["projects", "mental-model"],
+            {"tags_match": "all_strict"},
+        )
+
+        assert filtering.tags == ["projects", "mental-model"]
+        assert filtering.tags_match == "all_strict"
+        assert filtering.tag_groups is None
+
+
 @pytest.mark.hs_llm_core
 # All tests in this class drive the reflect agent against Gemini 2.5 Flash Lite,
 # which occasionally bails out of the loop with "I don't have information."
@@ -1558,8 +1577,7 @@ class TestMentalModelTriggerTagsConfig:
     async def test_trigger_tags_match_any_includes_untagged_content(self, memory: MemoryEngine, request_context):
         """Test that setting trigger.tags_match='any' allows a tagged model to see untagged memories.
 
-        This is the fix for #786: by default, tagged models use all_strict which excludes
-        untagged content. Setting tags_match='any' in the trigger overrides this.
+        Explicit tags_match='any' allows a tagged model to see untagged memories.
         """
         bank_id = f"test-trigger-tags-match-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
@@ -1613,9 +1631,9 @@ class TestMentalModelTriggerTagsConfig:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
-    async def test_trigger_tags_match_default_preserves_strict_isolation(self, memory: MemoryEngine, request_context):
-        """Test that without trigger.tags_match, tagged models still use all_strict (backward compat)."""
-        bank_id = f"test-trigger-default-strict-{uuid.uuid4().hex[:8]}"
+    async def test_trigger_tags_match_defaults_to_any(self, memory: MemoryEngine, request_context):
+        """Without trigger.tags_match, tagged models use the same any default as recall and reflect."""
+        bank_id = f"test-trigger-default-any-{uuid.uuid4().hex[:8]}"
         await memory.get_bank_profile(bank_id, request_context=request_context)
 
         # Add tagged and untagged memories
@@ -1630,7 +1648,7 @@ class TestMentalModelTriggerTagsConfig:
         )
         await memory.wait_for_background_tasks()
 
-        # Create a tagged mental model WITHOUT trigger.tags_match (should default to all_strict)
+        # Create a tagged mental model without trigger.tags_match.
         mm = await memory.create_mental_model(
             bank_id=bank_id,
             name="Alice's Summary",
@@ -1649,16 +1667,15 @@ class TestMentalModelTriggerTagsConfig:
         await assert_meets_criteria(
             response=refreshed["content"],
             criteria=(
-                "The content does NOT mention Bob, Python (as Bob's language), or 200 employees. "
-                "It should only contain information about Alice (frontend, React). "
-                "Minor phrasing variations are acceptable."
+                "The content includes all three categories: Alice (frontend or React), "
+                "Bob (backend or Python), and the untagged company fact (200 employees)."
             ),
             context=(
-                "Alice's data (should appear): frontend engineer, React. "
-                "Bob's data (MUST NOT appear): backend engineer, Python. "
-                "Untagged data (MUST NOT appear): 200 employees worldwide."
+                "Tagged memories: Alice is a frontend engineer using React; "
+                "Bob is a backend engineer using Python. "
+                "Untagged memory: the company has 200 employees worldwide."
             ),
-            msg="Default all_strict isolation was violated",
+            msg="Default any filtering did not match the recall/reflect scope",
         )
 
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2548,7 +2548,7 @@ export type MentalModelTriggerInput = {
   /**
    * Tags Match
    *
-   * Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh.
+   * Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories.
    */
   tags_match?: "any" | "all" | "any_strict" | "all_strict" | "exact" | null;
   /**
@@ -2622,7 +2622,7 @@ export type MentalModelTriggerOutput = {
   /**
    * Tags Match
    *
-   * Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh.
+   * Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories.
    */
   tags_match?: "any" | "all" | "any_strict" | "all_strict" | "exact" | null;
   /**

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -638,7 +638,7 @@
             }
           ],
           "default": null,
-          "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh.",
+          "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories.",
           "title": "Tags Match"
         },
         "tag_groups": {

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -10142,7 +10142,7 @@
               }
             ],
             "title": "Tags Match",
-            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh."
+            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories."
           },
           "tag_groups": {
             "anyOf": [
@@ -10301,7 +10301,7 @@
               }
             ],
             "title": "Tags Match",
-            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh."
+            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories."
           },
           "tag_groups": {
             "anyOf": [

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -10142,7 +10142,7 @@
               }
             ],
             "title": "Tags Match",
-            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh."
+            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories."
           },
           "tag_groups": {
             "anyOf": [
@@ -10301,7 +10301,7 @@
               }
             ],
             "title": "Tags Match",
-            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'all_strict' when the model has tags (security isolation) or 'any' when the model has no tags. Set to 'any' to include untagged memories alongside tagged ones during refresh."
+            "description": "Override how the model's tags filter memories during refresh. If not set, defaults to 'any', matching recall and reflect: memories with any model tag and untagged memories are included. Set an explicit strict mode such as 'all_strict' when refresh must exclude untagged or partially matching memories."
           },
           "tag_groups": {
             "anyOf": [


### PR DESCRIPTION
## Problem

Tagged mental models without an explicit `trigger.tags_match` refresh with `all_strict`, while recall, reflect, and staleness checks default to `any`. With multiple model tags this can mark a model stale and then refresh it from an empty corpus. Fixes #2808.

## Fix

- default refresh filtering to `any`
- preserve explicit modes such as `all_strict`
- update the refresh integration expectation and add focused resolver regressions

## Test

- `uv run --directory hindsight-api-slim pytest tests/test_mental_models.py -k "TestRefreshTagFiltering" -q` (2 passed)
- pre-commit lint hooks passed
- `uv run --directory hindsight-api-slim ruff format --check hindsight_api/engine/memory_engine.py tests/test_mental_models.py`

The database-backed staleness test could not complete locally because the test database fixture did not become ready; the existing overlap test already asserts the `any` staleness behavior, and hosted CI should cover the integration path.

## Risk

The implicit scope becomes broader for tagged models and includes untagged memories. Deployments that require strict isolation can retain it by setting `trigger.tags_match` to `all_strict` explicitly.