### PR TITLE
fix(retain): make entities a plain list of strings (#2749)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -32,7 +32,7 @@ def _extract_map_entities(
     entity_obj: dict,
     fields: dict[str, MapField],
     prefix: str,
-    validated_entities: "list[Entity]",
+    validated_entities: list[str],
     existing_texts_lower: set[str],
 ) -> None:
     """Recursively extract key:field:value entity strings from a map entity dict."""
@@ -59,7 +59,7 @@ def _extract_map_entities(
                     continue
                 label_str = f"{prefix}{field_name}:{v.strip()}"
                 if label_str.lower() not in existing_texts_lower:
-                    validated_entities.append(Entity(text=label_str))
+                    validated_entities.append(label_str)
                     existing_texts_lower.add(label_str.lower())
         else:
             # text or value — single string
@@ -67,7 +67,7 @@ def _extract_map_entities(
                 continue
             label_str = f"{prefix}{field_name}:{field_val.strip()}"
             if label_str.lower() not in existing_texts_lower:
-                validated_entities.append(Entity(text=label_str))
+                validated_entities.append(label_str)
                 existing_texts_lower.add(label_str.lower())
 
 
@@ -114,12 +114,33 @@ def _sanitize_text(text: str | None) -> str | None:
     return sanitize_llm_output(text)
 
 
-class Entity(BaseModel):
-    """An entity extracted from text."""
+def _coerce_entity_strings(v: Any) -> Any:
+    """
+    Normalize the LLM's `entities` field to a plain list of strings.
 
-    text: str = Field(
-        description="The specific, named entity as it appears in the fact. Must be a proper noun or specific identifier."
-    )
+    The schema previously asked for `Entity` objects ({"text": "..."}) while the
+    prompt's few-shot examples taught a flat string array. Models that followed
+    the examples literally returned strings, and the entities were silently
+    dropped — none were ever persisted (#2749). The `Entity` wrapper carried no
+    information beyond the string, so it was removed rather than taught to the
+    prompt; the object form is still unwrapped here for models that learned it
+    and for in-flight batch jobs.
+
+    Returns non-list input untouched so pydantic reports the type error itself.
+    """
+    if v is None:
+        return []
+    if not isinstance(v, list):
+        return v
+    coerced = []
+    for item in v:
+        if isinstance(item, dict):
+            text = item.get("text")
+            if isinstance(text, str):
+                coerced.append(text)
+        else:
+            coerced.append(item)
+    return coerced
 
 
 class Fact(BaseModel):
@@ -144,7 +165,7 @@ class Fact(BaseModel):
     )
 
     # Optional structured data
-    entities: list[Entity] | None = None
+    entities: list[str] | None = None
     causal_relations: list["CausalRelation"] | None = None
 
 
@@ -195,7 +216,9 @@ class ExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts, including user preferences, rules, corrections, and constraints even when stated during a conversation. 'assistant' = actions, experiences, or observations the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[str] = Field(
+        default_factory=list, description='People, places, concepts - plain strings, e.g. ["Alice", "Kubernetes"]'
+    )
     causal_relations: list[FactCausalRelation] | None = Field(
         default=None, description="Links to previous facts (target_index < this fact's index)"
     )
@@ -203,10 +226,7 @@ class ExtractedFact(BaseModel):
     @field_validator("entities", mode="before")
     @classmethod
     def ensure_entities_list(cls, v):
-        """Ensure entities is always a list (convert None to empty list)."""
-        if v is None:
-            return []
-        return v
+        return _coerce_entity_strings(v)
 
     def build_fact_text(self) -> str:
         """Combine all dimensions into a single comprehensive fact string."""
@@ -348,9 +368,9 @@ class ExtractedFactVerbose(BaseModel):
         description="'world' = objective/external facts about the user, other people, events, general knowledge, preferences, rules, corrections, or constraints. 'assistant' = actions, experiences, or observations the assistant/agent actually performed (e.g., 'I changed X', 'I discovered Y')."
     )
 
-    entities: list[Entity] | None = Field(
-        default=None,
-        description="Named entities, objects, AND abstract concepts from the fact. Include: people names, organizations, places, significant objects (e.g., 'coffee maker', 'car'), AND abstract concepts/themes (e.g., 'friendship', 'career growth', 'loss', 'celebration'). Extract anything that could help link related facts together.",
+    entities: list[str] = Field(
+        default_factory=list,
+        description="Named entities, objects, AND abstract concepts from the fact, as plain strings (e.g. [\"Alice\", \"friendship\"]). Include: people names, organizations, places, significant objects (e.g., 'coffee maker', 'car'), AND abstract concepts/themes (e.g., 'friendship', 'career growth', 'loss', 'celebration'). Extract anything that could help link related facts together.",
     )
 
     causal_relations: list[FactCausalRelation] | None = Field(
@@ -362,9 +382,7 @@ class ExtractedFactVerbose(BaseModel):
     @field_validator("entities", mode="before")
     @classmethod
     def ensure_entities_list(cls, v):
-        if v is None:
-            return []
-        return v
+        return _coerce_entity_strings(v)
 
 
 class FactExtractionResponseVerbose(BaseModel):
@@ -397,17 +415,15 @@ class ExtractedFactNoCausal(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = about the user/others, including user preferences, rules, corrections, and constraints. 'assistant' = actions or experiences the assistant/agent actually performed."
     )
-    entities: list[Entity] | None = Field(
-        default=None,
-        description="Named entities, objects, and concepts from the fact.",
+    entities: list[str] = Field(
+        default_factory=list,
+        description='Named entities, objects, and concepts from the fact, as plain strings (e.g. ["Alice", "Kubernetes"]).',
     )
 
     @field_validator("entities", mode="before")
     @classmethod
     def ensure_entities_list(cls, v):
-        if v is None:
-            return []
-        return v
+        return _coerce_entity_strings(v)
 
 
 class FactExtractionResponseNoCausal(BaseModel):
@@ -439,14 +455,14 @@ class VerbatimExtractedFact(BaseModel):
     fact_type: Literal["world", "assistant"] = Field(
         description="'world' = objective/external facts. 'assistant' = first-person actions, experiences, or observations by the speaker."
     )
-    entities: list[Entity] | None = Field(default=None, description="People, places, concepts")
+    entities: list[str] = Field(
+        default_factory=list, description='People, places, concepts - plain strings, e.g. ["Alice", "Kubernetes"]'
+    )
 
     @field_validator("entities", mode="before")
     @classmethod
     def ensure_entities_list(cls, v):
-        if v is None:
-            return []
-        return v
+        return _coerce_entity_strings(v)
 
 
 class VerbatimFactExtractionResponse(BaseModel):
@@ -729,6 +745,11 @@ Use "Event Date" from input as reference for relative dates.
 ══════════════════════════════════════════════════════════════════════════
 ENTITIES
 ══════════════════════════════════════════════════════════════════════════
+
+ALWAYS return "entities" as an array of plain strings — never objects, never null.
+Correct: entities=["Alice", "Kubernetes", "CKA"]
+Wrong:   entities as an array of objects with a "text" key ← never use this form
+Use an empty array [] only when the fact truly names nothing.
 
 Include: people names, organizations, places, key objects, abstract concepts (career, friendship, etc.)
 Always include "user" when fact is about the user.{examples}"""
@@ -1147,8 +1168,8 @@ def _build_extraction_prompt_and_schema(config) -> tuple[str, type]:
             }
             if not free_form_entities:
                 dynamic_fields["entities"] = (
-                    list[Entity] | None,
-                    Field(default=None, description="Leave empty — labels-only mode"),
+                    list[str],
+                    Field(default_factory=list, description="Leave empty — labels-only mode"),
                 )
             # Inherit parent's required fields and add 'labels' so it appears in the JSON schema
             # required array (the base class json_schema_extra overrides required entirely)
@@ -1511,21 +1532,9 @@ async def _extract_facts_from_chunk(
                     elif fact_data.get("occurred_start"):
                         fact_data["occurred_end"] = fact_data["occurred_start"]
 
-                # Add entities if present (validate as Entity objects)
-                # LLM sometimes returns strings instead of {"text": "..."} format
-                entities = get_value("entities")
-                validated_entities = []
-                if entities:
-                    # Validate and normalize each entity
-                    for ent in entities:
-                        if isinstance(ent, str):
-                            # Normalize string to Entity object
-                            validated_entities.append(Entity(text=ent))
-                        elif isinstance(ent, dict) and "text" in ent:
-                            try:
-                                validated_entities.append(Entity.model_validate(ent))
-                            except Exception as e:
-                                logger.warning(f"Invalid entity {ent}: {e}")
+                # Entities are plain strings. Older prompts taught a {"text": ...}
+                # object form, so keep unwrapping it for models that still emit it.
+                validated_entities = _coerce_entity_strings(get_value("entities"))
 
                 # Post-process label entities from structured labels object
                 entity_labels_raw = getattr(config, "entity_labels", None)
@@ -1535,7 +1544,7 @@ async def _extract_facts_from_chunk(
                     labels_lookup = build_labels_lookup(labels_cfg)
                     labels_data = llm_fact.get("labels") or {}
                     if isinstance(labels_data, dict):
-                        existing_texts_lower = {e.text.lower() for e in validated_entities}
+                        existing_texts_lower = {e.lower() for e in validated_entities}
                         for group in labels_cfg.attributes:
                             value = labels_data.get(group.key)
                             if not value:
@@ -1560,12 +1569,12 @@ async def _extract_facts_from_chunk(
                                 label_str = f"{group.key}:{v.strip()}"
                                 if group.type == "text":
                                     if label_str.lower() not in existing_texts_lower:
-                                        validated_entities.append(Entity(text=label_str))
+                                        validated_entities.append(label_str)
                                         existing_texts_lower.add(label_str.lower())
                                 elif (
                                     label_str.lower() in labels_lookup and label_str.lower() not in existing_texts_lower
                                 ):
-                                    validated_entities.append(Entity(text=label_str))
+                                    validated_entities.append(label_str)
                                     existing_texts_lower.add(label_str.lower())
                                 else:
                                     logger.warning(f"Label '{label_str}' not in valid label values, skipping")
@@ -1573,7 +1582,7 @@ async def _extract_facts_from_chunk(
                     # In labels-only mode, keep only label entities
                     if not free_form_entities:
                         validated_entities = [
-                            e for e in validated_entities if is_label_entity(e.text, labels_cfg, labels_lookup)
+                            e for e in validated_entities if is_label_entity(e, labels_cfg, labels_lookup)
                         ]
                 elif not free_form_entities:
                     # No labels but free_form disabled: clear all entities
@@ -2275,18 +2284,9 @@ async def extract_facts_from_contents_batch_api(
                 elif fact_data.get("occurred_start"):
                     fact_data["occurred_end"] = fact_data["occurred_start"]
 
-            # Entities
-            entities = get_value("entities")
-            validated_entities = []
-            if entities:
-                for ent in entities:
-                    if isinstance(ent, str):
-                        validated_entities.append(Entity(text=ent))
-                    elif isinstance(ent, dict) and "text" in ent:
-                        try:
-                            validated_entities.append(Entity.model_validate(ent))
-                        except Exception:
-                            pass
+            # Entities are plain strings. Older prompts taught a {"text": ...}
+            # object form, so keep unwrapping it for models that still emit it.
+            validated_entities = _coerce_entity_strings(get_value("entities"))
 
             # Post-process label entities from structured labels object
             entity_labels_raw = getattr(config, "entity_labels", None)
@@ -2296,7 +2296,7 @@ async def extract_facts_from_contents_batch_api(
                 labels_lookup_batch = build_labels_lookup(labels_cfg_batch)
                 labels_data = llm_fact.get("labels") or {}
                 if isinstance(labels_data, dict):
-                    existing_texts_lower = {e.text.lower() for e in validated_entities}
+                    existing_texts_lower = {e.lower() for e in validated_entities}
                     for group in labels_cfg_batch.attributes:
                         value = labels_data.get(group.key)
                         if not value:
@@ -2321,18 +2321,18 @@ async def extract_facts_from_contents_batch_api(
                             label_str = f"{group.key}:{v.strip()}"
                             if group.type == "text":
                                 if label_str.lower() not in existing_texts_lower:
-                                    validated_entities.append(Entity(text=label_str))
+                                    validated_entities.append(label_str)
                                     existing_texts_lower.add(label_str.lower())
                             elif (
                                 label_str.lower() in labels_lookup_batch
                                 and label_str.lower() not in existing_texts_lower
                             ):
-                                validated_entities.append(Entity(text=label_str))
+                                validated_entities.append(label_str)
                                 existing_texts_lower.add(label_str.lower())
 
                 if not free_form_entities_batch:
                     validated_entities = [
-                        e for e in validated_entities if is_label_entity(e.text, labels_cfg_batch, labels_lookup_batch)
+                        e for e in validated_entities if is_label_entity(e, labels_cfg_batch, labels_lookup_batch)
                     ]
             elif not free_form_entities_batch:
                 validated_entities = []
@@ -2419,7 +2419,7 @@ async def extract_facts_from_contents_batch_api(
             extracted_fact = ExtractedFactType(
                 fact_text=fact_from_llm.fact,
                 fact_type=fact_from_llm.fact_type,
-                entities=[e.text for e in (fact_from_llm.entities or [])],
+                entities=list(fact_from_llm.entities or []),
                 occurred_start=_parse_datetime(fact_from_llm.occurred_start) if fact_from_llm.occurred_start else None,
                 occurred_end=_parse_datetime(fact_from_llm.occurred_end) if fact_from_llm.occurred_end else None,
                 causal_relations=_convert_causal_relations(fact_from_llm.causal_relations or [], global_fact_idx),
@@ -2616,7 +2616,7 @@ async def extract_facts_from_contents(
                     extracted_fact = ExtractedFactType(
                         fact_text=fact_from_llm.fact,
                         fact_type=fact_from_llm.fact_type,
-                        entities=[e.text for e in (fact_from_llm.entities or [])],
+                        entities=list(fact_from_llm.entities or []),
                         # occurred_start/end: from LLM only, leave None if not provided
                         occurred_start=_parse_datetime(fact_from_llm.occurred_start)
                         if fact_from_llm.occurred_start

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -495,7 +495,6 @@ def test_inject_label_tags_no_labels_config_is_noop():
 def test_label_entity_post_processing():
     """Structured labels dict is parsed into key:value entity strings; invalid values filtered."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_cfg = parse_entity_labels(
         [
@@ -514,7 +513,7 @@ def test_label_entity_post_processing():
     # Simulated LLM response — structured dict, not a flat list
     labels_data = {"pedagogy": "scaffolding"}  # single-value field
 
-    validated_entities: list[Entity] = []
+    validated_entities: list[str] = []
     if isinstance(labels_data, dict) and labels_lookup:
         existing_texts_lower: set[str] = set()
         for group in labels_cfg.attributes:
@@ -525,24 +524,23 @@ def test_label_entity_post_processing():
             for v in values_list:
                 label_str = f"{group.key}:{v}"
                 if label_str.lower() in labels_lookup and label_str.lower() not in existing_texts_lower:
-                    validated_entities.append(Entity(text=label_str))
+                    validated_entities.append(label_str)
                     existing_texts_lower.add(label_str.lower())
 
-    entity_texts = {e.text for e in validated_entities}
+    entity_texts = set(validated_entities)
     assert "pedagogy:scaffolding" in entity_texts
 
 
 def test_label_entity_post_processing_invalid_value_ignored():
     """Values not in the lookup are silently dropped."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_cfg = parse_entity_labels([{"key": "pedagogy", "values": [{"value": "scaffolding", "description": ""}]}])
     labels_lookup = build_labels_lookup(labels_cfg)
 
     labels_data = {"pedagogy": "unknown_value"}
 
-    validated_entities: list[Entity] = []
+    validated_entities: list[str] = []
     existing_texts_lower: set[str] = set()
     for group in labels_cfg.attributes:
         value = labels_data.get(group.key)
@@ -552,7 +550,7 @@ def test_label_entity_post_processing_invalid_value_ignored():
         for v in values_list:
             label_str = f"{group.key}:{v}"
             if label_str.lower() in labels_lookup and label_str.lower() not in existing_texts_lower:
-                validated_entities.append(Entity(text=label_str))
+                validated_entities.append(label_str)
 
     assert validated_entities == []
 
@@ -560,7 +558,6 @@ def test_label_entity_post_processing_invalid_value_ignored():
 def test_label_entity_post_processing_multi_value():
     """Multi-value list field produces one entity per value."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_cfg = parse_entity_labels(
         [
@@ -579,7 +576,7 @@ def test_label_entity_post_processing_multi_value():
     # Multi-value: LLM returns a list
     labels_data = {"pedagogy": ["scaffolding", "active_engagement"]}
 
-    validated_entities: list[Entity] = []
+    validated_entities: list[str] = []
     existing_texts_lower: set[str] = set()
     for group in labels_cfg.attributes:
         value = labels_data.get(group.key)
@@ -589,10 +586,10 @@ def test_label_entity_post_processing_multi_value():
         for v in values_list:
             label_str = f"{group.key}:{v}"
             if label_str.lower() in labels_lookup and label_str.lower() not in existing_texts_lower:
-                validated_entities.append(Entity(text=label_str))
+                validated_entities.append(label_str)
                 existing_texts_lower.add(label_str.lower())
 
-    entity_texts = {e.text for e in validated_entities}
+    entity_texts = set(validated_entities)
     assert "pedagogy:scaffolding" in entity_texts
     assert "pedagogy:active_engagement" in entity_texts
 
@@ -600,10 +597,9 @@ def test_label_entity_post_processing_multi_value():
 def _run_label_post_processing(labels_cfg, labels_data: dict) -> set[str]:
     """Helper: mirrors the production label post-processing logic, returns entity text set."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_lookup = build_labels_lookup(labels_cfg)
-    validated_entities: list[Entity] = []
+    validated_entities: list[str] = []
     existing_texts_lower: set[str] = set()
 
     effective_data = labels_data or {}
@@ -619,13 +615,13 @@ def _run_label_post_processing(labels_cfg, labels_data: dict) -> set[str]:
                 label_str = f"{group.key}:{v.strip()}"
                 if group.type == "text":
                     if label_str.lower() not in existing_texts_lower:
-                        validated_entities.append(Entity(text=label_str))
+                        validated_entities.append(label_str)
                         existing_texts_lower.add(label_str.lower())
                 elif label_str.lower() in labels_lookup and label_str.lower() not in existing_texts_lower:
-                    validated_entities.append(Entity(text=label_str))
+                    validated_entities.append(label_str)
                     existing_texts_lower.add(label_str.lower())
 
-    return {e.text for e in validated_entities}
+    return set(validated_entities)
 
 
 def test_free_values_label_accepts_any_string():
@@ -730,7 +726,6 @@ def test_optional_label_null_does_not_affect_other_labels():
 def test_free_form_entities_false_clears_entities():
     """When retain_free_form_entities=False, non-label entities are removed."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_cfg = parse_entity_labels(
         {
@@ -747,16 +742,16 @@ def test_free_form_entities_false_clears_entities():
 
     # Mix of label and free-form entities
     validated_entities = [
-        Entity(text="pedagogy:scaffolding"),
-        Entity(text="Alice"),
-        Entity(text="Google"),
+        "pedagogy:scaffolding",
+        "Alice",
+        "Google",
     ]
 
     # Apply free_form filtering
     if not free_form_entities and labels_lookup:
-        validated_entities = [e for e in validated_entities if e.text.lower() in labels_lookup]
+        validated_entities = [e for e in validated_entities if e.lower() in labels_lookup]
 
-    entity_texts = {e.text for e in validated_entities}
+    entity_texts = set(validated_entities)
     assert "pedagogy:scaffolding" in entity_texts
     assert "Alice" not in entity_texts
     assert "Google" not in entity_texts
@@ -765,7 +760,6 @@ def test_free_form_entities_false_clears_entities():
 def test_free_form_entities_true_keeps_all():
     """When retain_free_form_entities=True (default), all entities are kept."""
     from hindsight_api.engine.retain.entity_labels import build_labels_lookup, parse_entity_labels
-    from hindsight_api.engine.retain.fact_extraction import Entity
 
     labels_cfg = parse_entity_labels(
         {
@@ -781,15 +775,15 @@ def test_free_form_entities_true_keeps_all():
     free_form_entities = True  # default value
 
     validated_entities = [
-        Entity(text="pedagogy:scaffolding"),
-        Entity(text="Alice"),
+        "pedagogy:scaffolding",
+        "Alice",
     ]
 
     # With free_form_entities=True, should NOT filter
     if not free_form_entities and labels_lookup:
-        validated_entities = [e for e in validated_entities if e.text.lower() in labels_lookup]
+        validated_entities = [e for e in validated_entities if e.lower() in labels_lookup]
 
-    entity_texts = {e.text for e in validated_entities}
+    entity_texts = set(validated_entities)
     assert "pedagogy:scaffolding" in entity_texts
     assert "Alice" in entity_texts
 
@@ -1388,7 +1382,7 @@ def test_build_labels_prompt_section_mixed():
 
 def test_map_entity_post_processing():
     """Map-type labels are converted to key:field:value entity strings."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1397,11 +1391,11 @@ def test_map_entity_post_processing():
     }
     entity_obj = {"name": "Alice", "role": "Senior Engineer", "organization": "Acme Corp"}
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Alice" in texts
     assert "person:role:Senior Engineer" in texts
     assert "person:organization:Acme Corp" in texts
@@ -1409,7 +1403,7 @@ def test_map_entity_post_processing():
 
 def test_map_entity_post_processing_null_fields_skipped():
     """Null/empty fields in map entities are skipped."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1417,30 +1411,30 @@ def test_map_entity_post_processing_null_fields_skipped():
     }
     entity_obj = {"name": "Bob", "role": None}
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Bob" in texts
     assert len(texts) == 1  # role was null, so only name
 
 
 def test_map_entity_post_processing_multiple_entities():
     """Multiple map entities in a single fact produce separate entity strings."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
         "role": MapField(type="text"),
     }
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities({"name": "Alice", "role": "Engineer"}, fields, "person:", validated, existing)
     _extract_map_entities({"name": "Bob", "role": "Manager"}, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Alice" in texts
     assert "person:role:Engineer" in texts
     assert "person:name:Bob" in texts
@@ -1534,7 +1528,7 @@ def test_is_label_entity_recursive_map():
 
 def test_recursive_map_post_processing():
     """Nested map entities produce deeply-joined key:field:subfield:value strings."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1552,11 +1546,11 @@ def test_recursive_map_post_processing():
         "address": [{"city": "New York", "country": "US"}],
     }
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Alice" in texts
     assert "person:address:city:New York" in texts
     assert "person:address:country:US" in texts
@@ -1621,7 +1615,7 @@ def test_build_labels_prompt_section_recursive_map():
 
 def test_map_field_value_post_processing():
     """Map field with type='value' extracts a single enum entity string."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1632,11 +1626,11 @@ def test_map_field_value_post_processing():
     }
     entity_obj = {"name": "Alice", "department": "engineering"}
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Alice" in texts
     assert "person:department:engineering" in texts
     assert len(texts) == 2
@@ -1644,7 +1638,7 @@ def test_map_field_value_post_processing():
 
 def test_map_field_multi_values_post_processing():
     """Map field with type='multi-values' extracts one entity per value."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1655,11 +1649,11 @@ def test_map_field_multi_values_post_processing():
     }
     entity_obj = {"name": "Alice", "skills": ["python", "rust"]}
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Alice" in texts
     assert "person:skills:python" in texts
     assert "person:skills:rust" in texts
@@ -1669,18 +1663,18 @@ def test_map_field_multi_values_post_processing():
 
 def test_map_field_multi_values_null_skipped():
     """Null/sentinel values in multi-values are skipped."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "tags": MapField(type="multi-values"),
     }
     entity_obj = {"tags": ["valid", "none", "null", "", "  ", "n/a", "also_valid"]}
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "item:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "item:tags:valid" in texts
     assert "item:tags:also_valid" in texts
     assert len(texts) == 2
@@ -1688,7 +1682,7 @@ def test_map_field_multi_values_null_skipped():
 
 def test_nested_map_with_enum_fields_post_processing():
     """Nested map containing value/multi-values fields produces correct paths."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
@@ -1712,11 +1706,11 @@ def test_nested_map_with_enum_fields_post_processing():
         "job": [{"title": "Engineer", "level": "senior", "languages": ["python", "java"]}],
     }
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities(entity_obj, fields, "person:", validated, existing)
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert "person:name:Bob" in texts
     assert "person:job:title:Engineer" in texts
     assert "person:job:level:senior" in texts
@@ -1856,18 +1850,18 @@ def test_prompt_section_map_with_all_field_types():
 
 def test_duplicate_entity_strings_deduplicated():
     """Same entity string from multiple nested objects is only added once."""
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     fields = {
         "name": MapField(type="text"),
     }
     # Two entities with the same name
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing: set[str] = set()
     _extract_map_entities({"name": "Alice"}, fields, "person:", validated, existing)
     _extract_map_entities({"name": "Alice"}, fields, "person:", validated, existing)
 
-    texts = [e.text for e in validated]
+    texts = list(validated)
     assert texts == ["person:name:Alice"]  # only once
 
 
@@ -2285,13 +2279,13 @@ def test_map_entity_emits_complete_id_name_pair():
     the pipeline is capable of producing the complete pair, so any missing half
     seen end-to-end comes from the model's structured output, not from a bug here.
     """
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     cfg = parse_entity_labels(_build_application_label_config()["entity_labels"])
     assert cfg is not None
     group = cfg.attributes[0]
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     existing_lower: set[str] = set()
     # Simulated LLM output for one tagged element: [[SystemA (SystemA, SYS001)]]
     _extract_map_entities(
@@ -2302,7 +2296,7 @@ def test_map_entity_emits_complete_id_name_pair():
         existing_texts_lower=existing_lower,
     )
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert texts == {"application:name:SystemA", "application:id:SYS001"}, (
         f"Expected the complete id/name pair, got: {texts}"
     )
@@ -2315,12 +2309,12 @@ def test_map_entity_partial_object_drops_half_the_pair():
     half — there is no inference of the missing member. This shows the pairing
     must be guaranteed upstream (by the model), and post-processing won't backfill.
     """
-    from hindsight_api.engine.retain.fact_extraction import Entity, _extract_map_entities
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
 
     cfg = parse_entity_labels(_build_application_label_config()["entity_labels"])
     group = cfg.attributes[0]
 
-    validated: list[Entity] = []
+    validated: list[str] = []
     # LLM returned the name but omitted the id — the reported "part only" case.
     _extract_map_entities(
         entity_obj={"name": ["SystemA"]},
@@ -2330,7 +2324,7 @@ def test_map_entity_partial_object_drops_half_the_pair():
         existing_texts_lower=set(),
     )
 
-    texts = {e.text for e in validated}
+    texts = set(validated)
     assert texts == {"application:name:SystemA"}, texts
     assert "application:id:SYS001" not in texts
 

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_llm.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_llm.py
@@ -1,0 +1,50 @@
+"""
+Real-LLM check that the model actually populates `entities` (#2749).
+
+The bug was behavioural, not structural: the prompt's few-shot examples taught a
+flat string array while the schema demanded objects, so models that follow the
+prompt literally returned strings or omitted the field entirely and every entity
+was dropped. MockLLM cannot reproduce that — it takes a real model reading the
+real prompt, so this runs the actual extraction pipeline.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+
+pytestmark = pytest.mark.hs_llm_core
+
+
+@pytest.mark.asyncio
+async def test_extraction_populates_entities():
+    text = (
+        "Alice has 5 years of Kubernetes experience and holds a CKA certification. "
+        "She's been leading the infrastructure team at Acme Corp since March."
+    )
+
+    facts, _, _ = await extract_facts_from_text(
+        text=text,
+        event_date=datetime(2025, 3, 28),
+        llm_config=LLMConfig.from_env(),
+        agent_name="test-agent",
+        context="professional background",
+        config=_get_raw_config(),
+    )
+
+    assert len(facts) > 0, "Should extract at least one fact"
+
+    all_entities = [e for f in facts for e in (f.entities or [])]
+    # The regression: this list was empty because the model returned strings for a
+    # field the schema declared as objects, and the entities were dropped.
+    assert all_entities, f"No entities extracted. Facts: {[(f.fact, f.entities) for f in facts]}"
+    assert all(isinstance(e, str) and e.strip() for e in all_entities), (
+        f"Entities must be non-empty strings, got {all_entities}"
+    )
+    # "Alice" is named unambiguously and repeatedly; any model that populates the
+    # field at all should surface her. Matched case-insensitively / as a substring
+    # since models legitimately vary on casing and qualifiers ("Alice (team lead)").
+    assert any("alice" in e.lower() for e in all_entities), f"Expected 'Alice' among entities, got {all_entities}"

--- a/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_entities_schema.py
@@ -1,0 +1,76 @@
+"""Regression tests for the `entities` extraction contract (issue #2749).
+
+The prompt's few-shot examples teach a flat string array, so the LLM-facing
+schema must ask for strings too. Entities stay optional: an omitted field is
+coerced to [], so requiring it would buy nothing.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_api.engine.retain.fact_extraction import (
+    ExtractedFact,
+    ExtractedFactNoCausal,
+    ExtractedFactVerbose,
+    VerbatimExtractedFact,
+    _build_extraction_prompt_and_schema,
+)
+
+LLM_FACT_MODELS = (ExtractedFact, ExtractedFactVerbose, ExtractedFactNoCausal, VerbatimExtractedFact)
+
+
+def _baseline_config() -> MagicMock:
+    config = MagicMock()
+    config.entity_labels = None
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = False
+    config.retain_mission = None
+    config.retain_custom_instructions = None
+    config.llm_output_language = None
+    return config
+
+
+@pytest.mark.parametrize("model", LLM_FACT_MODELS)
+def test_entities_is_an_optional_array_of_strings(model):
+    schema = model.model_json_schema()
+
+    assert schema["properties"]["entities"] == {
+        "description": schema["properties"]["entities"]["description"],
+        "items": {"type": "string"},
+        "title": "Entities",
+        "type": "array",
+    }
+    # Deliberately NOT in `required` — an omitted field is coerced to [] anyway,
+    # and forcing it would make strict-schema providers reject otherwise-fine facts.
+    assert "entities" not in schema["required"]
+
+
+@pytest.mark.parametrize("model", LLM_FACT_MODELS)
+def test_entities_defaults_to_empty_list_and_accepts_legacy_objects(model):
+    fields = {name: "x" for name, f in model.model_fields.items() if f.is_required()}
+    fields["fact_type"] = "world"
+
+    assert model.model_validate({**fields, "entities": []}).entities == []
+    # Older prompts taught {"text": ...} objects; keep accepting them.
+    assert model.model_validate({**fields, "entities": [{"text": "Alice"}, "Bob"]}).entities == ["Alice", "Bob"]
+    assert model.model_validate({**fields, "entities": None}).entities == []
+
+
+def test_concise_prompt_demands_plain_string_entities():
+    prompt, _ = _build_extraction_prompt_and_schema(_baseline_config())
+
+    assert 'ALWAYS return "entities" as an array of plain strings' in prompt
+    assert 'entities=["Alice", "Kubernetes", "CKA"]' in prompt
+
+
+def test_labels_only_mode_keeps_entities_as_strings():
+    config = _baseline_config()
+    config.entities_allow_free_form = False
+    config.entity_labels = [{"key": "topic", "type": "text"}]
+
+    _, schema = _build_extraction_prompt_and_schema(config)
+
+    entities_schema = schema.model_fields["facts"].annotation.__args__[0].model_json_schema()["properties"]["entities"]
+    assert entities_schema["items"] == {"type": "string"}

--- a/skills/hindsight-docs/references/developer/retain.md
+++ b/skills/hindsight-docs/references/developer/retain.md
@@ -89,9 +89,10 @@ Hindsight automatically identifies and tracks **entities** — the people, organ
 
 ### Entity Resolution
 
-The same entity mentioned different ways gets unified:
+The same entity mentioned different ways gets unified through **fuzzy name matching**, reinforced by co-occurrence and temporal proximity:
 - "Alice" + "Alice Chen" + "Alice C." → one person
-- "Bob" + "Robert Chen" → one person (nickname resolution)
+
+Because resolution keys off name similarity, close variants merge automatically. Names that do not resemble each other (a nickname and an unrelated formal name, for example) are not unified on the name alone, though shared co-occurring entities can still link them.
 
 **Why it matters:** You can ask "What do I know about Alice?" and get everything, even if she was mentioned as "Alice Chen" in some conversations.
 

--- a/skills/hindsight-docs/references/sdks/integrations/zcode.md
+++ b/skills/hindsight-docs/references/sdks/integrations/zcode.md
@@ -1,0 +1,163 @@
+
+# ZCode
+
+Persistent memory for [ZCode](https://zcode.z.ai) — Z.ai's GLM desktop coding agent — using [Hindsight](https://vectorize.io/hindsight). ZCode embeds the Claude Code agent runtime, so Python hook scripts automatically recall relevant context before each prompt and retain conversations after each turn. No MCP server, no changes to your ZCode workflow.
+
+## Quick Start
+
+> **💡 Recommended: Hindsight Cloud**
+>
+[Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key — no self-hosting, no local daemon to manage.
+```bash
+# Install the CLI
+pip install hindsight-zcode
+
+# Install the hooks (defaults to Hindsight Cloud)
+hindsight-zcode install --api-url https://api.hindsight.vectorize.io --api-token your-api-key
+
+# Restart ZCode — memory is live
+```
+
+The installer copies the hook scripts to `~/.zcode/hooks/hindsight/`, registers them in `~/.zcode/cli/config.json` (merged with any existing hooks), and creates `~/.hindsight/zcode.json` for your personal config. It never touches your Claude Code config at `~/.claude/settings.json`.
+
+**Self-hosting alternative** — connect to a local `hindsight-embed` daemon by omitting the flags:
+
+```bash
+hindsight-zcode install
+```
+
+To uninstall:
+
+```bash
+hindsight-zcode uninstall
+```
+
+### Alternative: install as a ZCode plugin
+
+ZCode can install Hindsight directly from a plugin marketplace — no `pip` step. The same hook scripts ship as a hooks-only Claude Code plugin (`hindsight-zcode`) in the Hindsight marketplace:
+
+```
+# In ZCode: add the Hindsight marketplace, then install the plugin
+zcode plugins add-marketplace vectorize-io/hindsight
+zcode plugins install hindsight-zcode
+```
+
+When installed this way, ZCode registers the hooks automatically (no config-file edit). Provide your Hindsight credentials via environment variables (`HINDSIGHT_API_URL`, `HINDSIGHT_API_TOKEN`) or by creating `~/.hindsight/zcode.json`:
+
+```json
+{
+  "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+  "hindsightApiToken": "hsk_your_token"
+}
+```
+
+## Features
+
+- **Auto-recall** — before each prompt, queries Hindsight for relevant memories and injects them as additional context (visible to the model, not the transcript)
+- **Auto-retain** — after each response, stores the turn to Hindsight for future recall
+- **No MCP required** — plain Python hook scripts calling Hindsight's REST API; nothing to run alongside ZCode
+- **Cross-tool memory** — the same Hindsight bank is shared across Claude Code, Cursor, and other Hindsight integrations, so memory follows you between tools
+- **Dynamic bank IDs** — supports per-project memory isolation based on the working directory
+- **Zero runtime dependencies** — the hook scripts are pure Python stdlib; the `pip install` only ships the one-time installer
+
+## Architecture
+
+ZCode embeds the Claude Code agent runtime and reads the standard Claude Code hook schema from its own config namespace, `~/.zcode/cli/config.json` (with `hooks.enabled: true`). The plugin wires three hook events:
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `session_start.py` | `SessionStart` | Warm up — verify Hindsight is reachable |
+| `recall.py` | `UserPromptSubmit` | **Auto-recall** — query memories, inject as `additionalContext` |
+| `retain.py` | `Stop` | **Auto-retain** — assemble the turn, POST to Hindsight |
+
+On `UserPromptSubmit`, the hook reads the prompt, queries Hindsight for the most relevant memories, and emits a context block that ZCode injects before sending the turn to the model:
+
+```
+<hindsight_memories>
+Relevant memories from past conversations...
+Current time - 2026-03-27 09:14
+
+- Project uses FastAPI with asyncpg — not SQLAlchemy [world] (2026-03-26)
+- Preferred testing framework: pytest with pytest-asyncio [experience] (2026-03-26)
+</hindsight_memories>
+```
+
+On `Stop`, the hook pairs the user prompt (captured at `UserPromptSubmit`) with the agent's response and POSTs the turn to Hindsight. ZCode does not provide a `SessionEnd` hook event, so retention rides `Stop` — every turn is stored as it completes.
+
+## Connection Modes
+
+### 1. External API (recommended)
+
+Connect to a running Hindsight server (cloud or self-hosted) via `~/.hindsight/zcode.json`:
+
+```json
+{
+  "hindsightApiUrl": "https://api.hindsight.vectorize.io",
+  "hindsightApiToken": "hsk_your_token"
+}
+```
+
+### 2. Local Daemon
+
+Run `hindsight-embed` locally. The `session_start.py` hook detects it on `apiPort` (default `9077`). The daemon is not auto-started by the plugin — start it separately:
+
+```bash
+uvx hindsight-embed
+```
+
+Then leave `hindsightApiUrl` empty in your config and the plugin connects to `http://localhost:9077`.
+
+## Configuration
+
+Default config ships in `~/.zcode/hooks/hindsight/settings.json`. For personal overrides that survive updates, create `~/.hindsight/zcode.json`. Most settings can also be overridden via environment variable.
+
+**Loading order** (later entries win):
+
+1. Built-in defaults
+2. Plugin `settings.json` (at `~/.zcode/hooks/hindsight/settings.json`)
+3. User config (`~/.hindsight/zcode.json`)
+4. Environment variables
+
+---
+
+### Connection
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `hindsightApiUrl` | `HINDSIGHT_API_URL` | `""` | URL of the Hindsight API server. Empty = local daemon. |
+| `hindsightApiToken` | `HINDSIGHT_API_TOKEN` | `null` | API token for authentication. Required for Hindsight Cloud. |
+| `apiPort` | `HINDSIGHT_API_PORT` | `9077` | Port for the local `hindsight-embed` daemon. |
+
+---
+
+### Memory Bank
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `bankId` | `HINDSIGHT_BANK_ID` | `"zcode"` | The bank to read from and write to. All sessions share this bank unless `dynamicBankId` is enabled. |
+| `bankMission` | `HINDSIGHT_BANK_MISSION` | coding assistant prompt | Describes the agent's purpose. Sent when creating or updating the bank. |
+| `dynamicBankId` | `HINDSIGHT_DYNAMIC_BANK_ID` | `false` | When `true`, derives a unique bank ID from `dynamicBankGranularity` fields — useful for per-project isolation. |
+| `agentName` | `HINDSIGHT_AGENT_NAME` | `"zcode"` | Agent name used in dynamic bank ID derivation. |
+
+---
+
+### Auto-Recall
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `autoRecall` | `HINDSIGHT_AUTO_RECALL` | `true` | Master switch for auto-recall. |
+| `recallBudget` | `HINDSIGHT_RECALL_BUDGET` | `"mid"` | Search depth: `"low"` (fast), `"mid"` (balanced), `"high"` (thorough). |
+| `recallMaxTokens` | `HINDSIGHT_RECALL_MAX_TOKENS` | `1024` | Token budget for the injected memory block. |
+
+---
+
+### Auto-Retain
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `autoRetain` | `HINDSIGHT_AUTO_RETAIN` | `true` | Master switch for auto-retain. |
+| `retainEveryNTurns` | `HINDSIGHT_RETAIN_EVERY_N_TURNS` | `1` | Retain every N turns. Default `1` stores every turn on `Stop`. |
+
+## Relationship to ZCode's built-in memory
+
+ZCode ships its own local, per-project memory (`~/.zcode/cli/memories/`). Hindsight is complementary: it stores memory in a **cloud (or self-hosted) bank that is shared across tools** — the same bank powers Claude Code, Cursor, and other Hindsight integrations — so your context follows you between agents and machines rather than staying local to one ZCode project.


### PR DESCRIPTION
Fixes #2749.

## Problem

The extraction contract was internally inconsistent. The prompt's few-shot examples taught a flat string array:

```
entities=["Alice", "Kubernetes", "CKA"]
```

while the LLM-facing schema declared `list[Entity]` — objects with a `text` field.

Models that follow the prompt literally returned strings, so the entities were dropped: `entities`, `unit_entities` and `entity_cooccurrences` all stayed at 0 while retain reported success and recall kept working. Nothing failed loudly.

## Fix

Aligned on **strings**, matching what the examples already taught. The issue suggested the opposite direction — teaching the prompt to emit objects — but `Entity` was a single-field wrapper (`text: str`) carrying no information the bare string didn't, so it is **removed** rather than propagated into the prompt.

`entities` is now `list[str]` end to end:

- the four LLM-facing extraction models (`ExtractedFact`, `ExtractedFactVerbose`, `ExtractedFactNoCausal`, `VerbatimExtractedFact`) and the dynamically built labels-only model;
- the storage `Fact` model;
- which matches what the rest of the stack already used — `response_models.ExtractedFact` and the pipeline dataclass `retain.types.ExtractedFact` were both `list[str]` already. The `Entity` wrapper only ever existed between the LLM boundary and storage, and every consumer immediately unwrapped it via `[e.text for e in ...]`.

Deleting it also removes the `Entity(text=...)` / `.text` round-trip from the label post-processing path in both the streaming and batch parsers.

**`entities` stays optional** (not added to `json_schema_extra["required"]`): an omitted field is coerced to an empty list anyway, so requiring it would buy nothing and risks strict-schema providers rejecting otherwise-valid facts.

A shared `_coerce_entity_strings` before-validator still unwraps the legacy `{"text": "..."}` form, so responses from models that learned that shape — and in-flight batch jobs — are not lost. The prompt's `ENTITIES` section now states the string contract explicitly.

## Note on the prompt template

The "wrong form" line is phrased without literal `{}` braces on purpose. That template is `.format()`ed **twice** — assembly at import, then `retain_mission_section` at request time — so JSON braces there would need quadruple-escaping or raise `KeyError` at request time.

## Tests

- `tests/test_fact_extraction_entities_schema.py` — fast, no LLM: the array-of-strings JSON schema per model, that `entities` is deliberately *not* required, empty-list default, legacy-object coercion, and the labels-only dynamic model.
- `tests/test_fact_extraction_entities_llm.py` — marked `hs_llm_core`. The bug was **behavioural**: it takes a real model reading the real prompt, so MockLLM cannot reproduce it. Runs the actual pipeline and asserts entities come back populated.
- `tests/test_entity_labels.py` — updated for the string representation.

Verified locally (on an isolated pg0 port, see below): **95 passed** across `test_entity_labels.py` (including all 8 DB-backed retain/label tests) plus the two new suites, and **28 passed** across `test_batch_api.py` / `test_recall_observation_entities.py` / `test_entity_resolver.py` — the batch parser's entity block was rewritten, so that coverage matters. `./scripts/hooks/lint.sh` passes.

Local pg0 note: the DB-backed tests only run here with `HINDSIGHT_TEST_PG_PORT` set to a free port — the default 5556 is held by another worktree's instance, which surfaces as a setup error rather than a test failure.

## Unrelated change included

`skills/hindsight-docs/` (`retain.md`, `zcode.md`) is **pre-existing regen drift from `main`**, not from this change — the `generate-docs-skill.sh` pre-commit hook refreshed it and blocks committing without it. `verify-generated-files` would fail on it regardless of this PR.
