### PR TITLE
fix(db): re-apply session GUCs on pool acquire (asyncpg RESET ALL wipes them)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/postgresql.py
@@ -95,7 +95,12 @@ class PostgreSQLBackend(DatabaseBackend):
             command_timeout=command_timeout,
             statement_cache_size=statement_cache_size,
             timeout=acquire_timeout,
+            # init runs once per new connection; setup runs on every acquire,
+            # after asyncpg's release-time RESET ALL. Passing init_callback as
+            # both keeps the per-connection session GUCs (hnsw.ef_search, etc.)
+            # applied after a connection is reused, not just on first creation.
             init=init_callback,
+            setup=init_callback,
         )
         logger.info(
             f"PostgreSQL pool created (min={min_size}, max={max_size}, "

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -592,6 +592,26 @@ class TestPostgreSQLBackendUnit:
         assert ready_during_close is False
         assert backend.is_ready is False
 
+    @pytest.mark.asyncio
+    async def test_init_callback_also_passed_as_setup(self):
+        # asyncpg runs RESET ALL when a connection is released back to the pool,
+        # which wipes the session GUCs the init callback SET. The same callback
+        # must also be wired as setup= so it re-applies on every acquire.
+        backend = PostgreSQLBackend()
+
+        async def cb(conn):
+            return None
+
+        with patch(
+            "hindsight_api.engine.db.postgresql.asyncpg.create_pool",
+            new=AsyncMock(return_value=object()),
+        ) as create_pool:
+            await backend.initialize("postgresql://localhost/test", init_callback=cb)
+
+        kwargs = create_pool.call_args.kwargs
+        assert kwargs["init"] is cb
+        assert kwargs["setup"] is cb
+
 
 # ---------------------------------------------------------------------------
 # Config integration test


### PR DESCRIPTION
## Problem

`PostgreSQLBackend.initialize` (`hindsight-api-slim/hindsight_api/engine/db/postgresql.py`) wires the per-connection tuning callback only as `init=` on `asyncpg.create_pool`. That callback (`_init_connection` in `memory_engine.py`) `SET`s the ANN recall knobs — `hnsw.ef_search` and the other high-recall tuning from `ann_search_tuning_settings(...)` — plus `statement_timeout`.

asyncpg runs `init` exactly once, when a physical connection is created. On **release** back to the pool it runs `Connection.reset()`, which issues `RESET ALL`. So every GUC the init callback set is wiped the first time a connection is returned to the pool, and every later checkout of that connection runs untuned: `hnsw.ef_search` falls back to the pgvector default of 40, and `statement_timeout` is gone.

The `_init_connection` comment even states the intent — *"SET (not SET LOCAL) so per-backend ANN tuning persists for the connection lifetime"* — but `RESET ALL` on release defeats it. The result is that recall silently degrades after the first turn on each pooled connection and stays degraded for the life of the pool.

### Reproduction

Wire an init-only pool that sets a session GUC, then acquire → release → acquire:

```python
pool = await asyncpg.create_pool(dsn, min_size=1, max_size=1, init=set_ef_search_200)

conn = await pool.acquire()
await conn.fetchval("SHOW hnsw.ef_search")   # -> '200'  (init applied)
await pool.release(conn)

conn = await pool.acquire()
await conn.fetchval("SHOW hnsw.ef_search")   # -> '40'   (RESET ALL wiped it)
```

The first acquire reports the tuned value; after one release the same connection reports the pgvector default.

## Fix

Pass the same callback as `setup=` in addition to `init=`. asyncpg runs `setup` on every acquire, *after* the release-time reset, so the session GUCs are re-applied on connection reuse instead of only at creation. `init` is left in place, so first-connection behaviour is unchanged.

```python
init=init_callback,
setup=init_callback,
```

The re-application is a handful of `SET`s on an already-open connection, negligible against a recall/retain round-trip. Scoped to the asyncpg PostgreSQL backend, which is where `RESET ALL` applies.

## Tests

Added a no-live-DB unit test in `tests/test_db_abstraction.py` (`TestPostgreSQLBackendUnit`), mirroring the existing mocked-`create_pool` style there: it patches `asyncpg.create_pool` and asserts `initialize(..., init_callback=cb)` forwards `cb` as both `init=` and `setup=`.

```
tests/test_db_abstraction.py::TestPostgreSQLBackendUnit  3 passed
ruff check  All checks passed!
```

The end-to-end GUC-survives-reset behaviour needs a live Postgres pool (acquire → release → acquire against a real connection). I kept this PR to the unit assertion to stay minimal; happy to add an integration test under the DB-backed suite on request.
