### PR TITLE
feat: add tags filtering to list_memories / list_memory_units

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3588,6 +3588,8 @@ def _register_routes(app: FastAPI):
         consolidation_state: str | None = None,
         state: str | None = None,
         document_id: str | None = None,
+        tags: list[str] | None = Query(default=None),
+        tags_match: TagsMatch = Query(default="any"),
         limit: int = Query(default=100, ge=0),
         offset: int = Query(default=0, ge=0),
         request_context: RequestContext = Depends(get_request_context),
@@ -3604,6 +3606,8 @@ def _register_routes(app: FastAPI):
             q: Search query for full-text search (searches text and context)
             consolidation_state: Filter by consolidation state for source memories
                 (world/experience). One of 'failed', 'pending', or 'done'.
+            tags: Optional list of tag names to filter by.
+            tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
             limit: Maximum number of results (default: 100)
             offset: Offset for pagination (default: 0)
         """
@@ -3615,6 +3619,8 @@ def _register_routes(app: FastAPI):
                 consolidation_state=consolidation_state,
                 state=state,
                 document_id=document_id,
+                tags=tags,
+                tags_match=tags_match,
                 limit=limit,
                 offset=offset,
                 request_context=request_context,

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3607,7 +3607,9 @@ def _register_routes(app: FastAPI):
             consolidation_state: Filter by consolidation state for source memories
                 (world/experience). One of 'failed', 'pending', or 'done'.
             tags: Optional list of tag names to filter by.
-            tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
+            tags_match: How to combine tags: 'any' (OR, default) or 'all' (AND) both
+                also include untagged memories; 'any_strict'/'all_strict' exclude
+                untagged; 'exact' matches the tag set exactly.
             limit: Maximum number of results (default: 100)
             offset: Offset for pagination (default: 0)
         """

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7536,6 +7536,8 @@ class MemoryEngine(MemoryEngineInterface):
         consolidation_state: str | None = None,
         state: str | None = None,
         document_id: str | None = None,
+        tags: list[str] | None = None,
+        tags_match: TagsMatch = "any",
         limit: int = 100,
         offset: int = 0,
         request_context: "RequestContext",
@@ -7548,6 +7550,11 @@ class MemoryEngine(MemoryEngineInterface):
             fact_type: Filter by fact type (world, experience)
             search_query: Full-text search query (searches text and context fields)
             document_id: Optional filter to a single source document.
+            tags: Optional list of tag names to filter by. Only memory units
+                associated with at least one (tags_match='any') or all
+                (tags_match='all') of the given tags are returned.
+            tags_match: How to combine multiple tags: 'any' (OR, default) returns
+                units matching any tag, 'all' (AND) returns units matching all tags.
             state: Optional curation-state filter ('valid' or 'invalidated').
                 Invalidated facts live in a separate archive table; 'invalidated'
                 reads that archive. Omitted/('valid') lists live facts.
@@ -7622,6 +7629,15 @@ class MemoryEngine(MemoryEngineInterface):
                     raise ValueError(
                         f"Invalid consolidation_state '{consolidation_state}': expected 'failed', 'pending', or 'done'."
                     )
+
+            if tags:
+                tags_clause, tags_params, next_param = build_tags_where_clause(
+                    tags, param_count + 1, "", tags_match
+                )
+                if tags_clause:
+                    query_conditions.append(tags_clause.lstrip("AND "))
+                    query_params.extend(tags_params)
+                    param_count = next_param - 1
 
             where_clause = "WHERE " + " AND ".join(query_conditions) if query_conditions else ""
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7550,11 +7550,13 @@ class MemoryEngine(MemoryEngineInterface):
             fact_type: Filter by fact type (world, experience)
             search_query: Full-text search query (searches text and context fields)
             document_id: Optional filter to a single source document.
-            tags: Optional list of tag names to filter by. Only memory units
-                associated with at least one (tags_match='any') or all
-                (tags_match='all') of the given tags are returned.
-            tags_match: How to combine multiple tags: 'any' (OR, default) returns
-                units matching any tag, 'all' (AND) returns units matching all tags.
+            tags: Optional list of tag names to filter by. When omitted, no tag
+                filtering is applied (except tags_match='exact', which then selects
+                the untagged/global scope).
+            tags_match: How to combine tags (same modes as recall): 'any' (OR,
+                default) or 'all' (AND) both also include untagged units;
+                'any_strict'/'all_strict' exclude untagged units; 'exact' matches
+                units whose tag set equals the given tags exactly.
             state: Optional curation-state filter ('valid' or 'invalidated').
                 Invalidated facts live in a separate archive table; 'invalidated'
                 reads that archive. Omitted/('valid') lists live facts.
@@ -7631,13 +7633,15 @@ class MemoryEngine(MemoryEngineInterface):
                     )
 
             if tags:
-                tags_clause, tags_params, next_param = build_tags_where_clause(
-                    tags, param_count + 1, "", tags_match
-                )
+                tags_clause, tags_params, next_param = build_tags_where_clause(tags, param_count + 1, "", tags_match)
                 if tags_clause:
-                    query_conditions.append(tags_clause.lstrip("AND "))
+                    query_conditions.append(tags_clause.removeprefix("AND "))
                     query_params.extend(tags_params)
                     param_count = next_param - 1
+            elif tags_match == "exact":
+                # Exact match with no tags is the "global" scope: rows that carry no
+                # tags at all. (Other match modes treat empty tags as "no filter".)
+                query_conditions.append("(tags IS NULL OR tags = '{}')")
 
             where_clause = "WHERE " + " AND ".join(query_conditions) if query_conditions else ""
 

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -2245,6 +2245,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             limit: int = 100,
             offset: int = 0,
             bank_id: str | None = None,
+            tags: list[str] | None = None,
+            tags_match: str = "any",
         ) -> str:
             """
             Browse stored memories with optional filtering.
@@ -2258,6 +2260,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                 limit: Maximum number of results (default: 100)
                 offset: Pagination offset (default: 0)
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
+                tags: Optional list of tag names to filter by.
+                tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
             """
             try:
                 target_bank = bank_id or config.bank_id_resolver()
@@ -2270,6 +2274,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                     search_query=q,
                     limit=limit,
                     offset=offset,
+                    tags=tags,
+                    tags_match=tags_match,
                     request_context=_get_request_context(config),
                 )
                 return json.dumps(result, indent=2, default=str)
@@ -2288,6 +2294,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             q: str | None = None,
             limit: int = 100,
             offset: int = 0,
+            tags: list[str] | None = None,
+            tags_match: str = "any",
         ) -> dict:
             """
             Browse stored memories with optional filtering.
@@ -2300,6 +2308,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                 q: Optional text search query to filter memories
                 limit: Maximum number of results (default: 100)
                 offset: Pagination offset (default: 0)
+                tags: Optional list of tag names to filter by.
+                tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
             """
             try:
                 target_bank = config.bank_id_resolver()
@@ -2312,6 +2322,8 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                     search_query=q,
                     limit=limit,
                     offset=offset,
+                    tags=tags,
+                    tags_match=tags_match,
                     request_context=_get_request_context(config),
                 )
                 return result

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -23,7 +23,7 @@ from hindsight_api.config import (
 from hindsight_api.engine.audit import AuditEntry, AuditLogger
 from hindsight_api.engine.memory_engine import Budget
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MinScores
-from hindsight_api.engine.search.tags import TagGroup
+from hindsight_api.engine.search.tags import TagGroup, TagsMatch
 from hindsight_api.extensions import OperationValidationError
 from hindsight_api.models import RequestContext
 
@@ -2246,7 +2246,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             offset: int = 0,
             bank_id: str | None = None,
             tags: list[str] | None = None,
-            tags_match: str = "any",
+            tags_match: TagsMatch = "any",
         ) -> str:
             """
             Browse stored memories with optional filtering.
@@ -2261,7 +2261,9 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                 offset: Pagination offset (default: 0)
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
                 tags: Optional list of tag names to filter by.
-                tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
+                tags_match: How to combine tags: 'any' (OR, default) or 'all' (AND)
+                    both also include untagged memories; 'any_strict'/'all_strict'
+                    exclude untagged; 'exact' matches the tag set exactly.
             """
             try:
                 target_bank = bank_id or config.bank_id_resolver()
@@ -2295,7 +2297,7 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
             limit: int = 100,
             offset: int = 0,
             tags: list[str] | None = None,
-            tags_match: str = "any",
+            tags_match: TagsMatch = "any",
         ) -> dict:
             """
             Browse stored memories with optional filtering.
@@ -2309,7 +2311,9 @@ def _register_list_memories(mcp: FastMCP, memory: MemoryEngine, config: MCPTools
                 limit: Maximum number of results (default: 100)
                 offset: Pagination offset (default: 0)
                 tags: Optional list of tag names to filter by.
-                tags_match: How to combine multiple tags: 'any' (OR, default) or 'all' (AND).
+                tags_match: How to combine tags: 'any' (OR, default) or 'all' (AND)
+                    both also include untagged memories; 'any_strict'/'all_strict'
+                    exclude untagged; 'exact' matches the tag set exactly.
             """
             try:
                 target_bank = config.bank_id_resolver()

--- a/hindsight-api-slim/tests/test_tags_visibility.py
+++ b/hindsight-api-slim/tests/test_tags_visibility.py
@@ -1450,6 +1450,105 @@ async def test_list_memories_includes_tags(api_client, test_bank_id):
 
 
 # ============================================================================
+# Integration Tests for tags filtering on list_memories / GET /memories/list
+# ============================================================================
+
+# Signatures of the four seeded items (sorted tag tuples). Assertions compare the
+# SET of signatures returned rather than raw counts, so they are robust to how many
+# units the extractor emits per retained item.
+_ALPHA_ALICE = ("project:alpha", "user:alice")
+_ALPHA_BOB = ("project:alpha", "user:bob")
+_BETA = ("project:beta",)
+_UNTAGGED: tuple[str, ...] = ()
+
+
+async def _seed_tagged_bank(api_client) -> str:
+    """Retain four items (three tagged, one untagged) into a fresh isolated bank."""
+    bank_id = f"list_tags_{datetime.now().timestamp()}"
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories",
+        json={
+            "items": [
+                {"content": "Alice leads the Alpha project.", "tags": ["project:alpha", "user:alice"]},
+                {"content": "Bob contributes to the Alpha project.", "tags": ["project:alpha", "user:bob"]},
+                {"content": "Carol manages the Beta project.", "tags": ["project:beta"]},
+                {"content": "Dave enjoys sailing on weekends."},
+            ]
+        },
+    )
+    assert response.status_code == 200
+    return bank_id
+
+
+async def _list_signatures(api_client, bank_id: str, params: dict | list) -> set[tuple[str, ...]]:
+    """GET /memories/list with the given query params, return the set of tag signatures."""
+    response = await api_client.get(f"/v1/default/banks/{bank_id}/memories/list", params=params)
+    assert response.status_code == 200, response.text
+    return {tuple(sorted(item["tags"])) for item in response.json()["items"]}
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_any_includes_untagged(api_client):
+    """any (default): OR match on the tag, plus untagged units; other-tagged excluded."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags": ["project:alpha"], "tags_match": "any"})
+    assert _ALPHA_ALICE in sigs and _ALPHA_BOB in sigs
+    assert _UNTAGGED in sigs, "any must include untagged units"
+    assert _BETA not in sigs, "project:beta does not match project:alpha"
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_any_strict_excludes_untagged(api_client):
+    """any_strict: OR match, but untagged units are excluded."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags": ["project:alpha"], "tags_match": "any_strict"})
+    assert sigs == {_ALPHA_ALICE, _ALPHA_BOB}
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_all(api_client):
+    """all: AND match (unit must carry every requested tag), plus untagged."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags": ["project:alpha", "user:alice"], "tags_match": "all"})
+    assert _ALPHA_ALICE in sigs
+    assert _UNTAGGED in sigs, "all still includes untagged units"
+    assert _ALPHA_BOB not in sigs, "Bob lacks user:alice, so AND match excludes it"
+    assert _BETA not in sigs
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_all_strict(api_client):
+    """all_strict: AND match with untagged excluded."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags": ["project:alpha"], "tags_match": "all_strict"})
+    assert sigs == {_ALPHA_ALICE, _ALPHA_BOB}
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_exact(api_client):
+    """exact: set-equality; only the unit whose tag set matches exactly."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags": ["project:alpha", "user:alice"], "tags_match": "exact"})
+    assert sigs == {_ALPHA_ALICE}
+
+
+@pytest.mark.asyncio
+async def test_list_memories_filter_tags_exact_empty_selects_untagged(api_client):
+    """exact with no tags is the global scope: only untagged units are returned."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {"tags_match": "exact"})
+    assert sigs == {_UNTAGGED}
+
+
+@pytest.mark.asyncio
+async def test_list_memories_no_tag_filter_returns_all(api_client):
+    """Sanity: without a tag filter every seeded signature is present."""
+    bank_id = await _seed_tagged_bank(api_client)
+    sigs = await _list_signatures(api_client, bank_id, {})
+    assert {_ALPHA_ALICE, _ALPHA_BOB, _BETA, _UNTAGGED} <= sigs
+
+
+# ============================================================================
 # Integration Tests for tag_groups compound filtering
 # ============================================================================
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -209,6 +209,31 @@ paths:
         style: form
       - explode: true
         in: query
+        name: tags
+        required: false
+        schema:
+          items:
+            type: string
+          nullable: true
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: tags_match
+        required: false
+        schema:
+          default: any
+          enum:
+          - any
+          - all
+          - any_strict
+          - all_strict
+          - exact
+          title: Tags Match
+          type: string
+        style: form
+      - explode: true
+        in: query
         name: limit
         required: false
         schema:

--- a/hindsight-clients/go/api_memory.go
+++ b/hindsight-clients/go/api_memory.go
@@ -875,6 +875,8 @@ type ApiListMemoriesRequest struct {
 	consolidationState *string
 	state *string
 	documentId *string
+	tags *[]string
+	tagsMatch *string
 	limit *int32
 	offset *int32
 	authorization *string
@@ -902,6 +904,16 @@ func (r ApiListMemoriesRequest) State(state string) ApiListMemoriesRequest {
 
 func (r ApiListMemoriesRequest) DocumentId(documentId string) ApiListMemoriesRequest {
 	r.documentId = &documentId
+	return r
+}
+
+func (r ApiListMemoriesRequest) Tags(tags []string) ApiListMemoriesRequest {
+	r.tags = &tags
+	return r
+}
+
+func (r ApiListMemoriesRequest) TagsMatch(tagsMatch string) ApiListMemoriesRequest {
+	r.tagsMatch = &tagsMatch
 	return r
 }
 
@@ -977,6 +989,23 @@ func (a *MemoryAPIService) ListMemoriesExecute(r ApiListMemoriesRequest) (*ListM
 	}
 	if r.documentId != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "document_id", r.documentId, "form", "")
+	}
+	if r.tags != nil {
+		t := *r.tags
+		if reflect.TypeOf(t).Kind() == reflect.Slice {
+			s := reflect.ValueOf(t)
+			for i := 0; i < s.Len(); i++ {
+				parameterAddToHeaderOrQuery(localVarQueryParams, "tags", s.Index(i).Interface(), "form", "multi")
+			}
+		} else {
+			parameterAddToHeaderOrQuery(localVarQueryParams, "tags", t, "form", "multi")
+		}
+	}
+	if r.tagsMatch != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "tags_match", r.tagsMatch, "form", "")
+	} else {
+		var defaultValue string = "any"
+		r.tagsMatch = &defaultValue
 	}
 	if r.limit != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "limit", r.limit, "form", "")

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -1940,6 +1940,8 @@ class MemoryApi:
         consolidation_state: Optional[StrictStr] = None,
         state: Optional[StrictStr] = None,
         document_id: Optional[StrictStr] = None,
+        tags: Optional[List[StrictStr]] = None,
+        tags_match: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         authorization: Optional[StrictStr] = None,
@@ -1972,6 +1974,10 @@ class MemoryApi:
         :type state: str
         :param document_id:
         :type document_id: str
+        :param tags:
+        :type tags: List[str]
+        :param tags_match:
+        :type tags_match: str
         :param limit:
         :type limit: int
         :param offset:
@@ -2007,6 +2013,8 @@ class MemoryApi:
             consolidation_state=consolidation_state,
             state=state,
             document_id=document_id,
+            tags=tags,
+            tags_match=tags_match,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2040,6 +2048,8 @@ class MemoryApi:
         consolidation_state: Optional[StrictStr] = None,
         state: Optional[StrictStr] = None,
         document_id: Optional[StrictStr] = None,
+        tags: Optional[List[StrictStr]] = None,
+        tags_match: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         authorization: Optional[StrictStr] = None,
@@ -2072,6 +2082,10 @@ class MemoryApi:
         :type state: str
         :param document_id:
         :type document_id: str
+        :param tags:
+        :type tags: List[str]
+        :param tags_match:
+        :type tags_match: str
         :param limit:
         :type limit: int
         :param offset:
@@ -2107,6 +2121,8 @@ class MemoryApi:
             consolidation_state=consolidation_state,
             state=state,
             document_id=document_id,
+            tags=tags,
+            tags_match=tags_match,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2140,6 +2156,8 @@ class MemoryApi:
         consolidation_state: Optional[StrictStr] = None,
         state: Optional[StrictStr] = None,
         document_id: Optional[StrictStr] = None,
+        tags: Optional[List[StrictStr]] = None,
+        tags_match: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         offset: Optional[Annotated[int, Field(strict=True, ge=0)]] = None,
         authorization: Optional[StrictStr] = None,
@@ -2172,6 +2190,10 @@ class MemoryApi:
         :type state: str
         :param document_id:
         :type document_id: str
+        :param tags:
+        :type tags: List[str]
+        :param tags_match:
+        :type tags_match: str
         :param limit:
         :type limit: int
         :param offset:
@@ -2207,6 +2229,8 @@ class MemoryApi:
             consolidation_state=consolidation_state,
             state=state,
             document_id=document_id,
+            tags=tags,
+            tags_match=tags_match,
             limit=limit,
             offset=offset,
             authorization=authorization,
@@ -2235,6 +2259,8 @@ class MemoryApi:
         consolidation_state,
         state,
         document_id,
+        tags,
+        tags_match,
         limit,
         offset,
         authorization,
@@ -2247,6 +2273,7 @@ class MemoryApi:
         _host = None
 
         _collection_formats: Dict[str, str] = {
+            'tags': 'multi',
         }
 
         _path_params: Dict[str, str] = {}
@@ -2281,6 +2308,14 @@ class MemoryApi:
         if document_id is not None:
             
             _query_params.append(('document_id', document_id))
+            
+        if tags is not None:
+            
+            _query_params.append(('tags', tags))
+            
+        if tags_match is not None:
+            
+            _query_params.append(('tags_match', tags_match))
             
         if limit is not None:
             

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4332,6 +4332,14 @@ export type ListMemoriesData = {
      */
     document_id?: string | null;
     /**
+     * Tags
+     */
+    tags?: Array<string> | null;
+    /**
+     * Tags Match
+     */
+    tags_match?: "any" | "all" | "any_strict" | "all_strict" | "exact";
+    /**
      * Limit
      */
     limit?: number;

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -337,6 +337,42 @@
             }
           },
           {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tags"
+            }
+          },
+          {
+            "name": "tags_match",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "any",
+                "all",
+                "any_strict",
+                "all_strict",
+                "exact"
+              ],
+              "type": "string",
+              "default": "any",
+              "title": "Tags Match"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -337,6 +337,42 @@
             }
           },
           {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tags"
+            }
+          },
+          {
+            "name": "tags_match",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "any",
+                "all",
+                "any_strict",
+                "all_strict",
+                "exact"
+              ],
+              "type": "string",
+              "default": "any",
+              "title": "Tags Match"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,


### PR DESCRIPTION
## Summary

Add `tags` and `tags_match` parameters to `list_memory_units`, MCP `list_memories` tool, and HTTP `GET /memories/list` endpoint, bringing the browse side's tag filtering capability in line with the write side (`retain`) and semantic search side (`recall`).

## Problem

Currently there is an asymmetry in tag handling:
- **Write side**: `retain` accepts `tags` and stores them in `memory_units.tags` (PostgreSQL array column)
- **Read side**: `recall` supports `tags`/`tags_match`/`tag_groups` filtering
- **Browse side**: `list_memory_units` and `list_memories` have **no `tags` parameter at all**

Users who tag memories for scoping (e.g., `project:alpha`, `user:bob`) cannot browse memories by those tags without falling back to semantic `recall`, which returns relevance-ranked results — not always the desired behavior for deterministic browsing.

## Changes

### `hindsight_api/engine/memory_engine.py`
- Add `tags: list[str] | None = None` and `tags_match: TagsMatch = "any"` parameters to `list_memory_units`
- Call `build_tags_where_clause` (already available in `hindsight_api/engine/search/tags.py`) to append the tags filter to the SQL query

### `hindsight_api/mcp_tools.py`
- Add `tags` and `tags_match` parameters to both versions of the MCP `list_memories` tool (with and without `bank_id`)
- Pass through to `list_memory_units`

### `hindsight_api/api/http.py`
- Add `tags: list[str] | None = Query(default=None)` and `tags_match: TagsMatch = Query(default="any")` to the `GET /memories/list` endpoint
- Pass through to `list_memory_units`

## Matching modes

Supports all five modes (same as `recall`):
- `any` (default): OR matching, includes untagged memories
- `all`: AND matching, includes untagged memories
- `any_strict`: OR matching, excludes untagged memories
- `all_strict`: AND matching, excludes untagged memories
- `exact`: set-equality matching, excludes untagged memories

## Testing

Verified against a live Hindsight instance (v0.8.4, pg0, 2172 memories):

| Query | Result |
|-------|--------|
| No tag filter | 2172 |
| `tags=["session:xxx"]` + `any_strict` | 48 (only tagged) |
| `tags=["session:xxx"]` + `any` | 113 (tagged + untagged) |
| `tags=["nonexistent"]` + `any_strict` | 0 |

Closes #2842
Related: #792
