### PR TITLE
fix(pg0): honor URL credentials during MemoryEngine startup

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -999,6 +999,8 @@ class MemoryEngine(MemoryEngineInterface):
         self._use_pg0 = _parsed_pg0.is_pg0
         self._pg0_instance_name = _parsed_pg0.instance_name
         self._pg0_port = _parsed_pg0.port
+        self._pg0_username = _parsed_pg0.username
+        self._pg0_password = _parsed_pg0.password
         if self._use_pg0:
             self.db_url = None
         else:
@@ -2793,9 +2795,15 @@ class MemoryEngine(MemoryEngineInterface):
         async def start_pg0():
             """Start pg0 if configured."""
             if self._use_pg0:
-                kwargs = {"name": self._pg0_instance_name}
+                kwargs: dict[str, object] = {"name": self._pg0_instance_name}
                 if self._pg0_port is not None:
                     kwargs["port"] = self._pg0_port
+                # Preserve an explicitly empty password: pg0://user:@instance is
+                # distinct from omitting credentials and using pg0's defaults.
+                if self._pg0_username is not None:
+                    kwargs["username"] = self._pg0_username
+                if self._pg0_password is not None:
+                    kwargs["password"] = self._pg0_password
                 pg0 = EmbeddedPostgres(**kwargs)
                 # Check if pg0 is already running before we start it
                 was_already_running = await pg0.is_running()

--- a/hindsight-api-slim/tests/test_pg0_url.py
+++ b/hindsight-api-slim/tests/test_pg0_url.py
@@ -1,6 +1,35 @@
-"""Unit tests for pg0 URL parsing (`parse_pg0_url`)."""
+"""Unit tests for pg0 URL parsing and MemoryEngine startup."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hindsight_api import MemoryEngine
+from hindsight_api.engine.task_backend import SyncTaskBackend
 from hindsight_api.pg0 import Pg0Url, parse_pg0_url
+
+
+class _StopInitialization(Exception):
+    """Abort startup after pg0 is constructed, before opening a database pool."""
+
+
+class _NoopEmbeddings:
+    provider_name = "test"
+
+    async def initialize(self) -> None:
+        return None
+
+
+class _NoopCrossEncoder:
+    provider_name = "test"
+
+    async def initialize(self) -> None:
+        return None
+
+
+class _NoopQueryAnalyzer:
+    def load(self) -> None:
+        return None
 
 
 def test_bare_pg0():
@@ -63,3 +92,51 @@ def test_empty_password_after_colon_is_empty_string():
     assert parse_pg0_url("pg0://alice:@mydb") == Pg0Url(
         is_pg0=True, instance_name="mydb", username="alice", password=""
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("db_url", "expected_username", "expected_password"),
+    [
+        ("pg0://alice:s3cret@mydb:5544", "alice", "s3cret"),
+        ("pg0://alice:@mydb:5544", "alice", ""),
+        ("pg0://mydb:5544", None, None),
+    ],
+)
+async def test_memory_engine_forwards_pg0_credentials(
+    db_url: str,
+    expected_username: str | None,
+    expected_password: str | None,
+) -> None:
+    """The primary server startup must honor the same URL contract as the parser."""
+    with patch("hindsight_api.engine.memory_engine.EmbeddedPostgres") as embedded_postgres:
+        pg0 = embedded_postgres.return_value
+        pg0.is_running = AsyncMock(return_value=True)
+        pg0.ensure_running = AsyncMock(return_value="postgresql://resolved")
+
+        engine = MemoryEngine(
+            db_url=db_url,
+            memory_llm_provider="none",
+            memory_llm_model="none",
+            embeddings=_NoopEmbeddings(),
+            cross_encoder=_NoopCrossEncoder(),
+            query_analyzer=_NoopQueryAnalyzer(),
+            run_migrations=False,
+            task_backend=SyncTaskBackend(),
+            skip_llm_verification=True,
+        )
+        assert engine._backend is not None
+        engine._backend.initialize = AsyncMock(side_effect=_StopInitialization)  # type: ignore[method-assign]
+
+        with pytest.raises(_StopInitialization):
+            await engine.initialize()
+
+    if expected_username is None:
+        embedded_postgres.assert_called_once_with(name="mydb", port=5544)
+    else:
+        embedded_postgres.assert_called_once_with(
+            name="mydb",
+            port=5544,
+            username=expected_username,
+            password=expected_password,
+        )


### PR DESCRIPTION
## Summary

- retain parsed pg0 username/password in `MemoryEngine`
- forward them when the primary API startup constructs `EmbeddedPostgres`
- preserve both legacy default credentials and the explicit empty-password form

## Context

#2832 added optional credentials to `pg0://` URLs and forwards them through `resolve_database_url()`. The main server path parses the same URL separately, but previously kept only the instance name and port, so `pg0://alice:s3cret@mydb:5544` silently started or connected with pg0's default credentials instead.

The regression test exercises `MemoryEngine.initialize()` itself for full credentials, an explicitly empty password, and a credential-free URL.

## Verification

- `uv run pytest -q tests/test_pg0_url.py` — 13 passed
- repository `./scripts/hooks/lint.sh` — passed
- Codex adversarial review — approved
