### PR TITLE
fix: disable built-in tools in ClaudeCodeLLM.call() to prevent ToolSearch deferral eating max_turns=1

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -224,9 +224,19 @@ class ClaudeCodeLLM(LLMInterface):
             user_content += schema_instruction
 
         # Configure SDK options
+        #
+        # tools=[] is required here for the same reason call_with_tools() below
+        # already sets it: with `tools` left at its default (None -> full
+        # "claude_code" built-in preset), allowed_tools=[] alone does not stop
+        # the CLI from loading the full built-in toolset and deferring into
+        # ToolSearch before answering, which burns the single max_turns=1
+        # budget on a tool-deferral step instead of a text response. Without
+        # this, single-turn calls intermittently fail with "Reached maximum
+        # number of turns (1)" even though the prompt itself needs no tools.
         options = ClaudeAgentOptions(
             system_prompt=system_prompt if system_prompt else None,
             max_turns=1,  # Single-turn for API-style interactions
+            tools=[],  # Disable built-in tools so nothing forces a ToolSearch deferral
             allowed_tools=[],  # Disable tools for standard LLM calls
             env=_get_isolated_claude_env(),
         )


### PR DESCRIPTION
*Beep boop, I am Claude Code 🤖, my user has reviewed and approved the following written by me:*

## Summary

`ClaudeCodeLLM.call()` (the single-turn path used by structured/consolidation
extraction) leaves `ClaudeAgentOptions.tools` at its default and only sets
`allowed_tools=[]`. Per `tools`'s own docstring, the default (`None`) loads the
full `claude_code` built-in preset (Read, Write, Bash, ToolSearch, etc.) —
`allowed_tools=[]` only restricts what the model may call *without prompting*,
it doesn't stop the toolset from loading. `call_with_tools()` a few hundred
lines below already sets `tools=[]` for exactly this reason, with a comment
explaining that without it "the Claude Code CLI defers MCP tools when too many
built-in tools are loaded, forcing Claude to use ToolSearch first — which
wastes the `max_turns` budget." `call()` never got the same fix applied.

With `max_turns=1` and no tools actually needed by the extraction prompt, a
turn spent on CLI-side tool deferral is a turn that can't also produce the
text response — surfacing as an intermittent `Claude Code returned an error
result: Reached maximum number of turns (1)`.

## Evidence

Observed repeatedly on a local `hindsight-embed` instance (`claude-code` LLM
provider) during consolidation:

```
Claude Code error (attempt 1/4): Claude Code returned an error result: Reached maximum number of turns (1)
Claude Code error (attempt 2/4): Claude Code returned an error result: Reached maximum number of turns (1)
Claude Code error (attempt 3/4): Claude Code returned an error result: Reached maximum number of turns (1)
Claude Code error after 4 attempts: Claude Code returned an error result: Reached maximum number of turns (1)
[CONSOLIDATION] LLM batch call failed after 1 attempts for N memories ...
```

The adaptive-splitting retry (down to a single memory) had already ruled out
batch-size and worker-concurrency as the cause — isolated single-memory
batches failed identically, which is what pointed at an SDK-configuration
cause rather than a content/prompt cause.

The failures were frequent enough to trip a local retry-storm safeguard
(killing the daemon after 5+ provider errors in 120s), which is what prompted
looking at this path directly rather than guessing from the error text alone.

**After the fix** (`tools=[]` added to `call()`'s `ClaudeAgentOptions`,
verified via the `embedPackagePath` dev-mode override), a stuck backlog of 16
unconsolidated memories on the same bank — previously failing consistently —
consolidated cleanly on the first pass, zero `max_turns` errors, across two
LLM batches:

```
[CONSOLIDATION] bank=claude_code llm_batch #1 (8 memories, 1 llm calls) | processed=8/16 | llm=94.444s | created=1 updated=7 skipped=0
[CONSOLIDATION] bank=claude_code llm_batch #2 (8 memories, 1 llm calls) | processed=16/16 | llm=73.426s | created=3 updated=5 skipped=0
[CONSOLIDATION] bank=claude_code completed: 16 processed
```

## Change

One line: add `tools=[]` to `call()`'s `ClaudeAgentOptions`, matching the
pattern `call_with_tools()` already uses, plus a comment cross-referencing
why.

## Notes

- Searched existing issues/PRs for `claude_code_llm`, `max_turns`, and
  `Reached maximum number of turns` first — found #2675, which is a distinct
  bug (crash-interrupted retry/claim-tracking loop), not this one.
- No test added — this is a single-line config fix in a third-party-CLI
  integration path that's awkward to unit test without mocking the SDK's
  `query()` streaming interface; happy to add one if there's a preferred
  pattern already used elsewhere in this file's test suite.

*Beep boop, Claude Code 🤖 out!*
