### PR TITLE
fix(migrations): install maintenance routines into each run's own schema

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py
@@ -1,0 +1,229 @@
+"""Install the maintenance discovery routines into each run's own schema.
+
+The three discovery routines driving the background maintenance loop —
+``banks_needing_consolidation()``, ``schemas_with_expired_rows(...)`` and
+``mental_models_with_cron()`` — were installed into ``public`` and gated on the
+run being the base run (no ``target_schema``) or an explicit
+``target_schema='public'`` run (``e5f6a7b8c9d0`` → ``b2d4f6a8c1e3`` →
+``c7e9f1a3b5d2``, ``f4d1c2b3a5e6``).
+
+That leaves a **single-tenant deployment migrated into a dedicated, non-**
+``public`` **schema** (``HINDSIGHT_API_DATABASE_SCHEMA=<non-public>``) with no
+routines at all: the runtime migrates only that one schema, so ``target_schema``
+is never falsy or ``public``, the gate never opens, and the maintenance loop
+logs, forever::
+
+    function public.banks_needing_consolidation() does not exist
+    function public.schemas_with_expired_rows(...) does not exist
+
+The revision is stamped applied, so redeploying the same version does not help
+(issue #2638; #2056 only fixed the ``public``/base-run case).
+
+**Fix: stop putting them in a shared schema.** Install all three into *this
+run's own schema*, unconditionally. What the routines return does not depend on
+where they live — each enumerates ``pg_class`` across the whole database and
+dispatches per schema — so a copy in any one schema is fully functional, and the
+maintenance loop calls the copy in its configured schema
+(``get_config().database_schema``), which is by definition a schema that got
+migrated.
+
+This also removes the concurrency hazard the old gate existed to dodge, rather
+than locking around it. Each migration process only ever writes
+``CREATE OR REPLACE FUNCTION "<its own target_schema>".fn()``, so two concurrent
+per-schema runs never touch the same ``pg_proc`` row and the
+``tuple concurrently updated`` race cannot occur. No cross-process coordination
+is needed — notably no advisory lock, which is unusable here because Hindsight
+runs behind connection poolers and managed PG services (see the revert of
+#2690).
+
+Existing installs self-heal: this revision runs on every schema and creates the
+routine exactly where that deployment's loop looks for it. The base/``public``
+run keeps creating the ``public.*`` copies, so nothing changes for a default
+deployment. Function bodies are byte-identical to ``c7e9f1a3b5d2`` /
+``f4d1c2b3a5e6``.
+
+The cost is one duplicate routine per tenant schema in a multi-tenant install —
+a few catalog rows each, and the honest price of needing no coordination.
+
+PostgreSQL only: the maintenance loop and worker poller are PG-only, so the
+Oracle slot is intentionally absent (mirrors ``e5f6a7b8c9d0``).
+
+Revision ID: b6d2f8a4c1e7
+Revises: a8c1e4f7b0d3
+Create Date: 2026-07-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import context, op
+
+from hindsight_api.alembic._dialect import run_for_dialect
+
+revision: str = "b6d2f8a4c1e7"
+down_revision: str | Sequence[str] | None = "a8c1e4f7b0d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _schema_prefix() -> str:
+    """Qualifier for the schema this run targets, or ``""`` for the base run.
+
+    An empty prefix leaves the object to ``search_path``, which env.py points at
+    the target schema (base run: ``public``) — matching every other raw-SQL
+    migration in this tree.
+    """
+    schema = context.config.get_main_option("target_schema")
+    return f'"{schema}".' if schema else ""
+
+
+def _pg_upgrade() -> None:
+    schema = _schema_prefix()
+
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION {schema}banks_needing_consolidation()
+        RETURNS TABLE(schema_name text, bank_id text)
+        LANGUAGE plpgsql STABLE
+        AS $fn$
+        DECLARE
+            sch text;
+        BEGIN
+            FOR sch IN
+                SELECT n.nspname
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relname = 'memory_units' AND c.relkind = 'r'
+            LOOP
+                BEGIN
+                    RETURN QUERY EXECUTE format($q$
+                        SELECT %1$L::text, m.bank_id
+                        FROM %1$I.memory_units m
+                        JOIN %1$I.banks b ON b.bank_id = m.bank_id
+                        WHERE m.consolidated_at IS NULL
+                          AND m.consolidation_failed_at IS NULL
+                          AND m.fact_type IN ('experience', 'world')
+                          AND COALESCE(b.config -> 'enable_auto_consolidation', 'true'::jsonb) <> 'false'::jsonb
+                          AND NOT EXISTS (
+                              SELECT 1 FROM %1$I.async_operations o
+                              WHERE o.bank_id = m.bank_id
+                                AND o.operation_type = 'consolidation'
+                                AND o.status IN ('pending', 'processing')
+                          )
+                        GROUP BY m.bank_id
+                    $q$, sch);
+                EXCEPTION
+                    -- Schema or its tables vanished between the pg_class
+                    -- snapshot and this query (tenant dropped or migrating).
+                    WHEN undefined_table OR invalid_schema_name OR undefined_column THEN
+                        CONTINUE;
+                END;
+            END LOOP;
+        END;
+        $fn$;
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION {schema}schemas_with_expired_rows(
+            p_table text, p_ts_col text, p_days int
+        )
+        RETURNS SETOF text
+        LANGUAGE plpgsql STABLE
+        AS $fn$
+        DECLARE
+            sch text;
+            has_expired boolean;
+        BEGIN
+            IF p_days IS NULL OR p_days <= 0 THEN
+                RETURN;
+            END IF;
+            FOR sch IN
+                SELECT n.nspname
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relname = p_table AND c.relkind = 'r'
+            LOOP
+                BEGIN
+                    EXECUTE format(
+                        'SELECT EXISTS (SELECT 1 FROM %I.%I WHERE %I < NOW() - make_interval(days => $1))',
+                        sch, p_table, p_ts_col
+                    ) INTO has_expired USING p_days;
+                EXCEPTION
+                    -- Schema or its table vanished mid-scan; skip it.
+                    WHEN undefined_table OR invalid_schema_name OR undefined_column THEN
+                        CONTINUE;
+                END;
+                IF has_expired THEN
+                    RETURN NEXT sch;
+                END IF;
+            END LOOP;
+        END;
+        $fn$;
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION {schema}mental_models_with_cron()
+        RETURNS TABLE(schema_name text, bank_id text, mental_model_id text,
+                     refresh_cron text, last_refreshed_at timestamptz)
+        LANGUAGE plpgsql STABLE
+        AS $fn$
+        DECLARE
+            sch text;
+        BEGIN
+            FOR sch IN
+                SELECT n.nspname
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relname = 'mental_models' AND c.relkind = 'r'
+            LOOP
+                BEGIN
+                    RETURN QUERY EXECUTE format($q$
+                        SELECT %1$L::text, mm.bank_id::text, mm.id::text,
+                               mm.trigger->>'refresh_cron', mm.last_refreshed_at
+                        FROM %1$I.mental_models mm
+                        WHERE COALESCE(mm.trigger->>'refresh_cron', '') <> ''
+                          AND NOT EXISTS (
+                              SELECT 1 FROM %1$I.async_operations o
+                              WHERE o.bank_id = mm.bank_id
+                                AND o.operation_type = 'refresh_mental_model'
+                                AND o.status IN ('pending', 'processing')
+                                AND o.task_payload->>'mental_model_id' = mm.id::text
+                          )
+                    $q$, sch);
+                EXCEPTION
+                    -- Schema or its tables vanished between the pg_class
+                    -- snapshot and this query (tenant dropped or migrating).
+                    WHEN undefined_table OR invalid_schema_name OR undefined_column THEN
+                        CONTINUE;
+                END;
+            END LOOP;
+        END;
+        $fn$;
+        """
+    )
+
+
+def _pg_downgrade() -> None:
+    # Drop only the copies this migration uniquely owns — the ones in a
+    # non-``public`` schema. The ``public`` copies belong to e5f6a7b8c9d0 /
+    # f4d1c2b3a5e6, which are still applied at this point and drop them on their
+    # own downgrade; removing them here would strand those migrations without the
+    # functions they claim to have installed.
+    target_schema = context.config.get_main_option("target_schema")
+    if not target_schema or target_schema == "public":
+        return
+    schema = f'"{target_schema}".'
+    op.execute(f"DROP FUNCTION IF EXISTS {schema}mental_models_with_cron()")
+    op.execute(f"DROP FUNCTION IF EXISTS {schema}schemas_with_expired_rows(text, text, int)")
+    op.execute(f"DROP FUNCTION IF EXISTS {schema}banks_needing_consolidation()")
+
+
+def upgrade() -> None:
+    run_for_dialect(pg=_pg_upgrade)
+
+
+def downgrade() -> None:
+    run_for_dialect(pg=_pg_downgrade)

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -21,9 +21,10 @@ from one place, so we don't spawn a separate ``asyncio`` task per concern:
 The loop wakes on a short fixed tick and runs each job when its own
 ``last_run + interval`` is due (run-at-start, then on interval), so adding jobs
 with different cadences doesn't burst CPU. Cross-tenant discovery goes through
-server-side PL/pgSQL routines (``public.schemas_with_expired_rows`` and
-``public.banks_needing_consolidation``) — one round-trip each — instead of a
-per-schema query storm, which matters at thousands of tenants.
+server-side PL/pgSQL routines (``schemas_with_expired_rows`` and
+``banks_needing_consolidation``, in the configured schema — see ``_routine``) —
+one round-trip each — instead of a per-schema query storm, which matters at
+thousands of tenants.
 """
 
 from __future__ import annotations
@@ -49,6 +50,19 @@ logger = logging.getLogger(__name__)
 _TICK_SECONDS = 60
 # Retention sweeps are not time-sensitive; hourly matches the previous per-sweep cadence.
 _RETENTION_INTERVAL_SECONDS = 3600
+
+
+def _routine(name: str) -> str:
+    """Schema-qualified name of a cross-tenant discovery routine.
+
+    The routines are installed into every migrated schema (``b6d2f8a4c1e7``), so
+    the copy to call is the one in this deployment's configured schema — which,
+    unlike a hardcoded ``public.``, exists even when the deployment lives in a
+    dedicated non-``public`` schema (#2638). Each copy enumerates ``pg_class``
+    across the whole database, so which one runs does not change the result.
+    """
+    schema = get_config().database_schema or "public"
+    return '"' + schema.replace('"', '""') + '".' + name
 
 
 class MaintenanceLoop:
@@ -163,7 +177,7 @@ class MaintenanceLoop:
         try:
             async with acquire_with_retry(backend, max_retries=1) as conn:
                 rows = await conn.fetch(
-                    "SELECT * FROM public.schemas_with_expired_rows($1, $2, $3)", table, ts_col, days
+                    f"SELECT * FROM {_routine('schemas_with_expired_rows')}($1, $2, $3)", table, ts_col, days
                 )
                 for row in rows:
                     schema = row[0]
@@ -185,7 +199,7 @@ class MaintenanceLoop:
         engine = self._engine
         try:
             async with acquire_with_retry(engine._backend, max_retries=1) as conn:
-                rows = await conn.fetch("SELECT schema_name, bank_id FROM public.banks_needing_consolidation()")
+                rows = await conn.fetch(f"SELECT schema_name, bank_id FROM {_routine('banks_needing_consolidation')}()")
         except Exception as e:
             logger.warning(f"Consolidation reconcile discovery failed: {e}")
             return
@@ -244,7 +258,7 @@ class MaintenanceLoop:
 
         Discovery (the set of cron-scheduled models, minus any with an in-flight
         refresh) is one cross-tenant round-trip via
-        ``public.mental_models_with_cron()``. Cron *due-ness* is evaluated here in
+        ``mental_models_with_cron()``. Cron *due-ness* is evaluated here in
         Python — a scheduled fire has elapsed when the most recent cron boundary at
         or before now is later than ``last_refreshed_at`` — because cron arithmetic
         isn't expressible in plain SQL. Each due model is refreshed only when it is
@@ -256,7 +270,7 @@ class MaintenanceLoop:
             async with acquire_with_retry(engine._backend, max_retries=1) as conn:
                 rows = await conn.fetch(
                     "SELECT schema_name, bank_id, mental_model_id, refresh_cron, last_refreshed_at "
-                    "FROM public.mental_models_with_cron()"
+                    f"FROM {_routine('mental_models_with_cron')}()"
                 )
         except Exception as e:
             logger.warning(f"Scheduled mental model refresh discovery failed: {e}")

--- a/hindsight-api-slim/tests/test_maintenance_routines.py
+++ b/hindsight-api-slim/tests/test_maintenance_routines.py
@@ -8,6 +8,7 @@ table in a single round-trip. These tests drive them directly against pg0.
 
 import importlib.util
 import uuid
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -182,3 +183,124 @@ async def test_schemas_with_expired_rows(memory: MemoryEngine):
         # Disabled retention (days <= 0): always empty.
         disabled = await conn.fetch("SELECT * FROM public.schemas_with_expired_rows('audit_log', 'started_at', 0)")
         assert len(disabled) == 0
+
+
+def _load_schema_local_migration():
+    """Import the #2638 schema-local install migration by path."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py"
+    )
+    spec = importlib.util.spec_from_file_location("_maint_routines_schema_local", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeAlembicContext:
+    """Stands in for ``alembic.context``, whose ``config`` only exists inside a
+    live migration run."""
+
+    def __init__(self, target_schema: str | None) -> None:
+        self.config = SimpleNamespace(get_main_option=lambda name: target_schema if name == "target_schema" else None)
+
+
+def _capture_upgrade(migration, monkeypatch, target_schema: str | None) -> list[str]:
+    """Run the migration's ``_pg_upgrade`` for ``target_schema``, capturing SQL."""
+    monkeypatch.setattr(migration, "context", _FakeAlembicContext(target_schema))
+    executed: list[str] = []
+    monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
+    migration._pg_upgrade()
+    return executed
+
+
+@pytest.mark.parametrize(
+    ("target_schema", "expected_prefix"),
+    [
+        (None, ""),  # base run: search_path resolves to public
+        ("public", '"public".'),
+        ("tenant_xyz", '"tenant_xyz".'),  # the #2638 case: must NOT be skipped
+    ],
+)
+def test_schema_local_install_runs_for_every_target_schema(monkeypatch, target_schema, expected_prefix):
+    """Regression for #2638: a deploy migrated into a non-``public`` schema must
+    still get the routines. They now go into the run's *own* schema on every run,
+    so no gate can skip them — and because each process writes only its own
+    ``pg_proc`` row, no cross-process lock is needed to make that safe.
+    """
+    migration = _load_schema_local_migration()
+    joined = "\n".join(_capture_upgrade(migration, monkeypatch, target_schema))
+
+    for routine in ("banks_needing_consolidation", "schemas_with_expired_rows", "mental_models_with_cron"):
+        assert f"CREATE OR REPLACE FUNCTION {expected_prefix}{routine}" in joined
+    # The public-only gate that caused #2638 must not come back...
+    assert not hasattr(migration, "_should_install_public_routines")
+    # ...and neither must an advisory lock (unusable behind poolers; see #2690).
+    assert "advisory" not in joined.lower()
+
+
+@pytest.mark.asyncio
+async def test_routines_callable_from_non_public_schema(memory: MemoryEngine, request_context, monkeypatch):
+    """End-to-end #2638: with the deployment schema set to a non-``public`` schema,
+    the migration installs the routines there and ``_routine()`` resolves to that
+    copy, which returns the same cross-tenant results as the ``public`` one.
+    """
+    from hindsight_api.engine import maintenance
+
+    migration = _load_schema_local_migration()
+    schema = f"tenant_{uuid.uuid4().hex[:8]}"
+
+    bank_id = await _make_bank(memory, request_context, "nonpublic")
+    async with memory._pool.acquire() as conn:
+        await _insert_fact(conn, bank_id)
+        await conn.execute(f'CREATE SCHEMA "{schema}"')
+        try:
+            # Drive the migration exactly as a per-schema run would.
+            for stmt in _capture_upgrade(migration, monkeypatch, schema):
+                await conn.execute(stmt)
+
+            # The loop's qualifier now points at the non-public copy...
+            # Config is a read-only proxy, so swap the accessor rather than the field.
+            monkeypatch.setattr(maintenance, "get_config", lambda: SimpleNamespace(database_schema=schema))
+            assert maintenance._routine("banks_needing_consolidation") == f'"{schema}".banks_needing_consolidation'
+
+            # ...and that copy works: it enumerates pg_class database-wide, so it
+            # still finds the bank living in the public schema.
+            rows = await conn.fetch(f'SELECT schema_name, bank_id FROM "{schema}".banks_needing_consolidation()')
+            assert bank_id in {r["bank_id"] for r in rows}
+        finally:
+            await conn.execute(f'DROP SCHEMA "{schema}" CASCADE')
+
+
+@pytest.mark.parametrize("target_schema", [None, "public"])
+def test_schema_local_downgrade_leaves_public_copies_alone(monkeypatch, target_schema):
+    """Downgrade must only drop the copies this migration uniquely owns.
+
+    The ``public`` copies belong to e5f6a7b8c9d0 / f4d1c2b3a5e6, which are still
+    applied when this one is downgraded — dropping them here would strand those
+    migrations without the functions they claim to have installed.
+    """
+    migration = _load_schema_local_migration()
+    monkeypatch.setattr(migration, "context", _FakeAlembicContext(target_schema))
+    executed: list[str] = []
+    monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
+
+    migration._pg_downgrade()
+
+    assert executed == []
+
+
+def test_schema_local_downgrade_drops_non_public_copies(monkeypatch):
+    """A non-``public`` run's copies exist only because of this migration, so its
+    downgrade must remove them."""
+    migration = _load_schema_local_migration()
+    monkeypatch.setattr(migration, "context", _FakeAlembicContext("tenant_xyz"))
+    executed: list[str] = []
+    monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
+
+    migration._pg_downgrade()
+
+    joined = "\n".join(executed)
+    for routine in ("banks_needing_consolidation", "schemas_with_expired_rows", "mental_models_with_cron"):
+        assert f'DROP FUNCTION IF EXISTS "tenant_xyz".{routine}' in joined


### PR DESCRIPTION
## Summary

Fixes #2638, lock-free. Follows #2817, which reverted the advisory-lock migration (`f2a4b6c8d0e2`) that tried to fix this.

### The bug

The three cross-tenant discovery routines driving the maintenance loop — `banks_needing_consolidation()`, `schemas_with_expired_rows(...)`, `mental_models_with_cron()` — were installed into `public` and gated on the run being the base run or an explicit `target_schema='public'` run.

A single-tenant deployment migrated into a dedicated non-`public` schema (`HINDSIGHT_API_DATABASE_SCHEMA=<non-public>`) migrates only that one schema, so the gate never opens and **no routine is ever created**. The loop logs `function public.… does not exist` every cycle, and the revision is stamped applied so redeploying doesn't help. #2056 fixed only the `public`/base-run case.

### The fix: stop putting them in a shared schema

Migration `b6d2f8a4c1e7` installs all three into the run's **own** `target_schema`, unconditionally, and `maintenance.py` qualifies its calls with `get_config().database_schema` (`_routine()`) instead of a hardcoded `public.`.

Where a routine *lives* doesn't affect what it *returns* — each enumerates `pg_class` across the whole database and dispatches per schema — so the copy in the configured schema is fully functional, and that schema is by definition one that got migrated.

**This removes the concurrency hazard the old gate existed to dodge, instead of locking around it.** Each process only ever writes `CREATE OR REPLACE FUNCTION "<its own schema>".fn()`, so two concurrent per-schema runs never contend on the same `pg_proc` row — `tuple concurrently updated` cannot occur. No cross-process coordination, and in particular no advisory lock (unusable behind poolers and managed PG; see the Database Locking standard added in #2817).

The cost is one duplicate routine per tenant schema in a multi-tenant install: a few catalog rows each, and the honest price of needing no coordination.

Also note #2690 only covered two of the three routines — `mental_models_with_cron()` had the same bug and is fixed here.

### Compatibility

- Default `public` deployments: unchanged (base run still creates `public.*`, `_routine()` still resolves to `public.`).
- Existing broken installs **self-heal** — the revision runs on every schema and creates the routine exactly where that deployment's loop looks.
- Function bodies byte-identical to `c7e9f1a3b5d2` / `f4d1c2b3a5e6`. PG-only, mirroring `e5f6a7b8c9d0`.
- Downgrade drops only the non-`public` copies this migration uniquely owns; the `public` ones belong to `e5f6a7b8c9d0` / `f4d1c2b3a5e6`, which are still applied and drop them on their own downgrade.

## Testing

- `test_schema_local_install_runs_for_every_target_schema` — parametrized over base / `public` / `tenant_xyz`; asserts all three routines are created with the right qualifier, and that neither the public-only gate nor an advisory lock comes back.
- `test_routines_callable_from_non_public_schema` — end-to-end on pg0: creates a real non-`public` schema, drives `_pg_upgrade()` as a per-schema run would, asserts `_routine()` resolves there and the resulting routine returns the bank living in `public`.
- Two downgrade tests covering the ownership split.
- Suites green: `test_maintenance_routines`, `test_migration_shape`, `test_maintenance_loop`, `test_maintenance_multitenant`, `test_operation_retention_migration`, `test_mental_model_scheduled_refresh` — **189 passed / 87 skipped** combined.
- Single alembic head (`b6d2f8a4c1e7`) on top of merged `main`.
- `ruff check` + `ruff format` + `ty check` clean; `./scripts/hooks/lint.sh` green.

## Heads-up for #2819

`fix/operation-retention-followup` adds `public.schemas_with_expired_operations` using the same public-only gate, so it will ship with this exact bug. It should adopt `_schema_prefix()` + `_routine()` once this lands.
