### PR TITLE
style: apply ruff format to reflect/agent.py

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -1074,7 +1074,9 @@ async def _run_reflect_agent_inner(
                 # Generate structured output if schema provided
                 structured_output = None
                 if response_schema and answer:
-                    struct = await _generate_structured_output(answer, response_schema, llm_config, reflect_id, max_tokens)
+                    struct = await _generate_structured_output(
+                        answer, response_schema, llm_config, reflect_id, max_tokens
+                    )
                     structured_output = struct.structured_output
                     total_input_tokens += struct.input_tokens
                     total_output_tokens += struct.output_tokens


### PR DESCRIPTION
## Summary

`hindsight_api/engine/reflect/agent.py` has a call in `_generate_structured_output` that exceeds the 120-char line limit and was committed unformatted. `ruff format` rewrites it on every CI run, which fails the `verify-generated-files` job:

```
❌ Error: Generated files are out of sync with committed files.
 M hindsight-api-slim/hindsight_api/engine/reflect/agent.py
 1 file changed, 3 insertions(+), 1 deletion(-)
```

That job now fails on **every** `hindsight-api-slim` PR regardless of content — it's the sole red check on #2820 and #2819, neither of which touches this file.

Formatting only, produced by `./scripts/hooks/lint.sh`. No behaviour change.