### PR TITLE
fix(lint): ruff-format test_query_analyzer.py to unblock verify-generated-files

### DIFF
--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -875,9 +875,7 @@ def test_query_analyzer_rejects_bare_word_false_positive(query_analyzer):
 
     analysis = query_analyzer.analyze("what did we discuss", reference_date)
 
-    assert analysis.temporal_constraint is None, (
-        "A bare false-positive word must not produce a temporal constraint"
-    )
+    assert analysis.temporal_constraint is None, "A bare false-positive word must not produce a temporal constraint"
 
 
 def test_query_analyzer_prefers_explicit_date_over_leading_weak_word(query_analyzer):
@@ -885,9 +883,7 @@ def test_query_analyzer_prefers_explicit_date_over_leading_weak_word(query_analy
     ("me"/"we") regardless of position in the query."""
     reference_date = datetime(2026, 7, 17, 12, 0, 0)  # Friday
 
-    analysis = query_analyzer.analyze(
-        "tell me what we decided on 2026-06-10", reference_date
-    )
+    analysis = query_analyzer.analyze("tell me what we decided on 2026-06-10", reference_date)
 
     assert analysis.temporal_constraint is not None, "Should extract the explicit date"
     assert analysis.temporal_constraint.start_date.year == 2026


### PR DESCRIPTION
`hindsight-api-slim/tests/test_query_analyzer.py` landed on `main` with formatting that `ruff format` doesn't consider stable (multi-line asserts/calls that fit within the 120-col limit collapse to one line).

The `verify-generated-files` CI job runs `ruff format` and fails on the resulting diff, so it has been **red on every open PR that runs it** — #2826 and #2828 both fail `verify-generated-files` for this reason, independent of their own changes. That ambient red masks real failures.

Format-only, no behavioural change. `ruff format --check .` is now clean across `hindsight-api-slim` (535 files already formatted; this was the lone drift).