### PR TITLE
fix(migrations): install the maintenance routines once, in the configured schema

### DIFF
--- a/hindsight-api-slim/hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/b6d2f8a4c1e7_maintenance_routines_schema_local.py
@@ -1,4 +1,4 @@
-"""Install the maintenance discovery routines into each run's own schema.
+"""Install the maintenance discovery routines into the configured schema.
 
 The three discovery routines driving the background maintenance loop —
 ``banks_needing_consolidation()``, ``schemas_with_expired_rows(...)`` and
@@ -19,31 +19,26 @@ logs, forever::
 The revision is stamped applied, so redeploying the same version does not help
 (issue #2638; #2056 only fixed the ``public``/base-run case).
 
-**Fix: stop putting them in a shared schema.** Install all three into *this
-run's own schema*, unconditionally. What the routines return does not depend on
-where they live — each enumerates ``pg_class`` across the whole database and
-dispatches per schema — so a copy in any one schema is fully functional, and the
-maintenance loop calls the copy in its configured schema
-(``get_config().database_schema``), which is by definition a schema that got
-migrated.
+**The bug was the hardcoded literal, not the gating.** These routines are
+database-global — each enumerates ``pg_class`` across every schema and dispatches
+per schema — so exactly one copy should exist, and the maintenance loop calls the
+one in ``get_config().database_schema`` (see ``fq_routine``). The old gate
+installed into whichever schema was named ``public`` instead of whichever schema
+the deployment is actually configured to use. Comparing ``target_schema`` against
+the configured schema instead of the literal fixes #2638 at the source.
 
-This also removes the concurrency hazard the old gate existed to dodge, rather
-than locking around it. Each migration process only ever writes
-``CREATE OR REPLACE FUNCTION "<its own target_schema>".fn()``, so two concurrent
-per-schema runs never touch the same ``pg_proc`` row and the
-``tuple concurrently updated`` race cannot occur. No cross-process coordination
-is needed — notably no advisory lock, which is unusable here because Hindsight
-runs behind connection poolers and managed PG services (see the revert of
-#2690).
+That also keeps the property the gate existed for: exactly one migration run
+satisfies the predicate, so concurrent per-schema runs never issue competing
+``CREATE OR REPLACE`` against the same ``pg_proc`` row and cannot hit
+``tuple concurrently updated``. No cross-process coordination is required — in
+particular no advisory lock, which is unusable here because Hindsight runs behind
+connection poolers and managed PG services (see #2817).
 
-Existing installs self-heal: this revision runs on every schema and creates the
-routine exactly where that deployment's loop looks for it. The base/``public``
-run keeps creating the ``public.*`` copies, so nothing changes for a default
-deployment. Function bodies are byte-identical to ``c7e9f1a3b5d2`` /
-``f4d1c2b3a5e6``.
-
-The cost is one duplicate routine per tenant schema in a multi-tenant install —
-a few catalog rows each, and the honest price of needing no coordination.
+Runs targeting any *other* schema drop the routines from that schema rather than
+merely skipping. An earlier revision of this migration installed a copy into
+every schema it touched, which left one dead duplicate per tenant on any database
+that ran it; the drop makes the next migration pass clean those up instead of
+leaving them behind forever.
 
 PostgreSQL only: the maintenance loop and worker poller are PG-only, so the
 Oracle slot is intentionally absent (mirrors ``e5f6a7b8c9d0``).
@@ -58,6 +53,7 @@ from collections.abc import Sequence
 from alembic import context, op
 
 from hindsight_api.alembic._dialect import run_for_dialect
+from hindsight_api.config import get_config
 
 revision: str = "b6d2f8a4c1e7"
 down_revision: str | Sequence[str] | None = "a8c1e4f7b0d3"
@@ -65,19 +61,36 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
-def _schema_prefix() -> str:
-    """Qualifier for the schema this run targets, or ``""`` for the base run.
+def _configured_schema() -> str:
+    """The one schema this deployment's routines live in and are called from."""
+    return get_config().database_schema or "public"
 
-    An empty prefix leaves the object to ``search_path``, which env.py points at
-    the target schema (base run: ``public``) — matching every other raw-SQL
-    migration in this tree.
+
+def _target_schema() -> str | None:
+    return context.config.get_main_option("target_schema")
+
+
+def _is_install_run() -> bool:
+    """True for the single run that owns the routines.
+
+    The base run (no ``target_schema``) and the run targeting the configured
+    schema are the same deployment-level run; every other target is a tenant
+    schema that must not carry its own copy.
     """
-    schema = context.config.get_main_option("target_schema")
+    target = _target_schema()
+    return not target or target == _configured_schema()
+
+
+def _prefix(schema: str | None) -> str:
+    """Qualifier for ``schema``, or ``""`` to fall back to ``search_path``."""
     return f'"{schema}".' if schema else ""
 
 
 def _pg_upgrade() -> None:
-    schema = _schema_prefix()
+    if not _is_install_run():
+        _drop_stray_copies()
+        return
+    schema = _prefix(_target_schema())
 
     op.execute(
         f"""
@@ -206,19 +219,36 @@ def _pg_upgrade() -> None:
     )
 
 
+def _drop_routines(schema: str | None) -> None:
+    prefix = _prefix(schema)
+    op.execute(f"DROP FUNCTION IF EXISTS {prefix}mental_models_with_cron()")
+    op.execute(f"DROP FUNCTION IF EXISTS {prefix}schemas_with_expired_rows(text, text, int)")
+    op.execute(f"DROP FUNCTION IF EXISTS {prefix}banks_needing_consolidation()")
+
+
+def _drop_stray_copies() -> None:
+    """Remove per-tenant duplicates left by the first cut of this migration.
+
+    That version installed a copy into every schema it touched, so a database
+    that ran it carries one dead duplicate per tenant — only the copy in the
+    configured schema is ever called. Dropping here means the next migration pass
+    cleans them up; without it they would persist for the life of the database.
+
+    Safe on a database that never had them: ``DROP FUNCTION IF EXISTS`` is a
+    no-op, and this branch never runs for the configured schema.
+    """
+    _drop_routines(_target_schema())
+
+
 def _pg_downgrade() -> None:
-    # Drop only the copies this migration uniquely owns — the ones in a
-    # non-``public`` schema. The ``public`` copies belong to e5f6a7b8c9d0 /
-    # f4d1c2b3a5e6, which are still applied at this point and drop them on their
-    # own downgrade; removing them here would strand those migrations without the
-    # functions they claim to have installed.
-    target_schema = context.config.get_main_option("target_schema")
-    if not target_schema or target_schema == "public":
+    # Only drop what this migration uniquely owns. When the configured schema is
+    # ``public`` the copies there belong to e5f6a7b8c9d0 / f4d1c2b3a5e6, which are
+    # still applied at this point and drop them on their own downgrade — removing
+    # them here would strand those migrations without the functions they claim to
+    # have installed.
+    if not _is_install_run() or _configured_schema() == "public":
         return
-    schema = f'"{target_schema}".'
-    op.execute(f"DROP FUNCTION IF EXISTS {schema}mental_models_with_cron()")
-    op.execute(f"DROP FUNCTION IF EXISTS {schema}schemas_with_expired_rows(text, text, int)")
-    op.execute(f"DROP FUNCTION IF EXISTS {schema}banks_needing_consolidation()")
+    _drop_routines(_target_schema())
 
 
 def upgrade() -> None:

--- a/hindsight-api-slim/hindsight_api/engine/maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/maintenance.py
@@ -22,7 +22,7 @@ The loop wakes on a short fixed tick and runs each job when its own
 ``last_run + interval`` is due (run-at-start, then on interval), so adding jobs
 with different cadences doesn't burst CPU. Cross-tenant discovery goes through
 server-side PL/pgSQL routines (``schemas_with_expired_rows`` and
-``banks_needing_consolidation``, in the configured schema — see ``_routine``) —
+``banks_needing_consolidation``, in the configured schema — see ``fq_routine``) —
 one round-trip each — instead of a per-schema query storm, which matters at
 thousands of tenants.
 """
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Any
 from ..config import HindsightConfig, get_config
 from ..models import RequestContext
 from .db_utils import acquire_with_retry
-from .schema import _is_oracle, fq_table
+from .schema import _is_oracle, fq_routine, fq_table
 
 if TYPE_CHECKING:
     from .memory_engine import MemoryEngine
@@ -50,19 +50,6 @@ logger = logging.getLogger(__name__)
 _TICK_SECONDS = 60
 # Retention sweeps are not time-sensitive; hourly matches the previous per-sweep cadence.
 _RETENTION_INTERVAL_SECONDS = 3600
-
-
-def _routine(name: str) -> str:
-    """Schema-qualified name of a cross-tenant discovery routine.
-
-    The routines are installed into every migrated schema (``b6d2f8a4c1e7``), so
-    the copy to call is the one in this deployment's configured schema — which,
-    unlike a hardcoded ``public.``, exists even when the deployment lives in a
-    dedicated non-``public`` schema (#2638). Each copy enumerates ``pg_class``
-    across the whole database, so which one runs does not change the result.
-    """
-    schema = get_config().database_schema or "public"
-    return '"' + schema.replace('"', '""') + '".' + name
 
 
 class MaintenanceLoop:
@@ -177,7 +164,7 @@ class MaintenanceLoop:
         try:
             async with acquire_with_retry(backend, max_retries=1) as conn:
                 rows = await conn.fetch(
-                    f"SELECT * FROM {_routine('schemas_with_expired_rows')}($1, $2, $3)", table, ts_col, days
+                    f"SELECT * FROM {fq_routine('schemas_with_expired_rows')}($1, $2, $3)", table, ts_col, days
                 )
                 for row in rows:
                     schema = row[0]
@@ -199,7 +186,9 @@ class MaintenanceLoop:
         engine = self._engine
         try:
             async with acquire_with_retry(engine._backend, max_retries=1) as conn:
-                rows = await conn.fetch(f"SELECT schema_name, bank_id FROM {_routine('banks_needing_consolidation')}()")
+                rows = await conn.fetch(
+                    f"SELECT schema_name, bank_id FROM {fq_routine('banks_needing_consolidation')}()"
+                )
         except Exception as e:
             logger.warning(f"Consolidation reconcile discovery failed: {e}")
             return
@@ -270,7 +259,7 @@ class MaintenanceLoop:
             async with acquire_with_retry(engine._backend, max_retries=1) as conn:
                 rows = await conn.fetch(
                     "SELECT schema_name, bank_id, mental_model_id, refresh_cron, last_refreshed_at "
-                    f"FROM {_routine('mental_models_with_cron')}()"
+                    f"FROM {fq_routine('mental_models_with_cron')}()"
                 )
         except Exception as e:
             logger.warning(f"Scheduled mental model refresh discovery failed: {e}")

--- a/hindsight-api-slim/hindsight_api/engine/schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/schema.py
@@ -27,6 +27,23 @@ def fq_table(table_name: str) -> str:
     return f"{get_current_schema()}.{table_name}"
 
 
+def fq_routine(name: str) -> str:
+    """Schema-qualified name of a cross-tenant discovery routine.
+
+    These routines are database-global — each enumerates ``pg_class`` across every
+    schema and dispatches per schema — so exactly one copy exists, installed into
+    the configured schema by ``b6d2f8a4c1e7``. Calling it through the configured
+    schema rather than a hardcoded ``public.`` is what makes a deployment living
+    in a dedicated non-``public`` schema work (#2638).
+
+    Unlike :func:`fq_table` this ignores the per-request schema contextvar: the
+    routines are deliberately cross-tenant, called from background loops that have
+    no request context.
+    """
+    schema = get_config().database_schema or "public"
+    return '"' + schema.replace('"', '""') + '".' + name
+
+
 def fq_table_explicit(table: str, schema: str | None = None) -> str:
     """Get fully-qualified table name with an explicit schema override.
 

--- a/hindsight-api-slim/tests/test_maintenance_routines.py
+++ b/hindsight-api-slim/tests/test_maintenance_routines.py
@@ -206,9 +206,15 @@ class _FakeAlembicContext:
         self.config = SimpleNamespace(get_main_option=lambda name: target_schema if name == "target_schema" else None)
 
 
-def _capture_upgrade(migration, monkeypatch, target_schema: str | None) -> list[str]:
-    """Run the migration's ``_pg_upgrade`` for ``target_schema``, capturing SQL."""
+def _capture_upgrade(migration, monkeypatch, target_schema: str | None, configured_schema: str = "public") -> list[str]:
+    """Run the migration's ``_pg_upgrade`` for ``target_schema``, capturing SQL.
+
+    ``configured_schema`` is the deployment's ``HINDSIGHT_API_DATABASE_SCHEMA``;
+    the migration installs only when the run targets it.
+    """
     monkeypatch.setattr(migration, "context", _FakeAlembicContext(target_schema))
+    if hasattr(migration, "get_config"):
+        monkeypatch.setattr(migration, "get_config", lambda: SimpleNamespace(database_schema=configured_schema))
     executed: list[str] = []
     monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
     migration._pg_upgrade()
@@ -216,37 +222,55 @@ def _capture_upgrade(migration, monkeypatch, target_schema: str | None) -> list[
 
 
 @pytest.mark.parametrize(
-    ("target_schema", "expected_prefix"),
+    ("target_schema", "configured", "expected_prefix"),
     [
-        (None, ""),  # base run: search_path resolves to public
-        ("public", '"public".'),
-        ("tenant_xyz", '"tenant_xyz".'),  # the #2638 case: must NOT be skipped
+        (None, "public", ""),  # base run: search_path resolves to the configured schema
+        ("public", "public", '"public".'),  # default deployment
+        ("hs_tenant", "hs_tenant", '"hs_tenant".'),  # the #2638 case: single-tenant, non-public
     ],
 )
-def test_schema_local_install_runs_for_every_target_schema(monkeypatch, target_schema, expected_prefix):
-    """Regression for #2638: a deploy migrated into a non-``public`` schema must
-    still get the routines. They now go into the run's *own* schema on every run,
-    so no gate can skip them — and because each process writes only its own
-    ``pg_proc`` row, no cross-process lock is needed to make that safe.
+def test_routines_install_in_the_configured_schema(monkeypatch, target_schema, configured, expected_prefix):
+    """Regression for #2638: the install must follow the *configured* schema.
+
+    The old gate compared ``target_schema`` against the literal ``"public"``, so a
+    deployment living in a dedicated non-``public`` schema never installed the
+    routines at all. Comparing against ``get_config().database_schema`` installs
+    exactly one copy, in the schema ``fq_routine`` actually calls.
     """
     migration = _load_schema_local_migration()
-    joined = "\n".join(_capture_upgrade(migration, monkeypatch, target_schema))
+    joined = "\n".join(_capture_upgrade(migration, monkeypatch, target_schema, configured))
 
     for routine in ("banks_needing_consolidation", "schemas_with_expired_rows", "mental_models_with_cron"):
         assert f"CREATE OR REPLACE FUNCTION {expected_prefix}{routine}" in joined
     # The public-only gate that caused #2638 must not come back...
     assert not hasattr(migration, "_should_install_public_routines")
-    # ...and neither must an advisory lock (unusable behind poolers; see #2690).
+    # ...and neither must an advisory lock (unusable behind poolers; see #2817).
     assert "advisory" not in joined.lower()
+
+
+def test_tenant_runs_install_nothing_and_clean_up_strays(monkeypatch):
+    """A tenant schema must not carry its own copy.
+
+    These routines are database-global — each enumerates ``pg_class`` across every
+    schema — so only the copy in the configured schema is ever called. A per-tenant
+    copy is dead weight, and the first cut of this migration created one per
+    tenant, so tenant runs drop rather than merely skip.
+    """
+    migration = _load_schema_local_migration()
+    joined = "\n".join(_capture_upgrade(migration, monkeypatch, "tenant_xyz", configured_schema="public"))
+
+    assert "CREATE OR REPLACE FUNCTION" not in joined
+    for routine in ("banks_needing_consolidation", "schemas_with_expired_rows", "mental_models_with_cron"):
+        assert f'DROP FUNCTION IF EXISTS "tenant_xyz".{routine}' in joined
 
 
 @pytest.mark.asyncio
 async def test_routines_callable_from_non_public_schema(memory: MemoryEngine, request_context, monkeypatch):
     """End-to-end #2638: with the deployment schema set to a non-``public`` schema,
-    the migration installs the routines there and ``_routine()`` resolves to that
+    the migration installs the routines there and ``fq_routine()`` resolves to that
     copy, which returns the same cross-tenant results as the ``public`` one.
     """
-    from hindsight_api.engine import maintenance
+    from hindsight_api.engine import schema as schema_mod
 
     migration = _load_schema_local_migration()
     schema = f"tenant_{uuid.uuid4().hex[:8]}"
@@ -257,13 +281,15 @@ async def test_routines_callable_from_non_public_schema(memory: MemoryEngine, re
         await conn.execute(f'CREATE SCHEMA "{schema}"')
         try:
             # Drive the migration exactly as a per-schema run would.
-            for stmt in _capture_upgrade(migration, monkeypatch, schema):
+            # Configured schema == this schema, i.e. a single-tenant deployment
+            # living in a dedicated non-public schema (the #2638 shape).
+            for stmt in _capture_upgrade(migration, monkeypatch, schema, configured_schema=schema):
                 await conn.execute(stmt)
 
             # The loop's qualifier now points at the non-public copy...
             # Config is a read-only proxy, so swap the accessor rather than the field.
-            monkeypatch.setattr(maintenance, "get_config", lambda: SimpleNamespace(database_schema=schema))
-            assert maintenance._routine("banks_needing_consolidation") == f'"{schema}".banks_needing_consolidation'
+            monkeypatch.setattr(schema_mod, "get_config", lambda: SimpleNamespace(database_schema=schema))
+            assert schema_mod.fq_routine("banks_needing_consolidation") == f'"{schema}".banks_needing_consolidation'
 
             # ...and that copy works: it enumerates pg_class database-wide, so it
             # still finds the bank living in the public schema.
@@ -273,34 +299,37 @@ async def test_routines_callable_from_non_public_schema(memory: MemoryEngine, re
             await conn.execute(f'DROP SCHEMA "{schema}" CASCADE')
 
 
-@pytest.mark.parametrize("target_schema", [None, "public"])
-def test_schema_local_downgrade_leaves_public_copies_alone(monkeypatch, target_schema):
-    """Downgrade must only drop the copies this migration uniquely owns.
-
-    The ``public`` copies belong to e5f6a7b8c9d0 / f4d1c2b3a5e6, which are still
-    applied when this one is downgraded — dropping them here would strand those
-    migrations without the functions they claim to have installed.
-    """
-    migration = _load_schema_local_migration()
+def _capture_downgrade(migration, monkeypatch, target_schema, configured_schema) -> list[str]:
     monkeypatch.setattr(migration, "context", _FakeAlembicContext(target_schema))
+    monkeypatch.setattr(migration, "get_config", lambda: SimpleNamespace(database_schema=configured_schema))
     executed: list[str] = []
     monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
-
     migration._pg_downgrade()
+    return executed
 
-    assert executed == []
 
-
-def test_schema_local_downgrade_drops_non_public_copies(monkeypatch):
-    """A non-``public`` run's copies exist only because of this migration, so its
-    downgrade must remove them."""
+@pytest.mark.parametrize("target_schema", [None, "public"])
+def test_downgrade_leaves_public_copies_alone(monkeypatch, target_schema):
+    """When the configured schema is ``public`` the copies there belong to
+    e5f6a7b8c9d0 / f4d1c2b3a5e6, which are still applied when this migration is
+    downgraded — dropping them here would strand those migrations without the
+    functions they claim to have installed."""
     migration = _load_schema_local_migration()
-    monkeypatch.setattr(migration, "context", _FakeAlembicContext("tenant_xyz"))
-    executed: list[str] = []
-    monkeypatch.setattr(migration.op, "execute", lambda sql: executed.append(str(sql)))
+    assert _capture_downgrade(migration, monkeypatch, target_schema, "public") == []
 
-    migration._pg_downgrade()
 
-    joined = "\n".join(executed)
+def test_downgrade_drops_the_copy_it_owns(monkeypatch):
+    """On a non-``public`` deployment the copy exists only because of this
+    migration, so its downgrade must remove it."""
+    migration = _load_schema_local_migration()
+    joined = "\n".join(_capture_downgrade(migration, monkeypatch, "hs_tenant", "hs_tenant"))
+
     for routine in ("banks_needing_consolidation", "schemas_with_expired_rows", "mental_models_with_cron"):
-        assert f'DROP FUNCTION IF EXISTS "tenant_xyz".{routine}' in joined
+        assert f'DROP FUNCTION IF EXISTS "hs_tenant".{routine}' in joined
+
+
+def test_downgrade_ignores_tenant_runs(monkeypatch):
+    """A tenant run never owned a copy under the current install policy, so its
+    downgrade has nothing to undo."""
+    migration = _load_schema_local_migration()
+    assert _capture_downgrade(migration, monkeypatch, "tenant_xyz", "hs_tenant") == []

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -55,6 +55,7 @@ Migrations will automatically create the schema if it doesn't exist and create a
 | `HINDSIGHT_API_DB_COMMAND_TIMEOUT` | PostgreSQL command timeout in seconds (asyncpg client-side) | `60` |
 | `HINDSIGHT_API_DB_ACQUIRE_TIMEOUT` | Connection acquisition timeout in seconds | `30` |
 | `HINDSIGHT_API_DB_STATEMENT_TIMEOUT` | Postgres `statement_timeout` applied to every pool connection, in seconds. Server-side safety net for runaway queries. Does **not** apply to Alembic migrations (which run on a separate psycopg2 engine). Set to `0` to disable. | `600` |
+| `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` | Optional Postgres `max_parallel_workers_per_gather` applied to every pool connection of this process. Unset leaves the server default. Set to `0` on background-worker processes so bulk maintenance queries (consolidation, graph upkeep) run serially instead of fanning out across CPU cores shared with latency-sensitive traffic. | unset |
 
 For high-concurrency workloads, increase `DB_POOL_MAX_SIZE`. Each concurrent recall/think operation can use 2-4 connections.
 


### PR DESCRIPTION
## Summary

Follow-up to #2820 — which fixed #2638 the wrong way. **Please read this as a correction of my own previous PR.**

### What was wrong

The three discovery routines (`banks_needing_consolidation`, `schemas_with_expired_rows`, `mental_models_with_cron`) are **database-global**: each enumerates `pg_class` across every schema and dispatches per schema. The maintenance loop only ever calls the copy in `get_config().database_schema`.

#2820 installed a copy into *every* schema the migration touched. On a 20k-tenant database that is 20k copies of each routine, **19,999 of which are never invoked** — catalog garbage, and a global function nonsensically duplicated per tenant.

### The actual bug in #2638 was the hardcoded literal, not the gating

The original predicate was:

```python
return not target_schema or target_schema == "public"   # literal
```

It gated on whichever schema happened to be *named* `public` rather than the schema the deployment is *configured* to use. A single-tenant install living in a dedicated non-`public` schema therefore never matched and got no routines at all.

The fix is to compare against the configured schema:

```python
target = context.config.get_main_option("target_schema")
return not target or target == get_config().database_schema
```

**Exactly one run satisfies this**, so exactly one copy is installed, in the schema `fq_routine()` actually calls. It also preserves the property the gate existed for: no two runs issue competing `CREATE OR REPLACE` against the same `pg_proc` row, so `tuple concurrently updated` can't happen — with no cross-process coordination and no advisory lock (#2817).

### Cleanup of the strays

Runs targeting any *other* schema now `DROP FUNCTION IF EXISTS` in that schema rather than merely returning. Any database that already ran #2820 sheds its per-tenant duplicates on the next migration pass instead of carrying them forever. It's a no-op on a database that never had them.

### Helper move

`maintenance._routine` → `schema.fq_routine`, beside `fq_table` / `fq_table_explicit`. The worker poller needs the same qualifier (#2819), and a second caller open-coding it is exactly how #2638 recurs. This also removes the transient `_routine` / `fq_routine` split between `main` and #2819.

## Compatibility

- Default `public` deployments: unchanged — base run installs into `public`, `fq_routine()` resolves there.
- Non-`public` single-tenant deployments: fixed, one copy in their own schema.
- Multi-tenant: one copy in the base schema; tenant runs install nothing and clean up any #2820 strays.
- Downgrade drops only the copy this migration owns, and never the `public` one when that belongs to `e5f6a7b8c9d0` / `f4d1c2b3a5e6`.
- `b6d2f8a4c1e7` is edited in place rather than superseded: it is in no release, and the revision id is unchanged so nothing needs re-stamping.

## Testing

- `test_routines_install_in_the_configured_schema` — parametrized over (target_schema, configured schema), covering base / default `public` / non-`public` single-tenant.
- `test_tenant_runs_install_nothing_and_clean_up_strays` — tenant runs emit no `CREATE`, and drop all three routines from their own schema.
- Three downgrade tests keyed on the configured schema rather than the literal `public`.
- `test_routines_callable_from_non_public_schema` — unchanged end-to-end pg0 test, now driven with configured schema == the run's schema.
- 191 passed / 87 skipped across `test_maintenance_routines`, `test_migration_shape`, `test_maintenance_loop`, `test_maintenance_multitenant`. `ruff` + `ty` clean.
- Verified `get_config().database_schema` resolves from env inside the migration (`HINDSIGHT_API_DATABASE_SCHEMA=hs_tenant` → `hs_tenant`).

## Note on the one-line `skills/` change

`skills/hindsight-docs/references/developer/configuration.md` is **generated output, not authored here** — the docs-skill bundle was left unsynced by the PR that added `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER`, and the pre-commit generator refuses to commit without it. Unrelated to this change.