### PR TITLE
fix(worker): count crash-recovery attempts toward max-retry budget (#2675)

### DIFF
--- a/hindsight-api-slim/hindsight_api/worker/main.py
+++ b/hindsight-api-slim/hindsight_api/worker/main.py
@@ -269,6 +269,7 @@ def main():
             max_slots=config.worker_max_slots,
             slot_reservations=config.worker_slot_reservations,
             consolidation_bank_priority=config.worker_consolidation_bank_priority or None,
+            max_retries=config.worker_max_retries,
         )
 
         # Create the HTTP app for metrics/health

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -847,8 +847,14 @@ class WorkerPoller:
                         self._worker_id,
                         max_retries,
                     )
-                    # Tasks that exceeded the limit: move to failed
-                    failed_result = await conn.execute(
+                    # Tasks that exceeded the limit: move to failed. RETURNING
+                    # gives us the ids so their parent aggregators can be rolled
+                    # up below — a batch_retain child sub-batch carries
+                    # parent_operation_id (not batch_id) in its metadata, so it IS
+                    # eligible to be failed here, and without propagating that
+                    # terminal state the parent is stranded in 'processing' forever
+                    # (the same crash loop this method fixes, one level up).
+                    failed_rows = await conn.fetch(
                         f"""
                         UPDATE {table}
                         SET status = 'failed', worker_id = NULL, claimed_at = NULL,
@@ -857,13 +863,25 @@ class WorkerPoller:
                         WHERE status = 'processing' AND worker_id = $1
                           AND result_metadata->>'batch_id' IS NULL
                           AND COALESCE(retry_count, 0) >= $2
+                        RETURNING operation_id
                         """,
                         self._worker_id,
                         max_retries,
                     )
 
+                # Roll each failed child up to its parent aggregator, one
+                # transaction per child so a single problematic parent can't undo
+                # the others — mirrors the per-task transaction the in-process
+                # _mark_failed path uses. The failing UPDATE above already committed,
+                # so the children stay failed regardless; _maybe_update_parent_operation
+                # no-ops for tasks without a parent_operation_id.
+                for failed_row in failed_rows:
+                    async with self._backend.acquire() as conn:
+                        async with conn.transaction():
+                            await self._maybe_update_parent_operation(str(failed_row["operation_id"]), schema, conn)
+
                 pending_count = int(result.split()[-1]) if result else 0
-                failed_count = int(failed_result.split()[-1]) if failed_result else 0
+                failed_count = len(failed_rows)
                 total_count += pending_count
                 if failed_count > 0:
                     schema_display = f'"{schema}"' if schema else str(schema)

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -161,6 +161,7 @@ class WorkerPoller:
         max_slots: int = 10,
         slot_reservations: dict[str, int] | None = None,
         consolidation_bank_priority: dict[str, int] | None = None,
+        max_retries: int = 3,
     ):
         """
         Initialize the worker poller.
@@ -183,6 +184,8 @@ class WorkerPoller:
                 Patterns support ``*`` as wildcard. A bare ``*`` key is the catch-all default.
                 When set, consolidation tasks are claimed in priority tiers rather than
                 pure created_at order. None or empty dict preserves current behavior.
+            max_retries: Maximum retry attempts before a task is marked failed.
+                Must be >= 0. Default 3 (matches DEFAULT_WORKER_MAX_RETRIES).
         """
         self._backend = backend
         self._worker_id = worker_id
@@ -204,6 +207,7 @@ class WorkerPoller:
         self._consolidation_bank_priority: dict[str, int] | None = (
             consolidation_bank_priority if consolidation_bank_priority else None
         )
+        self._max_retries = max(0, max_retries)  # Never negative
         # Cache of which optional PG routines are installed on the server
         # (probed once, memoised for the life of the poller).
         from ..engine.db.optional_routines import OptionalRoutines
@@ -797,14 +801,18 @@ class WorkerPoller:
 
         This handles the case where a worker crashes while processing tasks.
         On startup, we reset any tasks stuck in 'processing' for this worker_id
-        back to 'pending' so they can be picked up again.
+        back to 'pending' so they can be picked up again — provided their
+        ``retry_count`` has not reached ``max_retries``. Tasks at/over the
+        limit are moved to 'failed' with an explanatory error message,
+        breaking the infinite loop where a task that kills the worker
+        (OOM, infinite loop) is re-claimed forever.
 
         Also recovers batch API operations that were in-flight.
 
         If tenant_extension is configured, recovers across all tenant schemas.
 
         Returns:
-            Number of tasks recovered
+            Number of tasks recovered (reset to pending, not including failed)
         """
         schemas = await self._get_schemas()
         total_count = 0
@@ -817,20 +825,53 @@ class WorkerPoller:
                 batch_count = await self._recover_batch_operations(schema)
                 total_count += batch_count
 
-                # Then reset normal worker tasks
+                # Then reset normal worker tasks. Crash-interrupted tasks count
+                # toward the retry budget (worker_max_retries / HINDSIGHT_API_WORKER_MAX_RETRIES).
+                # Without this, a task that kills the worker (OOM, infinite loop)
+                # is reset forever: claim → grind → crash → recover → re-claim…
+                # Two separate UPDATEs so their row counts are meaningful:
+                #   1. Tasks under limit → increment retry_count, reset to pending
+                #   2. Tasks at/over limit → move to failed with a clear reason
+                max_retries = self._max_retries
                 async with self._backend.acquire() as conn:
+                    # Tasks under the limit: increment retry_count and reset to pending
                     result = await conn.execute(
                         f"""
                         UPDATE {table}
-                        SET status = 'pending', worker_id = NULL, claimed_at = NULL, updated_at = now()
-                        WHERE status = 'processing' AND worker_id = $1 AND result_metadata->>'batch_id' IS NULL
+                        SET status = 'pending', worker_id = NULL, claimed_at = NULL,
+                            retry_count = COALESCE(retry_count, 0) + 1, updated_at = now()
+                        WHERE status = 'processing' AND worker_id = $1
+                          AND result_metadata->>'batch_id' IS NULL
+                          AND COALESCE(retry_count, 0) < $2
                         """,
                         self._worker_id,
+                        max_retries,
+                    )
+                    # Tasks that exceeded the limit: move to failed
+                    failed_result = await conn.execute(
+                        f"""
+                        UPDATE {table}
+                        SET status = 'failed', worker_id = NULL, claimed_at = NULL,
+                            error_message = 'exceeded max recovery attempts after crash (retry_count >= {max_retries})',
+                            completed_at = now(), updated_at = now()
+                        WHERE status = 'processing' AND worker_id = $1
+                          AND result_metadata->>'batch_id' IS NULL
+                          AND COALESCE(retry_count, 0) >= $2
+                        """,
+                        self._worker_id,
+                        max_retries,
                     )
 
-                # Parse "UPDATE N" to get count
-                count = int(result.split()[-1]) if result else 0
-                total_count += count
+                pending_count = int(result.split()[-1]) if result else 0
+                failed_count = int(failed_result.split()[-1]) if failed_result else 0
+                total_count += pending_count
+                if failed_count > 0:
+                    schema_display = f'"{schema}"' if schema else str(schema)
+                    logger.warning(
+                        f"Worker {self._worker_id} moved {failed_count} tasks to 'failed' "
+                        f"(exceeded {max_retries} recovery attempts in schema "
+                        f"{schema_display})"
+                    )
             except Exception as e:
                 # Format schema for logging: custom schemas in quotes, None as-is
                 schema_display = f'"{schema}"' if schema else str(schema)

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1290,11 +1290,16 @@ class TestWorkerRecovery:
                  worker_id, retry_count, claimed_at)
             VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, 1, now())
             """,
-            op_id, bank_id, payload, worker_id,
+            op_id,
+            bank_id,
+            payload,
+            worker_id,
         )
 
         poller = WorkerPoller(
-            backend=backend, worker_id=worker_id, executor=lambda x: None,
+            backend=backend,
+            worker_id=worker_id,
+            executor=lambda x: None,
         )
         recovered = await poller.recover_own_tasks()
         assert recovered == 1
@@ -1328,11 +1333,17 @@ class TestWorkerRecovery:
                      worker_id, retry_count, claimed_at)
                 VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, $5, now())
                 """,
-                op_id, bank_id, payload, worker_id, rc,
+                op_id,
+                bank_id,
+                payload,
+                worker_id,
+                rc,
             )
 
         poller = WorkerPoller(
-            backend=backend, worker_id=worker_id, executor=lambda x: None,
+            backend=backend,
+            worker_id=worker_id,
+            executor=lambda x: None,
             max_retries=3,
         )
         recovered = await poller.recover_own_tasks()
@@ -1374,11 +1385,16 @@ class TestWorkerRecovery:
                  worker_id, claimed_at)
             VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, now())
             """,
-            op_id, bank_id, payload, worker_id,
+            op_id,
+            bank_id,
+            payload,
+            worker_id,
         )
 
         poller = WorkerPoller(
-            backend=backend, worker_id=worker_id, executor=lambda x: None,
+            backend=backend,
+            worker_id=worker_id,
+            executor=lambda x: None,
         )
         recovered = await poller.recover_own_tasks()
         assert recovered == 1

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1406,6 +1406,76 @@ class TestWorkerRecovery:
         assert row["status"] == "pending"
         assert row["retry_count"] == 1  # COALESCE(NULL, 0) + 1
 
+    @pytest.mark.asyncio
+    async def test_recover_own_tasks_failed_child_propagates_to_parent(self, pool, backend, clean_operations):
+        """A crash-failed batch_retain child must roll its parent up to a terminal state.
+
+        A batch_retain child sub-batch carries `parent_operation_id` (not `batch_id`)
+        in its metadata, so crash recovery *can* move it to 'failed' once it exceeds
+        the retry budget. If that terminal transition does not propagate to the parent
+        aggregator operation, the parent is left stuck in 'processing' forever — the
+        same failure mode this PR set out to fix, one level up.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        worker_id = "crash-loop-batch-worker"
+
+        # Parent aggregator: 'processing', not owned by any worker (children do the
+        # work). Recovery must not touch it directly — only via child roll-up.
+        parent_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, result_metadata)
+            VALUES ($1, $2, 'batch_retain', 'processing', '{}'::jsonb)
+            """,
+            parent_id,
+            bank_id,
+        )
+
+        # Sole child sub-batch, crash-interrupted at the retry limit.
+        child_id = uuid.uuid4()
+        child_payload = json.dumps({"type": "retain", "bank_id": bank_id})
+        child_metadata = json.dumps({"parent_operation_id": str(parent_id)})
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload,
+                 result_metadata, worker_id, retry_count, claimed_at)
+            VALUES ($1, $2, 'retain', 'processing', $3::jsonb, $4::jsonb, $5, 3, now())
+            """,
+            child_id,
+            bank_id,
+            child_payload,
+            child_metadata,
+            worker_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend,
+            worker_id=worker_id,
+            executor=lambda x: None,
+            max_retries=3,
+        )
+        await poller.recover_own_tasks()
+
+        # Child exceeded the budget → failed.
+        child_row = await pool.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            child_id,
+        )
+        assert child_row["status"] == "failed"
+
+        # Parent must roll up to failed once its only child is terminal — not be
+        # left stranded in 'processing'.
+        parent_row = await pool.fetchrow(
+            "SELECT status FROM async_operations WHERE operation_id = $1",
+            parent_id,
+        )
+        assert parent_row["status"] == "failed"
+
 
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -1271,6 +1271,125 @@ class TestWorkerRecovery:
         recovered_count = await poller.recover_own_tasks()
         assert recovered_count == 0
 
+    @pytest.mark.asyncio
+    async def test_recover_own_tasks_increments_retry_count(self, pool, backend, clean_operations):
+        """Test that crash recovery increments retry_count."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        worker_id = "crashed-worker-v2"
+
+        # Create a task with existing retry_count=1
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload,
+                 worker_id, retry_count, claimed_at)
+            VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, 1, now())
+            """,
+            op_id, bank_id, payload, worker_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend, worker_id=worker_id, executor=lambda x: None,
+        )
+        recovered = await poller.recover_own_tasks()
+        assert recovered == 1
+
+        # retry_count should have been incremented from 1 → 2
+        row = await pool.fetchrow(
+            "SELECT status, retry_count FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending"
+        assert row["retry_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_recover_own_tasks_moves_exceeded_to_failed(self, pool, backend, clean_operations):
+        """Test that tasks exceeding max_retries are moved to failed."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        worker_id = "crash-loop-worker"
+
+        # Create 2 tasks at the threshold (retry_count=3, max_retries=3 → at limit)
+        op_ok = uuid.uuid4()
+        op_fail = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        for i, (op_id, rc) in enumerate([(op_ok, 2), (op_fail, 3)]):
+            await pool.execute(
+                """
+                INSERT INTO async_operations
+                    (operation_id, bank_id, operation_type, status, task_payload,
+                     worker_id, retry_count, claimed_at)
+                VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, $5, now())
+                """,
+                op_id, bank_id, payload, worker_id, rc,
+            )
+
+        poller = WorkerPoller(
+            backend=backend, worker_id=worker_id, executor=lambda x: None,
+            max_retries=3,
+        )
+        recovered = await poller.recover_own_tasks()
+        # Only the under-limit task should be counted as recovered
+        assert recovered == 1
+
+        # Task at retry_count=2 → should become pending (now retry_count=3)
+        row_ok = await pool.fetchrow(
+            "SELECT status, retry_count FROM async_operations WHERE operation_id = $1",
+            op_ok,
+        )
+        assert row_ok["status"] == "pending"
+        assert row_ok["retry_count"] == 3
+
+        # Task at retry_count=3 → should be moved to failed
+        row_fail = await pool.fetchrow(
+            "SELECT status, retry_count, error_message FROM async_operations WHERE operation_id = $1",
+            op_fail,
+        )
+        assert row_fail["status"] == "failed"
+        assert row_fail["error_message"] is not None
+        assert "exceeded" in row_fail["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_recover_own_tasks_handles_null_retry_count(self, pool, backend, clean_operations):
+        """Test that COALESCE handles NULL retry_count gracefully."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+        worker_id = "null-retry-worker"
+
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "test_task", "bank_id": bank_id})
+        await pool.execute(
+            """
+            INSERT INTO async_operations
+                (operation_id, bank_id, operation_type, status, task_payload,
+                 worker_id, claimed_at)
+            VALUES ($1, $2, 'test', 'processing', $3::jsonb, $4, now())
+            """,
+            op_id, bank_id, payload, worker_id,
+        )
+
+        poller = WorkerPoller(
+            backend=backend, worker_id=worker_id, executor=lambda x: None,
+        )
+        recovered = await poller.recover_own_tasks()
+        assert recovered == 1
+
+        row = await pool.fetchrow(
+            "SELECT status, retry_count FROM async_operations WHERE operation_id = $1",
+            op_id,
+        )
+        assert row["status"] == "pending"
+        assert row["retry_count"] == 1  # COALESCE(NULL, 0) + 1
+
 
 class TestConcurrentWorkers:
     """Tests for concurrent worker task claiming (FOR UPDATE SKIP LOCKED)."""


### PR DESCRIPTION
## Summary

When a worker crashes while processing an `async_operations` row (OOM, infinite loop, etc.), no failure bookkeeping runs — `retry_count` is only incremented by in-process failure handling. On restart, `recover_own_tasks` resets `processing` rows back to `pending` with `retry_count` untouched, and the row is re-claimed as if brand new.

An operation that can never complete therefore loops forever: claim → grind → crash → recover → re-claim…

**This bug still exists in main after #2819** (which refactored operation cleanup into database routines but removed the crash-recovery retry-counting logic as a side effect of simplifying `recover_own_tasks`).

## Changes

- `Poller.__init__`: accepts `max_retries` (default 3, matches `DEFAULT_WORKER_MAX_RETRIES`)
- `recover_own_tasks`: two UPDATEs:
  - Tasks under the limit: increment `retry_count` via `COALESCE(retry_count, 0) + 1`, reset to pending
  - Tasks at/over the limit: move to `failed` with an explanatory `error_message`
- `main.py`: wires `config.worker_max_retries` into the Poller

## What changed from #2786

The original PR (#2786) introduced a **new** config field (`max_recovery_attempts`). This version **reuses the existing `HINDSIGHT_API_WORKER_MAX_RETRIES`** (per review feedback: "nice catch, but we must reuse HINDSIGHT_API_WORKER_MAX_RETRIES"). It is also adapted to the post-#2819 codebase (no conflicts, no added retention/cleanup parameters).

## Verification

- ✅ 3 new tests: `retry_count` increment, exceeded→failed threshold, NULL `retry_count` handling
- ✅ Existing recovery tests unchanged (still pass — the default `max_retries=3` preserves existing behavior for fresh tasks)
- ✅ No conflicts with upstream main (built on top of #2819)
- ✅ `ruff check` passes
- ✅ `max_retries=0` edge case: all crash-interrupted tasks fail immediately (clamped via `max(0, max_retries)`)

Closes #2675