### PR TITLE
feat(pg0): carry optional user/password in pg0:// URLs

### DIFF
--- a/hindsight-api-slim/hindsight_api/admin/cli.py
+++ b/hindsight-api-slim/hindsight_api/admin/cli.py
@@ -76,7 +76,8 @@ async def _admin_connect(db_url: str) -> asyncpg.Connection:
     is the only step needed to connect. JSON codecs are registered so ``jsonb``
     columns decode to Python objects (used by the export row dumps).
     """
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     conn = await asyncpg.connect(await resolve_database_url(db_url))
@@ -177,7 +178,8 @@ async def _restore(database_url: str, input_path: Path, schema: str = "public") 
 
 async def _run_backup(db_url: str, output: Path, schema: str = "public") -> dict[str, Any]:
     """Resolve database URL and run backup."""
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)
@@ -186,7 +188,8 @@ async def _run_backup(db_url: str, output: Path, schema: str = "public") -> dict
 
 async def _run_restore(db_url: str, input_file: Path, schema: str = "public") -> dict[str, Any]:
     """Resolve database URL and run restore."""
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)
@@ -261,7 +264,8 @@ async def _run_migration(
     """Resolve database URL and run migrations for one schema or all discovered schemas."""
     from ..migrations import run_migrations_for_schemas
 
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)
@@ -472,7 +476,8 @@ def import_bank_command(
 
 async def _decommission_worker(db_url: str, worker_id: str, schema: str = "public") -> int:
     """Release all tasks owned by a worker, setting them back to pending status."""
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)
@@ -531,7 +536,8 @@ def decommission_worker(
 
 async def _decommission_all_workers(db_url: str, schema: str = "public") -> list[dict[str, Any]]:
     """Release all processing tasks from all workers, setting them back to pending status."""
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)
@@ -596,7 +602,8 @@ def decommission_workers(
 
 async def _worker_status(db_url: str, schema: str = "public") -> list[dict[str, Any]]:
     """Get all processing tasks grouped by worker with their last update time."""
-    is_pg0, instance_name, _ = parse_pg0_url(db_url)
+    _pg0 = parse_pg0_url(db_url)
+    is_pg0, instance_name = _pg0.is_pg0, _pg0.instance_name
     if is_pg0:
         typer.echo(f"Starting embedded PostgreSQL (instance: {instance_name})...")
     resolved_url = await resolve_database_url(db_url)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -995,7 +995,10 @@ class MemoryEngine(MemoryEngineInterface):
         # Initialize PostgreSQL connection URL
         # The actual URL will be set during initialize() after starting the server
         # Supports: "pg0" (default instance), "pg0://instance-name" (named instance), or regular postgresql:// URL
-        self._use_pg0, self._pg0_instance_name, self._pg0_port = parse_pg0_url(db_url)
+        _parsed_pg0 = parse_pg0_url(db_url)
+        self._use_pg0 = _parsed_pg0.is_pg0
+        self._pg0_instance_name = _parsed_pg0.instance_name
+        self._pg0_port = _parsed_pg0.port
         if self._use_pg0:
             self.db_url = None
         else:

--- a/hindsight-api-slim/hindsight_api/pg0.py
+++ b/hindsight-api-slim/hindsight_api/pg0.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -153,7 +154,22 @@ async def stop_embedded_postgres() -> None:
         await _default_instance.stop()
 
 
-def parse_pg0_url(db_url: str) -> tuple[bool, str | None, int | None]:
+@dataclass(frozen=True)
+class Pg0Url:
+    """Parsed representation of a ``pg0`` embedded-database URL.
+
+    ``username``/``password`` are ``None`` when the URL omits credentials, in
+    which case the pg0 defaults (``hindsight``/``hindsight``) apply.
+    """
+
+    is_pg0: bool
+    instance_name: str | None = None
+    port: int | None = None
+    username: str | None = None
+    password: str | None = None
+
+
+def parse_pg0_url(db_url: str) -> Pg0Url:
     """
     Parse a database URL and check if it's a pg0:// embedded database URL.
 
@@ -161,29 +177,47 @@ def parse_pg0_url(db_url: str) -> tuple[bool, str | None, int | None]:
     - "pg0" -> default instance "hindsight"
     - "pg0://instance-name" -> named instance
     - "pg0://instance-name:port" -> named instance with explicit port
+    - "pg0://user:pwd@instance-name:port" -> named instance with credentials
+      (``user`` or ``user:pwd``; either half may be present)
     - Any other URL (e.g., postgresql://) -> not a pg0 URL
 
     Args:
         db_url: The database URL to parse
 
     Returns:
-        Tuple of (is_pg0, instance_name, port)
-        - is_pg0: True if this is a pg0 URL
-        - instance_name: The instance name (or None if not pg0)
-        - port: The explicit port (or None for auto-assign)
+        A :class:`Pg0Url`. When ``is_pg0`` is False the remaining fields are None.
     """
     if db_url == "pg0":
-        return True, "hindsight", None
+        return Pg0Url(is_pg0=True, instance_name="hindsight")
 
-    if db_url.startswith("pg0://"):
-        url_part = db_url[6:]  # Remove "pg0://"
-        if ":" in url_part:
-            instance_name, port_str = url_part.rsplit(":", 1)
-            return True, instance_name or "hindsight", int(port_str)
-        else:
-            return True, url_part or "hindsight", None
+    if not db_url.startswith("pg0://"):
+        return Pg0Url(is_pg0=False)
 
-    return False, None, None
+    url_part = db_url[6:]  # Remove "pg0://"
+
+    # Split optional "user:pwd@" credentials from the "instance:port" host part.
+    # rsplit on the last "@" so passwords may contain "@".
+    username: str | None = None
+    password: str | None = None
+    if "@" in url_part:
+        creds, url_part = url_part.rsplit("@", 1)
+        user_part, sep, pwd_part = creds.partition(":")
+        username = user_part or None
+        password = pwd_part if sep else None
+
+    if ":" in url_part:
+        instance_name, port_str = url_part.rsplit(":", 1)
+        port: int | None = int(port_str)
+    else:
+        instance_name, port = url_part, None
+
+    return Pg0Url(
+        is_pg0=True,
+        instance_name=instance_name or "hindsight",
+        port=port,
+        username=username,
+        password=password,
+    )
 
 
 async def resolve_database_url(db_url: str) -> str:
@@ -199,8 +233,13 @@ async def resolve_database_url(db_url: str) -> str:
     Returns:
         The resolved postgresql:// connection URL
     """
-    is_pg0, instance_name, port = parse_pg0_url(db_url)
-    if is_pg0:
-        pg0 = EmbeddedPostgres(name=instance_name, port=port)
+    parsed = parse_pg0_url(db_url)
+    if parsed.is_pg0:
+        kwargs: dict[str, object] = {"name": parsed.instance_name, "port": parsed.port}
+        if parsed.username is not None:
+            kwargs["username"] = parsed.username
+        if parsed.password is not None:
+            kwargs["password"] = parsed.password
+        pg0 = EmbeddedPostgres(**kwargs)
         return await pg0.ensure_running()
     return db_url

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -163,7 +163,7 @@ def pg0_db_url(db_url, tmp_path_factory, worker_id):
     from hindsight_api.pg0 import parse_pg0_url as _parse_pg0_url
 
     # Determine pg0 instance name/port from db_url (if it's a pg0:// URL) or use defaults
-    if db_url and not _parse_pg0_url(db_url)[0]:
+    if db_url and not _parse_pg0_url(db_url).is_pg0:
         # Plain postgresql:// URL - use it directly but still run migrations
         from hindsight_api.migrations import run_migrations
 
@@ -171,9 +171,9 @@ def pg0_db_url(db_url, tmp_path_factory, worker_id):
         return db_url
 
     if db_url:
-        _, pg0_name, pg0_port = _parse_pg0_url(db_url)
-        pg0_instance_name = pg0_name or DEFAULT_PG0_INSTANCE_NAME
-        pg0_instance_port = pg0_port or DEFAULT_PG0_PORT
+        _parsed = _parse_pg0_url(db_url)
+        pg0_instance_name = _parsed.instance_name or DEFAULT_PG0_INSTANCE_NAME
+        pg0_instance_port = _parsed.port or DEFAULT_PG0_PORT
     else:
         pg0_instance_name = DEFAULT_PG0_INSTANCE_NAME
         pg0_instance_port = DEFAULT_PG0_PORT

--- a/hindsight-api-slim/tests/test_pg0_url.py
+++ b/hindsight-api-slim/tests/test_pg0_url.py
@@ -1,0 +1,65 @@
+"""Unit tests for pg0 URL parsing (`parse_pg0_url`)."""
+
+from hindsight_api.pg0 import Pg0Url, parse_pg0_url
+
+
+def test_bare_pg0():
+    assert parse_pg0_url("pg0") == Pg0Url(is_pg0=True, instance_name="hindsight")
+
+
+def test_named_instance():
+    assert parse_pg0_url("pg0://mydb") == Pg0Url(is_pg0=True, instance_name="mydb")
+
+
+def test_named_instance_with_port():
+    assert parse_pg0_url("pg0://mydb:5544") == Pg0Url(is_pg0=True, instance_name="mydb", port=5544)
+
+
+def test_empty_instance_falls_back_to_default():
+    assert parse_pg0_url("pg0://").instance_name == "hindsight"
+    assert parse_pg0_url("pg0://:5544") == Pg0Url(is_pg0=True, instance_name="hindsight", port=5544)
+
+
+def test_non_pg0_url_passthrough():
+    parsed = parse_pg0_url("postgresql://user:pwd@localhost:5432/db")
+    assert parsed == Pg0Url(is_pg0=False)
+
+
+def test_credentials_user_and_password():
+    assert parse_pg0_url("pg0://alice:s3cret@mydb:5544") == Pg0Url(
+        is_pg0=True,
+        instance_name="mydb",
+        port=5544,
+        username="alice",
+        password="s3cret",
+    )
+
+
+def test_credentials_user_only():
+    assert parse_pg0_url("pg0://alice@mydb") == Pg0Url(
+        is_pg0=True, instance_name="mydb", username="alice", password=None
+    )
+
+
+def test_credentials_without_port():
+    assert parse_pg0_url("pg0://alice:s3cret@mydb") == Pg0Url(
+        is_pg0=True, instance_name="mydb", username="alice", password="s3cret"
+    )
+
+
+def test_password_may_contain_at_sign():
+    # rsplit on the last "@" keeps an "@" inside the password intact.
+    assert parse_pg0_url("pg0://alice:p@ss@mydb:5544") == Pg0Url(
+        is_pg0=True,
+        instance_name="mydb",
+        port=5544,
+        username="alice",
+        password="p@ss",
+    )
+
+
+def test_empty_password_after_colon_is_empty_string():
+    # "user:" explicitly sets an empty password (distinct from omitting it).
+    assert parse_pg0_url("pg0://alice:@mydb") == Pg0Url(
+        is_pg0=True, instance_name="mydb", username="alice", password=""
+    )

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -875,9 +875,7 @@ def test_query_analyzer_rejects_bare_word_false_positive(query_analyzer):
 
     analysis = query_analyzer.analyze("what did we discuss", reference_date)
 
-    assert analysis.temporal_constraint is None, (
-        "A bare false-positive word must not produce a temporal constraint"
-    )
+    assert analysis.temporal_constraint is None, "A bare false-positive word must not produce a temporal constraint"
 
 
 def test_query_analyzer_prefers_explicit_date_over_leading_weak_word(query_analyzer):
@@ -885,9 +883,7 @@ def test_query_analyzer_prefers_explicit_date_over_leading_weak_word(query_analy
     ("me"/"we") regardless of position in the query."""
     reference_date = datetime(2026, 7, 17, 12, 0, 0)  # Friday
 
-    analysis = query_analyzer.analyze(
-        "tell me what we decided on 2026-06-10", reference_date
-    )
+    analysis = query_analyzer.analyze("tell me what we decided on 2026-06-10", reference_date)
 
     assert analysis.temporal_constraint is not None, "Should extract the explicit date"
     assert analysis.temporal_constraint.start_date.year == 2026


### PR DESCRIPTION
## Summary

Extend the embedded `pg0` database URL syntax to carry optional credentials:

```
pg0://user:pwd@instance:port
```

Every half is optional, so all of these are valid and backward compatible:

| URL | instance | port | user | pwd |
|---|---|---|---|---|
| `pg0` | hindsight | auto | default | default |
| `pg0://mydb` | mydb | auto | default | default |
| `pg0://mydb:5544` | mydb | 5544 | default | default |
| `pg0://alice@mydb` | mydb | auto | alice | default |
| `pg0://alice:s3cret@mydb:5544` | mydb | 5544 | alice | s3cret |

Previously every pg0 instance was pinned to the hardcoded `hindsight`/`hindsight`
credentials, because the URL parser only carried instance name and port.
`EmbeddedPostgres` already accepted `username`/`password` — they just weren't
threaded through the URL layer. This wires them, so a single
`HINDSIGHT_API_DATABASE_URL` fully describes the connection.

## Changes

- `parse_pg0_url` now returns a `Pg0Url` dataclass instead of a 3-tuple
  (clears the multi-item tuple return per project standards, matches the recent
  dataclass refactor on the graph-maintenance work). Callers in `admin/cli.py`,
  `engine/memory_engine.py`, and `tests/conftest.py` updated to attribute access.
- `resolve_database_url` passes `username`/`password` into `EmbeddedPostgres`
  only when present, so omitting them keeps the pg0 defaults.
- Credentials split on the **last** `@` so passwords may contain `@`.
- New `tests/test_pg0_url.py` covering the legacy forms plus credentials,
  `@`-in-password, and the `user:` empty-password edge case.

## Supersedes #2799

#2799 addressed the same underlying concern (pg0 hardcoded credentials) by adding
a dedicated `HINDSIGHT_API_PG0_PASSWORD` env var. This PR generalizes that: rather
than a single password-only override, credentials live in the connection URL
alongside instance/port, so both user and password are configurable through the
existing `HINDSIGHT_API_DATABASE_URL` with no new env var. Closing #2799 in favor
of this approach.
