### PR TITLE
fix(memory): preserve bank attribution during curation

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -113,9 +113,9 @@ def _bind_bank_id(
         @functools.wraps(func)
         async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             value = sig.bind(*args, **kwargs).arguments.get(arg)
-            if key is not None and isinstance(value, dict):
+            if key is not None and type(value) is dict:
                 value = value.get(key)
-            token = _current_bank_id.set(value if isinstance(value, str) else None)
+            token = _current_bank_id.set(value if type(value) is str else None)
             try:
                 return await func(*args, **kwargs)
             finally:
@@ -6613,6 +6613,7 @@ class MemoryEngine(MemoryEngineInterface):
         )
         return ", ".join(f'"{r["attname"]}"' for r in rows)
 
+    @_bind_bank_id()
     async def update_memory_unit(
         self,
         bank_id: str,

--- a/hindsight-api-slim/tests/test_bank_attribution.py
+++ b/hindsight-api-slim/tests/test_bank_attribution.py
@@ -98,9 +98,10 @@ class TestBindBankIdDecorator:
 
         assert await op(12345) is None
 
-    async def test_reflect_async_binds_and_resets_its_bank_argument(self):
+    async def test_engine_provider_paths_bind_and_reset_their_bank_arguments(self):
         engine = object.__new__(MemoryEngine)
         engine._reflect_llm_config = None
+        engine._operation_validator = None
         observed_bank_ids: list[str | None] = []
 
         with patch(
@@ -111,6 +112,25 @@ class TestBindBankIdDecorator:
                 await engine.reflect_async("user-reflect", "question", request_context=RequestContext())
 
         assert observed_bank_ids == ["user-reflect", "user-reflect"]
+        assert get_current_bank_id() is None
+
+        with (
+            patch.object(
+                engine,
+                "_authenticate_tenant",
+                AsyncMock(side_effect=lambda _context: observed_bank_ids.append(get_current_bank_id())),
+            ),
+            patch.object(engine, "_get_backend", AsyncMock(side_effect=RuntimeError("stop after authentication"))),
+        ):
+            with pytest.raises(RuntimeError, match="stop after authentication"):
+                await engine.update_memory_unit(
+                    "user-update",
+                    "54a647e5-0a22-4e5d-8504-b8bfca2a6142",
+                    text="corrected",
+                    request_context=RequestContext(),
+                )
+
+        assert observed_bank_ids[-1] == "user-update"
         assert get_current_bank_id() is None
 
 


### PR DESCRIPTION
## Summary

- bind `update_memory_unit` to the same per-bank context used by retain, recall, reflect, and worker operations
- preserve the canonical OpenAI `user=<bank_id>` attribution on embeddings generated while editing or restoring a memory
- use exact canonical value types in the bank-context decorator
- strengthen the existing bank-attribution regression test without adding a new test

## Why

Editing a memory re-embeds its text. `update_memory_unit` did not bind `_current_bank_id`, so an OpenAI-compatible embeddings gateway that requires Hindsight bank attribution received no `user` field and rejected the update. The engine already owns the bank ID at this boundary; binding it here keeps update/revert provider calls consistent with the other bank-scoped engine operations.

## Validation

- `uv run pytest tests/test_bank_attribution.py -q` (15 passed)
- `./scripts/hooks/lint.sh` (passed)

The broader local curation suite was not used as a signal because its persistent development database is at migration `d7b2f8a1c934`, newer than the checked-out code, and fails before exercising this change (`invalidated_memory_units.search_vector` schema mismatch). The deterministic regression suite above covers the changed context boundary.